### PR TITLE
[device/Seastone] Update sensors conf on DX010

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sensors.conf
+++ b/device/celestica/x86_64-cel_seastone-r0/sensors.conf
@@ -8,6 +8,16 @@ chip "dps460-i2c-*-5a"
     label temp3 "Power Supply 1 temp sensor 3"
     ignore fan2
     ignore fan3
+    ignore in2
+    
+    set in1_max 240
+    set in1_min 100
+    set in1_crit 264
+    set in1_lcrit 90
+    set in3_max 12.6
+    set in3_min 11.4
+    set in3_crit 13.0
+    set in3_lcrit 11.0 
 
 chip "dps460-i2c-*-5b"
     label temp1 "Power Supply 2 temp sensor 1"
@@ -15,6 +25,16 @@ chip "dps460-i2c-*-5b"
     label temp3 "Power Supply 2 temp sensor 3"
     ignore fan2
     ignore fan3
+    ignore in2
+
+    set in1_max 240
+    set in1_min 100
+    set in1_crit 264
+    set in1_lcrit 90
+    set in3_max 12.6
+    set in3_min 11.4
+    set in3_crit 13.0
+    set in3_lcrit 11.0  
 
 # These sensors located on Main Switch Board.
 chip "dx010_lm75b-i2c-*-48"


### PR DESCRIPTION
Update sensors configuration file. Add threshold to PSU sensors values.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
**What I did**
- Update the sensors configuration file for Celestica Seastone DX010.  
- Update power supply voltage constrain in sensors.conf.  

**How to verify it**
- In cli run sensors to check the constrain of PSU and compare to configuration file.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

