### PR TITLE
[debian]: Disable receiving default routes for ipv6 on mgmt interface

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -237,6 +237,8 @@ set /files/etc/sysctl.conf/net.ipv6.conf.eth0.forwarding 0
 
 set /files/etc/sysctl.conf/net.ipv6.conf.default.accept_dad 0
 set /files/etc/sysctl.conf/net.ipv6.conf.all.accept_dad 0
+
+set /files/etc/sysctl.conf/net.ipv6.conf.eth0.disable_ipv6 1
 " -r $FILESYSTEM_ROOT
 
 ## docker-py is needed by Ansible docker module

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -238,7 +238,7 @@ set /files/etc/sysctl.conf/net.ipv6.conf.eth0.forwarding 0
 set /files/etc/sysctl.conf/net.ipv6.conf.default.accept_dad 0
 set /files/etc/sysctl.conf/net.ipv6.conf.all.accept_dad 0
 
-set /files/etc/sysctl.conf/net.ipv6.conf.eth0.disable_ipv6 1
+set /files/etc/sysctl.conf/net.ipv6.conf.eth0.accept_ra_defrtr 0
 " -r $FILESYSTEM_ROOT
 
 ## docker-py is needed by Ansible docker module


### PR DESCRIPTION
Otherwise quagga will not add any ipv6 default into routing table, because there're already exist default routes to eth0.