### PR TITLE
[vs]: add teamd test on vs platform

### DIFF
--- a/platform/vs/tests/conftest.py
+++ b/platform/vs/tests/conftest.py
@@ -220,6 +220,7 @@ class DockerVirtualSwitch(object):
         tar = tarfile.open(fileobj=tarstr, mode="w")
         tar.add(filename, os.path.basename(filename))
         tar.close()
+        self.ctn.exec_run("mkdir -p %s" % path)
         self.ctn.put_archive(path, tarstr.getvalue())
         tarstr.close()
 

--- a/platform/vs/tests/teamd/files/po01.conf
+++ b/platform/vs/tests/teamd/files/po01.conf
@@ -1,0 +1,14 @@
+{
+    "device": "PortChannel0001",
+    "hwaddr": "ec:f4:bb:fe:80:90",
+    "runner": {
+        "name": "loadbalance",
+        "tx_hash": ["eth", "ipv4", "ipv6"]
+    },
+    "link_watch": {
+        "name": "ethtool"
+    },
+    "ports": {
+        "Ethernet112": {}
+    }
+}

--- a/platform/vs/tests/teamd/test_portchannel.py
+++ b/platform/vs/tests/teamd/test_portchannel.py
@@ -1,0 +1,37 @@
+from swsscommon import swsscommon
+import time
+import re
+import json
+
+def test_PortChannel(dvs):
+
+    dvs.copy_file("/etc/teamd/", "teamd/files/po01.conf")
+    dvs.runcmd("teamd -f /etc/teamd/po01.conf -d")
+    dvs.runcmd("ifconfig PortChannel0001 up")
+
+    time.sleep(1)
+
+    # test lag table in app db
+    appdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+
+    tbl = swsscommon.Table(appdb, "LAG_TABLE")
+
+    (status, fvs) = tbl.get("PortChannel0001")
+
+    assert status == True
+
+    # test lag member table in app db
+    tbl = swsscommon.Table(appdb, "LAG_MEMBER_TABLE")
+
+    (status, fvs) = tbl.get("PortChannel0001:Ethernet112")
+
+    assert status == True
+
+    # test lag table in state db
+    confdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
+
+    tbl = swsscommon.Table(confdb, "LAG_TABLE")
+
+    (status, fvs) = tbl.get("PortChannel0001")
+
+    assert status == True


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
add teamd test on vs platform

**- How I did it**

**- How to verify it**
```
lgh@gulv-vm1:/data/sonic/sonic-buildimage/platform/vs/tests$ sudo py.test -v
================================================= test session starts =================================================
platform linux2 -- Python 2.7.12, pytest-3.3.1, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /data/sonic/sonic-buildimage/platform/vs/tests, inifile:
collected 2 items                                                                                                     

bgp/test_invalid_nexthop.py::test_InvalidNexthop PASSED                                                         [ 50%]
teamd/test_portchannel.py::test_PortChannel PASSED                                                              [100%]

============================================== 2 passed in 73.64 seconds ==============================================
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
