### PR TITLE
[docker-orchagent]: Generate config-files for IPinIP and Everflow.

### DIFF
--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -23,10 +23,13 @@ debs/{{ deb }}{{' '}}
 {%- endfor %}
 
 COPY start.sh /usr/bin/start.sh
+COPY config.sh /usr/bin/config.sh
+COPY ipinip.conf.j2 /usr/share/sonic/templates/ipinip.conf.j2
+COPY mirror.conf.j2 /usr/share/sonic/templates/mirror.conf.j2
 
 ## Clean up
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["/bin/bash"]
-CMD ["/usr/bin/start.sh"]
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["/usr/bin/config.sh && /usr/bin/start.sh"]

--- a/dockers/docker-orchagent/config.sh
+++ b/dockers/docker-orchagent/config.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/ipinip.conf.j2 > /etc/swss/config.d/ipinip.conf
+sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/mirror.conf.j2 > /etc/swss/config.d/mirror.conf

--- a/dockers/docker-orchagent/ipinip.conf.j2
+++ b/dockers/docker-orchagent/ipinip.conf.j2
@@ -1,0 +1,13 @@
+[
+    {
+        "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
+            "tunnel_type":"IPINIP",
+            "src_ip":"{{ minigraph_lo_interfaces[0]['addr'] }}",
+            "dst_ip":"{{ minigraph_lo_interfaces[0]['addr'] }}",
+            "dscp_mode":"uniform",
+            "ecn_mode":"standard",
+            "ttl_mode":"pipe"
+        },
+        "OP": "SET"
+    }
+]

--- a/dockers/docker-orchagent/mirror.conf.j2
+++ b/dockers/docker-orchagent/mirror.conf.j2
@@ -1,0 +1,13 @@
+[
+    {
+        "MIRROR_SESSION_TABLE:everflow": {
+            "src_ip": "{{ minigraph_lo_interfaces[0]['addr'] }}",
+            "dst_ip": "{{ erspan_dst[0] }}",
+            "gre_type": "0x88be",
+            "dscp": "8",
+            "ttl": "255",
+            "queue": "1"
+        },
+        "OP": "SET"
+    }
+]

--- a/dockers/docker-orchagent/start.sh
+++ b/dockers/docker-orchagent/start.sh
@@ -50,7 +50,7 @@ elif [ "$HWSKU" == "AS7512" ]; then
 elif [ "$HWSKU" == "INGRASYS-S9100-C32" ]; then
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
 elif [ "$HWSKU" == "ACS-MSN2700" ]; then
-    SWSSCONFIG_ARGS+="msn2700.32ports.buffers.json msn2700.32ports.qos.json "
+    SWSSCONFIG_ARGS+="msn2700.32ports.buffers.json msn2700.32ports.qos.json ipinip.conf mirror.conf "
 fi
 
 rm -f /var/run/rsyslogd.pid

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -278,6 +278,7 @@ def parse_meta(meta, hname):
     dhcp_servers = []
     ntp_servers = []
     mgmt_routes = []
+    erspan_dst = []
     device_metas = meta.find(str(QName(ns, "Devices")))
     for device in device_metas.findall(str(QName(ns1, "DeviceMetadata"))):
         if device.find(str(QName(ns1, "Name"))).text == hname:
@@ -294,7 +295,9 @@ def parse_meta(meta, hname):
                     syslog_servers = value_group
                 elif name == "ForcedMgmtRoutes":
                     mgmt_routes = value_group
-    return syslog_servers, dhcp_servers, ntp_servers, mgmt_routes
+                elif name == "ErspanDestinationIpv4":
+                    erspan_dst = value_group
+    return syslog_servers, dhcp_servers, ntp_servers, mgmt_routes, erspan_dst
 
 
 def get_console_info(devices, dev, port):
@@ -387,6 +390,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
     dhcp_servers = []
     ntp_servers = []
     mgmt_routes = []
+    erspan_dst = []
 
     hwsku_qn = QName(ns, "HwSku")
     hostname_qn = QName(ns, "Hostname")
@@ -408,7 +412,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
         elif child.tag == str(QName(ns, "UngDec")):
             (u_neighbors, u_devices, _, _, _, _) = parse_png(child, hostname)
         elif child.tag == str(QName(ns, "MetadataDeclaration")):
-            (syslog_servers, dhcp_servers, ntp_servers, mgmt_routes) = parse_meta(child, hostname)
+            (syslog_servers, dhcp_servers, ntp_servers, mgmt_routes, erspan_dst) = parse_meta(child, hostname)
 
     Tree = lambda: defaultdict(Tree)
 
@@ -456,6 +460,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
     results['dhcp_servers'] = dhcp_servers
     results['ntp_servers'] = ntp_servers
     results['forced_mgmt_routes'] = mgmt_routes
+    results['erspan_dst'] = erspan_dst
 
     return results
 


### PR DESCRIPTION
    * Added templates for IPinIP and Everflow configuration file.
    * Added config.sh to generate configs using templates.
    * Extended minigraph.py to read ErspanIPv4 section.

Use {{ erspan_dst[0] }} to read Everflow destination IPv4 address in your config/minigraph file.