### PR TITLE
[build_debuian]: Fix issue #267 (docker connect failure).

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -37,7 +37,6 @@ trap_push clean_sys
 sudo LANG=C chroot $FILESYSTEM_ROOT mount sysfs /sys -t sysfs
 
 sudo chroot $FILESYSTEM_ROOT service docker start
-sudo chroot $FILESYSTEM_ROOT docker version
 
 # Apply apt configuration files
 sudo cp $IMAGE_CONFIGS/apt/sources.list $FILESYSTEM_ROOT/etc/apt/


### PR DESCRIPTION
Docker version command gets information from docker engine via socket. Service runs docker engine but it doesn't wait until it will be fully initialized. In some cases docker version command was run before docker engine socket was initialized (it depends on system load). Information returned by docker version command is not needed in compile time so it is removed. 