### PR TITLE
Fix the issue of ma1 not found in boot0

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -216,8 +216,13 @@ write_boot_configs() {
 
     # Pass the MAC address to the new kernel as a command line parameter. This makes it
     # possible to restore the MAC address in the new kernel without requiring driver modifications.
-    [ "${NETDEV}" ] || NETDEV=ma1
-    echo "hwaddr_${NETDEV}=$(cat /sys/class/net/${NETDEV}/address)" >> /tmp/append
+    if [ -f /sys/class/net/ma1/address ]; then
+        echo "hwaddr_ma1=$(cat /sys/class/net/ma1/address)" >> /tmp/append
+    elif [ -f /sys/class/net/eth0/address ]; then
+        echo "hwaddr_ma1=$(cat /sys/class/net/eth0/address)" >> /tmp/append
+    else
+        echo "ERROR: Management port is not found."
+    fi
 
     # use extra parameters from kernel-params hook if the file exists
     if [ -f "$target_path/$kernel_params" ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
A bug was introduced by the latest change of boot0, i.e., when running boot0 in SONiC, boot0 attempted to read the MAC address of ma1, while actually the desired port is not named as ma1.  This fix will check the existence of ma1 or eth0 before reading the MAC address.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
