### PR TITLE
[build] allow user to override the default number of build jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@
 #  * PASSWORD: Desired password -- default at rules/config
 #  * KEEP_SLAVE_ON: Keeps slave container up after building-process concludes.
 #  * SOURCE_FOLDER: host path to be mount as /var/src, only effective when KEEP_SLAVE_ON=yes
+#  * SONIC_BUILD_JOB: Specifying number of concurrent build job(s) to run
 #
 ###############################################################################
 
@@ -59,7 +60,8 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            SHUTDOWN_BGP_ON_START=$(SHUTDOWN_BGP_ON_START) \
                            ENABLE_SYNCD_RPC=$(ENABLE_SYNCD_RPC) \
                            PASSWORD=$(PASSWORD) \
-                           USERNAME=$(USERNAME)
+                           USERNAME=$(USERNAME) \
+                           SONIC_BUILD_JOBS=$(SONIC_BUILD_JOBS)
 
 .PHONY: sonic-slave-build sonic-slave-bash init
 

--- a/slave.mk
+++ b/slave.mk
@@ -74,7 +74,11 @@ ifeq ($(PASSWORD),)
 override PASSWORD := $(DEFAULT_PASSWORD)
 endif
 
-MAKEFLAGS += -j $(SONIC_CONFIG_BUILD_JOBS)
+ifeq ($(SONIC_BUILD_JOBS),)
+override SONIC_BUILD_JOBS := $(SONIC_CONFIG_BUILD_JOBS)
+endif
+
+MAKEFLAGS += -j $(SONIC_BUILD_JOBS)
 export SONIC_CONFIG_MAKE_JOBS
 
 ###############################################################################
@@ -86,7 +90,7 @@ $(info )
 $(info Build Configuration)
 $(info "CONFIGURED_PLATFORM"             : "$(if $(PLATFORM),$(PLATFORM),$(CONFIGURED_PLATFORM))")
 $(info "SONIC_CONFIG_PRINT_DEPENDENCIES" : "$(SONIC_CONFIG_PRINT_DEPENDENCIES)")
-$(info "SONIC_CONFIG_BUILD_JOBS"         : "$(SONIC_CONFIG_BUILD_JOBS)")
+$(info "SONIC_BUILD_JOBS"                : "$(SONIC_BUILD_JOBS)")
 $(info "SONIC_CONFIG_MAKE_JOBS"          : "$(SONIC_CONFIG_MAKE_JOBS)")
 $(info "DEFAULT_USERNAME"                : "$(DEFAULT_USERNAME)")
 $(info "DEFAULT_PASSWORD"                : "$(DEFAULT_PASSWORD)")


### PR DESCRIPTION
**- What I did**
User could issue SONIC_BUILD_JOBS=\<num\> to set number of concurrent
build job(s) to run.

With this commit, the default setting is still left at 1.

**- How to verify it**
Tested building with SONIC_BUILD_JOBS=10, worked. Up to 10 jobs will be started.
Tested without specifying the parameter, worked. Up to 1 job (default) will be started.
Tested building with SONIC_BUILD_JOBS=0, worked. A warning from make was observed, build continued with 1 job.
Tested building with SONIC_BUILD_JOBS=-10, worked. Multiple jobs were started, make either take it as abs(-10) or (unsigned)(-10).