### PR TITLE
[minigraph]: ignore minigraph ports which are not in port_config.ini

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -439,10 +439,18 @@ def parse_xml(filename, platform=None, port_config_file=None):
     results['PORTCHANNEL_INTERFACE'] = pc_intfs
 
     for port_name in port_speeds:
+        # ignore port not in port_config.ini
+        if not ports.has_key(port_name):
+            continue
+
         ports.setdefault(port_name, {})['speed'] = port_speeds[port_name]
         if port_speeds[port_name] == '100000':
             ports.setdefault(port_name, {})['fec'] = 'rs'
     for port_name in port_descriptions:
+        # ignore port not in port_config.ini
+        if not ports.has_key(port_name):
+            continue
+
         ports.setdefault(port_name, {})['description'] = port_descriptions[port_name]
 
     results['PORT'] = ports

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -228,6 +228,19 @@
           <EnableAutoNegotiation>true</EnableAutoNegotiation>
           <EnableFlowControl>true</EnableFlowControl>
           <Index>1</Index>
+          <InterfaceName>fortyGigE0/1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>10000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
           <InterfaceName>fortyGigE0/4</InterfaceName>
           <InterfaceType i:nil="true"/>
           <MultiPortsInterface>false</MultiPortsInterface>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -153,6 +153,43 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'alias': 'fortyGigE0/12', 'lanes': '33,34,35,36', 'fec': 'rs', 'speed': '100000', 'description': 'Interface description'}")
 
+    def test_minigraph_extra_ethernet_interfaces(self):
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "PORT"'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), \
+                "{'Ethernet8': {'alias': 'fortyGigE0/8', 'lanes': '37,38,39,40', 'description': 'Interface description', 'speed': '40000'}, "
+                "'Ethernet0': {'alias': 'fortyGigE0/0', 'lanes': '29,30,31,32', 'speed': '10000'}, "
+                "'Ethernet4': {'alias': 'fortyGigE0/4', 'lanes': '25,26,27,28', 'speed': '25000'}, "
+                "'Ethernet108': {'alias': 'fortyGigE0/108', 'lanes': '81,82,83,84'}, "
+                "'Ethernet100': {'alias': 'fortyGigE0/100', 'lanes': '125,126,127,128'}, "
+                "'Ethernet104': {'alias': 'fortyGigE0/104', 'lanes': '85,86,87,88'}, "
+                "'Ethernet68': {'alias': 'fortyGigE0/68', 'lanes': '69,70,71,72'}, "
+                "'Ethernet96': {'alias': 'fortyGigE0/96', 'lanes': '121,122,123,124'}, "
+                "'Ethernet124': {'alias': 'fortyGigE0/124', 'lanes': '101,102,103,104'}, "
+                "'Ethernet92': {'alias': 'fortyGigE0/92', 'lanes': '113,114,115,116'}, "
+                "'Ethernet120': {'alias': 'fortyGigE0/120', 'lanes': '97,98,99,100'}, "
+                "'Ethernet52': {'alias': 'fortyGigE0/52', 'lanes': '53,54,55,56'}, "
+                "'Ethernet56': {'alias': 'fortyGigE0/56', 'lanes': '61,62,63,64'}, "
+                "'Ethernet76': {'alias': 'fortyGigE0/76', 'lanes': '73,74,75,76'}, "
+                "'Ethernet72': {'alias': 'fortyGigE0/72', 'lanes': '77,78,79,80'}, "
+                "'Ethernet64': {'alias': 'fortyGigE0/64', 'lanes': '65,66,67,68'}, "
+                "'Ethernet32': {'alias': 'fortyGigE0/32', 'lanes': '9,10,11,12'}, "
+                "'Ethernet16': {'alias': 'fortyGigE0/16', 'lanes': '41,42,43,44'}, "
+                "'Ethernet36': {'alias': 'fortyGigE0/36', 'lanes': '13,14,15,16'}, "
+                "'Ethernet12': {'alias': 'fortyGigE0/12', 'lanes': '33,34,35,36', 'fec': 'rs', 'speed': '100000', 'description': 'Interface description'}, "
+                "'Ethernet88': {'alias': 'fortyGigE0/88', 'lanes': '117,118,119,120'}, "
+                "'Ethernet116': {'alias': 'fortyGigE0/116', 'lanes': '93,94,95,96'}, "
+                "'Ethernet80': {'alias': 'fortyGigE0/80', 'lanes': '105,106,107,108'}, "
+                "'Ethernet112': {'alias': 'fortyGigE0/112', 'lanes': '89,90,91,92'}, "
+                "'Ethernet84': {'alias': 'fortyGigE0/84', 'lanes': '109,110,111,112'}, "
+                "'Ethernet48': {'alias': 'fortyGigE0/48', 'lanes': '49,50,51,52'}, "
+                "'Ethernet44': {'alias': 'fortyGigE0/44', 'lanes': '17,18,19,20'}, "
+                "'Ethernet40': {'alias': 'fortyGigE0/40', 'lanes': '21,22,23,24'}, "
+                "'Ethernet28': {'alias': 'fortyGigE0/28', 'lanes': '1,2,3,4'}, "
+                "'Ethernet60': {'alias': 'fortyGigE0/60', 'lanes': '57,58,59,60'}, "
+                "'Ethernet20': {'alias': 'fortyGigE0/20', 'lanes': '45,46,47,48'}, "
+                "'Ethernet24': {'alias': 'fortyGigE0/24', 'lanes': '5,6,7,8'}}")
+
     def test_metadata_everflow(self):
         argument = '-m "' + self.sample_graph_metadata + '" -p "' + self.port_config + '" -v "MIRROR_SESSION"'
         output = self.run_script(argument)


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
ignore minigraph ports which are not in port_config.ini

**- How I did it**

**- How to verify it**
pass unit tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
