### PR TITLE
[quagga] enable core dump for bgpd and zebra

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -243,6 +243,7 @@ set /files/etc/sysctl.conf/kernel.core_pattern '|/usr/bin/coredump-compress %e %
 
 set /files/etc/sysctl.conf/kernel.softlockup_panic 1
 set /files/etc/sysctl.conf/kernel.panic 10
+set /files/etc/sysctl.conf/fs.suid_dumpable 2
 
 set /files/etc/sysctl.conf/net.ipv4.conf.default.forwarding 1
 set /files/etc/sysctl.conf/net.ipv4.conf.all.forwarding 1

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -239,7 +239,7 @@ EOF
 ## Config sysctl
 sudo mkdir -p $FILESYSTEM_ROOT/var/core
 sudo augtool --autosave "
-set /files/etc/sysctl.conf/kernel.core_pattern '|/usr/bin/coredump-compress %e %p'
+set /files/etc/sysctl.conf/kernel.core_pattern '|/usr/bin/coredump-compress %e %t %p'
 
 set /files/etc/sysctl.conf/kernel.softlockup_panic 1
 set /files/etc/sysctl.conf/kernel.panic 10


### PR DESCRIPTION
bgpd and zebra are started by root but they downgrade their privilege to quagga user shortly after
started.

As result, core dump for setuid process needs to be enabled so that we could get core dump from
them when they crashes.