### PR TITLE
Change third party repos from git:// to https:// for better compatibility

### DIFF
--- a/src/isc-dhcp/Makefile
+++ b/src/isc-dhcp/Makefile
@@ -10,7 +10,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf ./isc-dhcp
 
 	# Clone isc-dhcp repo
-	git clone git://anonscm.debian.org/pkg-dhcp/isc-dhcp.git
+	git clone https://anonscm.debian.org/cgit/pkg-dhcp/isc-dhcp.git
 	pushd ./isc-dhcp
 	git checkout -f debian/4.3.1-6
 	popd

--- a/src/supervisor/Makefile
+++ b/src/supervisor/Makefile
@@ -9,7 +9,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf ./supervisor
 
 	# Clone isc-dhcp repo
-	git clone git://github.com/Supervisor/supervisor.git
+	git clone https://github.com/Supervisor/supervisor.git
 	pushd ./supervisor
 	git checkout -f 3.3.2
 

--- a/src/supervisor/Makefile
+++ b/src/supervisor/Makefile
@@ -8,7 +8,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Remove any stale files
 	rm -rf ./supervisor
 
-	# Clone isc-dhcp repo
+	# Clone supervisor repo
 	git clone https://github.com/Supervisor/supervisor.git
 	pushd ./supervisor
 	git checkout -f 3.3.2


### PR DESCRIPTION
I was motivated by our own infra that has a firewall to block the git protocol. It seems the equivalent https protocol does offer the same repo access, and I believe it is more compatible and transparent for various proxies and firewall settings.

See the detailed explanation by GitHub [here](https://help.github.com/articles/which-remote-url-should-i-use/).