### PR TITLE
[config-engine]: Fix bug multiple ports connecting to same neighbor

### DIFF
--- a/dockers/docker-lldp-sv2/lldpd.conf.j2
+++ b/dockers/docker-lldp-sv2/lldpd.conf.j2
@@ -1,3 +1,3 @@
-{% for neighbor in DEVICE_NEIGHBOR %}
-configure ports {{ DEVICE_NEIGHBOR[neighbor]['local_port'] }} lldp portidsubtype local {{ PORT[DEVICE_NEIGHBOR[neighbor]['local_port']]['alias'] }} description {{ neighbor }}:{{ DEVICE_NEIGHBOR[neighbor]['port'] }}
+{% for local_port in DEVICE_NEIGHBOR %}
+configure ports {{ local_port }} lldp portidsubtype local {{ PORT[local_port]['alias'] }} description {{ DEVICE_NEIGHBOR[local_port]['name'] }}:{{ DEVICE_NEIGHBOR[local_port]['port'] }}
 {% endfor %}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -91,21 +91,17 @@ def parse_png(png, hname):
                 if enddevice == hname:
                     if port_alias_map.has_key(endport):
                         endport = port_alias_map[endport]
-                    neighbors[startdevice] = {'local_port': endport, 'port': startport}
+                    neighbors[endport] = {'name': startdevice, 'port': startport}
                 else:
                     if port_alias_map.has_key(startport):
                         startport = port_alias_map[startport]
-                    neighbors[enddevice] = {'local_port': startport, 'port': endport}
+                    neighbors[startport] = {'name': enddevice, 'port': endport}
 
         if child.tag == str(QName(ns, "Devices")):
             for device in child.findall(str(QName(ns, "Device"))):
                 (lo_prefix, mgmt_prefix, name, hwsku, d_type) = parse_device(device)
                 device_data = {'lo_addr': lo_prefix, 'type': d_type, 'mgmt_addr': mgmt_prefix, 'hwsku': hwsku } 
-                name = name.replace('"', '')
-                if neighbors.has_key(name):
-                    neighbors[name].update(device_data)
-                else:
-                    devices[name] = device_data
+                devices[name] = device_data
 
         if child.tag == str(QName(ns, "DeviceInterfaceLinks")):
             for if_link in child.findall(str(QName(ns, 'DeviceLinkBase'))):

--- a/src/sonic-config-engine/tests/sample_output/lldpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/lldpd.conf
@@ -1,0 +1,5 @@
+configure ports Ethernet116 lldp portidsubtype local fortyGigE0/116 description ARISTA02T1:Ethernet1/1
+configure ports Ethernet124 lldp portidsubtype local fortyGigE0/124 description ARISTA04T1:Ethernet1/1
+configure ports Ethernet112 lldp portidsubtype local fortyGigE0/112 description ARISTA01T1:Ethernet1/1
+configure ports Ethernet120 lldp portidsubtype local fortyGigE0/120 description ARISTA03T1:Ethernet1/1
+

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -106,9 +106,9 @@ class TestCfgGen(TestCase):
         self.assertEqual(output.strip(), "[('PortChannel01', 'FC00::71/126'), ('PortChannel01', '10.0.0.56/31')]")
 
     def test_minigraph_neighbors(self):
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "DEVICE_NEIGHBOR[\'ARISTA01T1\']"'
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v "DEVICE_NEIGHBOR[\'Ethernet124\']"'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'mgmt_addr': None, 'hwsku': 'Arista', 'lo_addr': None, 'local_port': 'Ethernet112', 'type': 'LeafRouter', 'port': 'Ethernet1/1'}")
+        self.assertEqual(output.strip(), "{'name': 'ARISTA04T1', 'port': 'Ethernet1/1'}")
 
     def test_minigraph_bgp(self):
         argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v "BGP_NEIGHBOR[\'10.0.0.59\']"'

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -26,10 +26,16 @@ class TestJ2Files(TestCase):
 
     def test_alias_map(self):
         alias_map_template = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-snmp-sv2', 'alias_map.j2')
-        argument = '-m "' + self.t0_minigraph + '" -p "' + self.t0_port_config + '" -t "' + alias_map_template + '"'
+        argument = '-m ' + self.t0_minigraph + ' -p ' + self.t0_port_config + ' -t ' + alias_map_template
         output = self.run_script(argument)
         data = json.loads(output)
         self.assertEqual(data["Ethernet4"], "fortyGigE0/4")        
+
+    def test_lldp(self):
+        lldpd_conf_template = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-lldp-sv2', 'lldpd.conf.j2')
+        argument = '-m ' + self.t0_minigraph + ' -p ' + self.t0_port_config + ' -t ' + lldpd_conf_template + ' > ' + self.output_file
+        self.run_script(argument)
+        self.assertTrue(filecmp.cmp(os.path.join(self.test_dir, 'sample_output', 'lldpd.conf'), self.output_file))
         
     def test_teamd(self):
 


