### PR TITLE
Reduce SONiC migration partition from 8G to 1G.

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -217,7 +217,9 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     unzip                   \
     gdisk                   \
     sysfsutils              \
-    grub2-common
+    grub2-common            \
+    dosfstools              \
+    parted
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
     grub-pc-bin

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -133,6 +133,10 @@ sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/setfacl
 sudo cp files/initramfs-tools/arista-net $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-net
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-net
 
+# Hook into initramfs: resize root partition after migration from another NOS to SONiC on Dell switches
+sudo cp files/initramfs-tools/resize-rootfs $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/resize-rootfs
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/resize-rootfs
+
 ## Hook into initramfs: after partition mount and loop file mount
 ## 1. Prepare layered file system
 ## 2. Bind-mount docker working directory (docker aufs cannot work over aufs rootfs)
@@ -217,9 +221,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     unzip                   \
     gdisk                   \
     sysfsutils              \
-    grub2-common            \
-    dosfstools              \
-    parted
+    grub2-common
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
     grub-pc-bin

--- a/build_image.sh
+++ b/build_image.sh
@@ -56,7 +56,7 @@ elif [ "$IMAGE_TYPE" = "raw" ]; then
     echo "Creating SONiC raw partition : $OUTPUT_RAW_IMAGE of size $RAW_IMAGE_DISK_SIZE MB"
     fallocate -l "$RAW_IMAGE_DISK_SIZE"M $OUTPUT_RAW_IMAGE
 
-    ## Generate a compressed 8GB partition dump that can be used to 'dd' in-lieu of using the onie-nos-installer
+    ## Generate a partition dump that can be used to 'dd' in-lieu of using the onie-nos-installer
     ## Run the installer 
     ## The 'build' install mode of the installer is used to generate this dump.
     sudo chmod a+x $OUTPUT_ONIE_IMAGE
@@ -67,14 +67,32 @@ elif [ "$IMAGE_TYPE" = "raw" ]; then
         exit 1
     }
 
-    gzip $OUTPUT_RAW_IMAGE
+    if [ $CHUNK_SIZE = "0" ]; then
+        # Create a single compressed partition dump
+        gzip $OUTPUT_RAW_IMAGE
 
-    [ -r $OUTPUT_RAW_IMAGE.gz ] || {
-        echo "Error : gzip $OUTPUT_RAW_IMAGE failed!"
-        exit 1
-    }
+        [ -r $OUTPUT_RAW_IMAGE.gz ] || {
+            echo "Error : gzip $OUTPUT_RAW_IMAGE failed!"
+            exit 1
+        }
 
-    mv $OUTPUT_RAW_IMAGE.gz $OUTPUT_RAW_IMAGE
+        mv $OUTPUT_RAW_IMAGE.gz $OUTPUT_RAW_IMAGE
+    else
+        # Split the partition dump into chunks, compress each chunk
+        # and tar the chunks to be used as the raw image
+        split -a 4 -b "$CHUNK_SIZE"M -d $OUTPUT_RAW_IMAGE sonic-$TARGET_MACHINE-chunk
+        rm $OUTPUT_RAW_IMAGE
+        gzip sonic-$TARGET_MACHINE-chunk*
+        tar -cf sonic-$TARGET_MACHINE.tar --remove-files sonic-$TARGET_MACHINE-chunk*
+
+        [ -r sonic-$TARGET_MACHINE.tar ] || {
+            echo "Error : tar sonic-$TARGET_MACHINE.tar failed!"
+            exit 1
+        }
+
+        mv sonic-$TARGET_MACHINE.tar $OUTPUT_RAW_IMAGE
+    fi
+
     echo "The compressed raw image is in $OUTPUT_RAW_IMAGE"
 
 ## Use 'aboot' as target machine category which includes Aboot as bootloader

--- a/build_image.sh
+++ b/build_image.sh
@@ -67,32 +67,14 @@ elif [ "$IMAGE_TYPE" = "raw" ]; then
         exit 1
     }
 
