### PR TITLE
[isc-dhcp] Add patch to fix bug which caused log messages to also print to stderr in release builds

### DIFF
--- a/src/isc-dhcp/patch/0004-Bugfix-Don-t-print-log-messages-to-stderr-in-release.patch
+++ b/src/isc-dhcp/patch/0004-Bugfix-Don-t-print-log-messages-to-stderr-in-release.patch
@@ -1,0 +1,28 @@
+From 2bb21fcf4a9ad7535867809c50d2cf0ba1088e17 Mon Sep 17 00:00:00 2001
+From: Joe LeVeque <jolevequ@microsoft.com>
+Date: Fri, 9 Mar 2018 01:43:35 +0000
+Subject: [PATCH] [Bugfix] Don't print log messages to stderr in release builds
+
+---
+ omapip/errwarn.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/omapip/errwarn.c b/omapip/errwarn.c
+index 7c91d9d..aa74fd8 100644
+--- a/omapip/errwarn.c
++++ b/omapip/errwarn.c
+@@ -39,9 +39,9 @@
+ #include <syslog.h>
+ 
+ #ifdef DEBUG
+-int log_perror = -1;
+-#else
+ int log_perror = 1;
++#else
++int log_perror = 0;
+ #endif
+ void (*log_cleanup) (void);
+ 
+-- 
+2.1.4
+

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -2,3 +2,4 @@
 0001-Customizable-Option-82-circuit-ID-and-remote-ID-fiel.patch
 0002-Support-for-obtaining-name-of-physical-interface-tha.patch
 0003-Support-for-loading-port-alias-map-file-to-replace-p.patch
+0004-Bugfix-Don-t-print-log-messages-to-stderr-in-release.patch


### PR DESCRIPTION
- Fixing an 18-year-old bug in isc-dhcp source. :)
- Also submitted a bug report to the Internet Systems Consortium. Hoping they will fix upstream.