### PR TITLE
allow to use http(s) proxy in the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,14 @@ SLAVE_IMAGE = sonic-slave-$(USER)
 DOCKER_RUN := docker run --rm=true --privileged \
     -v $(PWD):/sonic \
     -w /sonic \
+    -e "http_proxy=$(http_proxy)" \
+    -e "https_proxy=$(https_proxy)" \
     -i$(if $(TERM),t,)
 
 DOCKER_BASE_BUILD = docker build --no-cache \
 		    -t $(SLAVE_BASE_IMAGE) \
+		    --build-arg http_proxy=$(http_proxy) \
+		    --build-arg https_proxy=$(https_proxy) \
 		    sonic-slave && \
 		    docker tag $(SLAVE_BASE_IMAGE):latest $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG)
 
@@ -61,7 +65,9 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            ENABLE_SYNCD_RPC=$(ENABLE_SYNCD_RPC) \
                            PASSWORD=$(PASSWORD) \
                            USERNAME=$(USERNAME) \
-                           SONIC_BUILD_JOBS=$(SONIC_BUILD_JOBS)
+                           SONIC_BUILD_JOBS=$(SONIC_BUILD_JOBS) \
+                           HTTP_PROXY=$(http_proxy) \
+                           HTTPS_PROXY=$(https_proxy)
 
 .PHONY: sonic-slave-build sonic-slave-bash init reset
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ To build SONiC installer image and docker images, run the following commands:
 
     make
 
- **NOTE**: We recommend reserving 50G free space to build one platform.
-    
+ **NOTE**:
+
+- We recommend reserving 50G free space to build one platform.
+- Use ```http_proxy=[your_proxy] https_proxy=[your_proxy] make``` to enable http(s) proxy in the build process.
+
 The SONiC installer contains all docker images needed. SONiC uses one image for all devices of a same ASIC vendor. The supported ASIC vendors are:
 
 - PLATFORM=broadcom

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -64,17 +64,17 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 # Install SONiC config engine Python package
 CONFIG_ENGINE_WHEEL_NAME=$(basename {{config_engine_wheel_path}})
 sudo cp {{config_engine_wheel_path}} $FILESYSTEM_ROOT/$CONFIG_ENGINE_WHEEL_NAME
-sudo LANG=C chroot $FILESYSTEM_ROOT pip install $CONFIG_ENGINE_WHEEL_NAME
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install $CONFIG_ENGINE_WHEEL_NAME
 sudo rm -rf $FILESYSTEM_ROOT/$CONFIG_ENGINE_WHEEL_NAME
 
 # Install Python client for Redis
-sudo LANG=C chroot $FILESYSTEM_ROOT pip install redis
-sudo LANG=C chroot $FILESYSTEM_ROOT pip install redis-dump-load
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install redis
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install redis-dump-load
 
 # Install SwSS SDK Python 2 package
 SWSSSDK_PY2_WHEEL_NAME=$(basename {{swsssdk_py2_wheel_path}})
 sudo cp {{swsssdk_py2_wheel_path}} $FILESYSTEM_ROOT/$SWSSSDK_PY2_WHEEL_NAME
-sudo LANG=C chroot $FILESYSTEM_ROOT pip install $SWSSSDK_PY2_WHEEL_NAME
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install $SWSSSDK_PY2_WHEEL_NAME
 sudo rm -rf $FILESYSTEM_ROOT/$SWSSSDK_PY2_WHEEL_NAME
 
 # Install SONiC Utilities (and its dependencies via 'apt-get -y install -f')


### PR DESCRIPTION
**- What I did**
allow to use http(s) proxy in the build

**- How I did it**
To enable this, use following command
http_proxy=[your_proxy] https_proxy=[your_proxy] make

**- How to verify it**
manual tested

**- Description for the changelog**
allow to use http(s) proxy in the build

To enable this, use following command
http_proxy=[your_proxy] https_proxy=[your_proxy] make

**- A picture of a cute animal (not mandatory but encouraged)**
