### PR TITLE
[build]: add sonic-config-engine to sonic-utilitie build dependency

### DIFF
--- a/rules/sonic-utilities.mk
+++ b/rules/sonic-utilities.mk
@@ -2,4 +2,5 @@
 
 SONIC_UTILS = python-sonic-utilities_1.1-1_all.deb
 $(SONIC_UTILS)_SRC_PATH = $(SRC_PATH)/sonic-utilities
+$(SONIC_UTILS)_WHEEL_DEPENDS = $(SONIC_CONFIG_ENGINE)
 SONIC_PYTHON_STDEB_DEBS += $(SONIC_UTILS)

--- a/slave.mk
+++ b/slave.mk
@@ -222,7 +222,8 @@ SONIC_TARGET_LIST += $(addprefix $(DEBS_PATH)/, $(SONIC_DPKG_DEBS))
 #     $(SOME_NEW_DEB)_SRC_PATH = $(SRC_PATH)/project_name
 #     $(SOME_NEW_DEB)_DEPENDS = $(SOME_OTHER_DEB1) $(SOME_OTHER_DEB2) ...
 #     SONIC_PYTHON_STDEB_DEBS += $(SOME_NEW_DEB)
-$(addprefix $(DEBS_PATH)/, $(SONIC_PYTHON_STDEB_DEBS)) : $(DEBS_PATH)/% : .platform $$(addsuffix -install,$$(addprefix $(DEBS_PATH)/,$$($$*_DEPENDS)))
+$(addprefix $(DEBS_PATH)/, $(SONIC_PYTHON_STDEB_DEBS)) : $(DEBS_PATH)/% : .platform $$(addsuffix -install,$$(addprefix $(DEBS_PATH)/,$$($$*_DEPENDS))) \
+                                                                                    $$(addsuffix -install,$$(addprefix $(PYTHON_WHEELS_PATH)/,$$($$*_WHEEL_DEPENDS)))
 	$(HEADER)
 	# Apply series of patches if exist
 	if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; popd; fi


### PR DESCRIPTION
**- What I did**
add sonic-config-engine to sonic-utilities build dependency

**- How I did it**
change slave.mk and sonic-utilities.mk

**- How to verify it**
make -f slave.mk target/debs/python-sonic-utilities_1.1-1_all.deb

```
lgh@ba2755a9022e:/data/sonic/sonic-buildimage$ make -f slave.mk  target/debs/python-sonic-utilities_1.1-1_all.deb
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "vs"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_CONFIG_BUILD_JOBS"         : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "4"
"DEFAULT_USERNAME"                : "admin"
"DEFAULT_PASSWORD"                : "YourPaSsWoRd"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"SONIC_CONFIG_DEBUG"              : ""
"ROUTING_STACK"                   : "quagga"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"

[ 01 ] [ target/debs/python-sonic-utilities_1.1-1_all.deb ]

sonic_config_engine-1.0-py2-none-any.whl-install.log 

```
**- Description for the changelog**
add sonic-config-engine to sonic-utilities build dependency

**- A picture of a cute animal (not mandatory but encouraged)**
