### PR TITLE
Re-commit PR #432 (SHA 4546372) 

### DIFF
--- a/dockers/docker-orchagent/start.sh
+++ b/dockers/docker-orchagent/start.sh
@@ -12,6 +12,18 @@ function start_app {
     done
 }
 
+function config_acl {
+    if [ -f "/etc/sonic/acl.json" ]; then
+        mkdir -p /etc/swss/config.d/acl
+        rm -rf /etc/swss/config.d/acl/*
+        translate_acl -m /etc/sonic/minigraph.xml -o /etc/swss/config.d/acl /etc/sonic/acl.json
+        for filename in /etc/swss/config.d/acl/*.json; do
+            [ -e "$filename" ] || break
+            swssconfig $filename
+        done
+    fi
+}
+
 function clean_up {
     pkill -9 orchagent
     pkill -9 portsyncd
@@ -61,6 +73,7 @@ while true; do
     result=`echo -en "SELECT 1\nHLEN HIDDEN" | redis-cli | sed -n 2p`
     if [ "$result" != "0" ]; then
         start_app
+        config_acl
         read
     fi
     sleep 1

--- a/files/dhcp/dhclient.conf
+++ b/files/dhcp/dhclient.conf
@@ -21,5 +21,5 @@ request subnet-mask, broadcast-address, time-offset, routers,
         domain-name, domain-name-servers, domain-search, host-name,
         dhcp6.name-servers, dhcp6.domain-search,
         netbios-name-servers, netbios-scope, interface-mtu,
-        rfc3442-classless-static-routes, ntp-servers, snmp-community, minigraph-url, acl-url;
+        rfc3442-classless-static-routes, ntp-servers, snmp-community, minigraph-url;
 

--- a/files/dhcp/dhclient.conf
+++ b/files/dhcp/dhclient.conf
@@ -14,11 +14,12 @@
 option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
 option snmp-community code 224 = text;
 option minigraph-url code 225 = text;
+option acl-url code 226 = text;
 
 send host-name = gethostname();
 request subnet-mask, broadcast-address, time-offset, routers,
         domain-name, domain-name-servers, domain-search, host-name,
         dhcp6.name-servers, dhcp6.domain-search,
         netbios-name-servers, netbios-scope, interface-mtu,
-        rfc3442-classless-static-routes, ntp-servers, snmp-community, minigraph-url;
+        rfc3442-classless-static-routes, ntp-servers, snmp-community, minigraph-url, acl-url;
 

--- a/files/dhcp/graphserviceurl
+++ b/files/dhcp/graphserviceurl
@@ -5,5 +5,8 @@ case $reason in
         else
             echo "N/A" > /tmp/dhcp_graph_url
         fi
+        if [ -n "$new_acl_url" ]; then
+            echo $new_acl_url > /tmp/dhcp_acl_url
+        fi
         ;;
 esac

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -12,6 +12,8 @@ if [ "$enabled" != "true" ]; then
     exit 0
 fi
 
+ACL_URL=$acl_src
+
 if [ "$src" = "dhcp" ]; then
     while [ ! -f /tmp/dhcp_graph_url ]; do
         echo "Waiting for DHCP response..."
@@ -38,6 +40,18 @@ if [ "$src" = "dhcp" ]; then
         sed -i "/src=/d" /etc/sonic/updategraph.conf
         echo "src=\"$GRAPH_URL\"" >> /etc/sonic/updategraph.conf
     fi
+
+    if [ -f /tmp/dhcp_acl_url ]; then
+        ACL_URL=`sonic-cfggen -t /tmp/dhcp_acl_url -a "{\"hostname\": \"$HOSTNAME\"}"`
+        if [[ ! $ACL_URL =~ $URL_REGEX ]]; then
+            echo "\"$ACL_URL\" is not a valid url. Skipping acl update."
+            ACL_URL=""
+        fi
+        if [ "$dhcp_as_static" = "true" ]; then
+            sed -i "/acl_src=/d" /etc/sonic/updategraph.conf
+            echo "acl_src=\"$ACL_URL\"" >> /etc/sonic/updategraph.conf
+        fi
+    fi
 else
     GRAPH_URL=$src
 fi
@@ -53,3 +67,19 @@ while true; do
     curl -f $GRAPH_URL -o /etc/sonic/minigraph.xml --connect-timeout 15 && break
     sleep 5
 done
+
+if [ -n "$ACL_URL" ]; then
+    if [ -f /etc/sonic/acl.json ]; then
+        echo "Renaming acl.json to acl.json.old"
+        mv /etc/sonic/acl.json /etc/sonic/acl.json.old
+    fi
+    echo "Getting ACL config from $ACL_URL"
+
+    while true; do
+        curl -f $ACL_URL -o /etc/sonic/acl.json --connect-timeout 15 && break
+        sleep 5
+    done
+else
+    echo "Skip ACL config download."
+fi
+

--- a/src/sonic-config-engine/translate_acl
+++ b/src/sonic-config-engine/translate_acl
@@ -129,7 +129,6 @@ def translate_acl_fixed_port(filename, output_path, port, max_priority):
 
 def translate_acl(filename, output_path, attach_to, max_priority):
     yang_acl = pybindJSON.load(filename, openconfig_acl, "openconfig_acl")
-    print attach_to.keys()
     for aclsetname in yang_acl.acl.acl_sets.acl_set:
         tablename = aclsetname.replace(" ", "_").replace("-", "_")
         if attach_to.has_key(tablename):
@@ -151,7 +150,8 @@ def main():
         translate_acl_fixed_port(args.input, args.output_path, args.port, args.max_priority)
     elif args.minigraph:
         mini_data = parse_xml(args.minigraph)
-        translate_acl(args.input, args.output_path, mini_data['minigraph_acls'], args.max_priority)
+        if mini_data['minigraph_acls']:
+            translate_acl(args.input, args.output_path, mini_data['minigraph_acls'], args.max_priority)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
We reverted #432 in #457 as we observed in Microsoft testbed that sonic switches were unable to get correct DHCP response after that commit.

However, by investigation it turns out that this is an environment issue rather than SONiC code issue. (Certain brand of switches that are used as mgmt switch in Microsoft testbed failed to forward the DHCP ACK packet). Therefore we are re-committing this change back. Though, we'll disable the feature temporarily by not requesting that DHCP option until we find a final solution to the testbed issue.