### PR TITLE
Add DCS-7060CX-32S support in boot0

### DIFF
--- a/files/Aboot/boot0
+++ b/files/Aboot/boot0
@@ -64,16 +64,22 @@ EOF
 
 platform_specific() {
     local platform="$(grep -Eo 'platform=[^ ]+' /etc/cmdline | cut -f2 -d=)"
-    # This is temporary as the platform= parameter doesn't provide enough
+    local sid="$(grep -Eo 'sid=[^ ]+' /etc/cmdline | cut -f2 -d=)"
+    # This is temporary as the platform= and sid= parameters don't provide enough
     # information to identify the SKU
     # An initramfs hook or a later processing done by the initscripts will be
-    # required
+    # required to read the system eeprom
     if [ "$platform" = "raven" ]; then
         aboot_machine=arista_7050_qx32
         echo "modprobe.blacklist=radeon" >>/tmp/append
     fi
     if [ "$platform" = "crow" ]; then
         aboot_machine=arista_7050_qx32s
+        echo "modprobe.blacklist=radeon" >>/tmp/append
+    fi
+    if [ "$sid" = "Upperlake" ]; then
+        aboot_machine=arista_7060_cx32s
+        echo "amd_iommu=off" >> /tmp/append
     fi
 }
 
@@ -95,7 +101,6 @@ fi
 if ! grep -q "root=" /tmp/append; then
    rootdev=$(mount | grep '/mnt/flash' | cut -f1 -d' ')
    rootfstype=$(mount | grep '/mnt/flash' | cut -f5 -d' ')
-   # reformat if vfat?
    echo "root=$rootdev" >>/tmp/append
 fi
 


### PR DESCRIPTION
Set the proper cmdline arguments to boot on a DCS-7060CX-32S in boot0.

@lguohan and @qiluo-msft in all the sonic codebase it seems like the hw_sku names for Arista platforms differs from the ones we actually give.
You use either `arista_7050_qx32s` or `Arista-7050-QX32S` in place of `DCS-7050QX-32S`. I agree that replacing `DCS` by `Arista` is better in this case but the dash/underscore being moved will yield some strange naming at some point.
Consider the SKU `DCS-7050QX2-32S`. With this one you'll end up with `Arista-7050-QX232S` since consistency matters in the naming.
I personally don't mind much since the transformation from our SKU naming to this one is easily done programatically but I wanted to bring that up before we add more platform and while we can still change it. 
So I was wondering if I should go ahead and do the changes in `sonic-buildimage` (syncd, orchagent, boot0) and `sonic-mgmt` everywhere for the `Arista-7050QX-32`.
Otherwise, should I just do this only for the new platforms or should I just drop the idea and continue with the way it is currently done?