### PR TITLE
Add fstrim service files to systemd

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -248,7 +248,7 @@ sudo sed -i 's/^ListenAddress ::/#ListenAddress ::/' $FILESYSTEM_ROOT/etc/ssh/ss
 sudo sed -i 's/^#ListenAddress 0.0.0.0/ListenAddress 0.0.0.0/' $FILESYSTEM_ROOT/etc/ssh/sshd_config
 
 ## Copy fstrim service
-cp $FILESYSTEM_ROOT/usr/share/doc/util-linux/examples/fstrim.{service,timer} $FILESYSTEM_ROOT/etc/systemd/system
+sudo cp $FILESYSTEM_ROOT/usr/share/doc/util-linux/examples/fstrim.{service,timer} $FILESYSTEM_ROOT/etc/systemd/system
 
 ## Config monit
 sudo sed -i '

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -247,6 +247,9 @@ sudo augtool --autosave "set /files/etc/ssh/sshd_config/UseDNS no" -r $FILESYSTE
 sudo sed -i 's/^ListenAddress ::/#ListenAddress ::/' $FILESYSTEM_ROOT/etc/ssh/sshd_config
 sudo sed -i 's/^#ListenAddress 0.0.0.0/ListenAddress 0.0.0.0/' $FILESYSTEM_ROOT/etc/ssh/sshd_config
 
+## Copy fstrim service
+cp $FILESYSTEM_ROOT/usr/share/doc/util-linux/examples/fstrim.{service,timer} $FILESYSTEM_ROOT/etc/systemd/system
+
 ## Config monit
 sudo sed -i '
     s/^# set logfile syslog/set logfile syslog/;


### PR DESCRIPTION
**- What I did**
Add the fstrim.service and fstrim.timer so platform modules may start fstrim service if needed.

**- How I did it**

Extract from util-linux

**- How to verify it**

Check that the files are present in /etc/systemd/system

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Some of the Dell units need SSD trim support.

**- A picture of a cute animal (not mandatory but encouraged)**
