### PR TITLE
[baseimage]: enable auto logout for console (ttyS*) sessions

### DIFF
--- a/files/image_config/bash/bash.bashrc
+++ b/files/image_config/bash/bash.bashrc
@@ -53,3 +53,6 @@ if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-no
         fi
     }
 fi
+
+# enable auto-logout for console ttyS* sessions
+tty | grep ttyS >/dev/null && TMOUT=300


### PR DESCRIPTION
**- What I did**
enable auto logout for console (ttyS*) sessions (5 minutes)

**- How I did it**
setup TMOUT=300 when tty matches ttyS*

**- How to verify it**
from console:
```
admin@str-s6000-acs-7:~$ set | grep TM
TMOUT=300
admin@str-s6000-acs-7:~$ sudo bash
root@str-s6000-acs-7:/home/admin# set | grep TM
TMOUT=300
```

from ssh session
```
admin@str-s6000-acs-7:/etc$ set | grep TM    
admin@str-s6000-acs-7:/etc$ 
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
