### PR TITLE
Use default table instead of main table for forced_mgmt_routes

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -29,13 +29,13 @@ iface eth0 inet static
     up ip route add default via {{ minigraph_mgmt_interface['gwaddr'] }} dev eth0 table default
     up ip rule add from {{ minigraph_mgmt_interface['addr'] }}/32 table default
 {% for prefix in forced_mgmt_routes %}
-    up ip route add {{ prefix }} via {{ minigraph_mgmt_interface['gwaddr'] }} dev eth0
+    up ip rule add to {{ prefix }} table default
 {% endfor %}
     # management port down rules
     down ip route delete default via {{ minigraph_mgmt_interface['gwaddr'] }} dev eth0 table default
     down ip rule delete from {{ minigraph_mgmt_interface['addr'] }}/32 table default
 {% for prefix in forced_mgmt_routes %}
-    down ip route delete {{ prefix }} via {{ minigraph_mgmt_interface['gwaddr'] }} dev eth0
+    down ip rule delete to {{ prefix }} table default
 {% endfor %}
 {# TODO: COPP policy type rules #}
 {% else %}


### PR DESCRIPTION
In the previous version, we forced certain prefixes to use mgmt route by adding routes into routing table in eth0 interface up script. This is mainly for connection to crucial mgmt services such as syslog when front panel port networking is not healthy. However, this creates an issue when BGP neighbor announces the same prefixes - those routes will fail to be added into kernel routing table, thus fail to be synced into ASIC.

The correct way to add forced mgmt routes is to create another routing table using mgmt network (which we already did), and to use ip rule to use this routing table for certain destinations. By this approach control plane and data plane routes are isolated and could be configured independently.