### PR TITLE
[oneimage] Add ":latest" to docker run script

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -14,7 +14,7 @@ start() {
             -v /var/run/redis:/var/run/redis:rw \
             -v /usr/share/sonic/device/$PLATFORM:/usr/share/sonic/platform:ro \
             -v /usr/share/sonic/device/$PLATFORM/$HWSKU:/usr/share/sonic/hwsku:ro \
-            --name={{docker_container_name}} {{docker_image_name}}
+            --name={{docker_container_name}} {{docker_image_name}}:latest
     fi
 }
 


### PR DESCRIPTION
To keep consistency with container info on pre-oneimage switches