### PR TITLE
[updategraph service] Disable itself after first time

### DIFF
--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -68,6 +68,10 @@ while true; do
     sleep 5
 done
 
+# Mark as disabled after graph is successfully downloaded
+sed -i "/enabled=/d" /etc/sonic/updategraph.conf
+echo "enabled=false" >> /etc/sonic/updategraph.conf
+
 if [ -n "$ACL_URL" ]; then
     if [ -f /etc/sonic/acl.json ]; then
         echo "Renaming acl.json to acl.json.old"


### PR DESCRIPTION
Updategraph service will now disable itself after graph is successfully downloaded in the first run. Therefore it will no longer try to download graph during each reboot. Manually enable it in `/etc/sonic/updategraph.conf` to override this behavior.