### PR TITLE
Add get_presence implementation for SFP on Mellanox platforms

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2410-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/plugins/sfputil.py
@@ -46,8 +46,23 @@ class SfpUtil(SfpUtilBase):
         SfpUtilBase.__init__(self)
 
     def get_presence(self, port_num):
+        # Check for invalid port_num
+        if port_num < self.port_start or port_num > self.port_end:
+            return False
 
-        raise NotImplementedError
+        try:
+            reg_file = open("/bsp/qsfp/qsfp%d_status" % (port_num+1))
+        except IOError as e:
+            print "Error: unable to open file: %s" % str(e)
+            return False
+
+        content = reg_file.readline().rstrip()
+
+        # content is a string with the qsfp status
+        if content == "good":
+            return True
+
+        return False
 
     def get_low_power_mode(self, port_num):
 

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -46,8 +46,23 @@ class SfpUtil(SfpUtilBase):
         SfpUtilBase.__init__(self)
 
     def get_presence(self, port_num):
+        # Check for invalid port_num
+        if port_num < self.port_start or port_num > self.port_end:
+            return False
 
-        raise NotImplementedError
+        try:
+            reg_file = open("/bsp/qsfp/qsfp%d_status" % (port_num+1))
+        except IOError as e:
+            print "Error: unable to open file: %s" % str(e)
+            return False
+
+        content = reg_file.readline().rstrip()
+
+        # content is a string with the qsfp status
+        if content == "good":
+            return True
+
+        return False
 
     def get_low_power_mode(self, port_num):
 

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/plugins/sfputil.py
@@ -46,8 +46,23 @@ class SfpUtil(SfpUtilBase):
         SfpUtilBase.__init__(self)
 
     def get_presence(self, port_num):
+        # Check for invalid port_num
+        if port_num < self.port_start or port_num > self.port_end:
+            return False
 
-        raise NotImplementedError
+        try:
+            reg_file = open("/bsp/qsfp/qsfp%d_status" % (port_num+1))
+        except IOError as e:
+            print "Error: unable to open file: %s" % str(e)
+            return False
+
+        content = reg_file.readline().rstrip()
+
+        # content is a string with the qsfp status
+        if content == "good":
+            return True
+
+        return False
 
     def get_low_power_mode(self, port_num):
 


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

**- What I did**
Add get_presence implementation for SFP on Mellanox platforms

**- How I did it**
Added implementation in sfputil.py

**- How to verify it**
*Before* implementation:
```
root@arc-switch1028:/# sfputil show presence
Traceback (most recent call last):
  File "/usr/bin/sfputil", line 9, in <module>
    load_entry_point('sonic-utilities==1.1', 'console_scripts', 'sfputil')()
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/sfputil/main.py", line 469, in presence
    presence = platform_sfputil.get_presence(physical_port)
  File "/usr/share/sonic/device/x86_64-mlnx_msn2700-r0/plugins/sfputil.py", line 50, in get_presence
    raise NotImplementedError
NotImplementedError
root@arc-switch1028:/#
```
*After* implementation
```
root@arc-switch1028:/# sfputil show presence
Port         Presence
-----------  -----------
Ethernet0    Present
Ethernet4    Present
Ethernet8    Present
Ethernet12   Not present
Ethernet16   Not present
Ethernet20   Not present
Ethernet24   Not present
Ethernet28   Not present
Ethernet32   Present
Ethernet36   Present
Ethernet40   Not present
Ethernet44   Not present
Ethernet48   Not present
Ethernet52   Not present
Ethernet56   Not present
Ethernet60   Not present
Ethernet64   Not present
Ethernet68   Not present
Ethernet72   Not present
Ethernet76   Not present
Ethernet80   Not present
Ethernet84   Not present
Ethernet88   Not present
Ethernet92   Not present
Ethernet96   Not present
Ethernet100  Not present
Ethernet104  Not present
Ethernet108  Not present
Ethernet112  Not present
Ethernet116  Present
Ethernet120  Present
Ethernet124  Present
root@arc-switch1028:/#
```