### PR TITLE
Revert "[mellanox]: Enable fast boot mode for SX kernel (#853)"

### DIFF
--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -18,7 +18,6 @@ ExecStartPre=/usr/bin/docker exec database redis-cli -n 1 FLUSHDB
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 2 FLUSHDB
 
 {% if sonic_asic_platform == 'mellanox' %}
-Environment=FAST_BOOT=1
 ExecStartPre=/etc/init.d/sxdkernel start
 ExecStartPre=/usr/bin/mst start
 ExecStartPre=/sbin/modprobe i2c-dev


### PR DESCRIPTION
This reverts commit 77a0bcbe30070f0f0c69457027b63cadf7afd872.

Revert due to issue with BGPv6 sessions