### PR TITLE
[Arista]: Fix the udev waiting in networking start

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -188,6 +188,11 @@ sudo dpkg --root=$FILESYSTEM_ROOT -P {{ debname }}
 
 sudo rm -f $FILESYSTEM_ROOT/usr/sbin/policy-rc.d
 
+## Revise /etc/init.d/networking for Arista switches
+if [ "$image_type" = "aboot" ]; then
+    sed -i 's/udevadm settle/udevadm settle -E \/sys\/class\/net\/eth0/' $FILESYSTEM_ROOT/etc/init.d/networking
+fi
+
 ## copy platform rc.local
 sudo cp $IMAGE_CONFIGS/platform/rc.local $FILESYSTEM_ROOT/etc/
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -190,7 +190,7 @@ sudo rm -f $FILESYSTEM_ROOT/usr/sbin/policy-rc.d
 
 ## Revise /etc/init.d/networking for Arista switches
 if [ "$image_type" = "aboot" ]; then
-    sed -i 's/udevadm settle/udevadm settle -E \/sys\/class\/net\/eth0/' $FILESYSTEM_ROOT/etc/init.d/networking
+    sudo sed -i 's/udevadm settle/udevadm settle -E \/sys\/class\/net\/eth0/' $FILESYSTEM_ROOT/etc/init.d/networking
 fi
 
 ## copy platform rc.local


### PR DESCRIPTION
This change is to fix the issue in https://github.com/aristanetworks/sonic/issues/16
We noticed that the long waiting time in service networking start is because the original 'udevadm settle' waits for some irrelevant devices. By the change, only eth0 is waited for.
For the checking condition used, this change is only applied to Arista switches

Signed-off-by: Boyang Yu <byu@arista.com>

