### PR TITLE
[build/onie installer] Install grub for SONiC post migration from another NOS

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -63,6 +63,7 @@ if [[ -d $FILESYSTEM_ROOT ]]; then
 fi
 mkdir -p $FILESYSTEM_ROOT
 mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR
+mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/x86_64-grub
 touch $FILESYSTEM_ROOT/$PLATFORM_DIR/firsttime
 
 ## Build a basic Debian system by debootstrap
@@ -206,9 +207,12 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     kexec-tools             \
     less                    \
     unzip                   \
-    xz-utils                \
     gdisk
 
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
+    grub-pc-bin
+
+sudo mv $FILESYSTEM_ROOT/grub-pc-bin*.deb $FILESYSTEM_ROOT/$PLATFORM_DIR/x86_64-grub
 
 ## Disable kexec supported reboot which was installed by default
 sudo sed -i 's/LOAD_KEXEC=true/LOAD_KEXEC=false/' $FILESYSTEM_ROOT/etc/default/kexec

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -205,7 +205,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     curl                    \
     kexec-tools             \
     less                    \
-    unzip
+    unzip                   \
+    xz-utils                \
+    gdisk
+
 
 ## Disable kexec supported reboot which was installed by default
 sudo sed -i 's/LOAD_KEXEC=true/LOAD_KEXEC=false/' $FILESYSTEM_ROOT/etc/default/kexec

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -29,6 +29,7 @@ if [ ! -e /host/machine.conf ]; then
         done
     fi
 
+    migration="TRUE"
     umount /mnt/onie-boot
 fi
 
