### PR TITLE
[installer]: support new onie machine.conf format

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -455,7 +455,7 @@ if [ "$install_env" = "onie" ]; then
     if [ -f /etc/machine-build.conf ]; then
         # onie_ variable are generate at runtime.
         # they are no longer hardcoded in /etc/machine.conf
-        set | grep onie_ > $demo_mnt/machine.conf
+        set | grep ^onie_ > $demo_mnt/machine.conf
     else
         cp /etc/machine.conf $demo_mnt
     fi

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -452,7 +452,13 @@ unzip -op $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPT
 
 if [ "$install_env" = "onie" ]; then
     # Store machine description in target file system
-    cp /etc/machine.conf $demo_mnt
+    if [ -f /etc/machine-build.conf ]; then
+        # onie_ variable are generate at runtime.
+        # they are no longer hardcoded in /etc/machine.conf
+        set | grep onie_ > $demo_mnt/machine.conf
+    else
+        cp /etc/machine.conf $demo_mnt
+    fi
 
     # Store installation log in target file system
     rm -f $onie_initrd_tmp/tmp/onie-support*.tar.bz2


### PR DESCRIPTION
onie_* variable are generated at runtime in /etc/machine.conf.
We can no longer copy the static machine.conf into sonic image.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
support new onie machine.conf format

**- How I did it**
export the onie_* varilable into sonic static machine.conf

**- How to verify it**
alphanetwork validated.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
