### PR TITLE
[docker-orchagent]: ports.json.j2 template fixed

### DIFF
--- a/dockers/docker-orchagent/ports.json.j2
+++ b/dockers/docker-orchagent/ports.json.j2
@@ -1,13 +1,14 @@
 [
 {% if PORT %}
+{% set ns = {'firstPrinted': False} %}
 {% for port in PORT %}
 {% if PORT[port].has_key('speed') %}
-    {
+    {% if ns.firstPrinted %},{% endif %}{
         "PORT_TABLE:{{ port }}": {
             "speed": "{{ PORT[port]['speed'] }}"
         },
         "OP": "SET"
-    }{% if not loop.last %},{% endif %}
+    }{% if ns.update({'firstPrinted': True}) %} {% endif %}
 
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
* ports.json file is generating correctly now, without excess comma in case if
the last port in list has no port speed setting in the redis-db

Signed-off-by: Denis Maslov <Denis.Maslov@cavium.com>

**- What I did**
ports.json.j2 fixed to generate valid ports.json with speed configuration

**- How I did it**
The principle of comma placement changed

**- How to verify it**
Set port speed for some ports in config_db or minigraph.
1. Perform:
    ```bash
    docker exec -ti swss bash
    cat /etc/swss/config.d/ports.json
    [
        {
            "PORT_TABLE:Ethernet2": {
                "speed": "40000"
            },
            "OP": "SET"
        }
        ,{
            "PORT_TABLE:Ethernet5": {
                "speed": "100000"
            },
            "OP": "SET"
        }
    ]
    ```
    The last entry must be without comma after it.

**- Description for the changelog**
ports.json file is generating correctly now, without excess comma in case if
the last port in list has no port speed setting in the redis-db


**- A picture of a cute animal (not mandatory but encouraged)**
^._.^
