### PR TITLE
[radv] Rename service unit file Jinja template to radv.service.j2

### DIFF
--- a/files/build_templates/radv.service.j2
+++ b/files/build_templates/radv.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=Router advertiser container
-Requires=updategraph.service
+Requires=updategraph.service swss.service
 After=updategraph.service swss.service
 
 [Service]


### PR DESCRIPTION
  - Service unit file not getting generated because I changed the docker
    container name from 'router_advertiser' to 'radv', however I didn't
    rename the service unit file template name to match. However,
    slave.mk generates a service file for every docker based on its
    container name, and since there was no matching 'radv.service.j2'
    template file, this file stopped getting generated and therefore
    the docker container was never getting started.

  - Also add swss.service to 'Requires'