### PR TITLE
[rc.local]: Copy saved minigraph if available.

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -29,7 +29,11 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         exit 0
     fi
 
-    cp /usr/share/sonic/device/$platform/minigraph.xml /etc/sonic/
+    if [ -f /host/minigraph.xml ]; then
+        mv /host/minigraph.xml /etc/sonic/
+    else
+        cp /usr/share/sonic/device/$platform/minigraph.xml /etc/sonic/
+    fi
 
     if [ -d /host/image-$sonic_version/platform/$platform ]; then
         dpkg -i /host/image-$sonic_version/platform/$platform/*.deb

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -29,6 +29,7 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         exit 0
     fi
 
+    # Try to take minigraph saved during installation
     if [ -f /host/minigraph.xml ]; then
         mv /host/minigraph.xml /etc/sonic/
     else


### PR DESCRIPTION
In case of sonic-to-sonic update old image stores minigraph under /host
directory. Upon first boot this minigraph will be used by new image to
save configuration.

Signed-off-by: marian-pritsak <marianp@mellanox.com>