### PR TITLE
[System logs]: Fix logrotate bugs

### DIFF
--- a/files/image_config/cron.d/logrotate
+++ b/files/image_config/cron.d/logrotate
@@ -1,3 +1,3 @@
 # Attempt to rotate system logs once per minute
-* * * * * root /usr/sbin/logrotate -f /etc/logrotate.d/rsyslog
+* * * * * root /usr/sbin/logrotate /etc/logrotate.d/rsyslog
 

--- a/files/image_config/logrotate.d/rsyslog
+++ b/files/image_config/logrotate.d/rsyslog
@@ -10,6 +10,10 @@
     compress
     delaycompress
     postrotate
+        # Calling kill directly instead of 'service rsyslog rotate >/dev/null' due
+        # to bug in init-system-helpers. Bug has apparently been fixed in v1.47.
+        # However, Debian Jessie is still using v1.22.
+        # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=672218
         kill -HUP $(cat /var/run/rsyslogd.pid)
     endscript
 }
@@ -35,6 +39,10 @@
     delaycompress
     sharedscripts
     postrotate
+        # Calling kill directly instead of 'service rsyslog rotate >/dev/null' due
+        # to bug in init-system-helpers. Bug has apparently been fixed in v1.47.
+        # However, Debian Jessie is still using v1.22.
+        # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=672218
         kill -HUP $(cat /var/run/rsyslogd.pid)
     endscript
 }

--- a/files/image_config/logrotate.d/rsyslog
+++ b/files/image_config/logrotate.d/rsyslog
@@ -3,16 +3,14 @@
 /var/log/teamd.log
 {
     rotate 7
-# Removed 'daily' interval, as we now call logrotate more frequently via cron
-# and we want to check these logs every time
-#    daily
-    size 100M
+    daily
+    maxsize 100M
     missingok
     notifempty
     compress
     delaycompress
     postrotate
-        invoke-rc.d rsyslog rotate > /dev/null
+        kill -HUP $(cat /var/run/rsyslogd.pid)
     endscript
 }
 /var/log/mail.info
@@ -30,14 +28,14 @@
 {
     rotate 4
     weekly
-    size 100M
+    maxsize 100M
     missingok
     notifempty
     compress
     delaycompress
     sharedscripts
     postrotate
-        invoke-rc.d rsyslog rotate > /dev/null
+        kill -HUP $(cat /var/run/rsyslogd.pid)
     endscript
 }
 

--- a/files/image_config/systemd/journald.conf
+++ b/files/image_config/systemd/journald.conf
@@ -15,10 +15,10 @@
 #SyncIntervalSec=5m
 #RateLimitInterval=30s
 #RateLimitBurst=1000
-SystemMaxUse=50MB
+SystemMaxUse=50M
 #SystemKeepFree=
 #SystemMaxFileSize=
-RuntimeMaxUse=50MB
+RuntimeMaxUse=50M
 #RuntimeKeepFree=
 #RuntimeMaxFileSize=
 #MaxRetentionSec=


### PR DESCRIPTION
- rsyslog logs were being rotated regardless of whether they exceeded their maixmum size. This was due to "-f" flag passed to logrotate in cron job.

- After rotation, /var/log/syslog was never written to again. Instead, logs were written to /var/log/syslog.1. This was due to rsyslog not properly closing the file descriptor to the pre-rotated log.

- Also addresses issue https://github.com/Azure/sonic-buildimage/issues/528

- Also brought back time-related rotation via the new(er) `maxsize` option, which performs a boolean OR operation. If the log exceeds the maxsize OR the log hasn't been rotated in the specified, it will be rotated. Using the older `size` option, the time-based rotation was ignored.