### PR TITLE
[build]: sonic-utilities package depends on swsssdk; build as wheel and add build dependency

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -77,9 +77,11 @@ sudo cp {{swsssdk_py2_wheel_path}} $FILESYSTEM_ROOT/$SWSSSDK_PY2_WHEEL_NAME
 sudo LANG=C chroot $FILESYSTEM_ROOT pip install $SWSSSDK_PY2_WHEEL_NAME
 sudo rm -rf $FILESYSTEM_ROOT/$SWSSSDK_PY2_WHEEL_NAME
 
-# Install SONiC Utilities (and its dependencies via 'apt-get -y install -f')
-sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/python-sonic-utilities_*.deb || \
-    sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
+# Install SONiC Utilities Python package
+SONIC_UTILITIES_WHEEL_NAME=$(basename {{sonic_utilities_wheel_path}})
+sudo cp {{sonic_utilities_wheel_path}} $FILESYSTEM_ROOT/$SONIC_UTILITIES_WHEEL_NAME
+sudo LANG=C chroot $FILESYSTEM_ROOT pip install $SONIC_UTILITIES_WHEEL_NAME
+sudo rm -rf $FILESYSTEM_ROOT/$SONIC_UTILITIES_WHEEL_NAME
 
 # SONiC utilities installs bash-completion as a dependency. However, it is disabled by default
 # in bash.bashrc, so we copy a version of the file with it enabled here.

--- a/rules/sonic-utilities.mk
+++ b/rules/sonic-utilities.mk
@@ -1,6 +1,6 @@
 # sonic utilities package
 
-SONIC_UTILITIES = sonic-utilities_1.1-py2-none-any.whl
+SONIC_UTILITIES = sonic_utilities-1.1-py2-none-any.whl
 $(SONIC_UTILITIES)_SRC_PATH = $(SRC_PATH)/sonic-utilities
 $(SONIC_UTILITIES)_PYTHON_VERSION = 2
 $(SONIC_UTILITIES)_DEPENDS += $(SWSSSDK_PY2)

--- a/rules/sonic-utilities.mk
+++ b/rules/sonic-utilities.mk
@@ -2,4 +2,5 @@
 
 SONIC_UTILS = python-sonic-utilities_1.1-1_all.deb
 $(SONIC_UTILS)_SRC_PATH = $(SRC_PATH)/sonic-utilities
+$(SONIC_UTILS)_DEPENDS += $(SWSSSDK_PY2)
 SONIC_PYTHON_STDEB_DEBS += $(SONIC_UTILS)

--- a/rules/sonic-utilities.mk
+++ b/rules/sonic-utilities.mk
@@ -1,6 +1,7 @@
 # sonic utilities package
 
-SONIC_UTILS = python-sonic-utilities_1.1-1_all.deb
-$(SONIC_UTILS)_SRC_PATH = $(SRC_PATH)/sonic-utilities
-$(SONIC_UTILS)_DEPENDS += $(SWSSSDK_PY2)
-SONIC_PYTHON_STDEB_DEBS += $(SONIC_UTILS)
+SONIC_UTILITIES = sonic-utilities_1.1-py2-none-any.whl
+$(SONIC_UTILITIES)_SRC_PATH = $(SRC_PATH)/sonic-utilities
+$(SONIC_UTILITIES)_PYTHON_VERSION = 2
+$(SONIC_UTILITIES)_DEPENDS += $(SWSSSDK_PY2)
+SONIC_PYTHON_WHEELS += $(SONIC_UTILITIES)

--- a/slave.mk
+++ b/slave.mk
@@ -380,7 +380,7 @@ $(DOCKER_LOAD_TARGETS) : $(TARGET_PATH)/%.gz-load : .platform docker-start $$(TA
 ###############################################################################
 
 # targets for building installers with base image
-$(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : .platform onie-image.conf $$(addprefix $(DEBS_PATH)/,$$($$*_DEPENDS)) $$(addprefix $(DEBS_PATH)/,$$($$*_INSTALLS)) $$(addprefix $(FILES_PATH)/,$$($$*_FILES)) $(addprefix $(DEBS_PATH)/,$(INITRAMFS_TOOLS) $(LINUX_KERNEL) $(IGB_DRIVER) $(SONIC_DEVICE_DATA) $(SONIC_UTILS)) $$(addprefix $(TARGET_PATH)/,$$($$*_DOCKERS)) $$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_CONFIG_ENGINE))
+$(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : .platform onie-image.conf $$(addprefix $(DEBS_PATH)/,$$($$*_DEPENDS)) $$(addprefix $(DEBS_PATH)/,$$($$*_INSTALLS)) $$(addprefix $(FILES_PATH)/,$$($$*_FILES)) $(addprefix $(DEBS_PATH)/,$(INITRAMFS_TOOLS) $(LINUX_KERNEL) $(IGB_DRIVER) $(SONIC_DEVICE_DATA)) $$(addprefix $(TARGET_PATH)/,$$($$*_DOCKERS)) $$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_CONFIG_ENGINE)) $$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_UTILITIES))
 	$(HEADER)
 	# Pass initramfs and linux kernel explicitly. They are used for all platforms
 	export initramfs_tools="$(DEBS_PATH)/$(INITRAMFS_TOOLS)"
@@ -397,6 +397,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : .platform
 	export installer_images="$(addprefix $(TARGET_PATH)/,$($*_DOCKERS))"
 	export config_engine_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_CONFIG_ENGINE))"
 	export swsssdk_py2_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SWSSSDK_PY2))"
+	export sonic_utilities_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_UTILITIES))"
 	
 	$(foreach docker, $($*_DOCKERS),\
 		export docker_image="$(docker)"


### PR DESCRIPTION
- Resolves https://github.com/Azure/SONiC/issues/113

- Our current make dependency system assumes .deb dependencies are all of the .deb package format and all .whl dependencies are of the .whl package format. Now that sonic-utilities depends on swsssdk, it either needs to be built as a wheel or the dependency system needs to be refactored to allow for cross-dependencies. Wheel is the current Python standard, so maybe we should consider building all Python packages as wheels.