### PR TITLE
[dhcp_relay] complete the dhcp_relay service dependency towards teamd

### DIFF
--- a/files/build_templates/dhcp_relay.service.j2
+++ b/files/build_templates/dhcp_relay.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=DHCP relay container
 Requires=docker.service teamd.service
-After=swss.service
+After=swss.service teamd.service
 
 [Service]
 User={{ sonicadmin_user }}
@@ -10,4 +10,4 @@ ExecStart=/usr/bin/{{ docker_container_name }}.sh attach
 ExecStop=/usr/bin/{{ docker_container_name }}.sh stop
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target teamd.service


### PR DESCRIPTION
**- What I did**
This change makes sure that the dhcp_relay service will be started
after teamd service is started from a stopped state.

This change completes the fix started by commit #1348.

**- How to verify it**
I now have a test (will create PR later), it test following scenario:

1. Test dhcp_relay, makes sure it passes.
2. Restart teamd service. Wait until system recovers.
3. Retest dhcp_relay, makes sure it passes.
4. Stop teamd service, start teamd service. Wait until system recovers.
5. Retest dhcp_relay, makes sure it passes.

https://github.com/Azure/sonic-mgmt/pull/440 is the test for this fix.