### PR TITLE
Remove snmpd hw_fsys module, remove disk monitoring which is not in use

### DIFF
--- a/dockers/docker-snmp-sv2/snmpd.conf.j2
+++ b/dockers/docker-snmp-sv2/snmpd.conf.j2
@@ -60,14 +60,6 @@ sysServices    72
 #  Note that this table will be empty if there are no "proc" entries in the snmpd.conf file
 
 
-#
-#  Disk Monitoring
-#
-                               # 10MBs required on root disk, 5% free on /var, 10% free on all other disks
-disk       /     10000
-disk       /var  5%
-includeAllDisks  10%
-
 #  Walk the UCD-SNMP-MIB::dskTable to see the resulting output
 #  Note that this table will be empty if there are no "disk" entries in the snmpd.conf file
 

--- a/dockers/docker-snmp-sv2/supervisord.conf
+++ b/dockers/docker-snmp-sv2/supervisord.conf
@@ -29,7 +29,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:snmpd]
-command=/usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw -p /run/snmpd.pid
+command=/usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw,hw_fsys -p /run/snmpd.pid
 priority=4
 autostart=false
 autorestart=false


### PR DESCRIPTION
**- What I did**
  - Remove snmpd hw_fsys module
  - Remove disk monitoring in snmpd conf which are not in use

**- How I did it**

**- How to verify it**
Test on specific platform for 2 hours, which previous log these errors every 10 min

```
May  1 02:11:31.696348 sonic ERR snmpd[34]: Cannot statfs /root/host: Permission denied
May  1 02:11:31.696795 sonic ERR snmpd[34]: Cannot statfs /root/dev: Permission denied
May  1 02:11:31.697109 sonic ERR snmpd[34]: Cannot statfs /root/dev/pts: Permission denied
```

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**
