### PR TITLE
[bgp]: Fix the deployment_id with DEVICE_METADATA

### DIFF
--- a/dockers/docker-fpm-quagga/bgpd.conf.j2
+++ b/dockers/docker-fpm-quagga/bgpd.conf.j2
@@ -94,7 +94,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% for bgp_peer in BGP_PEER_RANGE.values() %}
   neighbor {{ bgp_peer['name'] }} peer-group
   neighbor {{ bgp_peer['name'] }} passive
-  neighbor {{ bgp_peer['name'] }} remote-as {{deployment_id_asn_map[deployment_id] }}
+  neighbor {{ bgp_peer['name'] }} remote-as {{ deployment_id_asn_map[DEVICE_METADATA['localhost']['deployment_id']] }}
   neighbor {{ bgp_peer['name'] }} ebgp-multihop 255
   neighbor {{ bgp_peer['name'] }} soft-reconfiguration inbound
   neighbor {{ bgp_peer['name'] }} update-source Loopback0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Update the template.

**- How to verify it**
Restart docker-bgp and verify that the docker starts successfully.
