### PR TITLE
[slave.mk]: Clear deb_dist directory

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -235,6 +235,7 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_PYTHON_STDEB_DEBS)) : $(DEBS_PATH)/% : .platf
 	if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; popd; fi
 	# Build project
 	pushd $($*_SRC_PATH) $(LOG)
+	rm -rf deb_dist/* $(LOG)
 	python setup.py --command-packages=stdeb.command bdist_deb $(LOG)
 	popd $(LOG)
 	# Clean up


### PR DESCRIPTION
Python packages, having their version changed, will fail to build
because deb_dist directory contains both build directories for old and
new version, and (for some uncleaer reason) debian utilities don't know
which one to choose.

Signed-off-by: marian-pritsak <marianp@mellanox.com>
