### PR TITLE
[snmp]: Add swss dependency for snmp service

### DIFF
--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=SNMP container
-Requires=database.service
-After=database.service
+Requires=database.service swss.service
+After=database.service swss.service
 
 [Service]
 User={{ sonicadmin_user }}


### PR DESCRIPTION
- snmp service needs swss to be ready to get the port counter map

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/__main__.py", line 74, in <module>
    from .main import main
  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/main.py", line 12, in <module>
    from sonic_ax_impl.mibs import ieee802_1ab
  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ieee802_1ab.py", line 99, in <module>
    _lldp_updater = LLDPUpdater()
  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ieee802_1ab.py", line 34, in __init__
    self.reinit_data()
  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/ieee802_1ab.py", line 50, in reinit_data
    self.oid_name_map = mibs.init_sync_d_interface_tables(self.db_conn)
  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/__init__.py", line 77, in init_sync_d_interface_tables
    if_name_map, if_id_map = port_util.get_interface_oid_map(db_conn)
  File "/usr/local/lib/python3.6/dist-packages/swsssdk/port_util.py", line 40, in get_interface_oid_map
    if_name_map = db.get_all('COUNTERS_DB', 'COUNTERS_PORT_NAME_MAP', blocking=True)
  File "/usr/local/lib/python3.6/dist-packages/swsssdk/interface.py", line 38, in wrapped
    ret_data = f(inst, db_name, *args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/swsssdk/interface.py", line 303, in get_all
    raise UnavailableDataError(message, _hash)
swsssdk.exceptions.UnavailableDataError: Key 'COUNTERS_PORT_NAME_MAP' unavailable in database 'COUNTERS_DB'
```