### PR TITLE
[swss]: Change the hash seed to 0 for ToR and 10 for Leaf routers

### DIFF
--- a/dockers/docker-orchagent/switch.json.j2
+++ b/dockers/docker-orchagent/switch.json.j2
@@ -1,10 +1,11 @@
+{# the range of hash_seed is 0-15 #}
 {# set default hash seed to 0 #}
 {% set hash_seed = 0 %}
 {% if DEVICE_METADATA.localhost.type %}
 {% if DEVICE_METADATA.localhost.type == "ToRRouter" %}
-{% set hash_seed = 10 %}
+{% set hash_seed = 0 %}
 {% elif DEVICE_METADATA.localhost.type == "LeafRouter" %}
-{% set hash_seed = 20 %}
+{% set hash_seed = 10 %}
 {% endif %}
 {% endif %}
 [


### PR DESCRIPTION
Due to some ASIC platform limitations, the hash seed range is from 0
to 15. Thus the switch.json.j2 template is updated so that ToRRouter
is using hash seed 0 and LeafRouter is using hash seed 10.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>