### PR TITLE
[Broadcom SAI] upgrade Broadcom SAI to version 3.1.3.4-10

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.1.3.4-9_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.4-9_amd64.deb?sv=2015-04-05&sr=b&sig=J2TrGxJuOEKXNPOw%2B00%2BL8LLbAmvg9NQtqb73HPsEUY%3D&se=2031-12-19T21%3A33%3A18Z&sp=r"
+BRCM_SAI = libsaibcm_3.1.3.4-10_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.4-10_amd64.deb?sv=2015-04-05&sr=b&sig=72n19AElVmbqo3ahrEFVBwMgR%2FoQ7fhUj4tcadx8pVE%3D&se=2031-12-20T20%3A27%3A14Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.1.3.4-9_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.1.3.4-10_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.4-9_amd64.deb?sv=2015-04-05&sr=b&sig=mEIYvBBUKIFwUpGvL6%2FOd6c2Wl0jS6rO9ZizOiPu1fA%3D&se=2031-12-19T21%3A32%3A42Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.4-10_amd64.deb?sv=2015-04-05&sr=b&sig=cN4qsWX8XW04ZObBDonwh5Uzgmp5A0iRBkpZA9N5Zb8%3D&se=2031-12-20T20%3A26%3A45Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI) $(BRCM_SAI_DEV)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)

--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.1.3.4-7_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.4-7_amd64.deb?sv=2015-04-05&sr=b&sig=elzOgHCA3G8oKKMfWcbFa%2BvQzAh727mtYJnnVOzVJtY%3D&se=2155-02-07T23%3A37%3A54Z&sp=r"
+BRCM_SAI = libsaibcm_3.1.3.4-9_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.4-9_amd64.deb?sv=2015-04-05&sr=b&sig=J2TrGxJuOEKXNPOw%2B00%2BL8LLbAmvg9NQtqb73HPsEUY%3D&se=2031-12-19T21%3A33%3A18Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.1.3.4-7_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.1.3.4-9_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.4-7_amd64.deb?sv=2015-04-05&sr=b&sig=rysxdbCA%2BaqBgDnxztdRA2ixiME3ypqRvzyEds8hLw4%3D&se=2155-02-07T23%3A38%3A39Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.4-9_amd64.deb?sv=2015-04-05&sr=b&sig=mEIYvBBUKIFwUpGvL6%2FOd6c2Wl0jS6rO9ZizOiPu1fA%3D&se=2031-12-19T21%3A32%3A42Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI) $(BRCM_SAI_DEV)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
**- What I did**
Includes configuration files for following devices:

- Quanta 1X1B-32X
- Dell Z9264F
- Inventec D7054Q28B and D7032Q28B

**- How to verify it**
Build image, installed on DUT, checked all expected files are there.