### PR TITLE
Disable snmpd module disk_hw, so no syslog messages about unavailable disks

### DIFF
--- a/dockers/docker-snmp-sv2/snmpd.conf.j2
+++ b/dockers/docker-snmp-sv2/snmpd.conf.j2
@@ -28,7 +28,7 @@ agentAddress udp:{{ prefix | ip }}:161
 {% endif %}
 {% endfor %}
 {% else %}
-# Listen on all addresses as mgmt ip not specified 
+# Listen on all addresses as mgmt ip not specified
 agentAddress udp:161
 {% endif %}
 
@@ -114,7 +114,7 @@ load   12 10 5
 #  Event MIB - automatically generate alerts
 #
 # Remember to activate the 'createUser' lines above
-#iquerySecName   internalUser       
+#iquerySecName   internalUser
 #rouser          internalUser
 # generate traps on UCD error conditions
 #defaultMonitors          yes

--- a/dockers/docker-snmp-sv2/snmpd.conf.j2
+++ b/dockers/docker-snmp-sv2/snmpd.conf.j2
@@ -61,7 +61,7 @@ sysServices    72
 #
 #  Process Monitoring
 #
-# TODO: should we enable snmp based monitoring of sswsyncd and other processes?
+# todo: should we enable snmp based monitoring of sswsyncd and other processes?
 
 # At least one 'sendmail' process, but no more than 10
 #proc  sendmail 10 1
@@ -76,12 +76,7 @@ sysServices    72
                                # 10MBs required on root disk, 5% free on /var, 10% free on all other disks
 disk       /     10000
 disk       /var  5%
-
-# Note: includeAllDisks will conflict with ignoredisk
-# TODO: /root/* are introduced by aufs union mount, happening in initramfs stage. Clean them in the mount list.
-ignoredisk /root/host
-ignoredisk /root/dev
-ignoredisk /root/dev/pts
+includeAllDisks  10%
 
 #  Walk the UCD-SNMP-MIB::dskTable to see the resulting output
 #  Note that this table will be empty if there are no "disk" entries in the snmpd.conf file
@@ -119,7 +114,7 @@ load   12 10 5
 #  Event MIB - automatically generate alerts
 #
 # Remember to activate the 'createUser' lines above
-#iquerySecName   internalUser
+#iquerySecName   internalUser       
 #rouser          internalUser
 # generate traps on UCD error conditions
 #defaultMonitors          yes

--- a/dockers/docker-snmp-sv2/supervisord.conf
+++ b/dockers/docker-snmp-sv2/supervisord.conf
@@ -20,7 +20,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:snmpd]
-command=/usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip -p /run/snmpd.pid
+command=/usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw -p /run/snmpd.pid
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed https://github.com/Azure/sonic-snmpagent/issues/22

**- How I did it**
Disabled the module of snmpd

**- How to verify it**
Tested in lab

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
