### PR TITLE
[snmp]: Save S/N in state DB prior to starting service

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -17,6 +17,9 @@ function postStartAction()
         sleep 1
     done
 {%- endif %}
+{%- if docker_container_name == "snmp" %}
+    docker exec -i database redis-cli -n 6 HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
+{%- endif %}
 }
 
 # Obtain our platform as we will mount directories with these names in each docker

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -4,7 +4,6 @@ Requires=database.service swss.service
 After=database.service swss.service
 
 [Service]
-User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh attach
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop


### PR DESCRIPTION
snmp.service needs to read chassis serial number for one of its mibs.
We save this value in state DB so that it is accessible from container.

Signed-off-by: marian-pritsak <marianp@mellanox.com>
