### PR TITLE
[installer] FIX. ONIE installer error issue:

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -455,9 +455,7 @@ if [ "$install_env" = "onie" ]; then
     cp /etc/machine.conf $demo_mnt
 
     # Store installation log in target file system
-    rm -f $onie_initrd_tmp/tmp/onie-support.tar.bz2
-    ${onie_bin} onie-support /tmp
-    mv $onie_initrd_tmp/tmp/onie-support.tar.bz2 $demo_mnt/$image_dir/
+    ${onie_bin} onie-support $demo_mnt/$image_dir
 
     if [ "$firmware" = "uefi" ] ; then
         demo_install_uefi_grub "$demo_mnt" "$blk_dev"

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -455,7 +455,9 @@ if [ "$install_env" = "onie" ]; then
     cp /etc/machine.conf $demo_mnt
 
     # Store installation log in target file system
-    ${onie_bin} onie-support $demo_mnt/$image_dir
+    rm -f $onie_initrd_tmp/tmp/onie-support*.tar.bz2
+    ${onie_bin} onie-support /tmp
+    mv $onie_initrd_tmp/tmp/onie-support*.tar.bz2 $demo_mnt/$image_dir/
 
     if [ "$firmware" = "uefi" ] ; then
         demo_install_uefi_grub "$demo_mnt" "$blk_dev"


### PR DESCRIPTION
<!--
Problem Description: ONIE install failure
Success: Support tarball created: /tmp/onie-support-accton_as7712_32x.tar.bz2
mv: can't rename '//tmp/onie-support.tar.bz2': No such file or directory
Failure: Unable to install image: tftp://192.168.3.199/sonic-broadcom-l_n324-10.bin

Signed-off-by: polly_hsu@accton.com
-->

**- What I did**
FIX:  ONIE install failure

**- How I did it**
FIX the failure based on the discussion with the Accton ONIE contributor

**- How to verify it**
1. Cloned the master pull on 2017-11-14 (commit id: 50b4868a)
2. Updated the revision
3. Built the target image, sonic-broadcom.bin
4. ONIE-installed (3) at the AS5712-54X device and booted it up OK

**- Description for the changelog**
Removed the intermediate */tmp* manipulation around *specific* ONIE  TAR ball name, which will result in the ONIE installation failure
<!--
$ git diff installer/x86_64/install.sh
diff --git a/installer/x86_64/install.sh b/installer/x86_64/install.sh
index 358da41..d53bd17 100755
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -455,9 +455,7 @@ if [ "$install_env" = "onie" ]; then
     cp /etc/machine.conf $demo_mnt

     # Store installation log in target file system
-    rm -f $onie_initrd_tmp/tmp/onie-support.tar.bz2
-    ${onie_bin} onie-support /tmp
-    mv $onie_initrd_tmp/tmp/onie-support.tar.bz2 $demo_mnt/$image_dir/
+    ${onie_bin} onie-support $demo_mnt/$image_dir
-->

**- A picture of a cute animal (not mandatory but encouraged)**
