### PR TITLE
[Device]: remove s6100 qos config via swssconfig

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -43,10 +43,6 @@ HWSKU=`sonic-cfggen -d -v "DEVICE_METADATA['localhost']['hwsku']"`
 
 SWSSCONFIG_ARGS="00-copp.config.json ipinip.json ports.json switch.json "
 
-if [ "$HWSKU" == "Force10-S6100" ]; then
-    SWSSCONFIG_ARGS+="th.64ports.buffers.json th.64ports.qos.json "
-fi
-
 for file in $SWSSCONFIG_ARGS; do
     swssconfig /etc/swss/config.d/$file
     sleep 1


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove s6100 qos config via swssconfig since we have changed to use buffer template and qos.json for those configurations
**- How I did it**
Change swssconfig.sh
**- How to verify it**
Verified the buffer and qos configuration in config db and pfcwd function
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
