### PR TITLE
Delta ag9064 add load module

### DIFF
--- a/platform/broadcom/sonic-platform-modules-delta/debian/platform-modules-ag9064.init
+++ b/platform/broadcom/sonic-platform-modules-delta/debian/platform-modules-ag9064.init
@@ -23,6 +23,8 @@ start)
     modprobe i2c-mei
     modprobe i2c-mux-pca954x
     modprobe at24
+    modprobe ipmi_devintf
+    modprobe ipmi_si trydefaults=1
     modprobe delta_ag9064_platform
 
     /usr/local/bin/ag9064_platform_init.sh


### PR DESCRIPTION
add load IPMI module instead of kernel build in.

