### PR TITLE
Subnet route added for management interface (eth0) - "fixes #1023"

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -28,12 +28,14 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     ########## management network policy routing rules
     # management port up rules
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table default
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table default
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table default
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     up ip rule add to {{ route }} table default
 {% endfor %}
     # management port down rules
     down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table default
+    down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table default
     down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table default
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     down ip rule delete to {{ route }} table default

--- a/src/sonic-config-engine/tests/sample_output/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/interfaces
@@ -35,11 +35,11 @@ iface eth0 inet6 static
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default
-    up ip -6 route add  2603:10e2:0:2902::/64 dev eth0 table default
+    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
     up ip -6 rule add from 2603:10e2:0:2902::8/128 table default
     # management port down rules
     down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table default
-    down ip -6 route delete  2603:10e2:0:2902::/64 dev eth0 table default
+    down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
     down ip -6 rule delete from 2603:10e2:0:2902::8/128 table default
 #
 # The switch front panel interfaces

--- a/src/sonic-config-engine/tests/sample_output/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/interfaces
@@ -23,9 +23,11 @@ iface eth0 inet static
     ########## management network policy routing rules
     # management port up rules
     up ip -4 route add default via 10.0.0.1 dev eth0 table default
+    up ip -4 route add 10.0.0.0/24 dev eth0 table default
     up ip -4 rule add from 10.0.0.100/32 table default
     # management port down rules
     down ip -4 route delete default via 10.0.0.1 dev eth0 table default
+    down ip -4 route delete 10.0.0.0/24 dev eth0 table default
     down ip -4 rule delete from 10.0.0.100/32 table default
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
@@ -33,9 +35,11 @@ iface eth0 inet6 static
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default
+    up ip -6 route add  2603:10e2:0:2902::/64 dev eth0 table default
     up ip -6 rule add from 2603:10e2:0:2902::8/128 table default
     # management port down rules
     down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table default
+    down ip -6 route delete  2603:10e2:0:2902::/64 dev eth0 table default
     down ip -6 rule delete from 2603:10e2:0:2902::8/128 table default
 #
 # The switch front panel interfaces


### PR DESCRIPTION
**- What I did**
Added a subnet route in "default" kernel route table based on the IP address/prefix of management interface (eth0)

**- How I did it**
Modified the interface.j2 template to add/delete subnet route for eth0

**- How to verify it**
Execute the following command:

```
admin@str-acs-10:~$ ip route show table default
default via 10.64.246.1 dev eth0 
10.64.246.0/23 dev eth0  scope link

admin@str-acs-10:~$ sudo ifdown eth0
admin@str-acs-10:~$ ip route show table default
admin@str-acs-10:~$ 
admin@str-acs-10:~$ sudo ifup eth0
Waiting for DAD... Done
admin@str-acs-10:~$ 
admin@str-acs-10:~$ ip route show table default
default via 10.64.246.1 dev eth0 
10.64.246.0/23 dev eth0  scope link 
admin@str-acs-10:~$ 
```

Note:  Instead of "ifdown/ifup", if interface is shut using `"ifconfig eth0 down"` or "`ip link set dev eth0 down`" and then "`ifconfig eth0 up`", then these entries *will* be deleted from the default route table and you've to restart network service to reconfigure the route entries.

**- Description for the changelog**
Added subnet route to default route table in kernel for management interface


**- A picture of a cute animal (not mandatory but encouraged)**
