### PR TITLE
[rsyslog]: Ignore snmpd statfs errors

### DIFF
--- a/files/image_config/rsyslog/rsyslog.d/00-sonic.conf
+++ b/files/image_config/rsyslog/rsyslog.d/00-sonic.conf
@@ -20,3 +20,8 @@ if $programname contains "teamd_" then {
     stop
 }
 
+## Snmpd exceptions
+
+if $programname == "snmpd" and $msg contains "statfs" then {
+    stop
+}


### PR DESCRIPTION
ref: https://blog.emeidi.com/2017/02/19/elk-snmpd-cannot-statfs/
to resolve: https://github.com/Azure/sonic-snmpagent/issues/22