### PR TITLE
[docker-syncd-mlnx-rpc]: Configure send and receive buffers for PTF a…

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx-rpc/ptf_nn_agent.conf
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/ptf_nn_agent.conf
@@ -1,5 +1,5 @@
 [program:ptf_nn_agent]
-command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-3@Ethernet12 --set-iface-rcv-buffer=109430400
+command=/usr/bin/python /opt/ptf_nn_agent.py --device-socket 1@tcp://0.0.0.0:10900 -i 1-3@Ethernet12 --set-nn-rcv-buffer=109430400 --set-iface-rcv-buffer=109430400 --set-nn-snd-buffer=109430400 --set-iface-snd-buffer=109430400
 process_name=ptf_nn_agent
 stdout_logfile=/tmp/ptf_nn_agent.out.log
 stderr_logfile=/tmp/ptf_nn_agent.err.log


### PR DESCRIPTION
…gent

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Configure send and receive buffers for PTF agent on Mellanox platforms in order to fix packet drop issue  during running COPP tests.
**- How I did it**
Add appropriate PTF agent options in configuration file ("ptf_nn_agent.conf").
**- How to verify it**
Run the COPP tests and verify that test results are passed.
**- Description for the changelog**
[docker-syncd-mlnx-rpc]: Configure send and receive buffers for PTF agent
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
