### PR TITLE
Bugfix for sfputil in D7054

### DIFF
--- a/device/inventec/x86_64-inventec_d7054q28b-r0/plugins/sfputil.py
+++ b/device/inventec/x86_64-inventec_d7054q28b-r0/plugins/sfputil.py
@@ -95,7 +95,7 @@ class SfpUtil(SfpUtilBase):
 
     @property
     def qsfp_ports(self):
-        return range(0, self.PORTS_IN_BLOCK + 1)
+        return range(self.QSFP_PORT_START, self.PORTS_IN_BLOCK + 1)
 
     @property
     def port_to_eeprom_mapping(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- What I did
Fixed a bug in D7054.

- How I did it
Specifying the qsfp port start and end correctly in function qsfp_ports in sfputil.py.

- How to verify it
Connect sfp's or qsfp transceivers on D7054 board and execute sfputil show eeprom.

**- Description for the changelog**
<!--
Fixed a sfputil bug in D7054
-->


**- A picture of a cute animal (not mandatory but encouraged)**
