### PR TITLE
[interface-config] Fix a loopback addr config bug

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -2,3 +2,4 @@
 
 sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/interfaces.j2 >/etc/network/interfaces
 service networking restart
+ifdown lo && ifup lo


### PR DESCRIPTION
Fix a bug introduced in PR #430 that addresses on lo are not configured correctly.

It turns out that `service networking restart` won’t reconfigure `lo`.
What we need is `service networking restart` AND `ifdown lo && ifup lo`.
