### PR TITLE
[swss]: Wait for redis server start before database clean

### DIFF
--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -5,6 +5,8 @@ After=database.service
 
 [Service]
 User={{ sonicadmin_user }}
+# Wait for redis server start before database clean
+ExecStartPre=/bin/bash -c "while true; do if [ \"$(/usr/bin/docker exec database redis-cli ping)\" == \"PONG\" ]; then break; fi; sleep 1; done"
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 0 FLUSHDB
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 1 FLUSHDB
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 2 FLUSHDB


### PR DESCRIPTION
picked this change from sonic-mgmt repo.

https://github.com/Azure/sonic-mgmt/pull/110