-    if [ $CHUNK_SIZE = "0" ]; then
-        # Create a single compressed partition dump
-        gzip $OUTPUT_RAW_IMAGE
+    gzip $OUTPUT_RAW_IMAGE
 
-        [ -r $OUTPUT_RAW_IMAGE.gz ] || {
-            echo "Error : gzip $OUTPUT_RAW_IMAGE failed!"
-            exit 1
-        }
+    [ -r $OUTPUT_RAW_IMAGE.gz ] || {
+        echo "Error : gzip $OUTPUT_RAW_IMAGE failed!"
+        exit 1
+    }
 
-        mv $OUTPUT_RAW_IMAGE.gz $OUTPUT_RAW_IMAGE
-    else
-        # Split the partition dump into chunks, compress each chunk
-        # and tar the chunks to be used as the raw image
-        split -a 4 -b "$CHUNK_SIZE"M -d $OUTPUT_RAW_IMAGE sonic-$TARGET_MACHINE-chunk
-        rm $OUTPUT_RAW_IMAGE
-        gzip sonic-$TARGET_MACHINE-chunk*
-        tar -cf sonic-$TARGET_MACHINE.tar --remove-files sonic-$TARGET_MACHINE-chunk*
-
-        [ -r sonic-$TARGET_MACHINE.tar ] || {
-            echo "Error : tar sonic-$TARGET_MACHINE.tar failed!"
-            exit 1
-        }
-
-        mv sonic-$TARGET_MACHINE.tar $OUTPUT_RAW_IMAGE
-    fi
-
+    mv $OUTPUT_RAW_IMAGE.gz $OUTPUT_RAW_IMAGE
     echo "The compressed raw image is in $OUTPUT_RAW_IMAGE"
 
 ## Use 'aboot' as target machine category which includes Aboot as bootloader

--- a/files/initramfs-tools/mke2fs
+++ b/files/initramfs-tools/mke2fs
@@ -20,6 +20,7 @@ esac
 copy_exec /sbin/mke2fs
 copy_exec /sbin/sfdisk
 copy_exec /sbin/fdisk
+copy_exec /sbin/resize2fs
 
 fstypes="ext4 ext3"
 

--- a/files/initramfs-tools/mke2fs
+++ b/files/initramfs-tools/mke2fs
@@ -21,6 +21,7 @@ copy_exec /sbin/mke2fs
 copy_exec /sbin/sfdisk
 copy_exec /sbin/fdisk
 copy_exec /sbin/resize2fs
+copy_exec /sbin/findfs
 
 fstypes="ext4 ext3"
 

--- a/files/initramfs-tools/resize-rootfs
+++ b/files/initramfs-tools/resize-rootfs
@@ -11,14 +11,29 @@ set -- $(cat /proc/cmdline)
 for x in "$@"; do
     case "$x" in
         root=*)
-            root_dev="${x#root=}"
+            root_val="${x#root=}"
             ;;
         resize-rootfs)
-            [ -z "$root_dev" ] && exit 0
-            resize2fs -f $root_dev
-            if [ $? != 0 ]; then
-                echo "ERROR: Unable to resize the root file system. Manual intervention needed to fix the issue."
-            fi
+            need_resize=1
             ;;
     esac
 done
+
+if [ -n "$need_resize" ]; then
+    if [ -z "$root_val" ]; then
+        echo "ERROR: resize required but unable to get root location from command line"
+        exit 1
+    fi
+
+    root_dev=$(findfs $root_val)
+    if [ $? != 0 ]; then
+        echo "ERROR: resize required but findfs failed"
+        exit 1
+    fi
+
+    resize2fs -f $root_dev
+    if [ $? != 0 ]; then
+        echo "ERROR: Unable to resize the root file system. Manual intervention needed to fix the issue."
+        exit 1
+    fi
+fi

