### PR TITLE
Add arista-net initramfs hook

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -123,6 +123,10 @@ sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-
 sudo cp files/initramfs-tools/mke2fs $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/mke2fs
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/mke2fs
 
+# Hook into initramfs: rename the management interfaces on arista switches
+sudo cp files/initramfs-tools/arista-net $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-net
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-net
+
 ## Hook into initramfs: after partition mount and loop file mount
 ## 1. Prepare layered file system
 ## 2. Bind-mount docker working directory (docker aufs cannot work over aufs rootfs)

--- a/files/initramfs-tools/arista-net
+++ b/files/initramfs-tools/arista-net
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+case $1 in
+    prereqs)
+        exit 0
+        ;;
+esac
+
+set -e
+
+# Extract kernel parameters
+set -- $(cat /proc/cmdline)
+items=""
+for x in "$@"; do
+    case "$x" in
+        Aboot=*)
+            aboot_flag="${x#Aboot=}"
+            ;;
+        net_*)
+            item="${x#net_}"
+            items="$items $item"
+            ;;
+        platform=*)
+            platform_flag="${x#platform=}"
+            ;;
+    esac
+done
+
+arista_net_rename() {
+    local device_path="$1"
+    local new_name="$2"
+    local from_name="$3"
+    for path in $(ls -d /sys/class/net/$from_name* 2>/dev/null); do
+        local devid="$(realpath "$path/device")"
+        if echo "$devid" | grep -q "$device_path"; then
+            local cur_name="${path##*/}"
+            ip link set "$cur_name" name "$new_name"
+            return
+        fi
+    done
+}
+
+# Iterate over all the net_maX items found in the cmdline two times.
+# First time renaming the interfaces to maX.
+# The second time renaming them to their final name ethX.
+if [ -n "$aboot_flag" -a "$platform_flag" == 'rook' ]; then
+    for item in $items; do
+        key="${item%=*}"
+        value="${item#*=}"
+        arista_net_rename "$value" "$key" eth
+    done
+    for item in $items; do
+        key="${item%=*}"
+        value="${item#*=}"
+        index="${key#ma}"
+        index="$(( $index - 1 ))"
+        newKey="eth$index"
+        arista_net_rename "$value" "$newKey" ma
+    done
+fi
+


### PR DESCRIPTION
On some of the Arista models, the effective management interface was not named as eth0 in SONiC. This change will add an initramfs hook which fixes this issue by changing the names of management interfaces based on /proc/cmdline.