### PR TITLE
Enable graceful restart feature for ToR router

### DIFF
--- a/dockers/docker-fpm/bgpd.conf.j2
+++ b/dockers/docker-fpm/bgpd.conf.j2
@@ -22,6 +22,10 @@ log facility local4
 router bgp {{ minigraph_bgp_asn }}
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
+{# Advertise graceful restart capability for ToR #}
+{% if minigraph_devices[inventory_hostname]['type'] == 'ToRRouter' %}
+  bgp graceful-restart
+{% endif %}
 {# TODO: use lo[0] for backward compatibility, will revisit the case with multiple lo interfaces #}
   bgp router-id {{ minigraph_lo_interfaces[0]['addr'] }}
 {# advertise loopback #}


### PR DESCRIPTION
When we restart a switch with fast-reboot, we want our neighbors keep routing information for our box. It allows us to do a fast-reboot faster.