### PR TITLE
[docker-quagga]: Expect some processes to be restarted within 1 second

### DIFF
--- a/dockers/docker-fpm-quagga/supervisord.conf
+++ b/dockers/docker-fpm-quagga/supervisord.conf
@@ -8,6 +8,7 @@ command=/usr/bin/start.sh
 priority=1
 autostart=true
 autorestart=false
+startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -16,6 +17,7 @@ command=/usr/bin/bgpcfgd
 priority=2
 autostart=false
 autorestart=false
+startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -24,6 +26,7 @@ command=/usr/sbin/rsyslogd -n
 priority=3
 autostart=false
 autorestart=false
+startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -32,6 +35,7 @@ command=/usr/lib/quagga/zebra -A 127.0.0.1
 priority=4
 autostart=false
 autorestart=false
+startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -40,6 +44,7 @@ command=/usr/lib/quagga/bgpd -A 127.0.0.1 -F
 priority=5
 autostart=false
 autorestart=false
+startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog
 
@@ -48,5 +53,6 @@ command=fpmsyncd
 priority=6
 autostart=false
 autorestart=false
+startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add supervisor configuration to avoid treat quagga processes crashed when they exited in 1 second.

**- How I did it**
Add startsecs=0 to the supervisor configuration

**- How to verify it**
cat /etc/supervisor/conf.d/supervisor.conf inside of the quagga container

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
