### PR TITLE
[build_debian]: Install grub-common in the base image

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -208,7 +208,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     less                    \
     unzip                   \
     gdisk                   \
-    grub-common
+    grub2-common
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
     grub-pc-bin

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -207,7 +207,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     kexec-tools             \
     less                    \
     unzip                   \
-    gdisk
+    gdisk                   \
+    grub-common
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
     grub-pc-bin


### PR DESCRIPTION
**- How to verify it**
`apt-get install -y grub-common`
output:
```
root@str-s6000-on-2:/home/admin# grub-                                                                   
grub-editenv          grub-macbless         grub-mkimage          grub-mkrescue         grub-script-check
grub-file             grub-menulst2cfg      grub-mklayout         grub-mkstandalone     grub-syslinux2cfg
grub-fstest           grub-mkconfig         grub-mknetdir         grub-mount                             
grub-glue-efi         grub-mkdevicemap      grub-mkpasswd-pbkdf2  grub-probe                             
grub-kbdcomp          grub-mkfont           grub-mkrelpath        grub-render-label                      
```
