### PR TITLE
Set hostname in all default minigraphs to 'sonic'

### DIFF
--- a/device/accton/x86_64-accton_as5712_54x-r0/minigraph.xml
+++ b/device/accton/x86_64-accton_as5712_54x-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -1014,224 +1014,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE2</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE3</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE4</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE5</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE6</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE7</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE8</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE9</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE10</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE11</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE12</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE13</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE14</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE15</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE16</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE17</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE18</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE19</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE20</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE21</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE22</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE23</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE24</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE25</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE26</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE27</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE28</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE29</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE30</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE31</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>tenGigE1</StartPort>
@@ -1239,7 +1239,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Accton-AS5712-54X</HwSku>
       </Device>
     </Devices>
@@ -1247,7 +1247,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1269,6 +1269,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Accton-AS5712-54X</HwSku>
 </DeviceMiniGraph>

--- a/device/accton/x86_64-accton_as7312_54x-r0/minigraph.xml
+++ b/device/accton/x86_64-accton_as7312_54x-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -924,224 +924,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet1</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet2</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet3</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet5</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet6</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet7</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet9</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet10</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet11</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet13</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet14</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet15</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet17</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet18</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet19</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet21</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet22</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet23</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet25</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet26</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet27</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet29</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet30</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet31</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1149,7 +1149,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Accton-AS7312-54X</HwSku>
       </Device>
     </Devices>
@@ -1157,7 +1157,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1179,6 +1179,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Accton-AS7312-54X</HwSku>
 </DeviceMiniGraph>

--- a/device/accton/x86_64-accton_as7512_32x-r0/minigraph.xml
+++ b/device/accton/x86_64-accton_as7512_32x-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet64</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet68</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet72</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet76</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet80</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet84</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet88</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet92</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet96</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet100</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet104</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet108</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet112</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet116</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet120</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet124</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>AS7512</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>AS7512</HwSku>
 </DeviceMiniGraph>

--- a/device/accton/x86_64-accton_as7712_32x-r0/minigraph.xml
+++ b/device/accton/x86_64-accton_as7712_32x-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet64</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet68</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet72</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet76</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet80</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet84</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet88</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet92</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet96</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet100</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet104</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet108</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet112</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet116</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet120</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet124</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Accton-AS7712-32X</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1069,6 +1069,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Accton-AS7712-32X</HwSku>
 </DeviceMiniGraph>

--- a/device/accton/x86_64-accton_as7716_32x-r0/minigraph.xml
+++ b/device/accton/x86_64-accton_as7716_32x-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet64</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet68</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet72</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet76</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet80</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet84</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet88</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet92</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet96</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet100</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet104</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet108</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet112</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet116</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet120</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet124</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Accton-AS7716-32X</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1069,6 +1069,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Accton-AS7716-32X</HwSku>
 </DeviceMiniGraph>

--- a/device/accton/x86_64-accton_as7816_64x-r0/minigraph.xml
+++ b/device/accton/x86_64-accton_as7816_64x-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet64</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet68</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet72</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet76</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet80</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet84</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet88</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet92</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet96</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet100</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet104</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet108</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet112</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet116</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet120</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet124</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Accton-AS7712-32X</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1069,6 +1069,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Accton-AS7712-32X</HwSku>
 </DeviceMiniGraph>

--- a/device/arista/x86_64-arista_7050_qx32/minigraph.xml
+++ b/device/arista/x86_64-arista_7050_qx32/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet1/1</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet2/1</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet3/1</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4/1</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet5/1</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet6/1</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet7/1</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8/1</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet9/1</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet10/1</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet11/1</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12/1</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet13/1</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet14/1</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet15/1</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16/1</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet17/1</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet18/1</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet19/1</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20/1</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet21/1</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet22/1</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet23/1</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24/1</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet25</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet26</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet27</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet29</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet30</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet31</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Arista-7050-QX32</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Arista-7050-QX32</HwSku>
 </DeviceMiniGraph>

