### PR TITLE
[logrotate]: Add /var/log/swss/*.rec to logrotate target

### DIFF
--- a/files/image_config/logrotate.d/rsyslog
+++ b/files/image_config/logrotate.d/rsyslog
@@ -1,6 +1,7 @@
 /var/log/syslog
 /var/log/quagga/*.log
 /var/log/teamd.log
+/var/log/swss/*.rec
 {
     rotate 7
     daily


### PR DESCRIPTION
SwSS record files in /var/log/swss/ folder get larger and larger and were not rotated.
Add them here to rotate these files.