### PR TITLE
[swss]: Update sonic-swss to enable SAI_NUM_ECMP_MEMBERS option in sai.profile

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/sai.profile
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/etc/bcm/td2-a7050-qx32-32x40G.config.bcm
+SAI_NUM_ECMP_MEMBERS=32

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/sai.profile
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/sai.profile
@@ -1,1 +1,2 @@
 SAI_INIT_CONFIG_FILE=/etc/bcm/td2-s6000-32x40G.config.bcm
+SAI_NUM_ECMP_MEMBERS=32

--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_2.1.5.1-1-20170407044929.18_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_2.1.5.1-1-20170407044929.18_amd64.deb?sv=2015-04-05&sr=b&sig=lKKP8Ot01SW9NwbbnafZly5rTkIK2rpTdBuUwcWdr5U%3D&se=2030-12-15T04%3A51%3A54Z&sp=r"
+BRCM_SAI = libsaibcm_2.1.5.1-2-20170419194756.21_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_2.1.5.1-2-20170419194756.21_amd64.deb?sv=2015-04-05&sr=b&sig=On9N1tlOSbYj%2Fb0JudmUjYRTbvS5cvqcGJUEIDX8wzk%3D&se=2030-12-27T20%3A56%3A24Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_2.1.5.1-1-20170407044929.18_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_2.1.5.1-2-20170419194756.21_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_2.1.5.1-1-20170407044929.18_amd64.deb?sv=2015-04-05&sr=b&sig=AsDdE0zR3aTxwdK76Iro0jGypl%2FSqVoYmwz0drr78Ho%3D&se=2030-12-15T04%3A52%3A31Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_2.1.5.1-2-20170419194756.21_amd64.deb?sv=2015-04-05&sr=b&sig=iVQRbQUTmeKqd01pMMR%2FIwlEUsAeiGIxCrqfr24lQ8k%3D&se=2030-12-27T20%3A57%3A08Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI) $(BRCM_SAI_DEV)
 $(BRCM_SAI)_DEPENDS += $(BRCM_OPENNSL)


### PR DESCRIPTION
- Update Broadcom libsaibcm debian package to 2.1.5.1-2
- Add SAI_NUM_ECMP_MEMBERS=32 to two Trident II platforms
- Update sonic-swss submodule version to support such changes

Signed-off-by: Shuotian Cheng <shuche@microsoft.com>