--- a/device/arista/x86_64-arista_7050_qx32s/minigraph.xml
+++ b/device/arista/x86_64-arista_7050_qx32s/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet1/1</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet2/1</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet3/1</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4/1</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet5/1</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet6/1</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet7/1</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8/1</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet9/1</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet10/1</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet11/1</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12/1</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet13/1</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet14/1</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet15/1</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16/1</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet17/1</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet18/1</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet19/1</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20/1</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet21/1</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet22/1</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet23/1</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24/1</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet25</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet26</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet27</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet29</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet30</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet31</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Arista-7050-QX-32S</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Arista-7050-QX-32S</HwSku>
 </DeviceMiniGraph>

--- a/device/arista/x86_64-arista_7060_cx32s/minigraph.xml
+++ b/device/arista/x86_64-arista_7060_cx32s/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet1/1</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet2/1</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet3/1</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4/1</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet5/1</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet6/1</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet7/1</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8/1</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet9/1</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet10/1</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet11/1</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12/1</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet13/1</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet14/1</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet15/1</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16/1</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet17/1</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet18/1</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet19/1</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20/1</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet21/1</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet22/1</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet23/1</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24/1</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet25/1</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet26/1</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet27/1</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28/1</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet29/1</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet30/1</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet31/1</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32/1</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Arista-7060CX-32S-C32</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Arista-7060CX-32S-C32</HwSku>
 </DeviceMiniGraph>

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/minigraph.xml
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -1214,224 +1214,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/1</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/2</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/3</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/4</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/5</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/6</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/7</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/8</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/9</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/10</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/11</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/12</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/13</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/14</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/15</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/16</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/17</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/18</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/19</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/20</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/21</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/22</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/23</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/24</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/25</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/26</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/27</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/28</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/29</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/30</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/31</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>tenGigE1/32</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1439,7 +1439,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Seastone-DX010-10-50</HwSku>
       </Device>
     </Devices>
@@ -1447,7 +1447,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1474,6 +1474,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Seastone-DX010-10-50</HwSku>
 </DeviceMiniGraph>

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50/minigraph.xml
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -974,224 +974,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/1</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/2</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/3</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/4</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/5</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/6</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/7</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/8</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/9</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/10</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/11</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/12</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/13</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/14</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/15</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/16</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/17</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/18</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/19</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/20</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/21</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/22</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/23</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/24</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/25</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/26</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/27</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/28</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/29</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/30</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/31</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fiftyGigE1/32</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1199,7 +1199,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Seastone-DX010-50</HwSku>
       </Device>
     </Devices>
@@ -1207,7 +1207,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1234,6 +1234,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Seastone-DX010-50</HwSku>
 </DeviceMiniGraph>

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/minigraph.xml
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/1</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/2</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/3</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/4</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/5</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/6</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/7</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/8</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/9</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/10</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/11</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/12</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/13</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/14</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/15</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/16</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/17</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/18</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/19</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/20</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/21</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/22</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/23</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/24</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/25</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/26</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/27</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/28</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/29</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/30</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/31</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/32</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Seastone-DX010</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Seastone-DX010</HwSku>
 </DeviceMiniGraph>

--- a/device/celestica/x86_64-cel_seastone-r0/minigraph.xml
+++ b/device/celestica/x86_64-cel_seastone-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/1</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/2</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/3</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/4</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/5</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/6</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/7</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/8</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/9</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/10</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/11</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/12</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/13</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/14</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/15</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/16</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/17</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/18</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/19</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/20</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/21</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/22</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/23</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/24</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/25</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/26</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/27</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/28</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/29</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/30</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/31</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/32</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Seastone-DX010</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Seastone-DX010</HwSku>
 </DeviceMiniGraph>

--- a/device/centec/x86_64-centec_e582_48x6q-r0/minigraph.xml
+++ b/device/centec/x86_64-centec_e582_48x6q-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet64</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet68</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet72</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet76</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet80</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet84</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet88</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet92</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet96</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet100</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet104</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet108</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet112</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet116</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet120</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet124</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,11 +1039,11 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>E582-48x6q</HwSku>
       </Device>
     </Devices>
   </PngDec>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>E582-48x6q</HwSku>
 </DeviceMiniGraph>

