### PR TITLE
[slave.mk]: Use host timestamp for online targets.

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -130,7 +130,7 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_COPY_FILES)) : $(DEBS_PATH)/% : .platform
 $(addprefix $(DEBS_PATH)/, $(SONIC_ONLINE_DEBS)) : $(DEBS_PATH)/% : .platform
 	$(HEADER)
 	$(foreach deb,$* $($*_DERIVED_DEBS), \
-	    { wget -O $(DEBS_PATH)/$(deb) $($(deb)_URL) $(LOG) || exit 1 ; } ; )
+	    { wget --no-use-server-timestamps -O $(DEBS_PATH)/$(deb) $($(deb)_URL) $(LOG) || exit 1 ; } ; )
 	$(FOOTER)
 
 # Download regular files from online location
@@ -141,7 +141,7 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_ONLINE_DEBS)) : $(DEBS_PATH)/% : .platform
 #     SONIC_ONLINE_FILES += $(SOME_NEW_FILE)
 $(addprefix $(DEBS_PATH)/, $(SONIC_ONLINE_FILES)) : $(DEBS_PATH)/% : .platform
 	$(HEADER)
-	wget -O  $@ $($*_URL) $(LOG)
+	wget --no-use-server-timestamps -O  $@ $($*_URL) $(LOG)
 	$(FOOTER)
 
 ###############################################################################


### PR DESCRIPTION
By default, wget tries to use timestamp received from the server. This
behavior messes up make dependencies which are also based on last
modification time. In order to avoid this, we use the current time as a
timestamp to keep dependencies in correct order.

Signed-off-by: marian-pritsak <marianp@mellanox.com>