### PR TITLE
[union-mount] Rescan dev if root partition disapear

### DIFF
--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -8,6 +8,8 @@ esac
 ## Mount the aufs file system: rw layer over squashfs
 mkdir -p ${rootmnt}/host/rw
 mount -n -o dirs=${rootmnt}/host/rw:${rootmnt}=ro -t aufs root-aufs ${rootmnt}
+## Check if the root block device is still there
+[ -b ${ROOT} ] || mdev -s
 ## Mount the raw partition again
 mount ${ROOT} ${rootmnt}/host
 ## Mount the working directory of docker engine in the raw partition, bypass the aufs


### PR DESCRIPTION
On some platforms after the initramfs init scripts have mounted the root device its
block device disapear from /dev. The union-mount script therefore can't mount the
root device over the aufs. If this case happen, issue a rescan of the devices to
repopulate the /dev filesystem.