### PR TITLE
[DHCP relay]: Fix circuit ID and remote ID bugs

### DIFF
--- a/src/isc-dhcp/patch/0001-Customizable-Option-82-circuit-ID-and-remote-ID-fiel.patch
+++ b/src/isc-dhcp/patch/0001-Customizable-Option-82-circuit-ID-and-remote-ID-fiel.patch
@@ -1,14 +1,14 @@
-From 42319f1b56ba6362c874cd64383a055ba6498bee Mon Sep 17 00:00:00 2001
+From 6b61ecb106d46eab5152db1634e863930f700514 Mon Sep 17 00:00:00 2001
 From: Joe LeVeque <jolevequ@microsoft.com>
 Date: Mon, 11 Dec 2017 23:21:08 +0000
 Subject: [PATCH 1/3] Customizable Option 82 circuit ID and remote ID fields
 
 ---
- relay/dhcrelay.c | 172 +++++++++++++++++++++++++++++++++++++++++++++++--------
- 1 file changed, 147 insertions(+), 25 deletions(-)
+ relay/dhcrelay.c | 180 +++++++++++++++++++++++++++++++++++++++++++++----------
+ 1 file changed, 150 insertions(+), 30 deletions(-)
 
 diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
-index 15b4997..a26efca 100644
+index 15b4997..1b9248c 100644
 --- a/relay/dhcrelay.c
 +++ b/relay/dhcrelay.c
 @@ -73,6 +73,8 @@ int bad_circuit_id = 0;		/* Circuit ID option in matching RAI option
@@ -158,9 +158,12 @@ index 15b4997..a26efca 100644
   * Examine a packet to see if it's a candidate to have a Relay
   * Agent Information option tacked onto its tail.   If it is, tack
   * the option on.
-@@ -948,6 +1044,9 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+@@ -946,8 +1042,11 @@ static int
+ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+ 			unsigned length, struct in_addr giaddr) {
  	int is_dhcp = 0, mms;
- 	unsigned optlen;
+-	unsigned optlen;
++	unsigned optlen = 0;
  	u_int8_t *op, *nextop, *sp, *max, *end_pad = NULL;
 +    char circuit_id_buf[256] = { '\0' };
 +    char remote_id_buf[256] = { '\0' };
@@ -168,7 +171,7 @@ index 15b4997..a26efca 100644
  
  	/* If we're not adding agent options to packets, we can skip
  	   this. */
-@@ -1077,24 +1176,47 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+@@ -1077,24 +1176,45 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
  	op = sp;
  #endif
  
@@ -177,6 +180,13 @@ index 15b4997..a26efca 100644
 -		log_fatal("Circuit ID length %d out of range [1-255] on "
 -			  "%s\n", ip->circuit_id_len, ip->name);
 -	optlen = ip->circuit_id_len + 2;            /* RAI_CIRCUIT_ID + len */
+-
+-	if (ip->remote_id) {
+-		if (ip->remote_id_len > 255 || ip->remote_id_len < 1)
+-			log_fatal("Remote ID length %d out of range [1-255] "
+-				  "on %s\n", ip->circuit_id_len, ip->name);
+-		optlen += ip->remote_id_len + 2;    /* RAI_REMOTE_ID + len */
+-	}
 +    /* option82: custom string for circuit_id */
 +    if (agent_circuit_id_fmt) {
 +        circuit_id_len = format_relay_agent_rfc3046_msg(ip, packet, agent_circuit_id_fmt,
@@ -185,8 +195,15 @@ index 15b4997..a26efca 100644
 +        if (circuit_id_len == 0)
 +            strncpy(circuit_id_buf, ip->name, sizeof(ip->name));
 +
++        /* Sanity check. Had better not ever happen. */
++        if (circuit_id_len > 255 || circuit_id_len < 1)
++            log_fatal("Circuit ID length %d out of range [1-255] on %s\n",
++                      (int)circuit_id_len, ip->name);
++
++        optlen = circuit_id_len + 2;  // RAI_CIRCUIT_ID + len
++
 +        //log_debug("Sending on %s option82:circuit_id='%s' (%d)",
-+        //          ip->name, circuit_id_buf, circuit_id_len);
++        //          ip->name, circuit_id_buf, (int)circuit_id_len);
 +    }
 +
 +    /* option82: custom string for remote_id */
@@ -194,28 +211,15 @@ index 15b4997..a26efca 100644
 +        remote_id_len = format_relay_agent_rfc3046_msg(ip, packet, agent_remote_id_fmt,
 +                                             remote_id_buf, sizeof(remote_id_buf));
 +
++        if (remote_id_len > 255 || remote_id_len < 1)
++            log_fatal("Remote ID length %d out of range [1-255] on %s\n",
++                      (int)remote_id_len, ip->name);
++
++        optlen += remote_id_len + 2;  // RAI_REMOTE_ID + len
++
 +        //log_debug("Sending on %s option82:remote_id='%s' (%d)",
-+        //          ip->name, remote_id_buf, remote_id_len);
++        //          ip->name, remote_id_buf, (int)remote_id_len);
 +    }
