### PR TITLE
add version tag for the docker images

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -193,7 +193,10 @@ sudo cp $IMAGE_CONFIGS/platform/rc.local $FILESYSTEM_ROOT/etc/
 
 {% if installer_images.strip() -%}
 {% for image in installer_images.strip().split(' ') -%}
+{% set imagefilename = image.split('/')|last -%}
+{% set imagename = imagefilename.split('.')|first -%}
 sudo LANG=C chroot $FILESYSTEM_ROOT docker load < {{image}}
+sudo LANG=C chroot $FILESYSTEM_ROOT docker tag {{imagename}}:latest {{imagename}}:$(sonic_get_version)
 {% endfor %}
 sudo chroot $FILESYSTEM_ROOT service docker stop
 {% for script in installer_start_scripts.split(' ') -%}


### PR DESCRIPTION
docker images are also tagged with the same image version.

**- What I did**
add version tag for the docker images

**- How I did it**
use docker tag in the image build process

**- How to verify it**
```
admin@str-a7050-acs-1:~$ show version
SONiC Software Version: SONiC.dockertag.0-dirty-20171007.064313


REPOSITORY                TAG                                 IMAGE ID            CREATED             SIZE
docker-syncd-brcm         dockertag.0-dirty-20171007.064313   54702527a5d3        12 hours ago        323 MB
docker-syncd-brcm         latest                              54702527a5d3        12 hours ago        323 MB
docker-orchagent-brcm     dockertag.0-dirty-20171007.064313   dc767a23c8d5        12 hours ago        263.7 MB
docker-orchagent-brcm     latest                              dc767a23c8d5        12 hours ago        263.7 MB
docker-lldp-sv2           dockertag.0-dirty-20171007.064313   6f89bf9ba435        12 hours ago        261.3 MB
docker-lldp-sv2           latest                              6f89bf9ba435        12 hours ago        261.3 MB
docker-dhcp-relay         dockertag.0-dirty-20171007.064313   e3809814dca2        12 hours ago        258.2 MB
docker-dhcp-relay         latest                              e3809814dca2        12 hours ago        258.2 MB
docker-database           dockertag.0-dirty-20171007.064313   8ede8961ee10        12 hours ago        256.5 MB
docker-database           latest                              8ede8961ee10        12 hours ago        256.5 MB
docker-snmp-sv2           dockertag.0-dirty-20171007.064313   09cc600c1f6a        12 hours ago        296 MB
docker-snmp-sv2           latest                              09cc600c1f6a        12 hours ago        296 MB
docker-teamd              dockertag.0-dirty-20171007.064313   da85c770bcc3        13 hours ago        260.8 MB
docker-teamd              latest                              da85c770bcc3        13 hours ago        260.8 MB
docker-platform-monitor   dockertag.0-dirty-20171007.064313   15fdba02afc6        13 hours ago        275.8 MB
docker-platform-monitor   latest                              15fdba02afc6        13 hours ago        275.8 MB
docker-fpm-quagga         dockertag.0-dirty-20171007.064313   9b316169d8ca        13 hours ago        267.3 MB
docker-fpm-quagga         latest                              9b316169d8ca        13 hours ago        267.3 MB
```

**- Description for the changelog**
add version tag for the docker images

**- A picture of a cute animal (not mandatory but encouraged)**

```
ʕ •ᴥ•ʔ
```