--- a/files/initramfs-tools/resize-rootfs
+++ b/files/initramfs-tools/resize-rootfs
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+case $1 in
+    prereqs)
+        exit 0
+        ;;
+esac
+
+# Extract kernel parameters
+set -- $(cat /proc/cmdline)
+for x in "$@"; do
+    case "$x" in
+        root=*)
+            root_dev="${x#root=}"
+            ;;
+        resize-rootfs)
+            [ -z "$root_dev" ] && exit 0
+            resize2fs -f $root_dev
+            if [ $? != 0 ]; then
+                echo "ERROR: Unable to resize the root file system. Manual intervention needed to fix the issue."
+            fi
+            ;;
+    esac
+done

--- a/files/initramfs-tools/varlog
+++ b/files/initramfs-tools/varlog
@@ -17,12 +17,6 @@ for x in "$@"; do
     case "$x" in
         varlog_size=*)
             varlog_size="${x#varlog_size=}"
-            ;;
-        resize2fs-host)
-            resize_dev=`cat /proc/mounts | ${rootmnt}/bin/grep "/root/host" | ${rootmnt}/usr/bin/cut -d' ' -f1`
-            [ -z "$resize_dev" ] && exit 0
-            ${rootmnt}/sbin/resize2fs $resize_dev
-            ;;
     esac
 done
 

--- a/files/initramfs-tools/varlog
+++ b/files/initramfs-tools/varlog
@@ -17,6 +17,12 @@ for x in "$@"; do
     case "$x" in
         varlog_size=*)
             varlog_size="${x#varlog_size=}"
+            ;;
+        resize2fs-host)
+            resize_dev=`cat /proc/mounts | ${rootmnt}/bin/grep "/root/host" | ${rootmnt}/usr/bin/cut -d' ' -f1`
+            [ -z "$resize_dev" ] && exit 0
+            ${rootmnt}/sbin/resize2fs $resize_dev
+            ;;
     esac
 done
 

--- a/onie-image.conf
+++ b/onie-image.conf
@@ -33,9 +33,6 @@ OUTPUT_RAW_IMAGE=target/sonic-$TARGET_MACHINE.raw
 ### Raw image size in MB
 RAW_IMAGE_DISK_SIZE=1024
 
-### Chunk size in MB (0 => single chunk)
-CHUNK_SIZE=8
-
 ## Output file name for aboot installer
 OUTPUT_ABOOT_IMAGE=target/sonic-aboot-$TARGET_MACHINE.swi
 

--- a/onie-image.conf
+++ b/onie-image.conf
@@ -31,7 +31,10 @@ OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin
 OUTPUT_RAW_IMAGE=target/sonic-$TARGET_MACHINE.raw
 
 ### Raw image size in MB
-RAW_IMAGE_DISK_SIZE=8192
+RAW_IMAGE_DISK_SIZE=1024
+
+### Chunk size in MB (0 => single chunk)
+CHUNK_SIZE=8
 
 ## Output file name for aboot installer
 OUTPUT_ABOOT_IMAGE=target/sonic-aboot-$TARGET_MACHINE.swi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Currently, the sonic-broadcom.raw image is a gzip of the 8GB ext4 partition (created in the build environment). In order to facilitate faster migration time and to handle SSDs that cannot handle dd of such sizes, reduce the raw ext4 partition to 1G and resize the partition upon migration prior to varlog creation.

**- How I did it**

1.	Change the partition size from 8G to 1G
2.	Create a chunk size to split the RAW file into : default is 8M
3.	In build_image, based on chunk setting, either create the default 1-shot blob or split the partition into chunks and gzip and create tarball.
Note. The default implementation, sonic-broadcom.raw will be a single gz blob of 8G. With the current setting, the sonic-broadcom.raw will be a tar which will contain 128 gzipped chunks each of 8M. 
4.	Add a resize2fs-host boot parameter for (for migration) that will help in expanding the /host from 1G to 8G during initrd.
5.	Add dosfstools (to create vfat) and parted (to do partprobe) : these are needed if the script used to expand free blocks is to be used post migration.

**- How to verify it**

1.	Run script based on the sonic-broadcom.raw generated from these changes.
2.	Reboot the unit after migration and check SONiC comes up
3.	Onie install the sonic-broadcom.bin with these changes to verify regression.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Reduce raw image partition size and facilitate resize post migration.

**- A picture of a cute animal (not mandatory but encouraged)**
