### PR TITLE
[swss]: Export ASIC as the env variable

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -4,7 +4,7 @@
 # vendor specific code.
 export platform=`sonic-cfggen -v onie_switch_asic`
 
-ASIC=`sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type`
+export ASIC=`sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type`
 
 MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
 


### PR DESCRIPTION
- the env variable 'platform' is not universal across different platforms
  this line will be removed once the related code in sonic-swss is refactored

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

**- How to verify it**
Modify the file in the docker and restart service swss to verify everything is working.
