### PR TITLE
[Arista] Fix a typo in port_config.ini

### DIFF
--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini
@@ -80,7 +80,7 @@ Ethernet158     3,4               Ethernet40/3 78
 Ethernet160     17,18             Ethernet41/1 79
 Ethernet162     19,20             Ethernet41/3 80
 Ethernet164     29,30             Ethernet42/1 81
-Ethernet166     31,32             Ethernet42/1 82
+Ethernet166     31,32             Ethernet42/3 82
 Ethernet168     41,42             Ethernet43/1 83
 Ethernet170     43,44             Ethernet43/3 84
 Ethernet172     33,34             Ethernet44/1 85


### PR DESCRIPTION
This change fixes a typo in port_config.ini for Arista 7260CX3 T0 topology. Where port Ethernet42/1 was used twice, the second one should be Ethernet42/3.

This issue was caught by SNMP Test and the change was validated by SNMP Test