### PR TITLE
[device]: fix led_control plugin on Arista 7050-QX32S

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32s/plugins/led_control.py
+++ b/device/arista/x86_64-arista_7050_qx32s/plugins/led_control.py
@@ -81,13 +81,13 @@ class LedControl(LedControlBase):
             f.write("1")
 
         # Initialize all fan LEDs to green
-        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon2/fan1_led", "w") as f:
+        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon4/fan1_led", "w") as f:
             f.write("1")
-        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon2/fan2_led", "w") as f:
+        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon4/fan2_led", "w") as f:
             f.write("1")
-        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon2/fan3_led", "w") as f:
+        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon4/fan3_led", "w") as f:
             f.write("1")
-        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon2/fan4_led", "w") as f:
+        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon4/fan4_led", "w") as f:
             f.write("1")
 
 


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fix led_control plugin on Arista 7050-QX32S

issues:
```
Mar 24 08:51:18.986309 sonic INFO ledd: Loaded module 'led_control'.
Mar 24 08:51:18.986873 sonic INFO supervisord: ledd Traceback (most recent call last):
Mar 24 08:51:18.986873 sonic INFO supervisord: ledd   File "/usr/bin/ledd", line 225, in <module>
Mar 24 08:51:18.986900 sonic INFO supervisord: ledd     main()
Mar 24 08:51:18.987527 sonic INFO pmon.sh[1260]: 2018-03-24 08:51:18,987 INFO success: ledd entered RUNNING state, proc
ess has stayed up for > than 0 seconds (startsecs)
Mar 24 08:51:18.988167 sonic INFO supervisord: ledd   File "/usr/bin/ledd", line 192, in main
Mar 24 08:51:18.988167 sonic INFO supervisord: ledd     err = load_platform_led_control_module()
Mar 24 08:51:18.988167 sonic INFO supervisord: ledd   File "/usr/bin/ledd", line 147, in load_platform_led_control_modu
le
Mar 24 08:51:18.988167 sonic INFO supervisord: ledd     led_control = led_control_class()
Mar 24 08:51:18.988167 sonic INFO supervisord: ledd   File "/usr/share/sonic/platform/plugins/led_control.py", line 84,
 in __init__
Mar 24 08:51:18.988167 sonic INFO supervisord: ledd     with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2
c-3/3-0060/hwmon/hwmon2/fan1_led", "w") as f:
Mar 24 08:51:18.988167 sonic INFO supervisord: ledd IOError: [Errno 2] No such file or directory: '/sys/devices/pci0000
:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon2/fan1_led'
```

**- How I did it**
change hwmon2 to hwmon4, this is likely changed due arista driver update.

**- How to verify it**
Tested on two arista 7050 QX32S box.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
