### PR TITLE
[dockers]: Disable autorestart on all supervised processes inside containers

### DIFF
--- a/dockers/docker-basic_router/supervisord.conf
+++ b/dockers/docker-basic_router/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-database/supervisord.conf
+++ b/dockers/docker-database/supervisord.conf
@@ -7,6 +7,7 @@ nodaemon=true
 command=/usr/bin/redis-server /etc/redis/redis.conf
 priority=1
 autostart=true
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-dhcp-relay/supervisord.conf
+++ b/dockers/docker-dhcp-relay/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/isc-dhcp-relay.sh
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-fpm-gobgp/supervisord.conf
+++ b/dockers/docker-fpm-gobgp/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/sbin/gobgpd -p -f /etc/gobgp/gobgpd.conf -r
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -29,6 +31,7 @@ stderr_logfile=syslog
 command=fpmsyncd
 priority=5
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-fpm-quagga/supervisord.conf
+++ b/dockers/docker-fpm-quagga/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=fpmsyncd
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-lldp-sv2/supervisord.conf
+++ b/dockers/docker-lldp-sv2/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -27,6 +28,7 @@ stderr_logfile=syslog
 command=/usr/sbin/lldpd -d -I Ethernet*,eth*
 priority=100
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -34,7 +36,7 @@ stderr_logfile=syslog
 command=/opt/reconfigure.sh
 priority=150
 autostart=false
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -42,6 +44,7 @@ stderr_logfile=syslog
 command=/usr/bin/env python2 -m lldp_syncd
 priority=200
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/orchagent.sh
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-platform-monitor/supervisord.conf
+++ b/dockers/docker-platform-monitor/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,7 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/lm-sensors.sh
 priority=3
 autostart=false
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-saiserver-brcm/supervisord.conf
+++ b/dockers/docker-saiserver-brcm/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/saiserver -p /etc/sai/profile.ini -f /etc/sai/portmap.ini
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-saiserver-cavm/supervisord.conf
+++ b/dockers/docker-saiserver-cavm/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/saiserver -p /etc/sai/profile.ini -f /etc/sai/portmap.ini
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-saiserver-mlnx/supervisord.conf
+++ b/dockers/docker-saiserver-mlnx/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/saiserver -p /etc/sai/profile.ini -f /etc/sai/portmap.ini
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-snmp-sv2/supervisord.conf
+++ b/dockers/docker-snmp-sv2/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ip -p /run/snmpd.pid
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -29,6 +31,7 @@ stderr_logfile=syslog
 command=/usr/bin/env python3.6 -m sonic_ax_impl
 priority=4
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-teamd/supervisord.conf
+++ b/dockers/docker-teamd/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/teamd.sh
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/platform/broadcom/docker-syncd-brcm/supervisord.conf
+++ b/platform/broadcom/docker-syncd-brcm/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/syncd.sh
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/platform/cavium/docker-syncd-cavm/supervisord.conf
+++ b/platform/cavium/docker-syncd-cavm/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/syncd.sh
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/platform/centec/docker-syncd-centec/supervisord.conf
+++ b/platform/centec/docker-syncd-centec/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/syncd.sh
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/platform/mellanox/docker-syncd-mlnx/supervisord.conf
+++ b/platform/mellanox/docker-syncd-mlnx/supervisord.conf
@@ -7,7 +7,7 @@ nodaemon=true
 command=/usr/bin/start.sh
 priority=1
 autostart=true
-autorestart=false     ; One-shot
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -15,6 +15,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -22,6 +23,7 @@ stderr_logfile=syslog
 command=/usr/bin/syncd.sh
 priority=3
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 


### PR DESCRIPTION
By disabling autorestart on all processes and making them all one-shot runs, we regain our previous functionality.

In the near future, the plan will be to modify supervisord functionality as follows:
 - When a process managed by supervisord crashes, supervisord wil log the crash and exit immediately, thus causing the docker container to stop. The container will then be restarted by systemd as an atomic unit.