### PR TITLE
[build]: add swig3.0 for building python-based swsscommon library

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -200,7 +200,9 @@ RUN apt-get update && apt-get install -y \
         procmail \
 # For gtest
         libgtest-dev \
-        cmake
+        cmake \
+# For python-based swsscommon
+        swig3.0
 
 # For linux build
 RUN apt-get -y build-dep linux


### PR DESCRIPTION
**- What I did**
add swig3.0 into sonic-slave docker

**- How I did it**
change sonic-slave dockerfile

**- How to verify it**
```
swig3.0 --version


SWIG Version 3.0.2

Compiled with g++ [x86_64-unknown-linux-gnu]

Configured options: +pcre

Please see http://www.swig.org for reporting bugs and further information
```

**- Description for the changelog**
add swig3.0 for building python-based swsscommon library

**- A picture of a cute animal (not mandatory but encouraged)**
