### PR TITLE
[config]: Add SONIC_CONFIG_MAKE_JOBS

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -16,6 +16,11 @@
 # container.
 SONIC_CONFIG_BUILD_JOBS = 1
 
+# SONIC_CONFIG_BUILD_JOBS - set number of jobs for number of jobs per package.
+# Corresponding -j argument will be passed to make/dpkg commands that build separate packages
+# container.
+SONIC_CONFIG_BUILD_JOBS = $(shell nproc)
+
 # SONIC_CONFIG_LOG_TO_FILES - print output from execution of rule for each
 # target into separate log file under target/log/.
 # Useful when executing parallel build

--- a/rules/config
+++ b/rules/config
@@ -19,7 +19,7 @@ SONIC_CONFIG_BUILD_JOBS = 1
 # SONIC_CONFIG_BUILD_JOBS - set number of jobs for number of jobs per package.
 # Corresponding -j argument will be passed to make/dpkg commands that build separate packages
 # container.
-SONIC_CONFIG_BUILD_JOBS = $(shell nproc)
+SONIC_CONFIG_MAKE_JOBS = $(shell nproc)
 
 # SONIC_CONFIG_LOG_TO_FILES - print output from execution of rule for each
 # target into separate log file under target/log/.

--- a/slave.mk
+++ b/slave.mk
@@ -71,6 +71,7 @@ override PASSWORD := $(DEFAULT_PASSWORD)
 endif
 
 MAKEFLAGS += -j $(SONIC_CONFIG_BUILD_JOBS)
+export SONIC_CONFIG_MAKE_JOBS
 
 ###############################################################################
 ## Dumping key config attributes associated to current building exercise
@@ -178,7 +179,7 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_DPKG_DEBS)) : $(DEBS_PATH)/% : .platform $$(a
 	if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; popd; fi
 	pushd $($*_SRC_PATH) $(LOG)
 	[ ! -f ./autogen.sh ] || ./autogen.sh $(LOG)
-	dpkg-buildpackage -rfakeroot -b -us -uc $(LOG)
+	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) $(LOG)
 	popd $(LOG)
 	# clean up
 	if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && quilt pop -a -f; popd; fi

--- a/src/hiredis/Makefile
+++ b/src/hiredis/Makefile
@@ -14,7 +14,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	dpkg-source -x hiredis_$(HIREDIS_VERSION_FULL).dsc
 	pushd hiredis-$(HIREDIS_VERSION)
-	fakeroot debian/rules binary
+	fakeroot debian/rules -j$(SONIC_CONFIG_MAKE_JOBS) binary
 	popd
 
 	mv $* $(DERIVED_TARGETS) $(DEST)/

--- a/src/initramfs-tools/Makefile
+++ b/src/initramfs-tools/Makefile
@@ -15,7 +15,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Build the package
 	rm -f debian/*.debhelper.log
-	dpkg-buildpackage -rfakeroot -b -us -uc
+	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
 	mv $* $(DEST)/

--- a/src/isc-dhcp/Makefile
+++ b/src/isc-dhcp/Makefile
@@ -20,7 +20,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Build source and Debian packages
 	pushd ./isc-dhcp
-	dpkg-buildpackage -rfakeroot -b -us -uc
+	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
 	# Move the newly-built .deb packages to the destination directory

--- a/src/libnl3/Makefile
+++ b/src/libnl3/Makefile
@@ -27,7 +27,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	quilt push
 	quilt push
 	quilt push
-	dpkg-buildpackage -rfakeroot -b -us -uc
+	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -28,7 +28,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	mv tmp/debian libteam/
 	rm -rf tmp
 	pushd ./libteam
-	dpkg-buildpackage -rfakeroot -b -us -uc
+	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/mpdecimal/Makefile
+++ b/src/mpdecimal/Makefile
@@ -14,7 +14,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	dpkg-source -x mpdecimal_$(MPDECIMAL_VERSION_FULL).dsc
 	pushd mpdecimal-$(MPDECIMAL_VERSION)
-	dpkg-buildpackage -us -uc -b
+	dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
 	mv $* $(DERIVED_TARGETS) $(DEST)/

--- a/src/python3/Makefile
+++ b/src/python3/Makefile
@@ -32,7 +32,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	fi
 	done
 
-	dpkg-buildpackage -rfakeroot -us -uc -b
+	dpkg-buildpackage -rfakeroot -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
 	cp $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/redis/Makefile
+++ b/src/redis/Makefile
@@ -16,7 +16,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-source -x redis_$(REDIS_VERSION_FULL).dsc
 
 	pushd redis-$(REDIS_VERSION)
-	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -b
+	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -23,7 +23,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-source -x net-snmp_$(SNMPD_VERSION_FULL).dsc
 
 	pushd net-snmp-$(SNMPD_VERSION)
-	fakeroot debian/rules binary
+	fakeroot debian/rules -j$(SONIC_CONFIG_MAKE_JOBS) binary
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/thrift/Makefile
+++ b/src/thrift/Makefile
@@ -20,7 +20,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-source -x thrift_$(THRIFT_VERSION_FULL).dsc
 	pushd thrift-$(THRIFT_VERSION)
 	patch -p1 < ../patch/THRIFT-3577-assertion-failed.patch
-	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -d -rfakeroot -b -us -uc
+	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -d -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/


### PR DESCRIPTION
This config option allows user to specify -j value that will be passed
to each package build.

Signed-off-by: marian-pritsak <marianp@mellanox.com>