### PR TITLE
[device/dell] Workaround for sai.profile

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/sai.profile
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/sai.profile
@@ -1,1 +1,1 @@
-SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G.config.bcm
+SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t0.config.bcm


### PR DESCRIPTION
This commit has the workaround for sai.profile to point to
config.bcm T0 profile. This fix will be reverted once the
sai.profile.j2 dynamically generates this file.

Signed-off-by: Harish Venkatraman <Harish_Venkatraman@dell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
