### PR TITLE
[tacacs+] Obfuscate key before printing to syslog

### DIFF
--- a/src/tacacs/nss/0001-Modify-user-map-profile.patch
+++ b/src/tacacs/nss/0001-Modify-user-map-profile.patch
@@ -619,9 +619,9 @@ index 79e62b9..ecfa0b0 100644
 +        useradd_info_t *user;
 +
 +        for(n = 0; n < tac_srv_no; n++) {
-+            syslog(LOG_DEBUG, "%s: server[%d] { addr=%s, key=%s, timeout=%d }",
++            syslog(LOG_DEBUG, "%s: server[%d] { addr=%s, key=%c*****, timeout=%d }",
 +                        nssname, n, tac_ntop(tac_srv[n].addr->ai_addr),
-+                        tac_srv[n].key, tac_srv[n].timeout);
++                        tac_srv[n].key[0], tac_srv[n].timeout);
 +        }
 +        syslog(LOG_DEBUG, "%s: many_to_one %s", nssname, 1 == many_to_one
 +                    ? "enable" : "disable");

--- a/src/tacacs/pam/0003-Obfuscate-key-before-printing-to-syslog.patch
+++ b/src/tacacs/pam/0003-Obfuscate-key-before-printing-to-syslog.patch
@@ -1,0 +1,25 @@
+From 254e6cb86b667f6324bcbfd89fe982e865d05189 Mon Sep 17 00:00:00 2001
+From: Taoyu Li <taoyl@microsoft.com>
+Date: Sat, 3 Mar 2018 02:22:49 +0000
+Subject: [PATCH] obfuscate key before printing to syslog
+
+---
+ support.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/support.c b/support.c
+index 44efee3..f9ab8aa 100644
+--- a/support.c
++++ b/support.c
+@@ -282,7 +282,7 @@ int _pam_parse (int argc, const char **argv) {
+         _pam_log(LOG_DEBUG, "%d servers defined", tac_srv_no);
+ 
+         for(n = 0; n < tac_srv_no; n++) {
+-            _pam_log(LOG_DEBUG, "server[%d] { addr=%s, key='%s' }", n, tac_ntop(tac_srv[n].addr->ai_addr), tac_srv[n].key);
++            _pam_log(LOG_DEBUG, "server[%d] { addr=%s, key='%c*****' }", n, tac_ntop(tac_srv[n].addr->ai_addr), tac_srv[n].key[0]);
+         }
+ 
+         _pam_log(LOG_DEBUG, "tac_service='%s'", tac_service);
+-- 
+2.9.3
+

--- a/src/tacacs/pam/Makefile
+++ b/src/tacacs/pam/Makefile
@@ -16,6 +16,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Apply patch
 	git apply ../0001-Don-t-init-declarations-in-a-for-loop.patch
 	git apply ../0002-Fix-libtac2-bin-install-directory-error.patch
+	git apply ../0003-Obfuscate-key-before-printing-to-syslog.patch
 
 	dpkg-buildpackage -rfakeroot -b -us -uc
 	popd


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Modify NSS patch and add a PAM patch to make sure no tacacs credential is directly posted into syslog,
