### PR TITLE
[config-engine]: Fix 'get_sonic_version_info' API to return valid info

### DIFF
--- a/src/sonic-config-engine/sonic_platform.py
+++ b/src/sonic-config-engine/sonic_platform.py
@@ -33,10 +33,10 @@ def get_platform_info(machine_info):
     return None
 
 def get_sonic_version_info():
-    if not os.path.isfile('/etc/sonic/version.yml'):
+    if not os.path.isfile('/etc/sonic/sonic_version.yml'):
         return None
     data = {}
-    with open('/etc/sonic/version.yml') as stream:
+    with open('/etc/sonic/sonic_version.yml') as stream:
         data = yaml.load(stream)
     return data
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

**- What I did**
Fixed 'get_sonic_version_info' API to return valid info
**- How I did it**
'get_sonic_version_info' API reads info from configuration file, which was renamed, so corrected file  name (from "version.yml" to "sonic_version.yml")
**- How to verify it**
Build an image and run tests
**- Description for the changelog**
Fix 'get_sonic_version_info' API to return valid info
