### PR TITLE
[sonic-cfggen] Remove machine.conf info and add get_system_mac support

### DIFF
--- a/dockers/docker-orchagent/start.sh
+++ b/dockers/docker-orchagent/start.sh
@@ -6,7 +6,7 @@ sonic-cfggen -d -t /usr/share/sonic/templates/switch.json.j2 > /etc/swss/config.
 sonic-cfggen -d -t /usr/share/sonic/templates/ipinip.json.j2 > /etc/swss/config.d/ipinip.json
 sonic-cfggen -d -t /usr/share/sonic/templates/ports.json.j2 > /etc/swss/config.d/ports.json
 
-export platform=`sonic-cfggen -v platform`
+export platform=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
 
 rm -f /var/run/rsyslogd.pid
 

--- a/dockers/docker-snmp-sv2/snmpd-config-updater
+++ b/dockers/docker-snmp-sv2/snmpd-config-updater
@@ -172,7 +172,7 @@ def log_error(msg):
 
 # Determine whether we are running on an Arista platform
 def is_platform_arista():
-    proc = subprocess.Popen(["sonic-cfggen", "-v", "platform"],
+    proc = subprocess.Popen(["sonic-cfggen", "-H", "-v", "DEVICE_METADATA.localhost.platform"],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     (stdout, stderr) = proc.communicate()

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -20,7 +20,7 @@ function postStartAction()
 }
 
 # Obtain our platform as we will mount directories with these names in each docker
-PLATFORM=`sonic-cfggen -v platform`
+PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
 
 {%- if docker_container_name == "database" %}
 # Don't mount HWSKU in {{docker_container_name}} container.

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -30,7 +30,7 @@ ExecStartPre=/usr/bin/mst start
 ExecStartPre=/usr/bin/mlnx-fw-upgrade.sh
 ExecStartPre=/etc/init.d/sxdkernel start
 ExecStartPre=/sbin/modprobe i2c-dev
-ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -v platform)/hw-management start"
+ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)/hw-management start"
 {% elif sonic_asic_platform == 'cavium' %}
 ExecStartPre=/etc/init.d/xpnet.sh start
 {% endif %}
@@ -43,7 +43,7 @@ ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 ExecStopPost=/usr/bin/syncd.sh stop
 
 {% if sonic_asic_platform == 'mellanox' %}
-ExecStopPost=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -v platform)/hw-management stop"
+ExecStopPost=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)/hw-management stop"
 ExecStopPost=/etc/init.d/sxdkernel stop
 ExecStopPost=/usr/bin/mst stop
 {% elif sonic_asic_platform == 'cavium' %}

--- a/files/image_config/caclmgrd/caclmgrd-start.sh
+++ b/files/image_config/caclmgrd/caclmgrd-start.sh
@@ -2,7 +2,7 @@
 
 # Only start control plance ACL manager daemon if not an Arista platform.
 # Arista devices will use their own service ACL manager daemon(s) instead.
-if [ "$(sonic-cfggen -v "platform" | grep -c "arista")" -gt 0 ]; then
+if [ "$(sonic-cfggen -H -v "DEVICE_METADATA.localhost.platform" | grep -c "arista")" -gt 0 ]; then
     echo "Not starting caclmgrd - unsupported platform"
     exit 0
 fi

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -79,6 +79,11 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         firsttime_exit
     fi
 
+    if [ ! -f /etc/sonic/init_cfg.json ]; then
+        # Generate an empty init_cfg.json
+        echo '{}' > /etc/sonic/init_cfg.json
+    fi
+
     # Try to take old configuration saved during installation
     if test_config; then
         rm -f /host/old_config/sonic_version.yml

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -79,43 +79,25 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         firsttime_exit
     fi
 
