### PR TITLE
[sonic-cfggen]: translate_acl tool adds TCP mask

### DIFF
--- a/src/sonic-config-engine/tests/sample_output/rules_for_dataacl.json
+++ b/src/sonic-config-engine/tests/sample_output/rules_for_dataacl.json
@@ -25,5 +25,14 @@
             "priority":9998
         },
         "OP":"SET"
+    },
+    {
+        "ACL_RULE_TABLE:dataacl:Rule_4":{
+            "IP_PROTOCOL":6,
+            "PACKET_ACTION":"FORWARD",
+            "TCP_FLAGS":"0x10/0x10",
+            "priority":9996
+        },
+        "OP":"SET"
     }
 ]

--- a/src/sonic-config-engine/tests/t0-sample-acl.json
+++ b/src/sonic-config-engine/tests/t0-sample-acl.json
@@ -10,55 +10,77 @@
                                     "config": {
                                         "forwarding-action": "ACCEPT"
                                     }
-                                }, 
+                                },
                                 "config": {
                                     "sequence-id": 1
-                                }, 
+                                },
                                 "ip": {
                                     "config": {
-                                        "protocol": "IP_UDP", 
+                                        "protocol": "IP_UDP",
                                         "source-ip-address": "10.0.0.0/8"
                                     }
                                 }
-                            }, 
+                            },
                             "2": {
                                 "actions": {
                                     "config": {
                                         "forwarding-action": "ACCEPT"
                                     }
-                                }, 
+                                },
                                 "config": {
                                     "sequence-id": 2
-                                }, 
+                                },
                                 "ip": {
                                     "config": {
-                                        "protocol": "IP_UDP", 
+                                        "protocol": "IP_UDP",
                                         "source-ip-address": "100.64.0.0/10"
                                     }
                                 }
-                            }, 
+                            },
                             "3": {
                                 "actions": {
                                     "config": {
                                         "forwarding-action": "ACCEPT"
                                     }
-                                }, 
+                                },
                                 "config": {
                                     "sequence-id": 3
-                                }, 
+                                },
                                 "ip": {
                                     "config": {
-                                        "protocol": "IP_UDP", 
+                                        "protocol": "IP_UDP",
                                         "source-ip-address": "25.0.0.0/8"
+                                    }
+                                }
+                            },
+                            "4": {
+                                "actions": {
+                                    "config": {
+                                        "forwarding-action": "ACCEPT"
+                                    }
+                                },
+                                "config": {
+                                    "sequence-id": 4
+                                },
+                                "ip": {
+                                    "config": {
+                                        "protocol": "IP_TCP"
+                                    }
+                                },
+                                "transport": {
+                                    "config": {
+                                        "tcp-flags": [
+                                           "TCP_ACK"
+                                        ]
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "config": {
                         "name": "dataacl"
                     }
-                }, 
+                },
                 "everflow": {
                     "acl-entries": {
                         "acl-entry": {
@@ -67,26 +89,26 @@
                                     "config": {
                                         "forwarding-action": "ACCEPT"
                                     }
-                                }, 
+                                },
                                 "config": {
                                     "sequence-id": 1
-                                }, 
+                                },
                                 "ip": {
                                     "config": {
-                                        "destination-ip-address": "127.0.0.1/32", 
-                                        "protocol": "IP_TCP", 
+                                        "destination-ip-address": "127.0.0.1/32",
+                                        "protocol": "IP_TCP",
                                         "source-ip-address": "127.0.0.1/32"
                                     }
-                                }, 
+                                },
                                 "transport": {
                                     "config": {
-                                        "destination-port": "0", 
+                                        "destination-port": "0",
                                         "source-port": "0"
                                     }
                                 }
                             }
                         }
-                    }, 
+                    },
                     "config": {
                         "name": "everflow"
                     }

--- a/src/sonic-config-engine/translate_acl
+++ b/src/sonic-config-engine/translate_acl
@@ -97,7 +97,7 @@ def generate_rule_json(table_name, rule, max_priority, mirror):
         if flag == "TCP_CWR":
             tcp_flags = tcp_flags | 0x80
     if tcp_flags != 0x00:
-        rule_props["TCP_FLAGS"] = '0x{:02x}'.format(tcp_flags)
+        rule_props["TCP_FLAGS"] = '0x{:02x}/0x{:02x}'.format(tcp_flags, tcp_flags)
     return rule_data
 
 def generate_table_json(aclset, aclname, ports, mirror, max_priority, output_path='.'):


### PR DESCRIPTION
In orchagent, the TCP_FLAGS expects both value and mask as the input.
Right now, translate_acl tool only support one TCP flag and generate
the ACL with both value and mask equal to the flag. This rule will
match packets that have this specific flag set regardless of the other
flags.