### PR TITLE
Commenting out BGP configuration on default minigraph.xml's for Celestica SKUs

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/minigraph.xml
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/minigraph.xml
@@ -1,5 +1,6 @@
 <DeviceMiniGraph xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Search.Autopilot.Evolution">
   <CpgDec>
+    <?ignore
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
       <BGPSession>
@@ -620,6 +621,7 @@
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
     </Routers>
+    ?>
   </CpgDec>
   <DpgDec>
     <DeviceDataPlaneInfo>

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50/minigraph.xml
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50/minigraph.xml
@@ -1,5 +1,6 @@
 <DeviceMiniGraph xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Search.Autopilot.Evolution">
   <CpgDec>
+    <?ignore
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
       <BGPSession>
@@ -620,6 +621,7 @@
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
     </Routers>
+    ?>
   </CpgDec>
   <DpgDec>
     <DeviceDataPlaneInfo>

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/minigraph.xml
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/minigraph.xml
@@ -1,5 +1,6 @@
 <DeviceMiniGraph xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Search.Autopilot.Evolution">
   <CpgDec>
+    <?ignore
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
       <BGPSession>
@@ -620,6 +621,7 @@
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
     </Routers>
+    ?>
   </CpgDec>
   <DpgDec>
     <DeviceDataPlaneInfo>

--- a/device/celestica/x86_64-cel_seastone-r0/minigraph.xml
+++ b/device/celestica/x86_64-cel_seastone-r0/minigraph.xml
@@ -1,5 +1,6 @@
 <DeviceMiniGraph xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Search.Autopilot.Evolution">
   <CpgDec>
+    <?ignore
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
       <BGPSession>
@@ -620,6 +621,7 @@
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
     </Routers>
+    ?>
   </CpgDec>
   <DpgDec>
     <DeviceDataPlaneInfo>


### PR DESCRIPTION

The goal here is to prevent injecting irrelevant default config-state into configDB. We are commenting BGP configuration out (instead of deleting it) to reduce as much as possible the potential collisions that may be coming our way during subsequent changes to minigraph.xml files.

Before my changes:

127.0.0.1:6379[4]> keys "BGP*"
1) "BGP_NEIGHBOR|10.0.0.33"
2) "BGP_NEIGHBOR|10.0.0.43"
3) "BGP_NEIGHBOR|10.0.0.21"
4) "BGP_NEIGHBOR|10.0.0.9"
5) "BGP_NEIGHBOR|10.0.0.1"
...
...

After:

127.0.0.1:6379[4]> keys "BGP*"
(empty list or set)
127.0.0.1:6379[4]>

