### PR TITLE
Updategraph during NOS->SONiC migration

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -197,6 +197,7 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         mkdir -p /etc/sonic/old_config
         mv /host/migration/minigraph.xml /etc/sonic/old_config/
         touch /tmp/pending_config_migration
+        [ -f /etc/sonic/updategraph.conf ] && sed -i -e "s/enabled=false/enabled=true/g" /etc/sonic/updategraph.conf
     else
         touch /tmp/pending_config_initialization
     fi


### PR DESCRIPTION
**- What I did**

Enable updategraph for NOS->SONiC migration case

**- How I did it**

Enable flag in case of migration
Note : while it is possible to make this change during the build process itself, the change in rc.local is more concise.

**- How to verify it**

Performed a NOS -> SONiC migration and checked that minigraph was loading

**- Description for the changelog**
In case of NOS->SONiC migration, enable updategraph.


**- A picture of a cute animal (not mandatory but encouraged)**