--- a/device/centec/x86_64-ew_es6220_x48q2h4-r0/minigraph.xml
+++ b/device/centec/x86_64-ew_es6220_x48q2h4-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet64</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet68</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet72</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet76</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet80</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet84</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet88</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet92</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet96</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet100</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet104</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet108</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet112</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet116</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet120</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet124</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,11 +1039,11 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>ES6428A-X48Q2H4</HwSku>
       </Device>
     </Devices>
   </PngDec>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>ES6428A-X48Q2H4</HwSku>
 </DeviceMiniGraph>

--- a/device/dell/x86_64-dell_s6000_s1220-r0/minigraph.xml
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/64</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/68</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/72</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/76</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/80</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/84</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/88</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/92</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/96</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/100</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/104</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/108</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/112</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/116</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/120</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>fortyGigE0/124</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Force10-S6000</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Force10-S6000</HwSku>
 </DeviceMiniGraph>

--- a/device/dell/x86_64-dell_s6100_c2538-r0/minigraph.xml
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/minigraph.xml
@@ -5,7 +5,7 @@
       <BGPSession>
         <StartRouter>ARISTA01T1</StartRouter>
         <StartPeer>10.0.0.1</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.0</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
@@ -14,7 +14,7 @@
       <BGPSession>
         <StartRouter>ARISTA02T1</StartRouter>
         <StartPeer>10.0.0.5</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.4</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
@@ -23,7 +23,7 @@
       <BGPSession>
         <StartRouter>ARISTA03T1</StartRouter>
         <StartPeer>10.0.0.9</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.8</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
@@ -32,7 +32,7 @@
       <BGPSession>
         <StartRouter>ARISTA04T1</StartRouter>
         <StartPeer>10.0.0.13</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.12</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
@@ -41,7 +41,7 @@
       <BGPSession>
         <StartRouter>ARISTA01T1</StartRouter>
         <StartPeer>FC00::2</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>FC00::1</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
@@ -50,7 +50,7 @@
       <BGPSession>
         <StartRouter>ARISTA02T1</StartRouter>
         <StartPeer>FC00::A</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>FC00::9</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
@@ -59,7 +59,7 @@
       <BGPSession>
         <StartRouter>ARISTA03T1</StartRouter>
         <StartPeer>FC00::12</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>FC00::11</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
@@ -68,7 +68,7 @@
       <BGPSession>
         <StartRouter>ARISTA04T1</StartRouter>
         <StartPeer>FC00::1A</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>FC00::19</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
@@ -78,7 +78,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>64601</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <ElementType>BGPPeer</ElementType>
@@ -187,7 +187,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces>
         <PortChannel>
           <ElementType>PortChannelInterface</ElementType>
@@ -298,7 +298,7 @@
                 <EndDevice>ARISTA01T1</EndDevice>
                 <EndPort>Ethernet1</EndPort>
                 <FlowControl>true</FlowControl>
-                <StartDevice>switch1</StartDevice>
+                <StartDevice>sonic</StartDevice>
                 <StartPort>fortyGigE1/1/1</StartPort>
             </DeviceLinkBase>
             <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -308,7 +308,7 @@
                 <EndDevice>ARISTA01T1</EndDevice>
                 <EndPort>Ethernet2</EndPort>
                 <FlowControl>true</FlowControl>
-                <StartDevice>switch1</StartDevice>
+                <StartDevice>sonic</StartDevice>
                 <StartPort>fortyGigE1/1/2</StartPort>
             </DeviceLinkBase>
             <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -318,7 +318,7 @@
                 <EndDevice>ARISTA02T1</EndDevice>
                 <EndPort>Ethernet1</EndPort>
                 <FlowControl>true</FlowControl>
-                <StartDevice>switch1</StartDevice>
+                <StartDevice>sonic</StartDevice>
                 <StartPort>fortyGigE1/1/5</StartPort>
             </DeviceLinkBase>
             <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -328,7 +328,7 @@
                 <EndDevice>ARISTA02T1</EndDevice>
                 <EndPort>Ethernet2</EndPort>
                 <FlowControl>true</FlowControl>
-                <StartDevice>switch1</StartDevice>
+                <StartDevice>sonic</StartDevice>
                 <StartPort>fortyGigE1/1/6</StartPort>
             </DeviceLinkBase>
             <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -338,7 +338,7 @@
                 <EndDevice>ARISTA03T1</EndDevice>
                 <EndPort>Ethernet1</EndPort>
                 <FlowControl>true</FlowControl>
