### PR TITLE
[Arista7260cx3] update port_config.ini for Arista-7260CX3-D108C8

### DIFF
--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini
@@ -33,10 +33,12 @@ Ethernet60      121,122           Ethernet16/1 16
 Ethernet62      123,124           Ethernet16/3 16
 Ethernet64      141,142           Ethernet17/1 17
 Ethernet66      143,144           Ethernet17/3 17
-Ethernet68      133,134,135,136   Ethernet18/1 18
+Ethernet68      133,134           Ethernet18/1 18
+Ethernet70      135,136           Ethernet18/3 18
 Ethernet72      197,198           Ethernet19/1 19
 Ethernet74      199,200           Ethernet19/3 19
-Ethernet76      205,206,207,208   Ethernet20/1 20
+Ethernet76      205,206           Ethernet20/1 20
+Ethernet78      207,208           Ethernet20/3 20
 Ethernet80      217,218           Ethernet21/1 21
 Ethernet82      219,220           Ethernet21/3 21
 Ethernet84      213,214           Ethernet22/1 22


### PR DESCRIPTION
**- What I did**
Change port 18 and 20 to 50G breakout ports to match the intended production topology.

**- How to verify it**
Included this change on my arista7260cx3 dut along with the updated config.bcm file, these 2 ports came up as 50G breakout ports.