### PR TITLE
build_debian: Enable IPv6 forwarding

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -198,17 +198,27 @@ sudo augtool --autosave "set /files/etc/ssh/sshd_config/UseDNS no" -r $FILESYSTE
 sudo mkdir -p $FILESYSTEM_ROOT/var/core
 sudo augtool --autosave "
 set /files/etc/sysctl.conf/kernel.core_pattern '|/usr/bin/coredump-compress %e %p'
+
+set /files/etc/sysctl.conf/net.ipv4.conf.default.forwarding 1
+set /files/etc/sysctl.conf/net.ipv4.conf.all.forwarding 1
+set /files/etc/sysctl.conf/net.ipv4.conf.eth0.forwarding 0
+
 set /files/etc/sysctl.conf/net.ipv4.conf.default.arp_accept 0
 set /files/etc/sysctl.conf/net.ipv4.conf.default.arp_announce 0
 set /files/etc/sysctl.conf/net.ipv4.conf.default.arp_filter 0
 set /files/etc/sysctl.conf/net.ipv4.conf.default.arp_notify 0
 set /files/etc/sysctl.conf/net.ipv4.conf.default.arp_ignore 0
-set /files/etc/sysctl.conf/net.ipv6.conf.default.accept_dad 0
 set /files/etc/sysctl.conf/net.ipv4.conf.all.arp_accept 0
 set /files/etc/sysctl.conf/net.ipv4.conf.all.arp_announce 1
 set /files/etc/sysctl.conf/net.ipv4.conf.all.arp_filter 0
 set /files/etc/sysctl.conf/net.ipv4.conf.all.arp_notify 1
 set /files/etc/sysctl.conf/net.ipv4.conf.all.arp_ignore 2
+
+set /files/etc/sysctl.conf/net.ipv6.conf.default.forwarding 1
+set /files/etc/sysctl.conf/net.ipv6.conf.all.forwarding 1
+set /files/etc/sysctl.conf/net.ipv6.conf.eth0.forwarding 0
+
+set /files/etc/sysctl.conf/net.ipv6.conf.default.accept_dad 0
 set /files/etc/sysctl.conf/net.ipv6.conf.all.accept_dad 0
 " -r $FILESYSTEM_ROOT
 


### PR DESCRIPTION
Router behavior is assumed.
1. IsRouter flag is set in Neighbor Advertisements
2. Router Solicitations are not sent.
3. Router Advertisements are ignored.
4. Redirects are ignored.

ref: http://mirrors.deepspace6.net/Linux+IPv6-HOWTO/proc-sys-net-ipv6..html