### PR TITLE
Revert "[minigraph parser]  Fix minigraph parser issue when handling LAG related ACL table configuration"

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -149,15 +149,12 @@ def parse_dpg(dpg, hname):
         pcintfs = child.find(str(QName(ns, "PortChannelInterfaces")))
         pc_intfs = []
         pcs = {}
-        intfs_inpc = [] # List to hold all the LAG member interfaces 
         for pcintf in pcintfs.findall(str(QName(ns, "PortChannel"))):
             pcintfname = pcintf.find(str(QName(ns, "Name"))).text
             pcintfmbr = pcintf.find(str(QName(ns, "AttachTo"))).text
             pcmbr_list = pcintfmbr.split(';')
-            pc_intfs.append(pcintfname)
             for i, member in enumerate(pcmbr_list):
                 pcmbr_list[i] = port_alias_map.get(member, member)
-                intfs_inpc.append(pcmbr_list[i])
             if pcintf.find(str(QName(ns, "Fallback"))) != None:
                 pcs[pcintfname] = {'members': pcmbr_list, 'fallback': pcintf.find(str(QName(ns, "Fallback"))).text}
             else:
@@ -205,26 +202,15 @@ def parse_dpg(dpg, hname):
             for member in aclattach:
                 member = member.strip()
                 if pcs.has_key(member):
-                    # If try to attach ACL to a LAG interface then we shall add the LAG to
-                    # to acl_intfs directly instead of break it into member ports, ACL attach
-                    # to LAG will be applied to all the LAG members internally by SAI/SDK
-                    acl_intfs.append(member)
+                    acl_intfs.extend(pcs[member]['members'])  # For ACL attaching to port channels, we break them into port channel members
                 elif vlans.has_key(member):
                     print >> sys.stderr, "Warning: ACL " + aclname + " is attached to a Vlan interface, which is currently not supported"
                 elif port_alias_map.has_key(member):
                     acl_intfs.append(port_alias_map[member])
-                    # Give a warning if trying to attach ACL to a LAG member interface, correct way is to attach ACL to the LAG interface
-                    if port_alias_map[member] in intfs_inpc:
-                        print >> sys.stderr, "Warning: ACL " + aclname + " is attached to a LAG member interface " + port_alias_map[member] + ", instead of LAG interface"
                 elif member.lower() == 'erspan':
                     is_mirror = True;
-                    # Erspan session will be attached to all front panel ports,
-                    # if panel ports is a member port of LAG, should add the LAG 
-                    # to acl table instead of the panel ports
-                    acl_intfs = pc_intfs
-                    for panel_port in port_alias_map.values():
-                        if panel_port not in intfs_inpc:
-                            acl_intfs.append(panel_port)
+                    # Erspan session will be attached to all front panel ports
+                    acl_intfs = port_alias_map.values()
                     break;
             if acl_intfs:
                 acls[aclname] = {'policy_desc': aclname,

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -81,7 +81,7 @@ class TestCfgGen(TestCase):
         self.assertEqual(output.strip(), "Warning: Ignoring Control Plane ACL NTP_ACL without type\n"
                                          "{'SSH_ACL': {'services': ['SSH'], 'type': 'CTRLPLANE', 'policy_desc': 'SSH_ACL'},"
                                          " 'SNMP_ACL': {'services': ['SNMP'], 'type': 'CTRLPLANE', 'policy_desc': 'SNMP_ACL'},"
-                                         " 'DATAACL': {'type': 'L3', 'policy_desc': 'DATAACL', 'ports': ['PortChannel01', 'PortChannel02', 'PortChannel03', 'PortChannel04']},"
+                                         " 'DATAACL': {'type': 'L3', 'policy_desc': 'DATAACL', 'ports': ['Ethernet112', 'Ethernet116', 'Ethernet120', 'Ethernet124']},"
                                          " 'NTP_ACL': {'services': ['NTP'], 'type': 'CTRLPLANE', 'policy_desc': 'NTP_ACL'},"
                                          " 'ROUTER_PROTECT': {'services': ['SSH', 'SNMP'], 'type': 'CTRLPLANE', 'policy_desc': 'ROUTER_PROTECT'}}")
 


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#1609