### PR TITLE
Update sfputil support for Arista platforms

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-Q16S64/port_config.ini
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-Q16S64/port_config.ini
@@ -1,57 +1,57 @@
-# name          lanes             alias
-Ethernet0       125,126,127,128   Ethernet1/1
-Ethernet4       121,122,123,124   Ethernet2/1
-Ethernet8       13,14,15,16       Ethernet3/1
-Ethernet12      9,10,11,12        Ethernet4/1
-Ethernet16      17,18,19,20       Ethernet5/1
-Ethernet20      21,22,23,24       Ethernet6/1
-Ethernet24      25,26,27,28       Ethernet7/1
-Ethernet28      29,30,31,32       Ethernet8/1
-Ethernet32      37,38,39,40       Ethernet9/1
-Ethernet36      33,34,35,36       Ethernet10/1
-Ethernet40      45,46,47,48       Ethernet11/1
-Ethernet44      41,42,43,44       Ethernet12/1
-Ethernet48      53,54,55,56       Ethernet13/1
-Ethernet52      49,50,51,52       Ethernet14/1
-Ethernet56      69,70,71,72       Ethernet15/1
-Ethernet60      65,66,67,68       Ethernet16/1
-Ethernet64      77                Ethernet17/1
-Ethernet65      78                Ethernet17/2
-Ethernet66      79                Ethernet17/3
-Ethernet67      80                Ethernet17/4
-Ethernet68      73                Ethernet18/1
-Ethernet69      74                Ethernet18/2
-Ethernet70      75                Ethernet18/3
-Ethernet71      76                Ethernet18/4
-Ethernet72      93                Ethernet19/1
-Ethernet73      94                Ethernet19/2
-Ethernet74      95                Ethernet19/3
-Ethernet75      96                Ethernet19/4
-Ethernet76      89                Ethernet20/1
-Ethernet77      90                Ethernet20/2
-Ethernet78      91                Ethernet20/3
-Ethernet79      92                Ethernet20/4
-Ethernet80      101               Ethernet21/1
-Ethernet81      102               Ethernet21/2
-Ethernet82      103               Ethernet21/3
-Ethernet83      104               Ethernet21/4
-Ethernet84      97                Ethernet22/1
-Ethernet85      98                Ethernet22/2
-Ethernet86      99                Ethernet22/3
-Ethernet87      100               Ethernet22/4
-Ethernet88      109               Ethernet23/1
-Ethernet89      110               Ethernet23/2
-Ethernet90      111               Ethernet23/3
-Ethernet91      112               Ethernet23/4
-Ethernet92      105               Ethernet24/1
-Ethernet93      106               Ethernet24/2
-Ethernet94      107               Ethernet24/3
-Ethernet95      108               Ethernet24/4
-Ethernet96      61,62,63,64       Ethernet25
-Ethernet100     57,58,59,60       Ethernet26
-Ethernet104     81,82,83,84       Ethernet27
-Ethernet108     85,86,87,88       Ethernet28
-Ethernet112     117,118,119,120   Ethernet29
-Ethernet116     113,114,115,116   Ethernet30
-Ethernet120     5,6,7,8           Ethernet31
-Ethernet124     1,2,3,4           Ethernet32
+# name          lanes             alias         port
+Ethernet0       125,126,127,128   Ethernet1/1   1
+Ethernet4       121,122,123,124   Ethernet2/1   2
+Ethernet8       13,14,15,16       Ethernet3/1   3
+Ethernet12      9,10,11,12        Ethernet4/1   4
+Ethernet16      17,18,19,20       Ethernet5/1   5
+Ethernet20      21,22,23,24       Ethernet6/1   6
+Ethernet24      25,26,27,28       Ethernet7/1   7
+Ethernet28      29,30,31,32       Ethernet8/1   8
+Ethernet32      37,38,39,40       Ethernet9/1   9
+Ethernet36      33,34,35,36       Ethernet10/1  10
+Ethernet40      45,46,47,48       Ethernet11/1  11
+Ethernet44      41,42,43,44       Ethernet12/1  12
+Ethernet48      53,54,55,56       Ethernet13/1  13
+Ethernet52      49,50,51,52       Ethernet14/1  14
+Ethernet56      69,70,71,72       Ethernet15/1  15
+Ethernet60      65,66,67,68       Ethernet16/1  16
+Ethernet64      77                Ethernet17/1  17
+Ethernet65      78                Ethernet17/2  17
+Ethernet66      79                Ethernet17/3  17
+Ethernet67      80                Ethernet17/4  17
+Ethernet68      73                Ethernet18/1  18
+Ethernet69      74                Ethernet18/2  18
+Ethernet70      75                Ethernet18/3  18
+Ethernet71      76                Ethernet18/4  18
+Ethernet72      93                Ethernet19/1  19
+Ethernet73      94                Ethernet19/2  19
+Ethernet74      95                Ethernet19/3  19
+Ethernet75      96                Ethernet19/4  19
+Ethernet76      89                Ethernet20/1  20
+Ethernet77      90                Ethernet20/2  20
+Ethernet78      91                Ethernet20/3  20
+Ethernet79      92                Ethernet20/4  20
+Ethernet80      101               Ethernet21/1  21
+Ethernet81      102               Ethernet21/2  21
+Ethernet82      103               Ethernet21/3  21
+Ethernet83      104               Ethernet21/4  21
+Ethernet84      97                Ethernet22/1  22
+Ethernet85      98                Ethernet22/2  22
+Ethernet86      99                Ethernet22/3  22
+Ethernet87      100               Ethernet22/4  22
+Ethernet88      109               Ethernet23/1  23
+Ethernet89      110               Ethernet23/2  23
+Ethernet90      111               Ethernet23/3  23
+Ethernet91      112               Ethernet23/4  23
+Ethernet92      105               Ethernet24/1  24
+Ethernet93      106               Ethernet24/2  24
+Ethernet94      107               Ethernet24/3  24
+Ethernet95      108               Ethernet24/4  24
+Ethernet96      61,62,63,64       Ethernet25    25
+Ethernet100     57,58,59,60       Ethernet26    26
+Ethernet104     81,82,83,84       Ethernet27    27
+Ethernet108     85,86,87,88       Ethernet28    28
+Ethernet112     117,118,119,120   Ethernet29    29
+Ethernet116     113,114,115,116   Ethernet30    30
+Ethernet120     5,6,7,8           Ethernet31    31
+Ethernet124     1,2,3,4           Ethernet32    32

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/port_config.ini
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes             alias
-Ethernet0       125,126,127,128   Ethernet1/1
-Ethernet4       121,122,123,124   Ethernet2/1
-Ethernet8       13,14,15,16       Ethernet3/1
-Ethernet12      9,10,11,12        Ethernet4/1
-Ethernet16      17,18,19,20       Ethernet5/1
-Ethernet20      21,22,23,24       Ethernet6/1
-Ethernet24      25,26,27,28       Ethernet7/1
-Ethernet28      29,30,31,32       Ethernet8/1
-Ethernet32      37,38,39,40       Ethernet9/1
-Ethernet36      33,34,35,36       Ethernet10/1
-Ethernet40      45,46,47,48       Ethernet11/1
-Ethernet44      41,42,43,44       Ethernet12/1
-Ethernet48      53,54,55,56       Ethernet13/1
-Ethernet52      49,50,51,52       Ethernet14/1
-Ethernet56      69,70,71,72       Ethernet15/1
-Ethernet60      65,66,67,68       Ethernet16/1
-Ethernet64      77,78,79,80       Ethernet17/1
-Ethernet68      73,74,75,76       Ethernet18/1
-Ethernet72      93,94,95,96       Ethernet19/1
-Ethernet76      89,90,91,92       Ethernet20/1
-Ethernet80      101,102,103,104   Ethernet21/1
-Ethernet84      97,98,99,100      Ethernet22/1
-Ethernet88      109,110,111,112   Ethernet23/1
-Ethernet92      105,106,107,108   Ethernet24/1
-Ethernet96      61,62,63,64       Ethernet25
-Ethernet100     57,58,59,60       Ethernet26
-Ethernet104     81,82,83,84       Ethernet27
-Ethernet108     85,86,87,88       Ethernet28
-Ethernet112     117,118,119,120   Ethernet29
-Ethernet116     113,114,115,116   Ethernet30
-Ethernet120     5,6,7,8           Ethernet31
-Ethernet124     1,2,3,4           Ethernet32
+# name          lanes             alias         port
+Ethernet0       125,126,127,128   Ethernet1/1   1
+Ethernet4       121,122,123,124   Ethernet2/1   2
+Ethernet8       13,14,15,16       Ethernet3/1   3
+Ethernet12      9,10,11,12        Ethernet4/1   4
+Ethernet16      17,18,19,20       Ethernet5/1   5
+Ethernet20      21,22,23,24       Ethernet6/1   6
+Ethernet24      25,26,27,28       Ethernet7/1   7
+Ethernet28      29,30,31,32       Ethernet8/1   8
+Ethernet32      37,38,39,40       Ethernet9/1   9
+Ethernet36      33,34,35,36       Ethernet10/1  10
+Ethernet40      45,46,47,48       Ethernet11/1  11
+Ethernet44      41,42,43,44       Ethernet12/1  12
+Ethernet48      53,54,55,56       Ethernet13/1  13
+Ethernet52      49,50,51,52       Ethernet14/1  14
+Ethernet56      69,70,71,72       Ethernet15/1  15
+Ethernet60      65,66,67,68       Ethernet16/1  16
+Ethernet64      77,78,79,80       Ethernet17/1  17
+Ethernet68      73,74,75,76       Ethernet18/1  18
+Ethernet72      93,94,95,96       Ethernet19/1  19
+Ethernet76      89,90,91,92       Ethernet20/1  20
+Ethernet80      101,102,103,104   Ethernet21/1  21
+Ethernet84      97,98,99,100      Ethernet22/1  22
+Ethernet88      109,110,111,112   Ethernet23/1  23
+Ethernet92      105,106,107,108   Ethernet24/1  24
+Ethernet96      61,62,63,64       Ethernet25    25
+Ethernet100     57,58,59,60       Ethernet26    26
+Ethernet104     81,82,83,84       Ethernet27    27
+Ethernet108     85,86,87,88       Ethernet28    28
+Ethernet112     117,118,119,120   Ethernet29    29
+Ethernet116     113,114,115,116   Ethernet30    30
+Ethernet120     5,6,7,8           Ethernet31    31
+Ethernet124     1,2,3,4           Ethernet32    32

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/port_config.ini
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes             alias
-Ethernet0       9,10,11,12        Ethernet5/1
-Ethernet4       13,14,15,16       Ethernet6/1
-Ethernet8       17,18,19,20       Ethernet7/1
-Ethernet12      21,22,23,24       Ethernet8/1
-Ethernet16      29,30,31,32       Ethernet9/1
-Ethernet20      25,26,27,28       Ethernet10/1
-Ethernet24      33,34,35,36       Ethernet11/1
-Ethernet28      37,38,39,40       Ethernet12/1
-Ethernet32      45,46,47,48       Ethernet13/1
-Ethernet36      41,42,43,44       Ethernet14/1
-Ethernet40      49,50,51,52       Ethernet15/1
-Ethernet44      53,54,55,56       Ethernet16/1
-Ethernet48      69,70,71,72       Ethernet17/1
-Ethernet52      65,66,67,68       Ethernet18/1
-Ethernet56      73,74,75,76       Ethernet19/1
-Ethernet60      77,78,79,80       Ethernet20/1
-Ethernet64      93,94,95,96       Ethernet21/1
-Ethernet68      89,90,91,92       Ethernet22/1
-Ethernet72      97,98,99,100      Ethernet23/1
-Ethernet76      101,102,103,104   Ethernet24/1
-Ethernet80      109,110,111,112   Ethernet25/1
-Ethernet84      105,106,107,108   Ethernet26/1
-Ethernet88      121,122,123,124   Ethernet27/1
-Ethernet92      125,126,127,128   Ethernet28/1
-Ethernet96      61,62,63,64       Ethernet29
-Ethernet100     57,58,59,60       Ethernet30
-Ethernet104     81,82,83,84       Ethernet31
-Ethernet108     85,86,87,88       Ethernet32
-Ethernet112     117,118,119,120   Ethernet33
-Ethernet116     113,114,115,116   Ethernet34
-Ethernet120     1,2,3,4           Ethernet35
-Ethernet124     5,6,7,8           Ethernet36
+# name          lanes             alias         port
+Ethernet0       9,10,11,12        Ethernet5/1   5
+Ethernet4       13,14,15,16       Ethernet6/1   6
+Ethernet8       17,18,19,20       Ethernet7/1   7
+Ethernet12      21,22,23,24       Ethernet8/1   8
+Ethernet16      29,30,31,32       Ethernet9/1   9
+Ethernet20      25,26,27,28       Ethernet10/1  10
+Ethernet24      33,34,35,36       Ethernet11/1  11
+Ethernet28      37,38,39,40       Ethernet12/1  12
+Ethernet32      45,46,47,48       Ethernet13/1  13
+Ethernet36      41,42,43,44       Ethernet14/1  14
+Ethernet40      49,50,51,52       Ethernet15/1  15
+Ethernet44      53,54,55,56       Ethernet16/1  16
+Ethernet48      69,70,71,72       Ethernet17/1  17
+Ethernet52      65,66,67,68       Ethernet18/1  18
+Ethernet56      73,74,75,76       Ethernet19/1  19
+Ethernet60      77,78,79,80       Ethernet20/1  20
+Ethernet64      93,94,95,96       Ethernet21/1  21
+Ethernet68      89,90,91,92       Ethernet22/1  22
+Ethernet72      97,98,99,100      Ethernet23/1  23
+Ethernet76      101,102,103,104   Ethernet24/1  24
+Ethernet80      109,110,111,112   Ethernet25/1  25
+Ethernet84      105,106,107,108   Ethernet26/1  26
+Ethernet88      121,122,123,124   Ethernet27/1  27
+Ethernet92      125,126,127,128   Ethernet28/1  28
+Ethernet96      61,62,63,64       Ethernet29    29
+Ethernet100     57,58,59,60       Ethernet30    30
+Ethernet104     81,82,83,84       Ethernet31    31
+Ethernet108     85,86,87,88       Ethernet32    32
+Ethernet112     117,118,119,120   Ethernet33    33
+Ethernet116     113,114,115,116   Ethernet34    34
+Ethernet120     1,2,3,4           Ethernet35    35
+Ethernet124     5,6,7,8           Ethernet36    36

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060-CX32S/port_config.ini
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060-CX32S/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes             alias
-Ethernet0       33,34,35,36       Ethernet1/1
-Ethernet4       37,38,39,40       Ethernet2/1
-Ethernet8       41,42,43,44       Ethernet3/1
-Ethernet12      45,46,47,48       Ethernet4/1
-Ethernet16      49,50,51,52       Ethernet5/1
-Ethernet20      53,54,55,56       Ethernet6/1
-Ethernet24      57,58,59,60       Ethernet7/1
-Ethernet28      61,62,63,64       Ethernet8/1
-Ethernet32      65,66,67,68       Ethernet9/1
-Ethernet36      69,70,71,72       Ethernet10/1
-Ethernet40      73,74,75,76       Ethernet11/1
-Ethernet44      77,78,79,80       Ethernet12/1
-Ethernet48      81,82,83,84       Ethernet13/1
-Ethernet52      85,86,87,88       Ethernet14/1
-Ethernet56      89,90,91,92       Ethernet15/1
-Ethernet60      93,94,95,96       Ethernet16/1
-Ethernet64      97,98,99,100      Ethernet17/1
-Ethernet68      101,102,103,104   Ethernet18/1
-Ethernet72      105,106,107,108   Ethernet19/1
-Ethernet76      109,110,111,112   Ethernet20/1
-Ethernet80      113,114,115,116   Ethernet21/1
-Ethernet84      117,118,119,120   Ethernet22/1
-Ethernet88      121,122,123,124   Ethernet23/1
-Ethernet92      125,126,127,128   Ethernet24/1
-Ethernet96      1,2,3,4           Ethernet25/1
-Ethernet100     5,6,7,8           Ethernet26/1
-Ethernet104     9,10,11,12        Ethernet27/1
-Ethernet108     13,14,15,16       Ethernet28/1
-Ethernet112     17,18,19,20       Ethernet29/1
-Ethernet116     21,22,23,24       Ethernet30/1
-Ethernet120     25,26,27,28       Ethernet31/1
-Ethernet124     29,30,31,32       Ethernet32/1
+# name          lanes             alias         port
+Ethernet0       33,34,35,36       Ethernet1/1   1
+Ethernet4       37,38,39,40       Ethernet2/1   2
+Ethernet8       41,42,43,44       Ethernet3/1   3
+Ethernet12      45,46,47,48       Ethernet4/1   4
+Ethernet16      49,50,51,52       Ethernet5/1   5
+Ethernet20      53,54,55,56       Ethernet6/1   6
+Ethernet24      57,58,59,60       Ethernet7/1   7
+Ethernet28      61,62,63,64       Ethernet8/1   8
+Ethernet32      65,66,67,68       Ethernet9/1   9
+Ethernet36      69,70,71,72       Ethernet10/1  10
+Ethernet40      73,74,75,76       Ethernet11/1  11
+Ethernet44      77,78,79,80       Ethernet12/1  12
+Ethernet48      81,82,83,84       Ethernet13/1  13
+Ethernet52      85,86,87,88       Ethernet14/1  14
+Ethernet56      89,90,91,92       Ethernet15/1  15
+Ethernet60      93,94,95,96       Ethernet16/1  16
+Ethernet64      97,98,99,100      Ethernet17/1  17
+Ethernet68      101,102,103,104   Ethernet18/1  18
+Ethernet72      105,106,107,108   Ethernet19/1  19
+Ethernet76      109,110,111,112   Ethernet20/1  20
+Ethernet80      113,114,115,116   Ethernet21/1  21
+Ethernet84      117,118,119,120   Ethernet22/1  22
+Ethernet88      121,122,123,124   Ethernet23/1  23
+Ethernet92      125,126,127,128   Ethernet24/1  24
+Ethernet96      1,2,3,4           Ethernet25/1  25
+Ethernet100     5,6,7,8           Ethernet26/1  26
+Ethernet104     9,10,11,12        Ethernet27/1  27
+Ethernet108     13,14,15,16       Ethernet28/1  28
+Ethernet112     17,18,19,20       Ethernet29/1  29
+Ethernet116     21,22,23,24       Ethernet30/1  30
+Ethernet120     25,26,27,28       Ethernet31/1  31
+Ethernet124     29,30,31,32       Ethernet32/1  32