-                <StartDevice>switch1</StartDevice>
+                <StartDevice>sonic</StartDevice>
                 <StartPort>fortyGigE1/2/1</StartPort>
             </DeviceLinkBase>
             <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -348,7 +348,7 @@
                 <EndDevice>ARISTA03T1</EndDevice>
                 <EndPort>Ethernet2</EndPort>
                 <FlowControl>true</FlowControl>
-                <StartDevice>switch1</StartDevice>
+                <StartDevice>sonic</StartDevice>
                 <StartPort>fortyGigE1/2/2</StartPort>
             </DeviceLinkBase>
             <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -358,7 +358,7 @@
                 <EndDevice>ARISTA04T1</EndDevice>
                 <EndPort>Ethernet1</EndPort>
                 <FlowControl>true</FlowControl>
-                <StartDevice>switch1</StartDevice>
+                <StartDevice>sonic</StartDevice>
                 <StartPort>fortyGigE1/2/5</StartPort>
             </DeviceLinkBase>
             <DeviceLinkBase i:type="DeviceInterfaceLink">
@@ -368,14 +368,14 @@
                 <EndDevice>ARISTA04T1</EndDevice>
                 <EndPort>Ethernet2</EndPort>
                 <FlowControl>true</FlowControl>
-                <StartDevice>switch1</StartDevice>
+                <StartDevice>sonic</StartDevice>
                 <StartPort>fortyGigE1/2/6</StartPort>
             </DeviceLinkBase>
             <DeviceLinkBase i:type="DeviceInterfaceLink">
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/1/7</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-01</StartDevice>
@@ -385,7 +385,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/1/8</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-02</StartDevice>
@@ -395,7 +395,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/1/9</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-03</StartDevice>
@@ -405,7 +405,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/1/10</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-04</StartDevice>
@@ -415,7 +415,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/1/11</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-05</StartDevice>
@@ -425,7 +425,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/1/12</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-06</StartDevice>
@@ -435,7 +435,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/1/13</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-07</StartDevice>
@@ -445,7 +445,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/1/14</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-08</StartDevice>
@@ -455,7 +455,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/1/15</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-09</StartDevice>
@@ -465,7 +465,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/1/16</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-10</StartDevice>
@@ -475,7 +475,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/3/1</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-11</StartDevice>
@@ -485,7 +485,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/3/5</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-12</StartDevice>
@@ -495,7 +495,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/3/6</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-13</StartDevice>
@@ -505,7 +505,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/3/7</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-14</StartDevice>
@@ -515,7 +515,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/3/8</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-15</StartDevice>
@@ -525,7 +525,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/3/9</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-16</StartDevice>
@@ -535,7 +535,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/3/10</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-17</StartDevice>
@@ -545,7 +545,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/3/11</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-18</StartDevice>
@@ -555,7 +555,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/2/7</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-19</StartDevice>
@@ -565,7 +565,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/2/8</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-20</StartDevice>
@@ -575,7 +575,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/2/9</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-21</StartDevice>
@@ -585,7 +585,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/2/10</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-22</StartDevice>
@@ -595,7 +595,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/2/11</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-23</StartDevice>
@@ -605,7 +605,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/2/12</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-24</StartDevice>
@@ -615,7 +615,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/2/13</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-25</StartDevice>
@@ -625,7 +625,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/2/14</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-26</StartDevice>
@@ -635,7 +635,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/2/15</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-27</StartDevice>
@@ -645,7 +645,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/2/16</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-28</StartDevice>
@@ -655,7 +655,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/4/1</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-29</StartDevice>
@@ -665,7 +665,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/4/5</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-30</StartDevice>
@@ -675,7 +675,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/4/6</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-31</StartDevice>
@@ -685,7 +685,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/4/7</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-32</StartDevice>
@@ -695,7 +695,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/4/8</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-33</StartDevice>
@@ -705,7 +705,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/4/9</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-34</StartDevice>
@@ -715,7 +715,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/4/10</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-35</StartDevice>
@@ -725,7 +725,7 @@
                 <ElementType>DeviceInterfaceLink</ElementType>
                 <AutoNegotiation>true</AutoNegotiation>
                 <Bandwidth>40000</Bandwidth>
