### PR TITLE
[docker-syncd-*-rpc] Fix issue which prevented supervisord to start

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
@@ -50,7 +50,7 @@ RUN apt-get update \
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY ptf_nn_agent.conf /etc/supervisor/conf.d/ptf_nn_agent.conf
 
-RUN sed -i 's/read/sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/' /usr/bin/start.sh
+RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/" /usr/bin/start.sh
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/usr/bin/start.sh"]

--- a/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
@@ -50,7 +50,7 @@ RUN apt-get update \
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY ptf_nn_agent.conf /etc/supervisor/conf.d/ptf_nn_agent.conf
 
-RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/" /usr/bin/start.sh
+RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord" /usr/bin/start.sh
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/usr/bin/start.sh"]

--- a/platform/broadcom/docker-syncd-brcm-rpc/supervisord.conf
+++ b/platform/broadcom/docker-syncd-brcm-rpc/supervisord.conf
@@ -1,2 +1,2 @@
 [supervisord]
-nodaemon=true
+nodaemon=false

--- a/platform/cavium/docker-syncd-cavm-rpc/Dockerfile.j2
+++ b/platform/cavium/docker-syncd-cavm-rpc/Dockerfile.j2
@@ -50,7 +50,7 @@ RUN apt-get update \
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY ptf_nn_agent.conf /etc/supervisor/conf.d/ptf_nn_agent.conf
 
-RUN sed -i 's/read/sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/' /usr/bin/start.sh
+RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/" /usr/bin/start.sh
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/usr/bin/start.sh"]

--- a/platform/cavium/docker-syncd-cavm-rpc/Dockerfile.j2
+++ b/platform/cavium/docker-syncd-cavm-rpc/Dockerfile.j2
@@ -50,7 +50,7 @@ RUN apt-get update \
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY ptf_nn_agent.conf /etc/supervisor/conf.d/ptf_nn_agent.conf
 
-RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/" /usr/bin/start.sh
+RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord" /usr/bin/start.sh
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/usr/bin/start.sh"]

--- a/platform/cavium/docker-syncd-cavm-rpc/supervisord.conf
+++ b/platform/cavium/docker-syncd-cavm-rpc/supervisord.conf
@@ -1,2 +1,2 @@
 [supervisord]
-nodaemon=true
+nodaemon=false

--- a/platform/centec/docker-syncd-centec-rpc/Dockerfile.j2
+++ b/platform/centec/docker-syncd-centec-rpc/Dockerfile.j2
@@ -50,7 +50,7 @@ RUN apt-get update \
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY ptf_nn_agent.conf /etc/supervisor/conf.d/ptf_nn_agent.conf
 
-RUN sed -i 's/read/sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/' /usr/bin/start.sh
+RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/" /usr/bin/start.sh
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/usr/bin/start.sh"]

--- a/platform/centec/docker-syncd-centec-rpc/Dockerfile.j2
+++ b/platform/centec/docker-syncd-centec-rpc/Dockerfile.j2
@@ -50,7 +50,7 @@ RUN apt-get update \
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY ptf_nn_agent.conf /etc/supervisor/conf.d/ptf_nn_agent.conf
 
-RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/" /usr/bin/start.sh
+RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord" /usr/bin/start.sh
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/usr/bin/start.sh"]

--- a/platform/centec/docker-syncd-centec-rpc/supervisord.conf
+++ b/platform/centec/docker-syncd-centec-rpc/supervisord.conf
@@ -1,2 +1,2 @@
 [supervisord]
-nodaemon=true
+nodaemon=false

--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -50,7 +50,7 @@ RUN apt-get update \
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY ptf_nn_agent.conf /etc/supervisor/conf.d/ptf_nn_agent.conf
 
-RUN sed -i 's/read/sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/' /usr/bin/start.sh
+RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/" /usr/bin/start.sh
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/usr/bin/start.sh"]

--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -50,7 +50,7 @@ RUN apt-get update \
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY ptf_nn_agent.conf /etc/supervisor/conf.d/ptf_nn_agent.conf
 
-RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord/" /usr/bin/start.sh
+RUN sed -i "/service rsyslog start/a sysctl -w net.core.rmem_max=509430500 ; \/usr\/bin\/supervisord" /usr/bin/start.sh
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/usr/bin/start.sh"]

--- a/platform/mellanox/docker-syncd-mlnx-rpc/supervisord.conf
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/supervisord.conf
@@ -1,2 +1,2 @@
 [supervisord]
-nodaemon=true
+nodaemon=false


### PR DESCRIPTION
Previously we had supervisord started after syncd started. But service syncd start was blocking. So supervisord didn't start at all. This patch fixes this.
It runs supervisord in daeomon mode first and then it runs syncd.