### PR TITLE
[make] Introducing build option SOURCE_FOLDER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 #  * USERNAME: Desired username -- default at rules/config
 #  * PASSWORD: Desired password -- default at rules/config
 #  * KEEP_SLAVE_ON: Keeps slave container up after building-process concludes.
+#  * SOURCE_FOLDER: host path to be mount as /var/src, only effective when KEEP_SLAVE_ON=yes
 #
 ###############################################################################
 
@@ -72,7 +73,11 @@ SONIC_BUILD_INSTRUCTION :=  make \
 	    { echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
 	    $(DOCKER_BUILD) ; }
 ifeq "$(KEEP_SLAVE_ON)" "yes"
-	@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_BUILD_INSTRUCTION) $@; /bin/bash"
+    ifdef SOURCE_FOLDER
+		@$(DOCKER_RUN) -v $(SOURCE_FOLDER):/var/src $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_BUILD_INSTRUCTION) $@; /bin/bash"
+    else
+		@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_BUILD_INSTRUCTION) $@; /bin/bash"
+    endif
 else
 	@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) $(SONIC_BUILD_INSTRUCTION) $@
 endif


### PR DESCRIPTION
**- What I did**
When KEEP_SLAVE_ON=yes and SOURCE_FOLDER is defined, the path pointed
by SOURCE_FOLDER will be mounted in the build slave docker at /var/src.

This option allows user to mount an extra path into the build slave
when the slave is left running. Usually when user need to build extra
stuff in SOURCE_FOLDER.

**- How to verify it**
Build with KEEP_SLAVE_ON=yes, verified that the left running build slave doesn't have /var/src mounted.
Build with KEEP_SLAVE_ON=yes SOURCE_FOLDER="a valid path", verified that the <valid path> has been mounted in the left running build slave at /var/src and it is accessible.
Build with KEEP_SLAVE_ON=yes SOURCE_FOLDER="an invalid path", verified that /var/src is visible in left running build slave but not accessible.
