### PR TITLE
Update QoS config name for Mellanox platform

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -49,7 +49,7 @@ elif [ "$HWSKU" == "Arista-7050-QX32" ]; then
     SWSSCONFIG_ARGS+="td2.32ports.buffers.json td2.32ports.qos.json "
 elif [[ "$HWSKU" == "ACS-MSN27"* ]]; then
     sonic-cfggen -m /etc/sonic/minigraph.xml -t /usr/share/sonic/templates/msn27xx.32ports.buffers.json.j2 > /etc/swss/config.d/msn27xx.32ports.buffers.json
-    SWSSCONFIG_ARGS+="msn27xx.32ports.buffers.json msn2700.32ports.qos.json "
+    SWSSCONFIG_ARGS+="msn27xx.32ports.buffers.json msn27xx.32ports.qos.json "
 fi
 
 for file in $SWSSCONFIG_ARGS; do


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

**- What I did**
Updated QoS config name for Mellanox platform

**- Why I did it**
To match changes in sonic-swss@6f29a74

This needs to merged **only** if sonic-swss submodule is advanced to 6f29a7476d0a5457c9ad0d7650fd63468923cc25 or higher