### PR TITLE
[LLDP] Send interface name instead of mac as PORT_ID for mgmt interface

### DIFF
--- a/dockers/docker-lldp-sv2/lldpd.conf.j2
+++ b/dockers/docker-lldp-sv2/lldpd.conf.j2
@@ -1,3 +1,4 @@
+configure ports eth0 lldp portidsubtype local {{ MGMT_INTERFACE.keys()[0][0] }}
 {% for local_port in DEVICE_NEIGHBOR %}
 configure ports {{ local_port }} lldp portidsubtype local {{ PORT[local_port]['alias'] }} description {{ DEVICE_NEIGHBOR[local_port]['name'] }}:{{ DEVICE_NEIGHBOR[local_port]['port'] }}
 {% endfor %}

--- a/src/sonic-config-engine/tests/sample_output/lldpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/lldpd.conf
@@ -1,3 +1,4 @@
+configure ports eth0 lldp portidsubtype local eth0
 configure ports Ethernet116 lldp portidsubtype local fortyGigE0/116 description ARISTA02T1:Ethernet1/1
 configure ports Ethernet124 lldp portidsubtype local fortyGigE0/124 description ARISTA04T1:Ethernet1/1
 configure ports Ethernet112 lldp portidsubtype local fortyGigE0/112 description ARISTA01T1:Ethernet1/1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Send interface name instead of mac address as PORT_ID for management ports through LLDP. Behavior is now consistent with data ports.
