### PR TITLE
[radvd] Ensure at least one interface is specified in radvd.conf before starting radvd

### DIFF
--- a/dockers/docker-router-advertiser/start.sh
+++ b/dockers/docker-router-advertiser/start.sh
@@ -15,7 +15,7 @@ fi
 sonic-cfggen -d -t /usr/share/sonic/templates/radvd.conf.j2 > /etc/radvd.conf
 
 # Enusre at least one interface is specified in radvd.conf
-NUM_IFACES=$(grep -c "^interface" /etc/radvd.conf)
+NUM_IFACES=$(grep -c "^interface " /etc/radvd.conf)
 if [ $NUM_IFACES -eq 0 ]; then
     echo "No interfaces specified in radvd.conf. Not starting router advertiser process."
     exit 0

--- a/dockers/docker-router-advertiser/start.sh
+++ b/dockers/docker-router-advertiser/start.sh
@@ -14,5 +14,12 @@ fi
 # Generate /etc/radvd.conf config file
 sonic-cfggen -d -t /usr/share/sonic/templates/radvd.conf.j2 > /etc/radvd.conf
 
+# Enusre at least one interface is specified in radvd.conf
+NUM_IFACES=$(grep -c "^interface" /etc/radvd.conf)
+if [ $NUM_IFACES -eq 0 ]; then
+    echo "No interfaces specified in radvd.conf. Not starting router advertiser process."
+    exit 0
+fi
+
 # Start the router advertiser
 supervisorctl start radvd


### PR DESCRIPTION
If radvd is started with no interfaces specified in radvd.conf, radvd will exit with code 1.

We now count the number of interfaces specified in the generated radvd.conf. If there are none, we exit without starting radvd.