### PR TITLE
[teamd]: Update the start.sh script to clean up the teamd docker state

### DIFF
--- a/dockers/docker-teamd/start.sh
+++ b/dockers/docker-teamd/start.sh
@@ -2,9 +2,17 @@
 
 TEAMD_CONF_PATH=/etc/teamd
 
+# Before teamd could automatically add newly created host interfaces into the
+# LAG, this workaround will be needed. It will remove the obsolete files and
+# net devices that are failed to be removed in the previous run.
 function start_app {
+    # Remove *.pid and *.sock files if there are any
+    rm -f /var/run/teamd/*
     if [ -d $TEAMD_CONF_PATH ]; then
         for f in $TEAMD_CONF_PATH/*; do
+            # Remove netdevs if there are any
+            intf=`echo $f | awk -F'[/.]' '{print $4}'`
+            ip link del $intf
             teamd -f $f -d
         done
     fi


### PR DESCRIPTION
This change should be temporary because the current teamd cannot
re-create net devices acrosss restart. Basically, it will fail
when there're files in /var/run/teamd/ folder or the previously
created net devices are still there. Thus, the current workaround
is to remove the obsolete files to restart the docker-teamd.

This workaround cannot resolve the swss restart issue. Before
restarting swss, docker teamd needs to be stopped manually. After
swss starts, docker teamd needs to be restarted manually.

This change will only make sure that rebooting the switch will
make the switch at the correct state.

Signed-off-by: Shuotian Cheng <shuche@microsoft.com>