### PR TITLE
Enable proxy settings for docker run

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -102,8 +102,8 @@ RUN git clone https://github.com/Azure/sonic-mgmt
 # Sample command:
 #   docker run -e "http_proxy=ip1" -e "ftp_proxy=ip2" -it <image>
 #
-ENTRYPOINT bash -c "touch /etc/profile.d/proxy.sh \
-    && echo 'export http_proxy=${http_proxy}' >> /etc/profile.d/proxy.sh \
-    && echo 'export https_proxy=${http_proxy}' >> /etc/profile.d/proxy.sh \
-    && echo 'export ftp_proxy=${http_proxy}' >> /etc/profile.d/proxy.sh \
+ENTRYPOINT bash -c "sudo touch /etc/profile.d/proxy.sh \
+    && echo 'export http_proxy=${http_proxy}' | sudo tee -a /etc/profile.d/proxy.sh \
+    && echo 'export https_proxy=${https_proxy}' | sudo tee -a /etc/profile.d/proxy.sh \
+    && echo 'export ftp_proxy=${ftp_proxy}' | sudo tee -a /etc/profile.d/proxy.sh \
     && bash"

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -96,3 +96,14 @@ RUN tar -xvzf azure-cli_bundle.tar.gz
 RUN azure-cli_bundle_*/installer
 
 RUN git clone https://github.com/Azure/sonic-mgmt
+
+# Forward all proxy settings from 'docker run' command line to container scope startup script.
+# So even ssh client has them. All env variables are optional
+# Sample command:
+#   docker run -e "http_proxy=ip1" -e "ftp_proxy=ip2" -it <image>
+#
+ENTRYPOINT bash -c "touch /etc/profile.d/proxy.sh \
+    && echo 'export http_proxy=${http_proxy}' >> /etc/profile.d/proxy.sh \
+    && echo 'export https_proxy=${http_proxy}' >> /etc/profile.d/proxy.sh \
+    && echo 'export ftp_proxy=${http_proxy}' >> /etc/profile.d/proxy.sh \
+    && bash"


### PR DESCRIPTION
Signed-off-by: Qi Luo <qiluo-msft@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
1. docker build
2. docker run -e "http_proxy=ip1" -e "ftp_proxy=ip2" -it <image>
3. start sshd inside container
4. ssh to localhost
5. verify 'env' has these proxy env vars

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
