### PR TITLE
Fix racing condition between updategraph and rc.local

### DIFF
--- a/files/image_config/updategraph/updategraph.service
+++ b/files/image_config/updategraph/updategraph.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=download minigraph from graph service
+After=rc-local.service
 Before=database.service
 
 [Service]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a bug that updategraph service is not disabled correctly after upgrading through sonic-installer

**- How I did it**
The cause for the bug is that updategraph service starts before rc.local service copy old config to /etc/sonic. Added a timeline dependency to service definition to avoid this.
