### PR TITLE
[sonic_extension]: Add shell scripts in host FS to call executables inside dockers

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -172,12 +172,13 @@ sudo dpkg --root=$FILESYSTEM_ROOT -P {{ debname }}
 
 sudo rm -f $FILESYSTEM_ROOT/usr/sbin/policy-rc.d
 
-# On Broadcom platforms, copy our shell scripts that reference Broadcom
-# executables inside the Broadcom syncd docker
+# Copy shell scripts which reference executables inside dockers
 if [ $sonic_asic_platform == "broadcom" ]; then
     sudo cp -f $IMAGE_CONFIGS/bin/bcmcmd $FILESYSTEM_ROOT/usr/bin
-    sudo cp -f $IMAGE_CONFIGS/bin/dsserve $FILESYSTEM_ROOT/usr/bin
 fi
+sudo cp -f $IMAGE_CONFIGS/bin/redis-cli $FILESYSTEM_ROOT/usr/bin
+sudo cp -f $IMAGE_CONFIGS/bin/teamdctl $FILESYSTEM_ROOT/usr/bin
+sudo cp -f $IMAGE_CONFIGS/bin/vtysh $FILESYSTEM_ROOT/usr/bin
 
 ## copy platform rc.local
 sudo cp $IMAGE_CONFIGS/platform/rc.local $FILESYSTEM_ROOT/etc/

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -172,6 +172,13 @@ sudo dpkg --root=$FILESYSTEM_ROOT -P {{ debname }}
 
 sudo rm -f $FILESYSTEM_ROOT/usr/sbin/policy-rc.d
 
+# On Broadcom platforms, copy our shell scripts that reference Broadcom
+# executables inside the Broadcom syncd docker
+if [ $sonic_asic_platform == "broadcom" ]; then
+    sudo cp -f $IMAGE_CONFIGS/bin/bcmcmd $FILESYSTEM_ROOT/usr/bin
+    sudo cp -f $IMAGE_CONFIGS/bin/dsserve $FILESYSTEM_ROOT/usr/bin
+fi
+
 ## copy platform rc.local
 sudo cp $IMAGE_CONFIGS/platform/rc.local $FILESYSTEM_ROOT/etc/
 

--- a/files/image_config/bin/bcmcmd
+++ b/files/image_config/bin/bcmcmd
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -i syncd bcmcmd "$@"

--- a/files/image_config/bin/dsserve
+++ b/files/image_config/bin/dsserve
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker exec -i syncd dsserve "$@"

--- a/files/image_config/bin/dsserve
+++ b/files/image_config/bin/dsserve
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -i syncd dsserve "$@"

--- a/files/image_config/bin/redis-cli
+++ b/files/image_config/bin/redis-cli
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -it database redis-cli "$@"

--- a/files/image_config/bin/teamdctl
+++ b/files/image_config/bin/teamdctl
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -i teamd teamdctl "$@"

--- a/files/image_config/bin/vtysh
+++ b/files/image_config/bin/vtysh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -i bgp vtysh "$@"


### PR DESCRIPTION
- bcmcmd (on Broadcom platforms only)
- redis-cli
- teamdctl
- vtysh