### PR TITLE
[build-debian]: Add kernel configuration to reboot on kernel soft lockup

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -216,6 +216,9 @@ sudo mkdir -p $FILESYSTEM_ROOT/var/core
 sudo augtool --autosave "
 set /files/etc/sysctl.conf/kernel.core_pattern '|/usr/bin/coredump-compress %e %p'
 
+set /files/etc/sysctl.conf/kernel.softlockup_panic 1
+set /files/etc/sysctl.conf/kernel.panic 10
+
 set /files/etc/sysctl.conf/net.ipv4.conf.default.forwarding 1
 set /files/etc/sysctl.conf/net.ipv4.conf.all.forwarding 1
 set /files/etc/sysctl.conf/net.ipv4.conf.eth0.forwarding 0


### PR DESCRIPTION
Sometimes the Linux kernel goes into soft lockup because of RCU right after start. So such switch requires to be rebooted to fix it. This sysctl parameters allow to the kernel reboot itself in 10 seconds after this soft lockup happens.