### PR TITLE
Disable BCM54616S MII isolate mode

### DIFF
--- a/src/igb/Makefile
+++ b/src/igb/Makefile
@@ -12,6 +12,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Patch
 	pushd ./igb-$(IGB_DRIVER_VERSION)
 	patch -p1 < ../patch/0001-add-support-for-BCM54616-phy-for-intel-igb-driver.patch
+	patch -p1 < ../patch/0002-Force-disable-MII-isolate-mode-for-bcm54616.patch
 
 	# Build the package
 	pushd src

--- a/src/igb/patch/0002-Force-disable-MII-isolate-mode-for-bcm54616.patch
+++ b/src/igb/patch/0002-Force-disable-MII-isolate-mode-for-bcm54616.patch
@@ -1,0 +1,70 @@
+Ingrasys S9100 platform set the PHY address to 00h puts the device 
+into isolate mode during and after reset. So we must write 0 to 
+bit 10 of the MII Control register to return normal operation.
+
+From: wadelnn <wadelnn@users.noreply.github.com>
+
+---
+ src/e1000_82575.c |  6 ++++++
+ src/e1000_phy.c   | 15 +++++++++++++++
+ src/e1000_phy.h   |  1 +
+ 3 files changed, 22 insertions(+)
+
+diff --git a/src/e1000_82575.c b/src/e1000_82575.c
+index 049ab7b..41d70ab 100644
+--- a/src/e1000_82575.c
++++ b/src/e1000_82575.c
+@@ -1592,6 +1592,12 @@ static s32 e1000_setup_copper_link_82575(struct e1000_hw *hw)
+ 		case I210_I_PHY_ID:
+ 			ret_val = e1000_copper_link_setup_m88_gen2(hw);
+ 			break;
++		case BCM54616_E_PHY_ID:
++			ret_val = e1000_copper_link_setup_m88(hw);
++			if (e1000_disable_mii_isolate_bcm54616(hw) != 0) {
++				DEBUGOUT("Disable bcm54616 PHY MII isolate mode failed.\n");
++			}
++			break;
+ 		default:
+ 			ret_val = e1000_copper_link_setup_m88(hw);
+ 			break;
+diff --git a/src/e1000_phy.c b/src/e1000_phy.c
+index 5172691..84c5514 100644
+--- a/src/e1000_phy.c
++++ b/src/e1000_phy.c
+@@ -1367,6 +1367,21 @@ s32 e1000_copper_link_setup_igp(struct e1000_hw *hw)
+ 	return ret_val;
+ }
+ 
++s32 e1000_disable_mii_isolate_bcm54616(struct e1000_hw *hw)
++{
++	struct e1000_phy_info *phy = &hw->phy;
++	s32 ret_val;
++	u16 phy_data;
++
++	ret_val = phy->ops.read_reg(hw, PHY_CONTROL, &phy_data);
++	if (ret_val)
++		return ret_val;
++	phy_data &=~(MII_CR_ISOLATE);
++	ret_val = phy->ops.write_reg(hw, PHY_CONTROL, phy_data);
++
++	return ret_val;
++}
++
+ /**
+  *  e1000_phy_setup_autoneg - Configure PHY for auto-negotiation
+  *  @hw: pointer to the HW structure
+diff --git a/src/e1000_phy.h b/src/e1000_phy.h
+index a109c91..d72ae62 100644
+--- a/src/e1000_phy.h
++++ b/src/e1000_phy.h
+@@ -43,6 +43,7 @@ s32  e1000_check_reset_block_generic(struct e1000_hw *hw);
+ s32  e1000_copper_link_setup_igp(struct e1000_hw *hw);
+ s32  e1000_copper_link_setup_m88(struct e1000_hw *hw);
+ s32  e1000_copper_link_setup_m88_gen2(struct e1000_hw *hw);
++s32  e1000_disable_mii_isolate_bcm54616(struct e1000_hw *hw);
+ s32  e1000_phy_force_speed_duplex_igp(struct e1000_hw *hw);
+ s32  e1000_phy_force_speed_duplex_m88(struct e1000_hw *hw);
+ s32  e1000_phy_force_speed_duplex_ife(struct e1000_hw *hw);
+-- 
+2.1.4
+


### PR DESCRIPTION
* Add disable BCM54616S MII isolate mode

Ingrasys S9100 platform sets the PHY address to 00h during and after reset which puts
the device into isolate mode. This patch makes the PHY return to normal operation by
clearing writing MII isolate control register bit.

Signed-off-by: Wade He <chihen.he@gmail.com>