### PR TITLE
[updategraph] Support a special value to use empty configuration

### DIFF
--- a/files/dhcp/graphserviceurl
+++ b/files/dhcp/graphserviceurl
@@ -3,7 +3,7 @@ case $reason in
         if [ -n "$new_minigraph_url" ]; then
             echo $new_minigraph_url > /tmp/dhcp_graph_url
         else
-            echo "N/A" > /tmp/dhcp_graph_url
+            echo "default" > /tmp/dhcp_graph_url
         fi
         if [ -n "$new_acl_url" ]; then
             echo $new_acl_url > /tmp/dhcp_acl_url

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -20,14 +20,32 @@ if [ "$src" = "dhcp" ]; then
         sleep 1
     done
 
-    if [ "`cat /tmp/dhcp_graph_url`" = "N/A" ]; then
-        echo "No graph_url option in DHCP response. Skipping graph update."
+    if [ "`cat /tmp/dhcp_graph_url`" = "default" ]; then
+        echo "No graph_url option in DHCP response. Skipping graph update and using existing minigraph."
         if [ "$dhcp_as_static" = "true" ]; then
             sed -i "/enabled=/d" /etc/sonic/updategraph.conf
             echo "enabled=false" >> /etc/sonic/updategraph.conf
         fi
         exit 0
     fi
+    if [ "`cat /tmp/dhcp_graph_url`" = "N/A" ]; then
+        echo "'N/A' found in DHCP response. Skipping graph update and generating an empty configuration."
+        echo '{"DEVICE_METADATA":' > /tmp/device_meta.json
+        sonic-cfggen -m /etc/sonic/minigraph.xml --var-json DEVICE_METADATA >> /tmp/device_meta.json
+        echo '}' >> /tmp/device_meta.json
+        if [ -f /etc/sonic/init_cfg.json ]; then
+            sonic-cfggen -j /tmp/device_meta.json -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
+        else
+            cp -f /tmp/device_meta.json /etc/sonic/config_db.json
+        fi
+        
+        if [ "$dhcp_as_static" = "true" ]; then
+            sed -i "/enabled=/d" /etc/sonic/updategraph.conf
+            echo "enabled=false" >> /etc/sonic/updategraph.conf
+        fi
+        exit 0
+    fi
+
 
     HOSTNAME=`hostname -s`
     GRAPH_URL=`sonic-cfggen -t /tmp/dhcp_graph_url -a "{\"hostname\": \"$HOSTNAME\"}"`


### PR DESCRIPTION
When updategraph service is enabled, a special value "N/A" from DHCP response will now initialize the system with an empty configuration instead of existing minigraph.

A DHCP response without option 224 will remain the current behavior of skipping graph update and use existing (usually default) minigraph.
