### PR TITLE
Changed MTU value to 9100 

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -50,7 +50,7 @@ iface eth0 inet dhcp
 {% for (name, prefix) in INTERFACE %}
 allow-hotplug {{ name }}
 iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
-    mtu 9214
+    mtu 9100
     address {{ prefix | ip }}
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
 #
@@ -61,7 +61,7 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
 {% for member in VLAN[vlan]['members'] %}
 allow-hotplug {{ member }}
 iface {{ member }} inet manual
-    pre-up ifconfig {{ member }} up mtu 9214
+    pre-up ifconfig {{ member }} up mtu 9100
     post-up brctl addif {{ vlan }} {{ member }} || true
     post-down ifconfig {{ member }} down
 #
@@ -102,7 +102,7 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
 {% for (name, prefix) in PORTCHANNEL_INTERFACE.keys() | sort %}
 allow-hotplug {{ name }}
 iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
-    mtu 9214
+    mtu 9100
     address {{ prefix | ip }}
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
 #

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -50,7 +50,7 @@ iface eth0 inet dhcp
 {% for (name, prefix) in INTERFACE %}
 allow-hotplug {{ name }}
 iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
-    mtu 9216
+    mtu 9214
     address {{ prefix | ip }}
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
 #
@@ -61,7 +61,7 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
 {% for member in VLAN[vlan]['members'] %}
 allow-hotplug {{ member }}
 iface {{ member }} inet manual
-    pre-up ifconfig {{ member }} up mtu 9216
+    pre-up ifconfig {{ member }} up mtu 9214
     post-up brctl addif {{ vlan }} {{ member }} || true
     post-down ifconfig {{ member }} down
 #
@@ -102,7 +102,7 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
 {% for (name, prefix) in PORTCHANNEL_INTERFACE.keys() | sort %}
 allow-hotplug {{ name }}
 iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
-    mtu 9216
+    mtu 9214
     address {{ prefix | ip }}
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
 #

--- a/src/sonic-config-engine/tests/sample_output/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/interfaces
@@ -42,145 +42,145 @@ iface eth0 inet6 static
 # "|| true" is added to suppress the error when interface is already a member of VLAN
 allow-hotplug fortyGigE0/4
 iface fortyGigE0/4 inet manual
-    pre-up ifconfig fortyGigE0/4 up mtu 9216
+    pre-up ifconfig fortyGigE0/4 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/4 || true
     post-down ifconfig fortyGigE0/4 down
 #
 allow-hotplug fortyGigE0/8
 iface fortyGigE0/8 inet manual
-    pre-up ifconfig fortyGigE0/8 up mtu 9216
+    pre-up ifconfig fortyGigE0/8 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/8 || true
     post-down ifconfig fortyGigE0/8 down
 #
 allow-hotplug fortyGigE0/12
 iface fortyGigE0/12 inet manual
-    pre-up ifconfig fortyGigE0/12 up mtu 9216
+    pre-up ifconfig fortyGigE0/12 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/12 || true
     post-down ifconfig fortyGigE0/12 down
 #
 allow-hotplug fortyGigE0/16
 iface fortyGigE0/16 inet manual
-    pre-up ifconfig fortyGigE0/16 up mtu 9216
+    pre-up ifconfig fortyGigE0/16 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/16 || true
     post-down ifconfig fortyGigE0/16 down
 #
 allow-hotplug fortyGigE0/20
 iface fortyGigE0/20 inet manual
-    pre-up ifconfig fortyGigE0/20 up mtu 9216
+    pre-up ifconfig fortyGigE0/20 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/20 || true
     post-down ifconfig fortyGigE0/20 down
 #
 allow-hotplug fortyGigE0/24
 iface fortyGigE0/24 inet manual
-    pre-up ifconfig fortyGigE0/24 up mtu 9216
+    pre-up ifconfig fortyGigE0/24 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/24 || true
     post-down ifconfig fortyGigE0/24 down
 #
 allow-hotplug fortyGigE0/28
 iface fortyGigE0/28 inet manual
