### PR TITLE
Store switch mac to configDB switch table if the mac is not configure…

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -12,6 +12,9 @@ fi
 
 sonic-cfggen -d -a '{"hwaddr":"'$SYSTEM_MAC_ADDRESS'"}' -t /usr/share/sonic/templates/interfaces.j2 > /etc/network/interfaces
 
+# Also store the system mac to configDB switch table. User configured switch_mac is not supported for now.
+/usr/bin/docker exec database redis-cli -n 4 hset SWITCH\|SWITCH_ATTR switch_mac $SYSTEM_MAC_ADDRESS
+
 [ -f /var/run/dhclient.eth0.pid ] && kill `cat /var/run/dhclient.eth0.pid` && rm -f /var/run/dhclient.eth0.pid
 
 systemctl restart networking


### PR DESCRIPTION
…d yet

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**- What I did**
Store switch mac to configDB for the use of other modules.

**- How I did it**

**- How to verify it**
Run the script,  switch_mac is stored in configDB

127.0.0.1:6379[4]> hgetall "SWITCH|SWITCH_ATTR"
1) "switch_mac"
2) "00:05:64:30:73:c0"