-+
-+	/* Sanity check. Had better not ever happen. */
-+	if (circuit_id_len > 255 || circuit_id_len < 1)
-+		log_fatal("Circuit ID length %d out of range [1-255] on %s\n",
-+                  circuit_id_len, ip->name);
-+
-+	optlen = circuit_id_len + 2;  // RAI_CIRCUIT_ID + len
- 
- 	if (ip->remote_id) {
--		if (ip->remote_id_len > 255 || ip->remote_id_len < 1)
--			log_fatal("Remote ID length %d out of range [1-255] "
--				  "on %s\n", ip->circuit_id_len, ip->name);
--		optlen += ip->remote_id_len + 2;    /* RAI_REMOTE_ID + len */
-+		if (remote_id_len > 255 || remote_id_len < 1)
-+			log_fatal("Remote ID length %d out of range [1-255] on %s\n",
-+                      remote_id_len, ip->name);
-+
-+		optlen += remote_id_len + 2;  // RAI_REMOTE_ID + len
- 	}
  
 -	/* We do not support relay option fragmenting(multiple options to
 -	 * support an option data exceeding 255 bytes).
@@ -229,7 +233,7 @@ index 15b4997..a26efca 100644
  			   "[3 - 255] on %s\n", optlen, ip->name);
  
  	/*
-@@ -1102,7 +1224,7 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+@@ -1102,7 +1222,7 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
  	 * If not, forward without adding the option.
  	 */
  	if (max - sp >= optlen + 3) {
@@ -238,7 +242,7 @@ index 15b4997..a26efca 100644
  
  		/* Okay, cons up *our* Relay Agent Information option. */
  		*sp++ = DHO_DHCP_AGENT_OPTIONS;
-@@ -1110,16 +1232,16 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+@@ -1110,16 +1230,16 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
  
  		/* Copy in the circuit id... */
  		*sp++ = RAI_CIRCUIT_ID;
@@ -250,7 +254,8 @@ index 15b4997..a26efca 100644
 +		sp += circuit_id_len;
  
  		/* Copy in remote ID... */
- 		if (ip->remote_id) {
+-		if (ip->remote_id) {
++		if (remote_id_len > 0) {
  			*sp++ = RAI_REMOTE_ID;
 -			*sp++ = ip->remote_id_len;
 -			memcpy(sp, ip->remote_id, ip->remote_id_len);

--- a/src/isc-dhcp/patch/0001-Customizable-Option-82-circuit-ID-and-remote-ID-fiel.patch
+++ b/src/isc-dhcp/patch/0001-Customizable-Option-82-circuit-ID-and-remote-ID-fiel.patch
@@ -1,14 +1,14 @@
-From 6b61ecb106d46eab5152db1634e863930f700514 Mon Sep 17 00:00:00 2001
+From 284c87ff4b3873d0215904273fe3c86b07b4ba94 Mon Sep 17 00:00:00 2001
 From: Joe LeVeque <jolevequ@microsoft.com>
 Date: Mon, 11 Dec 2017 23:21:08 +0000
 Subject: [PATCH 1/3] Customizable Option 82 circuit ID and remote ID fields
 
 ---
- relay/dhcrelay.c | 180 +++++++++++++++++++++++++++++++++++++++++++++----------
- 1 file changed, 150 insertions(+), 30 deletions(-)
+ relay/dhcrelay.c | 182 ++++++++++++++++++++++++++++++++++++++++++++++---------
+ 1 file changed, 152 insertions(+), 30 deletions(-)
 
 diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
-index 15b4997..1b9248c 100644
+index 15b4997..b9f8326 100644
 --- a/relay/dhcrelay.c
 +++ b/relay/dhcrelay.c
 @@ -73,6 +73,8 @@ int bad_circuit_id = 0;		/* Circuit ID option in matching RAI option
@@ -171,7 +171,7 @@ index 15b4997..1b9248c 100644
  
  	/* If we're not adding agent options to packets, we can skip
  	   this. */
-@@ -1077,24 +1176,45 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+@@ -1077,24 +1176,47 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
  	op = sp;
  #endif
  
@@ -192,8 +192,10 @@ index 15b4997..1b9248c 100644
 +        circuit_id_len = format_relay_agent_rfc3046_msg(ip, packet, agent_circuit_id_fmt,
 +                                             circuit_id_buf, sizeof(circuit_id_buf));
 +
-+        if (circuit_id_len == 0)
++        if (circuit_id_len == 0) {
 +            strncpy(circuit_id_buf, ip->name, sizeof(ip->name));
++            circuit_id_len = strlen(circuit_id_buf);
++        }
 +
 +        /* Sanity check. Had better not ever happen. */
 +        if (circuit_id_len > 255 || circuit_id_len < 1)
@@ -233,7 +235,7 @@ index 15b4997..1b9248c 100644
  			   "[3 - 255] on %s\n", optlen, ip->name);
  
  	/*
-@@ -1102,7 +1222,7 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+@@ -1102,7 +1224,7 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
  	 * If not, forward without adding the option.
  	 */
  	if (max - sp >= optlen + 3) {
@@ -242,7 +244,7 @@ index 15b4997..1b9248c 100644
  
  		/* Okay, cons up *our* Relay Agent Information option. */
  		*sp++ = DHO_DHCP_AGENT_OPTIONS;
-@@ -1110,16 +1230,16 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+@@ -1110,16 +1232,16 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
  
  		/* Copy in the circuit id... */
  		*sp++ = RAI_CIRCUIT_ID;

--- a/src/isc-dhcp/patch/0002-Support-for-obtaining-name-of-physical-interface-tha.patch
+++ b/src/isc-dhcp/patch/0002-Support-for-obtaining-name-of-physical-interface-tha.patch
@@ -1,4 +1,4 @@
-From 40cfb5510c16d174af3c4d27455e6ec60751df49 Mon Sep 17 00:00:00 2001
+From caad3e05c31c9fad8cda378ce95a1969def771a2 Mon Sep 17 00:00:00 2001
 From: Joe LeVeque <jolevequ@microsoft.com>
 Date: Mon, 11 Dec 2017 23:39:10 +0000
 Subject: [PATCH 2/3] Support for obtaining name of physical interface that is
@@ -9,7 +9,7 @@ Subject: [PATCH 2/3] Support for obtaining name of physical interface that is
  1 file changed, 67 insertions(+), 2 deletions(-)
 
 diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
-index 1b9248c..d9d948b 100644
+index b9f8326..8458ea9 100644
 --- a/relay/dhcrelay.c
 +++ b/relay/dhcrelay.c
 @@ -758,6 +758,7 @@ do_relay4(struct interface_info *ip, struct dhcp_packet *packet,

--- a/src/isc-dhcp/patch/0002-Support-for-obtaining-name-of-physical-interface-tha.patch
+++ b/src/isc-dhcp/patch/0002-Support-for-obtaining-name-of-physical-interface-tha.patch
@@ -1,4 +1,4 @@
-From 18ca48b7c307e1644f653df4c8503f4ce2677f62 Mon Sep 17 00:00:00 2001
+From 40cfb5510c16d174af3c4d27455e6ec60751df49 Mon Sep 17 00:00:00 2001
 From: Joe LeVeque <jolevequ@microsoft.com>
 Date: Mon, 11 Dec 2017 23:39:10 +0000
 Subject: [PATCH 2/3] Support for obtaining name of physical interface that is
@@ -9,7 +9,7 @@ Subject: [PATCH 2/3] Support for obtaining name of physical interface that is
  1 file changed, 67 insertions(+), 2 deletions(-)
 
 diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
-index a26efca..84ec79d 100644
+index 1b9248c..d9d948b 100644
 --- a/relay/dhcrelay.c
 +++ b/relay/dhcrelay.c
 @@ -758,6 +758,7 @@ do_relay4(struct interface_info *ip, struct dhcp_packet *packet,
@@ -63,7 +63,7 @@ index a26efca..84ec79d 100644
 +    if (cmd != NULL) {
 +        while (fgets(buf, sizeof(buf), cmd)) {
 +            sscanf(buf, FDB_LINE_FORMAT, macAddr, interface, vlanid);
-+            //log_debug("bridgefdbquery: macAddr:%s interface: %s vlanid %d",
++            //log_debug("bridgefdbquery: macAddr: %s interface: %s vlanid: %d",
 +            //          macAddr, interface, *vlanid);
 +        }
 +        pclose(cmd);

--- a/src/isc-dhcp/patch/0003-Support-for-loading-port-alias-map-file-to-replace-p.patch
+++ b/src/isc-dhcp/patch/0003-Support-for-loading-port-alias-map-file-to-replace-p.patch
@@ -1,15 +1,15 @@
-From 3be065305283b90ddfef92a8736221cbf7cf06e0 Mon Sep 17 00:00:00 2001
+From 82fdfd3f42c90d78c4a3193cce9447f6366ab01b Mon Sep 17 00:00:00 2001
 From: Joe LeVeque <jolevequ@microsoft.com>
 Date: Tue, 12 Dec 2017 00:49:09 +0000
-Subject: [PATCH 3/3] Support for loading port alias map file to replace
- port name with alias in circuit id
+Subject: [PATCH 3/3] Support for loading port alias map file to replace port
+ name with alias in circuit id
 
 ---
- relay/dhcrelay.c | 103 ++++++++++++++++++++++++++++++++++++++++++++++++++++++-
- 1 file changed, 102 insertions(+), 1 deletion(-)
+ relay/dhcrelay.c | 106 ++++++++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 105 insertions(+), 1 deletion(-)
 
 diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
-index 84ec79d..0b56e2d 100644
+index d9d948b..11e4c78 100644
 --- a/relay/dhcrelay.c
 +++ b/relay/dhcrelay.c
 @@ -122,6 +122,14 @@ static void setup_streams(void);
@@ -81,24 +81,34 @@ index 84ec79d..0b56e2d 100644
  	return (0);
  }
  
-@@ -1056,6 +1077,16 @@ format_relay_agent_rfc3046_msg(const struct interface_info *ip, struct dhcp_pack
+@@ -1040,6 +1061,7 @@ format_relay_agent_rfc3046_msg(const struct interface_info *ip, struct dhcp_pack
+                     */
+                     if (packet->htype && !packet->giaddr.s_addr) {
+                         int ret = 0, vlanid = 0;
++                        char ifalias[IFNAMSIZ] = { 0 };
+ 
+                         ret = _bridgefdbquery(print_hw_addr(packet->htype, packet->hlen, packet->chaddr),
+                                               ifname,
+@@ -1056,6 +1078,18 @@ format_relay_agent_rfc3046_msg(const struct interface_info *ip, struct dhcp_pack
                              strncpy(ifname, ip->name, IFNAMSIZ);
                          }
  
 +                        // Attempt to translate SONiC interface name to vendor alias
-+                        if (get_interface_alias_by_name(ip->name, ifname) < 0) {
-+                            //log_debug("Failed to retrieve alias for interface name '%s'. Defaulting to interface name.", ip->name);
-+                            strncpy(ifname, ip->name, IFNAMSIZ);
++                        ret = get_interface_alias_by_name(ifname, ifalias);
++                        if (ret < 0) {
++                            //log_debug("Failed to retrieve alias for interface name '%s'. Defaulting to interface name.", ifname);
 +                        }
 +                        else {
 +                            //log_debug("Mapped interface name '%s' to alias '%s'. Adding as option 82 interface alias for MAC Address %s",
-+                            //          ip->name, ifname, print_hw_addr (packet->htype, packet->hlen, packet->chaddr),
++                            //          ifname, ifalias, print_hw_addr (packet->htype, packet->hlen, packet->chaddr));
++
++                            strncpy(ifname, ifalias, IFNAMSIZ);
 +                        }
 +
                          str = ifname;
                      }
                  break;
-@@ -1922,3 +1953,73 @@ dhcp_set_control_state(control_object_state_t oldstate,
+@@ -1920,3 +1954,73 @@ dhcp_set_control_state(control_object_state_t oldstate,
  
  	exit(0);
  }

--- a/src/isc-dhcp/patch/0003-Support-for-loading-port-alias-map-file-to-replace-p.patch
+++ b/src/isc-dhcp/patch/0003-Support-for-loading-port-alias-map-file-to-replace-p.patch
@@ -1,4 +1,4 @@
-From 82fdfd3f42c90d78c4a3193cce9447f6366ab01b Mon Sep 17 00:00:00 2001
+From 3a42b497716375c9347b51c3a28c5e91e7cd4cf4 Mon Sep 17 00:00:00 2001
 From: Joe LeVeque <jolevequ@microsoft.com>
 Date: Tue, 12 Dec 2017 00:49:09 +0000
 Subject: [PATCH 3/3] Support for loading port alias map file to replace port
@@ -9,7 +9,7 @@ Subject: [PATCH 3/3] Support for loading port alias map file to replace port
  1 file changed, 105 insertions(+), 1 deletion(-)
 
 diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
-index d9d948b..11e4c78 100644
+index 8458ea9..15f0acf 100644
 --- a/relay/dhcrelay.c
 +++ b/relay/dhcrelay.c
 @@ -122,6 +122,14 @@ static void setup_streams(void);
@@ -108,7 +108,7 @@ index d9d948b..11e4c78 100644
                          str = ifname;
                      }
                  break;
-@@ -1920,3 +1954,73 @@ dhcp_set_control_state(control_object_state_t oldstate,
+@@ -1922,3 +1956,73 @@ dhcp_set_control_state(control_object_state_t oldstate,
  
  	exit(0);
  }


### PR DESCRIPTION
- Fix two bugs that were introduced with https://github.com/Azure/sonic-buildimage/pull/1233
  - Remote ID not getting added to packet because of out-of-date conditional
  - Physical interface name/alias not overriding bridge interface name in circuit ID due to out-of-date 

- Also cleaned up compiler warnings