### PR TITLE
Make swssconfig status FATAL when it fails

### DIFF
--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -56,7 +56,7 @@ command=/usr/bin/swssconfig.sh
 priority=7
 autostart=false
 autorestart=unexpected
-startretries=1
+startretries=0
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -55,7 +55,8 @@ stderr_logfile=syslog
 command=/usr/bin/swssconfig.sh
 priority=7
 autostart=false
-autorestart=false
+autorestart=unexpected
+startretries=1
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -46,7 +46,7 @@ elif [ "$HWSKU" == "Force10-S6000-Q32" ]; then
 elif [ "$HWSKU" == "Arista-7050-QX32" ]; then
     SWSSCONFIG_ARGS+="td2.32ports.buffers.json td2.32ports.qos.json "
 elif [[ "$HWSKU" == "ACS-MSN27"* ]]; then
-    sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/msn27xx.32ports.buffers.json.j2 > /etc/swss/config.d/msn27xx.32ports.buffers.json
+    sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/msn27xx.32ports.buffers.json.j2 > /etc/swss/config.d/msn27xx.32ports.buffers.json || exit 1
     SWSSCONFIG_ARGS+="msn27xx.32ports.buffers.json msn2700.32ports.qos.json "
 fi
 

--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 function config_acl {
     if [ -f "/etc/sonic/acl.json" ]; then
         mkdir -p /etc/swss/config.d/acl
@@ -46,7 +48,7 @@ elif [ "$HWSKU" == "Force10-S6000-Q32" ]; then
 elif [ "$HWSKU" == "Arista-7050-QX32" ]; then
     SWSSCONFIG_ARGS+="td2.32ports.buffers.json td2.32ports.qos.json "
 elif [[ "$HWSKU" == "ACS-MSN27"* ]]; then
-    sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/msn27xx.32ports.buffers.json.j2 > /etc/swss/config.d/msn27xx.32ports.buffers.json || exit 1
+    sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/msn27xx.32ports.buffers.json.j2 > /etc/swss/config.d/msn27xx.32ports.buffers.json
     SWSSCONFIG_ARGS+="msn27xx.32ports.buffers.json msn2700.32ports.qos.json "
 fi
 


### PR DESCRIPTION
Make supervisor controled one-shot program autorestart 0 time, so the status will become FATAL instead of EXITED if fails. 'supervisorctl status' differentiates between normal exit and failure.

It will help diagnose in running switch.

Signed-off-by: Qi Luo <qiluo-msft@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The supervisor controlled one-shot program status will become FATAL instead of EXITED if failure happens
**- How I did it**
Make supervisor controled one-shot program autorestart 0 time
**- How to verify it**
Test in lab switch
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
