### PR TITLE
Keep updategraph service active after start

### DIFF
--- a/files/image_config/updategraph/updategraph.service
+++ b/files/image_config/updategraph/updategraph.service
@@ -7,6 +7,7 @@ Requires=database.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/updategraph
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**- What I did**
Added option to keep `updategraph `service active after start. It was observed that whenever a sonic service (`bgp, swss etc that depends on updategraph service`) is restarted, it also triggers a restart of `updategraph `service. This resulted in "_dependency_" failures during `config load_minigraph.` 

```
....
Running command: service swss restart
Running command: service bgp restart
A dependency job for bgp.service failed. See 'journalctl -xn' for details.
```


**- How I did it**
Modified `updategraph.service `script

**- How to verify it**
Execute` config load_minigraph` and verify the status of `updategraph `service using `systemctl status updategraph`. It must be _active_ as shown below:


```
updategraph.service - Update minigraph and set configuration based on minigraph
   Loaded: loaded (/etc/systemd/system/updategraph.service; enabled)
   Active: **active (exited)** since Thu 2018-04-26 21:04:59 UTC; 18min ago
  Process: 19302 ExecStart=/usr/bin/updategraph (code=exited, status=0/SUCCESS)
 Main PID: 19302 (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/updategraph.service

Apr 26 21:04:59 str-a7060cx-acs-1 updategraph[19302]: Disabled in updategraph.conf. Skipping graph update.
Apr 26 21:04:59 str-a7060cx-acs-1 systemd[1]: Started Update minigraph and set configuration based on minigraph.
```




**- Description for the changelog**
NA

**- A picture of a cute animal (not mandatory but encouraged)**
