### PR TITLE
[Broadcom]: Remove BRCM_OPENNSL library

### DIFF
--- a/platform/broadcom/rules.mk
+++ b/platform/broadcom/rules.mk
@@ -29,7 +29,7 @@ SONIC_ALL += $(SONIC_ONE_IMAGE) $(SONIC_ONE_ABOOT_IMAGE) \
              $(DOCKER_FPM)
 
 # Inject brcm sai into sairedis
-$(LIBSAIREDIS)_DEPENDS += $(BRCM_OPENNSL) $(BRCM_SAI) $(BRCM_SAI_DEV) #$(LIBSAITHRIFT_DEV_BRCM)
+$(LIBSAIREDIS)_DEPENDS += $(BRCM_SAI) $(BRCM_SAI_DEV) #$(LIBSAITHRIFT_DEV_BRCM)
 
 # Runtime dependency on brcm sai is set only for syncd
-$(SYNCD)_RDEPENDS += $(BRCM_OPENNSL) $(BRCM_SAI)
+$(SYNCD)_RDEPENDS += $(BRCM_SAI)

--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,12 +1,11 @@
-BRCM_SAI = libsaibcm_3.0.2.3_amd64.deb
+BRCM_SAI = libsaibcm_3.0.3.2_amd64.deb
 # TODO: upload new SAI build to blob
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.0.2.3_amd64.deb"
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.0.3.2_amd64.deb"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.0.2.3_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.0.3.2_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
 # TODO: upload new SAI build to blob
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.0.2.3_amd64.deb"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.0.3.2_amd64.deb"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI) $(BRCM_SAI_DEV)
-$(BRCM_SAI)_DEPENDS += $(BRCM_OPENNSL)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)

--- a/platform/broadcom/sdk.mk
+++ b/platform/broadcom/sdk.mk
@@ -1,9 +1,5 @@
-BRCM_OPENNSL = libopennsl_3.2.3.3_amd64.deb
-# TODO: upload new SDK build to blob
-$(BRCM_OPENNSL)_URL = "https://sonicstorage.blob.core.windows.net/packages/libopennsl_3.2.3.3_amd64.deb"
-
 BRCM_OPENNSL_KERNEL = opennsl-modules-3.16.0-4-amd64_3.2.3.3_amd64.deb
 # TODO: upload new SDK build to blob
 $(BRCM_OPENNSL_KERNEL)_URL = "https://sonicstorage.blob.core.windows.net/packages/opennsl-modules-3.16.0-4-amd64_3.2.3.3_amd64.deb"
 
-SONIC_ONLINE_DEBS += $(BRCM_OPENNSL) $(BRCM_OPENNSL_KERNEL)
+SONIC_ONLINE_DEBS += $(BRCM_OPENNSL_KERNEL)


### PR DESCRIPTION
This library will be archived in to BRCM_SAI library