### PR TITLE
[caclmgrd] Prevent service from blocking system boot indefinitely

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd.service
+++ b/files/image_config/caclmgrd/caclmgrd.service
@@ -4,7 +4,7 @@ Requires=database.service
 After=database.service
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/bin/caclmgrd-start.sh
 
 [Install]


### PR DESCRIPTION
- caclmgrd is not a "one-shot" service, as on non-Arista platforms it should never exit. Incorrect configuration in unit file was causing systemctl to hang and never finish start-up sequence.