### PR TITLE
[minigraph]: Add portchannels/vlans dictionary and update teamd templates

### DIFF
--- a/dockers/docker-fpm/zebra.conf.j2
+++ b/dockers/docker-fpm/zebra.conf.j2
@@ -19,6 +19,11 @@ interface {{ interface['alias'] }}
 link-detect
 !
 {% endfor %}
+{% for interface in minigraph_portchannel_interfaces %}
+interface {{ interface['name'] }}
+link-detect
+!
+{% endfor %}
 {% endblock interfaces %}
 !
 {% block default_route %}

--- a/dockers/docker-teamd/config.sh
+++ b/dockers/docker-teamd/config.sh
@@ -2,7 +2,7 @@
 
 mkdir -p /etc/teamd
 
-for pc in `sonic-cfggen -m /etc/sonic/minigraph.xml -v "' '.join(minigraph_portchannel_interfaces.keys())"`; do
+for pc in `sonic-cfggen -m /etc/sonic/minigraph.xml -v "minigraph_portchannels.keys() | join(' ')"`; do
   sonic-cfggen -m /etc/sonic/minigraph.xml -a '{"pc":"'$pc'"}' -t /usr/share/sonic/templates/teamd.j2 >/etc/teamd/$pc.conf
 done
 

--- a/dockers/docker-teamd/teamd.j2
+++ b/dockers/docker-teamd/teamd.j2
@@ -4,14 +4,14 @@
         "name": "lacp",
         "active": true,
 {# Use 75% links upperbound as min-links #}
-        "min_ports": {{ minigraph_portchannel_interfaces[pc] | length * 0.75 | round(0, 'ceil') | int}},
+        "min_ports": {{ minigraph_portchannels[pc]['members'] | length * 0.75 | round(0, 'ceil') | int}},
         "tx_hash": ["eth", "ipv4", "ipv6"]
     },
     "link_watch": {
         "name": "ethtool"
     },
     "ports": {
-        {% for member in minigraph_portchannel_interfaces[pc] %}
+        {% for member in minigraph_portchannels[pc]['members'] %}
 "{{member}}": {}{% if not loop.last %},{% endif %}
 
         {% endfor %}


### PR DESCRIPTION

- minigraph_portchannel_interfaces and minigraph_vlan_interfaces are lists
  of interfaces and the name could duplicate due to multiple IPs
- Add minigraph_portchannels and minigraph_vlans dictionaries to support
  querying port channels and vlans via the name
- Update teamd.j2 template and config.sh file in docker-teamd

Signed-off-by: Shuotian Cheng <shuche@microsoft.com>