### PR TITLE
[device/dell] Get Server ports from vlan config

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/buffers.json.j2
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/buffers.json.j2
@@ -35,7 +35,25 @@
     {%- if cable_len -%}
         {{ cable_len.0 }}
     {%- else -%}
-        {{ default_cable }}
+        {%- if switch_role == 'ToRRouter' -%}
+            {%- for local_port in VLAN_MEMBER -%}
+                {%- set vlan_port = local_port.split("|") -%}
+                {%- if vlan_port[1] == port_name -%}
+                    {%- set roles3 = switch_role + '_' + 'server' -%}
+                    {%- set roles3 = roles3 | lower -%}
+                    {%- if roles3 in ports2cable -%}
+                        {%- if cable_len.append(ports2cable[roles3]) -%}{%- endif -%}
+                    {%- endif -%}
+                {%- endif -%}
+            {%- endfor -%}
+            {%- if cable_len -%}
+                {{cable_len.0}}
+            {%- else -%}
+                {{ default_cable }}
+            {%- endif -%}
+        {%- else -%}
+            {{ default_cable }}
+        {%- endif -%}
     {%- endif -%}
 {% endmacro %}
 


### PR DESCRIPTION
This commit adds new support for dynamic buffer configuration. The cable_length macro is
updated to return the cable length for server ports. Since the server ports are part of
VLAN MEMBERS, the macro loops through the VLAN MEMBER ports and returns the cable length
accordingly. If the port is not part of the SERVER port then it defaults to default cable
length. The new code in the macro will be executed only if the switch is ToRRouter
which is connected to the server on one side.

Tested the code by loading minigraph configuration on the switch which had configuration
for leaf-router as DEVICE NEIGHHOR and server ports in VLAN and ports which are not part of
 either server or leaf router. The dynamically generated buffer.json and config_db.json file
had the cable_legnth updated accordingly for server ports with "5m" and leafrouter with "40m"
and unconnected port to default "300m". The redis database also reflects the buffer profile's
 for 5m, 40m and 300m.

Signed-off-by: Harish Venkatraman <Harish_Venkatraman@dell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
