### PR TITLE
[interfaces]: Remove bridge-utils from swss docker and add it to base image

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -171,6 +171,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     file                    \
     ifupdown                \
     iproute2                \
+    bridge-utils            \
     isc-dhcp-client         \
     sudo                    \
     vim                     \

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-RUN apt-get install -f -y ifupdown bridge-utils libdbus-1-3 libdaemon0 libjansson4
+RUN apt-get install -f -y ifupdown libdbus-1-3 libdaemon0 libjansson4
 
 ## Install redis-tools dependencies
 ## TODO: implicitly install dependencies

--- a/dockers/docker-orchagent/base_image_files/brctl
+++ b/dockers/docker-orchagent/base_image_files/brctl
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-docker exec -i swss brctl "$@"
-

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -75,8 +75,8 @@ iface {{ interface }} inet manual
 {% block vlan_interfaces %}
 {% for vlan_interface in minigraph_vlan_interfaces %}
 auto {{ vlan_interface['name'] }}
-allow-hotplug {{ vlan_interface['name'] }}
 iface {{ vlan_interface['name'] }} {{ 'inet' if vlan_interface['addr'] | ipv4 else 'inet6' }} static
+    bridge_ports none
     address {{ vlan_interface['addr'] }}
     netmask {{ vlan_interface['mask'] }}
 #

--- a/platform/broadcom/docker-orchagent-brcm.mk
+++ b/platform/broadcom/docker-orchagent-brcm.mk
@@ -16,4 +16,3 @@ $(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 $(DOCKER_ORCHAGENT_BRCM)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel
-$(DOCKER_ORCHAGENT_BRCM)_BASE_IMAGE_FILES += brctl:/usr/bin/brctl

--- a/platform/cavium/docker-orchagent-cavm.mk
+++ b/platform/cavium/docker-orchagent-cavm.mk
@@ -16,4 +16,3 @@ $(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 $(DOCKER_ORCHAGENT_CAVM)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel
-$(DOCKER_ORCHAGENT_CAVM)_BASE_IMAGE_FILES += brctl:/usr/bin/brctl

--- a/platform/centec/docker-orchagent-centec.mk
+++ b/platform/centec/docker-orchagent-centec.mk
@@ -16,4 +16,3 @@ $(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 $(DOCKER_ORCHAGENT_CENTEC)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel
-$(DOCKER_ORCHAGENT_CENTEC)_BASE_IMAGE_FILES += brctl:/usr/bin/brctl

--- a/platform/mellanox/docker-orchagent-mlnx.mk
+++ b/platform/mellanox/docker-orchagent-mlnx.mk
@@ -16,4 +16,3 @@ $(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 $(DOCKER_ORCHAGENT_MLNX)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel
-$(DOCKER_ORCHAGENT_MLNX)_BASE_IMAGE_FILES += brctl:/usr/bin/brctl


### PR DESCRIPTION
The reason is that /etc/network/interfaces file is in base image. After booting,
docker-swss is not ready and thus the empty VLAN interfaces cannot be created
when the brctl is pointing to the binary inside the swss docker.

Add the bridge-utils into the base image and add bridge_ports none to the
/etc/network/interfaces file so that after boot-up the empty VLAN interfaces
will be created to let the members to join later.

Signed-off-by: Shuotian Cheng <shuche@microsoft.com>