-    pre-up ifconfig fortyGigE0/28 up mtu 9216
+    pre-up ifconfig fortyGigE0/28 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/28 || true
     post-down ifconfig fortyGigE0/28 down
 #
 allow-hotplug fortyGigE0/32
 iface fortyGigE0/32 inet manual
-    pre-up ifconfig fortyGigE0/32 up mtu 9216
+    pre-up ifconfig fortyGigE0/32 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/32 || true
     post-down ifconfig fortyGigE0/32 down
 #
 allow-hotplug fortyGigE0/36
 iface fortyGigE0/36 inet manual
-    pre-up ifconfig fortyGigE0/36 up mtu 9216
+    pre-up ifconfig fortyGigE0/36 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/36 || true
     post-down ifconfig fortyGigE0/36 down
 #
 allow-hotplug fortyGigE0/40
 iface fortyGigE0/40 inet manual
-    pre-up ifconfig fortyGigE0/40 up mtu 9216
+    pre-up ifconfig fortyGigE0/40 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/40 || true
     post-down ifconfig fortyGigE0/40 down
 #
 allow-hotplug fortyGigE0/44
 iface fortyGigE0/44 inet manual
-    pre-up ifconfig fortyGigE0/44 up mtu 9216
+    pre-up ifconfig fortyGigE0/44 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/44 || true
     post-down ifconfig fortyGigE0/44 down
 #
 allow-hotplug fortyGigE0/48
 iface fortyGigE0/48 inet manual
-    pre-up ifconfig fortyGigE0/48 up mtu 9216
+    pre-up ifconfig fortyGigE0/48 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/48 || true
     post-down ifconfig fortyGigE0/48 down
 #
 allow-hotplug fortyGigE0/52
 iface fortyGigE0/52 inet manual
-    pre-up ifconfig fortyGigE0/52 up mtu 9216
+    pre-up ifconfig fortyGigE0/52 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/52 || true
     post-down ifconfig fortyGigE0/52 down
 #
 allow-hotplug fortyGigE0/56
 iface fortyGigE0/56 inet manual
-    pre-up ifconfig fortyGigE0/56 up mtu 9216
+    pre-up ifconfig fortyGigE0/56 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/56 || true
     post-down ifconfig fortyGigE0/56 down
 #
 allow-hotplug fortyGigE0/60
 iface fortyGigE0/60 inet manual
-    pre-up ifconfig fortyGigE0/60 up mtu 9216
+    pre-up ifconfig fortyGigE0/60 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/60 || true
     post-down ifconfig fortyGigE0/60 down
 #
 allow-hotplug fortyGigE0/64
 iface fortyGigE0/64 inet manual
-    pre-up ifconfig fortyGigE0/64 up mtu 9216
+    pre-up ifconfig fortyGigE0/64 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/64 || true
     post-down ifconfig fortyGigE0/64 down
 #
 allow-hotplug fortyGigE0/68
 iface fortyGigE0/68 inet manual
-    pre-up ifconfig fortyGigE0/68 up mtu 9216
+    pre-up ifconfig fortyGigE0/68 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/68 || true
     post-down ifconfig fortyGigE0/68 down
 #
 allow-hotplug fortyGigE0/72
 iface fortyGigE0/72 inet manual
-    pre-up ifconfig fortyGigE0/72 up mtu 9216
+    pre-up ifconfig fortyGigE0/72 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/72 || true
     post-down ifconfig fortyGigE0/72 down
 #
 allow-hotplug fortyGigE0/76
 iface fortyGigE0/76 inet manual
-    pre-up ifconfig fortyGigE0/76 up mtu 9216
+    pre-up ifconfig fortyGigE0/76 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/76 || true
     post-down ifconfig fortyGigE0/76 down
 #
 allow-hotplug fortyGigE0/80
 iface fortyGigE0/80 inet manual
-    pre-up ifconfig fortyGigE0/80 up mtu 9216
+    pre-up ifconfig fortyGigE0/80 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/80 || true
     post-down ifconfig fortyGigE0/80 down
 #
 allow-hotplug fortyGigE0/84
 iface fortyGigE0/84 inet manual
