### PR TITLE
[database]: Remove hard/soft limits for client-output-buffer in redis

### DIFF
--- a/dockers/docker-database/Dockerfile.j2
+++ b/dockers/docker-database/Dockerfile.j2
@@ -29,6 +29,7 @@ RUN sed -ri 's/^(save .*$)/# \1/g;                                              
              s/^logfile .*$/logfile ""/;                                                \
              s/^# syslog-enabled no$/syslog-enabled no/;                                \
              s/^# unixsocket/unixsocket/                                                \
+             s/^client-output-buffer-limit pubsub 32mb 8mb 60/client-output-buffer-limit pubsub 0 0 0/ \
             ' /etc/redis/redis.conf
 
 ENTRYPOINT ["/usr/bin/redis-server", "/etc/redis/redis.conf"]

--- a/dockers/docker-database/Dockerfile.j2
+++ b/dockers/docker-database/Dockerfile.j2
@@ -28,7 +28,7 @@ RUN sed -ri 's/^(save .*$)/# \1/g;                                              
              s/^daemonize yes$/daemonize no/;                                           \
              s/^logfile .*$/logfile ""/;                                                \
              s/^# syslog-enabled no$/syslog-enabled no/;                                \
-             s/^# unixsocket/unixsocket/                                                \
+             s/^# unixsocket/unixsocket/;                                               \
              s/^client-output-buffer-limit pubsub 32mb 8mb 60/client-output-buffer-limit pubsub 0 0 0/ \
             ' /etc/redis/redis.conf
 

--- a/dockers/docker-database/Dockerfile.j2
+++ b/dockers/docker-database/Dockerfile.j2
@@ -29,7 +29,7 @@ RUN sed -ri 's/^(save .*$)/# \1/g;                                              
              s/^logfile .*$/logfile ""/;                                                \
              s/^# syslog-enabled no$/syslog-enabled no/;                                \
              s/^# unixsocket/unixsocket/;                                               \
-             s/^client-output-buffer-limit pubsub 32mb 8mb 60/client-output-buffer-limit pubsub 0 0 0/ \
+             s/^client-output-buffer-limit pubsub \d+mb \d+mb \d+/client-output-buffer-limit pubsub 0 0 0/ \
             ' /etc/redis/redis.conf
 
 ENTRYPOINT ["/usr/bin/redis-server", "/etc/redis/redis.conf"]

--- a/dockers/docker-database/Dockerfile.j2
+++ b/dockers/docker-database/Dockerfile.j2
@@ -29,7 +29,7 @@ RUN sed -ri 's/^(save .*$)/# \1/g;                                              
              s/^logfile .*$/logfile ""/;                                                \
              s/^# syslog-enabled no$/syslog-enabled no/;                                \
              s/^# unixsocket/unixsocket/;                                               \
-             s/^client-output-buffer-limit pubsub \d+mb \d+mb \d+/client-output-buffer-limit pubsub 0 0 0/ \
+             s/^client-output-buffer-limit pubsub [0-9]+mb [0-9]+mb [0-9]+/client-output-buffer-limit pubsub 0 0 0/ \
             ' /etc/redis/redis.conf
 
 ENTRYPOINT ["/usr/bin/redis-server", "/etc/redis/redis.conf"]


### PR DESCRIPTION
Temporary/fast fix for https://github.com/Azure/sonic-sairedis/issues/176