### PR TITLE
[installer]: remove single quotes around the value when create machine.conf

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -455,7 +455,8 @@ if [ "$install_env" = "onie" ]; then
     if [ -f /etc/machine-build.conf ]; then
         # onie_ variable are generate at runtime.
         # they are no longer hardcoded in /etc/machine.conf
-        set | grep ^onie_ > $demo_mnt/machine.conf
+        # also remove single quotes around the value
+        set | grep ^onie | sed -e "s/='/=/" -e "s/'$//" > $demo_mnt/machine.conf
     else
         cp /etc/machine.conf $demo_mnt
     fi


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
remove single quotes around the value when create machine.conf

**- How I did it**

**- How to verify it**
verified by alphanetwork

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
