### PR TITLE
[QUANTA]: Add psuutil support for IX1B

### DIFF
--- a/device/quanta/x86_64-quanta_ix1b_32x-r0/plugins/psuutil.py
+++ b/device/quanta/x86_64-quanta_ix1b_32x-r0/plugins/psuutil.py
@@ -1,0 +1,171 @@
+#
+# psuutil.py
+# Platform-specific PSU status interface for SONiC
+#
+
+
+import os.path
+import commands
+import logging
+
+try:
+    from sonic_psu.psu_base import PsuBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+DEBUG = False
+
+def show_log(txt):
+    if DEBUG == True:
+        print "[IX1B]"+txt
+    return
+
+def exec_cmd(cmd, show):
+    logging.info('Run :'+cmd)
+    status, output = commands.getstatusoutput(cmd)
+    show_log (cmd +"with result:" + str(status))
+    show_log ("      output:"+output)
+    if status:
+        logging.info('Failed :'+cmd)
+        if show:
+            print('Failed :'+cmd)
+    return  status, output
+
+def my_log(txt):
+    if DEBUG == True:
+        print "[QUANTA DBG]: "+txt
+    return
+
+def log_os_system(cmd, show):
+    logging.info('Run :'+cmd)
+    status = 1
+    output = ""
+    status, output = commands.getstatusoutput(cmd)
+    my_log (cmd +"with result:" + str(status))
+    my_log ("cmd:" + cmd)
+    my_log ("      output:"+output)
+    if status:
+        logging.info('Failed :'+cmd)
+        if show:
+            print('Failed :'+cmd)
+    return  status, output
+
+def gpio16_exist():
+    ret, ls = log_os_system("ls /sys/class/gpio/ | grep gpio16", 0)
+    logging.info('mods:'+ls)
+    if len(ls) ==0:
+        return False
+
+def gpio17_exist():
+    ret, ls = log_os_system("ls /sys/class/gpio/ | grep gpio17", 0)
+    logging.info('mods:'+ls)
+    if len(ls) ==0:
+        return False
+
+def gpio19_exist():
+    ret, ls = log_os_system("ls /sys/class/gpio/ | grep gpio19", 0)
+    logging.info('mods:'+ls)
+    if len(ls) ==0:
+        return False
+
+def gpio20_exist():
+    ret, ls = log_os_system("ls /sys/class/gpio/ | grep gpio20", 0)
+    logging.info('mods:'+ls)
+    if len(ls) ==0:
+        return False
+
+class PsuUtil(PsuBase):
+    """Platform-specific PSUutil class"""
+
+    SYSFS_PSU_PRESENT_DIR = ["/sys/class/gpio/gpio16",
+                             "/sys/class/gpio/gpio19"]
+
+    SYSFS_PSU_POWERGOOD_DIR = ["/sys/class/gpio/gpio17",
+                               "/sys/class/gpio/gpio20"]
+    def __init__(self):
+        PsuBase.__init__(self)
+
+        if gpio16_exist() == False:
+            status, output = exec_cmd("echo 16 > /sys/class/gpio/export ", 1)
+            status, output = exec_cmd("echo in > /sys/class/gpio/gpio16/direction ", 1)
+
+        if gpio17_exist() == False:
+            status, output = exec_cmd("echo 17 > /sys/class/gpio/export ", 1)
+            status, output = exec_cmd("echo in > /sys/class/gpio/gpio17/direction ", 1)
+
+        if gpio19_exist() == False:
+            status, output = exec_cmd("echo 19 > /sys/class/gpio/export ", 1)
+            status, output = exec_cmd("echo in > /sys/class/gpio/gpio19/direction ", 1)
+
+        if gpio20_exist() == False:
+            status, output = exec_cmd("echo 20 > /sys/class/gpio/export ", 1)
+            status, output = exec_cmd("echo in > /sys/class/gpio/gpio20/direction ", 1)
+
+    # Get sysfs attribute
+    def get_attr_value(self, attr_path):
+
+        retval = 'ERR'
+        if (not os.path.isfile(attr_path)):
+            return retval
+
+        try:
+            with open(attr_path, 'r') as fd:
+                retval = fd.read()
+        except Exception as error:
+            logging.error("Unable to open ", attr_path, " file !")
+
+        retval = retval.rstrip('\r\n')
+        return retval
+
+    def get_num_psus(self):
+        """
+        Retrieves the number of PSUs available on the device
+        :return: An integer, the number of PSUs available on the device
+         """
+        MAX_PSUS = 2
+        return MAX_PSUS
+
+    def get_psu_status(self, index):
+        """
+        Retrieves the oprational status of power supply unit (PSU) defined
+                by index <index>
+        :param index: An integer, index of the PSU of which to query status
+        :return: Boolean, True if PSU is operating properly, False if PSU is\
+        faulty
+        """
+        status = 0
+        attr_file = 'value'
+        attr_path = self.SYSFS_PSU_POWERGOOD_DIR[index-1] +'/' + attr_file
+
+        attr_value = self.get_attr_value(attr_path)
+
+        if (attr_value != 'ERR'):
+            attr_value = int(attr_value, 16)
+            # Check for PSU status
+            if (attr_value == 1):
+                    status = 1
+
+        return status
+
+    def get_psu_presence(self, index):
+        """
+        Retrieves the presence status of power supply unit (PSU) defined
+                by index <index>
+        :param index: An integer, index of the PSU of which to query status
+        :return: Boolean, True if PSU is plugged, False if not
+        """
+        status = 0
+        psu_absent = 0
+        attr_file ='value'
+        attr_path = self.SYSFS_PSU_PRESENT_DIR[index-1] +'/' + attr_file
+
+        attr_value = self.get_attr_value(attr_path)
+
+        if (attr_value != 'ERR'):
+            attr_value = int(attr_value, 16)
+            # Check for PSU presence
+            if (attr_value == 0):
+                    status = 1
+
+        return status
+


### PR DESCRIPTION
- What I did
Add psuutil support for Quanta-IX1B-32X
Update Quanta submodule

- How I did it
Update Quanta-IX1B-32X platform module driver.

- How to verify it

admin@switch1:~$ sudo psuutil status
PSU    Status
-----  --------
PSU 1  OK
PSU 2  OK

- Description for the changelog
Add psuutil support for Quanta-IX1B-32X
Update Quanta submodule

- A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: Jonathan Tsai <jonathan.tsai@quantatw.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
