### PR TITLE
[minigraph.py] Only add 'service' field to control plane ACLs, not dataplane ACLs

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -202,15 +202,14 @@ def parse_dpg(dpg, hname):
             if acl_intfs:
                 acls[aclname] = {'policy_desc': aclname,
                                  'ports': acl_intfs,
-                                 'type': 'MIRROR' if is_mirror else 'L3',
-                                 'service': 'N/A'}
+                                 'type': 'MIRROR' if is_mirror else 'L3'}
             else:
                 # This ACL has no interfaces to attach to -- consider this a control plane ACL
                 aclservice = aclintf.find(str(QName(ns, "Type"))).text
                 acls[aclname] = {'policy_desc': aclname,
                                  'ports': acl_intfs,
                                  'type': 'CTRLPLANE',
-                                 'service': aclservice if aclservice is not None else ''}
+                                 'service': aclservice if aclservice is not None else 'UNKNOWN'}
         return intfs, lo_intfs, mgmt_intf, vlans, vlan_members, pcs, acls
     return None, None, None, None, None, None, None
 

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -73,7 +73,7 @@ class TestCfgGen(TestCase):
     def test_minigraph_acl(self):
         argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v ACL_TABLE'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'DATAACL': {'type': 'L3', 'policy_desc': 'DATAACL', 'service': 'N/A', 'ports': ['Ethernet112', 'Ethernet116', 'Ethernet120', 'Ethernet124']}}")
+        self.assertEqual(output.strip(), "{'DATAACL': {'type': 'L3', 'policy_desc': 'DATAACL', 'ports': ['Ethernet112', 'Ethernet116', 'Ethernet120', 'Ethernet124']}}")
 
     def test_minigraph_everflow(self):
         argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v MIRROR_SESSION'


### PR DESCRIPTION
**DO NOT MERGE YET - REQUIRES FURTHER TESTING**

- Only add "service" field to control plane ACLs. Adding the field to dataplane ACLs caused orchagent to fail upon creating the table due to considering the "service" field an unknown attribute.

- Resolves https://github.com/Azure/sonic-mgmt/issues/437
