### PR TITLE
[build_debian.sh]: Create loop device for /var/log

### DIFF
--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -18,3 +18,5 @@ mount --bind ${rootmnt}/host/{{ DOCKERFS_DIR }} ${rootmnt}/var/lib/docker
 ## Mount the boot directory in the raw partition, bypass the aufs
 mkdir -p ${rootmnt}/boot
 mount --bind ${rootmnt}/host/boot ${rootmnt}/boot
+## Mount loop device for /var/log
+[ -f ${rootmnt}/host/disk-img/var-log.ext4 ] && mount -t ext4 -o loop,rw ${rootmnt}/host/disk-img/var-log.ext4 ${rootmnt}/var/log

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -51,6 +51,10 @@ CONSOLE_SPEED=9600
 
 # Get platform specific linux kernel command line arguments
 ONIE_PLATFORM_EXTRA_CMDLINE_LINUX=""
+
+# Default var/log device size in MB
+VAR_LOG_SIZE=4096
+
 [ -r platforms/$onie_platform ] && source platforms/$onie_platform
 
 # Install demo on same block device as ONIE
@@ -399,6 +403,13 @@ unzip $ONIE_INSTALLER_PAYLOAD -d $demo_mnt
 
 if [ -f $demo_mnt/$FILESYSTEM_DOCKERFS ]; then
     cd $demo_mnt && mkdir -p $DOCKERFS_DIR && tar xf $FILESYSTEM_DOCKERFS -C $DOCKERFS_DIR; cd $OLDPWD
+fi
+
+# Create loop device for /var/log to limit its size to $VAR_LOG_SIZE MB
+if [ "$VAR_LOG_SIZE" != "0" ]; then
+    mkdir -p $demo_mnt/disk-img
+    dd if=/dev/zero of=$demo_mnt/disk-img/var-log.ext4 count=$((2048*$VAR_LOG_SIZE))
+    mkfs.ext4 -q $demo_mnt/disk-img/var-log.ext4 -F
 fi
 
 # Store machine description in target file system


### PR DESCRIPTION
/var/log size has to be limited to avoid eating up
all space on device

Signed-off-by: marian-pritsak <marianp@mellanox.com>