-    pre-up ifconfig fortyGigE0/84 up mtu 9216
+    pre-up ifconfig fortyGigE0/84 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/84 || true
     post-down ifconfig fortyGigE0/84 down
 #
 allow-hotplug fortyGigE0/88
 iface fortyGigE0/88 inet manual
-    pre-up ifconfig fortyGigE0/88 up mtu 9216
+    pre-up ifconfig fortyGigE0/88 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/88 || true
     post-down ifconfig fortyGigE0/88 down
 #
 allow-hotplug fortyGigE0/92
 iface fortyGigE0/92 inet manual
-    pre-up ifconfig fortyGigE0/92 up mtu 9216
+    pre-up ifconfig fortyGigE0/92 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/92 || true
     post-down ifconfig fortyGigE0/92 down
 #
 allow-hotplug fortyGigE0/96
 iface fortyGigE0/96 inet manual
-    pre-up ifconfig fortyGigE0/96 up mtu 9216
+    pre-up ifconfig fortyGigE0/96 up mtu 9214
     post-up brctl addif Vlan1000 fortyGigE0/96 || true
     post-down ifconfig fortyGigE0/96 down
 #
@@ -220,49 +220,49 @@ iface Vlan1000 inet static
 # Portchannel interfaces
 allow-hotplug PortChannel01
 iface PortChannel01 inet static
-    mtu 9216
+    mtu 9214
     address 10.0.0.56
     netmask 255.255.255.254
 #
 allow-hotplug PortChannel01
 iface PortChannel01 inet6 static
-    mtu 9216
+    mtu 9214
     address fc00::71
     netmask 126
 #
 allow-hotplug PortChannel02
 iface PortChannel02 inet static
-    mtu 9216
+    mtu 9214
     address 10.0.0.58
     netmask 255.255.255.254
 #
 allow-hotplug PortChannel02
 iface PortChannel02 inet6 static
-    mtu 9216
+    mtu 9214
     address fc00::75
     netmask 126
 #
 allow-hotplug PortChannel03
 iface PortChannel03 inet static
-    mtu 9216
+    mtu 9214
     address 10.0.0.60
     netmask 255.255.255.254
 #
 allow-hotplug PortChannel03
 iface PortChannel03 inet6 static
-    mtu 9216
+    mtu 9214
     address fc00::79
     netmask 126
 #
 allow-hotplug PortChannel04
 iface PortChannel04 inet static
-    mtu 9216
+    mtu 9214
     address 10.0.0.62
     netmask 255.255.255.254
 #
 allow-hotplug PortChannel04
 iface PortChannel04 inet6 static
-    mtu 9216
+    mtu 9214
     address fc00::7d
     netmask 126
 #

--- a/src/sonic-config-engine/tests/sample_output/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/interfaces
@@ -42,145 +42,145 @@ iface eth0 inet6 static
 # "|| true" is added to suppress the error when interface is already a member of VLAN
 allow-hotplug fortyGigE0/4
 iface fortyGigE0/4 inet manual
-    pre-up ifconfig fortyGigE0/4 up mtu 9214
+    pre-up ifconfig fortyGigE0/4 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/4 || true
     post-down ifconfig fortyGigE0/4 down
 #
 allow-hotplug fortyGigE0/8
 iface fortyGigE0/8 inet manual
-    pre-up ifconfig fortyGigE0/8 up mtu 9214
+    pre-up ifconfig fortyGigE0/8 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/8 || true
     post-down ifconfig fortyGigE0/8 down
 #
 allow-hotplug fortyGigE0/12
 iface fortyGigE0/12 inet manual
-    pre-up ifconfig fortyGigE0/12 up mtu 9214
+    pre-up ifconfig fortyGigE0/12 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/12 || true
     post-down ifconfig fortyGigE0/12 down
 #
 allow-hotplug fortyGigE0/16
 iface fortyGigE0/16 inet manual
