### PR TITLE
Add a build mode to the installer to facilitate partition dump

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -38,15 +38,13 @@ if [ "$IMAGE_TYPE" = "onie" ]; then
 
     ## Generate a compressed 8GB partition dump that can be used to 'dd' in-lieu of using the onie-nos-installer
     ## The 'build' install mode of the installer is used to generate this dump.
-    if [[ "$TARGET_MACHINE" == "broadcom" ]] && [[ -n "$DELL_Z9100_PLATFORM_MODULE_VERSION" || -n "$DELL_S6100_PLATFORM_MODULE_VERSION" ]]; then
-        sudo chmod a+x $OUTPUT_ONIE_IMAGE
-        sudo ./$OUTPUT_ONIE_IMAGE
+    sudo chmod a+x $OUTPUT_ONIE_IMAGE
+    sudo ./$OUTPUT_ONIE_IMAGE
 
-        if [ -r /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img.gz ]; then
-            sudo mv /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img.gz target
-        else
-            echo "/tmp/sonic-${TARGET_MACHINE}_8GB_dd.img.gz not found !\n"
-        fi
+    if [ -r /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img.gz ]; then
+        sudo mv /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img.gz target
+    else
+        echo "/tmp/sonic-${TARGET_MACHINE}_8GB_dd.img.gz not found !\n"
     fi
 
 ## Use 'aboot' as target machine category which includes Aboot as bootloader

--- a/build_image.sh
+++ b/build_image.sh
@@ -35,6 +35,20 @@ if [ "$IMAGE_TYPE" = "onie" ]; then
     ./onie-mk-demo.sh $TARGET_PLATFORM $TARGET_MACHINE $TARGET_PLATFORM-$TARGET_MACHINE-$ONIEIMAGE_VERSION \
           installer platform/$TARGET_MACHINE/platform.conf $OUTPUT_ONIE_IMAGE OS $IMAGE_VERSION $ONIE_IMAGE_PART_SIZE \
           $ONIE_INSTALLER_PAYLOAD
+
+    ## Generate a compressed 8GB partition dump that can be used to 'dd' in-lieu of using the onie-nos-installer
+    ## The 'build' install mode of the installer is used to generate this dump.
+    if [[ "$TARGET_MACHINE" == "broadcom" ]] && [[ -n "$DELL_Z9100_PLATFORM_MODULE_VERSION" || -n "$DELL_S6100_PLATFORM_MODULE_VERSION" ]]; then
+        sudo chmod a+x $OUTPUT_ONIE_IMAGE
+        sudo ./$OUTPUT_ONIE_IMAGE
+
+        if [ -r /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img.gz ]; then
+            sudo mv /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img.gz target
+        else
+            echo "/tmp/sonic-${TARGET_MACHINE}_8GB_dd.img.gz not found !\n"
+        fi
+    fi
+
 ## Use 'aboot' as target machine category which includes Aboot as bootloader
 elif [ "$IMAGE_TYPE" = "aboot" ]; then
     echo "Build Aboot installer"

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -11,11 +11,29 @@
 #
 # By default this script does nothing.
 
+sonic_version=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
+
+if [ -f /host/image-$sonic_version/platform/migration ]; then
+
+    # Extract the machine.conf from ONIE
+    if [ ! -e /host/machine.conf ]; then
+        onie_dev=$(blkid | grep ONIE-BOOT | head -n 1 | awk '{print $1}' |  sed -e 's/:.*$//')
+        mkdir -p /mnt/onie-boot
+        mount $onie_dev /mnt/onie-boot
+
+        if [ ! -e /mnt/onie-boot/onie/grub/grub-machine.cfg ]; then
+            echo "/mnt/onie-boot/onie/grub/grub-machine.cfg not found" >> /etc/migration.log
+        else        
+            grep "=" /mnt/onie-boot/onie/grub/grub-machine.cfg > /host/machine.conf
+        fi
+    fi
+
+    rm /host/image-$sonic_version/platform/migration
+fi
+
 . /host/machine.conf
 
 echo "install platform dependent packages at the first boot time"
-
-sonic_version=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
 
 if [ -f /host/image-$sonic_version/platform/firsttime ]; then
 

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -24,8 +24,25 @@ _trap_push true
 set -e
 cd $(dirname $0)
 
