### PR TITLE
Stop spamming logs with statfs permission denied log message

### DIFF
--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -23,6 +23,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-source -x net-snmp_$(SNMPD_VERSION_FULL).dsc
 
 	pushd net-snmp-$(SNMPD_VERSION)
+	patch -p0 < ../statfs_error.patch
 	fakeroot debian/rules -j$(SONIC_CONFIG_MAKE_JOBS) binary
 	popd
 

--- a/src/snmpd/statfs_error.patch
+++ b/src/snmpd/statfs_error.patch
@@ -1,0 +1,22 @@
+--- agent/mibgroup/hardware/fsys/fsys_mntctl.c.old	2018-04-30 23:26:58.097636453 +0000
++++ agent/mibgroup/hardware/fsys/fsys_mntctl.c	2018-04-30 23:27:36.189499479 +0000
+@@ -163,8 +163,6 @@
+             continue;
+ 
+         if ( statfs( entry->path, &stat_buf ) < 0 ) {
+-            snprintf( tmpbuf, sizeof(tmpbuf), "Cannot statfs %s", entry->path );
+-            snmp_log_perror( tmpbuf );
+             continue;
+         }
+         entry->units =  stat_buf.f_bsize;
+--- agent/mibgroup/hardware/fsys/fsys_mntent.c.old	2018-04-30 23:26:54.569649140 +0000
++++ agent/mibgroup/hardware/fsys/fsys_mntent.c	2018-04-30 23:27:22.001550497 +0000
+@@ -238,8 +238,6 @@
+         if ( NSFS_STATFS( entry->path, &stat_buf ) < 0 )
+ #endif
+         {
+-            snprintf( tmpbuf, sizeof(tmpbuf), "Cannot statfs %s", entry->path );
+-            snmp_log_perror( tmpbuf );
+             continue;
+         }
+         entry->units =  stat_buf.NSFS_SIZE;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Create a patch removing 'statfs' spam from snmpd

**- How I did it**
Removing couple lines manually.

**- How to verify it**
Build snmpd with the changes and test it

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
