### PR TITLE
[build] capture 2 initialization git commands in 'make init' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            PASSWORD=$(PASSWORD) \
                            USERNAME=$(USERNAME)
 
-.PHONY: sonic-slave-build sonic-slave-bash
+.PHONY: sonic-slave-build sonic-slave-bash init
 
 .DEFAULT_GOAL :=  all
 
@@ -89,3 +89,7 @@ sonic-slave-bash :
 	    { echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
 	    $(DOCKER_BUILD) ; }
 	@$(DOCKER_RUN) -t $(SLAVE_IMAGE):$(SLAVE_TAG) bash
+
+init :
+	git submodule update --init --recursive
+	git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $$(realpath --relative-to=. $$(cut -d" " -f2 .git))" > .git'

--- a/README.md
+++ b/README.md
@@ -25,19 +25,16 @@ To clone the code repository recursively, assuming git version 1.9 or newer:
 
     git clone --recursive https://github.com/Azure/sonic-buildimage.git
 
-NOTE: If the repo has already been cloned, however there are no files under the submodule directories (e.g., src/lldpd, src/ptf, src/sonic-linux-kernel, etc.), you can manually fetch all the git submodules as follows:
-
-    git submodule update --init --recursive
-
-You also need to change all git paths to relative path as we build all submodules inside the docker:
-
-    git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'
-    
 ## Usage
 
 To build SONiC installer image and docker images, run the following commands:
 
+    # Execute make init once after cloning the repo, or fetched remote repo with submodule updates
+    make init
+
+    # Execute make configure once to configure ASIC
     make configure PLATFORM=[ASIC_VENDOR]
+
     make
 
  **NOTE**: We recommend reserving 50G free space to build one platform.


### PR DESCRIPTION
**- What I did**
Added a new make target 'init'. It executes the 2 git commands in README.md:
       git submodule update --init --recursive
       git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $(realpath --relative-to=. $(cut -d" " -f2 .git))" > .git'

Updated README.md accordingly.

**- How to verify it**
Issue "make init" and confirm it is as good as executing the above 2 commands.
