### PR TITLE
[snmp] support multiple community strings (proposal 2)

### DIFF
--- a/dockers/docker-snmp-sv2/snmpd.conf.j2
+++ b/dockers/docker-snmp-sv2/snmpd.conf.j2
@@ -43,6 +43,9 @@ view   systemonly  included   .1.3.6.1.2.1.25.1
 
                                                  #  Default access to basic system info
 rocommunity {{ snmp_rocommunity }}
+{% for community in snmp_rocommunities %}
+rocommunity {{ community }}
+{% endfor %}
 
 
 ###############################################################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Old format of `/etc/sonic/snmp.yml`:

```
snmp_rocommunity: secret
snmp_location: public
```

New format which support multiple community strings:

```
snmp_rocommunities: 
  - secret1
  - secret2
  - secret3
snmp_location: public
```

For backward compatibility, old format is still supported.