### PR TITLE
Store ConfigDB init indicator boolean value as 1/0 in Redis to be language-agnostic

### DIFF
--- a/files/scripts/configdb-load.sh
+++ b/files/scripts/configdb-load.sh
@@ -10,5 +10,4 @@ if [ -r /etc/sonic/config_db.json ]; then
     sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
 fi
 
-echo -en "SELECT 4\nSET CONFIG_DB_INITIALIZED true" | redis-cli
-
+redis-cli -n 4 SET "CONFIG_DB_INITIALIZED" "1"


### PR DESCRIPTION
- Also simplify bash `redis-cli` command