### PR TITLE
Start Quagga BGPd with Forwarding State flag set

### DIFF
--- a/dockers/docker-fpm-quagga/supervisord.conf
+++ b/dockers/docker-fpm-quagga/supervisord.conf
@@ -36,7 +36,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:bgpd]
-command=/usr/lib/quagga/bgpd -A 127.0.0.1
+command=/usr/lib/quagga/bgpd -A 127.0.0.1 -F
 priority=5
 autostart=false
 autorestart=false


### PR DESCRIPTION
This is required for Fast-Reboot to prevent restarting of a bgp session after FR.
By default Quagga BGPd sends Graceful Restart capability with "Restarting" flag set.
This change will allow Quagga BGPd to signal the state was preserved.

In normal reboots it will not change anything, because the other side doesn't expect to see a host returning from the reboot.