### PR TITLE
[database]: Remove /var/run/rsyslogd.pid, otherwise rsyslogd will not start

### DIFF
--- a/dockers/docker-database/supervisord.conf
+++ b/dockers/docker-database/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [program:rsyslogd]
-command=/usr/sbin/rsyslogd -n
+command=/bin/bash -c "rm -f /var/run/rsyslogd.pid && /usr/sbin/rsyslogd -n"
 priority=1
 autostart=true
 autorestart=false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I updated supervisor.conf to remove /var/run/rsyslogd.pid before starting rsyslogd. If the file is present before the start, rsyslogd will restarted several times, but every time rsyslogd will just quit with exit code 1. The pid file is preserved each fast-reboot.

**- How I did it**
Edited the supervisor.conf file

**- How to verify it**
cat /etc/supervisor/conf.d/supervisord.conf. 
or
ps ax in the container
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
