### PR TITLE
[broadcom]: update broadcom SAI to 3.1.3.4-11

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.1.3.4-10_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.4-10_amd64.deb?sv=2015-04-05&sr=b&sig=72n19AElVmbqo3ahrEFVBwMgR%2FoQ7fhUj4tcadx8pVE%3D&se=2031-12-20T20%3A27%3A14Z&sp=r"
+BRCM_SAI = libsaibcm_3.1.3.4-11_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.4-11_amd64.deb?sv=2015-04-05&sr=b&sig=0pctCvAKfSqT8O%2FWSMxw532XAXFsxXdKljQqWfOX8xA%3D&se=2155-03-25T07%3A23%3A41Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.1.3.4-10_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.1.3.4-11_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.4-10_amd64.deb?sv=2015-04-05&sr=b&sig=cN4qsWX8XW04ZObBDonwh5Uzgmp5A0iRBkpZA9N5Zb8%3D&se=2031-12-20T20%3A26%3A45Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.4-11_amd64.deb?sv=2015-04-05&sr=b&sig=IO1g%2FdcObkureizN8ZMPqISP6opZXu%2FrHostog6aIrU%3D&se=2155-03-25T08%3A13%3A34Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI) $(BRCM_SAI_DEV)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
Provide better ECMP load-balancing via hash seed

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
