### PR TITLE
[minigraph.py] Convert ipv6 addresses into lower case parsing cpg

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -239,18 +239,18 @@ def parse_cpg(cpg, hname):
                     keepalive = 60
                 nhopself = 1 if session.find(str(QName(ns, "NextHopSelf"))) is not None else 0
                 if end_router == hname:
-                    bgp_sessions[start_peer] = {
+                    bgp_sessions[start_peer.lower()] = {
                         'name': start_router,
-                        'local_addr': end_peer,
+                        'local_addr': end_peer.lower(),
                         'rrclient': rrclient,
                         'holdtime': holdtime,
                         'keepalive': keepalive,
                         'nhopself': nhopself
                     }
                 else:
-                    bgp_sessions[end_peer] = {
+                    bgp_sessions[end_peer.lower()] = {
                         'name': end_router,
-                        'local_addr': start_peer,
+                        'local_addr': start_peer.lower(),
                         'rrclient': rrclient,
                         'holdtime': holdtime,
                         'keepalive': keepalive,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Convert ipv6 addresses into lower case in minigraph parser to make sure BGP_NEIGHBOR table keys are always lower case in configDB.
