### PR TITLE
[platform-monitor] Fix sensors.conf file path

### DIFF
--- a/dockers/docker-platform-monitor/config.sh
+++ b/dockers/docker-platform-monitor/config.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 
 mkdir -p /etc/sensors.d
-
-hwsku=`sonic-cfggen -m /etc/sonic/minigraph.xml -v minigraph_hwsku`
-
-if [ -e /usr/share/sonic/$hwsku/sensors.conf ]
+if [ -e /usr/share/sonic/platform/sensors.conf ]
 then
-  /bin/cp -rf /usr/share/sonic/$hwsku/sensors.conf /etc/sensors.d/
+  /bin/cp -rf /usr/share/sonic/platform/sensors.conf /etc/sensors.d/
 fi
 
 mkdir -p /var/sonic


### PR DESCRIPTION
As sensors.conf file was moved in PR #316.