### PR TITLE
Fix build by fixing pyangbind version

### DIFF
--- a/src/sonic-config-engine/setup.py
+++ b/src/sonic-config-engine/setup.py
@@ -17,6 +17,6 @@ setup(name='sonic-config-engine',
       url='https://github.com/Azure/sonic-buildimage',
       py_modules=['portconfig', 'minigraph', 'openconfig_acl', 'sonic_platform'],
       scripts=['sonic-cfggen'],
-      install_requires=['lxml', 'jinja2', 'netaddr', 'ipaddr', 'pyyaml', 'pyangbind'],
+      install_requires=['lxml', 'jinja2', 'netaddr', 'ipaddr', 'pyyaml', 'pyangbind==0.6.0'],
       test_suite='setup.get_test_suite',
      )


### PR DESCRIPTION
The root cause is new version of pyangbind 'Switch to using regex instead of re'
https://github.com/robshakir/pyangbind/commit/4a23ea61a1ccb869084a979aa58c3c872e268e9d#diff-b4ef698db8ca845e5845c4618278f29a

And then regex is a source package needing compilation during installing. In bootstrap environment, there is no gcc available.

The temporary solution is fixing on previous pyangbind.


