### PR TITLE
[DHCP relay]: Wait for all interfaces to be assigned IPv4 addresses before starting relay agent(s)

### DIFF
--- a/dockers/docker-dhcp-relay/start.sh
+++ b/dockers/docker-dhcp-relay/start.sh
@@ -6,7 +6,12 @@ rm -f /var/run/rsyslogd.pid
 # Start rsyslog
 supervisorctl start rsyslogd
 
-# Wait for all interfaces to come up before starting the DHCP relay agent(s)
+# Wait for all interfaces to come up and be assigned IPv4 addresses before
+# starting the DHCP relay agent(s). If an interface the relay should listen
+# on is down, the relay agent will not start. If an interface the relay should
+# listen on is up but does not have an IP address assigned when the relay
+# agent starts, it will not listen or send on that interface for the lifetime
+# of the process.
 /usr/bin/wait_for_intf.sh
 
 # Start the DHCP relay agent(s)

--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -30,7 +30,7 @@ function wait_until_iface_ready
 }
 
 
-# Wait for all interfaces to come up before starting the DHCP relay
+# Wait for all interfaces to come up and have IPv4 addresses assigned
 {% for (name, prefix) in INTERFACE %}
 wait_until_iface_ready {{ name }}
 {% endfor %}

--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -1,27 +1,42 @@
 #!/usr/bin/env bash
 
-function wait_until_iface_exists
+function wait_until_iface_ready
 {
     IFACE=$1
 
-    echo "Waiting for interface ${IFACE}..."
+    echo "Waiting until interface $IFACE is up..."
 
     # Wait for the interface to come up (i.e., 'ip link show' returns 0)
-    until ip link show $IFACE > /dev/null 2>&1; do
+    until ip link show dev $IFACE up > /dev/null 2>&1; do
         sleep 1
     done
 
-    echo "Interface ${IFACE} is created"
+    echo "Interface $IFACE is up"
+
+    echo "Waiting until interface $IFACE has an IPv4 address..."
+
+    # Wait until the interface gets assigned an IPv4 address
+    while true; do
+        IP=$(ip -4 addr show dev $IFACE | grep "inet " | awk '{ print $2 }' | cut -d '/' -f1)
+
+        if [ -n "$IP" ]; then
+            break
+        fi
+
+        sleep 1
+    done
+
+    echo "Interface $IFACE is configured with IP $IP"
 }
 
 
 # Wait for all interfaces to come up before starting the DHCP relay
 {% for (name, prefix) in INTERFACE %}
-wait_until_iface_exists {{ name }}
+wait_until_iface_ready {{ name }}
 {% endfor %}
 {% for (name, prefix) in VLAN_INTERFACE %}
-wait_until_iface_exists {{ name }}
+wait_until_iface_ready {{ name }}
 {% endfor %}
 {% for (name, prefix) in PORTCHANNEL_INTERFACE %}
-wait_until_iface_exists {{ name }}
+wait_until_iface_ready {{ name }}
 {% endfor %}


### PR DESCRIPTION
- The introduction of vlanmgrd and intfmgrd daemons introduced a longer delay between the time interfaces are brought up and when they are assigned IP addresses. This exaggerated a possible race condition, as we were previously only checking for the interfaces to be up before starting the relay agents. It was possible for a relay agent to bind to an interface which did not have an IP address assigned, which would cause the relay agent to fail to listen or send on that interface for the remainder of the process's lifetime.

- We should probably look into a universal solution to this in the future, possibly utilizing a database, and maybe implement a service that blocks until all interfaces are up and configured properly. That way, all services that rely on the interfaces being up and configured can simply depend on it.