### PR TITLE
[Makefile]: Add --no-cache to docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DOCKER_RUN := docker run --rm=true --privileged \
     -v $(PWD):/sonic \
     -i$(SONIC_SLAVE_TTY)
 
-DOCKER_BUILD = docker build \
+DOCKER_BUILD = docker build --no-cache \
 	       --build-arg user=$(USER) \
 	       --build-arg uid=$(shell id -u) \
 	       --build-arg guid=$(shell id -g) \


### PR DESCRIPTION
Option was removed by mistake in 38b9eb18299377a3cc2082d483cf407224be05ae

Signed-off-by: marian-pritsak <marianp@mellanox.com>