### PR TITLE
[docker]: Use j2 template for docker-syncd-cavm

### DIFF
--- a/platform/cavium/docker-syncd-cavm/Dockerfile.j2
+++ b/platform/cavium/docker-syncd-cavm/Dockerfile.j2
@@ -2,17 +2,19 @@ FROM docker-base
 
 RUN apt-get update
 
-COPY deps /deps
+COPY debs /debs
 
 RUN apt-get -y install libpcap-dev libxml2-dev python-dev swig libsensors4-dev
 
-SED_DPKG
+{% for deb in docker_syncd_cavm_debs.split(' ') -%}
+debs/{{ deb }}{{' '}}
+{%- endfor %}
 
 COPY ["start.sh", "/usr/bin/"]
 
 ## Clean up
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /deps
+RUN rm -rf /debs
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/usr/bin/start.sh"]


### PR DESCRIPTION
j2 is used for Dockerfile templates since
66aebb329ccec74e92ad25875ea3e8cc2de65055