--- a/device/arista/x86_64-arista_7060_cx32s/plugins/sfputil.py
+++ b/device/arista/x86_64-arista_7060_cx32s/plugins/sfputil.py
@@ -1,9 +1,12 @@
-#!/usr/bin/env python
+# sfputil.py
+#
+# Platform-specific SFP transceiver interface for SONiC
+#
 
 try:
     import arista.utils.sonic_sfputil as arista_sfputil
-except ImportError, e:
-    raise ImportError (str(e) + "- required module not found")
+except ImportError as e:
+    raise ImportError("%s - required module not found" % str(e))
 
 
-sfputil = arista_sfputil.getSfpUtil()
+SfpUtil = arista_sfputil.getSfpUtil()

--- a/device/arista/x86_64-arista_7260cx3_64/plugins/sfputil.py
+++ b/device/arista/x86_64-arista_7260cx3_64/plugins/sfputil.py
@@ -1,8 +1,12 @@
-#!/usr/bin/env python
+# sfputil.py
+#
+# Platform-specific SFP transceiver interface for SONiC
+#
 
 try:
-   import arista.utils.sonic_sfputil as arista_sfputil
-except ImportError, e:
-   raise ImportError (str(e) + "- required module not found")
+    import arista.utils.sonic_sfputil as arista_sfputil
+except ImportError as e:
+    raise ImportError("%s - required module not found" % str(e))
 
-sfputil = arista_sfputil.getSfpUtil()
+
+SfpUtil = arista_sfputil.getSfpUtil()


### PR DESCRIPTION
 * Bump sonic-platform-modules-arista submodule
    * Extend support of sfputil to all platforms
    * Improve loading time of the drivers drastically
 * Fix sfputil plugin for arista_7060_cx32s
 * Fix sfputil plugin for arista_7260cx3_64
 * Add front panel port number to all arista port_config.ini files