### PR TITLE
[Arista7260CX3] add port speed information to port_config.ini

### DIFF
--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/port_config.ini
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/port_config.ini
@@ -1,67 +1,67 @@
-# name          lanes             alias        index
-Ethernet0       77,78,79,80       Ethernet1/1  1
-Ethernet4       65,66,67,68       Ethernet2/1  2
-Ethernet8       85,86,87,88       Ethernet3/1  3
-Ethernet12      89,90,91,92       Ethernet4/1  4
-Ethernet16      109,110,111,112   Ethernet5/1  5
-Ethernet20      97,98,99,100      Ethernet6/1  6
-Ethernet24      5,6,7,8           Ethernet7/1  7
-Ethernet28      13,14,15,16       Ethernet8/1  8
-Ethernet32      25,26,27,28       Ethernet9/1  9
-Ethernet36      21,22,23,24       Ethernet10/1 10
-Ethernet40      37,38,39,40       Ethernet11/1 11
-Ethernet44      45,46,47,48       Ethernet12/1 12
-Ethernet48      57,58,59,60       Ethernet13/1 13
-Ethernet52      53,54,55,56       Ethernet14/1 14
-Ethernet56      117,118,119,120   Ethernet15/1 15
-Ethernet60      121,122,123,124   Ethernet16/1 16
-Ethernet64      141,142,143,144   Ethernet17/1 17
-Ethernet68      133,134,135,136   Ethernet18/1 18
-Ethernet72      197,198,199,200   Ethernet19/1 19
-Ethernet76      205,206,207,208   Ethernet20/1 20
-Ethernet80      217,218,219,220   Ethernet21/1 21
-Ethernet84      213,214,215,216   Ethernet22/1 22
-Ethernet88      229,230,231,232   Ethernet23/1 23
-Ethernet92      237,238,239,240   Ethernet24/1 24
-Ethernet96      249,250,251,252   Ethernet25/1 25
-Ethernet100     245,246,247,248   Ethernet26/1 26
-Ethernet104     149,150,151,152   Ethernet27/1 27
-Ethernet108     153,154,155,156   Ethernet28/1 28
-Ethernet112     173,174,175,176   Ethernet29/1 29
-Ethernet116     161,162,163,164   Ethernet30/1 30
-Ethernet120     181,182,183,184   Ethernet31/1 31
-Ethernet124     185,186,187,188   Ethernet32/1 32
-Ethernet128     69,70,71,72       Ethernet33/1 33
-Ethernet132     73,74,75,76       Ethernet34/1 34
-Ethernet136     93,94,95,96       Ethernet35/1 35
-Ethernet140     81,82,83,84       Ethernet36/1 36
-Ethernet144     101,102,103,104   Ethernet37/1 37
-Ethernet148     105,106,107,108   Ethernet38/1 38
-Ethernet152     9,10,11,12        Ethernet39/1 39
-Ethernet156     1,2,3,4           Ethernet40/1 40
-Ethernet160     17,18,19,20       Ethernet41/1 41
-Ethernet164     29,30,31,32       Ethernet42/1 42
-Ethernet168     41,42,43,44       Ethernet43/1 43
-Ethernet172     33,34,35,36       Ethernet44/1 44
-Ethernet176     49,50,51,52       Ethernet45/1 45
-Ethernet180     61,62,63,64       Ethernet46/1 46
-Ethernet184     125,126,127,128   Ethernet47/1 47
-Ethernet188     113,114,115,116   Ethernet48/1 48
-Ethernet192     129,130,131,132   Ethernet49/1 49
-Ethernet196     137,138,139,140   Ethernet50/1 50
-Ethernet200     201,202,203,204   Ethernet51/1 51
-Ethernet204     193,194,195,196   Ethernet52/1 52
-Ethernet208     209,210,211,212   Ethernet53/1 53
-Ethernet212     221,222,223,224   Ethernet54/1 54
-Ethernet216     233,234,235,236   Ethernet55/1 55
-Ethernet220     225,226,227,228   Ethernet56/1 56
-Ethernet224     241,242,243,244   Ethernet57/1 57
-Ethernet228     253,254,255,256   Ethernet58/1 58
-Ethernet232     157,158,159,160   Ethernet59/1 59
-Ethernet236     145,146,147,148   Ethernet60/1 60
-Ethernet240     165,166,167,168   Ethernet61/1 61
-Ethernet244     169,170,171,172   Ethernet62/1 62
-Ethernet248     189,190,191,192   Ethernet63/1 63
-Ethernet252     177,178,179,180   Ethernet64/1 64
-Ethernet256     257               Ethernet65   65
-Ethernet260     259               Ethernet66   66
+# name          lanes             alias        index  speed
+Ethernet0       77,78,79,80       Ethernet1/1  1      100000
+Ethernet4       65,66,67,68       Ethernet2/1  2      100000
+Ethernet8       85,86,87,88       Ethernet3/1  3      100000
+Ethernet12      89,90,91,92       Ethernet4/1  4      100000
+Ethernet16      109,110,111,112   Ethernet5/1  5      100000
+Ethernet20      97,98,99,100      Ethernet6/1  6      100000
+Ethernet24      5,6,7,8           Ethernet7/1  7      100000
+Ethernet28      13,14,15,16       Ethernet8/1  8      100000
+Ethernet32      25,26,27,28       Ethernet9/1  9      100000
+Ethernet36      21,22,23,24       Ethernet10/1 10     100000
+Ethernet40      37,38,39,40       Ethernet11/1 11     100000
+Ethernet44      45,46,47,48       Ethernet12/1 12     100000
+Ethernet48      57,58,59,60       Ethernet13/1 13     100000
+Ethernet52      53,54,55,56       Ethernet14/1 14     100000
+Ethernet56      117,118,119,120   Ethernet15/1 15     100000
+Ethernet60      121,122,123,124   Ethernet16/1 16     100000
+Ethernet64      141,142,143,144   Ethernet17/1 17     100000
+Ethernet68      133,134,135,136   Ethernet18/1 18     100000
+Ethernet72      197,198,199,200   Ethernet19/1 19     100000
+Ethernet76      205,206,207,208   Ethernet20/1 20     100000
+Ethernet80      217,218,219,220   Ethernet21/1 21     100000
+Ethernet84      213,214,215,216   Ethernet22/1 22     100000
+Ethernet88      229,230,231,232   Ethernet23/1 23     100000
+Ethernet92      237,238,239,240   Ethernet24/1 24     100000
+Ethernet96      249,250,251,252   Ethernet25/1 25     100000
+Ethernet100     245,246,247,248   Ethernet26/1 26     100000
+Ethernet104     149,150,151,152   Ethernet27/1 27     100000
+Ethernet108     153,154,155,156   Ethernet28/1 28     100000
+Ethernet112     173,174,175,176   Ethernet29/1 29     100000
+Ethernet116     161,162,163,164   Ethernet30/1 30     100000
+Ethernet120     181,182,183,184   Ethernet31/1 31     100000
+Ethernet124     185,186,187,188   Ethernet32/1 32     100000
+Ethernet128     69,70,71,72       Ethernet33/1 33     100000
+Ethernet132     73,74,75,76       Ethernet34/1 34     100000
+Ethernet136     93,94,95,96       Ethernet35/1 35     100000
+Ethernet140     81,82,83,84       Ethernet36/1 36     100000
+Ethernet144     101,102,103,104   Ethernet37/1 37     100000
+Ethernet148     105,106,107,108   Ethernet38/1 38     100000
+Ethernet152     9,10,11,12        Ethernet39/1 39     100000
+Ethernet156     1,2,3,4           Ethernet40/1 40     100000
+Ethernet160     17,18,19,20       Ethernet41/1 41     100000
+Ethernet164     29,30,31,32       Ethernet42/1 42     100000
+Ethernet168     41,42,43,44       Ethernet43/1 43     100000
+Ethernet172     33,34,35,36       Ethernet44/1 44     100000
+Ethernet176     49,50,51,52       Ethernet45/1 45     100000
+Ethernet180     61,62,63,64       Ethernet46/1 46     100000
+Ethernet184     125,126,127,128   Ethernet47/1 47     100000
+Ethernet188     113,114,115,116   Ethernet48/1 48     100000
+Ethernet192     129,130,131,132   Ethernet49/1 49     100000
+Ethernet196     137,138,139,140   Ethernet50/1 50     100000
+Ethernet200     201,202,203,204   Ethernet51/1 51     100000
+Ethernet204     193,194,195,196   Ethernet52/1 52     100000
+Ethernet208     209,210,211,212   Ethernet53/1 53     100000
+Ethernet212     221,222,223,224   Ethernet54/1 54     100000
+Ethernet216     233,234,235,236   Ethernet55/1 55     100000
+Ethernet220     225,226,227,228   Ethernet56/1 56     100000
+Ethernet224     241,242,243,244   Ethernet57/1 57     100000
+Ethernet228     253,254,255,256   Ethernet58/1 58     100000
+Ethernet232     157,158,159,160   Ethernet59/1 59     100000
+Ethernet236     145,146,147,148   Ethernet60/1 60     100000
+Ethernet240     165,166,167,168   Ethernet61/1 61     100000
+Ethernet244     169,170,171,172   Ethernet62/1 62     100000
+Ethernet248     189,190,191,192   Ethernet63/1 63     100000
+Ethernet252     177,178,179,180   Ethernet64/1 64     100000
+Ethernet256     257               Ethernet65   65     10000
+Ethernet260     259               Ethernet66   66     10000

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/port_config.ini
@@ -1,123 +1,123 @@
-# name          lanes             alias        index
-Ethernet0       77,78             Ethernet1/1  1
-Ethernet2       79,80             Ethernet1/3  1
-Ethernet4       65,66             Ethernet2/1  2
-Ethernet6       67,68             Ethernet2/3  2
-Ethernet8       85,86             Ethernet3/1  3
-Ethernet10      87,88             Ethernet3/3  3
-Ethernet12      89,90             Ethernet4/1  4
-Ethernet14      91,92             Ethernet4/3  4
-Ethernet16      109,110           Ethernet5/1  5
-Ethernet18      111,112           Ethernet5/3  5
-Ethernet20      97,98             Ethernet6/1  6
-Ethernet22      99,100            Ethernet6/3  6
-Ethernet24      5,6               Ethernet7/1  7
-Ethernet26      7,8               Ethernet7/3  7
-Ethernet28      13,14             Ethernet8/1  8
-Ethernet30      15,16             Ethernet8/3  8
-Ethernet32      25,26             Ethernet9/1  9
-Ethernet34      27,28             Ethernet9/3  9
-Ethernet36      21,22             Ethernet10/1 10
-Ethernet38      23,24             Ethernet10/3 10
-Ethernet40      37,38             Ethernet11/1 11
-Ethernet42      39,40             Ethernet11/3 11
-Ethernet44      45,46             Ethernet12/1 12
-Ethernet46      47,48             Ethernet12/3 12
-Ethernet48      57,58,59,60       Ethernet13/1 13
-Ethernet52      53,54,55,56       Ethernet14/1 14
-Ethernet56      117,118,119,120   Ethernet15/1 15
-Ethernet60      121,122,123,124   Ethernet16/1 16
-Ethernet64      141,142,143,144   Ethernet17/1 17
-Ethernet68      133,134,135,136   Ethernet18/1 18
-Ethernet72      197,198,199,200   Ethernet19/1 19
-Ethernet76      205,206,207,208   Ethernet20/1 20
-Ethernet80      217,218           Ethernet21/1 21
-Ethernet82      219,220           Ethernet21/3 21
-Ethernet84      213,214           Ethernet22/1 22
-Ethernet86      215,216           Ethernet22/3 22
-Ethernet88      229,230           Ethernet23/1 23
-Ethernet90      231,232           Ethernet23/3 23
-Ethernet92      237,238           Ethernet24/1 24
-Ethernet94      239,240           Ethernet24/3 24
-Ethernet96      249,250           Ethernet25/1 25
-Ethernet98      251,252           Ethernet25/3 25
-Ethernet100     245,246           Ethernet26/1 26
-Ethernet102     247,248           Ethernet26/3 26
-Ethernet104     149,150           Ethernet27/1 27
-Ethernet106     151,152           Ethernet27/3 27
-Ethernet108     153,154           Ethernet28/1 28
-Ethernet110     155,156           Ethernet28/3 28
-Ethernet112     173,174           Ethernet29/1 29
-Ethernet114     175,176           Ethernet29/3 29
-Ethernet116     161,162           Ethernet30/1 30
-Ethernet118     163,164           Ethernet30/3 30
-Ethernet120     181,182           Ethernet31/1 31
-Ethernet122     183,184           Ethernet31/3 31
-Ethernet124     185,186           Ethernet32/1 32
-Ethernet126     187,188           Ethernet32/3 32
-Ethernet128     69,70             Ethernet33/1 33
-Ethernet130     71,72             Ethernet33/3 33
-Ethernet132     73,74             Ethernet34/1 34
-Ethernet134     75,76             Ethernet34/3 34
-Ethernet136     93,94             Ethernet35/1 35
-Ethernet138     95,96             Ethernet35/3 35
-Ethernet140     81,82             Ethernet36/1 36
-Ethernet142     83,84             Ethernet36/3 36
-Ethernet144     101,102           Ethernet37/1 37
-Ethernet146     103,104           Ethernet37/3 37
-Ethernet148     105,106           Ethernet38/1 38
-Ethernet150     107,108           Ethernet38/3 38
-Ethernet152     9,10              Ethernet39/1 39
-Ethernet154     11,12             Ethernet39/3 39
-Ethernet156     1,2               Ethernet40/1 40
-Ethernet158     3,4               Ethernet40/3 40
-Ethernet160     17,18             Ethernet41/1 41
-Ethernet162     19,20             Ethernet41/3 41
-Ethernet164     29,30             Ethernet42/1 42
-Ethernet166     31,32             Ethernet42/3 42
-Ethernet168     41,42             Ethernet43/1 43
-Ethernet170     43,44             Ethernet43/3 43
-Ethernet172     33,34             Ethernet44/1 44
-Ethernet174     35,36             Ethernet44/3 44
-Ethernet176     49,50             Ethernet45/1 45
-Ethernet178     51,52             Ethernet45/3 45
-Ethernet180     61,62             Ethernet46/1 46
-Ethernet182     63,64             Ethernet46/3 46
-Ethernet184     125,126           Ethernet47/1 47
-Ethernet186     127,128           Ethernet47/3 47
-Ethernet188     113,114           Ethernet48/1 48
-Ethernet190     115,116           Ethernet48/3 48
-Ethernet192     129,130           Ethernet49/1 49
-Ethernet194     131,132           Ethernet49/3 49
-Ethernet196     137,138           Ethernet50/1 50
-Ethernet198     139,140           Ethernet50/3 50
-Ethernet200     201,202           Ethernet51/1 51
-Ethernet202     203,204           Ethernet51/3 51
-Ethernet204     193,194           Ethernet52/1 52
-Ethernet206     195,196           Ethernet52/3 52
-Ethernet208     209,210           Ethernet53/1 53
-Ethernet210     211,212           Ethernet53/3 53
-Ethernet212     221,222           Ethernet54/1 54
-Ethernet214     223,224           Ethernet54/3 54
-Ethernet216     233,234           Ethernet55/1 55
-Ethernet218     235,236           Ethernet55/3 55
-Ethernet220     225,226           Ethernet56/1 56
-Ethernet222     227,228           Ethernet56/3 56
-Ethernet224     241,242           Ethernet57/1 57
-Ethernet226     243,244           Ethernet57/3 57
-Ethernet228     253,254           Ethernet58/1 58
-Ethernet230     255,256           Ethernet58/3 58
-Ethernet232     157,158           Ethernet59/1 59
-Ethernet234     159,160           Ethernet59/3 59
-Ethernet236     145,146           Ethernet60/1 60
-Ethernet238     147,148           Ethernet60/3 60
-Ethernet240     165,166           Ethernet61/1 61
-Ethernet242     167,168           Ethernet61/3 61
-Ethernet244     169,170           Ethernet62/1 62
-Ethernet246     171,172           Ethernet62/3 62
-Ethernet248     189,190           Ethernet63/1 63
-Ethernet250     191,192           Ethernet63/3 63
-Ethernet252     177,178           Ethernet64/1 64
-Ethernet254     179,180           Ethernet64/3 64
-Ethernet256     257               Ethernet65   65
-Ethernet260     259               Ethernet66   66
+# name          lanes             alias        index  speed
+Ethernet0       77,78             Ethernet1/1  1      50000
+Ethernet2       79,80             Ethernet1/3  1      50000
+Ethernet4       65,66             Ethernet2/1  2      50000
+Ethernet6       67,68             Ethernet2/3  2      50000
+Ethernet8       85,86             Ethernet3/1  3      50000
+Ethernet10      87,88             Ethernet3/3  3      50000
+Ethernet12      89,90             Ethernet4/1  4      50000
+Ethernet14      91,92             Ethernet4/3  4      50000
+Ethernet16      109,110           Ethernet5/1  5      50000
+Ethernet18      111,112           Ethernet5/3  5      50000
+Ethernet20      97,98             Ethernet6/1  6      50000
+Ethernet22      99,100            Ethernet6/3  6      50000
+Ethernet24      5,6               Ethernet7/1  7      50000
+Ethernet26      7,8               Ethernet7/3  7      50000
+Ethernet28      13,14             Ethernet8/1  8      50000
+Ethernet30      15,16             Ethernet8/3  8      50000
+Ethernet32      25,26             Ethernet9/1  9      50000
+Ethernet34      27,28             Ethernet9/3  9      50000
+Ethernet36      21,22             Ethernet10/1 10     50000
+Ethernet38      23,24             Ethernet10/3 10     50000
+Ethernet40      37,38             Ethernet11/1 11     50000
+Ethernet42      39,40             Ethernet11/3 11     50000
+Ethernet44      45,46             Ethernet12/1 12     50000
+Ethernet46      47,48             Ethernet12/3 12     50000
+Ethernet48      57,58,59,60       Ethernet13/1 13     100000
+Ethernet52      53,54,55,56       Ethernet14/1 14     100000
+Ethernet56      117,118,119,120   Ethernet15/1 15     100000
+Ethernet60      121,122,123,124   Ethernet16/1 16     100000
+Ethernet64      141,142,143,144   Ethernet17/1 17     100000
+Ethernet68      133,134,135,136   Ethernet18/1 18     100000
+Ethernet72      197,198,199,200   Ethernet19/1 19     100000
+Ethernet76      205,206,207,208   Ethernet20/1 20     100000
+Ethernet80      217,218           Ethernet21/1 21     50000
+Ethernet82      219,220           Ethernet21/3 21     50000
+Ethernet84      213,214           Ethernet22/1 22     50000
+Ethernet86      215,216           Ethernet22/3 22     50000
+Ethernet88      229,230           Ethernet23/1 23     50000
+Ethernet90      231,232           Ethernet23/3 23     50000
+Ethernet92      237,238           Ethernet24/1 24     50000
+Ethernet94      239,240           Ethernet24/3 24     50000
+Ethernet96      249,250           Ethernet25/1 25     50000
+Ethernet98      251,252           Ethernet25/3 25     50000
+Ethernet100     245,246           Ethernet26/1 26     50000
+Ethernet102     247,248           Ethernet26/3 26     50000
+Ethernet104     149,150           Ethernet27/1 27     50000
+Ethernet106     151,152           Ethernet27/3 27     50000
+Ethernet108     153,154           Ethernet28/1 28     50000
+Ethernet110     155,156           Ethernet28/3 28     50000
+Ethernet112     173,174           Ethernet29/1 29     50000
+Ethernet114     175,176           Ethernet29/3 29     50000
+Ethernet116     161,162           Ethernet30/1 30     50000
+Ethernet118     163,164           Ethernet30/3 30     50000
+Ethernet120     181,182           Ethernet31/1 31     50000
+Ethernet122     183,184           Ethernet31/3 31     50000
+Ethernet124     185,186           Ethernet32/1 32     50000
+Ethernet126     187,188           Ethernet32/3 32     50000
+Ethernet128     69,70             Ethernet33/1 33     50000
+Ethernet130     71,72             Ethernet33/3 33     50000
+Ethernet132     73,74             Ethernet34/1 34     50000
+Ethernet134     75,76             Ethernet34/3 34     50000
+Ethernet136     93,94             Ethernet35/1 35     50000
+Ethernet138     95,96             Ethernet35/3 35     50000
+Ethernet140     81,82             Ethernet36/1 36     50000
+Ethernet142     83,84             Ethernet36/3 36     50000
+Ethernet144     101,102           Ethernet37/1 37     50000
+Ethernet146     103,104           Ethernet37/3 37     50000
+Ethernet148     105,106           Ethernet38/1 38     50000
+Ethernet150     107,108           Ethernet38/3 38     50000
+Ethernet152     9,10              Ethernet39/1 39     50000
+Ethernet154     11,12             Ethernet39/3 39     50000
+Ethernet156     1,2               Ethernet40/1 40     50000
+Ethernet158     3,4               Ethernet40/3 40     50000
+Ethernet160     17,18             Ethernet41/1 41     50000
+Ethernet162     19,20             Ethernet41/3 41     50000
+Ethernet164     29,30             Ethernet42/1 42     50000
+Ethernet166     31,32             Ethernet42/3 42     50000
+Ethernet168     41,42             Ethernet43/1 43     50000
+Ethernet170     43,44             Ethernet43/3 43     50000
+Ethernet172     33,34             Ethernet44/1 44     50000
+Ethernet174     35,36             Ethernet44/3 44     50000
+Ethernet176     49,50             Ethernet45/1 45     50000
+Ethernet178     51,52             Ethernet45/3 45     50000
+Ethernet180     61,62             Ethernet46/1 46     50000
+Ethernet182     63,64             Ethernet46/3 46     50000
+Ethernet184     125,126           Ethernet47/1 47     50000
+Ethernet186     127,128           Ethernet47/3 47     50000
+Ethernet188     113,114           Ethernet48/1 48     50000
+Ethernet190     115,116           Ethernet48/3 48     50000
+Ethernet192     129,130           Ethernet49/1 49     50000
+Ethernet194     131,132           Ethernet49/3 49     50000
+Ethernet196     137,138           Ethernet50/1 50     50000
+Ethernet198     139,140           Ethernet50/3 50     50000
+Ethernet200     201,202           Ethernet51/1 51     50000
+Ethernet202     203,204           Ethernet51/3 51     50000
+Ethernet204     193,194           Ethernet52/1 52     50000
+Ethernet206     195,196           Ethernet52/3 52     50000
+Ethernet208     209,210           Ethernet53/1 53     50000
+Ethernet210     211,212           Ethernet53/3 53     50000
+Ethernet212     221,222           Ethernet54/1 54     50000
+Ethernet214     223,224           Ethernet54/3 54     50000
+Ethernet216     233,234           Ethernet55/1 55     50000
+Ethernet218     235,236           Ethernet55/3 55     50000
+Ethernet220     225,226           Ethernet56/1 56     50000
+Ethernet222     227,228           Ethernet56/3 56     50000
+Ethernet224     241,242           Ethernet57/1 57     50000
+Ethernet226     243,244           Ethernet57/3 57     50000
+Ethernet228     253,254           Ethernet58/1 58     50000
+Ethernet230     255,256           Ethernet58/3 58     50000
+Ethernet232     157,158           Ethernet59/1 59     50000
+Ethernet234     159,160           Ethernet59/3 59     50000
+Ethernet236     145,146           Ethernet60/1 60     50000
+Ethernet238     147,148           Ethernet60/3 60     50000
+Ethernet240     165,166           Ethernet61/1 61     50000
+Ethernet242     167,168           Ethernet61/3 61     50000
+Ethernet244     169,170           Ethernet62/1 62     50000
+Ethernet246     171,172           Ethernet62/3 62     50000
+Ethernet248     189,190           Ethernet63/1 63     50000
+Ethernet250     191,192           Ethernet63/3 63     50000
+Ethernet252     177,178           Ethernet64/1 64     50000
+Ethernet254     179,180           Ethernet64/3 64     50000
+Ethernet256     257               Ethernet65   65     10000
+Ethernet260     259               Ethernet66   66     10000


### PR DESCRIPTION
This change depends on sonic-swss PR 445 and buildimage PR #1415 

**- What I did**
Add port speed information to Arista7260CX3 port_config.ini files.