@@ -74,6 +75,57 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
 
     if [ -d /host/image-$sonic_version/platform/$platform ]; then
         dpkg -i /host/image-$sonic_version/platform/$platform/*.deb
+    fi
+
+    # If the unit booted into SONiC from another NOS's grub, we now
+    # install a grub for SONiC based on ONIE grub.
+    if [ -n "$onie_platform" ] && [ -n "$migration" ]; then
+        mkdir -p /host/image-$sonic_version/tmp
+        cd /host/image-$sonic_version/tmp
+
+        # Extract ONIE's ramdisk which contain's the ONIE grub
+        mount $onie_dev /mnt/onie-boot
+        cp /mnt/onie-boot/onie/initrd.img-3.2.69-onie initrd.img-3.2.69-onie.xz
+        xz -d initrd.img-3.2.69-onie.xz 
+        mv initrd.img-3.2.69-onie initrd.img-3.2.69-onie.cpio
+        cpio -idv < initrd.img-3.2.69-onie.cpio
+        cpio_retval=$?
+
+        # Get the device and grub directory to be used for grub-install
+        sonic_dev=$(blkid | grep SONiC-OS | head -n 1 | awk '{print $1}' |  sed -e 's/[0-9]:.*$//')
+        grub_platform_dir=`find . -name kernel.img -print`
+        grub_platform_dir=$(dirname "${grub_platform_dir}")
+
+        # Install the grub for SONiC
+        if [ "$cpio_retval" -eq 0 ] && [ -n "$sonic_dev" ] && [ -n "$grub_platform_dir" ]; then
+            grub-install --boot-directory=/host --recheck $sonic_dev --directory=/host/image-$sonic_version/tmp/$grub_platform_dir 2>/dev/null
+        else
+            echo "Unable install grub" >> /etc/migration.log
+        fi
+
+        # The SONiC "raw" build mode has already generated a proto grub.cfg
+        # as part of the migration. Platform specific constants need to be
+        # retrieved from installer.conf and assigned.
+        . /usr/share/sonic/device/$platform/installer.conf
+
+        sed -i -e "s/%%CONSOLE_PORT%%/$CONSOLE_PORT/g" /host/grub.cfg
+        sed -i -e "s/%%CONSOLE_DEV%%/$CONSOLE_DEV/g" /host/grub.cfg
+
+        # Set the root based on the label
+        sonic_root=$(blkid | grep SONiC-OS | head -n 1 | awk '{print $1}' |  sed -e 's/:.*$//')
+        sonic_root=$(echo "$sonic_root" | sed 's/\//\\\//g')
+        sed -i -e "s/%%SONIC_ROOT%%/$sonic_root/g" /host/grub.cfg
+
+        # Add the Diag and ONIE entries
+        . /mnt/onie-boot/onie/grub.d/50_onie_grub >> /host/grub.cfg
+
+        # Set the SONiC's grub config
+        mv /host/grub.cfg /host/grub/grub.cfg
+
+        # Cleanup
+        cd /host/image-$sonic_version
+        rm -fr /host/image-$sonic_version/tmp
+        umount /mnt/onie-boot
     fi
 
     rm /host/image-$sonic_version/platform/firsttime

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -37,6 +37,26 @@ fi
 
 echo "install platform dependent packages at the first boot time"
 
+firsttime_exit()
+{
+    rm /host/image-$sonic_version/platform/firsttime
+    exit 0
+}
+
+# Given a string of tuples of the form field=value, extract the value for a field
+# In : $string, $field
+# Out: $value
+value_extract()
+{
+set -- $string
+for x in "$@"; do
+    case "$x" in
+        $field=*)
+            value="${x#$field=}"
+    esac
+done
+}
+
 sonic_version=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
 
 if [ -f /host/image-$sonic_version/platform/firsttime ]; then
@@ -47,8 +67,7 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         platform=$onie_platform
     else
         echo "Unknown sonic platform"
-        rm /host/image-$sonic_version/platform/firsttime
-        exit 0
+        firsttime_exit
     fi
 
     # Try to take old configuration saved during installation
@@ -77,39 +96,73 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         dpkg -i /host/image-$sonic_version/platform/$platform/*.deb
     fi
 
-    # If the unit booted into SONiC from another NOS's grub, we now
-    # install a grub for SONiC based on ONIE grub.
+    # If the unit booted into SONiC from another NOS's grub,
+    # we now install a grub for SONiC.
     if [ -n "$onie_platform" ] && [ -n "$migration" ]; then
-        mkdir -p /host/image-$sonic_version/tmp
-        cd /host/image-$sonic_version/tmp
 
-        # Extract ONIE's ramdisk which contain's the ONIE grub
-        mount $onie_dev /mnt/onie-boot
-        cp /mnt/onie-boot/onie/initrd.img-3.2.69-onie initrd.img-3.2.69-onie.xz
-        xz -d initrd.img-3.2.69-onie.xz 
-        mv initrd.img-3.2.69-onie initrd.img-3.2.69-onie.cpio
-        cpio -idv < initrd.img-3.2.69-onie.cpio
-        cpio_retval=$?
+        grub_bin=$(ls /host/image-$sonic_version/platform/x86_64-grub/grub-pc-bin*.deb 2> /dev/null)
+        if [ -z "$grub_bin" ]; then
+            echo "Unable to locate grub package !" >> /etc/migration.log
+            firsttime_exit
+        fi
 
-        # Get the device and grub directory to be used for grub-install
+        dpkg -i $grub_bin > /dev/null 2>&1
+        if [ $? != 0 ]; then
+            echo "Unable to install grub package !" >> /etc/migration.log
+            firsttime_exit
+        fi
+
+        # Determine the block device to install grub
         sonic_dev=$(blkid | grep SONiC-OS | head -n 1 | awk '{print $1}' |  sed -e 's/[0-9]:.*$//')
-        grub_platform_dir=`find . -name kernel.img -print`
-        grub_platform_dir=$(dirname "${grub_platform_dir}")
+        if [ -z "$sonic_dev" ]; then
+            echo "Unable to determine sonic partition !" >> /etc/migration.log
+            firsttime_exit
+        fi
 
-        # Install the grub for SONiC
-        if [ "$cpio_retval" -eq 0 ] && [ -n "$sonic_dev" ] && [ -n "$grub_platform_dir" ]; then
-            grub-install --boot-directory=/host --recheck $sonic_dev --directory=/host/image-$sonic_version/tmp/$grub_platform_dir 2>/dev/null
-        else
-            echo "Unable install grub" >> /etc/migration.log
+        grub-install --boot-directory=/host --recheck $sonic_dev 2>/dev/null
+        if [ $? != 0 ]; then
+            echo "grub install failed !" >> /etc/migration.log
+            firsttime_exit
         fi
 
         # The SONiC "raw" build mode has already generated a proto grub.cfg
         # as part of the migration. Platform specific constants need to be
-        # retrieved from installer.conf and assigned.
+        # retrieved from installer.conf (if present) and assigned.
         . /usr/share/sonic/device/$platform/installer.conf
 
-        sed -i -e "s/%%CONSOLE_PORT%%/$CONSOLE_PORT/g" /host/grub.cfg
-        sed -i -e "s/%%CONSOLE_DEV%%/$CONSOLE_DEV/g" /host/grub.cfg
+        if [ ! -z "$CONSOLE_PORT" ]; then
+            field="\-\-port"
+            string=$(grep $field /host/grub.cfg)
+            value_extract $string $field
+            console_port=$value
+            if [ ! -z "$console_port" ] && [ "$console_port" != "$CONSOLE_PORT" ]; then
+                sed -i -e "s/\-\-port=$console_port/\-\-port=$CONSOLE_PORT/g" /host/grub.cfg
+            fi
+            echo "grub.cfg console port=$console_port & installer.conf CONSOLE_PORT=$CONSOLE_PORT" >> /etc/migration.log
+        fi
+
+        if [ ! -z "$CONSOLE_DEV" ]; then
+            field="console"
+            string=$(grep $field /host/grub.cfg)
+            value_extract $string $field
+            console_dev_name=$(echo $value | sed -e "s/^.*=//" -e "s/,.*//")
+            console_dev="${console_dev_name#ttyS}"
+            if [ "$console_dev" != "$CONSOLE_DEV" ]; then
+                sed -i -e "s/console=ttyS$console_dev/console=ttyS$CONSOLE_DEV/g" /host/grub.cfg
+            fi
+            echo "grub.cfg console dev=$console_dev & installer.conf CONSOLE_DEV=$CONSOLE_DEV" >> /etc/migration.log
+        fi
+
+        if [ ! -z "$VAR_LOG_SIZE" ]; then
+            field="var_log_size"
+            string=$(grep $field /host/grub.cfg)
+            value_extract $string $field
+            var_log_size=$value
+            if [ ! -z "$var_log_size" ] && [ "$var_log_size" != "$VAR_LOG_SIZE" ]; then
+                sed -i -e "s/var_log_size=$var_log_size/var_log_size=$VAR_LOG_SIZE/g" /host/grub.cfg
+            fi
+            echo "grub.cfg var_log_size=$var_log_size & installer.conf VAR_LOG_SIZE=$VAR_LOG_SIZE" >> /etc/migration.log
+        fi
 
         # Set the root based on the label
         sonic_root=$(blkid | grep SONiC-OS | head -n 1 | awk '{print $1}' |  sed -e 's/:.*$//')
