### PR TITLE
[baseimage]: add mkfs.ext3 and fsck.ext3 in initrd to support ext3 fs

### DIFF
--- a/files/initramfs-tools/mke2fs
+++ b/files/initramfs-tools/mke2fs
@@ -21,7 +21,7 @@ copy_exec /sbin/mke2fs
 copy_exec /sbin/sfdisk
 copy_exec /sbin/fdisk
 
-fstypes="ext4"
+fstypes="ext4 ext3"
 
 for type in $fstypes; do
     prog="/sbin/mkfs.${type}"


### PR DESCRIPTION
**- What I did**
add mkfs.ext3 and fsck.ext3 in initrd to support ext3 parittion

**- How I did it**
adding ext3 in the initramfs tool

**- How to verify it**
check both tools exist in initrd

**- Description for the changelog**
add mkfs.ext3 and fsck.ext3 in initrd to support ext3 parittion

**- A picture of a cute animal (not mandatory but encouraged)**
