### PR TITLE
[logrotate.conf]: Truncate log files

### DIFF
--- a/files/image_config/logrotate/logrotate.conf
+++ b/files/image_config/logrotate/logrotate.conf
@@ -5,8 +5,8 @@ daily
 # Keep 4 days worth of backlogs by default
 rotate 4
 
-# create new (empty) log files after rotating old ones
-create
+# Truncate the original log file to zero size in place after creating a copy
+copytruncate
 
 # uncomment this if you want your log files compressed
 #compress


### PR DESCRIPTION
When creating a new file we have a problem
that the handle to an original log file is no longer valid.
It can be bad for those programs that write to log file
or read from it. So log file now is truncated instead.
