### PR TITLE
docker: Add ipaddress python module to the PTF docker

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -66,6 +66,7 @@ RUN rm -rf /debs \
     && pip install --upgrade cffi==1.7.0 \
     && pip install nnpy    \
     && pip install dpkt    \
+    && pip install ipaddress \
     && mkdir -p /opt       \
     && cd /opt             \
     && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py


### PR DESCRIPTION
Needed for the FIB test