### PR TITLE
[base image]: Install sysfsutils into the SONiC base image

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -216,6 +216,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     less                    \
     unzip                   \
     gdisk                   \
+    sysfsutils              \
     grub2-common
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Install sysfsutils into the base image. If we need to change sysfs entries, the best way is to use /etc/sysfs.conf file.

**- How I did it**
Using apt install

**- How to verify it**
```
cat /etc/sysfs.conf
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
