### PR TITLE
[docker-lldp]: Do not use TTY mode on lldpctl command

### DIFF
--- a/dockers/docker-lldp-sv2/base_image_files/lldpctl
+++ b/dockers/docker-lldp-sv2/base_image_files/lldpctl
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker exec -it lldp lldpctl "$@"
+docker exec -i lldp lldpctl "$@"


### PR DESCRIPTION
Signed-off-by: Shuotian Cheng <shuche@microsoft.com>