### PR TITLE
Moving get_routing_stack() to a centralized location to avoid code dups

### DIFF
--- a/src/sonic-config-engine/sonic_platform.py
+++ b/src/sonic-config-engine/sonic_platform.py
@@ -53,6 +53,11 @@ def get_system_mac():
         mac = mac[:-2] + aligned_last_byte
     return mac
 
+#
+# Function to obtain the routing-stack being utilized. Function is not
+# platform-specific; it's being placed in this file temporarily till a more
+# suitable location is identified as part of upcoming refactoring efforts.
+#
 def get_system_routing_stack():
     command = "sudo docker ps | grep bgp | awk '{print$2}' | cut -d'-' -f3 | cut -d':' -f1"
 

--- a/src/sonic-config-engine/sonic_platform.py
+++ b/src/sonic-config-engine/sonic_platform.py
@@ -44,7 +44,7 @@ def get_system_mac():
     proc = subprocess.Popen("ip link show eth0 | grep ether | awk '{print $2}'", shell=True, stdout=subprocess.PIPE)
     (mac, err) = proc.communicate()
     mac = mac.strip()
-    
+
     # Align last byte of MAC if necessary
     version_info = get_sonic_version_info()
     if version_info and (version_info['asic_type'] == 'mellanox' or version_info['asic_type'] == 'centec'):
@@ -53,3 +53,19 @@ def get_system_mac():
         mac = mac[:-2] + aligned_last_byte
     return mac
 
+def get_system_routing_stack():
+    command = "sudo docker ps | grep bgp | awk '{print$2}' | cut -d'-' -f3 | cut -d':' -f1"
+
+    try:
+        proc = subprocess.Popen(command,
+                                stdout=subprocess.PIPE,
+                                shell=True,
+                                stderr=subprocess.STDOUT)
+        stdout = proc.communicate()[0]
+        proc.wait()
+        result = stdout.rstrip('\n')
+
+    except OSError, e:
+        raise OSError("Cannot detect routing-stack")
+
+    return result


### PR DESCRIPTION

Moving get_routing_stack() to a centralized location to avoid code duplication.

Various areas of sonic-utilities are now demanding this functionality so i'm simply moving this routing to a centralized location. After spending some time debating about the ideal location for this function, we thought about sonic-config-engine/sonic_platform.py as the closest match.

Functional tests' output will be provided as part of the equivalent PR to be submitted shortly within sonic-utilities repo.
