### PR TITLE
[docker-platform-monitor]: Remove stale fancontrol.pid file (if exists) before starting fancontrol

### DIFF
--- a/dockers/docker-platform-monitor/start.sh
+++ b/dockers/docker-platform-monitor/start.sh
@@ -18,6 +18,9 @@ fi
 # If this platform has a fancontrol config file, copy it to it's proper place
 # and start fancontrol
 if [ -e /usr/share/sonic/platform/fancontrol ]; then
+    # Remove stale pid file if it exists
+    rm -f /var/run/fancontrol.pid
+
     /bin/cp -f /usr/share/sonic/platform/fancontrol /etc/
     supervisorctl start fancontrol
 fi


### PR DESCRIPTION
**- What I did**
  - Fix issue where fancontrol will not start again if shut down forcibly
  - Resolves https://github.com/Azure/sonic-buildimage/issues/975

**- How I did it**
  - Remove stale fancontrol.pid file (if it exists) before starting fancontrol

**- How to verify it**
  - Shutdown fancontrol forcibly (`reboot -f` `kill -9 fancontrol`) and ensure that upon starting platform monitor docker fancontrol service is able to write a new .pid file and start properly.