### PR TITLE
Fix VLAN_INTERFACE attach issue upon vlan id-name mismatch

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -400,7 +400,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
     phyport_intfs = {}
     vlan_intfs = {}
     pc_intfs = {}
-    vlan_invert_mapping = dict([[v['alias'],k] for k,v in vlans.items() if v.has_key('alias')])
+    vlan_invert_mapping = { v['alias']:k for k,v in vlans.items() if v.has_key('alias') }
 
     for intf in intfs:
         if intf[0][0:4] == 'Vlan':

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -177,6 +177,8 @@ def parse_dpg(dpg, hname):
                 vlan_attributes['dhcp_servers'] = vdhcpserver_list
 
             sonic_vlan_name = "Vlan%s" % vlanid
+            if sonic_vlan_name != vintfname:
+                vlan_attributes['alias'] = vintfname
             vlans[sonic_vlan_name] = vlan_attributes
 
         aclintfs = child.find(str(QName(ns, "AclInterfaces")))
@@ -398,9 +400,13 @@ def parse_xml(filename, platform=None, port_config_file=None):
     phyport_intfs = {}
     vlan_intfs = {}
     pc_intfs = {}
+    vlan_invert_mapping = dict([[v['alias'],k] for k,v in vlans.items() if v.has_key('alias')])
+
     for intf in intfs:
         if intf[0][0:4] == 'Vlan':
             vlan_intfs[intf] = {}
+        elif vlan_invert_mapping.has_key(intf[0]):
+            vlan_intfs[(vlan_invert_mapping[intf[0]], intf[1])] = {}
         elif intf[0][0:11] == 'PortChannel':
             pc_intfs[intf] = {}
         else:

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -128,7 +128,7 @@
       </PortChannelInterfaces>
       <VlanInterfaces>
         <VlanInterface>
-          <Name>Vlan1000</Name>
+          <Name>ab1</Name>
           <AttachTo>fortyGigE0/8</AttachTo>
           <DhcpRelays>192.0.0.1;192.0.0.2</DhcpRelays>
           <VlanID>1000</VlanID>
@@ -159,7 +159,7 @@
         </IPInterface>
         <IPInterface>
           <Name i:nil="true"/>
-          <AttachTo>Vlan1000</AttachTo>
+          <AttachTo>ab1</AttachTo>
           <Prefix>192.168.0.1/27</Prefix>
         </IPInterface>
       </IPInterfaces>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -89,7 +89,7 @@ class TestCfgGen(TestCase):
     def test_minigraph_vlans(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v VLAN'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'Vlan1000': {'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1000'}}")
+        self.assertEqual(output.strip(), "{'Vlan1000': {'alias': 'ab1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1000'}}")
 
     def test_minigraph_vlan_members(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v VLAN_MEMBER'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Together with #695, this will fix #1003.

**- How I did it**
When a Vlan has vlan name different with "Vlan"+id, it will be recorded as an alias. And when DPG is parsing, both "Vlan"+id and alias will be checked for "AttachTo" field.
