### PR TITLE
[swss]: Add switch.json.j2 to set the hash seed according to the switch type

### DIFF
--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -28,9 +28,8 @@ RUN rm -rf /debs
 
 COPY ["arp_update", "start.sh", "orchagent.sh", "swssconfig.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
-COPY ["ipinip.json.j2", "/usr/share/sonic/templates/"]
-COPY ["mirror.json.j2", "/usr/share/sonic/templates/"]
-COPY ["ports.json.j2", "/usr/share/sonic/templates/"]
-COPY ["msn27xx.32ports.buffers.json.j2", "/usr/share/sonic/templates/"]
+
+## Copy all Jinja2 template files into the templates folder
+COPY ["*.j2", "/usr/share/sonic/templates/"]
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-orchagent/start.sh
+++ b/dockers/docker-orchagent/start.sh
@@ -2,6 +2,7 @@
 
 mkdir -p /etc/swss/config.d/
 
+sonic-cfggen -m /etc/sonic/minigraph.xml -d -t /usr/share/sonic/templates/switch.json.j2 > /etc/swss/config.d/switch.json
 sonic-cfggen -m /etc/sonic/minigraph.xml -d -t /usr/share/sonic/templates/ipinip.json.j2 > /etc/swss/config.d/ipinip.json
 sonic-cfggen -m /etc/sonic/minigraph.xml -d -t /usr/share/sonic/templates/mirror.json.j2 > /etc/swss/config.d/mirror.json
 sonic-cfggen -m /etc/sonic/minigraph.xml -d -t /usr/share/sonic/templates/ports.json.j2 > /etc/swss/config.d/ports.json

--- a/dockers/docker-orchagent/switch.json.j2
+++ b/dockers/docker-orchagent/switch.json.j2
@@ -1,0 +1,18 @@
+{# set default hash seed to 0 #}
+{% set hash_seed = 0 %}
+{% if DEVICE_METADATA.localhost.type %}
+{% if DEVICE_METADATA.localhost.type == "ToRRouter" %}
+{% set hash_seed = 10 %}
+{% elif DEVICE_METADATA.localhost.type == "LeafRouter" %}
+{% set hash_seed = 20 %}
+{% endif %}
+{% endif %}
+[
+    {
+        "SWITCH_TABLE:switch": {
+            "ecmp_hash_seed": "{{ hash_seed }}",
+            "lag_hash_seed": "{{ hash_seed }}"
+        },
+        "OP": "SET"
+    }
+]

--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -39,7 +39,7 @@ fast_reboot
 
 HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -d -v "DEVICE_METADATA['localhost']['hwsku']"`
 
-SWSSCONFIG_ARGS="00-copp.config.json ipinip.json mirror.json ports.json "
+SWSSCONFIG_ARGS="00-copp.config.json ipinip.json mirror.json ports.json switch.json "
 
 if [ "$HWSKU" == "Force10-S6000" ]; then
     SWSSCONFIG_ARGS+="td2.32ports.buffers.json td2.32ports.qos.json "


### PR DESCRIPTION
Set the ECMP/LAG hash seed to 10 when the switch is a ToR, 20 when the switch
is a Leaf, 0 otherwise.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
