### PR TITLE
[interfaces]: Redirect brctl errors and add || true

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -53,29 +53,36 @@ iface {{ interface['attachto'] }} {{ 'inet' if interface['addr'] | ipv4 else 'in
     netmask {{ interface['mask'] }}
 #
 {% endfor %}
+{% if minigraph_vlans.keys() | length %}
+# "|| true" is added to suppress the error when interface is already a member of VLAN
+{% endif %}
 {% for vlan in minigraph_vlans.keys()|sort %}
 {% for member in minigraph_vlans[vlan]['members'] %}
 auto {{ member }}
 allow-hotplug {{ member }}
 iface {{ member }} inet manual
     pre-up ifconfig {{ member }} up
-    post-up brctl addif {{ vlan }} {{ member }}
+    post-up brctl addif {{ vlan }} {{ member }} || true
     post-down ifconfig {{ member }} down
 #
 {% endfor %}
 {% endfor %}
-# "|| true" is added to suppress the error when docker-teamd starts after docker-swss
+{% if minigraph_portchannels.keys() | length %}
+# "|| true" is added to suppress the error when interface is already a member of LAG
+{% endif %}
 {% for pc in minigraph_portchannels.keys()|sort %}
 {% for member in minigraph_portchannels[pc]['members'] %}
 auto {{ member }}
 allow-hotplug {{ member }}
 iface {{ member }} inet manual
     pre-up teamdctl {{ pc }} port add {{ member }} || true
+    post-up ifconfig {{ member }} up
     post-down ifconfig {{ member }} down
 #
 {% endfor %}
 {% endfor %}
 {% endblock front_panel_interfaces %}
+{% if minigraph_vlans.keys() | length %}
 {% block vlan_interfaces %}
 # Vlan interfaces
 {% for vlan_interface in minigraph_vlan_interfaces %}
@@ -87,6 +94,8 @@ iface {{ vlan_interface['attachto'] }} {{ 'inet' if vlan_interface['addr'] | ipv
 {% endfor %}
 #
 {% endblock vlan_interfaces %}
+{% endif %}
+{% if minigraph_portchannels.keys() | length %}
 {% block pc_interfaces %}
 # Portchannel interfaces
 {% for pc_interface in minigraph_portchannel_interfaces %}
@@ -98,3 +107,4 @@ iface {{ pc_interface['attachto'] }} {{ 'inet' if pc_interface['addr'] | ipv4 el
 #
 {% endfor %}
 {% endblock pc_interfaces %}
+{% endif %}

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -53,7 +53,7 @@ class TestCfgGen(TestCase):
         self.assertEqual(output.strip(), '[\'value1\', \'value2\']')
     
     def test_render_template(self):
-        argument = '-y ' + os.path.join(self.test_dir, 'test.yml') + ' -t' + os.path.join(self.test_dir, 'test.j2')
+        argument = '-y ' + os.path.join(self.test_dir, 'test.yml') + ' -t ' + os.path.join(self.test_dir, 'test.j2')
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'value1\nvalue2')
 
@@ -63,27 +63,27 @@ class TestCfgGen(TestCase):
         self.assertEqual(output.strip(), "{'DataAcl': ['Ethernet112', 'Ethernet116', 'Ethernet120', 'Ethernet124']}")
 
     def test_minigraph_interfaces(self):
-        argument = '-m "' + self.sample_graph_simple + '" -p  "' + self.port_config + '" -v minigraph_interfaces'
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v minigraph_interfaces'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "[{'subnet': IPv4Network('10.0.0.58/31'), 'peer_addr': IPv4Address('10.0.0.59'), 'addr': IPv4Address('10.0.0.58'), 'mask': IPv4Address('255.255.255.254'), 'attachto': 'Ethernet0', 'prefixlen': 31}, {'subnet': IPv6Network('fc00::74/126'), 'peer_addr': IPv6Address('fc00::76'), 'addr': IPv6Address('fc00::75'), 'mask': '126', 'attachto': 'Ethernet0', 'prefixlen': 126}]")
         
     def test_minigraph_vlans(self):
-        argument = '-m "' + self.sample_graph_simple + '" -p  "' + self.port_config + '" -v minigraph_vlans'
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v minigraph_vlans'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'Vlan1000': {'name': 'Vlan1000', 'members': ['Ethernet8'], 'vlanid': '1000'}}")
 
     def test_minigraph_vlan_interfaces(self):
-        argument = '-m "' + self.sample_graph_simple + '" -p  "' + self.port_config + '" -v minigraph_vlan_interfaces'
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v minigraph_vlan_interfaces'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "[{'prefixlen': 27, 'subnet': IPv4Network('192.168.0.0/27'), 'mask': IPv4Address('255.255.255.224'), 'addr': IPv4Address('192.168.0.1'), 'attachto': 'Vlan1000'}]")
 
     def test_minigraph_portchannels(self):
-        argument = '-m "' + self.sample_graph_simple + '" -p  "' + self.port_config + '" -v minigraph_portchannels'
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v minigraph_portchannels'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'PortChannel01': {'name': 'PortChannel01', 'members': ['Ethernet4']}}")
 
     def test_minigraph_portchannels(self):
-        argument = '-m "' + self.sample_graph_simple + '" -p  "' + self.port_config + '" -v minigraph_portchannel_interfaces'
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v minigraph_portchannel_interfaces'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "[{'subnet': IPv4Network('10.0.0.56/31'), 'peer_addr': IPv4Address('10.0.0.57'), 'addr': IPv4Address('10.0.0.56'), 'mask': IPv4Address('255.255.255.254'), 'attachto': 'PortChannel01', 'prefixlen': 31}, {'subnet': IPv6Network('fc00::70/126'), 'peer_addr': IPv6Address('fc00::72'), 'addr': IPv6Address('fc00::71'), 'mask': '126', 'attachto': 'PortChannel01', 'prefixlen': 126}]")
 


### PR DESCRIPTION
- This change is added so that when doing ifdown/ifup to flap the
  interface, it will success even when the interface is already
  enslaved as a member of VLAN.

Signed-off-by: Shuotian Cheng <shuche@microsoft.com>