### PR TITLE
Updated Mellanox buffers profile to use single pool for lossless

### DIFF
--- a/dockers/docker-orchagent/msn27xx.32ports.buffers.json.j2
+++ b/dockers/docker-orchagent/msn27xx.32ports.buffers.json.j2
@@ -5,14 +5,6 @@
 {% endfor %}
 {% set port_names = port_names_list | join(',') %}
     {
-        "BUFFER_POOL_TABLE:ingress_lossless_pool": {
-            "size": "3024486",
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "OP": "SET"
-    },
-    {
         "BUFFER_POOL_TABLE:ingress_lossy_pool": {
             "size": "6422528",
             "type": "ingress",
@@ -106,6 +98,7 @@
     },
 
 {# The following template part is for variable PG profile configuration #}
+{% set non_pg_lossless_pool_size = 866726 %}
 {% set pg_range = '3-4' %}
 {# Lists of supported speed and cable length #}
 {% set supported_speed = [10000, 25000, 40000, 50000, 100000] %}
@@ -239,7 +232,7 @@
     {%- set profile_config = pg_profiles[profile_name] %}
     {
         "BUFFER_PROFILE_TABLE:{{ profile_name }}": {
-            "pool":"[BUFFER_POOL_TABLE:ingress_lossless_pg_pool]",
+            "pool":"[BUFFER_POOL_TABLE:ingress_lossless_pool]",
             "xon":"{{ profile_config['xon'] }}",
             "xoff":"{{ profile_config['xoff'] }}",
             "size":"{{ profile_config['size'] }}",
@@ -249,10 +242,10 @@
     },
 {% endfor -%}
 
-    {# Pool declaration #}
+    {# Lossless pool declaration #}
     {
-        "BUFFER_POOL_TABLE:ingress_lossless_pg_pool": {
-            "size": "{{ ingress_lossless_pg_pool_size | sum }}",
+        "BUFFER_POOL_TABLE:ingress_lossless_pool": {
+            "size": "{{ ingress_lossless_pg_pool_size | sum + non_pg_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic"
         },

--- a/src/sonic-config-engine/tests/sample_output/msn27.32ports.json
+++ b/src/sonic-config-engine/tests/sample_output/msn27.32ports.json
@@ -1,13 +1,5 @@
 [
     {
-        "BUFFER_POOL_TABLE:ingress_lossless_pool": {
-            "size": "3024486",
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "OP": "SET"
-    },
-    {
         "BUFFER_POOL_TABLE:ingress_lossy_pool": {
             "size": "6422528",
             "type": "ingress",
@@ -297,7 +289,7 @@
 
     {
         "BUFFER_PROFILE_TABLE:pg_lossless_40G_300m_profile": {
-            "pool":"[BUFFER_POOL_TABLE:ingress_lossless_pg_pool]",
+            "pool":"[BUFFER_POOL_TABLE:ingress_lossless_pool]",
             "xon":"18432",
             "xoff":"75776",
             "size":"94208",
@@ -306,8 +298,8 @@
         "OP": "SET"
     },
     {
-        "BUFFER_POOL_TABLE:ingress_lossless_pg_pool": {
-            "size": "3014656",
+        "BUFFER_POOL_TABLE:ingress_lossless_pool": {
+            "size": "3881382",
             "type": "ingress",
             "mode": "dynamic"
         },


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

**- What I did**
Updated Mellanox buffers profile to use single for lossless 

**- How I did it**
Updated template. Combined pools for lossless and gp_lossless profiles

**- How to verify it**
Build. Install. Verify buffers profile successfully applied