### PR TITLE
[config] [oneimage & dhcp relay docker] Move ntp, rsyslog, and dhcp server information into minigraph

### DIFF
--- a/device/accton/x86_64-accton_as7512_32x-r0/minigraph.xml
+++ b/device/accton/x86_64-accton_as7512_32x-r0/minigraph.xml
@@ -1044,6 +1044,31 @@
       </Device>
     </Devices>
   </PngDec>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>switch1</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>0.debian.pool.ntp.org;1.debian.pool.ntp.org;2.debian.pool.ntp.org;3.debian.pool.ntp.org</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SyslogResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
   <Hostname>switch1</Hostname>
   <HwSku>AS7512</HwSku>
 </DeviceMiniGraph>

--- a/device/arista/x86_64-arista_7050_qx32/minigraph.xml
+++ b/device/arista/x86_64-arista_7050_qx32/minigraph.xml
@@ -1044,6 +1044,31 @@
       </Device>
     </Devices>
   </PngDec>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>switch1</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>0.debian.pool.ntp.org;1.debian.pool.ntp.org;2.debian.pool.ntp.org;3.debian.pool.ntp.org</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SyslogResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
   <Hostname>switch1</Hostname>
   <HwSku>Arista-7050-QX32</HwSku>
 </DeviceMiniGraph>

--- a/device/arista/x86_64-arista_7060_cx32s/minigraph.xml
+++ b/device/arista/x86_64-arista_7060_cx32s/minigraph.xml
@@ -1044,6 +1044,31 @@
       </Device>
     </Devices>
   </PngDec>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>switch1</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>0.debian.pool.ntp.org;1.debian.pool.ntp.org;2.debian.pool.ntp.org;3.debian.pool.ntp.org</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SyslogResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
   <Hostname>switch1</Hostname>
   <HwSku>Arista-7060-CX32S</HwSku>
 </DeviceMiniGraph>

--- a/device/dell/x86_64-dell_s6000_s1220-r0/minigraph.xml
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/minigraph.xml
@@ -1044,6 +1044,31 @@
       </Device>
     </Devices>
   </PngDec>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>switch1</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>0.debian.pool.ntp.org;1.debian.pool.ntp.org;2.debian.pool.ntp.org;3.debian.pool.ntp.org</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SyslogResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
   <Hostname>switch1</Hostname>
   <HwSku>Force10-S6000</HwSku>
 </DeviceMiniGraph>

--- a/device/dell/x86_64-dell_s6100_c2538-r0/minigraph.xml
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/minigraph.xml
@@ -739,6 +739,31 @@
       </Device>
     </Devices>
   </PngDec>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>switch1</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>0.debian.pool.ntp.org;1.debian.pool.ntp.org;2.debian.pool.ntp.org;3.debian.pool.ntp.org</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SyslogResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
   <Hostname>switch1</Hostname>
   <HwSku>Force10-S6100</HwSku>
 </DeviceMiniGraph>

--- a/device/dell/x86_64-dell_z9100_c2538-r0/minigraph.xml
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/minigraph.xml
@@ -1044,6 +1044,31 @@
       </Device>
     </Devices>
   </PngDec>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>switch1</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>0.debian.pool.ntp.org;1.debian.pool.ntp.org;2.debian.pool.ntp.org;3.debian.pool.ntp.org</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SyslogResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
   <Hostname>switch1</Hostname>
   <HwSku>Force10-Z9100</HwSku>
 </DeviceMiniGraph>

--- a/device/ingrasys/x86_64-ingrasys_s9100-r0/minigraph.xml
+++ b/device/ingrasys/x86_64-ingrasys_s9100-r0/minigraph.xml
@@ -109,7 +109,38 @@
         <StartPort>Ethernet4</StartPort>
       </DeviceLinkBase>
     </DeviceInterfaceLinks>
