### PR TITLE
[baseos] Avoid disconnecting mgmt when re-cfg interfaces

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+ifdown -a -X eth0
 sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/interfaces.j2 >/etc/network/interfaces
-service networking restart
-ifdown lo && ifup lo
+ifup -a -X eth0
+
+NEW_MGMT_IP=`sonic-cfggen -m /etc/sonic/minigraph.xml  -v 'minigraph_mgmt_interface["addr"]'`
+NEW_MGMT_MASK=`sonic-cfggen -m /etc/sonic/minigraph.xml  -v 'minigraph_mgmt_interface["mask"]'`
+
+ifconfig eth0 $NEW_MGMT_IP netmask $NEW_MGMT_MASK
+

--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -8,4 +8,5 @@ NEW_MGMT_IP=`sonic-cfggen -m /etc/sonic/minigraph.xml  -v 'minigraph_mgmt_interf
 NEW_MGMT_MASK=`sonic-cfggen -m /etc/sonic/minigraph.xml  -v 'minigraph_mgmt_interface["mask"]'`
 
 ifconfig eth0 $NEW_MGMT_IP netmask $NEW_MGMT_MASK
+[ -f /var/run/dhclient.eth0.pid ] && kill `cat /var/run/dhclient.eth0.pid` && rm -f /var/run/dhclient.eth0.pid
 


### PR DESCRIPTION
In the previous version of interfaces-config, we restarted network service after re-generate interfaces file based on minigraph. This might break ssh connection through mgmt port even though mgmt ip was not changed.

To address this, we are now calling ifdown/ifup on only interfaces other than eth0, and config eth0 address seperately. 