### PR TITLE
[device/accton] Correct exception function name

### DIFF
--- a/device/accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
@@ -83,10 +83,10 @@ class SfpUtil(SfpUtilBase):
         return True
 
     def set_low_power_mode(self, port_nuM, lpmode):
-        raise NotImplementedErro
+        raise NotImplementedError
 
     def get_low_power_mode(self, port_num):
-        raise NotImplementedErro
+        raise NotImplementedError
         
     def get_presence(self, port_num):
         # Check for invalid port_num


### PR DESCRIPTION
Fixed typo from NotImplementedErro to NotImplementedErro(r)

Signed-off-by: Phil Huang <phil_huang@edge-core.com>
