### PR TITLE
[docker]: Add -c option in teamd docker Dockerfile

### DIFF
--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -22,5 +22,5 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "-c"]
 CMD ["/usr/bin/config.sh && /usr/bin/start.sh"]


### PR DESCRIPTION
CMD is not longer a file name but a command that needs to be executed,
thus /bin/bash is not enough for the entrypoint and -c is needed.

Signed-off-by: Shuotian Cheng <shuche@microsoft.com>