### PR TITLE
Fixing lldp issue displaying mac-addr instead of ports

### DIFF
--- a/dockers/docker-lldp-sv2/lldpd.conf.j2
+++ b/dockers/docker-lldp-sv2/lldpd.conf.j2
@@ -1,4 +1,6 @@
+{% if MGMT_INTERFACE %}
 configure ports eth0 lldp portidsubtype local {{ MGMT_INTERFACE.keys()[0][0] }}
+{% endif %}
 {% for local_port in DEVICE_NEIGHBOR %}
 configure ports {{ local_port }} lldp portidsubtype local {{ PORT[local_port]['alias'] }} description {{ DEVICE_NEIGHBOR[local_port]['name'] }}:{{ DEVICE_NEIGHBOR[local_port]['port'] }}
 {% endfor %}


### PR DESCRIPTION
Current lldp.conf.j2 template demands the presence of MGMT_INTERFACE attribute in configDB, and by extension, also in config_db.json file. However, MGMT_INTERFACE configuration attribute is optional, so lldp shouldn't bail out if this one isn't provided in configuration.

For this reason, no lldp.conf file is ever created in lldp container in scenarios where MGMT_INTERFACE is not defined, and lldpd defaults to advertise the mac-address of the connected interface, instead of the interface name.

The fix is to simply relax this jinja2 statement to verify if MGMT_INTERFACE attribute is present.

<-- Before

root@lnos-x1-a-asw02:/# sonic-cfggen -d -t /usr/share/sonic/templates/lldpd.conf.j2 > /etc/lldpd.conf
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 223, in <module>
      main()
  File "/usr/local/bin/sonic-cfggen", line 204, in main
      print template.render(data)
  File
      "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line
      1008,
      in render return self.environment.handle_exception(exc_info, True)
  File
      "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 780, in handle_exception  reraise(exc_type, exc_value, tb)
  File "/usr/share/sonic/templates/lldpd.conf.j2", line 1, in top-level template code
      {% if MGMT_INTERFACE.keys() %}
  File
      "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py",
           line 430, in getattr return getattr(obj, attribute) jinja2.exceptions.UndefinedError: 'MGMT_INTERFACE' is undefined

admin@lnos-x1-a-csw01:~$ show lldp table
Command: sudo lldpshow
Capability codes: (R) Router, (B) Bridge, (O) Other
LocalPort    RemoteDevice     RemotePortID       Capability    RemotePortDescr
-----------  ---------------  -----------------  -----------------------------
Ethernet4    lnos-x1-a-asw02  00:e0:ec:3c:0a:16  BR            Ethernet112
--------------------------------------------------

<-- After

root@lnos-x1-a-asw02:/# sonic-cfggen -d -t /usr/share/sonic/templates/lldpd.conf.j2
...
configure ports Ethernet112 lldp portidsubtype local Eth29/1 description lnos-x1-a-csw01:Ethernet1

admin@lnos-x1-a-csw01:~$ show lldp table
Command: sudo lldpshow
Capability codes: (R) Router, (B) Bridge, (O) Other
LocalPort    RemoteDevice     RemotePortID       Capability    RemotePortDescr
-----------  ---------------  -----------------  -------------------------------------
Ethernet4    lnos-x1-a-asw02  Eth29/1            BR            lnos-x1-a-csw01:Ethernet1
--------------------------------------------------

