### PR TITLE
[arista] Delete sysfs entries for all Arista Digital Power Monitor/Management devices

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32s/sensors.conf
+++ b/device/arista/x86_64-arista_7050_qx32s/sensors.conf
@@ -29,14 +29,6 @@ chip "max6658-i2c-3-4c"
     set temp2_max 75
     set temp2_crit 80
 
-chip "pmbus-i2c-3-4e"
-    label temp1 "Power controller 1 sensor 1"
-    label temp2 "Power controller 1 sensor 2"
-
-chip "pmbus-i2c-7-4e"
-    label temp1 "Power controller 2 sensor 1"
-    label temp2 "Power controller 2 sensor 2"
-
 chip "pmbus-i2c-6-58"
     label temp1 "Power supply 1 hotspot sensor"
     label temp2 "Power supply 1 inlet temp sensor"

--- a/device/arista/x86_64-arista_7060_cx32s/sensors.conf
+++ b/device/arista/x86_64-arista_7060_cx32s/sensors.conf
@@ -40,14 +40,6 @@ chip "max6658-i2c-3-4c"
     set temp2_max 75
     set temp2_crit 80
 
-chip "pmbus-i2c-3-4e"
-    label temp1 "Power controller 1 sensor 1"
-    label temp2 "Power controller 1 sensor 2"
-
-chip "pmbus-i2c-7-4e"
-    label temp1 "Power controller 2 sensor 1"
-    label temp2 "Power controller 2 sensor 2"
-
 chip "pmbus-i2c-6-58"
     label temp1 "Power supply 1 hotspot sensor"
     label temp2 "Power supply 1 inlet temp sensor"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1) Delete sysfs entries for all Arista Digital Power Monitor/Management devices
2) Cleanup corresponding sensors.conf files

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