@@ -117,15 +170,12 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         sed -i -e "s/%%SONIC_ROOT%%/$sonic_root/g" /host/grub.cfg
 
         # Add the Diag and ONIE entries
+        mount $onie_dev /mnt/onie-boot
         . /mnt/onie-boot/onie/grub.d/50_onie_grub >> /host/grub.cfg
-
-        # Set the SONiC's grub config
-        mv /host/grub.cfg /host/grub/grub.cfg
-
-        # Cleanup
-        cd /host/image-$sonic_version
-        rm -fr /host/image-$sonic_version/tmp
         umount /mnt/onie-boot
+
+        # Initialize the SONiC's grub config
+        mv /host/grub.cfg /host/grub/grub.cfg
     fi
 
     rm /host/image-$sonic_version/platform/firsttime

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -484,13 +484,8 @@ trap_push "rm $grub_cfg || true"
 
 [ -r ./platform.conf ] && . ./platform.conf
 
-if [ "$install_env" = "build" ]; then
-    DEFAULT_GRUB_SERIAL_COMMAND="serial --port=%%CONSOLE_PORT%% --speed=${CONSOLE_SPEED} --word=8 --parity=no --stop=1"
-    DEFAULT_GRUB_CMDLINE_LINUX="console=tty0 console=ttyS%%CONSOLE_DEV%%,${CONSOLE_SPEED}n8 quiet"
-else
-    DEFAULT_GRUB_SERIAL_COMMAND="serial --port=${CONSOLE_PORT} --speed=${CONSOLE_SPEED} --word=8 --parity=no --stop=1"
-    DEFAULT_GRUB_CMDLINE_LINUX="console=tty0 console=ttyS${CONSOLE_DEV},${CONSOLE_SPEED}n8 quiet"
-fi
+DEFAULT_GRUB_SERIAL_COMMAND="serial --port=${CONSOLE_PORT} --speed=${CONSOLE_SPEED} --word=8 --parity=no --stop=1"
+DEFAULT_GRUB_CMDLINE_LINUX="console=tty0 console=ttyS${CONSOLE_DEV},${CONSOLE_SPEED}n8 quiet"
 GRUB_SERIAL_COMMAND=${GRUB_SERIAL_COMMAND:-"$DEFAULT_GRUB_SERIAL_COMMAND"}
 GRUB_CMDLINE_LINUX=${GRUB_CMDLINE_LINUX:-"$DEFAULT_GRUB_CMDLINE_LINUX"}
 export GRUB_SERIAL_COMMAND


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Currently, while migrating from another NOS into SONiC, SONiC will boot using the NOS's grub. After migration, it is desirable to install a grub for SONiC use rather than depend on NOS's grub so that subsequent reboots will use SONiC's own grub.

**- How I did it**

1.	During sonic-broadcom.raw build, generate and bundle a grub.cfg for use after migration.
2.	During SONiC init post migration, the ONIE’s grub is extracted and installed into SONiC.
3.	The platform constants are updated in the grub.cfg and the ONIE, Diag entries are also added and installed into SONiC’s newly installed grub. Currently the serial port, device and the SONiC root partition are updated post migration (since these are platform specific). Other parameters (say, CONSOLE_SPEED) may be added if necessary.
4.	Extraction of the ONIE’s grub required xz and the ONIE script to generate the ONIE & Diag grub configs needed sgdisk.

**- How to verify it**

1. Check that after dd (using sonic-broadcom.raw image), the boots into SONiC using the NOS's grub (sanity check is to see the grub menu entries).
2. After migration into SONiC check that SONiC's grub is correctly installed in /host/grub.
3. Reboot the unit and check that SONiC now comes up with SONiC's grub rather than the NOS's grub.
4. Reboot to check that with SONiC's grub, it is possible to get into ONIE.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Install grub for SONiC post migration from another NOS

**- A picture of a cute animal (not mandatory but encouraged)**
