### PR TITLE
[swss]: Fix missing comma in the ports.json.j2 file

### DIFF
--- a/dockers/docker-orchagent/ports.json.j2
+++ b/dockers/docker-orchagent/ports.json.j2
@@ -4,7 +4,7 @@
 {% if PORT[port].has_key('speed') %}
     {
         "PORT_TABLE:{{ port }}": {
-            "speed": "{{ PORT[port]['speed'] }}"
+            "speed": "{{ PORT[port]['speed'] }}",
             "description": "{{ PORT[port]['description'] }}"
         },
         "OP": "SET"

--- a/src/sonic-config-engine/tests/sample_output/ports.json
+++ b/src/sonic-config-engine/tests/sample_output/ports.json
@@ -1,0 +1,30 @@
+[
+    {
+        "PORT_TABLE:Ethernet8": {
+            "speed": "40000",
+            "description": "Interface description"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet0": {
+            "speed": "10000",
+            "description": ""
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet4": {
+            "speed": "25000",
+            "description": ""
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet12": {
+            "speed": "1000000",
+            "description": "Interface description"
+        },
+        "OP": "SET"
+    },
+]

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -257,6 +257,7 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
           <Speed>1000000</Speed>
+          <Description>Interface description</Description>
         </a:EthernetInterface>
       </EthernetInterfaces>
       <FlowControl>true</FlowControl>

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -9,6 +9,7 @@ class TestJ2Files(TestCase):
     def setUp(self):
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
         self.script_file = os.path.join(self.test_dir, '..', 'sonic-cfggen')
+        self.simple_minigraph = os.path.join(self.test_dir, 'simple-sample-graph.xml')
         self.t0_minigraph = os.path.join(self.test_dir, 't0-sample-graph.xml')
         self.pc_minigraph = os.path.join(self.test_dir, 'pc-test-graph.xml')
         self.t0_port_config = os.path.join(self.test_dir, 't0-sample-port-config.ini')
@@ -32,6 +33,12 @@ class TestJ2Files(TestCase):
         output = self.run_script(argument)
         data = json.loads(output)
         self.assertEqual(data["Ethernet4"], "fortyGigE0/4")
+
+    def test_ports_json(self):
+        ports_template = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-orchagent', 'ports.json.j2')
+        argument = '-m ' + self.simple_minigraph + ' -p ' + self.t0_port_config + ' -t ' + ports_template + ' > ' + self.output_file
+        self.run_script(argument)
+        self.assertTrue(filecmp.cmp(os.path.join(self.test_dir, 'sample_output', 'ports.json'), self.output_file))
 
     def test_lldp(self):
         lldpd_conf_template = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-lldp-sv2', 'lldpd.conf.j2')


### PR DESCRIPTION
Add J2 test case as well as a sample output

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

**- How to verify it**
Run the pytest

**- Description for the changelog**
this issue was introduced here: https://github.com/Azure/sonic-buildimage/pull/1207
