### PR TITLE
[teamd]: Remove deprecated blocking logic before starting teamd

### DIFF
--- a/dockers/docker-teamd/teamd.sh
+++ b/dockers/docker-teamd/teamd.sh
@@ -24,15 +24,5 @@ function clean_up {
 
 trap clean_up SIGTERM SIGKILL
 
-# Before teamd could automatically add newly created host interfaces into the
-# LAG, this workaround will wait until the host interfaces are created and then
-# the processes will be started.
-while true; do
-    # Check if front-panel ports are configured
-    result=`echo -en "SELECT 0\nHGETALL PORT_TABLE:ConfigDone" | redis-cli | sed -n 3p`
-    if [ "$result" == "0" ]; then
-        start_app
-        read
-    fi
-    sleep 1
-done
+start_app
+read


### PR DESCRIPTION
With the fixes in /etc/network/interfaces file, host interfaces
could be added into the corresponding LAGs automatically. Thus,
the logic of checking if port initialization is ready is no longer
needed.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

**- What I did**
remove deprecated codes
**- How to verify it**
restarting docker teamd and docker swss
rebooting the whole system
