### PR TITLE
Fix the network command for ipv6 vlan interfaces

### DIFF
--- a/dockers/docker-fpm-quagga/bgpd.conf.j2
+++ b/dockers/docker-fpm-quagga/bgpd.conf.j2
@@ -46,7 +46,13 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
 {% block vlan_advertisement %}
 {% for vlan_interface in minigraph_vlan_interfaces %}
+{% if vlan_interface['addr'] | ipv4 %}
   network {{ vlan_interface['subnet'] }}
+{% elif vlan_interface['addr'] | ipv6 %}
+  address-family ipv6
+   network {{ vlan_interface['subnet'] }}
+  exit-address-family
+{% endif %}
 {% endfor %}
 {% endblock vlan_advertisement %}
 {% block bgp_sessions %}


### PR DESCRIPTION
The network command for ipv6 addresses should be under address-family ipv6