### PR TITLE
[sonic-slave]: SLAVE_TAG should be for both Dockerfile and Dockerfile…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(shell rm -f .screen)
 MAKEFLAGS += -B
 
 SLAVE_BASE_TAG = $(shell shasum sonic-slave/Dockerfile | awk '{print substr($$1,0,11);}')
-SLAVE_TAG = $(shell shasum sonic-slave/Dockerfile.user | awk '{print substr($$1,0,11);}')
+SLAVE_TAG = $(shell cat sonic-slave/Dockerfile.user sonic-slave/Dockerfile | shasum | awk '{print substr($$1,0,11);}')
 SLAVE_BASE_IMAGE = sonic-slave-base
 SLAVE_IMAGE = sonic-slave-$(USER)
 


### PR DESCRIPTION
….user

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

SLAVE_TAG is now the sha value for both Dockerfile and Dockerfile.user

**- How I did it**

Modify the sonic-slave/Makefile to calculate the sha for both files.

**- How to verify it**

Modify sonic-slave/Dockerfile, it should now build the sonic-slave-${username} as well.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

SLAVE_TAG should be for both Dockerfile and Dockerfile.user

**- A picture of a cute animal (not mandatory but encouraged)**
