### PR TITLE
[slave]: remove apt-get clean

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://debian-archive.trafficmanager.net/debian/ jessie main contr
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get clean && apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
         apt-utils \
         default-jre-headless \
         openssh-server \


### PR DESCRIPTION
Similar as https://github.com/Azure/sonic-buildimage/pull/685 but in the slave image.

The debian jessie image updated recently (https://github.com/debuerreotype/docker-debian-artifacts/blob/0dcb9a06b2fcf9fdb416dc558db6f7b84cb6ab01/jessie/rootfs.tar.xz) and brought breaking change.
The path /var/cache/apt/archives/ is missing, and later 'apt-get clean' will fail with
```
E: Could not open lock file /var/cache/apt/archives/lock - open (2: No such file or directory)
E: Unable to lock the download directory
```
We found that 'apt-get update' will create the missing directory and files, so simple remove the 'apt-clean' to workaround this bug.