### PR TITLE
[ip-in-ip]: Fix config template to apply correct platform depended va…

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -11,7 +11,7 @@
             "tunnel_type":"IPINIP",
             "src_ip":"{{ ipv4_loopback_addresses | first | ip }}",
             "dst_ip":"{% for prefix in ipv4_loopback_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
-{% if onie_switch_asic == "mlnx" %}
+{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "dscp_mode":"uniform",
             "ecn_mode":"standard",
 {% else %}


### PR DESCRIPTION
…lues

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

**- What I did**
Fixed IP-in-IP config template to apply correct platform depended values.
**- How I did it**
Changed way to check platform type in "ipinip.json.j2" file because current is not working any more due to changes in config engine.
In order to check the platform and apply appropriate config need to use  "DEVICE_METADATA.localhost.platform" variable.
**- How to verify it**
Execute IP-in-IP (decap) ansible test.
**- Description for the changelog**
Fix IP-in-IP config template to apply correct platform depended values