### PR TITLE
[initramfs] Add setfacl in the initramfs

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -123,6 +123,8 @@ sudo cp files/initramfs-tools/arista-convertfs $FILESYSTEM_ROOT/etc/initramfs-to
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-convertfs
 sudo cp files/initramfs-tools/mke2fs $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/mke2fs
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/mke2fs
+sudo cp files/initramfs-tools/setfacl $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/setfacl
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/setfacl
 
 # Hook into initramfs: rename the management interfaces on arista switches
 sudo cp files/initramfs-tools/arista-net $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-net

--- a/files/initramfs-tools/arista-convertfs.j2
+++ b/files/initramfs-tools/arista-convertfs.j2
@@ -87,6 +87,9 @@ fixup_flash_permissions() {
     # this allows the sonic admin user to have read access on the flash
     local flash_mnt="$1"
     chmod o+rx "$flash_mnt"
+
+    # remove all the filesystem acls from the flash
+    setfacl -Rb "$flash_mnt"
 }
 
 # Extract kernel parameters

--- a/files/initramfs-tools/setfacl
+++ b/files/initramfs-tools/setfacl
@@ -1,0 +1,20 @@
+#!/bin/sh
+#Part of the code is revised based on initramfs-tools/hooks/fsck and initramfs-tool is under GPL v2.
+
+PREREQ=""
+
+prereqs()
+{
+    echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+    prereqs
+    exit 0
+    ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+copy_exec /usr/bin/setfacl /sbin/setfacl


### PR DESCRIPTION
Arista platforms need the filesystem ACLs to be removed on boot to
prevent invalid permission to be set for new files.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added setfacl in sonic initramfs
Issue a setfacl as part of the flash permission fixup

**- How I did it**

**- How to verify it**

Different boot scenarios between EOS and Sonic and Sonic to Sonic.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
