### PR TITLE
[docker-swss]: Restore FDB and ARP entries after fast reboot

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -12,6 +12,30 @@ function config_acl {
     fi
 }
 
+function fast_reboot {
+  case "$(cat /proc/cmdline)" in
+    *fast-reboot*)
+      if [[ -f /fdb.json ]];
+      then
+        swssconfig /fdb.json
+        rm -f /fdb.json
+      fi
+
+      if [[ -f /arp1.json ]];
+      then
+        swssconfig /arp1.json
+        rm -f /arp.json
+      fi
+      ;;
+    *)
+      ;;
+  esac
+}
+
+
+# Restore FDB and ARP table ASAP
+fast_reboot
+
 HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v minigraph_hwsku`
 
 SWSSCONFIG_ARGS="00-copp.config.json ipinip.json mirror.json "

--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -21,9 +21,9 @@ function fast_reboot {
         rm -f /fdb.json
       fi
 
-      if [[ -f /arp1.json ]];
+      if [[ -f /arp.json ]];
       then
-        swssconfig /arp1.json
+        swssconfig /arp.json
         rm -f /arp.json
       fi
       ;;


### PR DESCRIPTION
Restore FDB and ARP entries right after fast-reboot to minimize corruption of the fast reboot procedure.