### PR TITLE
[libteam]: Add 0002-libteam-Temporarily-remove-redundant-debug-mes.patch

### DIFF
--- a/src/libteam/0002-libteam-Temporarily-remove-redundant-debug-mes.patch
+++ b/src/libteam/0002-libteam-Temporarily-remove-redundant-debug-mes.patch
@@ -1,0 +1,25 @@
+From a5c8f3f41c575ebb7018e67cb3d1f724f0685850 Mon Sep 17 00:00:00 2001
+From: Shuotian Cheng <shuche@microsoft.com>
+Date: Mon, 27 Feb 2017 14:21:09 -0800
+Subject: [PATCH] libteam: Temporarily remove redundant debug messages
+
+---
+ teamd/teamd_runner_lacp.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 9c77fae..5e37a4c 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -922,8 +922,6 @@ static void lacp_port_actor_update(struct lacp_port *lacp_port)
+ 		state |= INFO_STATE_DEFAULTED;
+ 	if (teamd_port_count(lacp_port->ctx) > 0)
+ 		state |= INFO_STATE_AGGREGATION;
+-	teamd_log_dbg("%s: lacp info state: 0x%02X.", lacp_port->tdport->ifname,
+-						      state);
+ 	lacp_port->actor.state = state;
+ }
+ 
+-- 
+2.1.4
+

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -16,6 +16,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Apply patch
 	git apply ../0001-libteam-Add-team_get_port_enabled-function.patch
+	git apply ../0002-libteam-Temporarily-remove-redundant-debug-mes.patch
 	popd
 
 	# Obtain debian packaging


### PR DESCRIPTION
Just temporarily remove this line. Let's find out the reason later.

Signed-off-by: Shuotian Cheng <shuche@microsoft.com>