### PR TITLE
[cfggen] Fix a bug in --var-json option working with multiple keys

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -200,7 +200,7 @@ def main():
         print template.render(data)
 
     if args.var_json != None:
-        print json.dumps(data[args.var_json], indent=4, cls=minigraph_encoder)
+        print json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder)
 
     if args.write_to_db:
         configdb = ConfigDBConnector()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a bug in sonic-cfggen that --var-json option will not work properly when dealing with tables with multiple keys

**- How I did it**
Apply the same data serialization as in --print-data

**- How to verify it**
`sonic-cfggen --var-json INTERFACE`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[cfggen] Fix bug in --var-json option working with multiple keys

**- A picture of a cute animal (not mandatory but encouraged)**
```
　　　　　　 .__　 __
　　　　 　 / .| //ﾞ〉
　 　 　 　 |　l// /
　　　　　_/ / i /　__　　＿,,,,. --――-- ､
　　　 ／　　　 ｀;´　 ￣　　　　　　 　 　 　ヽ.
　　　/　●　　, '　　　　　　　　　　　　　　　 ヽ.
　　 （Y　　　, '　　　　　.､　　　　　 i´　　　　　 l´l
　　　`ー' ｀ｰ ､_　　 ､_　 ヽ　　　　l　　　 　 　 |ノ
　　　　　　　　 /ヽ､__/　∠＿＿＿_､　　　　_,ﾉ
　　　　　　　rr' ／rr' ／　　　　 ｒｒ‐'｀''ｰ''フ´
　 　 　 　 　 ￣ 　 ￣　　　　　　￣￣￣´
```