### PR TITLE
Restart ntp after ntp-config

### DIFF
--- a/files/image_config/ntp/ntp-config.service
+++ b/files/image_config/ntp/ntp-config.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Update NTP configuration
-Before=ntp.service
 Requires=database.service
 After=database.service
 

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 sonic-cfggen -d -t /usr/share/sonic/templates/ntp.conf.j2 >/etc/ntp.conf
+
+systemctl restart ntp


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In ntp-config service, explicitly restart ntp service after generating ntp.conf file