### PR TITLE
[dhcp_relay] make dhcp_relay service depends on teamd as well

### DIFF
--- a/files/build_templates/dhcp_relay.service.j2
+++ b/files/build_templates/dhcp_relay.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=DHCP relay container
-Requires=docker.service
+Requires=docker.service teamd.service
 After=swss.service
 
 [Service]


### PR DESCRIPTION
**- What I did**

When teamd service restarted, the port channels will be recreated.

Dhcp relay service needs to be restarted after that to listen on the
right port channels.

**- How to verify it**

Repeat the problem:
1. execute dhcp_relay test, the result should be pass.
2. on the dut, restart teamd service
3. wait until (a). all lags are up; (b) all bgp sessions are up.
4. execute dhcp_relay test again, it should fail.
5. restart dhcp_relay service
6. execute dhcp_relay test again, it should now pass.

After the fix:
1. execute dhcp_relay test, the result should be pass.
2. on the dut, restart teamd service
3. wait until (a). all lags are up; (b) all bgp sessions are up.
4. execute dhcp_relay test again, it should now pass.
