### PR TITLE
[swss]: Sleep 5 min regardless of arp_update return code

### DIFF
--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -60,7 +60,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:arp_update]
-command=bash -c "/usr/bin/arp_update && sleep 300"
+command=bash -c "/usr/bin/arp_update; sleep 300"
 priority=8
 autostart=false
 autorestart=true


### PR DESCRIPTION
- arp_update return code is not guaranteed to be true/false.
  When there is no VLAN, arp_update will return true.
  When there are VLANs, arp_update will return false because the
  command arping returns 1 due to the option '-w 0'.
- This script should be run every 5 minutes regardless of the return
  code.