### PR TITLE
Add version file to the SWI required by newer Aboot

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -35,6 +35,9 @@ elif [ "$IMAGE_TYPE" = "aboot" ]; then
     echo "$GIT_REVISION" >> .imagehash
     zip -g $OUTPUT_ONIE_IMAGE .imagehash
     rm .imagehash
+    echo "SWI_VERSION=42.0.0" > version
+    zip -g $OUTPUT_ONIE_IMAGE version
+    rm version
 else
     echo "Error: Non supported target platform: $TARGET_PLATFORM"
     exit 1


### PR DESCRIPTION
Newer Aboot versions looks do SWI checks by using this file.
It is required for Aboot to kexec into sonic.