### PR TITLE
[lldp]: Get all interfaces from the database

### DIFF
--- a/dockers/docker-lldp-sv2/Dockerfile.j2
+++ b/dockers/docker-lldp-sv2/Dockerfile.j2
@@ -30,7 +30,7 @@ RUN pip install /python-wheels/swsssdk-2.0.1-py2-none-any.whl && \
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
-COPY ["reconfigure.sh", "/opt/"]
+COPY ["reconfigure.sh", "/usr/bin/"]
 COPY ["lldpd.conf.j2", "/usr/share/sonic/templates/"]
 COPY ["lldpd", "/etc/default/"]
 

--- a/dockers/docker-lldp-sv2/reconfigure.sh
+++ b/dockers/docker-lldp-sv2/reconfigure.sh
@@ -2,9 +2,8 @@
 
 set -e
 
-num_of_interfaces=32
-if_step=4
-last_if_idx=$((num_of_interfaces*if_step - if_step))
+# TODO: Listen to state database when it is ready
+interfaces=$(sonic-cfggen -d -v "PORT.keys() | join(' ')")
 
 function wait_until_if_exists
 {
@@ -31,23 +30,23 @@ function wait_until_if_not_exists
 while /bin/true ;
 do
   # wait until all interfaces are created
-  echo Wait until all ifaces are created
-  for i in $(seq 0 $if_step $last_if_idx)
+  echo Wait until all interfaces are created
+  for i in $interfaces
   do
-    wait_until_if_exists "Ethernet$i"
+    wait_until_if_exists $i
   done
 
   echo Wait 10 seconds while lldpd finds new interfaces
   sleep 10
 
   # apply lldpd configuration
-  echo apply lldpd configuration
+  echo Apply lldpd configuration
   lldpcli -c /etc/lldpd.conf
 
   # wait until all interfaces are destroyed
   echo Wait until all ifaces are destroyed
-  for i in $(seq 0 $if_step $last_if_idx)
+  for i in $interfaces
   do
-    wait_until_if_not_exists "Ethernet$i"
+    wait_until_if_not_exists $i
   done
 done

--- a/dockers/docker-lldp-sv2/supervisord.conf
+++ b/dockers/docker-lldp-sv2/supervisord.conf
@@ -33,7 +33,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:lldpd-conf-reload]
-command=/opt/reconfigure.sh
+command=/usr/bin/reconfigure.sh
 priority=150
 autostart=false
 autorestart=false


### PR DESCRIPTION
The previous implementation only supports EthernetX while X
varies from 0 - 124. Remove such hard coded logics and use
the information from the database instead.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>


```
...
INFO supervisord: lldpd-conf-reload interface Ethernet63 is created
INFO supervisord: lldpd-conf-reload interface Ethernet46 is created
INFO supervisord: lldpd-conf-reload interface Ethernet21 is created
INFO supervisord: lldpd-conf-reload interface Ethernet20 is created
INFO supervisord: lldpd-conf-reload interface Ethernet23 is created
INFO supervisord: lldpd-conf-reload interface Ethernet35 is created
INFO supervisord: lldpd-conf-reload interface Ethernet25 is created
INFO supervisord: lldpd-conf-reload interface Ethernet24 is created
INFO supervisord: lldpd-conf-reload interface Ethernet27 is created
INFO supervisord: lldpd-conf-reload interface Ethernet26 is created
INFO supervisord: lldpd-conf-reload Wait 10 seconds while lldpd finds new interfaces
INFO lldp.sh[31070]: 2017-10-23 18:31:00,859 INFO success: lldpd-conf-reload entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
INFO supervisord 2017-10-23 18:30:59,455 INFO spawned: 'lldpd-conf-reload' with pid 22370
INFO supervisord 2017-10-23 18:31:00,859 INFO success: lldpd-conf-reload entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
INFO supervisord: lldpd-conf-reload Apply lldpd configuration
INFO supervisord: lldpd-conf-reload
INFO supervisord: lldpd-conf-reload Wait until all ifaces are destroyed
```