### PR TITLE
[docker-syncd-brcm]: start.sh returns 0 when exit normally

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/start.sh
+++ b/platform/broadcom/docker-syncd-brcm/start.sh
@@ -35,3 +35,5 @@ if [ -r ${PLATFORM_DIR}/led_proc_init.soc ]; then
     wait_syncd
     /usr/bin/bcmcmd -t 60 "rcload ${PLATFORM_DIR}/led_proc_init.soc"
 fi
+
+exit 0


### PR DESCRIPTION
when led_proc_init.soc does not exit, start.sh will return 1.
with this fix, it will return 0 in this case indicating exit normally.

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
start.sh returns 0 when exit normally

**- How I did it**
explicitly add exit 0 for start.sh in syncd

**- How to verify it**
config load_minigraph -y

check the /var/log/supervisor/supervisor.log in syncd docker

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
