### PR TITLE
Removed sx-libnl from Mellanox containers dependencies.

### DIFF
--- a/dockers/docker-saiserver-mlnx/Dockerfile
+++ b/dockers/docker-saiserver-mlnx/Dockerfile
@@ -2,7 +2,7 @@ FROM docker-base
 
 RUN apt-get update
 
-COPY ["deps/applibs_*.deb", "/deps/applibs-dev_*.deb", "/deps/sx-complib_*.deb", "/deps/sxd-libs_*.deb", "/deps/sx-scew_*.deb", "/deps/sx-examples_*.deb", "/deps/sx-gen-utils_*.deb", "/deps/python-sdk-api_*.deb", "/deps/sx-libnl_*.deb", "/deps/iproute2_*.deb", "/deps/mlnx-sai_*.deb", "/deps/libthrift-0.9.2_*.deb", "/deps/"]
+COPY ["deps/applibs_*.deb", "/deps/applibs-dev_*.deb", "/deps/sx-complib_*.deb", "/deps/sxd-libs_*.deb", "/deps/sx-scew_*.deb", "/deps/sx-examples_*.deb", "/deps/sx-gen-utils_*.deb", "/deps/python-sdk-api_*.deb", "/deps/iproute2_*.deb", "/deps/mlnx-sai_*.deb", "/deps/libthrift-0.9.2_*.deb", "/deps/libnl-3-200_*.deb", "/deps/libnl-genl-3-200_*.deb", "/deps/libnl-route-3-200_*.deb", "/deps/"]
 
 RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; \
     dpkg_apt /deps/applibs_*.deb           \
@@ -13,10 +13,12 @@ RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return
     && dpkg_apt /deps/sx-examples_*.deb    \
     && dpkg_apt /deps/sx-gen-utils_*.deb   \
     && dpkg_apt /deps/python-sdk-api_*.deb \
-    && dpkg_apt /deps/sx-libnl_*.deb       \
     && dpkg_apt /deps/iproute2_*.deb       \
     && dpkg_apt /deps/mlnx-sai_*.deb       \
-    && dpkg_apt /deps/libthrift-0.9.2_*.deb
+    && dpkg_apt /deps/libthrift-0.9.2_*.deb    \
+    && dpkg_apt /deps/libnl-3-200_*.deb        \
+    && dpkg_apt /deps/libnl-genl-3-200_*.deb   \
+    && dpkg_apt /deps/libnl-route-3-200_*.deb
 
 COPY ["deps/saiserver", "start.sh", "/usr/bin/"]
 

--- a/dockers/docker-syncd-mlnx/Dockerfile
+++ b/dockers/docker-syncd-mlnx/Dockerfile
@@ -13,7 +13,6 @@ RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return
     && dpkg_apt /deps/sx-examples_*.deb    \
     && dpkg_apt /deps/sx-gen-utils_*.deb   \
     && dpkg_apt /deps/python-sdk-api_*.deb \
-    && dpkg_apt /deps/sx-libnl_*.deb       \
     && dpkg_apt /deps/iproute2_*.deb       \
     && dpkg_apt /deps/mft*.deb             \
 

--- a/src/mlnx-sdk/filelist.txt
+++ b/src/mlnx-sdk/filelist.txt
@@ -19,9 +19,6 @@ sx-gen-utils-dev_1.mlnx.4.2.2100_amd64.deb
 sx-gen-utils_1.mlnx.4.2.2100_amd64.deb
 sx-kernel-dev_1.mlnx.4.2.2100_amd64.deb
 sx-kernel_1.mlnx.4.2.2100_amd64.deb
-sx-libnl-dev-static_1.mlnx.4.2.2100_amd64.deb
-sx-libnl-dev_1.mlnx.4.2.2100_amd64.deb
-sx-libnl_1.mlnx.4.2.2100_amd64.deb
 sx-scew-dev-static_1.mlnx.4.2.2100_amd64.deb
 sx-scew-dev_1.mlnx.4.2.2100_amd64.deb
 sx-scew_1.mlnx.4.2.2100_amd64.deb


### PR DESCRIPTION
Changed docker-syncd-mlnx docker-saiserver-mlnx dependencies to use libnl provided by build system instead of sx-libnl.