### PR TITLE
Sorting the information generated by sonic-cfggen for all j2 templates.

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -128,6 +128,12 @@ def deep_update(dst, src):
              dst[key] = value
     return dst
 
+def sort_data(data):
+    for table in data:
+        if type(data[table]) is dict:
+            data[table] = OrderedDict(natsorted(data[table].items()))
+    return data
+
 
 def main():
     parser=argparse.ArgumentParser(description="Render configuration file from minigraph data and jinja2 template.")
@@ -210,8 +216,8 @@ def main():
         for attr in ['ip', 'network', 'prefixlen', 'netmask']:
             env.filters[attr] = partial(prefix_attr, attr)
         template = env.get_template(template_file)
-        print template.render(data)
-    
+        print template.render(sort_data(data))
+
     if args.var != None:
         template = jinja2.Template('{{' + args.var + '}}')
         print template.render(data)

--- a/src/sonic-config-engine/tests/sample_output/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/docker-dhcp-relay.supervisord.conf
@@ -23,7 +23,7 @@ stderr_logfile=syslog
 programs=isc-dhcp-relay-Vlan1000
 
 [program:isc-dhcp-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -i Vlan1000 -i PortChannel02 -i PortChannel03 -i PortChannel04 -i PortChannel01 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -i Vlan1000 -i PortChannel01 -i PortChannel02 -i PortChannel03 -i PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/lldpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/lldpd.conf
@@ -1,6 +1,6 @@
 configure ports eth0 lldp portidsubtype local eth0
-configure ports Ethernet116 lldp portidsubtype local fortyGigE0/116 description ARISTA02T1:Ethernet1/1
-configure ports Ethernet124 lldp portidsubtype local fortyGigE0/124 description ARISTA04T1:Ethernet1/1
 configure ports Ethernet112 lldp portidsubtype local fortyGigE0/112 description ARISTA01T1:Ethernet1/1
+configure ports Ethernet116 lldp portidsubtype local fortyGigE0/116 description ARISTA02T1:Ethernet1/1
 configure ports Ethernet120 lldp portidsubtype local fortyGigE0/120 description ARISTA03T1:Ethernet1/1
+configure ports Ethernet124 lldp portidsubtype local fortyGigE0/124 description ARISTA04T1:Ethernet1/1
 

--- a/src/sonic-config-engine/tests/sample_output/msn27.32ports.json
+++ b/src/sonic-config-engine/tests/sample_output/msn27.32ports.json
@@ -1,38 +1,38 @@
 {
     "CABLE_LENGTH": {
         "AZURE": {
-            "Ethernet8": "300m",
             "Ethernet0": "300m",
             "Ethernet4": "300m",
-            "Ethernet108": "300m",
-            "Ethernet100": "300m",
-            "Ethernet104": "300m",
-            "Ethernet68": "300m",
-            "Ethernet96": "300m",
-            "Ethernet124": "300m",
-            "Ethernet92": "300m",
-            "Ethernet120": "300m",
+            "Ethernet8": "300m",
+            "Ethernet12": "300m",
+            "Ethernet16": "300m",
+            "Ethernet20": "300m",
+            "Ethernet24": "300m",
+            "Ethernet28": "300m",
+            "Ethernet32": "300m",
+            "Ethernet36": "300m",
+            "Ethernet40": "300m",
+            "Ethernet44": "300m",
+            "Ethernet48": "300m",
             "Ethernet52": "300m",
             "Ethernet56": "300m",
-            "Ethernet76": "300m",
-            "Ethernet72": "300m",
-            "Ethernet64": "300m",
-            "Ethernet32": "300m",
-            "Ethernet16": "300m",
-            "Ethernet36": "300m",
-            "Ethernet12": "300m",
-            "Ethernet88": "300m",
-            "Ethernet116": "300m",
-            "Ethernet80": "300m",
-            "Ethernet112": "300m",
-            "Ethernet84": "300m",
-            "Ethernet48": "300m",
-            "Ethernet44": "300m",
-            "Ethernet40": "300m",
-            "Ethernet28": "300m",
             "Ethernet60": "300m",
-            "Ethernet20": "300m",
-            "Ethernet24": "300m"
+            "Ethernet64": "300m",
+            "Ethernet68": "300m",
+            "Ethernet72": "300m",
+            "Ethernet76": "300m",
+            "Ethernet80": "300m",
+            "Ethernet84": "300m",
+            "Ethernet88": "300m",
+            "Ethernet92": "300m",
+            "Ethernet96": "300m",
+            "Ethernet100": "300m",
+            "Ethernet104": "300m",
+            "Ethernet108": "300m",
+            "Ethernet112": "300m",
+            "Ethernet116": "300m",
+            "Ethernet120": "300m",
+            "Ethernet124": "300m"
         }
     },
     "BUFFER_POOL": {
@@ -95,25 +95,25 @@
         }
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-        "Ethernet8,Ethernet0,Ethernet4,Ethernet108,Ethernet100,Ethernet104,Ethernet68,Ethernet96,Ethernet124,Ethernet92,Ethernet120,Ethernet52,Ethernet56,Ethernet76,Ethernet72,Ethernet64,Ethernet32,Ethernet16,Ethernet36,Ethernet12,Ethernet88,Ethernet116,Ethernet80,Ethernet112,Ethernet84,Ethernet48,Ethernet44,Ethernet40,Ethernet28,Ethernet60,Ethernet20,Ethernet24": {
+        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124": {
             "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         }
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-        "Ethernet8,Ethernet0,Ethernet4,Ethernet108,Ethernet100,Ethernet104,Ethernet68,Ethernet96,Ethernet124,Ethernet92,Ethernet120,Ethernet52,Ethernet56,Ethernet76,Ethernet72,Ethernet64,Ethernet32,Ethernet16,Ethernet36,Ethernet12,Ethernet88,Ethernet116,Ethernet80,Ethernet112,Ethernet84,Ethernet48,Ethernet44,Ethernet40,Ethernet28,Ethernet60,Ethernet20,Ethernet24": {
+        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         }
     },
     "BUFFER_PG": {
-        "Ethernet8,Ethernet0,Ethernet4,Ethernet108,Ethernet100,Ethernet104,Ethernet68,Ethernet96,Ethernet124,Ethernet92,Ethernet120,Ethernet52,Ethernet56,Ethernet76,Ethernet72,Ethernet64,Ethernet32,Ethernet16,Ethernet36,Ethernet12,Ethernet88,Ethernet116,Ethernet80,Ethernet112,Ethernet84,Ethernet48,Ethernet44,Ethernet40,Ethernet28,Ethernet60,Ethernet20,Ethernet24|0-1": {
+        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0-1": {
             "profile" : "[BUFFER_PROFILE|pg_lossy_profile]"
         }
     },
     "BUFFER_QUEUE": {
-        "Ethernet8,Ethernet0,Ethernet4,Ethernet108,Ethernet100,Ethernet104,Ethernet68,Ethernet96,Ethernet124,Ethernet92,Ethernet120,Ethernet52,Ethernet56,Ethernet76,Ethernet72,Ethernet64,Ethernet32,Ethernet16,Ethernet36,Ethernet12,Ethernet88,Ethernet116,Ethernet80,Ethernet112,Ethernet84,Ethernet48,Ethernet44,Ethernet40,Ethernet28,Ethernet60,Ethernet20,Ethernet24|3-4": {
+        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4": {
             "profile" : "[BUFFER_PROFILE|q_lossless_profile]"
         },
-        "Ethernet8,Ethernet0,Ethernet4,Ethernet108,Ethernet100,Ethernet104,Ethernet68,Ethernet96,Ethernet124,Ethernet92,Ethernet120,Ethernet52,Ethernet56,Ethernet76,Ethernet72,Ethernet64,Ethernet32,Ethernet16,Ethernet36,Ethernet12,Ethernet88,Ethernet116,Ethernet80,Ethernet112,Ethernet84,Ethernet48,Ethernet44,Ethernet40,Ethernet28,Ethernet60,Ethernet20,Ethernet24|0-1": {
+        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0-1": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         }
     }

--- a/src/sonic-config-engine/tests/sample_output/ports.json
+++ b/src/sonic-config-engine/tests/sample_output/ports.json
@@ -1,12 +1,5 @@
 [
     {
-        "PORT_TABLE:Ethernet8": {
-            "speed": "1000",
-            "description": "Interface description"
-        },
-        "OP": "SET"
-    },
-    {
         "PORT_TABLE:Ethernet0": {
             "speed": "10000",
             "description": ""
@@ -17,6 +10,13 @@
         "PORT_TABLE:Ethernet4": {
             "speed": "25000",
             "description": ""
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet8": {
+            "speed": "1000",
+            "description": "Interface description"
         },
         "OP": "SET"
     },

--- a/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
@@ -32,12 +32,12 @@ function wait_until_iface_ready
 
 # Wait for all interfaces to come up and have IPv4 addresses assigned
 wait_until_iface_ready Vlan1000
-wait_until_iface_ready PortChannel04
+wait_until_iface_ready PortChannel01
+wait_until_iface_ready PortChannel01
+wait_until_iface_ready PortChannel02
 wait_until_iface_ready PortChannel02
 wait_until_iface_ready PortChannel03
 wait_until_iface_ready PortChannel03
-wait_until_iface_ready PortChannel01
-wait_until_iface_ready PortChannel02
 wait_until_iface_ready PortChannel04
-wait_until_iface_ready PortChannel01
+wait_until_iface_ready PortChannel04
 


### PR DESCRIPTION
With this patch all the content of the files generated by "sonic-cfggen -d -t" instructions will now be sorted, which is very useful for operational and troubleshooting purposes. See below a few examples of this behavior. Also, a few sonic-cfggen UT's have been modified to accommodate the new sorted configurations, and thereby, allowing the building process to successfully complete.


```
admin@lnos-x1-a-asw02:~$ sonic-cfggen -d -t /usr/share/sonic/templates/interfaces.j2 | more
…
auto lo
iface lo inet loopback
iface lo inet static
  address 10.10.1.2
  netmask 255.255.255.255
auto eth0
iface eth0 inet dhcp
allow-hotplug Ethernet112
iface Ethernet112 inet static
   mtu 9100
   address 10.1.2.2
   netmask 255.255.255.0
allow-hotplug Ethernet112
iface Ethernet112 inet6 static
  mtu 9100
  address fc00:1:2::2
  netmask 64
allow-hotplug Ethernet116
iface Ethernet116 inet static
   mtu 9100
   address 10.2.2.2
   netmask 255.255.255.0
allow-hotplug Ethernet116
iface Ethernet116 inet6 static
  mtu 9100
  address fc00:2:2::2
  netmask 64
allow-hotplug Ethernet120
iface Ethernet120 inet static
  mtu 9100
  address 10.3.2.2
  netmask 255.255.255.0


root@lnos-x1-a-csw01:/# sonic-cfggen -d -y /etc/sonic/deployment_id_asn_map.yml -t /usr/share/sonic/templates/bgpd.conf.j2
…
router bgp 65100
…
  network 10.10.2.1/32
  neighbor 10.0.0.1 remote-as 65200
  neighbor 10.0.0.1 description ARISTA01T2
  address-family ipv4
    neighbor 10.0.0.1 activate
    maximum-paths 64
  exit-address-family
  neighbor 10.0.0.11 remote-as 65200
  neighbor 10.0.0.11 description ARISTA06T2
  address-family ipv4
    neighbor 10.0.0.11 activate
    maximum-paths 64
  exit-address-family
  neighbor 10.0.0.13 remote-as 65200
  neighbor 10.0.0.13 description ARISTA07T2
  address-family ipv4
    neighbor 10.0.0.13 activate
    maximum-paths 64
  exit-address-family
  neighbor 10.0.0.15 remote-as 65200
  neighbor 10.0.0.15 description ARISTA08T2
  address-family ipv4
    neighbor 10.0.0.15 activate
    maximum-paths 64
  exit-address-family


root@lnos-x1-a-asw02:/# sonic-cfggen -d -t /usr/share/sonic/templates/lldpd.conf.j2
…
configure ports Ethernet4 lldp portidsubtype local Eth2/1 description ixia-card2-port8:Eth1/2/8
configure ports Ethernet112 lldp portidsubtype local Eth29/1 description lnos-x1-a-csw01:Eth29/1
configure ports Ethernet116 lldp portidsubtype local Eth30/1 description lnos-x1-a-csw02:Eth30/1
configure ports Ethernet120 lldp portidsubtype local Eth31/1 description lnos-x1-a-csw03:Eth31/1
configure ports Ethernet124 lldp portidsubtype local Eth32/1 description lnos-x1-a-csw04:Eth32/1


root@lnos-x1-a-asw02:/# sonic-cfggen -d -t /usr/share/sonic/templates/ports.json.j2 | more
[
    {
            "PORT_TABLE:Ethernet0": {
                        "speed": "10000",
                        "description": ""
    },
        "OP": "SET"
    },
    {
            "PORT_TABLE:Ethernet1": {
                        "speed": "10000",
                        "description": ""
    },
        "OP": "SET"
    },
    {
            "PORT_TABLE:Ethernet2": {
                        "speed": "10000",
                        "description": ""
    },
        "OP": "SET"
    },
]
```