### PR TITLE
Derive varlog size based on total flash size

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -132,8 +132,13 @@ platform_specific() {
         flash_size=28000
     fi
     if [ "$platform" = "rook" ]; then
-        varlog_size=4096
         readprefdl -f /tmp/.system-prefdl -d > /mnt/flash/.system-prefdl
+    fi
+
+    if [ $flash_size -ge 28000 ]; then
+        varlog_size=4096
+    elif [ $flash_size -ge 3700 ]; then
+        varlog_size=400
     fi
 
     echo "varlog_size=$varlog_size" >>/tmp/append


### PR DESCRIPTION
**- What I did**
Logic added to derive var/log size based on flash size and not check for platform

**- How I did it**
Check for `flash_size `and assign `varlog_size` 

**- How to verify it**
Run the following command
```
admin@7060cx:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/loop1      380M  2.9M  353M   1% /var/log
```

Prior to this change, 

```
admin@7060cx:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/loop1       93M   56M   30M  66% /var/log

```

**- Description for the changelog**
Derive varlog_size based on flash_size 


**- A picture of a cute animal (not mandatory but encouraged)**
