### PR TITLE
[baseimage]: allocate varlog disk in the initramfs stage

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -132,6 +132,8 @@ sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-
 ## 2. Bind-mount docker working directory (docker aufs cannot work over aufs rootfs)
 sudo cp files/initramfs-tools/union-mount $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-bottom/union-mount
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-bottom/union-mount
+sudo cp files/initramfs-tools/varlog $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-bottom/varlog
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-bottom/varlog
 sudo cp files/initramfs-tools/union-fsck $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/union-fsck
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/union-fsck
 sudo chroot $FILESYSTEM_ROOT update-initramfs -u

--- a/files/initramfs-tools/arista-convertfs.j2
+++ b/files/initramfs-tools/arista-convertfs.j2
@@ -82,28 +82,6 @@ run_cmd() {
     fi
 }
 
-create_varlog_file() {
-    local err_msg="Error: create var-log ext4 file"
-    local cmd="[ -n "$varlog_size" ] && mkdir -p $root_mnt/disk-img && dd if=/dev/zero of=$root_mnt/disk-img/var-log.ext4 count=$((2048*$varlog_size)) && mke2fs -t ext4 -q -F $root_mnt/disk-img/var-log.ext4"
-    run_cmd "$cmd" "$err_msg"
-}
-
-mount_and_create_varlog_file() {
-    [ -z "$varlog_size" ] && exit 0
-    mkdir -p "$root_mnt"
-    mount -t ext4 "$root_dev" "$root_mnt"
-    # exit when the var_log.ext4 exists and the size matches
-    if [ -e "$root_mnt/disk-img/var-log.ext4" ]; then
-        cur_varlog_size=$(ls -l $root_mnt/disk-img/var-log.ext4 | awk '{print $5}')
-        if [ $cur_varlog_size == $((1024*1024*$varlog_size)) ]; then
-            exit 0
-        fi
-    fi
-    create_varlog_file
-    umount "$root_mnt"
-    exit 0
-}
-
 # Extract kernel parameters
 set -- $(cat /proc/cmdline)
 for x in "$@"; do
@@ -113,9 +91,6 @@ for x in "$@"; do
             ;;
         Aboot=*)
             aboot_flag="${x#Aboot=}"
-            ;;
-        varlog_size=*)
-            varlog_size="${x#varlog_size=}"
             ;;
         loop=*)
             x1="${x#loop=}"
@@ -135,8 +110,8 @@ if ! wait_for_root_dev; then
     exit 1
 fi
 
-# mount, create varlog file and exit when the root is ext4
-blkid | grep "$root_dev.*vfat" -q || mount_and_create_varlog_file
+# exit when the root is ext4
+blkid | grep "$root_dev.*vfat" -q || exit 0
 
 # Get flash dev name
 if [ -z "$block_flash" ]; then
@@ -201,5 +176,3 @@ run_cmd "$cmd" "$err_msg"
 err_msg="Error: copying files form $tmp_mnt to $root_mnt failed"
 cmd="cp -a $tmp_mnt/. $root_mnt/"
 run_cmd "$cmd" "$err_msg"
-
-create_varlog_file

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -1,6 +1,12 @@
 #!/bin/sh -e
+
+PREREQS="varlog"
+
+prereqs() { echo "$PREREQS"; }
+
 case $1 in
   prereqs)
+  prereqs
     exit 0
     ;;
 esac

--- a/files/initramfs-tools/varlog
+++ b/files/initramfs-tools/varlog
@@ -1,0 +1,36 @@
+#!/bin/sh -e
+
+PREREQS=""
+
+prereqs() { echo "$PREREQS"; }
+
+case $1 in
+  prereqs)
+  prereqs
+    exit 0
+    ;;
+esac
+
+# Extract kernel parameters
+set -- $(cat /proc/cmdline)
+for x in "$@"; do
+    case "$x" in
+        varlog_size=*)
+            varlog_size="${x#varlog_size=}"
+    esac
+done
+
+[ -z "$varlog_size" ] && exit 0
+
+# exit when the var_log.ext4 exists and the size matches
+if [ -e "${rootmnt}/host/disk-img/var-log.ext4" ]; then
+    cur_varlog_size=$(ls -l ${rootmnt}/host/disk-img/var-log.ext4 | awk '{print $5}')
+    if [ $cur_varlog_size == $((1024*1024*$varlog_size)) ]; then
+        exit 0
+    else
+        rm -rf ${rootmnt}/host/disk-img
+    fi
+fi
+
+# create varlog disk
+mkdir -p ${rootmnt}/host/disk-img && ${rootmnt}/usr/bin/fallocate -l "$varlog_size"M ${rootmnt}/host/disk-img/var-log.ext4 && mkfs.ext4 -q -F ${rootmnt}/host/disk-img/var-log.ext4

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -450,24 +450,6 @@ TAR_EXTRA_OPTION="--numeric-owner"
 mkdir -p $demo_mnt/$image_dir/$DOCKERFS_DIR
 unzip -op $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
 
-# Create loop device for /var/log to limit its size to $VAR_LOG_SIZE MB
-if [ -f $demo_mnt/disk-img/var-log.ext4 ]; then
-    current_log_size_mb=$(ls -l --block-size=M $demo_mnt/disk-img/var-log.ext4 | cut -f5 -d" ")
-    if [ "$current_log_size_mb" = "$VAR_LOG_SIZE"M ]; then
-        echo "Log file system already exists. Size: ${VAR_LOG_SIZE}MB"
-        VAR_LOG_SIZE=0
-    else
-        rm -rf $demo_mnt/disk-img
-    fi
-fi
-
-if [ "$VAR_LOG_SIZE" != "0" ]; then
-    echo "Creating new log file system. Size: ${VAR_LOG_SIZE}MB"
-    mkdir -p $demo_mnt/disk-img
-    dd if=/dev/zero of=$demo_mnt/disk-img/var-log.ext4 count=$((2048*$VAR_LOG_SIZE))
-    mkfs.ext4 -q $demo_mnt/disk-img/var-log.ext4 -F
-fi
-
 if [ "$install_env" = "onie" ]; then
     # Store machine description in target file system
     cp /etc/machine.conf $demo_mnt
@@ -563,7 +545,7 @@ menuentry '$demo_grub_entry' {
         insmod ext2
         linux   /$image_dir/boot/vmlinuz-3.16.0-4-amd64 root=$demo_dev rw $GRUB_CMDLINE_LINUX  \
                 loop=$image_dir/$FILESYSTEM_SQUASHFS loopfstype=squashfs                       \
-                apparmor=1 security=apparmor $ONIE_PLATFORM_EXTRA_CMDLINE_LINUX
+                apparmor=1 security=apparmor varlog_size=$VAR_LOG_SIZE $ONIE_PLATFORM_EXTRA_CMDLINE_LINUX
         echo    'Loading $demo_volume_label $demo_type initial ramdisk ...'
         initrd  /$image_dir/boot/initrd.img-3.16.0-4-amd64
 }


### PR DESCRIPTION
moving to initramfs unifies disk allocate on different platforms.
use fallocate instead of dd to speed up the disk allocation.

By default, mkfs.ext4 has -E discard option which discards the blocks
at the mkfs time, also speed up the initialization time.