### PR TITLE
[docker-swss]: mount /var/log/swss into the docker

### DIFF
--- a/platform/broadcom/docker-orchagent-brcm.mk
+++ b/platform/broadcom/docker-orchagent-brcm.mk
@@ -13,6 +13,6 @@ $(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /etc/network/interfaces:/etc/network/inte
 $(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interfaces.d/:ro
 $(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /host/machine.conf:/host/machine.conf:ro
 $(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /var/log:/var/log:rw
+$(DOCKER_ORCHAGENT_BRCM)_RUN_OPT += -v /var/log/swss:/var/log/swss:rw
 
 $(DOCKER_ORCHAGENT_BRCM)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel

--- a/platform/cavium/docker-orchagent-cavm.mk
+++ b/platform/cavium/docker-orchagent-cavm.mk
@@ -13,6 +13,6 @@ $(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /etc/network/interfaces:/etc/network/inte
 $(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interfaces.d/:ro
 $(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /host/machine.conf:/host/machine.conf:ro
 $(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /var/log:/var/log:rw
+$(DOCKER_ORCHAGENT_CAVM)_RUN_OPT += -v /var/log/swss:/var/log/swss:rw
 
 $(DOCKER_ORCHAGENT_CAVM)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel

--- a/platform/centec/docker-orchagent-centec.mk
+++ b/platform/centec/docker-orchagent-centec.mk
@@ -13,6 +13,6 @@ $(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /etc/network/interfaces:/etc/network/in
 $(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interfaces.d/:ro
 $(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /host/machine.conf:/host/machine.conf:ro
 $(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /var/log:/var/log:rw
+$(DOCKER_ORCHAGENT_CENTEC)_RUN_OPT += -v /var/log/swss:/var/log/swss:rw
 
 $(DOCKER_ORCHAGENT_CENTEC)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel

--- a/platform/mellanox/docker-orchagent-mlnx.mk
+++ b/platform/mellanox/docker-orchagent-mlnx.mk
@@ -13,6 +13,6 @@ $(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /etc/network/interfaces:/etc/network/inte
 $(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interfaces.d/:ro
 $(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /host/machine.conf:/host/machine.conf:ro
 $(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /var/log:/var/log:rw
+$(DOCKER_ORCHAGENT_MLNX)_RUN_OPT += -v /var/log/swss:/var/log/swss:rw
 
 $(DOCKER_ORCHAGENT_MLNX)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel


### PR DESCRIPTION
Fix the bug introduced by commit e6bb4b20a196f22a7e266f3e2de61df442ff09f4
The previous commit mount /var/log into the docker which override
the original /var/log directory structure, causing swss docker failed to
start due to following errors.

Error: The directory named as part of the path /var/log/supervisor/supervisord.log
does not exist.