### PR TITLE
[ptf]: Change device socket port to the first port

### DIFF
--- a/dockers/docker-ptf/conf.d/ptf_nn_agent.conf
+++ b/dockers/docker-ptf/conf.d/ptf_nn_agent.conf
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 0@tcp://127.0.0.1:10900 -i 0-3@eth3
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 0@tcp://127.0.0.1:10900 -i 0-0@eth0
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log
 stderr_logfile=/tmp/ptf_nn_agent.err.log

--- a/platform/broadcom/docker-syncd-brcm-rpc/ptf_nn_agent.conf
+++ b/platform/broadcom/docker-syncd-brcm-rpc/ptf_nn_agent.conf
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-3@Ethernet12 --set-iface-rcv-buffer=109430400
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-0@Ethernet0 --set-iface-rcv-buffer=109430400
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log
 stderr_logfile=/tmp/ptf_nn_agent.err.log

--- a/platform/cavium/docker-syncd-cavm-rpc/ptf_nn_agent.conf
+++ b/platform/cavium/docker-syncd-cavm-rpc/ptf_nn_agent.conf
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-3@Ethernet12 --set-iface-rcv-buffer=109430400
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-0@Ethernet0 --set-iface-rcv-buffer=109430400
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log
 stderr_logfile=/tmp/ptf_nn_agent.err.log

--- a/platform/centec/docker-syncd-centec-rpc/ptf_nn_agent.conf
+++ b/platform/centec/docker-syncd-centec-rpc/ptf_nn_agent.conf
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-3@Ethernet12 --set-iface-rcv-buffer=109430400
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-0@Ethernet0 --set-iface-rcv-buffer=109430400
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log
 stderr_logfile=/tmp/ptf_nn_agent.err.log

--- a/platform/marvell/docker-syncd-mrvl-rpc/ptf_nn_agent.conf
+++ b/platform/marvell/docker-syncd-mrvl-rpc/ptf_nn_agent.conf
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-3@Ethernet12 --set-iface-rcv-buffer=109430400
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-0@Ethernet0 --set-iface-rcv-buffer=109430400
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log
 stderr_logfile=/tmp/ptf_nn_agent.err.log

--- a/platform/mellanox/docker-syncd-mlnx-rpc/ptf_nn_agent.conf
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/ptf_nn_agent.conf
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-3@Ethernet12 --set-iface-rcv-buffer=109430400
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-0@Ethernet0 --set-iface-rcv-buffer=109430400
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log
 stderr_logfile=/tmp/ptf_nn_agent.err.log


### PR DESCRIPTION
- The third port is not always up in some topologies. This minor change allows
  the COPP test to be run on various topologies. Later, a better solution could
  be proposed to find a random UP port used for device socket.