### PR TITLE
[sonic-slave]: Split user commands from generic.

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -254,31 +254,3 @@ RUN add-apt-repository \
 RUN apt-get update
 RUN apt-get install -y docker-ce=17.03.2~ce-0~debian-jessie
 RUN echo "DOCKER_OPTS=\"--experimental\"" >> /etc/default/docker
-
-# Add user
-ARG user
-ARG uid
-ARG guid
-ARG hostname
-
-ENV BUILD_HOSTNAME $hostname
-ENV USER $user
-
-RUN groupadd -f -r -g $guid g$user
-
-RUN useradd $user -l -u $uid -g $guid -d /var/$user -m -s /bin/bash
-
-RUN gpasswd -a $user docker
-
-# Config git for stg
-RUN su $user -c "git config --global user.name $user"
-RUN su $user -c "git config --global user.email $user@contoso.com"
-
-COPY sonic-jenkins-id_rsa.pub /var/$user/.ssh/authorized_keys2
-RUN chown $user /var/$user/.ssh -R
-RUN chmod go= /var/$user/.ssh -R
-
-# Add user to sudoers
-RUN echo "$user ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
-
-USER $user

--- a/sonic-slave/Dockerfile.user
+++ b/sonic-slave/Dockerfile.user
@@ -1,0 +1,29 @@
+FROM sonic-slave-base
+
+# Add user
+ARG user
+ARG uid
+ARG guid
+ARG hostname
+
+ENV BUILD_HOSTNAME $hostname
+ENV USER $user
+
+RUN groupadd -f -r -g $guid g$user
+
+RUN useradd $user -l -u $uid -g $guid -d /var/$user -m -s /bin/bash
+
+RUN gpasswd -a $user docker
+
+# Config git for stg
+RUN su $user -c "git config --global user.name $user"
+RUN su $user -c "git config --global user.email $user@contoso.com"
+
+COPY sonic-jenkins-id_rsa.pub /var/$user/.ssh/authorized_keys2
+RUN chown $user /var/$user/.ssh -R
+RUN chmod go= /var/$user/.ssh -R
+
+# Add user to sudoers
+RUN echo "$user ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
+
+USER $user


### PR DESCRIPTION
In case when more than one user builds SONiC on same machine, we can
keep generic part that installs all packages to slave image apart from
creating user and calling user-related commands. Then generic base image
will be built only once, allowing other users to build only smaller
specific to them layers.

Signed-off-by: marian-pritsak <marianp@mellanox.com>