### PR TITLE
[build]: do not start docker service if it is already started

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -336,7 +336,7 @@ $(SONIC_INSTALL_WHEELS) : $(PYTHON_WHEELS_PATH)/%-install : .platform $$(addsuff
 
 # start docker daemon
 docker-start :
-	@sudo service docker start &> /dev/null && sleep 1
+	@sudo service docker status &> /dev/null || ( sudo service docker start &> /dev/null && sleep 1 )
 
 # targets for building simple docker images that do not depend on any debian packages
 $(addprefix $(TARGET_PATH)/, $(SONIC_SIMPLE_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform docker-start $$(addsuffix -load,$$(addprefix $(TARGET_PATH)/,$$($$*.gz_LOAD_DOCKERS)))


### PR DESCRIPTION
**- What I did**
do not start docker service if it is already started

**- How I did it**
first check if docker service is already started 

**- How to verify it**
```
make -f slave.mk docker-start
make -f slave.mk docker-start
sudo service docker stop
make -f slave.mk docker-start
```

**- Description for the changelog**
use docker restart instead of docker start

**- A picture of a cute animal (not mandatory but encouraged)**
