### PR TITLE
Disable DAD for eth0 explicitly

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -301,6 +301,7 @@ set /files/etc/sysctl.conf/net.ipv6.conf.eth0.forwarding 0
 
 set /files/etc/sysctl.conf/net.ipv6.conf.default.accept_dad 0
 set /files/etc/sysctl.conf/net.ipv6.conf.all.accept_dad 0
+set /files/etc/sysctl.conf/net.ipv6.conf.eth0.accept_dad 0
 
 set /files/etc/sysctl.conf/net.ipv6.conf.eth0.accept_ra_defrtr 0
 


### PR DESCRIPTION
**- What I did**
Disable IPv6 DAD for eth0 interface. Observed that sometimes DAD failed and resulted in failing to bring up eth0 interface.

```
ifup eth0
    Waiting for DAD... Timed out
    Failed to bring up eth0.
```

The current configuration to disable DAD 

**- How I did it**
Added option to `sysctl.conf` in build_debian script

**- How to verify it**
Check the following:

```
cat /etc/sysctl.d/99-sysctl.conf
    net.ipv6.conf.default.accept_dad = 0
    net.ipv6.conf.all.accept_dad = 0
    net.ipv6.conf.eth0.accept_dad = 0

cat /proc/sys/net/ipv6/conf/eth0/accept_dad
    0
```

Load the image and execute ifdown/ifup. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
