### PR TITLE
[docker-syncd-mlnx][start.sh]: Remove FW upgrade

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx/start.sh
+++ b/platform/mellanox/docker-syncd-mlnx/start.sh
@@ -4,8 +4,4 @@ rm -f /var/run/rsyslogd.pid
 
 supervisorctl start rsyslogd
 
-# mlnx-fw-upgrade.sh will exit if firmware was actually upgraded
-# or if some error occurs
-. mlnx-fw-upgrade.sh
-
 supervisorctl start syncd


### PR DESCRIPTION
FW upgrade is done outside the container.
This piece of code was left accidentally during the merge.
