### PR TITLE
[SAI] publish SAI 2.3.0.5-2 and opennsl 3.4.1.5-2

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_2.1.5.1-17_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_2.1.5.1-17_amd64.deb?sv=2015-04-05&sr=b&sig=6sJ4dd%2FF1hqStNQk5Z6d%2BYQGRZxLDihXRl60EeN7agc%3D&se=2031-05-02T09%3A37%3A54Z&sp=r"
+BRCM_SAI = libsaibcm_2.3.0.5-2_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_2.3.0.5-2_amd64.deb?sv=2015-04-05&sr=b&sig=5Q1rbpPp0EtyJtbb1Y5LM%2FBRAKmvy8moXAFuLj47xTM%3D&se=2031-06-05T21%3A50%3A55Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_2.1.5.1-17_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_2.3.0.5-2_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_2.1.5.1-17_amd64.deb?sv=2015-04-05&sr=b&sig=syV0rie0L2Dn4lhmndCTyCTgXQv8DPoWD3IxtlSdeNo%3D&se=2031-05-02T09%3A37%3A18Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_2.3.0.5-2_amd64.deb?sv=2015-04-05&sr=b&sig=%2BaLb2myxvGPmhIVL%2FZGOEi%2FxW9nSMVB7ZTa%2BzSTufOc%3D&se=2031-06-05T21%3A52%3A24Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI) $(BRCM_SAI_DEV)
 $(BRCM_SAI)_DEPENDS += $(BRCM_OPENNSL)

--- a/platform/broadcom/sdk.mk
+++ b/platform/broadcom/sdk.mk
@@ -1,7 +1,7 @@
-BRCM_OPENNSL = libopennsl_3.2.2.2-10-20170707181826.44_amd64.deb
-$(BRCM_OPENNSL)_URL = "https://sonicstorage.blob.core.windows.net/packages/libopennsl_3.2.2.2-10-20170707181826.44_amd64.deb?sv=2015-04-05&sr=b&sig=hc4PbMQvfOu7p7E0MR1kn0OA6vu%2BPIdYOLeDU9hPJMY%3D&se=2031-03-19T21%3A20%3A15Z&sp=r"
+BRCM_OPENNSL = libopennsl_3.4.1.5-2_amd64.deb
+$(BRCM_OPENNSL)_URL = "https://sonicstorage.blob.core.windows.net/packages/libopennsl_3.4.1.5-2_amd64.deb?sv=2015-04-05&sr=b&sig=gdqovE5An%2F3XffSjP%2F5hT9QB4jLfRsO5Ygm3hJbleRI%3D&se=2031-06-05T21%3A54%3A00Z&sp=r"
 
-BRCM_OPENNSL_KERNEL = opennsl-modules-3.16.0-4-amd64_3.2.2.2-10-20170707181826.44_amd64.deb
-$(BRCM_OPENNSL_KERNEL)_URL = "https://sonicstorage.blob.core.windows.net/packages/opennsl-modules-3.16.0-4-amd64_3.2.2.2-10-20170707181826.44_amd64.deb?sv=2015-04-05&sr=b&sig=xtGLlxX5SspadCxaObMGGVMQliPGrTkuN0T6A4wLETA%3D&se=2031-03-19T21%3A21%3A43Z&sp=r"
+BRCM_OPENNSL_KERNEL = opennsl-modules-3.16.0-4-amd64_3.4.1.5-2_amd64.deb
+$(BRCM_OPENNSL_KERNEL)_URL = "https://sonicstorage.blob.core.windows.net/packages/opennsl-modules-3.16.0-4-amd64_3.4.1.5-2_amd64.deb?sv=2015-04-05&sr=b&sig=yXB53no4GsaUNDJDUBwdP5SYeNiZSjaSh5USlg3YoJ4%3D&se=2031-06-05T21%3A55%3A14Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_OPENNSL) $(BRCM_OPENNSL_KERNEL)


### PR DESCRIPTION
By upgrading 201709 branch to build with Broadcom SAI 2.3.0.5 and Opennsl 3.4.1.5, there comes:

- A preliminary support for TomHawk2 ASIC on Arista 7260CX3 platform.
- Continue having support for Trident2 ASIC support.

Test done for this change:
- Passed nightly tests on TD2 platform (skipped some tests that are currently failing: IP-in-IP, lag2, DHCP-relay.
- Passed a subset of regular T0 nightly tests on TH2 platform.