### PR TITLE
Update sonic-utilities pointer and sonic-slave for test dependency

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -223,6 +223,9 @@ RUN pip install j2cli
 # For sonic config engine testing
 RUN pip install pyangbind==0.5.10
 
+# For sonic utilities testing
+RUN pip install click-default-group click natsort tabulate
+
 # For supervisor build
 RUN pip install meld3 mock
 


### PR DESCRIPTION
**- What I did**
Update sonic-utilities pointer, including https://github.com/Azure/sonic-utilities/pull/135 and https://github.com/Azure/sonic-utilities/pull/139.

As unit test was introduced in https://github.com/Azure/sonic-utilities/pull/135, sonic-slave needs to be updated to resolve test dependencies. https://github.com/Azure/sonic-buildimage/pull/1075 is also introduced for the same purpose.

