### PR TITLE
[minigraph.py] Mirror table might be wrongly parsed as ctrlplane acl

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -216,6 +216,8 @@ def parse_dpg(dpg, hname):
                 acls[aclname] = {'policy_desc': aclname,
                                  'ports': acl_intfs,
                                  'type': 'MIRROR' if is_mirror else 'L3'}
+            elif is_mirror:
+                acls[aclname] = {'policy_desc': aclname, 'type': 'MIRROR'}
             else:
                 # This ACL has no interfaces to attach to -- consider this a control plane ACL
                 try:


### PR DESCRIPTION
…ane table

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When running on a machine without `port_config.ini`, minigraph parsed might wrongly parse a mirror table as ctrlplane table. Though this won't have practical impact on switches, it might cause issue in testing/verification environment. This commit fix this issue.

**- How to verify it**
On a non-sonic Linux machine, install sonic-config-engine and try to parse a minigraph with ERSPAN AclInterface. Without this commit, it will be wrongly parsed as `'type': 'CTRLPLANE'`; with this fix, it will be correctly parse as `'type': 'MIRROR'`.
