### PR TITLE
Cron jobs log to /var/log/cron.log once again

### DIFF
--- a/files/image_config/logrotate.d/rsyslog
+++ b/files/image_config/logrotate.d/rsyslog
@@ -31,8 +31,8 @@
 /var/log/messages
 {
     rotate 4
-    weekly
-    maxsize 100M
+    daily
+    maxsize 50M
     missingok
     notifempty
     compress

--- a/files/image_config/rsyslog/rsyslog.d/99-default.conf
+++ b/files/image_config/rsyslog/rsyslog.d/99-default.conf
@@ -3,9 +3,9 @@
 #
 auth,authpriv.*                 /var/log/auth.log
 *.*;auth,authpriv.none          -/var/log/syslog
-# Do not redirect cron, daemon, kernel or lpr logs to
+cron.*                          /var/log/cron.log
+# Do not redirect daemon, kernel or lpr logs to
 # their own files. Let them log to /var/log/syslog
-#cron.*                          /var/log/cron.log
 #daemon.*                        -/var/log/daemon.log
 #kern.*                          -/var/log/kern.log
 #kern.*                          -/var/persist/log/kern.log


### PR DESCRIPTION
 - Now that logrotate is a cron job that runs every minute, it was polluting syslog
 - Also shrink max size of less-important logs to 50MB and rotate them daily by default