### PR TITLE
[dhcp_relay]: Check whether device requires DHCP relay upon docker start

### DIFF
--- a/dockers/docker-dhcp-relay/config.sh
+++ b/dockers/docker-dhcp-relay/config.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 
+MINIGRAPH_HOSTNAME=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "minigraph_hostname"`
+DEVICE_ROLE=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "minigraph_devices['$MINIGRAPH_HOSTNAME']['type']"`
+
+if [ $DEVICE_ROLE != "ToRRouter" ]; then
+    echo "Device does not require DHCP relay. docker-dhcp-relay exiting..."
+    exit 1
+fi
+
 sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/isc-dhcp-relay.j2 > /etc/default/isc-dhcp-relay
 

--- a/dockers/docker-dhcp-relay/config.sh
+++ b/dockers/docker-dhcp-relay/config.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-MINIGRAPH_HOSTNAME=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "minigraph_hostname"`
-DEVICE_ROLE=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "minigraph_devices['$MINIGRAPH_HOSTNAME']['type']"`
+DEVICE_ROLE=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "minigraph_devices[minigraph_hostname]['type']"`
 
 if [ $DEVICE_ROLE != "ToRRouter" ]; then
     echo "Device does not require DHCP relay. docker-dhcp-relay exiting..."


### PR DESCRIPTION
If not, log a message and exit docker. Other conditions can be added in the future as needed.

With OneImage, all dockers must be deployed, but DHCP relay may not be needed. It's cleaner to have docker exit than to continue running and serving no purpose. Log message is helpful to understand why.

Signed-off-by: Joe LeVeque <jolevequ@microsoft.com>