### PR TITLE
[docker-syncd-cavm]: Properly manage syncd with supervisord

### DIFF
--- a/platform/cavium/docker-syncd-cavm/syncd.sh
+++ b/platform/cavium/docker-syncd-cavm/syncd.sh
@@ -3,20 +3,18 @@
 export XP_ROOT=/usr/bin/
 
 while true; do
-
     # Check if redis-server starts
+    RESULT=$(redis-cli ping)
 
-    result=$(redis-cli ping)
-
-    if [ "$result" == "PONG" ]; then
-
-        redis-cli FLUSHALL
-        syncd -p /etc/ssw/AS7512/profile.ini -N
+    if [ "$RESULT" == "PONG" ]; then
         break
-
     fi
 
     sleep 1
-
 done
+
+
+redis-cli FLUSHALL
+
+exec syncd -p /etc/ssw/AS7512/profile.ini -N
 


### PR DESCRIPTION
This allows supervisord to log syncd exit events to syslog.