### PR TITLE
Add VFAT support in initramfs

### DIFF
--- a/files/initramfs-tools/modules
+++ b/files/initramfs-tools/modules
@@ -1,2 +1,5 @@
 squashfs
 aufs
+vfat
+nls_cp437
+nls_utf8


### PR DESCRIPTION
For the earlier commit of converting VFAT file system to EXT4,  VFAT support is needed in the initramfs. Sorry for missing this part of code.