### PR TITLE
[swss]: Temporarily disable QOS/buffer configurations

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -40,15 +40,16 @@ HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v minigraph_hwsku`
 
 SWSSCONFIG_ARGS="00-copp.config.json ipinip.json mirror.json "
 
-if [ "$HWSKU" == "Force10-S6000" ]; then
-    SWSSCONFIG_ARGS+="td2.32ports.buffers.json td2.32ports.qos.json "
-elif [ "$HWSKU" == "Force10-S6000-Q32" ]; then
-    SWSSCONFIG_ARGS+="td2.32ports.buffers.json td2.32ports.qos.json "
-elif [ "$HWSKU" == "Arista-7050-QX32" ]; then
-    SWSSCONFIG_ARGS+="td2.32ports.buffers.json td2.32ports.qos.json "
-elif [ "$HWSKU" == "ACS-MSN2700" ]; then
-    SWSSCONFIG_ARGS+="msn2700.32ports.buffers.json msn2700.32ports.qos.json "
-fi
+# FIXME: Temporarily disable QOS/buffer configurations for further debugging
+# if [ "$HWSKU" == "Force10-S6000" ]; then
+#     SWSSCONFIG_ARGS+="td2.32ports.buffers.json td2.32ports.qos.json "
+# elif [ "$HWSKU" == "Force10-S6000-Q32" ]; then
+#     SWSSCONFIG_ARGS+="td2.32ports.buffers.json td2.32ports.qos.json "
+# elif [ "$HWSKU" == "Arista-7050-QX32" ]; then
+#     SWSSCONFIG_ARGS+="td2.32ports.buffers.json td2.32ports.qos.json "
+# elif [ "$HWSKU" == "ACS-MSN2700" ]; then
+#     SWSSCONFIG_ARGS+="msn2700.32ports.buffers.json msn2700.32ports.qos.json "
+# fi
 
 for file in $SWSSCONFIG_ARGS; do
     swssconfig /etc/swss/config.d/$file


### PR DESCRIPTION
Found BGP sessions not set up stably due to unknown issues related
to QOS/buffer configurations. Temporarily disable this feature for
further debugging.