### PR TITLE
[docker-lldpd]: Use eth0 interface only as a source of lldpd SystemID

### DIFF
--- a/dockers/docker-lldp-sv2/supervisord.conf
+++ b/dockers/docker-lldp-sv2/supervisord.conf
@@ -25,7 +25,7 @@ stderr_logfile=syslog
 # - `-dd` means to stay in foreground, log warnings to console
 # - `-ddd` means to stay in foreground, log warnings and info to console
 # - `-dddd` means to stay in foreground, log all to console
-command=/usr/sbin/lldpd -d -I Ethernet*,eth*
+command=/usr/sbin/lldpd -d -I Ethernet*,eth* -C eth0
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add an option for lldpd to use eth0 interface for generation of lldpd SystemID

**- How I did it**
Use option -C for lldpd

**- How to verify it**
Check system id after this command: `lldpcli show chasis`
Check mac address issuing `ip link show dev eth0`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
