### PR TITLE
Revert "Remove snmpd hw_fsys module, remove disk monitoring which is not in use"

### DIFF
--- a/dockers/docker-snmp-sv2/snmpd.conf.j2
+++ b/dockers/docker-snmp-sv2/snmpd.conf.j2
@@ -60,6 +60,14 @@ sysServices    72
 #  Note that this table will be empty if there are no "proc" entries in the snmpd.conf file
 
 
+#
+#  Disk Monitoring
+#
+                               # 10MBs required on root disk, 5% free on /var, 10% free on all other disks
+disk       /     10000
+disk       /var  5%
+includeAllDisks  10%
+
 #  Walk the UCD-SNMP-MIB::dskTable to see the resulting output
 #  Note that this table will be empty if there are no "disk" entries in the snmpd.conf file
 

--- a/dockers/docker-snmp-sv2/supervisord.conf
+++ b/dockers/docker-snmp-sv2/supervisord.conf
@@ -29,7 +29,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:snmpd]
-command=/usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw,hw_fsys -p /run/snmpd.pid
+command=/usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw -p /run/snmpd.pid
 priority=4
 autostart=false
 autorestart=false


### PR DESCRIPTION
We found snmpd crash issue.
```
May  1 22:50:26.212948 sonic INFO kernel: [ 6981.102992] snmpd[19908]: segfault at 48 ip 00007fd78683f33c sp 00007ffc179e9a68 error 4 in libnetsnmpmibs.so.30.0.3[7fd7867b7000+13f000] 
```