### PR TITLE
[Arista7260cx3] Increase /var/log partition size to 4G

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -130,7 +130,7 @@ platform_specific() {
         aboot_machine=arista_7260cx3_64
     fi
     if [ "$platform" = "rook" ]; then
-        varlog_size=200
+        varlog_size=4096
         readprefdl -f /tmp/.system-prefdl -d > /mnt/flash/.system-prefdl
     fi
 


### PR DESCRIPTION
**- What I did**
Increase Arista7260cx3 /var/log partition size to 4GB.

**- How to verify it**
Tested the change on my dut, the partition size is increased to 4GB.