### PR TITLE
Script to create the 8GB blob that can be used in lieu of onie installer

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -35,6 +35,11 @@ if [ "$IMAGE_TYPE" = "onie" ]; then
     ./onie-mk-demo.sh $TARGET_PLATFORM $TARGET_MACHINE $TARGET_PLATFORM-$TARGET_MACHINE-$ONIEIMAGE_VERSION \
           installer platform/$TARGET_MACHINE/platform.conf $OUTPUT_ONIE_IMAGE OS $IMAGE_VERSION $ONIE_IMAGE_PART_SIZE \
           $ONIE_INSTALLER_PAYLOAD
+
+    if [[ "$TARGET_MACHINE" == "broadcom" ]] && [[ -n "$DELL_Z9100_PLATFORM_MODULE_VERSION" || -n "$DELL_S6100_PLATFORM_MODULE_VERSION" ]]; then
+	sudo scripts/dell/build_dd_image.sh
+    fi
+
 ## Use 'aboot' as target machine category which includes Aboot as bootloader
 elif [ "$IMAGE_TYPE" = "aboot" ]; then
     echo "Build Aboot installer"

--- a/scripts/dell/build_dd_image.sh
+++ b/scripts/dell/build_dd_image.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+PLATFORM=dell_broadcom
+IMAGE=image-HEAD
+
+#remove older image
+rm -f target/${PLATFORM}_8GB_dd.img.gz
+
+echo -e "\n# Creating ${PLATFORM}_8GB_dd.img..."
+fallocate -l 8G ${PLATFORM}_8GB_dd.img
+mkfs.ext4 ${PLATFORM}_8GB_dd.img
+
+echo -e "\n# Mounting ${PLATFORM}_8GB_dd.img on ${PLATFORM}_mount..."
+mkdir ${PLATFORM}_mount
+mount -t auto -o loop ${PLATFORM}_8GB_dd.img ${PLATFORM}_mount
+
+echo -e "\n# Extracting tarballs into ${PLATFORM}_mount..."
+mkdir -p ${PLATFORM}_mount/${IMAGE}/docker
+unzip -o fs.zip -x dockerfs.tar.gz -d ${PLATFORM}_mount/${IMAGE}
+unzip -op fs.zip dockerfs.tar.gz | tar xz --numeric-owner -f - -C ${PLATFORM}_mount/${IMAGE}/docker
+
+echo -e "\n# Creating 4GB logger..."
+mkdir -p ${PLATFORM}_mount/disk-img
+dd if=/dev/zero of=${PLATFORM}_mount/disk-img/var-log.ext4 count=8388608
+mkfs.ext4 -q ${PLATFORM}_mount/disk-img/var-log.ext4 -F
+
+echo -e "\n# Unmounting and removing ${PLATFORM}_mount..."
+umount ${PLATFORM}_mount
+rmdir ${PLATFORM}_mount
+
+echo -e "\n# Creating ${PLATFORM}_8GB_dd.img.gz..."
+gzip ${PLATFORM}_8GB_dd.img
+mv ${PLATFORM}_8GB_dd.img.gz target
+echo -e "\n# Done. DD image is under target/${PLATFORM}_8GB_dd.img.gz\n"
+


### PR DESCRIPTION
Compared to a ONIE based SONiC install, when the dd image generated from this script is used, the following services failed/have warnings:

[FAILED] Failed to start /etc/rc.local Compatibility.
[FAILED] Failed to start Update rsyslog configuration.
[FAILED] Failed to start Update NTP configuration.
[FAILED] Failed to start System Logging Service.
aufs au_opts_verify:1570:docker[679]: dirperm1 breaks the protection by the permission bits on the lower branch

This is under investigation.