### PR TITLE
[docker-teamd.mk]: Add volumes from database

### DIFF
--- a/rules/docker-teamd.mk
+++ b/rules/docker-teamd.mk
@@ -10,3 +10,4 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_TEAMD)
 $(DOCKER_TEAMD)_CONTAINER_NAME = teamd
 $(DOCKER_TEAMD)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_TEAMD)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_TEAMD)_RUN_OPT += --volumes-from database


### PR DESCRIPTION
teamsyncd requires volumes from database to
connect to DB.

Signed-off-by: marian-pritsak <marianp@mellanox.com>