### PR TITLE
[sudoer] Enable read-only commands for all users

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -37,6 +37,9 @@ Cmnd_Alias      PASSWD_CMDS = /usr/bin/config tacacs passkey *, \
 # User privilege specification
 root    ALL=(ALL:ALL) ALL
 
+# Allow all users to execute read only commands
+ALL     ALL=NOPASSWD: READ_ONLY_CMDS
+
 # Allow members of group sudo to execute any command
 %sudo   ALL=(ALL:ALL) NOPASSWD: ALL
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Normal user can now execute following commands without sudo:
```
/usr/bin/decode-syseeprom
/usr/bin/docker images *
/usr/bin/docker exec -it snmp cat /etc/snmp/snmpd.conf
/usr/bin/docker exec -it bgp cat /etc/quagga/bgpd.conf
/usr/bin/docker ps
/usr/bin/generate_dump
/usr/bin/lldpctl
/usr/bin/lldpshow
/usr/bin/sensors
/usr/bin/sfputil show *
/usr/bin/vtysh -c show *
/bin/cat /var/log/syslog
/usr/bin/tail -f /var/log/syslog
```