### PR TITLE
[config services] Not to block syslog service on minigraph update

### DIFF
--- a/files/image_config/rsyslog/rsyslog-config.service
+++ b/files/image_config/rsyslog/rsyslog-config.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Update rsyslog configuration
-Before=rsyslog.service
 
 [Service]
 Type=oneshot

--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/rsyslog.conf.j2 >/etc/rsyslog.conf
+systemctl restart rsyslog


### PR DESCRIPTION
Old logic: update graph -> generate rsyslog config -> start rsyslog service
New logic: start rsyslog service (local only) -> update graph -> generate rsyslog config -> restart rsyslog service with rsyslog server configured