### PR TITLE
[oneimage] Update dhclient.conf

### DIFF
--- a/files/dhcp/dhclient.conf
+++ b/files/dhcp/dhclient.conf
@@ -17,10 +17,9 @@ option minigraph-url code 225 = text;
 option acl-url code 226 = text;
 
 send host-name = gethostname();
-also request subnet-mask, broadcast-address, time-offset, routers,
-             domain-name, domain-name-servers, domain-search, host-name,
-             dhcp6.name-servers, dhcp6.domain-search,
-             netbios-name-servers, netbios-scope, interface-mtu,
-             rfc3442-classless-static-routes, ntp-servers, 
-             snmp-community, minigraph-url, acl-url;
+request subnet-mask, broadcast-address, time-offset, routers,
+        domain-name, domain-name-servers, domain-search, host-name,
+        dhcp6.name-servers, dhcp6.domain-search, interface-mtu,
+        rfc3442-classless-static-routes, ntp-servers, 
+        snmp-community, minigraph-url, acl-url;
 

--- a/files/dhcp/dhclient.conf
+++ b/files/dhcp/dhclient.conf
@@ -17,9 +17,10 @@ option minigraph-url code 225 = text;
 option acl-url code 226 = text;
 
 send host-name = gethostname();
-request subnet-mask, broadcast-address, time-offset, routers,
-        domain-name, domain-name-servers, domain-search, host-name,
-        dhcp6.name-servers, dhcp6.domain-search,
-        netbios-name-servers, netbios-scope, interface-mtu,
-        rfc3442-classless-static-routes, ntp-servers, snmp-community, minigraph-url;
+also request subnet-mask, broadcast-address, time-offset, routers,
+             domain-name, domain-name-servers, domain-search, host-name,
+             dhcp6.name-servers, dhcp6.domain-search,
+             netbios-name-servers, netbios-scope, interface-mtu,
+             rfc3442-classless-static-routes, ntp-servers, 
+             snmp-community, minigraph-url, acl-url;
 


### PR DESCRIPTION
Add request to option 226 back, and uses `also request` instead of `request`.

It turns out that certain dhcp server implementation (dnsmasq) will fail to send option 82 correctly under certain situation, and will lead to DHCP relay fail to forward the packet. Using "also request" instead of "request" happens to help us getting out of bugging situation of dnsmasq.