### PR TITLE
[interfaces]: Do not bring up LAG members when LAG is not up

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -76,7 +76,7 @@ auto {{ member }}
 allow-hotplug {{ member }}
 iface {{ member }} inet manual
     pre-up teamdctl {{ pc }} port add {{ member }} || true
-    post-up ifconfig {{ member }} up
+    post-up ip link show {{ pc }} && ifconfig {{ member }} up
     post-down ifconfig {{ member }} down
 #
 {% endfor %}


### PR DESCRIPTION
- Without this fix, the LAG members will be brought up. Due
  to the current design of teamd, interfaces cannot join teamd
  when they are up.

Signed-off-by: Shuotian Cheng <shuche@microsoft.com>