### PR TITLE
Fixing a couple of issues to enable FRR to run with latest SONiC code.

### DIFF
--- a/dockers/docker-fpm-frr/config.sh
+++ b/dockers/docker-fpm-frr/config.sh
@@ -12,5 +12,10 @@ sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/unisolate
 chown root:root /usr/sbin/bgp-unisolate
 chmod 0755 /usr/sbin/bgp-unisolate
 
+# If there's an integrated-config file, go ahead and remote it
+if [ -f /etc/frr/frr.conf ]; then
+    rm -rf /etc/frr/frr.conf
+fi
+
 mkdir -p /var/sonic
 echo "# Config files managed by sonic-config-engine" >/var/sonic/config_status

--- a/dockers/docker-fpm-frr/zebra.conf.j2
+++ b/dockers/docker-fpm-frr/zebra.conf.j2
@@ -15,12 +15,12 @@ enable password zebra
 {% block interfaces %}
 ! Enable link-detect (default disabled)
 {% for interface in minigraph_interfaces %}
-interface {{ interface['alias'] }}
+interface {{ interface['attachto'] }}
 link-detect
 !
 {% endfor %}
-{% for interface in minigraph_portchannel_interfaces %}
-interface {{ interface['name'] }}
+{% for interface in minigraph_portchannels.keys() %}
+interface {{ interface }}
 link-detect
 !
 {% endfor %}


### PR DESCRIPTION
    * Adjusting FRR's jinja template to meet latest sonic-cfgen requirements. Basically, i'm just extending #448 changes into FRR.

    * Eliminate FRR's integrated-config file to prevent daemons from bypassing their own config files. FRR daemons now default to an integrated-config file for config-parsing purposes. But we are still interested in having each daemon looking in their specific config file (bgpd.conf, zebra.conf, etc). So here i'm just deleting this integrating-config file to prevent FRR from running from a bogus config-file.