### PR TITLE
[Base image files] All 'docker exec' wrapper scripts now dynamically adjust their flags depending on whether or not they are run on a terminal

### DIFF
--- a/dockers/docker-database/base_image_files/redis-cli
+++ b/dockers/docker-database/base_image_files/redis-cli
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-docker exec -it database redis-cli "$@"
+DOCKER_EXEC_FLAGS="i"
+
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+    DOCKER_EXEC_FLAGS+="t"
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS database redis-cli "$@"

--- a/dockers/docker-fpm-frr/base_image_files/vtysh
+++ b/dockers/docker-fpm-frr/base_image_files/vtysh
@@ -1,2 +1,10 @@
 #!/bin/bash
-docker exec -it bgp vtysh "$@"
+
+DOCKER_EXEC_FLAGS="i"
+
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+    DOCKER_EXEC_FLAGS+="t"
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS bgp vtysh "$@"

--- a/dockers/docker-fpm-quagga/base_image_files/vtysh
+++ b/dockers/docker-fpm-quagga/base_image_files/vtysh
@@ -1,2 +1,10 @@
 #!/bin/bash
-docker exec -it bgp vtysh "$@"
+
+DOCKER_EXEC_FLAGS="i"
+
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+    DOCKER_EXEC_FLAGS+="t"
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS bgp vtysh "$@"

--- a/dockers/docker-lldp-sv2/base_image_files/lldpctl
+++ b/dockers/docker-lldp-sv2/base_image_files/lldpctl
@@ -1,2 +1,10 @@
 #!/bin/bash
-docker exec -i lldp lldpctl "$@"
+
+DOCKER_EXEC_FLAGS="i"
+
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+    DOCKER_EXEC_FLAGS+="t"
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS lldp lldpctl "$@"

--- a/dockers/docker-orchagent/base_image_files/swssloglevel
+++ b/dockers/docker-orchagent/base_image_files/swssloglevel
@@ -1,2 +1,10 @@
 #!/bin/bash
-docker exec -i swss swssloglevel "$@"
+
+DOCKER_EXEC_FLAGS="i"
+
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+    DOCKER_EXEC_FLAGS+="t"
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS swss swssloglevel "$@"

--- a/dockers/docker-platform-monitor/base_image_files/sensors
+++ b/dockers/docker-platform-monitor/base_image_files/sensors
@@ -1,2 +1,10 @@
 #!/bin/bash
-docker exec -i pmon sensors "$@"
+
+DOCKER_EXEC_FLAGS="i"
+
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+    DOCKER_EXEC_FLAGS+="t"
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS pmon sensors "$@"

--- a/dockers/docker-teamd/base_image_files/teamdctl
+++ b/dockers/docker-teamd/base_image_files/teamdctl
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-docker exec -i teamd teamdctl "$@"
+DOCKER_EXEC_FLAGS="i"
+
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+    DOCKER_EXEC_FLAGS+="t"
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS teamd teamdctl "$@"


### PR DESCRIPTION
Passing `-t` flag to `docker exec` will fail if the command is being called when no on a terminal (e.g., from systemctl or cron).

This commit will dynamically add the `t` flag if it is determined that the command is being executed on a terminal. Otherwise, it will only pass the `i` (interactive) flag.