### PR TITLE
Move all minigraph-related action from rc.local to updategraph

### DIFF
--- a/files/build_templates/bgp.service.j2
+++ b/files/build_templates/bgp.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=BGP container
-Requires=database.service
-After=database.service
+Requires=updategraph.service
+After=updategraph.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/dhcp_relay.service.j2
+++ b/files/build_templates/dhcp_relay.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=DHCP relay container
-Requires=docker.service teamd.service
-After=swss.service teamd.service
+Requires=updategraph.service swss.service teamd.service
+After=updategraph.service swss.service teamd.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/lldp.service.j2
+++ b/files/build_templates/lldp.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=LLDP container
-Requires=database.service
-After=database.service
+Requires=updategraph.service
+After=updategraph.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=Platform monitor container
-Requires=database.service
-After=database.service
+Requires=updategraph.service
+After=updategraph.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/router_advertiser.service.j2
+++ b/files/build_templates/router_advertiser.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=Router advertiser container
-Requires=docker.service
-After=swss.service
+Requires=updategraph.service
+After=updategraph.service swss.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=SNMP container
-Requires=database.service swss.service
-After=database.service swss.service
+Requires=updategraph.service swss.service
+After=updategraph.service swss.service
 
 [Service]
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -1,12 +1,12 @@
 [Unit]
 Description=switch state service
-Requires=database.service
+Requires=database.service updategraph.service
 {% if sonic_asic_platform == 'broadcom' %}
 Requires=opennsl-modules-3.16.0-5-amd64.service
 {% elif sonic_asic_platform == 'nephos' %}
 Requires=nps-modules-3.16.0-5-amd64.service
 {% endif %}
-After=database.service
+After=database.service updategraph.service
 After=interfaces-config.service
 {% if sonic_asic_platform == 'broadcom' %}
 After=opennsl-modules-3.16.0-5-amd64.service

--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=TEAMD container
-Requires=database.service
-After=database.service
+Requires=updategraph.service
+After=updategraph.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/image_config/caclmgrd/caclmgrd.service
+++ b/files/image_config/caclmgrd/caclmgrd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Control Plane ACL configuration daemon
-Requires=database.service
-After=database.service
+Requires=updategraph.service
+After=updategraph.service
 
 [Service]
 Type=simple

--- a/files/image_config/hostcfgd/hostcfgd.service
+++ b/files/image_config/hostcfgd/hostcfgd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Host config enforcer daemon
-Requires=database.service
-After=database.service
+Requires=updategraph.service
+After=updategraph.service
 
 [Service]
 Type=simple

--- a/files/image_config/hostname/hostname-config.service
+++ b/files/image_config/hostname/hostname-config.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Update hostname based on configdb
-Requires=database.service
-After=database.service
+Requires=updategraph.service
+After=updategraph.service
 
 [Service]
 Type=oneshot

--- a/files/image_config/interfaces/interfaces-config.service
+++ b/files/image_config/interfaces/interfaces-config.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Update interfaces configuration
-Requires=database.service
-After=database.service
+Requires=updategraph.service
+After=updategraph.service
 
 [Service]
 Type=oneshot

--- a/files/image_config/ntp/ntp-config.service
+++ b/files/image_config/ntp/ntp-config.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Update NTP configuration
-Requires=database.service
-After=database.service
+Requires=updategraph.service
+After=updategraph.service
 
 [Service]
 Type=oneshot

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -157,15 +157,6 @@ firsttime_exit()
     exit 0
 }
 
-test_config()
-{
-    if [ -d /host/old_config ] && ( [ -f /host/old_config/minigraph.xml ] || [ -f /host/old_config/config_db.json ] ); then
-        return 0
-    fi
-
-    return 1
-}
-
 # Given a string of tuples of the form field=value, extract the value for a field
 # In : $string, $field
 # Out: $value
@@ -193,46 +184,19 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         firsttime_exit
     fi
 
-    if [ ! -f /etc/sonic/init_cfg.json ]; then
-        # Generate an empty init_cfg.json
-        echo '{}' > /etc/sonic/init_cfg.json
-    fi
-
     # Try to take old configuration saved during installation
