### PR TITLE
[ledd] Exit with code 0 if we fail to find a platform-specific led_control module; no autorestart

### DIFF
--- a/dockers/docker-platform-monitor/supervisord.conf
+++ b/dockers/docker-platform-monitor/supervisord.conf
@@ -41,6 +41,7 @@ stderr_logfile=syslog
 command=/usr/bin/ledd
 priority=5
 autostart=false
+autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=0


### PR DESCRIPTION
Prevent infinite restarts/exits of ledd on platforms which don't utilize it. This also prevents syslog spam.