### PR TITLE
Added psuutil support for S6100/Z9100 Dell Platforms

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/plugins/psuutil.py
@@ -1,0 +1,80 @@
+#
+# psuutil.py
+# Platform-specific PSU status interface for SONiC
+#
+
+
+import os.path
+
+try:
+    from sonic_psu.psu_base import PsuBase
+except ImportError, e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class PsuUtil(PsuBase):
+    """Platform-specific PSUutil class"""
+
+    def __init__(self):
+        PsuBase.__init__(self)
+
+    # Get a mailbox register
+    def get_pmc_register(self, reg_name):
+        mailbox_dir = "/sys/devices/platform/dell_s6100_lpc"
+        retval = 'ERR'
+        mb_reg_file = mailbox_dir+'/' + reg_name
+        if (not os.path.isfile(mb_reg_file)):
+            print mb_reg_file,  'not found !'
+            return retval
+
+        try:
+            with open(mb_reg_file, 'r') as fd:
+                retval = fd.read()
+        except Exception as error:
+            logging.error("Unable to open ", mb_reg_file, "file !")
+
+        retval = retval.rstrip('\r\n')
+        return retval
+
+    def get_num_psus(self):
+        """
+        Retrieves the number of PSUs available on the device
+        :return: An integer, the number of PSUs available on the device
+         """
+        S6100_MAX_PSUS = 2
+        return S6100_MAX_PSUS
+
+    def get_psu_status(self, index):
+        """
+        Retrieves the oprational status of power supply unit (PSU) defined
+                by index <index>
+        :param index: An integer, index of the PSU of which to query status
+        :return: Boolean, True if PSU is operating properly, False if PSU is\
+        faulty
+        """
+        status = 0
+        psu_status = self.get_pmc_register('psu_'+str(index)+'_status')
+        if (psu_status != 'ERR'):
+            psu_status = int(psu_status, 16)
+            # Check for PSU statuse
+            if (~psu_status & 0b1000) or (psu_status & 0b0100):
+                    status = 1
+
+        return status
+
+    def get_psu_presence(self, index):
+        """
+        Retrieves the presence status of power supply unit (PSU) defined
+                by index <index>
+        :param index: An integer, index of the PSU of which to query status
+        :return: Boolean, True if PSU is plugged, False if not
+        """
+        status = 0
+        psu_presence = self.get_pmc_register('psu_'+str(index)+'_status')
+        if (psu_presence != 'ERR'):
+            psu_presence = int(psu_presence, 16)
+            # Check for PSU presence
+            if (~psu_presence & 0b1):
+                    status = 1
+
+        return status

--- a/device/dell/x86_64-dell_z9100_c2538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/plugins/psuutil.py
@@ -1,0 +1,80 @@
+#
+# psuutil.py
+# Platform-specific PSU status interface for SONiC
+#
+
+
+import os.path
+
+try:
+    from sonic_psu.psu_base import PsuBase
+except ImportError, e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class PsuUtil(PsuBase):
+    """Platform-specific PSUutil class"""
+
+    def __init__(self):
+        PsuBase.__init__(self)
+
+    # Get a mailbox register
+    def get_pmc_register(self, reg_name):
+        mailbox_dir = "/sys/devices/platform/dell_mailbox"
+        retval = 'ERR'
+        mb_reg_file = mailbox_dir+'/' + reg_name
+        if (not os.path.isfile(mb_reg_file)):
+            print mb_reg_file,  'not found !'
+            return retval
+
+        try:
+            with open(mb_reg_file, 'r') as fd:
+                retval = fd.read()
+        except Exception as error:
+            logging.error("Unable to open ", mb_reg_file, "file !")
+
+        retval = retval.rstrip('\r\n')
+        return retval
+
+    def get_num_psus(self):
+        """
+        Retrieves the number of PSUs available on the device
+        :return: An integer, the number of PSUs available on the device
+         """
+        Z9100_MAX_PSUS = 2
+        return Z9100_MAX_PSUS
+
+    def get_psu_status(self, index):
+        """
+        Retrieves the oprational status of power supply unit (PSU) defined
+                by index <index>
+        :param index: An integer, index of the PSU of which to query status
+        :return: Boolean, True if PSU is operating properly, False if PSU is\
+        faulty
+        """
+        status = 0
+        psu_status = self.get_pmc_register('psu_'+str(index)+'_status')
+        if (psu_status != 'ERR'):
+            psu_status = int(psu_status, 16)
+            # Check for PSU statuse
+            if (~psu_status & 0b1000) or (psu_status & 0b0100):
+                    status = 1
+
+        return status
+
+    def get_psu_presence(self, index):
+        """
+        Retrieves the presence status of power supply unit (PSU) defined
+                by index <index>
+        :param index: An integer, index of the PSU of which to query status
+        :return: Boolean, True if PSU is plugged, False if not
+        """
+        status = 0
+        psu_presence = self.get_pmc_register('psu_'+str(index)+'_status')
+        if (psu_presence != 'ERR'):
+            psu_presence = int(psu_presence, 16)
+            # Check for PSU presence
+            if (~psu_presence & 0b1):
+                    status = 1
+
+        return status


### PR DESCRIPTION
**- What I did**
Added psuutil support for S6100/Z9100 Dell Platforms

**- How I did it**

**- How to verify it**
```
root@switch1:/usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/plugins# psuutil status
+-------+----------+
| PSU   | Status   |
+=======+==========+
| PSU 1 | OK       |
+-------+----------+
| PSU 2 | OK       |
+-------+----------+

---> PSU is present no cable
root@switch1:/usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/plugins# psuutil status
+-------+----------+
| PSU   | Status   |
+=======+==========+
| PSU 1 | NOT OK   |
+-------+----------+
| PSU 2 | OK       |
+-------+----------+
```
**- Description for the changelog**
on behalf of dell engineer

**- A picture of a cute animal (not mandatory but encouraged)**
