### PR TITLE
[swss]: Enforce SwSS dependency with opennsl-modules

### DIFF
--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -1,7 +1,13 @@
 [Unit]
 Description=switch state service
 Requires=database.service
+{% if sonic_asic_platform == 'broadcom' %}
+Requires=opennsl-modules-3.16.0-4-amd64.service
+{% endif %}
 After=database.service
+{% if sonic_asic_platform == 'broadcom' %}
+After=opennsl-modules-3.16.0-4-amd64.service
+{% endif %}
 
 [Service]
 User=root
@@ -35,7 +41,6 @@ ExecStopPost=/usr/bin/mst stop
 ExecStopPost=/etc/init.d/xpnet.sh stop
 ExecStopPost=/etc/init.d/xpnet.sh start
 {% endif %}
-
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- This change ensures that when shuting down, opennsl-modules will
  not stop until swss stops. Otherwise it will cause kernel stack
  trace.

Signed-off-by: Shuotian Cheng <shuche@microsoft.com>