### PR TITLE
[Makefile]: Automatically rebuild sonic-slave

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,30 @@ PWD := $(shell pwd)
 
 MAKEFLAGS += -B
 
+SLAVE_TAG = $(shell shasum sonic-slave/Dockerfile | awk '{print substr($$1,0,11);}')
+SLAVE_IMAGE = sonic-slave-$(USER)
+
 DOCKER_RUN := docker run --rm=true --privileged \
     -v $(PWD):/sonic \
     -i$(SONIC_SLAVE_TTY)
 
-DOCKER_BUILD = docker build --no-cache \
+DOCKER_BUILD = docker build \
 	       --build-arg user=$(USER) \
 	       --build-arg uid=$(shell id -u) \
 	       --build-arg guid=$(shell id -g) \
-	       -t sonic-slave-$(USER) \
-	       sonic-slave
+	       -t $(SLAVE_IMAGE) \
+	       sonic-slave && \
+	       docker tag $(SLAVE_IMAGE):latest $(SLAVE_IMAGE):$(SLAVE_TAG)
 
 .PHONY: sonic-slave-build sonic-slave-bash
 
 .DEFAULT_GOAL :=  all
 
 %::
-	@docker inspect --type image sonic-slave-$(USER) &> /dev/null || $(DOCKER_BUILD)
-	@$(DOCKER_RUN) sonic-slave-$(USER) make \
+	@docker inspect --type image $(SLAVE_IMAGE):$(SLAVE_TAG) &> /dev/null || \
+	    { echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
+	    $(DOCKER_BUILD) ; }
+	@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) make \
 	    -C sonic \
 	    -f slave.mk \
 	    PLATFORM=$(PLATFORM) \
@@ -39,4 +45,7 @@ sonic-slave-build :
 	@$(DOCKER_BUILD)
 
 sonic-slave-bash :
-	@$(DOCKER_RUN) -t sonic-slave-$(USER) bash
+	@docker inspect --type image $(SLAVE_IMAGE):$(SLAVE_TAG) &> /dev/null || \
+	    { echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
+	    $(DOCKER_BUILD) ; }
+	@$(DOCKER_RUN) -t $(SLAVE_IMAGE):$(SLAVE_TAG) bash


### PR DESCRIPTION
sonic-slave is not built upon every make call, because it
takes a lot of time. So in order to track changes hash of
Dockerfile is included to sonic-slave image.

Signed-off-by: marian-pritsak <marianp@mellanox.com>