### PR TITLE
[teamd]: lacp runner will send a lacp update right after it received SIGINT

### DIFF
--- a/src/libteam/0003-teamd-lacp-runner-will-send-lacp-update-right-after-.patch
+++ b/src/libteam/0003-teamd-lacp-runner-will-send-lacp-update-right-after-.patch
@@ -1,0 +1,98 @@
+From 417e9dfdccbbee2cf86e46e994e8ece3433b46a4 Mon Sep 17 00:00:00 2001
+From: Pavel Shirshov <pavelsh@microsoft.com>
+Date: Wed, 20 Sep 2017 00:34:07 +0000
+Subject: [PATCH] [teamd] lacp runner will send lacp update right after it
+ received SIGINT signal
+
+---
+ teamd/teamd.c             |  1 +
+ teamd/teamd.h             |  3 +++
+ teamd/teamd_events.c      | 13 +++++++++++++
+ teamd/teamd_runner_lacp.c | 10 ++++++++++
+ 4 files changed, 27 insertions(+)
+
+diff --git a/teamd/teamd.c b/teamd/teamd.c
+index aac2511..c987333 100644
+--- a/teamd/teamd.c
++++ b/teamd/teamd.c
+@@ -386,6 +386,7 @@ static int teamd_run_loop_run(struct teamd_context *ctx)
+ 				case 'q':
+ 					if (quit_in_progress)
+ 						return -EBUSY;
++					teamd_refresh_ports(ctx);
+ 					err = teamd_flush_ports(ctx);
+ 					if (err)
+ 						return err;
+diff --git a/teamd/teamd.h b/teamd/teamd.h
+index 5dbfb9b..ef0fb1c 100644
+--- a/teamd/teamd.h
++++ b/teamd/teamd.h
+@@ -189,11 +189,14 @@ struct teamd_event_watch_ops {
+ 				   struct teamd_port *tdport, void *priv);
+ 	int (*port_ifname_changed)(struct teamd_context *ctx,
+ 				   struct teamd_port *tdport, void *priv);
++	void (*refresh)(struct teamd_context *ctx,
++                   struct teamd_port *tdport, void *priv);
+ 	int (*option_changed)(struct teamd_context *ctx,
+ 			      struct team_option *option, void *priv);
+ 	char *option_changed_match_name;
+ };
+ 
++void teamd_refresh_ports(struct teamd_context *ctx);
+ int teamd_event_port_added(struct teamd_context *ctx,
+ 			   struct teamd_port *tdport);
+ void teamd_event_port_removed(struct teamd_context *ctx,
+diff --git a/teamd/teamd_events.c b/teamd/teamd_events.c
+index 1a95974..5c2ef56 100644
+--- a/teamd/teamd_events.c
++++ b/teamd/teamd_events.c
+@@ -34,6 +34,19 @@ struct event_watch_item {
+ 	void *priv;
+ };
+ 
++void teamd_refresh_ports(struct teamd_context *ctx)
++{
++	struct teamd_port *tdport;
++	struct event_watch_item *watch;
++
++	teamd_for_each_tdport(tdport, ctx) {
++		list_for_each_node_entry(watch, &ctx->event_watch_list, list) {
++			if (!watch->ops->refresh) continue;
++			watch->ops->refresh(ctx, tdport, watch->priv);
++		}
++	}
++}
++
+ int teamd_event_port_added(struct teamd_context *ctx,
+ 			   struct teamd_port *tdport)
+ {
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 9c77fae..e38c291 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -1383,12 +1383,22 @@ static int lacp_event_watch_port_changed(struct teamd_context *ctx,
+ 	return lacp_port_link_update(lacp_port);
+ }
+ 
++static void lacp_event_watch_refresh(struct teamd_context *ctx, struct teamd_port *tdport, void *priv)
++{
++	struct lacp *lacp = priv;
++
++	struct lacp_port *lacp_port = lacp_port_get(lacp, tdport);
++	if (lacp_port_selected(lacp_port))
++		(void) lacpdu_send(lacp_port);
++}
++
+ static const struct teamd_event_watch_ops lacp_event_watch_ops = {
+ 	.hwaddr_changed = lacp_event_watch_hwaddr_changed,
+ 	.port_added = lacp_event_watch_port_added,
+ 	.port_removed = lacp_event_watch_port_removed,
+ 	.port_changed = lacp_event_watch_port_changed,
+ 	.admin_state_changed = lacp_event_watch_admin_state_changed,
++	.refresh = lacp_event_watch_refresh,
+ };
+ 
+ static int lacp_carrier_init(struct teamd_context *ctx, struct lacp *lacp)
+-- 
+2.7.4
+

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -17,6 +17,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Apply patch
 	git apply ../0001-libteam-Add-team_get_port_enabled-function.patch
 	git apply ../0002-libteam-Temporarily-remove-redundant-debug-mes.patch
+	git apply ../0003-teamd-lacp-runner-will-send-lacp-update-right-after-.patch
 	popd
 
 	# Obtain debian packaging


### PR DESCRIPTION
We need this to allow fast reboot to last up to 90 seconds.
With previous mode the fast reboot can last up to 60-90 seconds. Because we doesn't know when the last lacp update was sent. This patch makes the last update more deterministic.