### PR TITLE
[database docker]: Prevent supervisor from restarting configdb-load.sh if it exits too quickly

### DIFF
--- a/dockers/docker-database/supervisord.conf
+++ b/dockers/docker-database/supervisord.conf
@@ -24,5 +24,6 @@ command=/usr/bin/configdb-load.sh
 priority=3
 autostart=true
 autorestart=false
+startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog


### PR DESCRIPTION
If configdb-load.sh runs for less than a second supervisord restarts it more and more until it runs at least for a second. Supervisord treats an exit of a program less than a second as an unexpected.