-                <EndDevice>switch1</EndDevice>
+                <EndDevice>sonic</EndDevice>
                 <EndPort>fortyGigE1/4/11</EndPort>
                 <FlowControl>true</FlowControl>
                 <StartDevice>server-36</StartDevice>
@@ -734,7 +734,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="ToRRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Force10-S6100</HwSku>
       </Device>
     </Devices>
@@ -742,7 +742,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -769,6 +769,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Force10-S6100</HwSku>
 </DeviceMiniGraph>

--- a/device/dell/x86_64-dell_z9100_c2538-r0/minigraph.xml
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/1</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/2</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/3</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/4</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/5</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/6</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/7</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/8</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/9</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/10</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/11</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/12</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/13</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/14</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/15</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/16</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/17</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/18</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/19</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/20</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/21</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/22</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/23</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/24</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/25</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/26</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/27</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/28</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/29</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/30</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/31</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/32</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Force10-Z9100</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Force10-Z9100</HwSku>
 </DeviceMiniGraph>

--- a/device/delta/x86_64-delta_ag9032v1-r0/minigraph.xml
+++ b/device/delta/x86_64-delta_ag9032v1-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch1</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch1</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch1</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch1</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/1</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/2</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/3</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/4</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/5</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/6</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/7</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/8</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/9</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/10</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/11</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/12</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/13</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/14</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/15</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/16</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/17</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/18</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/19</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/20</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/21</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/22</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/23</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/24</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/25</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/26</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/27</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/28</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/29</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/30</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/31</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch1</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>hundredGigE1/32</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch1</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>Delta-ag9032v1</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch1</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch1</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>Delta-ag9032v1</HwSku>
 </DeviceMiniGraph>

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/minigraph.xml
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/minigraph.xml
@@ -3,7 +3,7 @@
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -12,7 +12,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -21,7 +21,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -30,7 +30,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -39,7 +39,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -48,7 +48,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -57,7 +57,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -66,7 +66,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -75,7 +75,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -84,7 +84,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -93,7 +93,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -102,7 +102,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -111,7 +111,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -120,7 +120,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -129,7 +129,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -138,7 +138,7 @@
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -150,7 +150,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch2</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.1</Address>
@@ -335,7 +335,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch2</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -430,112 +430,112 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -543,7 +543,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch2</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>ACS-MSN2700</HwSku>
       </Device>
     </Devices>`
@@ -551,7 +551,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch2</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -573,6 +573,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch2</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>ACS-MSN2100</HwSku>
 </DeviceMiniGraph>

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/minigraph.xml
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch2</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch2</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -934,224 +934,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet64</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet68</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet72</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet76</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet80</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet84</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet88</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet92</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet96</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet100</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet104</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet108</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet112</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet116</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet120</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet124</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1159,7 +1159,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch2</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>ACS-MSN2410</HwSku>
       </Device>
     </Devices>
@@ -1167,7 +1167,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch2</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1194,6 +1194,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch2</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>ACS-MSN2410</HwSku>
 </DeviceMiniGraph>

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/minigraph.xml
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch2</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch2</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet64</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet68</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet72</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet76</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet80</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet84</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet88</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet92</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet96</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet100</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet104</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet108</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet112</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet116</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet120</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet124</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch2</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>ACS-MSN2700</HwSku>
       </Device>
     </Devices>
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch2</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch2</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>ACS-MSN2700</HwSku>
 </DeviceMiniGraph>

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/minigraph.xml
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/minigraph.xml
@@ -5,14 +5,14 @@
       <BGPSession>
         <StartRouter>ARISTA01T0</StartRouter>
         <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.32</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.0</StartPeer>
         <EndRouter>ARISTA01T2</EndRouter>
         <EndPeer>10.0.0.1</EndPeer>
@@ -23,14 +23,14 @@
       <BGPSession>
         <StartRouter>ARISTA02T0</StartRouter>
         <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.34</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.2</StartPeer>
         <EndRouter>ARISTA02T2</EndRouter>
         <EndPeer>10.0.0.3</EndPeer>
@@ -41,14 +41,14 @@
       <BGPSession>
         <StartRouter>ARISTA03T0</StartRouter>
         <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.36</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.4</StartPeer>
         <EndRouter>ARISTA03T2</EndRouter>
         <EndPeer>10.0.0.5</EndPeer>
@@ -59,14 +59,14 @@
       <BGPSession>
         <StartRouter>ARISTA04T0</StartRouter>
         <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.38</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.6</StartPeer>
         <EndRouter>ARISTA04T2</EndRouter>
         <EndPeer>10.0.0.7</EndPeer>
@@ -77,14 +77,14 @@
       <BGPSession>
         <StartRouter>ARISTA05T0</StartRouter>
         <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.40</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.8</StartPeer>
         <EndRouter>ARISTA05T2</EndRouter>
         <EndPeer>10.0.0.9</EndPeer>
@@ -95,14 +95,14 @@
       <BGPSession>
         <StartRouter>ARISTA06T0</StartRouter>
         <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.42</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.10</StartPeer>
         <EndRouter>ARISTA06T2</EndRouter>
         <EndPeer>10.0.0.11</EndPeer>
@@ -113,14 +113,14 @@
       <BGPSession>
         <StartRouter>ARISTA07T0</StartRouter>
         <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.44</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.12</StartPeer>
         <EndRouter>ARISTA07T2</EndRouter>
         <EndPeer>10.0.0.13</EndPeer>
@@ -131,14 +131,14 @@
       <BGPSession>
         <StartRouter>ARISTA08T0</StartRouter>
         <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.46</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.14</StartPeer>
         <EndRouter>ARISTA08T2</EndRouter>
         <EndPeer>10.0.0.15</EndPeer>
@@ -149,14 +149,14 @@
       <BGPSession>
         <StartRouter>ARISTA09T0</StartRouter>
         <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.48</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.16</StartPeer>
         <EndRouter>ARISTA09T2</EndRouter>
         <EndPeer>10.0.0.17</EndPeer>
@@ -167,14 +167,14 @@
       <BGPSession>
         <StartRouter>ARISTA10T0</StartRouter>
         <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.50</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.18</StartPeer>
         <EndRouter>ARISTA10T2</EndRouter>
         <EndPeer>10.0.0.19</EndPeer>
@@ -185,14 +185,14 @@
       <BGPSession>
         <StartRouter>ARISTA11T0</StartRouter>
         <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.52</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.20</StartPeer>
         <EndRouter>ARISTA11T2</EndRouter>
         <EndPeer>10.0.0.21</EndPeer>
@@ -203,14 +203,14 @@
       <BGPSession>
         <StartRouter>ARISTA12T0</StartRouter>
         <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.54</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.22</StartPeer>
         <EndRouter>ARISTA12T2</EndRouter>
         <EndPeer>10.0.0.23</EndPeer>
@@ -221,14 +221,14 @@
       <BGPSession>
         <StartRouter>ARISTA13T0</StartRouter>
         <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.56</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.24</StartPeer>
         <EndRouter>ARISTA13T2</EndRouter>
         <EndPeer>10.0.0.25</EndPeer>
@@ -239,14 +239,14 @@
       <BGPSession>
         <StartRouter>ARISTA14T0</StartRouter>
         <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.58</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.26</StartPeer>
         <EndRouter>ARISTA14T2</EndRouter>
         <EndPeer>10.0.0.27</EndPeer>
@@ -257,14 +257,14 @@
       <BGPSession>
         <StartRouter>ARISTA15T0</StartRouter>
         <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.60</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.28</StartPeer>
         <EndRouter>ARISTA15T2</EndRouter>
         <EndPeer>10.0.0.29</EndPeer>
@@ -275,14 +275,14 @@
       <BGPSession>
         <StartRouter>ARISTA16T0</StartRouter>
         <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>switch2</EndRouter>
+        <EndRouter>sonic</EndRouter>
         <EndPeer>10.0.0.62</EndPeer>
         <Multihop>1</Multihop>
         <HoldTime>180</HoldTime>
         <KeepAliveTime>60</KeepAliveTime>
       </BGPSession>
       <BGPSession>
-        <StartRouter>switch2</StartRouter>
+        <StartRouter>sonic</StartRouter>
         <StartPeer>10.0.0.30</StartPeer>
         <EndRouter>ARISTA16T2</EndRouter>
         <EndPeer>10.0.0.31</EndPeer>
@@ -294,7 +294,7 @@
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
-        <a:Hostname>switch2</a:Hostname>
+        <a:Hostname>sonic</a:Hostname>
         <a:Peers>
           <BGPPeer>
             <Address>10.0.0.33</Address>
@@ -639,7 +639,7 @@
       <MplsInterfaces/>
       <MplsTeInterfaces/>
       <RsvpInterfaces/>
-      <Hostname>switch2</Hostname>
+      <Hostname>sonic</Hostname>
       <PortChannelInterfaces/>
       <VlanInterfaces/>
       <IPInterfaces>
@@ -814,224 +814,224 @@
     <DeviceInterfaceLinks>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet0</EndPort>
         <StartDevice>ARISTA01T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet4</EndPort>
         <StartDevice>ARISTA02T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet8</EndPort>
         <StartDevice>ARISTA03T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet12</EndPort>
         <StartDevice>ARISTA04T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet16</EndPort>
         <StartDevice>ARISTA05T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet20</EndPort>
         <StartDevice>ARISTA06T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet24</EndPort>
         <StartDevice>ARISTA07T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet28</EndPort>
         <StartDevice>ARISTA08T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet32</EndPort>
         <StartDevice>ARISTA09T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet36</EndPort>
         <StartDevice>ARISTA10T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet40</EndPort>
         <StartDevice>ARISTA11T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet44</EndPort>
         <StartDevice>ARISTA12T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet48</EndPort>
         <StartDevice>ARISTA13T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet52</EndPort>
         <StartDevice>ARISTA14T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet56</EndPort>
         <StartDevice>ARISTA15T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet60</EndPort>
         <StartDevice>ARISTA16T2</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet64</EndPort>
         <StartDevice>ARISTA01T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet68</EndPort>
         <StartDevice>ARISTA02T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet72</EndPort>
         <StartDevice>ARISTA03T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet76</EndPort>
         <StartDevice>ARISTA04T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet80</EndPort>
         <StartDevice>ARISTA05T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet84</EndPort>
         <StartDevice>ARISTA06T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet88</EndPort>
         <StartDevice>ARISTA07T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet92</EndPort>
         <StartDevice>ARISTA08T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet96</EndPort>
         <StartDevice>ARISTA09T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet100</EndPort>
         <StartDevice>ARISTA10T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet104</EndPort>
         <StartDevice>ARISTA11T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet108</EndPort>
         <StartDevice>ARISTA12T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet112</EndPort>
         <StartDevice>ARISTA13T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet116</EndPort>
         <StartDevice>ARISTA14T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet120</EndPort>
         <StartDevice>ARISTA15T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>switch2</EndDevice>
+        <EndDevice>sonic</EndDevice>
         <EndPort>Ethernet124</EndPort>
         <StartDevice>ARISTA16T0</StartDevice>
         <StartPort>Ethernet1</StartPort>
@@ -1039,7 +1039,7 @@
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">
-        <Hostname>switch2</Hostname>
+        <Hostname>sonic</Hostname>
         <HwSku>ACS-MSN2740</HwSku>
       </Device>
     </Devices>`
@@ -1047,7 +1047,7 @@
   <MetadataDeclaration>
     <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:DeviceMetadata>
-        <a:Name>switch2</a:Name>
+        <a:Name>sonic</a:Name>
         <a:Properties>
           <a:DeviceProperty>
             <a:Name>DhcpResources</a:Name>
@@ -1074,6 +1074,6 @@
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <Hostname>switch2</Hostname>
+  <Hostname>sonic</Hostname>
   <HwSku>ACS-MSN2740</HwSku>
 </DeviceMiniGraph>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Default minigraphs for different platforms set SONiC hostname as either 'switch1' or 'switch2'. This PR unify them to be 'sonic'.

**- How I did it**
```
find . -name "*.xml" -exec sed -i 's/switch1/sonic/g' {} \;
find . -name "*.xml" -exec sed -i 's/switch2/sonic/g' {} \;
```

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
