### PR TITLE
[device/dell] Added dynamic sai.profile generation

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/buffers_defaults_t0.j2
@@ -3,7 +3,7 @@
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
-    {%- for port_idx in range(0,63) %}
+    {%- for port_idx in range(0,64) %}
         {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
     {%- endfor %}
 {%- endmacro %}

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/buffers_defaults_t1.j2
@@ -3,7 +3,7 @@
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
-    {%- for port_idx in range(0,63) %}
+    {%- for port_idx in range(0,64) %}
         {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
     {%- endfor %}
 {%- endmacro %}

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/port_config.ini
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/port_config.ini
@@ -1,65 +1,65 @@
-# name          lanes     alias              index
-Ethernet0       101,102   fortyGigE1/1/1     0
-Ethernet1       103,104   fortyGigE1/1/2     1
-Ethernet2       97,98     fortyGigE1/1/3     2
-Ethernet3       99,100    fortyGigE1/1/4     3
-Ethernet4       69,70     fortyGigE1/1/5     4
-Ethernet5       71,72     fortyGigE1/1/6     5
-Ethernet6       65,66     fortyGigE1/1/7     6
-Ethernet7       67,68     fortyGigE1/1/8     7
-Ethernet8       53,54     fortyGigE1/1/9     8
-Ethernet9       55,56     fortyGigE1/1/10    9
-Ethernet10      49,50     fortyGigE1/1/11    10
-Ethernet11      51,52     fortyGigE1/1/12    11
-Ethernet12      21,22     fortyGigE1/1/13    12
-Ethernet13      23,24     fortyGigE1/1/14    13
-Ethernet14      17,18     fortyGigE1/1/15    14
-Ethernet15      19,20     fortyGigE1/1/16    15
-Ethernet16      25,26     fortyGigE1/2/1     16
-Ethernet17      27,28     fortyGigE1/2/2     17
-Ethernet18      29,30     fortyGigE1/2/3     18
-Ethernet19      31,32     fortyGigE1/2/4     19
-Ethernet20      57,58     fortyGigE1/2/5     20
-Ethernet21      59,60     fortyGigE1/2/6     21
-Ethernet22      61,62     fortyGigE1/2/7     22
-Ethernet23      63,64     fortyGigE1/2/8     23
-Ethernet24      73,74     fortyGigE1/2/9     24
-Ethernet25      75,76     fortyGigE1/2/10    25
-Ethernet26      77,78     fortyGigE1/2/11    26
-Ethernet27      79,80     fortyGigE1/2/12    27
-Ethernet28      105,106   fortyGigE1/2/13    28
-Ethernet29      107,108   fortyGigE1/2/14    29
-Ethernet30      109,110   fortyGigE1/2/15    30
-Ethernet31      111,112   fortyGigE1/2/16    31
-Ethernet32      13,14     fortyGigE1/3/1     32
-Ethernet33      15,16     fortyGigE1/3/2     33
-Ethernet34      9,10      fortyGigE1/3/3     34
-Ethernet35      11,12     fortyGigE1/3/4     35
-Ethernet36      125,126   fortyGigE1/3/5     36
-Ethernet37      127,128   fortyGigE1/3/6     37
-Ethernet38      121,122   fortyGigE1/3/7     38
-Ethernet39      123,124   fortyGigE1/3/8     39
-Ethernet40      93,94     fortyGigE1/3/9     40
-Ethernet41      95,96     fortyGigE1/3/10    41
-Ethernet42      89,90     fortyGigE1/3/11    42
-Ethernet43      91,92     fortyGigE1/3/12    43
-Ethernet44      45,46     fortyGigE1/3/13    44
-Ethernet45      47,48     fortyGigE1/3/14    45
-Ethernet46      41,42     fortyGigE1/3/15    46
-Ethernet47      43,44     fortyGigE1/3/16    47
-Ethernet48      113,114   fortyGigE1/4/1     48
-Ethernet49      115,116   fortyGigE1/4/2     49
-Ethernet50      117,118   fortyGigE1/4/3     50
-Ethernet51      119,120   fortyGigE1/4/4     51
-Ethernet52      1,2       fortyGigE1/4/5     52
-Ethernet53      3,4       fortyGigE1/4/6     53
-Ethernet54      5,6       fortyGigE1/4/7     54
-Ethernet55      7,8       fortyGigE1/4/8     55
-Ethernet56      33,34     fortyGigE1/4/9     56
-Ethernet57      35,36     fortyGigE1/4/10    57
-Ethernet58      37,38     fortyGigE1/4/11    58
-Ethernet59      39,40     fortyGigE1/4/12    59
-Ethernet60      81,82     fortyGigE1/4/13    60
-Ethernet61      83,84     fortyGigE1/4/14    61
-Ethernet62      85,86     fortyGigE1/4/15    62
-Ethernet63      87,88     fortyGigE1/4/16    63
+# name          lanes     alias              index   speed
+Ethernet0       101,102   fortyGigE1/1/1     0       40000
+Ethernet1       103,104   fortyGigE1/1/2     1       40000
+Ethernet2       97,98     fortyGigE1/1/3     2       40000
+Ethernet3       99,100    fortyGigE1/1/4     3       40000
+Ethernet4       69,70     fortyGigE1/1/5     4       40000
+Ethernet5       71,72     fortyGigE1/1/6     5       40000
+Ethernet6       65,66     fortyGigE1/1/7     6       40000
+Ethernet7       67,68     fortyGigE1/1/8     7       40000
+Ethernet8       53,54     fortyGigE1/1/9     8       40000
+Ethernet9       55,56     fortyGigE1/1/10    9       40000
+Ethernet10      49,50     fortyGigE1/1/11    10      40000
+Ethernet11      51,52     fortyGigE1/1/12    11      40000
+Ethernet12      21,22     fortyGigE1/1/13    12      40000
+Ethernet13      23,24     fortyGigE1/1/14    13      40000
+Ethernet14      17,18     fortyGigE1/1/15    14      40000
+Ethernet15      19,20     fortyGigE1/1/16    15      40000
+Ethernet16      25,26     fortyGigE1/2/1     16      40000
+Ethernet17      27,28     fortyGigE1/2/2     17      40000
+Ethernet18      29,30     fortyGigE1/2/3     18      40000
+Ethernet19      31,32     fortyGigE1/2/4     19      40000
+Ethernet20      57,58     fortyGigE1/2/5     20      40000
+Ethernet21      59,60     fortyGigE1/2/6     21      40000
+Ethernet22      61,62     fortyGigE1/2/7     22      40000
+Ethernet23      63,64     fortyGigE1/2/8     23      40000
+Ethernet24      73,74     fortyGigE1/2/9     24      40000
+Ethernet25      75,76     fortyGigE1/2/10    25      40000
+Ethernet26      77,78     fortyGigE1/2/11    26      40000
+Ethernet27      79,80     fortyGigE1/2/12    27      40000
+Ethernet28      105,106   fortyGigE1/2/13    28      40000
+Ethernet29      107,108   fortyGigE1/2/14    29      40000
+Ethernet30      109,110   fortyGigE1/2/15    30      40000
+Ethernet31      111,112   fortyGigE1/2/16    31      40000
+Ethernet32      13,14     fortyGigE1/3/1     32      40000
+Ethernet33      15,16     fortyGigE1/3/2     33      40000
+Ethernet34      9,10      fortyGigE1/3/3     34      40000
+Ethernet35      11,12     fortyGigE1/3/4     35      40000
+Ethernet36      125,126   fortyGigE1/3/5     36      40000
+Ethernet37      127,128   fortyGigE1/3/6     37      40000
+Ethernet38      121,122   fortyGigE1/3/7     38      40000
+Ethernet39      123,124   fortyGigE1/3/8     39      40000
+Ethernet40      93,94     fortyGigE1/3/9     40      40000
+Ethernet41      95,96     fortyGigE1/3/10    41      40000
+Ethernet42      89,90     fortyGigE1/3/11    42      40000
+Ethernet43      91,92     fortyGigE1/3/12    43      40000
+Ethernet44      45,46     fortyGigE1/3/13    44      40000
+Ethernet45      47,48     fortyGigE1/3/14    45      40000
+Ethernet46      41,42     fortyGigE1/3/15    46      40000
+Ethernet47      43,44     fortyGigE1/3/16    47      40000
+Ethernet48      113,114   fortyGigE1/4/1     48      40000
+Ethernet49      115,116   fortyGigE1/4/2     49      40000
+Ethernet50      117,118   fortyGigE1/4/3     50      40000
+Ethernet51      119,120   fortyGigE1/4/4     51      40000
+Ethernet52      1,2       fortyGigE1/4/5     52      40000
+Ethernet53      3,4       fortyGigE1/4/6     53      40000
+Ethernet54      5,6       fortyGigE1/4/7     54      40000
+Ethernet55      7,8       fortyGigE1/4/8     55      40000
+Ethernet56      33,34     fortyGigE1/4/9     56      40000
+Ethernet57      35,36     fortyGigE1/4/10    57      40000
+Ethernet58      37,38     fortyGigE1/4/11    58      40000
+Ethernet59      39,40     fortyGigE1/4/12    59      40000
+Ethernet60      81,82     fortyGigE1/4/13    60      40000
+Ethernet61      83,84     fortyGigE1/4/14    61      40000
+Ethernet62      85,86     fortyGigE1/4/15    62      40000
+Ethernet63      87,88     fortyGigE1/4/16    63      40000

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/sai.profile
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/sai.profile
@@ -1,1 +1,0 @@
-SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t0.config.bcm

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/sai.profile.j2
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/sai.profile.j2
@@ -2,12 +2,12 @@
 {%- if DEVICE_METADATA is defined -%}
 {%-     set switch_role = DEVICE_METADATA['localhost']['type'] -%}
 {%-     if switch_role.lower() == 'torrouter' %}
-{%         set sai_profile_filename = 'SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t0.config.bcm' -%}
+{%         set sai_profile_contents = 'SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t0.config.bcm' -%}
 {%-     else %}
-{%-         set sai_profile_filename = 'SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t1.config.bcm' -%}
+{%-         set sai_profile_contents = 'SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t1.config.bcm' -%}
 {%-     endif %}
 {%- else %}
-{%-     set sai_profile_filename = 'SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t1.config.bcm' -%}
+{%-     set sai_profile_contents = 'SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t1.config.bcm' -%}
 {%- endif %}
 {# Write the contents of sai_ profile_filename to sai.profile file #}
-{{ sai_profile_filename }}
+{{ sai_profile_contents }}

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/sai.profile.j2
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/sai.profile.j2
@@ -1,0 +1,13 @@
+{# Get sai.profile based on switch_role #}
+{%- if DEVICE_METADATA is defined -%}
+{%-     set switch_role = DEVICE_METADATA['localhost']['type'] -%}
+{%-     if switch_role.lower() == 'torrouter' %}
+{%         set sai_profile_filename = 'SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t0.config.bcm' -%}
+{%-     else %}
+{%-         set sai_profile_filename = 'SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t1.config.bcm' -%}
+{%-     endif %}
+{%- else %}
+{%-     set sai_profile_filename = 'SAI_INIT_CONFIG_FILE=/etc/bcm/th-s6100-64x40G-t1.config.bcm' -%}
+{%- endif %}
+{# Write the contents of sai_ profile_filename to sai.profile file #}
+{{ sai_profile_filename }}

--- a/platform/broadcom/docker-syncd-brcm/start.sh
+++ b/platform/broadcom/docker-syncd-brcm/start.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 
 PLATFORM_DIR=/usr/share/sonic/platform
+HWSKU_DIR=/usr/share/sonic/hwsku
 
 rm -f /var/run/rsyslogd.pid
 
+
 supervisorctl start rsyslogd
+
+mkdir -p /etc/sai.d/
+
+# Create/Copy the sai.profile to /etc/sai.d/sai.profile
+if [ -f $HWSKU_DIR/sai.profile.j2 ]; then
+    sonic-cfggen -d -t $HWSKU_DIR/sai.profile.j2 > /etc/sai.d/sai.profile
+else
+    if [ -f $HWSKU_DIR/sai.profile ]; then
+        cp $HWSKU_DIR/sai.profile /etc/sai.d/sai.profile
+    fi
+fi
 
 supervisorctl start syncd
 

--- a/platform/broadcom/docker-syncd-brcm/start.sh
+++ b/platform/broadcom/docker-syncd-brcm/start.sh
@@ -5,7 +5,6 @@ HWSKU_DIR=/usr/share/sonic/hwsku
 
 rm -f /var/run/rsyslogd.pid
 
-
 supervisorctl start rsyslogd
 
 mkdir -p /etc/sai.d/


### PR DESCRIPTION
This commit addds new code for generating dynamic sai.profile file.
The sai.profile.j2 will generate the sai.profile dynamically based on
the topology. It will generate the sai.profile under /etc/sai.d/ directory
in syncd. Before syncd is started this J2 file will be run from the start.sh
file from /usr/bin/ directory. Since the sai.profile is dynamically generated
the old sai.profile file is not required so deleted the file for S6100.
It also address couple of more changes for port_config.ini support is added
for speed in the file which can be used later to find the port speed. Also
the buffer_default_t*.j2 file the ports should be from 0 to 64 changed.

Unit tested the code on S6100 for dynamic generation of sai.profile file for
both T0 and T1 and the file was created in /etc/sai.d/sai.profile
Similarly tested the sonic binary on S6000 to make sure that the sai.profile is
copied from the /usr/share/sonic/hwsku/sai.profile to /etc/sai.d/sai.profile.

Signed-off-by: Harish Venkatraman <Harish_Venkatraman@dell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
