### PR TITLE
[dockerbase]: remove apt-get clean

### DIFF
--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -19,7 +19,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ## Configure data sources for apt/dpkg
 COPY ["sources.list", "/etc/apt/sources.list"]
 COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
-RUN mkdir -p /var/cache/apt/archives && apt-get clean && apt-get update
+RUN apt-get update
 
 ## Pre-install fundamental packages
 RUN apt-get -y install \


### PR DESCRIPTION
(qiluo-msft added)
The debian jessie image updated recently (https://github.com/debuerreotype/docker-debian-artifacts/blob/0dcb9a06b2fcf9fdb416dc558db6f7b84cb6ab01/jessie/rootfs.tar.xz) and brought breaking change.
The path /var/cache/apt/archives/ is missing, and later 'apt-get clean' will fail with
```
E: Could not open lock file /var/cache/apt/archives/lock - open (2: No such file or directory)
E: Unable to lock the download directory
```
We found that 'apt-get update' will create the missing directory and files, so simple remove the 'apt-clean' to workaround this bug.