+if [ -d "/etc/sonic" ]; then
+    echo "Installing SONiC in SONiC"
+    install_env="sonic"
+elif grep -Fxqs "DISTRIB_ID=onie" /etc/lsb-release > /dev/null
+then
+    echo "Installing SONiC in ONIE"
+    install_env="onie"
+else
+    echo "Installing SONiC in BUILD"
+    install_env="build"
+fi
+
+if [ -r ./machine.conf ]; then
 . ./machine.conf
+fi
+
+if [ -r ./onie-image.conf ]; then
 . ./onie-image.conf
+fi
 
 echo "ONIE Installer: platform: $platform"
 
@@ -40,7 +57,7 @@ if [ -r /etc/machine.conf ]; then
     . /etc/machine.conf
 elif [ -r /host/machine.conf ]; then
     . /host/machine.conf
-else
+elif [ "$install_env" != "build" ]; then
     echo "cannot find machine.conf"
     exit 1
 fi
@@ -58,26 +75,20 @@ ONIE_PLATFORM_EXTRA_CMDLINE_LINUX=""
 # Default var/log device size in MB
 VAR_LOG_SIZE=4096
 
-if [ -d "/etc/sonic" ]; then
-    echo "Installing SONiC in SONiC"
-    install_env="sonic"
-else
-    echo "Installing SONiC in ONIE"
-    install_env="onie"
-fi
-
 [ -r platforms/$onie_platform ] && . platforms/$onie_platform
 
 # Install demo on same block device as ONIE
-onie_dev=$(blkid | grep ONIE-BOOT | head -n 1 | awk '{print $1}' |  sed -e 's/:.*$//')
-blk_dev=$(echo $onie_dev | sed -e 's/[1-9][0-9]*$//' | sed -e 's/\([0-9]\)\(p\)/\1/')
-# Note: ONIE has no mount setting for / with device node, so below will be empty string
-cur_part=$(cat /proc/mounts | awk "{ if(\$2==\"/\") print \$1 }" | grep $blk_dev || true)
+if [ "$install_env" != "build" ]; then
+    onie_dev=$(blkid | grep ONIE-BOOT | head -n 1 | awk '{print $1}' |  sed -e 's/:.*$//')
+    blk_dev=$(echo $onie_dev | sed -e 's/[1-9][0-9]*$//' | sed -e 's/\([0-9]\)\(p\)/\1/')
+    # Note: ONIE has no mount setting for / with device node, so below will be empty string
+    cur_part=$(cat /proc/mounts | awk "{ if(\$2==\"/\") print \$1 }" | grep $blk_dev || true)
+fi
 
-[ -b "$blk_dev" ] || {
+if [ "$install_env" != "build" ] && [ ! -b "$blk_dev" ]; then
     echo "Error: Unable to determine block device of ONIE install"
     exit 1
-}
+fi
 
 # If running in ONIE
 if [ "$install_env" = "onie" ]; then
@@ -108,7 +119,7 @@ else
     firmware="bios"
 fi
 
-if [ "$install_env" != "sonic" ]; then
+if [ "$install_env" = "onie" ]; then
     # determine ONIE partition type
     onie_partition_type=$(${onie_bin} onie-sysinfo -t)
     # demo partition size in MB
@@ -310,6 +321,7 @@ demo_install_grub()
             cat $grub_install_log && rm -f $grub_install_log
             exit 1
         }
+
         rm -f $grub_install_log
 
         # restore immutable flag on the core.img file as discussed
@@ -374,7 +386,7 @@ demo_install_uefi_grub()
 
 image_dir="image-$image_version"
 
-if [ "$install_env" != "sonic" ]; then
+if [ "$install_env" = "onie" ]; then
     eval $create_demo_partition $blk_dev
     demo_dev=$(echo $blk_dev | sed -e 's/\(mmcblk[0-9]\)/\1p/')$demo_part
 
@@ -391,7 +403,8 @@ if [ "$install_env" != "sonic" ]; then
         echo "Error: Unable to mount $demo_dev on $demo_mnt"
         exit 1
     }
