### PR TITLE
[hostcfgd] Fix a bug that tacacs key is wrongly modified

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -5,6 +5,7 @@ import os
 import sys
 import subprocess
 import syslog
+import copy
 import jinja2
 from swsssdk import ConfigDBConnector
 
@@ -155,15 +156,17 @@ class HostConfigDaemon:
 
     def tacacs_server_handler(self, key, data):
         self.aaacfg.tacacs_server_update(key, data)
-        if data.has_key('passkey'):
-            data['passkey'] = obfuscate(data['passkey'])
-        syslog.syslog(syslog.LOG_DEBUG, 'value for {} changed to {}'.format(key, data))
+        log_data = copy.deepcopy(data)
+        if log_data.has_key('passkey'):
+            log_data['passkey'] = obfuscate(log_data['passkey'])
+        syslog.syslog(syslog.LOG_DEBUG, 'value of {} changed to {}'.format(key, log_data))
 
     def tacacs_global_handler(self, key, data):
         self.aaacfg.tacacs_global_update(key, data)
-        if data.has_key('passkey'):
-            data['passkey'] = obfuscate(data['passkey'])
-        syslog.syslog(syslog.LOG_DEBUG, 'value for {} changed to {}'.format(key, data))
+        log_data = copy.deepcopy(data)
+        if log_data.has_key('passkey'):
+            log_data['passkey'] = obfuscate(log_data['passkey'])
+        syslog.syslog(syslog.LOG_DEBUG, 'value of {} changed to {}'.format(key, log_data))
 
     def start(self):
         self.config_db.subscribe('AAA', lambda table, key, data: self.aaa_handler(key, data))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a bug introduced by #1444 that `/etc/pam.d/common-auth-sonic` will have wrong secret value after `config aaa authentication login tacacs+`.

**- How to verify it**
```
config aaa authentication login tacacs+
config tacacs add 10.0.0.3
config tacacs passkey mysecret
config aaa authentication login local
config aaa authentication login tacacs+
```

Before the fix `/etc/pam.d/common-auth-sonic` will have value `secret=m*****`. After the fix it will have correct value `secret=mysecret`.
