### PR TITLE
Add time stamp suffix to the dirty images version string

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -55,7 +55,7 @@ sonic_get_version() {
     local latest_tag=$(git describe --tags --abbrev=0)
     local branch_name=$(git rev-parse --abbrev-ref HEAD)
     if [ -n "$(git status --untracked-files=no -s --ignore-submodules)" ]; then
-        local dirty="-dirty"
+        local dirty="-dirty-$DIRTY_SUFFIX"
     fi
     BUILD_NUMBER=${BUILD_NUMBER:-0}
     ## Check if we are on tagged commit

--- a/slave.mk
+++ b/slave.mk
@@ -421,6 +421,8 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : .platform
 		chmod +x sonic_debian_extension.sh,
 	)
 
+	DIRTY_SUFFIX="$(shell date +%s)"
+	export DIRTY_SUFFIX
 	./build_debian.sh "$(USERNAME)" "$(shell perl -e 'print crypt("$(PASSWORD)", "salt"),"\n"')" $(LOG)
 	TARGET_MACHINE=$($*_MACHINE) IMAGE_TYPE=$($*_IMAGE_TYPE) ./build_image.sh $(LOG)
 

--- a/slave.mk
+++ b/slave.mk
@@ -421,7 +421,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : .platform
 		chmod +x sonic_debian_extension.sh,
 	)
 
-	DIRTY_SUFFIX="$(shell date +%s)"
+	DIRTY_SUFFIX="$(shell date +%Y%m%d\.%H%M%S)"
 	export DIRTY_SUFFIX
 	./build_debian.sh "$(USERNAME)" "$(shell perl -e 'print crypt("$(PASSWORD)", "salt"),"\n"')" $(LOG)
 	TARGET_MACHINE=$($*_MACHINE) IMAGE_TYPE=$($*_IMAGE_TYPE) ./build_image.sh $(LOG)


### PR DESCRIPTION
This will allow to build different debug images without
having to update BUILD_NUMBER variable before the build
