### PR TITLE
[interfaces.j2] Route to syslog servers through mgmt port

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -28,9 +28,15 @@ iface eth0 inet static
     # management port up rules
     up ip route add default via {{ minigraph_mgmt_interface['gwaddr'] }} dev eth0 table default
     up ip rule add from {{ minigraph_mgmt_interface['addr'] }}/32 table default
+{% for server in syslog_servers %}
+    up ip route add {{ server }} via {{ minigraph_mgmt_interface['gwaddr'] }} dev eth0
+{% endfor %}
     # management port down rules
     down ip route delete default via {{ minigraph_mgmt_interface['gwaddr'] }} dev eth0 table default
     down ip rule delete from {{ minigraph_mgmt_interface['addr'] }}/32 table default
+{% for server in syslog_servers %}
+    down ip route delete {{ server }} via {{ minigraph_mgmt_interface['gwaddr'] }} dev eth0
+{% endfor %}
     {# TODO: COPP policy type rules #}
 {% else %}
 iface eth0 inet dhcp


### PR DESCRIPTION
To make sure syslog is forwarded even when front panel ports are not working correctly