### PR TITLE
[sudoers] Add 'docker ps' to READ_ONLY_CMDS

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -21,6 +21,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /usr/bin/decode-syseeprom, \
                                  /usr/bin/docker images *, \
                                  /usr/bin/docker exec -it snmp cat /etc/snmp/snmpd.conf, \
                                  /usr/bin/docker exec -it bgp cat /etc/quagga/bgpd.conf, \
+                                 /usr/bin/docker ps, \
                                  /usr/bin/generate_dump, \
                                  /usr/bin/lldpctl, \
                                  /usr/bin/lldpshow, \


### PR DESCRIPTION
- `docker ps` is now called from the `show` command to determine the routing stack in use (by Docker container name). This was prompting for a sudo password when running the `show` command.