### PR TITLE
snmpd disables inetCidrRouteTable module

### DIFF
--- a/dockers/docker-snmp-sv2/supervisord.conf
+++ b/dockers/docker-snmp-sv2/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:snmpd]
-command=/usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable -p /run/snmpd.pid
+command=/usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable -p /run/snmpd.pid
 priority=100
 
 [program:snmp-subagent]


### PR DESCRIPTION
This is a temporary solution. Currently sonic-snmpagent doesn't implement inetCidrRouteTable, just ipCidrRouteTable. The snmpd default implementation has no ECMP nexthops.