### PR TITLE
[docker-lldpd]: Various fixes

### DIFF
--- a/dockers/docker-lldp-sv2/lldpd.conf.j2
+++ b/dockers/docker-lldp-sv2/lldpd.conf.j2
@@ -1,6 +1,3 @@
 {% if MGMT_INTERFACE %}
 configure ports eth0 lldp portidsubtype local {{ MGMT_INTERFACE.keys()[0][0] }}
 {% endif %}
-{% for local_port in DEVICE_NEIGHBOR %}
-configure ports {{ local_port }} lldp portidsubtype local {{ PORT[local_port]['alias'] }} description {{ DEVICE_NEIGHBOR[local_port]['name'] }}:{{ DEVICE_NEIGHBOR[local_port]['port'] }}
-{% endfor %}

--- a/dockers/docker-lldp-sv2/lldpmgrd
+++ b/dockers/docker-lldp-sv2/lldpmgrd
@@ -20,6 +20,7 @@ try:
     import subprocess
     import sys
     import syslog
+    import os.path
     from swsscommon import swsscommon
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
@@ -70,6 +71,19 @@ def signal_handler(sig, frame):
     else:
         log_warning("Caught unhandled signal '" + sig + "'")
 
+# ========================== Helpers ==================================
+
+def is_port_up(port_name):
+    filename = "/sys/class/net/%s/operstate" % port_name
+    if not os.path.exists(filename):
+        return False
+
+    with open(filename) as fp:
+        state = fp.read()
+        if 'up' in state:
+            return True
+        else:
+            return False
 
 # ============================== Classes ==============================
 
@@ -159,6 +173,11 @@ class LldpManager(object):
         to_delete = []
 
         for (port_name, cmd) in self.pending_cmds.iteritems():
+            if not is_port_up(port_name):
+                # it doesn't make any sense to configure lldpd if the target port is unavailable
+                # let's postpone the command for the next iteration
+                continue
+
             log_debug("Running command: '{}'".format(cmd))
 
             proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/dockers/docker-lldp-sv2/start.sh
+++ b/dockers/docker-lldp-sv2/start.sh
@@ -6,6 +6,7 @@ mkdir -p /var/sonic
 echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status
 
 rm -f /var/run/rsyslogd.pid
+rm -f /var/run/lldpd.socket
 
 supervisorctl start rsyslogd
 supervisorctl start lldpd

--- a/dockers/docker-lldp-sv2/start.sh
+++ b/dockers/docker-lldp-sv2/start.sh
@@ -12,3 +12,26 @@ supervisorctl start rsyslogd
 supervisorctl start lldpd
 supervisorctl start lldp-syncd
 supervisorctl start lldpmgrd
+
+# Current lldpd version has a bug.
+# When lldpd starts it is in the pause state by default
+# But then it execute 'lldpcli resume' to configure and unpause itself.
+# When lldpd execute lldpcli, it doesn't check the return code
+# Sometimes lldpcli returns failure, but lldpd doesn't catch it
+# and keeps working paused and unconfigured
+#
+# The fix below addresses the issue.
+#
+
+# wait until lldpd started
+until [[ -e /var/run/lldpd.socket ]];
+do
+    sleep 1;
+done
+
+# Manually try to resume lldpd, until it's successful
+while /bin/true;
+do
+    lldpcli -u /var/run/lldpd.socket -c /etc/lldpd.conf -c /etc/lldpd.d resume > /dev/null && break
+    sleep 1
+done

--- a/src/sonic-config-engine/tests/sample_output/lldpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/lldpd.conf
@@ -1,1 +1,2 @@
 configure ports eth0 lldp portidsubtype local eth0
+

--- a/src/sonic-config-engine/tests/sample_output/lldpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/lldpd.conf
@@ -1,6 +1,1 @@
 configure ports eth0 lldp portidsubtype local eth0
-configure ports Ethernet112 lldp portidsubtype local fortyGigE0/112 description ARISTA01T1:Ethernet1/1
-configure ports Ethernet116 lldp portidsubtype local fortyGigE0/116 description ARISTA02T1:Ethernet1/1
-configure ports Ethernet120 lldp portidsubtype local fortyGigE0/120 description ARISTA03T1:Ethernet1/1
-configure ports Ethernet124 lldp portidsubtype local fortyGigE0/124 description ARISTA04T1:Ethernet1/1
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Removed default lldpd configuration for the front panel ports. We configure the ports by lldpmgr
2. Fix lldpmgr. It will not try to configure ports, which aren't exist yet, or not in running state. Otherwise lldpd will send us errors
3. Remove old lldpd.socket file on the start. Otherwise lldpd would be confused
4. Add a quick fix for lldpd bug. When lldpd starts it is in the pause state by default. But then it execute 'lldpcli resume' to configure and unpause itself. When lldpd execute lldpcli, it doesn't check the return code. Sometimes lldpcli returns failure, but lldpd doesn't catch that and keeps working paused and not configured.

**- How I did it**
1. Remove configuration from .j2 template
2. Add a function which check port status using Linux sysfs
3. Add 'rm' command into start.sh file
4. Wait until /var/run/lldpd.socket is created and run `lldpcli resume` command.

**- How to verify it**
Apply fixes to the container manually and reboot the box. Check /var/log/syslog. You'll see reduced numbers of error messages.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
