### PR TITLE
[aboot]: extract dockerfs in initramfs stage when the root fs is vfat

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -53,11 +53,19 @@ extract_image() {
     ## Remove installer swi as it has lots of redundunt contents
     rm -f $swipath
 
-    ## Further extract docker archive
-    tar xf "$target_path/{{ FILESYSTEM_DOCKERFS }}" -C "$target_path"
+    ## detect rootfs type
+    rootfs_type=`grep /mnt/flash /proc/mounts | cut -d' ' -f3`
 
-    ## clean up docker archive
-    rm -f "$target_path/{{ FILESYSTEM_DOCKERFS }}"
+    ## vfat does not support symbol link
+    if [ $rootfs_type != "vfat" ]; then
+        ## Further extract docker archive
+        tar xf "$target_path/{{ FILESYSTEM_DOCKERFS }}" -C "$target_path"
+
+        ## clean up docker archive
+        rm -f "$target_path/{{ FILESYSTEM_DOCKERFS }}"
+    else
+        echo "/mnt/flash is $rootfs_type, extract {{ FILESYSTEM_DOCKERFS }} in later stage"
+    fi
 
     ## replace with boot swi
     mv "$target_path/{{ ABOOT_BOOT_IMAGE }}" "$swipath"

--- a/files/initramfs-tools/arista-convertfs
+++ b/files/initramfs-tools/arista-convertfs
@@ -164,7 +164,10 @@ err_msg="Error: mounting $root_dev to $root_mnt failed"
 cmd="mount -t ext4 $root_dev $root_mnt"
 run_cmd "$cmd" "$err_msg"
 
+err_msg="Error: extract docker directory"
+cmd="[ -f $tmp_mnt/dockerfs.tar.gz ] && rm -rf $tmp_mnt/var && tar xzf $tmp_mnt/dockerfs.tar.gz -C $root_mnt && rm -f $tmp_mnt/dockerfs.tar.gz"
+run_cmd "$cmd" "$err_msg"
+
 err_msg="Error: copying files form $tmp_mnt to $root_mnt failed"
 cmd="cp -a $tmp_mnt/. $root_mnt/"
 run_cmd "$cmd" "$err_msg"
-


### PR DESCRIPTION
vfat does not support symbol links used in aufs