### PR TITLE
Add default dhcp_relay.yml file to OneImage build

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -111,6 +111,9 @@ sudo bash -c "echo enabled=false > $FILESYSTEM_ROOT/etc/sonic/updategraph.conf"
 # Copy SNMP configuration files
 sudo cp $IMAGE_CONFIGS/snmp/snmp.yml $FILESYSTEM_ROOT/etc/sonic/
 
+# Copy initial DHCP relay configuration file, will be overwritten after docker starts
+sudo cp $IMAGE_CONFIGS/dhcp_relay/dhcp_relay.yml $FILESYSTEM_ROOT/etc/sonic/
+
 # Generate build version file
 export git_revision=$(git rev-parse --short HEAD)
 export sonic_hwsku={{sonic_hwsku}}

--- a/files/image_config/dhcp_relay/dhcp_relay.yml
+++ b/files/image_config/dhcp_relay/dhcp_relay.yml
@@ -1,0 +1,1 @@
+dhcp_servers: []


### PR DESCRIPTION
Fixes https://github.com/Azure/sonic-buildimage/issues/330.