### PR TITLE
[SAI]: Remove the SAI submodule from buildimage repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,10 +57,6 @@
 [submodule "platform/broadcom/sonic-platform-modules-ingrasys"]
 	path = platform/broadcom/sonic-platform-modules-ingrasys
 	url = https://github.com/Ingrasys-sonic/sonic-platform-modules-ingrasys
-[submodule "src/SAI"]
-	path = src/SAI
-	url = https://github.com/opencomputeproject/SAI
-	branch = v0.9.4
 [submodule "src/sonic-platform-daemons"]
 	path = src/sonic-platform-daemons
 	url = https://github.com/Azure/sonic-platform-daemons


### PR DESCRIPTION
SAI is a submodule of sonic-sairedis repository. Remove the dependency
from this repository.