### PR TITLE
[Nephos] Update SDK version to 3.16.0-5 in swss.service.j2

### DIFF
--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -4,14 +4,14 @@ Requires=database.service
 {% if sonic_asic_platform == 'broadcom' %}
 Requires=opennsl-modules-3.16.0-5-amd64.service
 {% elif sonic_asic_platform == 'nephos' %}
-Requires=nps-modules-3.16.0-4-amd64.service
+Requires=nps-modules-3.16.0-5-amd64.service
 {% endif %}
 After=database.service
 After=interfaces-config.service
 {% if sonic_asic_platform == 'broadcom' %}
 After=opennsl-modules-3.16.0-5-amd64.service
 {% elif sonic_asic_platform == 'nephos' %}
-After=nps-modules-3.16.0-4-amd64.service
+After=nps-modules-3.16.0-5-amd64.service
 {% endif %}
 
 [Service]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updating SDK version from 3.16.0-4 to 3.16.0-5

**- How I did it**
Updating SDK version in files/build_templates/swss.service.j2

**- How to verify it**
Checking command "config load_minigraph" without errors

**- Description for the changelog**
Updating SDK version from 3.16.0-4 to 3.16.0-5 in swss.service.j2
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
