### PR TITLE
[config] Fix an issue that bgp asn data type is not consistent

### DIFF
--- a/dockers/docker-fpm-frr/bgpd.conf.j2
+++ b/dockers/docker-fpm-frr/bgpd.conf.j2
@@ -48,7 +48,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endblock vlan_advertisement %}
 {% block bgp_sessions %}
 {% for neighbor_addr, bgp_session in BGP_NEIGHBOR.iteritems() %}
-{% if bgp_session['asn'] != 0 %}
+{% if bgp_session['asn'] | int != 0 %}
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
 {% if DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
@@ -57,7 +57,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% if neighbor_addr | ipv4 %}
   address-family ipv4
     neighbor {{ neighbor_addr }} activate
-{% if bgp_session['rrclient'] != 0 %}
+{% if bgp_session['rrclient'] | int != 0 %}
     neighbor {{ neighbor_addr }} route-reflector-client
 {% endif %}
     maximum-paths 64
@@ -66,7 +66,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% if neighbor_addr | ipv6 %}
   address-family ipv6
     neighbor {{ neighbor_addr }} activate
-{% if bgp_session['rrclient'] != 0 %}
+{% if bgp_session['rrclient'] | int != 0 %}
     neighbor {{ neighbor_addr }} route-reflector-client
 {% endif %}
     maximum-paths 64

--- a/dockers/docker-fpm-gobgp/gobgpd.conf.j2
+++ b/dockers/docker-fpm-gobgp/gobgpd.conf.j2
@@ -2,7 +2,7 @@
   as = {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   router-id = "{{ LOOPBACK_INTERFACE.keys()[0][1] }}"
 {% for neighbor_addr, bgp_session in BGP_NEIGHBOR.iteritems() %}
-{% if bgp_session['asn'] != 0 %}
+{% if bgp_session['asn'] | int != 0 %}
 [[neighbors]]
   [neighbors.config]
     peer-as = {{ bgp_session['asn'] }}

--- a/dockers/docker-fpm-quagga/bgpd.conf.j2
+++ b/dockers/docker-fpm-quagga/bgpd.conf.j2
@@ -62,7 +62,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endblock vlan_advertisement %}
 {% block bgp_sessions %}
 {% for neighbor_addr, bgp_session in BGP_NEIGHBOR.iteritems() %}
-{% if bgp_session['asn'] != 0 %}
+{% if bgp_session['asn'] | int != 0 %}
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
 {% if bgp_session.has_key('admin_status') and bgp_session['admin_status'] == 'down' or not bgp_session.has_key('admin_status') and DEVICE_METADATA['localhost'].has_key('default_bgp_status') and DEVICE_METADATA['localhost']['default_bgp_status'] == 'down' %}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -238,7 +238,7 @@ def parse_cpg(cpg, hname):
                 else:
                     rrclient = '0'
                 if hostname == hname:
-                    myasn = int(asn)
+                    myasn = asn
                     peers = router.find(str(QName(ns1, "Peers")))
                     for bgpPeer in peers.findall(str(QName(ns, "BGPPeer"))):
                         addr = bgpPeer.find(str(QName(ns, "Address"))).text
@@ -254,8 +254,8 @@ def parse_cpg(cpg, hname):
                     for peer in bgp_sessions:
                         bgp_session = bgp_sessions[peer]
                         if hostname == bgp_session['name']:
-                            bgp_session['asn'] = int(asn)
-                        bgp_session['rrclient'] = int(rrclient)
+                            bgp_session['asn'] = asn
+                        bgp_session['rrclient'] = rrclient
 
     return bgp_sessions, myasn, bgp_peers_with_range
 

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -110,8 +110,8 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'mgmt_addr': None, 'hwsku': 'Arista', 'lo_addr': None, 'local_port': 'Ethernet112', 'type': 'LeafRouter', 'port': 'Ethernet1/1'}")
 
-    def test_minigraph_peers_with_range(self):
-        argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v "BGP_NEIGHBORS[\'10.0.0.59\']"'
+    def test_minigraph_bgp(self):
+        argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v "BGP_NEIGHBOR[\'10.0.0.59\']"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'rrclient': '0', 'local_addr': '10.0.0.58', 'asn': '64600', 'name': 'ARISTA02T1'}")
 

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -111,6 +111,11 @@ class TestCfgGen(TestCase):
         self.assertEqual(output.strip(), "{'mgmt_addr': None, 'hwsku': 'Arista', 'lo_addr': None, 'local_port': 'Ethernet112', 'type': 'LeafRouter', 'port': 'Ethernet1/1'}")
 
     def test_minigraph_peers_with_range(self):
+        argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v "BGP_NEIGHBORS[\'10.0.0.59\']"'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), "{'rrclient': '0', 'local_addr': '10.0.0.58', 'asn': '64600', 'name': 'ARISTA02T1'}")
+
+    def test_minigraph_peers_with_range(self):
         argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v BGP_PEER_RANGE.values\(\)'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "[{'name': 'BGPSLBPassive', 'ip_range': ['10.10.10.10/26', '100.100.100.100/26']}]")


### PR DESCRIPTION
Before fix: `int` when reading from minigraph parser, `str` when reading from DB. 
After fix: unified to be `str`