-    # setup initial switch mac
-    SONIC_ASIC_TYPE=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
-    SYSTEM_MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
-
-    # Align last byte of MAC if necessary
-    if [ "$SONIC_ASIC_TYPE" = "mellanox" ] || [ "$SONIC_ASIC_TYPE" = "centec" ]; then
-        last_byte=$(python -c "print '$SYSTEM_MAC_ADDRESS'[-2:]")
-        aligned_last_byte=$(python -c "print format(int(int('$last_byte', 16) & 0b11000000), '02x')")  # put mask and take away the 0x prefix
-        SYSTEM_MAC_ADDRESS=$(python -c "print '$SYSTEM_MAC_ADDRESS'[:-2] + '$aligned_last_byte'")      # put aligned byte into the end of MAC
-    fi
-
-    if [ -f /etc/sonic/init_cfg.json ]; then
-        sonic-cfggen -j /etc/sonic/init_cfg.json -a '{"DEVICE_METADATA":{"localhost": {"mac": "'$SYSTEM_MAC_ADDRESS'"}}}' --print-data > /tmp/init_cfg.json
-        mv /tmp/init_cfg.json /etc/sonic/init_cfg.json
-    else
-        sonic-cfggen -a '{"DEVICE_METADATA":{"localhost": {"mac": "'$SYSTEM_MAC_ADDRESS'"}}}' --print-data > /etc/sonic/init_cfg.json
-    fi
-
     # Try to take old configuration saved during installation
     if test_config; then
         rm -f /host/old_config/sonic_version.yml
         mv -f /host/old_config/* /etc/sonic/
         if [ ! -f /etc/sonic/config_db.json ]; then
-            sonic-cfggen -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
+            sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
         fi
     elif [ -f /host/minigraph.xml ]; then
         mv /host/minigraph.xml /etc/sonic/
         # Combine information in minigraph and init_cfg.json to form initiate config DB dump file.
         # TODO: After moving all information from minigraph to DB, sample config DB dump should be provide
-        sonic-cfggen -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
+        sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
     else
         # Use default minigraph.xml
         cp /usr/share/sonic/device/$platform/minigraph.xml /etc/sonic/
-        sonic-cfggen -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
+        sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
     fi
 
-    HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']"`
+    HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v DEVICE_METADATA.localhost.hwsku`
     if [ -f /usr/share/sonic/device/$platform/$HWSKU/buffers.json.j2 ]; then
         # generate and merge buffers configuration into config file
         sonic-cfggen -m -t /usr/share/sonic/device/$platform/$HWSKU/buffers.json.j2 > /tmp/buffers.json

--- a/files/image_config/ssh/sshd-config-updater
+++ b/files/image_config/ssh/sshd-config-updater
@@ -153,7 +153,7 @@ def log_error(msg):
 
 # Determine whether we are running on an Arista platform
 def is_platform_arista():
-    proc = subprocess.Popen(["sonic-cfggen", "-v", "platform"],
+    proc = subprocess.Popen(["sonic-cfggen", "-H", "-v", "DEVICE_METADATA.localhost.platform"],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     (stdout, stderr) = proc.communicate()

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -31,7 +31,7 @@ if [ "$src" = "dhcp" ]; then
     if [ "`cat /tmp/dhcp_graph_url`" = "N/A" ]; then
         echo "'N/A' found in DHCP response. Skipping graph update and generating an empty configuration."
         echo '{"DEVICE_METADATA":' > /tmp/device_meta.json
-        sonic-cfggen -m /etc/sonic/minigraph.xml --var-json DEVICE_METADATA >> /tmp/device_meta.json
+        sonic-cfggen -H -m /etc/sonic/minigraph.xml --var-json DEVICE_METADATA >> /tmp/device_meta.json
         echo '}' >> /tmp/device_meta.json
         if [ -f /etc/sonic/init_cfg.json ]; then
             sonic-cfggen -j /tmp/device_meta.json -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
@@ -88,9 +88,9 @@ done
 
 echo "Regenerating config DB from minigraph..."
 if [ -f /etc/sonic/init_cfg.json ]; then
-    sonic-cfggen -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
+    sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
 else
-    sonic-cfggen -m --print-data > /etc/sonic/config_db.json
+    sonic-cfggen -H -m --print-data > /etc/sonic/config_db.json
 fi
 
 # Mark as disabled after graph is successfully downloaded

--- a/platform/p4/docker-sonic-p4/start.sh
+++ b/platform/p4/docker-sonic-p4/start.sh
@@ -19,12 +19,6 @@ fi
 
 mkdir -p /etc/swss/config.d/
 
-# sonic-cfggen -m /etc/sonic/minigraph.xml -d -t /usr/share/sonic/templates/ipinip.json.j2 > /etc/swss/config.d/ipinip.json
-# sonic-cfggen -m /etc/sonic/minigraph.xml -d -t /usr/share/sonic/templates/mirror.json.j2 > /etc/swss/config.d/mirror.json
-# sonic-cfggen -m /etc/sonic/minigraph.xml -d -t /usr/share/sonic/templates/ports.json.j2 > /etc/swss/config.d/ports.json
-
-# export platform=`sonic-cfggen -v platform`
-
 rm -f /var/run/rsyslogd.pid
 
 echo "Start rsyslogd"

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -18,12 +18,6 @@ fi
 
 mkdir -p /etc/swss/config.d/
 
-# sonic-cfggen -m /etc/sonic/minigraph.xml -d -t /usr/share/sonic/templates/ipinip.json.j2 > /etc/swss/config.d/ipinip.json
-# sonic-cfggen -m /etc/sonic/minigraph.xml -d -t /usr/share/sonic/templates/mirror.json.j2 > /etc/swss/config.d/mirror.json
-# sonic-cfggen -m /etc/sonic/minigraph.xml -d -t /usr/share/sonic/templates/ports.json.j2 > /etc/swss/config.d/ports.json
-
-# export platform=`sonic-cfggen -v platform`
-
 rm -f /var/run/rsyslogd.pid
 
 supervisorctl start rsyslogd

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -188,7 +188,7 @@ def main():
         configdb.connect()
         deep_update(data, FormatConverter.db_to_output(configdb.get_config()))
 
-    if args.platform_info != None:
+    if args.platform_info:
         hardware_data = {'DEVICE_METADATA': {'localhost': {
             'platform': platform,
             'mac': get_system_mac()

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -28,6 +28,7 @@ from minigraph import parse_xml
 from minigraph import parse_device_desc_xml
 from sonic_platform import get_machine_info
 from sonic_platform import get_platform_info
+from sonic_platform import get_system_mac
 from swsssdk import ConfigDBConnector
 
 def is_ipv4(value):
@@ -135,6 +136,7 @@ def main():
     parser.add_argument("-j", "--json", help="json file that contains additional variables", action='append', default=[])
     parser.add_argument("-a", "--additional-data", help="addition data, in json string")
     parser.add_argument("-d", "--from-db", help="read config from configdb", action='store_true')
+    parser.add_argument("-H", "--platform-info", help="read platform and hardware info", action='store_true')
     parser.add_argument("-s", "--redis-unix-sock-file", help="unix sock file for redis connection")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-t", "--template", help="render the data with the template file")
@@ -144,25 +146,22 @@ def main():
     group.add_argument("--print-data", help="print all data", action='store_true')
     args = parser.parse_args()
 
-    data = {}
-    machine_info = get_machine_info()
-    if machine_info != None:
-        deep_update(data, machine_info)
-        platform_info = get_platform_info(machine_info)
-        if platform_info != None:
-            data['platform'] = platform_info
+    platform = get_platform_info(get_machine_info())
 
     db_kwargs = {}
     if args.redis_unix_sock_file != None:
         db_kwargs['unix_socket_path'] = args.redis_unix_sock_file
 
+    data = {}
+
+
     if args.minigraph != None:
         minigraph = args.minigraph
-        if data.has_key('platform'):
+        if platform:
             if args.port_config != None:
-                deep_update(data, parse_xml(minigraph, data['platform'], args.port_config))
+                deep_update(data, parse_xml(minigraph, platform, args.port_config))
             else:
-                deep_update(data, parse_xml(minigraph, data['platform']))
+                deep_update(data, parse_xml(minigraph, platform))
         else:
             if args.port_config != None:
                 deep_update(data, parse_xml(minigraph, port_config_file=args.port_config))
@@ -188,6 +187,13 @@ def main():
         configdb = ConfigDBConnector(**db_kwargs)
         configdb.connect()
         deep_update(data, FormatConverter.db_to_output(configdb.get_config()))
+
+    if args.platform_info != None:
+        hardware_data = {'DEVICE_METADATA': {'localhost': {
+            'platform': platform,
+            'mac': get_system_mac()
+            }}}
+        deep_update(data, hardware_data)
 
     if args.template != None:
         template_file = os.path.abspath(args.template)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Add `-H` option in `sonic-cfggen` to read platform info and system mac address into `DEVICE_METADATA`.
1. Corresponding logic is removed from `rc.local`.
1. Information in `machine.conf` is no longer included in `sonic-cfggen` output.
1. Modify callers to adapt to this change. (This include https://github.com/Azure/sonic-utilities/pull/205.)
