### PR TITLE
[database]: Mount /var/run/redis/ folder from host for all dockers

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -240,6 +240,9 @@ sudo LANG=C chroot $FILESYSTEM_ROOT easy_install pip
 sudo LANG=C chroot $FILESYSTEM_ROOT pip install 'docker-py==1.6.0'
 ## Note: keep pip installed for maintainance purpose
 
+## Create /var/run/redis folder for docker-database to mount
+sudo mkdir -p $FILESYSTEM_ROOT/var/run/redis
+
 ## Config DHCP for eth0
 sudo tee -a $FILESYSTEM_ROOT/etc/network/interfaces > /dev/null <<EOF
 

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -10,6 +10,7 @@ start() {
         docker start -a {{docker_container_name}}
     else
         docker run {{docker_image_run_opt}} \
+            -v /var/run/redis:/var/run/redis:rw \
             -v /usr/share/sonic/device/$PLATFORM:/usr/share/sonic/platform:ro \
             -v /usr/share/sonic/device/$PLATFORM/$HWSKU:/usr/share/sonic/hwsku:ro \
             --name={{docker_container_name}} {{docker_image_name}}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -64,7 +64,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 # Install SONiC config engine
 CONFIG_ENGINE_WHL_NAME=`basename {{config_engine}}`
 sudo cp {{config_engine}} $FILESYSTEM_ROOT/$CONFIG_ENGINE_WHL_NAME
-sudo chroot $FILESYSTEM_ROOT pip install $CONFIG_ENGINE_WHL_NAME
+sudo LANG=C chroot $FILESYSTEM_ROOT pip install $CONFIG_ENGINE_WHL_NAME
+
+# Install Python client for Redis
+sudo LANG=C chroot $FILESYSTEM_ROOT pip install redis
 
 # Install SONiC Utilities (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/python-sonic-utilities_*.deb || \

--- a/platform/broadcom/docker-orchagent-brcm.mk
+++ b/platform/broadcom/docker-orchagent-brcm.mk
@@ -9,7 +9,6 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_ORCHAGENT_BRCM)
 
 $(DOCKER_ORCHAGENT_BRCM)_CONTAINER_NAME = swss
 $(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += --volumes-from database
 $(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /etc/network/interfaces:/etc/network/interfaces:ro
 $(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interfaces.d/:ro
 $(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /host/machine.conf:/host/machine.conf

--- a/platform/broadcom/docker-syncd-brcm.mk
+++ b/platform/broadcom/docker-syncd-brcm.mk
@@ -12,7 +12,6 @@ $(DOCKER_SYNCD_BRCM)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BRCM)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
-$(DOCKER_SYNCD_BRCM)_RUN_OPT += --volumes-from database
 $(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 $(DOCKER_SYNCD_BRCM)_BASE_IMAGE_FILES += bcmcmd:/usr/bin/bcmcmd

--- a/platform/cavium/docker-orchagent-cavm.mk
+++ b/platform/cavium/docker-orchagent-cavm.mk
@@ -9,7 +9,6 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_ORCHAGENT_CAVM)
 
 $(DOCKER_ORCHAGENT_CAVM)_CONTAINER_NAME = swss
 $(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += --volumes-from database
 $(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /etc/network/interfaces:/etc/network/interfaces:ro
 $(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interfaces.d/:ro
 $(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /host/machine.conf:/host/machine.conf

--- a/platform/cavium/docker-syncd-cavm.mk
+++ b/platform/cavium/docker-syncd-cavm.mk
@@ -10,5 +10,4 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_SYNCD_CAVM)
 $(DOCKER_SYNCD_CAVM)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_CAVM)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_SYNCD_CAVM)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
-$(DOCKER_SYNCD_CAVM)_RUN_OPT += --volumes-from database
 $(DOCKER_SYNCD_CAVM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/centec/docker-orchagent-centec.mk
+++ b/platform/centec/docker-orchagent-centec.mk
@@ -9,7 +9,6 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_ORCHAGENT_CENTEC)
 
 $(DOCKER_ORCHAGENT_CENTEC)_CONTAINER_NAME = swss
 $(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += --volumes-from database
 $(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /etc/network/interfaces:/etc/network/interfaces:ro
 $(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interfaces.d/:ro
 $(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /host/machine.conf:/host/machine.conf

--- a/platform/centec/docker-syncd-centec.mk
+++ b/platform/centec/docker-syncd-centec.mk
@@ -11,5 +11,4 @@ $(DOCKER_SYNCD_CENTEC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
-$(DOCKER_SYNCD_CENTEC)_RUN_OPT += --volumes-from database
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/mellanox/docker-orchagent-mlnx.mk
+++ b/platform/mellanox/docker-orchagent-mlnx.mk
@@ -9,7 +9,6 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_ORCHAGENT_MLNX)
 
 $(DOCKER_ORCHAGENT_MLNX)_CONTAINER_NAME = swss
 $(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += --volumes-from database
 $(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /etc/network/interfaces:/etc/network/interfaces:ro
 $(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interfaces.d/:ro
 $(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /host/machine.conf:/host/machine.conf

--- a/platform/mellanox/docker-syncd-mlnx.mk
+++ b/platform/mellanox/docker-syncd-mlnx.mk
@@ -11,5 +11,4 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_SYNCD_MLNX)
 $(DOCKER_SYNCD_MLNX)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_MLNX)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_SYNCD_MLNX)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
-$(DOCKER_SYNCD_MLNX)_RUN_OPT += --volumes-from database
 $(DOCKER_SYNCD_MLNX)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/rules/docker-database.mk
+++ b/rules/docker-database.mk
@@ -9,7 +9,5 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_DATABASE)
 
 $(DOCKER_DATABASE)_CONTAINER_NAME = database
 $(DOCKER_DATABASE)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_DATABASE)_RUN_OPT += -v /var/run/redis
 
 $(DOCKER_DATABASE)_BASE_IMAGE_FILES += redis-cli:/usr/bin/redis-cli
-

--- a/rules/docker-fpm-gobgp.mk
+++ b/rules/docker-fpm-gobgp.mk
@@ -8,6 +8,4 @@ SONIC_DOCKER_IMAGES += $(DOCKER_FPM_GOBGP)
 
 $(DOCKER_FPM_GOBGP)_CONTAINER_NAME = bgp
 $(DOCKER_FPM_GOBGP)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_FPM_GOBGP)_RUN_OPT += --volumes-from database
 $(DOCKER_FPM_GOBGP)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-

--- a/rules/docker-fpm.mk
+++ b/rules/docker-fpm.mk
@@ -9,7 +9,6 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_FPM)
 
 $(DOCKER_FPM)_CONTAINER_NAME = bgp
 $(DOCKER_FPM)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_FPM)_RUN_OPT += --volumes-from database
 $(DOCKER_FPM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 $(DOCKER_FPM)_BASE_IMAGE_FILES += vtysh:/usr/bin/vtysh

--- a/rules/docker-lldp-sv2.mk
+++ b/rules/docker-lldp-sv2.mk
@@ -11,6 +11,5 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_LLDP_SV2)
 $(DOCKER_LLDP_SV2)_CONTAINER_NAME = lldp
 $(DOCKER_LLDP_SV2)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_LLDP_SV2)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_LLDP_SV2)_RUN_OPT += --volumes-from database
 
 $(DOCKER_LLDP_SV2)_BASE_IMAGE_FILES += lldpctl:/usr/bin/lldpctl

--- a/rules/docker-snmp-sv2.mk
+++ b/rules/docker-snmp-sv2.mk
@@ -12,4 +12,3 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_SNMP_SV2)
 $(DOCKER_SNMP_SV2)_CONTAINER_NAME = snmp
 $(DOCKER_SNMP_SV2)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_SNMP_SV2)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_SNMP_SV2)_RUN_OPT += --volumes-from database

--- a/rules/docker-teamd.mk
+++ b/rules/docker-teamd.mk
@@ -10,7 +10,5 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_TEAMD)
 $(DOCKER_TEAMD)_CONTAINER_NAME = teamd
 $(DOCKER_TEAMD)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_TEAMD)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_TEAMD)_RUN_OPT += --volumes-from database
 
 $(DOCKER_TEAMD)_BASE_IMAGE_FILES += teamdctl:/usr/bin/teamdctl
-


### PR DESCRIPTION
- Create /var/run/redis/ folder on the host
- Mount /var/run/redis/ as read/write from host for all dockers
- Enable accessing the database everywhere including on the host and from remote

Signed-off-by: Shuotian Cheng <shuche@microsoft.com>