### PR TITLE
Make Dell S6100 and Z9100 psuutil.py plugins compliant with Python 3.6

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/plugins/psuutil.py
@@ -24,7 +24,7 @@ class PsuUtil(PsuBase):
         retval = 'ERR'
         mb_reg_file = mailbox_dir+'/' + reg_name
         if (not os.path.isfile(mb_reg_file)):
-            print mb_reg_file,  'not found !'
+            logging.error(mb_reg_file, "not found !")
             return retval
 
         try:

--- a/device/dell/x86_64-dell_z9100_c2538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/plugins/psuutil.py
@@ -24,7 +24,7 @@ class PsuUtil(PsuBase):
         retval = 'ERR'
         mb_reg_file = mailbox_dir+'/' + reg_name
         if (not os.path.isfile(mb_reg_file)):
-            print mb_reg_file,  'not found !'
+            logging.error(mb_reg_file, "not found !")
             return retval
 
         try:


### PR DESCRIPTION
Removed non-Python-3.X-compliant `print` statement. Could have replaced with compliant `print()` function, but opted to replace with `logging.error()` function to align with rest of file.

This was causing snmp-subagent to crash when querying PSU status.