### PR TITLE
[port_config.ini]: Change all column headers from 'port' to 'index'

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-Q16S64/port_config.ini
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-Q16S64/port_config.ini
@@ -1,4 +1,4 @@
-# name          lanes             alias         port
+# name          lanes             alias         index
 Ethernet0       125,126,127,128   Ethernet1/1   1
 Ethernet4       121,122,123,124   Ethernet2/1   2
 Ethernet8       13,14,15,16       Ethernet3/1   3

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/port_config.ini
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/port_config.ini
@@ -1,4 +1,4 @@
-# name          lanes             alias         port
+# name          lanes             alias         index
 Ethernet0       125,126,127,128   Ethernet1/1   1
 Ethernet4       121,122,123,124   Ethernet2/1   2
 Ethernet8       13,14,15,16       Ethernet3/1   3

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/port_config.ini
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/port_config.ini
@@ -1,4 +1,4 @@
-# name          lanes             alias         port
+# name          lanes             alias         index
 Ethernet0       9,10,11,12        Ethernet5/1   5
 Ethernet4       13,14,15,16       Ethernet6/1   6
 Ethernet8       17,18,19,20       Ethernet7/1   7

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060-CX32S/port_config.ini
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060-CX32S/port_config.ini
@@ -1,4 +1,4 @@
-# name          lanes             alias         port
+# name          lanes             alias         index
 Ethernet0       33,34,35,36       Ethernet1/1   1
 Ethernet4       37,38,39,40       Ethernet2/1   2
 Ethernet8       41,42,43,44       Ethernet3/1   3

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/port_config.ini
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/port_config.ini
@@ -1,4 +1,4 @@
-# name          lanes             alias        port
+# name          lanes             alias        index
 Ethernet0       77,78,79,80       Ethernet1/1  1
 Ethernet4       65,66,67,68       Ethernet2/1  2
 Ethernet8       85,86,87,88       Ethernet3/1  3

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini
@@ -1,4 +1,4 @@
-# name          lanes             alias        port
+# name          lanes             alias        index
 Ethernet0       77,78             Ethernet1/1  1
 Ethernet2       79,80             Ethernet1/3  2
 Ethernet4       65,66             Ethernet2/1  3

--- a/device/ingrasys/x86_64-ingrasys_s8810_32q-r0/INGRASYS-S8810-32Q/port_config.ini
+++ b/device/ingrasys/x86_64-ingrasys_s8810_32q-r0/INGRASYS-S8810-32Q/port_config.ini
@@ -1,4 +1,4 @@
-# name          lanes             alias           port
+# name          lanes             alias           index
 Ethernet0       37,38,39,40       Ethernet1/1     0
 Ethernet4       33,34,35,36       Ethernet2/1     1
 Ethernet8       45,46,47,48       Ethernet3/1     2

--- a/device/ingrasys/x86_64-ingrasys_s8900_54xc-r0/INGRASYS-S8900-54XC/port_config.ini
+++ b/device/ingrasys/x86_64-ingrasys_s8900_54xc-r0/INGRASYS-S8900-54XC/port_config.ini
@@ -1,4 +1,4 @@
-# name          lanes               alias                  port
+# name          lanes               alias                  index
 Ethernet0       1                   Ethernet1              0
 Ethernet1       2                   Ethernet2              1
 Ethernet2       3                   Ethernet3              2

--- a/device/ingrasys/x86_64-ingrasys_s8900_64xc-r0/INGRASYS-S8900-64XC/port_config.ini
+++ b/device/ingrasys/x86_64-ingrasys_s8900_64xc-r0/INGRASYS-S8900-64XC/port_config.ini
@@ -1,4 +1,4 @@
-# name          lanes             alias            port
+# name          lanes             alias            index
 Ethernet0       17                Ethernet1        0
 Ethernet1       18                Ethernet2        1
 Ethernet2       19                Ethernet3        2

--- a/device/ingrasys/x86_64-ingrasys_s9100-r0/INGRASYS-S9100-C32/port_config.ini
+++ b/device/ingrasys/x86_64-ingrasys_s9100-r0/INGRASYS-S9100-C32/port_config.ini
@@ -1,4 +1,4 @@
-# name          lanes             alias             port
+# name          lanes             alias             index
 Ethernet0       5,6,7,8           Ethernet1/1       0
 Ethernet4       1,2,3,4           Ethernet2/1       1 
 Ethernet8       13,14,15,16       Ethernet3/1       2 


### PR DESCRIPTION
**- What I did**
  - Unify the header lines of all port_config.ini files. Change `port` column header to `index`

**- How I did it**
  - I used vim ;)

**- How to verify it**
  - Visually examine the files, check for typos or missed files

**- Description for the changelog**
[port_config.ini]: Change all column headers from 'port' to 'index'