### PR TITLE
[updategraph] Remove pending_initialization flag after first boot

### DIFF
--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -66,12 +66,14 @@ if [ -f /tmp/pending_config_migration ]; then
     exit 0
 fi
 
-if [ -f /tmp/pending_config_initialization ] && [ "$enabled" != "true" ]; then 
-    copy_default_minigraph
-    reload_minigraph
-    sonic-cfggen -d --print-data > /etc/sonic/config_db.json
+if [ -f /tmp/pending_config_initialization ]; then
     rm -f /tmp/pending_config_initialization
-    exit 0
+    if [ "$enabled" != "true" ]; then 
+        copy_default_minigraph
+        reload_minigraph
+        sonic-cfggen -d --print-data > /etc/sonic/config_db.json
+        exit 0
+    fi
 fi
 
 if [ "$enabled" = "reload_only" ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a bug that in certain procedure manual-deployed minigraph could get overwritten by default minigraph.
 
**- How I did it**
To always remove `/tmp/pending_config_initialization` flag no matter if `$enabled=true` (default minigraph copied) or not (minigraph got from DHCP).

**- How to verify it**
1. Do a new installation with an image with `ENABLE_DHCP_GRAPH_SERVICE = y` option (mapped to `$enabled=true` in `/etc/sonic/updategraph.conf`)
1. Boot normally. Use DHCP service to deploy a minigraph A, or default minigraph, or minimal minigraph.
1. Manually copy minigraph B onto device
1. `config load_minigraph`
Under above steps, before fix, minigraph B will be overwritten by default minigraph before loaded into configDB. After fix, minigraph B will be loaded correctly.