-  </PngDec>
+    <Devices>
+      <Device i:type="LeafRouter">
+        <Hostname>OCPSCH01040GGLF</Hostname>
+        <HwSku>ingrasys-s9100</HwSku>
+      </Device>
+    </Devices>
+   </PngDec>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>OCPSCH01040GGLF</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>0.debian.pool.ntp.org;1.debian.pool.ntp.org;2.debian.pool.ntp.org;3.debian.pool.ntp.org</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SyslogResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
   <Hostname>OCPSCH01040GGLF</Hostname>
   <HwSku>ingrasys-s9100</HwSku>
 </DeviceMiniGraph>

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/minigraph.xml
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/minigraph.xml
@@ -1044,6 +1044,31 @@
       </Device>
     </Devices>`
   </PngDec>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>switch2</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>0.debian.pool.ntp.org;1.debian.pool.ntp.org;2.debian.pool.ntp.org;3.debian.pool.ntp.org</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SyslogResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value></a:Value>
+          </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
   <Hostname>switch2</Hostname>
   <HwSku>ACS-MSN2700</HwSku>
 </DeviceMiniGraph>

--- a/dockers/docker-dhcp-relay/config.sh
+++ b/dockers/docker-dhcp-relay/config.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sonic-cfggen -m /etc/sonic/minigraph.xml -y /etc/sonic/dhcp_relay.yml -t /usr/share/sonic/templates/isc-dhcp-relay.j2 > /etc/default/isc-dhcp-relay
+sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/isc-dhcp-relay.j2 > /etc/default/isc-dhcp-relay
 

--- a/dockers/docker-dhcp-relay/isc-dhcp-relay.j2
+++ b/dockers/docker-dhcp-relay/isc-dhcp-relay.j2
@@ -1,4 +1,4 @@
-SERVERS="{{ dhcp_servers }}"
+SERVERS="{{ dhcp_servers | join(' ') }}"
 
 INTERFACES="{{ minigraph_vlan_interfaces[0]['name'] }}"
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -83,14 +83,12 @@ sudo cp $IMAGE_CONFIGS/ntp/ntp-config.service $FILESYSTEM_ROOT/etc/systemd/syste
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable ntp-config.service
 sudo cp $IMAGE_CONFIGS/ntp/ntp-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/ntp/ntp.conf.j2 $FILESYSTEM_ROOT/usr/share/sonic/templates/
-sudo cp $IMAGE_CONFIGS/ntp/ntp.yml $FILESYSTEM_ROOT/etc/sonic/
 
 # Copy rsyslog configuration files and templates
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog-config.service  $FILESYSTEM_ROOT/etc/systemd/system/
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable rsyslog-config.service
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.conf.j2 $FILESYSTEM_ROOT/usr/share/sonic/templates/
-sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.yml $FILESYSTEM_ROOT/etc/sonic/
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.d/* $FILESYSTEM_ROOT/etc/rsyslog.d/
 
 # Copy interfaces configuration files and templates

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sonic-cfggen -m /etc/sonic/minigraph.xml -y /etc/sonic/ntp.yml -t /usr/share/sonic/templates/ntp.conf.j2 >/etc/ntp.conf
+sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/ntp.conf.j2 >/etc/ntp.conf

--- a/files/image_config/ntp/ntp.yml
+++ b/files/image_config/ntp/ntp.yml
@@ -1,6 +1,0 @@
-ntp_servers:
-  - 0.debian.pool.ntp.org
-  - 1.debian.pool.ntp.org
-  - 2.debian.pool.ntp.org
-  - 3.debian.pool.ntp.org
-

--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sonic-cfggen -m /etc/sonic/minigraph.xml -y /etc/sonic/rsyslog.yml -t /usr/share/sonic/templates/rsyslog.conf.j2 >/etc/rsyslog.conf
+sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/rsyslog.conf.j2 >/etc/rsyslog.conf

--- a/files/image_config/rsyslog/rsyslog.yml
+++ b/files/image_config/rsyslog/rsyslog.yml
@@ -1,1 +1,0 @@
-syslog_servers: []

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -266,6 +266,25 @@ def parse_cpg(cpg, hname):
 
     return bgp_sessions, myasn
 
+def parse_meta(meta, hname):
+    syslog_servers = []
+    dhcp_servers = []
+    ntp_servers = []
+    device_metas = meta.find(str(QName(ns, "Devices")))
+    for device in device_metas.findall(str(QName(ns1, "DeviceMetadata"))):
+        if device.find(str(QName(ns1, "Name"))).text == hname:
+            properties = device.find(str(QName(ns1, "Properties")))
+            for device_property in properties.findall(str(QName(ns1, "DeviceProperty"))):
+                name = device_property.find(str(QName(ns1, "Name"))).text
+                value = device_property.find(str(QName(ns1, "Value"))).text
+                value_group = value.split(';') if value and value != "" else []
+                if name == "DhcpResources":
+                    dhcp_servers = value_group
+                elif name == "NtpResources":
+                    ntp_servers = value_group
+                elif name == "SyslogResources":
+                    syslog_servers = value_group
+    return syslog_servers, dhcp_servers, ntp_servers                
 
 def get_console_info(devices, dev, port):
     for k, v in devices.items():
@@ -340,6 +359,9 @@ def parse_xml(filename, platform=None):
     neighbors = None
     devices = None
     hostname = None
+    syslog_servers = []
+    dhcp_servers = []
+    ntp_servers = []
 
     hwsku_qn = QName(ns, "HwSku")
     hostname_qn = QName(ns, "Hostname")
@@ -363,6 +385,8 @@ def parse_xml(filename, platform=None):
             (neighbors, devices, console_dev, console_port, mgmt_dev, mgmt_port) = parse_png(child, hostname)
         elif child.tag == str(QName(ns, "UngDec")):
             (u_neighbors, u_devices, _, _, _, _) = parse_png(child, hostname)
+        elif child.tag == str(QName(ns, "MetadataDeclaration")):
+            (syslog_servers, dhcp_servers, ntp_servers) = parse_meta(child, hostname)
 
     Tree = lambda: defaultdict(Tree)
 
@@ -389,6 +413,9 @@ def parse_xml(filename, platform=None):
         results['minigraph_mgmt'] = get_mgmt_info(devices, mgmt_dev, mgmt_port)
     results['minigraph_hostname'] = hostname
     results['inventory_hostname'] = hostname
+    results['syslog_servers'] = syslog_servers
+    results['dhcp_servers'] = dhcp_servers
+    results['ntp_servers'] = ntp_servers
     results['alias_map'] = alias_map_list
 
     return results


### PR DESCRIPTION
Move ntp, rsyslog, and dhcp server information into minigraph, remove corresponding yml files.