### PR TITLE
[platform] Control only 2 thermals (4A & 4B) for AS7512

### DIFF
--- a/device/accton/x86_64-accton_as7512_32x-r0/fancontrol
+++ b/device/accton/x86_64-accton_as7512_32x-r0/fancontrol
@@ -1,5 +1,5 @@
 INTERVAL=10
-FCTEMPS=/sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/3-0048/hwmon/hwmon[[:print:]]*/temp1_input /sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/3-0049/hwmon/hwmon[[:print:]]*/temp1_input /sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/3-004a/hwmon/hwmon[[:print:]]*/temp1_input
+FCTEMPS=/sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/3-004b/hwmon/hwmon[[:print:]]*/temp1_input /sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/3-004a/hwmon/hwmon[[:print:]]*/temp1_input
 FCFANS=/sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/2-0066/fan1_front_speed_rpm /sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/2-0066/fan2_front_speed_rpm /sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/2-0066/fan3_front_speed_rpm /sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/2-0066/fan4_front_speed_rpm /sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/2-0066/fan5_front_speed_rpm /sys/bus/i2c/devices/2-0066/fan_pwm=/sys/bus/i2c/devices/2-0066/fan6_front_speed_rpm
 MINTEMP=/sys/bus/i2c/devices/2-0066/fan_pwm=20
 MAXTEMP=/sys/bus/i2c/devices/2-0066/fan_pwm=60


### PR DESCRIPTION
- Control only 4A & 4B thermals based on latest Accton`s mail.

Signed-off-by: Nadiya.Stetskovych <Nadiya.Stetskovych@cavium.com>