### PR TITLE
[hostcfgd/tacacs] Avoid printing credential into syslog

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -32,6 +32,13 @@ def sub(l, start, end):
     return l[start:end]
 
 
+def obfuscate(data):
+    if data:
+        return data[0] + '*****'
+    else:
+        return data
+
+
 class AaaCfg(object):
     def __init__(self):
         self.auth_default = {
@@ -148,9 +155,15 @@ class HostConfigDaemon:
 
     def tacacs_server_handler(self, key, data):
         self.aaacfg.tacacs_server_update(key, data)
+        if data.has_key('passkey'):
+            data['passkey'] = obfuscate(data['passkey'])
+        syslog.syslog(syslog.LOG_DEBUG, 'value for {} changed to {}'.format(key, data))
 
     def tacacs_global_handler(self, key, data):
         self.aaacfg.tacacs_global_update(key, data)
+        if data.has_key('passkey'):
+            data['passkey'] = obfuscate(data['passkey'])
+        syslog.syslog(syslog.LOG_DEBUG, 'value for {} changed to {}'.format(key, data))
 
     def start(self):
         self.config_db.subscribe('AAA', lambda table, key, data: self.aaa_handler(key, data))

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -144,15 +144,12 @@ class HostConfigDaemon:
         self.aaacfg.load(aaa, tacacs_global, tacacs_server)
 
     def aaa_handler(self, key, data):
-        syslog.syslog(syslog.LOG_DEBUG, 'value for {} changed to {}'.format(key, data))
         self.aaacfg.aaa_update(key, data)
 
     def tacacs_server_handler(self, key, data):
-        syslog.syslog(syslog.LOG_DEBUG, 'value for {} changed to {}'.format(key, data))
         self.aaacfg.tacacs_server_update(key, data)
 
     def tacacs_global_handler(self, key, data):
-        syslog.syslog(syslog.LOG_DEBUG, 'value for {} changed to {}'.format(key, data))
         self.aaacfg.tacacs_global_update(key, data)
 
     def start(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
`hostcfgd` print debug information into syslog when any tacacs-related field changes, which might include confidential information (passkey). This change is to remove this logging to avoid credential leak.
