### PR TITLE
Config docker-database's log-driver and log-opt

### DIFF
--- a/rules/docker-database.mk
+++ b/rules/docker-database.mk
@@ -8,6 +8,6 @@ SONIC_DOCKER_IMAGES += $(DOCKER_DATABASE)
 SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_DATABASE)
 
 $(DOCKER_DATABASE)_CONTAINER_NAME = database
-$(DOCKER_DATABASE)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_DATABASE)_RUN_OPT += --net=host --privileged -t --log-driver=syslog --log-opt=tag="{{.ID}}({{.Name}})"
 
 $(DOCKER_DATABASE)_BASE_IMAGE_FILES += redis-cli:/usr/bin/redis-cli


### PR DESCRIPTION
This feature is missing in OneImage. So there is no syslog from redis process.
Redis in the database container is running in the non daemon mode, and print logs on stdout.