### PR TITLE
[baseimage]: bring down eth0 before restart networking

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ifdown eth0
+
 sonic-cfggen -d -t /usr/share/sonic/templates/interfaces.j2 > /etc/network/interfaces
 
 [ -f /var/run/dhclient.eth0.pid ] && kill `cat /var/run/dhclient.eth0.pid` && rm -f /var/run/dhclient.eth0.pid


### PR DESCRIPTION
cfggen generates new eth0 configuration. Need to first
clean existing configuration on eth0 before bring up
new configuration on eth0. Thus, we need to first bring
down eth0 before putting new configuration into /etc/network/
interfaces

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
sometimes, we found the dhclient on eth0 is not killed after restarting networking.
 
bring down eth0 before restart networking

**- How I did it**

**- How to verify it**
Tested on real device arista 7060

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
