### PR TITLE
Use permanent URL for mlnx SDK

### DIFF
--- a/platform/mellanox/sdk.mk
+++ b/platform/mellanox/sdk.mk
@@ -1,4 +1,4 @@
-MLNX_SDK_BASE_URL = https://github.com/Mellanox/SAI-Implementation/raw/sonic/sdk
+MLNX_SDK_BASE_URL = https://github.com/Mellanox/SAI-Implementation/raw/9ae5a29e344e23cd4ce92805f990f8ce8fab292a/sdk
 MLNX_SDK_VERSION = 4.2.3002
 MLNX_SDK_RDEBS += $(APPLIBS) $(IPROUTE2) $(SX_ACL_RM) $(SX_COMPLIB) \
 		  $(SX_EXAMPLES) $(SX_GEN_UTILS) $(SX_SCEW) $(SX_SDN_HAL) \


### PR DESCRIPTION
Change branch name into commit hash to have a
permanent URL for SDK