### PR TITLE
[fast-reboot]: Dump default routes before fast-reboot procedure

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -16,6 +16,13 @@ function fast_reboot {
         swssconfig /arp.json
         rm -f /arp.json
       fi
+
+      if [[ -f /default_routes.json ]];
+      then
+        swssconfig /default_routes.json
+        rm -f /default_routes.json
+      fi
+
       ;;
     *)
       ;;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add a logic to dump and restore default routes in fast-reboot procedure

**- How I did it**
Update sonic-utilities submodule and add logic into swssconfig.sh

**- How to verify it**
cat /var/log/syslog | grep 'swssconfig' | grep default_routes.json

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Used saved default routes before the fast-reboot to make the procedure faster.


**- A picture of a cute animal (not mandatory but encouraged)**
