### PR TITLE
[Aboot]: Add '--numeric-owner' when untarring docker filesystem to preserve original owners

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -67,8 +67,12 @@ extract_image() {
     if [ -n "$sonic_upgrade" ] || [ "$rootfs_type" != "vfat" ]; then
         mkdir -p "$image_path/{{ DOCKERFS_DIR }}"
 
+        if [ -n "$sonic_upgrade" ]; then
+            TAR_EXTRA_OPTION="--numeric-owner"
+        fi
+
         ## extract docker archive
-        tar xf "$image_path/{{ FILESYSTEM_DOCKERFS }}" -C "$image_path/{{ DOCKERFS_DIR }}"
+        tar xf "$image_path/{{ FILESYSTEM_DOCKERFS }}" -C "$image_path/{{ DOCKERFS_DIR }}" $TAR_EXTRA_OPTION
 
         ## clean up docker archive
         rm -f "$image_path/{{ FILESYSTEM_DOCKERFS }}"


### PR DESCRIPTION
- This applies the equivalent fix for SONiC-to-SONiC upgrades on Aboot platforms as the fix for ONIE platforms @ https://github.com/Azure/sonic-buildimage/pull/626