### PR TITLE
[build] support sai1.0 for centec platform

### DIFF
--- a/platform/centec/sai.mk
+++ b/platform/centec/sai.mk
@@ -1,5 +1,5 @@
 # Centec SAI
 CENTEC_SAI = libsai_1.0.0_amd64.deb
-$(CENTEC_SAI)_URL = https://github.com/CentecNetworks/goldengate-sai/raw/master/lib/SONiC_0.9.4/libsai_1.0.0_amd64.deb
+$(CENTEC_SAI)_URL = https://github.com/CentecNetworks/goldengate-sai/raw/master/lib/SONiC_1.0/libsai_1.0.0_amd64.deb
 
 SONIC_ONLINE_DEBS += $(CENTEC_SAI)

--- a/platform/centec/sdk.mk
+++ b/platform/centec/sdk.mk
@@ -1,4 +1,4 @@
 CENTEC_SDK_KERNEL = centec-gg-sdk3.5-modules-3.16.0-4-amd64.deb
-$(CENTEC_SDK_KERNEL)_URL = "https://github.com/CentecNetworks/goldengate-sai/raw/master/lib/centec-gg-sdk3.5-modules-3.16.0-4-amd64.deb"
+$(CENTEC_SDK_KERNEL)_URL = "https://github.com/CentecNetworks/goldengate-sai/raw/master/lib/SONiC_1.0/centec-gg-sdk3.5-modules-3.16.0-4-amd64.deb"
 
 SONIC_ONLINE_DEBS += $(CENTEC_SDK_KERNEL)


### PR DESCRIPTION
Signed-off-by: chenyq chenyq@centecnetworks.com

- What I did
update CENTEC platform to support SAI1.0

- How to verify it
build centec board image and test SAI1.0 about function.
