### PR TITLE
Change the FRR as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,6 @@
 [submodule "platform/broadcom/sonic-platform-modules-cel"]
 	path = platform/broadcom/sonic-platform-modules-cel
 	url = https://github.com/celestica-Inc/sonic-platform-modules-cel.git
+[submodule "src/sonic-frr/frr"]
+	path = src/sonic-frr/frr
+	url = https://github.com/FRRouting/frr.git

--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -5,11 +5,6 @@ SHELL = /bin/bash
 MAIN_TARGET = frr_$(FRR_VERSION)_amd64.deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
-        # Cloning FRR repo if not already done
-	if [ ! -d "frr" ]; then \
-		git clone -b stable/$(FRR_VERSION) https://github.com/FRRouting/frr.git; \
-	fi
-
         # Replacing frr's rules/install files with SONiC's own versions to activate
         # specific knobs and adjust install process to address SONiC's needs.
 	cp sonic_frr.rules frr/debian/rules


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Change the FRR as submodule

**- How I did it**
Change the FRR as submodule

**- How to verify it**
Build the sonic-buildimage with SONIC_ROUTING_STACK = quagga in rules/config

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Change the FRR as submodule

**- A picture of a cute animal (not mandatory but encouraged)**
