### PR TITLE
Fix a bug that causes syncd fails to start

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Obtain our platform and HWSKU as we will mount directories with these names in each docker
-PLATFORM=`/usr/bin/sonic-cfggen -v platform`
-HWSKU=`/usr/bin/sonic-cfggen -m /etc/sonic/minigraph.xml -v minigraph_hwsku`
+PLATFORM=`sonic-cfggen -v platform`
+HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v minigraph_hwsku`
 
 start() {
     docker inspect --type container {{docker_container_name}} &>/dev/null


### PR DESCRIPTION
Installation path for sonic-cfggen changed as moving from deb to whl.
