### PR TITLE
Revert "Restart ntp after ntp-config"

### DIFF
--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
 sonic-cfggen -d -t /usr/share/sonic/templates/ntp.conf.j2 >/etc/ntp.conf
-
-systemctl restart ntp


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#1098

sadly it breaks the nightly NTP test. we need to find an alternative solution for this issue.