### PR TITLE
[Arista7260CX3] Fix a typo in port_ini.cfg

### DIFF
--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini
@@ -80,7 +80,7 @@ Ethernet158     3,4               Ethernet40/3 40
 Ethernet160     17,18             Ethernet41/1 41
 Ethernet162     19,20             Ethernet41/3 41
 Ethernet164     29,30             Ethernet42/1 42
-Ethernet166     31,32             Ethernet42/1 42
+Ethernet166     31,32             Ethernet42/3 42
 Ethernet168     41,42             Ethernet43/1 43
 Ethernet170     43,44             Ethernet43/3 43
 Ethernet172     33,34             Ethernet44/1 44


### PR DESCRIPTION
**- What I did**
Fix a typo in port_config.ini of Arista7260CX3 t0 SKU. The issue caused 2 different ports linked to a same alias, therefore from the o.s level, it seems that only one of them are actually reached link up.

**- How to verify it**
This issue was caught by nightly test, the fix was verified by nightly tests. After making the change, both affected Ethernet ports reached link up. 