-else
+    
+elif [ "$install_env" = "sonic" ]; then
     demo_mnt="/host"
     running_sonic_revision=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
     # Prevent installing existing SONiC if it is running
@@ -406,6 +419,20 @@ else
             rm -rf $f
         fi
     done
+else
+    TARGET_MACHINE=`grep machine ./machine.conf | cut -d '=' -f 2`
+    demo_mnt="build_dd_image_mnt"
+
+    #remove older partition dump
+    rm -f /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img.gz
+
+    echo "Creating sonic-${TARGET_MACHINE}_8GB_dd.img..."
+    fallocate -l 8G /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img
+    mkfs.ext4 /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img
+
+    echo "Mounting /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img on $demo_mnt..."
+    mkdir $demo_mnt
+    mount -t auto -o loop /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img $demo_mnt
 fi
 
 echo "Installing SONiC to $demo_mnt/$image_dir"
@@ -423,6 +450,12 @@ fi
 
 # Decompress the file for the file system directly to the partition
 unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" -d $demo_mnt/$image_dir
+
+# Indicate that this filesystem is being generated using the installer on the build server
+# to facilitate migration from a 3rd party OS into SONiC
+if [ "$install_env" = "build" ]; then
+   touch $demo_mnt/$image_dir/platform/migration
+fi
 
 TAR_EXTRA_OPTION="--numeric-owner"
 mkdir -p $demo_mnt/$image_dir/$DOCKERFS_DIR
@@ -446,7 +479,7 @@ if [ "$VAR_LOG_SIZE" != "0" ]; then
     mkfs.ext4 -q $demo_mnt/disk-img/var-log.ext4 -F
 fi
 
-if [ "$install_env" != "sonic" ]; then
+if [ "$install_env" = "onie" ]; then
     # Store machine description in target file system
     cp /etc/machine.conf $demo_mnt
 
@@ -470,6 +503,14 @@ fi
 
 grub_cfg=$(mktemp)
 trap_push "rm $grub_cfg || true"
+
+# These parameters will be initialized post migration
+if [ "$install_env" = "build" ]; then
+    CONSOLE_PORT="CONSOLE_PORT"
+    CONSOLE_DEV="CONSOLE_DEV"
+    CONSOLE_SPEED="CONSOLE_SPEED"
+    demo_dev="ROOT_DEV"
+fi
 
 # Set a few GRUB_xxx environment variables that will be picked up and
 # used by the 50_onie_grub script.  This is similiar to what an OS
@@ -547,7 +588,7 @@ menuentry '$demo_grub_entry' {
 }
 EOF
 
-if [ "$install_env" != "sonic" ]; then
+if [ "$install_env" = "onie" ]; then
     # Add menu entries for ONIE -- use the grub fragment provided by the
     # ONIE distribution.
     $onie_root_dir/grub.d/50_onie_grub >> $grub_cfg
@@ -559,7 +600,13 @@ $onie_menuentry
 EOF
 fi
 
-cp $grub_cfg $onie_initrd_tmp/$demo_mnt/grub/grub.cfg
+if [ "$install_env" = "build" ]; then
+    cp $grub_cfg $demo_mnt/$image_dir/platform/grub.cfg.migration
+    gzip /tmp/sonic-${TARGET_MACHINE}_8GB_dd.img
+    umount $demo_mnt
+else
+    cp $grub_cfg $onie_initrd_tmp/$demo_mnt/grub/grub.cfg
+fi
 
 cd /
 


### PR DESCRIPTION
1. Add a new "build" mode in addition to the sonic & onie modes in the installer. If the installer is run on a build server, it should create a SONiC partition dump that can be used to 'dd' the partition instead of going thru ONIE or sonic install. This is useful in case a user wants to migrate into SONiC from another 3rd party OS.
2. Use the installer to create the 8GB blob for Dell's Z9100 & S6100
3. Once the SONiC boots up the 'firsttime' post a migration from a 3rd party OS, it performs certain initializations from rc.local like reconstructing machine.conf from ONIE.

Note: The installer currently checks the /etc/lsb-release to determine if it's a onie environment. The assumption is that DISTRIB_ID=onie will be present in all the ONIE builds across platforms.