### PR TITLE
[docker-syncd]: Fix mount point for machine.conf

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-rpc.mk
+++ b/platform/broadcom/docker-syncd-brcm-rpc.mk
@@ -12,6 +12,6 @@ endif
 
 $(DOCKER_SYNCD_BRCM_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/broadcom/docker-syncd-brcm.mk
+++ b/platform/broadcom/docker-syncd-brcm.mk
@@ -12,7 +12,7 @@ endif
 
 $(DOCKER_SYNCD_BRCM)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BRCM)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 

--- a/platform/cavium/docker-syncd-cavm-rpc.mk
+++ b/platform/cavium/docker-syncd-cavm-rpc.mk
@@ -11,5 +11,5 @@ endif
 
 $(DOCKER_SYNCD_CAVM_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_CAVM_RPC)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_SYNCD_CAVM_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_CAVM_RPC)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_SYNCD_CAVM_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/cavium/docker-syncd-cavm.mk
+++ b/platform/cavium/docker-syncd-cavm.mk
@@ -11,5 +11,5 @@ endif
 
 $(DOCKER_SYNCD_CAVM)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_CAVM)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_SYNCD_CAVM)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_CAVM)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_SYNCD_CAVM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/centec/docker-syncd-centec-rpc.mk
+++ b/platform/centec/docker-syncd-centec-rpc.mk
@@ -11,6 +11,6 @@ endif
 
 $(DOCKER_SYNCD_CENTEC_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/centec/docker-syncd-centec.mk
+++ b/platform/centec/docker-syncd-centec.mk
@@ -11,6 +11,6 @@ endif
 
 $(DOCKER_SYNCD_CENTEC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/marvell/docker-syncd-mrvl-rpc.mk
+++ b/platform/marvell/docker-syncd-mrvl-rpc.mk
@@ -11,5 +11,5 @@ endif
 
 $(DOCKER_SYNCD_MRVL_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/marvell/docker-syncd-mrvl.mk
+++ b/platform/marvell/docker-syncd-mrvl.mk
@@ -11,5 +11,5 @@ endif
 
 $(DOCKER_SYNCD_MRVL)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_MRVL)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_SYNCD_MRVL)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_MRVL)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_SYNCD_MRVL)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/mellanox/docker-syncd-mlnx-rpc.mk
+++ b/platform/mellanox/docker-syncd-mlnx-rpc.mk
@@ -11,5 +11,5 @@ endif
 
 $(DOCKER_SYNCD_MLNX_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_MLNX_RPC)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_SYNCD_MLNX_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_MLNX_RPC)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_SYNCD_MLNX_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/mellanox/docker-syncd-mlnx.mk
+++ b/platform/mellanox/docker-syncd-mlnx.mk
@@ -11,5 +11,5 @@ endif
 
 $(DOCKER_SYNCD_MLNX)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_MLNX)_RUN_OPT += --net=host --privileged -t
-$(DOCKER_SYNCD_MLNX)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_MLNX)_RUN_OPT += -v /host/machine.conf:/host/machine.conf
 $(DOCKER_SYNCD_MLNX)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro


### PR DESCRIPTION
machine.conf must be mounted under /host directory in each container so
that config engine can find and parse it

Signed-off-by: marian-pritsak <marianp@mellanox.com>