### PR TITLE
[rsyslog]: Remove /var/run/rsyslogd.pid before starting rsyslog

### DIFF
--- a/dockers/docker-basic_router/Dockerfile
+++ b/dockers/docker-basic_router/Dockerfile
@@ -17,5 +17,6 @@ RUN dpkg -i /deps/libopennsl_*.deb;         \
 
 RUN mv /deps/basic_router /usr/sbin/basic_router
 
-ENTRYPOINT service rsyslog start    \
+ENTRYPOINT rm -f /var/run/rsyslogd.pid  \
+    && service rsyslog start            \
     && /bin/bash

--- a/dockers/docker-dhcp-relay/Dockerfile
+++ b/dockers/docker-dhcp-relay/Dockerfile
@@ -18,6 +18,5 @@ COPY ["config.sh", "/usr/bin/"]
 COPY ["start.sh", "/usr/bin/"]
 
 ENTRYPOINT /usr/bin/config.sh \
-    && service rsyslog start  \
     && /usr/bin/start.sh      \
     && /bin/bash

--- a/dockers/docker-dhcp-relay/start.sh
+++ b/dockers/docker-dhcp-relay/start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+rm -f /var/run/rsyslogd.pid
+service rsyslog start
+
 VLAN_IFACE_NAME=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "minigraph_vlan_interfaces[0]['name']"`
 
 # Wait for the VLAN to come up (i.e., 'ip link show' returns 0)

--- a/dockers/docker-fpm-gobgp/start.sh
+++ b/dockers/docker-fpm-gobgp/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 service quagga start
 fpmsyncd &

--- a/dockers/docker-fpm/start.sh
+++ b/dockers/docker-fpm/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 service quagga start
 fpmsyncd &

--- a/dockers/docker-lldp-sv2/config.sh
+++ b/dockers/docker-lldp-sv2/config.sh
@@ -5,3 +5,4 @@ sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/lldpd.con
 mkdir -p /var/sonic
 echo "# Config files managed by sonic-config-engine" >/var/sonic/config_status
 
+rm -f /var/run/rsyslogd.pid

--- a/dockers/docker-orchagent/start.sh
+++ b/dockers/docker-orchagent/start.sh
@@ -65,6 +65,7 @@ elif [ "$HWSKU" == "ACS-MSN2700" ]; then
     SWSSCONFIG_ARGS+="msn2700.32ports.buffers.json msn2700.32ports.qos.json "
 fi
 
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 
 while true; do

--- a/dockers/docker-platform-monitor/config.sh
+++ b/dockers/docker-platform-monitor/config.sh
@@ -9,3 +9,4 @@ fi
 mkdir -p /var/sonic
 echo "# Config files managed by sonic-config-engine" >/var/sonic/config_status
 
+rm -f /var/run/rsyslogd.pid

--- a/dockers/docker-saiserver-brcm/start.sh
+++ b/dockers/docker-saiserver-brcm/start.sh
@@ -13,6 +13,7 @@ start_bcm()
 
 trap clean_up SIGTERM SIGKILL
 
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 
 start_bcm

--- a/dockers/docker-saiserver-cavm/start.sh
+++ b/dockers/docker-saiserver-cavm/start.sh
@@ -6,6 +6,7 @@ function clean_up {
 
 trap clean_up SIGTERM SIGKILL
 
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 
 /usr/bin/saiserver -p /etc/sai/profile.ini -f /etc/sai/portmap.ini

--- a/dockers/docker-saiserver-mlnx/start.sh
+++ b/dockers/docker-saiserver-mlnx/start.sh
@@ -11,6 +11,7 @@ start_mlnx()
 
 trap clean_up SIGTERM SIGKILL
 
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 
 start_mlnx

--- a/dockers/docker-snmp-sv2/config.sh
+++ b/dockers/docker-snmp-sv2/config.sh
@@ -13,3 +13,4 @@ sonic-cfggen -m /etc/sonic/minigraph.xml -s >/etc/snmp/alias_map.json
 mkdir -p /var/sonic
 echo "# Config files managed by sonic-config-engine" >/var/sonic/config_status
 
+rm -f /var/run/rsyslogd.pid

--- a/dockers/docker-teamd/start.sh
+++ b/dockers/docker-teamd/start.sh
@@ -28,6 +28,7 @@ function clean_up {
 
 trap clean_up SIGTERM SIGKILL
 
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 
 # Before teamd could automatically add newly created host interfaces into the

--- a/dockers/docker-vas/Dockerfile
+++ b/dockers/docker-vas/Dockerfile
@@ -30,7 +30,8 @@ VOLUME /var/opt/quest/vas/vasd/
 VOLUME /home/
 
 ## Delete the symlinks and create full copies to host folder
-ENTRYPOINT service rsyslog start                                                        \
+ENTRYPOINT rm -f /var/run/rsyslogd.pid                                                  \
+    && service rsyslog start                                                            \
     && cp --remove-destination /opt/quest/lib64/nss/libnss_vas4.so.2                    \
                                /host/lib/x86_64-linux-gnu/                              \
     && cp --remove-destination /opt/quest/lib64/security/pam_vas3.so                    \

--- a/platform/broadcom/docker-syncd-brcm/start.sh
+++ b/platform/broadcom/docker-syncd-brcm/start.sh
@@ -8,6 +8,7 @@ function clean_up {
 
 trap clean_up SIGTERM SIGKILL
 
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 service syncd start
 

--- a/platform/cavium/docker-syncd-cavm/start.sh
+++ b/platform/cavium/docker-syncd-cavm/start.sh
@@ -2,6 +2,7 @@
 
 export XP_ROOT=/usr/bin/
 
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 
 while true; do

--- a/platform/centec/docker-syncd-centec/start.sh
+++ b/platform/centec/docker-syncd-centec/start.sh
@@ -8,6 +8,7 @@ function clean_up {
 
 trap clean_up SIGTERM SIGKILL
 
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 service syncd start
 

--- a/platform/p4/docker-sonic-p4/startup.sh
+++ b/platform/p4/docker-sonic-p4/startup.sh
@@ -4,6 +4,7 @@ echo "Set onie_platform to x86_64-barefoot_p4-r0"
 export onie_platform=x86_64-barefoot_p4-r0
 
 echo "Start rsyslog"
+rm -f /var/run/rsyslogd.pid
 service rsyslog start
 
 echo "Start redis server"


### PR DESCRIPTION
See the issue here:
https://github.com/Azure/SONiC/issues/62

Remove /var/run/rsyslog/rsyslogd.pid. Otherwise service rsyslogd start will stuck for 30-60 seconds.

I'm using just 'rm -f /var/run/rsyslogd.pid' because it doesn't require any file existence check. See:
http://man7.org/linux/man-pages/man1/rm.1.html
-f, --force
              ignore nonexistent files and arguments, never prompt

