### PR TITLE
[device]: do not export gpio{1,2} if already exist on S6000

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/installer.conf
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/installer.conf
@@ -5,8 +5,8 @@ if [ "$install_env" = "onie" ]; then
 echo "Replace ONIE reboot with Dell reset commands"
 
 # set I2C GPIO mux
-echo 1 > /sys/class/gpio/export
-echo 2 > /sys/class/gpio/export
+[ -d /sys/class/gpio/gpio1 ] || echo 1 > /sys/class/gpio/export
+[ -d /sys/class/gpio/gpio2 ] || echo 2 > /sys/class/gpio/export
 echo out > /sys/class/gpio/gpio1/direction
 echo out > /sys/class/gpio/gpio2/direction
 echo 0 > /sys/class/gpio/gpio1/value


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
do not export gpio{1,2} if already exist on S6000

otherwise, it cause onie installation failure

**- How I did it**

**- How to verify it**
tested on real device.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
