### PR TITLE
[device/arista]: Add MAX6697 sensor for Arista 7060CX-32S

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/sensors.conf
+++ b/device/arista/x86_64-arista_7060_cx32s/sensors.conf
@@ -11,12 +11,25 @@ bus "i2c-7" "SCD SMBus master 0 bus 5"
 chip "k10temp-pci-00c3"
     label temp1 "Cpu temp sensor"
 
-# missing support for
-# chip "max6697-i2c-2-1a"
-#   board sensor 65 75
-#   (1) switch chip left sensor 95 105
-#   (5) switch chip right sensor 95 105
-#   (6) front panel temp sensor 65 75
+chip "max6697-i2c-2-1a"
+    label temp1 "Board sensor"
+    set temp1_max 95
+
+    label temp2 "Switch chip left sensor"
+    set temp2_max 95
+    set temp2_crit 105
+
+    ignore temp3
+    ignore temp4
+    ignore temp5
+
+    label temp6 "Switch chip right sensor"
+    set temp6_max 95
+    set temp6_crit 105
+
+    label temp7 "Front panel temp sensor"
+    set temp7_max 65
+    set temp7_crit 75
 
 chip "max6658-i2c-3-4c"
     label temp1 "Cpu board temp sensor"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add support for MAX6697 temperature sensor for the Arista 7060CX-32S

**- How I did it**
Add the MAX6697 kernel module to [sonic-linux-kernel](https://github.com/Azure/sonic-linux-kernel/pull/36) and add the appropriate configuration to Arista 7060CX-32S sensor configuration

**- How to verify it**
Boot an Arista 7060CX-32S with the new sensor configuration and kernel. Verify that the MAX6697 is loaded by hwmon by checking for output from:
$ show environment | grep 'max6697*'

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add MAX6697 temperature sensor for Arista 7060CX-32S