### PR TITLE
[tacacs] User with priv_lvl 0 should not be in docker group

### DIFF
--- a/src/tacacs/nss/0001-Modify-user-map-profile.patch
+++ b/src/tacacs/nss/0001-Modify-user-map-profile.patch
@@ -564,9 +564,9 @@ index 79e62b9..ecfa0b0 100644
 +    useradd_info_t *user;
 +
 +    user = &useradd_grp_list[MIN_TACACS_USER_PRIV];
-+    user->gid = 999;
++    user->gid = 100;
 +    user->info = strdup("remote_user");
-+    user->secondary_grp = strdup("docker");
++    user->secondary_grp = strdup("users");
 +    user->shell = strdup("/bin/bash");
 +
 +    user = &useradd_grp_list[MAX_TACACS_USER_PRIV];


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Current default users with minimal priv_lv are created in docker group (999), which grants them full access within the docker. This commit moves them into users group (100) instead.

**- How to verify it**
Create a user with priv_lv 0 on TACACS server and use this user account to login onto sonic device. This user should not have full access to dockers.
