### PR TITLE
[dhcp_relay] Only attempt to start 'isc-dhcp-relay' group if it is not empty

### DIFF
--- a/dockers/docker-dhcp-relay/start.sh
+++ b/dockers/docker-dhcp-relay/start.sh
@@ -6,13 +6,16 @@ rm -f /var/run/rsyslogd.pid
 # Start rsyslog
 supervisorctl start rsyslogd
 
-# Wait for all interfaces to come up and be assigned IPv4 addresses before
-# starting the DHCP relay agent(s). If an interface the relay should listen
-# on is down, the relay agent will not start. If an interface the relay should
-# listen on is up but does not have an IP address assigned when the relay
-# agent starts, it will not listen or send on that interface for the lifetime
-# of the process.
-/usr/bin/wait_for_intf.sh
+# If our supervisor config has entries in the "isc-dhcp-relay" group...
+if [ $(supervisorctl status | grep -c "^isc-dhcp-relay:") -gt 0 ]; then
+    # Wait for all interfaces to come up and be assigned IPv4 addresses before
+    # starting the DHCP relay agent(s). If an interface the relay should listen
+    # on is down, the relay agent will not start. If an interface the relay
+    # should listen on is up but does not have an IP address assigned when the
+    # relay agent starts, it will not listen or send on that interface for the
+    # lifetime of the process.
+    /usr/bin/wait_for_intf.sh
 
-# Start the DHCP relay agent(s)
-supervisorctl start isc-dhcp-relay:*
+    # Start all DHCP relay agent(s)
+    supervisorctl start isc-dhcp-relay:*
+fi


### PR DESCRIPTION
DHCP relay is only expected to run on T0 devices. On T1 devices, the "isc-dhcp-relay" group in the supervisor config file will not get populated. When Docker container is started, calling `supervisorctl start isc-dhcp-relay:*` with no entries in the "isc-dhcp-relay" group will generate an error message to the syslog (`INFO supervisord: start.sh isc-dhcp-relay: ERROR (no such group)`). This PR prevents us from receiving this erroneous error message.