### PR TITLE
[BCM SAI] update Broadcom SDK and SAI

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.1.3.4-4_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.4-4_amd64.deb?sv=2015-04-05&sr=b&sig=hSWtsH1f5FIV7rk4%2FJA99S%2B7HoJ%2BSvHN8fPXZNnO6mI%3D&se=2031-11-15T03%3A11%3A01Z&sp=r"
+BRCM_SAI = libsaibcm_3.1.3.4-5_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.4-5_amd64.deb?sv=2015-04-05&sr=b&sig=s757Jmeq0blUuQa%2BnWXfe80sChLHWAnuSDf2J84s4OE%3D&se=2031-11-16T21%3A58%3A22Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.1.3.4-4_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.1.3.4-5_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.4-4_amd64.deb?sv=2015-04-05&sr=b&sig=nEo71IhiVDrk2ydJf3ejyZvQ5QES%2BxjWdQ5SEOOyaic%3D&se=2031-11-15T03%3A10%3A12Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.4-5_amd64.deb?sv=2015-04-05&sr=b&sig=BOLw2xZ53Tp1JfBXZtqsKAltbYGTJuRV89Y9jDSSp50%3D&se=2031-11-16T21%3A56%3A19Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI) $(BRCM_SAI_DEV)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)

--- a/platform/broadcom/sdk.mk
+++ b/platform/broadcom/sdk.mk
@@ -1,4 +1,4 @@
-BRCM_OPENNSL_KERNEL = opennsl-modules-3.16.0-5-amd64_3.4.1.11-1_amd64.deb
-$(BRCM_OPENNSL_KERNEL)_URL = "https://sonicstorage.blob.core.windows.net/packages/opennsl-modules-3.16.0-5-amd64_3.4.1.11-1_amd64.deb?sv=2015-04-05&sr=b&sig=jsHYNwfuoTU%2B2mhhyhC2%2FaQ%2BcaZA%2Fd21LzaaUq%2BG65c%3D&se=2031-10-17T01%3A35%3A15Z&sp=r"
+BRCM_OPENNSL_KERNEL = opennsl-modules-3.16.0-5-amd64_3.4.1.11-2_amd64.deb
+$(BRCM_OPENNSL_KERNEL)_URL = "https://sonicstorage.blob.core.windows.net/packages/opennsl-modules-3.16.0-5-amd64_3.4.1.11-2_amd64.deb?sv=2015-04-05&sr=b&sig=xtf8nafmS1pcqx5hhBsfmLNSx2BeqmwN4Dwq5uwM1bo%3D&se=2031-11-16T21%3A54%3A27Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_OPENNSL_KERNEL)


### PR DESCRIPTION
**- What I did**
SDK: no functional change, update version number to 3.4.1.11-2.
SAI: upgrade to 3.1.3.4-5, enable warm shutdown feature.

**- How to verify it**
Warn shutdown was verified with instrumented code and manual test. After shutdown, ptf host can no longer ping the vlan IP. But fdb test will pass by issuing the test command directly on ptf host (executing the whole test will fail earlier).

Passed nightly test.