### PR TITLE
Fix FRR template for router-id

### DIFF
--- a/dockers/docker-fpm-frr/bgpd.conf.j2
+++ b/dockers/docker-fpm-frr/bgpd.conf.j2
@@ -23,8 +23,13 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
 {# TODO: use lo[0] for backward compatibility, will revisit the case with multiple lo interfaces #}
-  bgp router-id {{ LOOPBACK_INTERFACE.keys()[0][1] }}
+{% for (name, prefix) in LOOPBACK_INTERFACE %}
+{% if prefix | ipv4 and name == 'Loopback0' %}
+  bgp router-id {{ prefix | ip }}
+{% endif %}
+{% endfor %}
 {# advertise loopback #}
+
 {% for (name, prefix) in LOOPBACK_INTERFACE %}
 {% if prefix | ipv4 %}
   network {{ prefix | ip }}/32


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the FRR template  for router-id setup

**- How I did it**
Fix the template

**- How to verify it**
The router-id should be loopback interface IP now (without the /prefix)

**- Description for the changelog**
Fix the FRR template  for router-id setup
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
