### PR TITLE
[scripts]: Fix issues with checking status of the DB. Use one approach everywhere.

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -10,11 +10,8 @@ function postStartAction()
 {%- if docker_container_name != "database" %}
     :
 {%- else %}
-    while true; do
-        if [[ "$(docker exec -i database redis-cli ping)" =~ PONG.* ]]; then
-            break
-        fi
-        sleep 1
+    until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]]; do
+      sleep 1;
     done
 {%- endif %}
 {%- if docker_container_name == "snmp" %}

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -17,7 +17,7 @@ After=nps-modules-3.16.0-4-amd64.service
 [Service]
 User=root
 # Wait for redis server start before database clean
-ExecStartPre=/bin/bash -c "while true; do if [ \"$(/usr/bin/docker exec database redis-cli ping)\" == \"PONG\" ]; then break; fi; sleep 1; done"
+ExecStartPre=/bin/bash -c 'until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]]; do sleep 1; done'
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 0 FLUSHDB
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 1 FLUSHDB
 ExecStartPre=/usr/bin/docker exec database redis-cli -n 2 FLUSHDB

--- a/files/scripts/configdb-load.sh
+++ b/files/scripts/configdb-load.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 
 # Wait until redis starts
-while true; do
-    if [ `redis-cli ping` == "PONG" ]; then
-        break
-    fi
-    sleep 1
+until [[ $(redis-cli ping | grep -c PONG) -gt 0 ]]; do
+  sleep 1;
 done
 
 # If there is a config db dump file, load it


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Change scripts which checked the database status by polling it.
Otherwise two scripts have bugs:
1. swss.service.j2 - check the database status just once, then it loops indefinitely without the DB status check
2. configdb-load.sh - if database is not available it doesn't wait for it.
```
Jan 19 06:38:58.328410 hostname INFO supervisord 2018-01-19 06:20:04,244 INFO exited: configdb-load.sh (exit status 0; not expected)

Jan 19 06:38:58.328410 hostname INFO supervisord 2018-01-19 06:20:03,745 INFO spawned: 'configdb-load.sh' with pid 17
Jan 19 06:38:58.328410 hostname INFO supervisord 2018-01-19 06:20:04,244 INFO exited: configdb-load.sh (exit status 0; not expected)
Jan 19 06:38:58.328410 hostname INFO supervisord 2018-01-19 06:20:05,247 INFO success: rsyslogd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Jan 19 06:38:58.328410 hostname INFO supervisord 2018-01-19 06:20:05,248 INFO success: redis-server entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Jan 19 06:38:58.328410 hostname INFO supervisord 2018-01-19 06:20:05,249 INFO spawned: 'configdb-load.sh' with pid 41
Jan 19 06:38:58.328410 hostname INFO supervisord 2018-01-19 06:20:05,852 INFO exited: configdb-load.sh (exit status 0; not expected)
Jan 19 06:38:58.328410 hostname INFO supervisord 2018-01-19 06:20:07,855 INFO spawned: 'configdb-load.sh' with pid 48
Jan 19 06:38:58.328410 hostname INFO supervisord 2018-01-19 06:20:08,859 INFO success: configdb-load.sh entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)

```
**- How I did it**
Use one approach which works in all cases. 

**- How to verify it**
Put all my fixes into working SONiC and reboot the box.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix checks of database readyness

**- A picture of a cute animal (not mandatory but encouraged)**
