### PR TITLE
Set FEC to reed-solomon if the port speed is 100G

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -418,6 +418,8 @@ def parse_xml(filename, platform=None, port_config_file=None):
 
     for port_name in port_speeds:
         ports.setdefault(port_name, {})['speed'] = port_speeds[port_name]
+        if port_speeds[port_name] == '100000':
+            ports.setdefault(port_name, {})['fec'] = 'rs'
     for port_name in port_descriptions:
         ports.setdefault(port_name, {})['description'] = port_descriptions[port_name]
 

--- a/src/sonic-config-engine/tests/sample_output/ports.json
+++ b/src/sonic-config-engine/tests/sample_output/ports.json
@@ -22,7 +22,7 @@
     },
     {
         "PORT_TABLE:Ethernet12": {
-            "speed": "1000000",
+            "speed": "100000",
             "description": "Interface description"
         },
         "OP": "SET"

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -260,7 +260,7 @@
           <MultiPortsInterface>false</MultiPortsInterface>
           <PortName>0</PortName>
           <Priority>0</Priority>
-          <Speed>1000000</Speed>
+          <Speed>100000</Speed>
           <Description>Interface description</Description>
         </a:EthernetInterface>
       </EthernetInterfaces>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -140,3 +140,6 @@ class TestCfgGen(TestCase):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet8\']"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'alias': 'fortyGigE0/8', 'lanes': '37,38,39,40', 'description': 'Interface description', 'speed': '40000'}")
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet12\']"'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), "{'alias': 'fortyGigE0/12', 'lanes': '33,34,35,36', 'fec': 'rs', 'speed': '100000', 'description': 'Interface description'}")


### PR DESCRIPTION
**- What I did**
Set FEC to reed-solomon if the port speed is 100G

**- How I did it**
Modified minigraph parser to check port-speed and set fec mode

**- How to verify it**
Execute `sonic-cfggen -m`
```
'Ethernet8': {'alias': 'Ethernet3/1', 'lanes': '41,42,43,44', 'fec': 'rs', 'speed': '100000', 'index': '3'}
127.0.0.1:6379[4]> HGETALL "PORT|Ethernet8"
 1) "alias"
 2) "Ethernet3/1"
 3) "lanes"
 4) "41,42,43,44"
 5) "fec"
 6) "rs"
 7) "speed"
 8) "100000"
 9) "index"
10) "3"

orchagent: :- doPortTask: Set port Ethernet8 fec to rs
```
Ran Unit-Test:
```
sonic-config-engine$ python setup.py test
----------------------------------------------------------------------
Ran 31 tests in 7.113s

OK
```


**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
