### PR TITLE
[interfaces.j2] Get mtu value from config DB if provided

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -50,7 +50,7 @@ iface eth0 inet dhcp
 {% for (name, prefix) in INTERFACE %}
 allow-hotplug {{ name }}
 iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
-    mtu 9100
+    mtu {{ PORT[name]['mtu'] if PORT[name]['mtu'] else 9100 }}
     address {{ prefix | ip }}
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
 #
@@ -76,7 +76,7 @@ iface {{ member }} inet manual
 {% for (name, prefix) in PORTCHANNEL_INTERFACE.keys() | sort %}
 allow-hotplug {{ name }}
 iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
-    mtu 9100
+    mtu {{ PORTCHANNEL[name]['mtu'] if PORTCHANNEL[name]['mtu'] else 9100 }}
     address {{ prefix | ip }}
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
 #


### PR DESCRIPTION
Signed-off-by: Haiyang Zheng <haiyang.z@alibaba-inc.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Get MTU value from config DB if configured. Otherwise use default jumbo value 9100

**- How I did it**
Modified the interfaces.j2 template to get mtu from config DB if provided. 

**- How to verify it**
Update the port inside config_db.json file with new mtu field, and verify the /etc/network/interfaces being updated correctly after reload.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
