### PR TITLE
Sorting all json config-elements residing in config_db.json

### DIFF
--- a/dockers/docker-config-engine/Dockerfile.j2
+++ b/dockers/docker-config-engine/Dockerfile.j2
@@ -5,8 +5,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-# Dependencies for sonic-cfggen 
-RUN apt-get install -y python-lxml python-yaml python-bitarray python-pip python-dev
+# Dependencies for sonic-cfggen
+RUN apt-get install -y python-lxml python-yaml python-bitarray python-pip python-dev python-natsort
 
 RUN pip install --upgrade pip
 

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -29,6 +29,8 @@ from minigraph import parse_device_desc_xml
 from sonic_platform import get_machine_info
 from sonic_platform import get_platform_info
 from swsssdk import ConfigDBConnector
+from collections import OrderedDict
+from natsort import natsorted
 
 def is_ipv4(value):
     if not value:
@@ -98,6 +100,7 @@ TODO(taoyl): Current version of config db only supports BGP admin states.
     def to_serialized(data):
         for table in data:
             if type(data[table]) is dict:
+                data[table] = OrderedDict(natsorted(data[table].items()))
                 for key in data[table].keys():
                     new_key = ConfigDBConnector.serialize_key(key)
                     if new_key != key:


### PR DESCRIPTION
A simple change to make sonic's user life a little bit easier. Displaying the multiple elements of config_db.json in an orderly fashion allows a more intuitive user-experience.

For this change i'm simply intercepting the config-state that is about to be dumped to config_db.json, and i'm placing it in an ordered-dictionary, so that information is pushed to file in natural/alphanumerical ordering.

Example:

admin@lnos-x1-a-csw01:~$ sudo sonic-cfggen -m /etc/sonic/minigraph.xml --print-data
{
...
      "PORT": {
        "Ethernet0": {
             "alias": "Eth1/1",
             "lanes": "65"
},
        "Ethernet1": {
             "alias": "Eth1/2",
             "lanes": "66"
},
        "Ethernet2": {
             "alias": "Eth1/3",
             "lanes": "67"
},
        "Ethernet3": {
            "alias": "Eth1/4",
            "lanes": "68"
},
        "Ethernet4": {
             "alias": "Eth2/1",
             "lanes": "69"
},
...
...
    "INTERFACE": {
       "Ethernet0|10.0.0.0/31": {},
       "Ethernet1|10.0.0.2/31": {},
       "Ethernet2|10.0.0.4/31": {},
       "Ethernet3|10.0.0.6/31": {},
       "Ethernet4|10.0.0.8/31": {},