### PR DESCRIPTION

    [config-engine]: Fix bug multiple ports connecting to same neighbor

    The current DEVICE_NEIGHBOR format doesn't support multiple different
    ports connecting with same neighbor. Thus the lldpd.conf file is not
    generated correctly, causing missing information for LAG members.

    This fix reverts the data structure in the previous version of
    minigraph parser - using local port as the key and remote port/device
    as the value of the map. Sample format is:

    DEVICE_NEIGHBOR['Ethernet124'] = {
        'name': 'ARISTA04T1',
        'port': 'Ethernet1/1'
    }

    The corresponding unit test in test_cfggen is updated.
    Add one more unit test for lldpd.conf.j2 verification.

    Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
See above.

**- How I did it**
Vim.

**- How to verify it**
Replace the minigraph.py file and the lldpd.conf.j2 file in the lldp docker and check the generated lldpd.conf file. This is especially the case when the topology is t1-lag.

See the output:
```
configure ports Ethernet124 lldp portidsubtype local fortyGigE0/124 description ARISTA16T0:Ethernet1
configure ports Ethernet104 lldp portidsubtype local fortyGigE0/104 description ARISTA11T0:Ethernet1
configure ports Ethernet100 lldp portidsubtype local fortyGigE0/100 description ARISTA10T0:Ethernet1
configure ports Ethernet40 lldp portidsubtype local fortyGigE0/40 description ARISTA11T2:Ethernet1
configure ports Ethernet44 lldp portidsubtype local fortyGigE0/44 description ARISTA11T2:Ethernet2
configure ports Ethernet32 lldp portidsubtype local fortyGigE0/32 description ARISTA09T2:Ethernet1
configure ports Ethernet36 lldp portidsubtype local fortyGigE0/36 description ARISTA09T2:Ethernet2
configure ports Ethernet96 lldp portidsubtype local fortyGigE0/96 description ARISTA09T0:Ethernet1
configure ports Ethernet84 lldp portidsubtype local fortyGigE0/84 description ARISTA06T0:Ethernet1
configure ports Ethernet92 lldp portidsubtype local fortyGigE0/92 description ARISTA08T0:Ethernet1
configure ports Ethernet88 lldp portidsubtype local fortyGigE0/88 description ARISTA07T0:Ethernet1
configure ports Ethernet24 lldp portidsubtype local fortyGigE0/24 description ARISTA07T2:Ethernet1
configure ports Ethernet28 lldp portidsubtype local fortyGigE0/28 description ARISTA07T2:Ethernet2
configure ports Ethernet0 lldp portidsubtype local fortyGigE0/0 description ARISTA01T2:Ethernet1
configure ports Ethernet4 lldp portidsubtype local fortyGigE0/4 description ARISTA01T2:Ethernet2
configure ports Ethernet64 lldp portidsubtype local fortyGigE0/64 description ARISTA01T0:Ethernet1
configure ports Ethernet16 lldp portidsubtype local fortyGigE0/16 description ARISTA05T2:Ethernet1
configure ports Ethernet20 lldp portidsubtype local fortyGigE0/20 description ARISTA05T2:Ethernet2
configure ports Ethernet80 lldp portidsubtype local fortyGigE0/80 description ARISTA05T0:Ethernet1
configure ports Ethernet68 lldp portidsubtype local fortyGigE0/68 description ARISTA02T0:Ethernet1
configure ports Ethernet72 lldp portidsubtype local fortyGigE0/72 description ARISTA03T0:Ethernet1
configure ports Ethernet8 lldp portidsubtype local fortyGigE0/8 description ARISTA03T2:Ethernet1
configure ports Ethernet12 lldp portidsubtype local fortyGigE0/12 description ARISTA03T2:Ethernet2
configure ports Ethernet76 lldp portidsubtype local fortyGigE0/76 description ARISTA04T0:Ethernet1
configure ports Ethernet120 lldp portidsubtype local fortyGigE0/120 description ARISTA15T0:Ethernet1
configure ports Ethernet56 lldp portidsubtype local fortyGigE0/56 description ARISTA15T2:Ethernet1
configure ports Ethernet60 lldp portidsubtype local fortyGigE0/60 description ARISTA15T2:Ethernet2
configure ports Ethernet116 lldp portidsubtype local fortyGigE0/116 description ARISTA14T0:Ethernet1
configure ports Ethernet108 lldp portidsubtype local fortyGigE0/108 description ARISTA12T0:Ethernet1
configure ports Ethernet48 lldp portidsubtype local fortyGigE0/48 description ARISTA13T2:Ethernet1
configure ports Ethernet52 lldp portidsubtype local fortyGigE0/52 description ARISTA13T2:Ethernet2
configure ports Ethernet112 lldp portidsubtype local fortyGigE0/112 description ARISTA13T0:Ethernet1

```


**- A picture of a cute animal**
```
                       m
   $m                mm            m
    "$mmmmm        m$"    mmmmmmm$"
          """$m   m$    m$""""""
        mmmmmmm$$$$$$$$$"mmmm
  mmm$$$$$$$$$$$$$$$$$$ m$$$$m  "    m  "
$$$$$$$$$$$$$$$$$$$$$$  $$$$$$"$$$
 mmmmmmbugmmmmmmmmmmmm  $$$$$$$$$$
 $$$$$$$$$$$$$$$$$$$$$  $$$$$$$"""  m
 "$$$$$$$$$$$$$$$$$$$$$ $$$$$$  "      "
     """""""$$$$$$$$$$$m """"
       mmmmmmmm"  m$   "$mmmmm
     $$""""""      "$     """"""$$
   m$"               "m           "
                       "
```