### PR TITLE
Add write socket buffer to fix CoPP rx performance issue

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -282,6 +282,7 @@ set /files/etc/sysctl.conf/net.ipv6.conf.all.accept_dad 0
 set /files/etc/sysctl.conf/net.ipv6.conf.eth0.accept_ra_defrtr 0
 
 set /files/etc/sysctl.conf/net.core.rmem_max 2097152
+set /files/etc/sysctl.conf/net.core.wmem_max 2097152
 " -r $FILESYSTEM_ROOT
 
 ## docker-py is needed by Ansible docker module


### PR DESCRIPTION
Add write socket buffer to fix CoPP rx performance issue

**- What I did**

Add write socket buffer to fix packet drop issue in ptf_nn_agent.py

**- How I did it**

Add set command in the file build_debian.sh

**- How to verify it**

Run the CoPP tests in the testbed and verify the test results are passed

**- Description for the changelog**

Add write socket buffer to fix CoPP rx performance issue

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->








<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