-    pre-up ifconfig fortyGigE0/16 up mtu 9214
+    pre-up ifconfig fortyGigE0/16 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/16 || true
     post-down ifconfig fortyGigE0/16 down
 #
 allow-hotplug fortyGigE0/20
 iface fortyGigE0/20 inet manual
-    pre-up ifconfig fortyGigE0/20 up mtu 9214
+    pre-up ifconfig fortyGigE0/20 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/20 || true
     post-down ifconfig fortyGigE0/20 down
 #
 allow-hotplug fortyGigE0/24
 iface fortyGigE0/24 inet manual
-    pre-up ifconfig fortyGigE0/24 up mtu 9214
+    pre-up ifconfig fortyGigE0/24 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/24 || true
     post-down ifconfig fortyGigE0/24 down
 #
 allow-hotplug fortyGigE0/28
 iface fortyGigE0/28 inet manual
-    pre-up ifconfig fortyGigE0/28 up mtu 9214
+    pre-up ifconfig fortyGigE0/28 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/28 || true
     post-down ifconfig fortyGigE0/28 down
 #
 allow-hotplug fortyGigE0/32
 iface fortyGigE0/32 inet manual
-    pre-up ifconfig fortyGigE0/32 up mtu 9214
+    pre-up ifconfig fortyGigE0/32 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/32 || true
     post-down ifconfig fortyGigE0/32 down
 #
 allow-hotplug fortyGigE0/36
 iface fortyGigE0/36 inet manual
-    pre-up ifconfig fortyGigE0/36 up mtu 9214
+    pre-up ifconfig fortyGigE0/36 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/36 || true
     post-down ifconfig fortyGigE0/36 down
 #
 allow-hotplug fortyGigE0/40
 iface fortyGigE0/40 inet manual
-    pre-up ifconfig fortyGigE0/40 up mtu 9214
+    pre-up ifconfig fortyGigE0/40 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/40 || true
     post-down ifconfig fortyGigE0/40 down
 #
 allow-hotplug fortyGigE0/44
 iface fortyGigE0/44 inet manual
-    pre-up ifconfig fortyGigE0/44 up mtu 9214
+    pre-up ifconfig fortyGigE0/44 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/44 || true
     post-down ifconfig fortyGigE0/44 down
 #
 allow-hotplug fortyGigE0/48
 iface fortyGigE0/48 inet manual
-    pre-up ifconfig fortyGigE0/48 up mtu 9214
+    pre-up ifconfig fortyGigE0/48 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/48 || true
     post-down ifconfig fortyGigE0/48 down
 #
 allow-hotplug fortyGigE0/52
 iface fortyGigE0/52 inet manual
-    pre-up ifconfig fortyGigE0/52 up mtu 9214
+    pre-up ifconfig fortyGigE0/52 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/52 || true
     post-down ifconfig fortyGigE0/52 down
 #
 allow-hotplug fortyGigE0/56
 iface fortyGigE0/56 inet manual
-    pre-up ifconfig fortyGigE0/56 up mtu 9214
+    pre-up ifconfig fortyGigE0/56 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/56 || true
     post-down ifconfig fortyGigE0/56 down
 #
 allow-hotplug fortyGigE0/60
 iface fortyGigE0/60 inet manual
-    pre-up ifconfig fortyGigE0/60 up mtu 9214
+    pre-up ifconfig fortyGigE0/60 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/60 || true
     post-down ifconfig fortyGigE0/60 down
 #
 allow-hotplug fortyGigE0/64
 iface fortyGigE0/64 inet manual
-    pre-up ifconfig fortyGigE0/64 up mtu 9214
+    pre-up ifconfig fortyGigE0/64 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/64 || true
     post-down ifconfig fortyGigE0/64 down
 #
 allow-hotplug fortyGigE0/68
 iface fortyGigE0/68 inet manual
-    pre-up ifconfig fortyGigE0/68 up mtu 9214
+    pre-up ifconfig fortyGigE0/68 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/68 || true
     post-down ifconfig fortyGigE0/68 down
 #
 allow-hotplug fortyGigE0/72
 iface fortyGigE0/72 inet manual
