### PR TITLE
[build_debian] pip install pexpect in the base image for ansible module

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -289,6 +289,9 @@ sudo LANG=C chroot $FILESYSTEM_ROOT easy_install pip
 sudo LANG=C chroot $FILESYSTEM_ROOT pip install 'docker-py==1.6.0'
 ## Note: keep pip installed for maintainance purpose
 
+## pexpect is needed by Ansible pexpect module
+sudo LANG=C chroot $FILESYSTEM_ROOT pip install 'pexpect'
+
 ## Create /var/run/redis folder for docker-database to mount
 sudo mkdir -p $FILESYSTEM_ROOT/var/run/redis
 


### PR DESCRIPTION
Signed-off-by: Okanchou9 <kenie7@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
PIP install pexpect in the base image for ansible module(sonic-mgmt)

**- How I did it**
Add a line to pip install pexpect in file build_debian.sh

**- How to verify it**
Build a test image with this change and check if pexpect is installed in this test image without any issue

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
