### PR TITLE
[SONiC Telemetry]: Fix the problem of ENABLE_SYSTEM_TELEMETRY not taking effect in rules…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            SONIC_BUILD_JOBS=$(SONIC_BUILD_JOBS) \
                            HTTP_PROXY=$(http_proxy) \
                            HTTPS_PROXY=$(https_proxy) \
-                           ENABLE_SYSTEM_TELEMETRY=$(ENABLE_SYSTEM_TELEMETRY)
+                           SONIC_ENABLE_SYSTEM_TELEMETRY=$(ENABLE_SYSTEM_TELEMETRY)
 
 .PHONY: sonic-slave-build sonic-slave-bash init reset
 

--- a/slave.mk
+++ b/slave.mk
@@ -63,6 +63,10 @@ ifeq ($(SONIC_ENABLE_PFCWD_ON_START),y)
 ENABLE_PFCWD_ON_START = y
 endif
 
+ifeq ($(SONIC_ENABLE_SYSTEM_TELEMETRY),y)
+ENABLE_SYSTEM_TELEMETRY = y
+endif
+
 include $(RULES_PATH)/config
 include $(RULES_PATH)/functions
 include $(RULES_PATH)/*.mk


### PR DESCRIPTION
…/config

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**- What I did**
The value of ENABLE_SYSTEM_TELEMETRY  in Makefile overwrites the same ENABLE_SYSTEM_TELEMETRY defined in rules/config.  By default it is empty,  the value specified in rules/config won't take effect. 

Use temporary SONIC_ENABLE_SYSTEM_TELEMETRY to take the value specified at make configure, so value defined in rules/config takes precedence if specified there. 

**- How I did it**
With this patch,  uncomment "ENABLE_SYSTEM_TELEMETRY = y", telemetry docker will be created.
Previously only make command like "make configure  ENABLE_SYSTEM_TELEMETRY=y  PLATFORM=broadcom" worked. 

$ make configure   PLATFORM=broadcom
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "broadcom"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "8"
"SONIC_CONFIG_MAKE_JOBS"          : "8"
"DEFAULT_USERNAME"                : "admin"
"DEFAULT_PASSWORD"                : "admin"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : "y"
"SONIC_CONFIG_DEBUG"              : "y"
"ROUTING_STACK"                   : "quagga"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : "y"


**- How to verify it**