-    pre-up ifconfig fortyGigE0/72 up mtu 9214
+    pre-up ifconfig fortyGigE0/72 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/72 || true
     post-down ifconfig fortyGigE0/72 down
 #
 allow-hotplug fortyGigE0/76
 iface fortyGigE0/76 inet manual
-    pre-up ifconfig fortyGigE0/76 up mtu 9214
+    pre-up ifconfig fortyGigE0/76 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/76 || true
     post-down ifconfig fortyGigE0/76 down
 #
 allow-hotplug fortyGigE0/80
 iface fortyGigE0/80 inet manual
-    pre-up ifconfig fortyGigE0/80 up mtu 9214
+    pre-up ifconfig fortyGigE0/80 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/80 || true
     post-down ifconfig fortyGigE0/80 down
 #
 allow-hotplug fortyGigE0/84
 iface fortyGigE0/84 inet manual
-    pre-up ifconfig fortyGigE0/84 up mtu 9214
+    pre-up ifconfig fortyGigE0/84 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/84 || true
     post-down ifconfig fortyGigE0/84 down
 #
 allow-hotplug fortyGigE0/88
 iface fortyGigE0/88 inet manual
-    pre-up ifconfig fortyGigE0/88 up mtu 9214
+    pre-up ifconfig fortyGigE0/88 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/88 || true
     post-down ifconfig fortyGigE0/88 down
 #
 allow-hotplug fortyGigE0/92
 iface fortyGigE0/92 inet manual
-    pre-up ifconfig fortyGigE0/92 up mtu 9214
+    pre-up ifconfig fortyGigE0/92 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/92 || true
     post-down ifconfig fortyGigE0/92 down
 #
 allow-hotplug fortyGigE0/96
 iface fortyGigE0/96 inet manual
-    pre-up ifconfig fortyGigE0/96 up mtu 9214
+    pre-up ifconfig fortyGigE0/96 up mtu 9100
     post-up brctl addif Vlan1000 fortyGigE0/96 || true
     post-down ifconfig fortyGigE0/96 down
 #
@@ -220,49 +220,49 @@ iface Vlan1000 inet static
 # Portchannel interfaces
 allow-hotplug PortChannel01
 iface PortChannel01 inet static
-    mtu 9214
+    mtu 9100
     address 10.0.0.56
     netmask 255.255.255.254
 #
 allow-hotplug PortChannel01
 iface PortChannel01 inet6 static
-    mtu 9214
+    mtu 9100
     address fc00::71
     netmask 126
 #
 allow-hotplug PortChannel02
 iface PortChannel02 inet static
-    mtu 9214
+    mtu 9100
     address 10.0.0.58
     netmask 255.255.255.254
 #
 allow-hotplug PortChannel02
 iface PortChannel02 inet6 static
-    mtu 9214
+    mtu 9100
     address fc00::75
     netmask 126
 #
 allow-hotplug PortChannel03
 iface PortChannel03 inet static
-    mtu 9214
+    mtu 9100
     address 10.0.0.60
     netmask 255.255.255.254
 #
 allow-hotplug PortChannel03
 iface PortChannel03 inet6 static
-    mtu 9214
+    mtu 9100
     address fc00::79
     netmask 126
 #
 allow-hotplug PortChannel04
 iface PortChannel04 inet static
-    mtu 9214
+    mtu 9100
     address 10.0.0.62
     netmask 255.255.255.254
 #
 allow-hotplug PortChannel04
 iface PortChannel04 inet6 static
-    mtu 9214
+    mtu 9100
     address fc00::7d
     netmask 126
 #


### PR DESCRIPTION
**- What I did**
Modified MTU value to 9100 from 9216. 

**- How to verify it**
Execute "ifconfig -a". The output shall show the MTU as 9100. 

**- Description for the changelog**
MTU 9100 is used in deployments and there is no single _standard_ value (Different vendors have different default values like 9000, 9214, 9216 etc).  For Sonic, we are changing the IP MTU from 9216 to 9100
