### PR TITLE
Add service to config hostname based on configdb

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -120,6 +120,11 @@ sudo cp $IMAGE_CONFIGS/interfaces/*.j2 $FILESYSTEM_ROOT/usr/share/sonic/template
 # Copy initial interfaces configuration file, will be overwritten on first boot
 sudo cp $IMAGE_CONFIGS/interfaces/init_interfaces $FILESYSTEM_ROOT/etc/network
 
+# Copy hostname configuration scripts
+sudo cp $IMAGE_CONFIGS/hostname/hostname-config.service  $FILESYSTEM_ROOT/etc/systemd/system/
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable hostname-config.service
+sudo cp $IMAGE_CONFIGS/hostname/hostname-config.sh $FILESYSTEM_ROOT/usr/bin/
+
 # Copy updategraph script and service file
 sudo cp $IMAGE_CONFIGS/updategraph/updategraph.service  $FILESYSTEM_ROOT/etc/systemd/system/
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable updategraph.service

--- a/files/image_config/hostname/hostname-config.service
+++ b/files/image_config/hostname/hostname-config.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Update hostname based on configdb
+Requires=database.service
+After=database.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/hostname-config.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/files/image_config/hostname/hostname-config.sh
+++ b/files/image_config/hostname/hostname-config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+CURRENT_HOSTNAME=`hostname`
+HOSTNAME=`sonic-cfggen -d -v DEVICE_METADATA[\'localhost\'][\'hostname\']`
+
+echo $HOSTNAME > /etc/hostname
+hostname -F /etc/hostname
+
+sed -i "/\s$CURRENT_HOSTNAME$/d" /etc/hosts
+echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Read hostname from DEVICE_METADATA, and set hostname, /etc/hostname. and /etc/hosts according to it.
