### PR TITLE
[Makefile]: Fix unmatched variable name ENABLE_SYNCD_RPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            BUILD_NUMBER=$(BUILD_NUMBER) \
                            ENABLE_DHCP_GRAPH_SERVICE=$(ENABLE_DHCP_GRAPH_SERVICE) \
                            SHUTDOWN_BGP_ON_START=$(SHUTDOWN_BGP_ON_START) \
-                           SONIC_ENABLE_SYNCD_RPC=$(ENABLE_SYNCD_RPC) \
+                           ENABLE_SYNCD_RPC=$(ENABLE_SYNCD_RPC) \
                            PASSWORD=$(PASSWORD) \
                            USERNAME=$(USERNAME)
 

--- a/slave.mk
+++ b/slave.mk
@@ -59,10 +59,6 @@ list :
 ## Include other rules
 ###############################################################################
 
-ifeq ($(SONIC_ENABLE_SYNCD_RPC),y)
-ENABLE_SYNCD_RPC = y
-endif
-
 include $(RULES_PATH)/config
 include $(RULES_PATH)/functions
 include $(RULES_PATH)/*.mk


### PR DESCRIPTION
Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

That's the correct output:
```
│➜  build git:(internal) ✗ make ENABLE_SYNCD_RPC=y target/docker-syncd-brcm-rpc.gz
│SONiC Build System
│
│Build Configuration
│"CONFIGURED_PLATFORM"             : "broadcom"
│"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
│"SONIC_CONFIG_BUILD_JOBS"         : "1"
│"SONIC_CONFIG_MAKE_JOBS"          : "4"
│"DEFAULT_USERNAME"                : "admin"
│"DEFAULT_PASSWORD"                : "YourPaSsWoRd"
│"ENABLE_DHCP_GRAPH_SERVICE"       : ""
│"SHUTDOWN_BGP_ON_START"           : ""
│"SONIC_CONFIG_DEBUG"              : ""
│"ROUTING_STACK"                   : "quagga"
│"ENABLE_SYNCD_RPC"                : "y"
│"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
```