-    if test_config; then
-        rm -f /host/old_config/sonic_version.yml
-        mv -f /host/old_config/* /etc/sonic/
-        if [ ! -f /etc/sonic/config_db.json ]; then
-            sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
-        fi
+    # If taken, create a flag in /tmp/ to let updategraph service know
+    if [ -d /host/old_config ]; then
+        mv -f /host/old_config /etc/sonic/
+        touch /tmp/migration
     elif [ -f /host/minigraph.xml ]; then
-        mv /host/minigraph.xml /etc/sonic/
-        # Combine information in minigraph and init_cfg.json to form initiate config DB dump file.
-        # TODO: After moving all information from minigraph to DB, sample config DB dump should be provide
-        sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
+        mkdir -p /etc/sonic/old_config
+        mv /host/minigraph.xml /etc/sonic/old_config/
+        touch /tmp/migration
     elif [ -n "$migration" ] && [ -f /host/migration/minigraph.xml ];  then
-        # Use the minigraph that was imported from the NOS
-        mv /host/migration/minigraph.xml /etc/sonic/
-        sonic-cfggen -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
-    else
-        # Use default minigraph.xml
-        cp /usr/share/sonic/device/$platform/minigraph.xml /etc/sonic/
-        sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
-    fi
-
-    HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v DEVICE_METADATA.localhost.hwsku`
-    if [ -f /usr/share/sonic/device/$platform/$HWSKU/buffers.json.j2 ]; then
-        # generate and merge buffers configuration into config file
-        sonic-cfggen -m -t /usr/share/sonic/device/$platform/$HWSKU/buffers.json.j2 > /tmp/buffers.json
-        sonic-cfggen -j /etc/sonic/config_db.json -j /tmp/buffers.json --print-data > /tmp/config_db.json
-        mv /tmp/config_db.json /etc/sonic/config_db.json
-
-        # Only apply qos.json when buffer configuration is available.
-        if [ -f /usr/share/sonic/device/$platform/$HWSKU/qos.json ]; then
-            # merge qos configuration into init config file
-            sonic-cfggen -j /etc/sonic/config_db.json -j /usr/share/sonic/device/$platform/$HWSKU/qos.json --print-data > /tmp/config_db.json
-            mv /tmp/config_db.json /etc/sonic/config_db.json
-        fi
+        mkdir -p /etc/sonic/old_config
+        mv /host/migration/minigraph.xml /etc/sonic/old_config/
+        touch /tmp/migration
     fi
 
     if [ -d /host/image-$sonic_version/platform/$platform ]; then

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -185,7 +185,7 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
     fi
 
     # Try to take old configuration saved during installation
-    # If taken, create a flag in /tmp/ to let updategraph service know
+    # and create a flag in /tmp/ to let updategraph service know
     if [ -d /host/old_config ]; then
         mv -f /host/old_config /etc/sonic/
         touch /tmp/migration
@@ -197,6 +197,8 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         mkdir -p /etc/sonic/old_config
         mv /host/migration/minigraph.xml /etc/sonic/old_config/
         touch /tmp/migration
+    else
+        touch /tmp/firstboot
     fi
 
     if [ -d /host/image-$sonic_version/platform/$platform ]; then

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -188,17 +188,17 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
     # and create a flag in /tmp/ to let updategraph service know
     if [ -d /host/old_config ]; then
         mv -f /host/old_config /etc/sonic/
-        touch /tmp/migration
+        touch /tmp/pending_config_migration
     elif [ -f /host/minigraph.xml ]; then
         mkdir -p /etc/sonic/old_config
         mv /host/minigraph.xml /etc/sonic/old_config/
-        touch /tmp/migration
+        touch /tmp/pending_config_migration
     elif [ -n "$migration" ] && [ -f /host/migration/minigraph.xml ];  then
         mkdir -p /etc/sonic/old_config
         mv /host/migration/minigraph.xml /etc/sonic/old_config/
-        touch /tmp/migration
+        touch /tmp/pending_config_migration
     else
-        touch /tmp/firstboot
+        touch /tmp/pending_config_initialization
     fi
 
     if [ -d /host/image-$sonic_version/platform/$platform ]; then

--- a/files/image_config/rsyslog/rsyslog-config.service
+++ b/files/image_config/rsyslog/rsyslog-config.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Update rsyslog configuration
-Requires=database.service
-After=database.service
+Requires=updategraph.service
+After=updategraph.service
 
 [Service]
 Type=oneshot

--- a/files/image_config/ssh/sshd-config-updater.service
+++ b/files/image_config/ssh/sshd-config-updater.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Takes care of updates to SSH config file with respect to the SSH allow list
-After=database.service
+After=updategraph.service
+Requires=updategraph.service
 ConditionPathExists=!/etc/ssh/sshd_not_to_be_run
 
 [Service]

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -1,14 +1,16 @@
 #!/bin/bash
 
+CONFIG_DB_INDEX=4
+
 reload_minigraph()
 {
     echo "Reloading minigraph..."
     if [ ! -f /etc/sonic/init_cfg.json ]; then
         echo "{}" > /etc/sonic/init_cfg.json
     fi
-    redis-cli -n 4 FLUSHDB
+    redis-cli -n $CONFIG_DB_INDEX FLUSHDB
     sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
-    redis-cli -n 4 SET "CONFIG_DB_INITIALIZED" "1"
+    redis-cli -n $CONFIG_DB_INDEX SET "CONFIG_DB_INITIALIZED" "1"
     if [ -f /etc/sonic/acl.json ]; then
         acl-loader update full /etc/sonic/acl.json
     fi
@@ -38,7 +40,7 @@ fi
 
 . /etc/sonic/updategraph.conf
 
-if [ -f /tmp/firstboot ]; then
+if [ -f /tmp/migration ]; then
     if [ "$enabled" = "true" ]; then
         echo "Use minigraph.xml from old system..."
         cp /etc/sonic/old_config/minigraph.xml /etc/sonic/
@@ -52,7 +54,7 @@ if [ -f /tmp/firstboot ]; then
             cp /etc/sonic/old_config/acl.json /etc/sonic/
         fi
         reload_minigraph
-        sonic-cfggen -d --print_data > /etc/sonic/config_db.json
+        sonic-cfggen -d --print-data > /etc/sonic/config_db.json
     elif [ -f /etc/sonic/old_config/config_db.json ]; then
         echo "Use config_db.json from old system..."
         cp /etc/sonic/old_config/config_db.json /etc/sonic/
@@ -60,9 +62,9 @@ if [ -f /tmp/firstboot ]; then
     else
         copy_default_minigraph
         reload_minigraph
-        sonic-cfggen -d --print_data > /etc/sonic/config_db.json
+        sonic-cfggen -d --print-data > /etc/sonic/config_db.json
     fi
-    rm -f /tmp/firstboot
+    rm -f /tmp/migration
     sed -i "/enabled=/d" /etc/sonic/updategraph.conf
     echo "enabled=false" >> /etc/sonic/updategraph.conf
     exit 0
@@ -106,9 +108,9 @@ if [ "$src" = "dhcp" ]; then
         else
             cp -f /tmp/device_meta.json /etc/sonic/config_db.json
         fi
-        redis-cli -n 4 FLUSHDB
+        redis-cli -n $CONFIG_DB_INDEX FLUSHDB
         sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
-        redis-cli -n 4 SET "CONFIG_DB_INITIALIZED" "1"
+        redis-cli -n $CONFIG_DB_INDEX SET "CONFIG_DB_INITIALIZED" "1"
         if [ "$dhcp_as_static" = "true" ]; then
             sed -i "/enabled=/d" /etc/sonic/updategraph.conf
             echo "enabled=false" >> /etc/sonic/updategraph.conf
@@ -172,7 +174,7 @@ else
 fi
 
 reload_minigraph
-sonic-cfggen -d --print_data > /etc/sonic/config_db.json
+sonic-cfggen -d --print-data > /etc/sonic/config_db.json
 
 # Mark as disabled after graph is successfully downloaded
 sed -i "/enabled=/d" /etc/sonic/updategraph.conf

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -40,7 +40,7 @@ fi
 
 . /etc/sonic/updategraph.conf
 
-if [ -f /tmp/migration ]; then
+if [ -f /tmp/pending_config_migration ]; then
     if [ "$enabled" = "true" ]; then
         echo "Use minigraph.xml from old system..."
         cp /etc/sonic/old_config/minigraph.xml /etc/sonic/
@@ -60,17 +60,17 @@ if [ -f /tmp/migration ]; then
         cp /etc/sonic/old_config/config_db.json /etc/sonic/
         sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
     fi
-    rm -f /tmp/migration
+    rm -f /tmp/pending_config_migration
     sed -i "/enabled=/d" /etc/sonic/updategraph.conf
     echo "enabled=false" >> /etc/sonic/updategraph.conf
     exit 0
 fi
 
-if [ -f /tmp/firstboot ] && [ "$enabled" != "true" ]; then 
+if [ -f /tmp/pending_config_initialization ] && [ "$enabled" != "true" ]; then 
     copy_default_minigraph
     reload_minigraph
     sonic-cfggen -d --print-data > /etc/sonic/config_db.json
-    rm -f /tmp/firstboot
+    rm -f /tmp/pending_config_initialization
     exit 0
 fi
 

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -1,11 +1,79 @@
 #!/bin/bash
 
+reload_minigraph()
+{
+    echo "Reloading minigraph..."
+    if [ ! -f /etc/sonic/init_cfg.json ]; then
+        echo "{}" > /etc/sonic/init_cfg.json
+    fi
+    redis-cli -n 4 FLUSHDB
+    sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
+    redis-cli -n 4 SET "CONFIG_DB_INITIALIZED" "1"
+    if [ -f /etc/sonic/acl.json ]; then
+        acl-loader update full /etc/sonic/acl.json
+    fi
+    config qos reload
+}
+
+copy_default_minigraph()
+{
+    . /host/machine.conf
+    if [ -n "$aboot_platform" ]; then
+        platform=$aboot_platform
+    elif [ -n "$onie_platform" ]; then
+        platform=$onie_platform
+    else
+        echo "Unknown sonic platform."
+        exit 1
+    fi
+    echo "Copying default minigraph..."
+    cp /usr/share/sonic/device/$platform/minigraph.xml /etc/sonic/
+}
+
+
 if [ ! -f /etc/sonic/updategraph.conf ]; then
     echo "No updategraph.conf found, generating a default one."
     echo "enabled=false" >/etc/sonic/updategraph.conf
 fi
 
 . /etc/sonic/updategraph.conf
+
+if [ -f /tmp/firstboot ]; then
+    if [ "$enabled" = "true" ]; then
+        echo "Use minigraph.xml from old system..."
+        cp /etc/sonic/old_config/minigraph.xml /etc/sonic/
+        if [ -f /etc/sonic/old_config/init_cfg.json ]; then
+            cp /etc/sonic/old_config/init_cfg.json /etc/sonic/
+        fi
+        if [ -f /etc/sonic/old_config/snmp.yml ]; then
+            cp /etc/sonic/old_config/snmp.yml /etc/sonic/
+        fi
+        if [ -f /etc/sonic/old_config/acl.json ]; then
+            cp /etc/sonic/old_config/acl.json /etc/sonic/
+        fi
+        reload_minigraph
+        sonic-cfggen -d --print_data > /etc/sonic/config_db.json
+    elif [ -f /etc/sonic/old_config/config_db.json ]; then
+        echo "Use config_db.json from old system..."
+        cp /etc/sonic/old_config/config_db.json /etc/sonic/
+        sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
+    else
+        copy_default_minigraph
+        reload_minigraph
+        sonic-cfggen -d --print_data > /etc/sonic/config_db.json
+    fi
+    rm -f /tmp/firstboot
+    sed -i "/enabled=/d" /etc/sonic/updategraph.conf
+    echo "enabled=false" >> /etc/sonic/updategraph.conf
+    exit 0
+fi
+
+if [ "$enabled" = "reload_only" ]; then
+    reload_minigraph
+    sed -i "/enabled=/d" /etc/sonic/updategraph.conf
+    echo "enabled=false" >> /etc/sonic/updategraph.conf
+    exit 0
+fi
 
 if [ "$enabled" != "true" ]; then
     echo "Disabled in updategraph.conf. Skipping graph update."
@@ -38,7 +106,9 @@ if [ "$src" = "dhcp" ]; then
         else
             cp -f /tmp/device_meta.json /etc/sonic/config_db.json
         fi
-        
+        redis-cli -n 4 FLUSHDB
+        sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
+        redis-cli -n 4 SET "CONFIG_DB_INITIALIZED" "1"
         if [ "$dhcp_as_static" = "true" ]; then
             sed -i "/enabled=/d" /etc/sonic/updategraph.conf
             echo "enabled=false" >> /etc/sonic/updategraph.conf
@@ -86,17 +156,6 @@ while true; do
     sleep 5
 done
 
-echo "Regenerating config DB from minigraph..."
-if [ -f /etc/sonic/init_cfg.json ]; then
-    sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --print-data > /etc/sonic/config_db.json
-else
-    sonic-cfggen -H -m --print-data > /etc/sonic/config_db.json
-fi
-
-# Mark as disabled after graph is successfully downloaded
-sed -i "/enabled=/d" /etc/sonic/updategraph.conf
-echo "enabled=false" >> /etc/sonic/updategraph.conf
-
 if [ -n "$ACL_URL" ]; then
     if [ -f /etc/sonic/acl.json ]; then
         echo "Renaming acl.json to acl.json.old"
@@ -111,3 +170,11 @@ if [ -n "$ACL_URL" ]; then
 else
     echo "Skip ACL config download."
 fi
+
+reload_minigraph
+sonic-cfggen -d --print_data > /etc/sonic/config_db.json
+
+# Mark as disabled after graph is successfully downloaded
+sed -i "/enabled=/d" /etc/sonic/updategraph.conf
+echo "enabled=false" >> /etc/sonic/updategraph.conf
+

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -55,18 +55,22 @@ if [ -f /tmp/migration ]; then
         fi
         reload_minigraph
         sonic-cfggen -d --print-data > /etc/sonic/config_db.json
-    elif [ -f /etc/sonic/old_config/config_db.json ]; then
+    else
         echo "Use config_db.json from old system..."
         cp /etc/sonic/old_config/config_db.json /etc/sonic/
         sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
-    else
-        copy_default_minigraph
-        reload_minigraph
-        sonic-cfggen -d --print-data > /etc/sonic/config_db.json
     fi
     rm -f /tmp/migration
     sed -i "/enabled=/d" /etc/sonic/updategraph.conf
     echo "enabled=false" >> /etc/sonic/updategraph.conf
+    exit 0
+fi
+
+if [ -f /tmp/firstboot ] && [ "$enabled" != "true" ]; then 
+    copy_default_minigraph
+    reload_minigraph
+    sonic-cfggen -d --print-data > /etc/sonic/config_db.json
+    rm -f /tmp/firstboot
     exit 0
 fi
 

--- a/files/image_config/updategraph/updategraph.service
+++ b/files/image_config/updategraph/updategraph.service
@@ -1,7 +1,8 @@
 [Unit]
-Description=download minigraph from graph service
+Description=Update minigraph and set configuration based on minigraph
 After=rc-local.service
-Before=database.service
+After=database.service
+Requires=database.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. `rc.local` no longer do configuration-related stuff. Instead, `updategraph` service now has the functionality to support first-time boot configuration behavior. The detail behavior is that
-- For pure new installation, generate configuration from default minigraph if updategraph is not enabled during build time; attempt to configure through DHCP if updategraph is enabled.
-- For sonic version upgrade, generate configuration from minigraph on old system if updategraph is enabled during build time; use old configDB content if not enabled.

1. Reconsider the dependency between services - `updategraph` is now after `database`. All feature services are now **after and depending on** `updategraph`. That means restarting `updategraph` will automatically trigger restarting of feature services.

1. `updategraph` now supports the scenario of not updating minigraph from data source but only reloading local graph. We plan to adapt to this approach in sonic-utilities `config load_minigraph` to simplify the code and unify behavior.