### PR TITLE
Marvell's updates for SONiC 201803 over SAI v1.2

### DIFF
--- a/platform/marvell/rules.mk
+++ b/platform/marvell/rules.mk
@@ -12,7 +12,7 @@ SONIC_ALL += $(SONIC_ONE_IMAGE) \
              $(DOCKER_SYNCD_MRVL_RPC)
 
 # Inject mrvl sai into sairedis
-$(LIBSAIREDIS)_DEPENDS += $(MRVL_FPA) $(MRVL_SAI) #$(LIBSAITHRIFT_DEV_MRVL)
+$(LIBSAIREDIS)_DEPENDS += $(MRVL_FPA) $(MRVL_SAI) $(LIBSAITHRIFT_DEV_MRVL)
 
 # Runtime dependency on mrvl sai is set only for syncd
 $(SYNCD)_RDEPENDS += $(MRVL_SAI)

--- a/platform/marvell/sai.mk
+++ b/platform/marvell/sai.mk
@@ -1,7 +1,7 @@
 # Marvell SAI
 
-export MRVL_SAI_VERSION = 1.0.1
-export MRVL_SAI_TAG = SONiC.201712
+export MRVL_SAI_VERSION = 1.2.1
+export MRVL_SAI_TAG = SONiC.201803
 export MRVL_SAI = mrvllibsai_$(MRVL_SAI_VERSION).deb
 
 $(MRVL_SAI)_SRC_PATH = $(PLATFORM_PATH)/sai

--- a/platform/marvell/sdk.mk
+++ b/platform/marvell/sdk.mk
@@ -1,7 +1,7 @@
 # Marvell FPA
 
-export MRVL_FPA_VERSION = 1.0.1
-export MRVL_FPA_TAG = SONiC.201712
+export MRVL_FPA_VERSION = 1.2.1
+export MRVL_FPA_TAG = SONiC.201803
 export MRVL_FPA = mrvllibfpa_$(MRVL_FPA_VERSION).deb
 
 $(MRVL_FPA)_SRC_PATH = $(PLATFORM_PATH)/sdk


### PR DESCRIPTION
Updated Marvell's SAI and SDK .mk files to import  Marvell's SAI & SDK v1.2 for SONiC 201803.

* Please integrate these changes to branch 201803 as well.