### PR TITLE
Revert "Suppress tar xz warning about time stamp in the future, if date is not correctly set"

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -446,11 +446,7 @@ fi
 # Decompress the file for the file system directly to the partition
 unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" -d $demo_mnt/$image_dir
 
-if [ "$install_env" != "build" ]; then
-    TAR_EXTRA_OPTION="--numeric-owner"
-else
-    TAR_EXTRA_OPTION="--numeric-owner --warning=no-timestamp"
-fi
+TAR_EXTRA_OPTION="--numeric-owner"
 mkdir -p $demo_mnt/$image_dir/$DOCKERFS_DIR
 unzip -op $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
 


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#1560