### PR TITLE
[slave.mk] Define SPACE variable such that the line doesn't end in whitespace

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -12,8 +12,8 @@ GUID = $(shell id -g)
 
 .SECONDEXPANSION:
 
-SPACE :=
-SPACE +=
+NULL :=
+SPACE := $(NULL) $(NULL)
 
 ###############################################################################
 ## General definitions


### PR DESCRIPTION
Previous definition of `SPACE` required the line to end in whitespace, which was removed in PR https://github.com/Azure/sonic-buildimage/pull/1526. Surprisingly, this did not seem to affect the build, but I figured it would be best to redefine it in a way that didn't require ending a line with whitespace for posterity's sake.