### PR TITLE
Disable autosuspend for USB devices

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -551,7 +551,7 @@ menuentry '$demo_grub_entry' {
         insmod ext2
         linux   /$image_dir/boot/vmlinuz-3.16.0-4-amd64 root=$grub_cfg_root rw $GRUB_CMDLINE_LINUX  \
                 loop=$image_dir/$FILESYSTEM_SQUASHFS loopfstype=squashfs                       \
-                apparmor=1 security=apparmor varlog_size=$VAR_LOG_SIZE $ONIE_PLATFORM_EXTRA_CMDLINE_LINUX
+                apparmor=1 security=apparmor varlog_size=$VAR_LOG_SIZE usbcore.autosuspend=-1 $ONIE_PLATFORM_EXTRA_CMDLINE_LINUX
         echo    'Loading $demo_volume_label $demo_type initial ramdisk ...'
         initrd  /$image_dir/boot/initrd.img-3.16.0-4-amd64
 }


### PR DESCRIPTION
Otherwise an USB disk could be stopped and then renamed after waking up. It gives us the "disk R/O" issues.

**- What I did**
Disable autosuspend feature for USB devices

**- How I did it**
Put -1 usbcore.autosuspend kernel parameter, which means never put any usb device into powersaving/sleep mode.

**- How to verify it**
`find /sys/bus/usb/devices/*/power/autosuspend | xargs cat`
Output should contains `-1` only.

**- Description for the changelog**
Fix the "USB RO" issue by disabling autosuspend feature for USB devices.
