### PR TITLE
Define SAI_HEADER_DIR for saithrift compilation to avoid headers installation

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -31,6 +31,7 @@ PROJECT_ROOT = $(shell pwd)
 CONFIGURED_PLATFORM := $(shell [ -f .platform ] && cat .platform || echo generic)
 PLATFORM_PATH = platform/$(CONFIGURED_PLATFORM)
 export BUILD_NUMBER
+export SAI_HEADER_DIR = $(PROJECT_ROOT)/$(SRC_PATH)/sonic-sairedis/SAI/inc
 
 ###############################################################################
 ## Utility rules


### PR DESCRIPTION
Signed-off-by: Nadiya Stetskovych <Nadiya.Stetskovych@cavium.com>

**- What I did**
Define SAI_HEADER_DIR for saithrift
to build thrift for the currently used SAI version
https://github.com/opencomputeproject/SAI/blob/949cec8a15e926239e78c92a8e57c49c9f0e3874/test/saithrift/Makefile#L3
**- How I did it**
export variable to a sub-make
**- How to verify it**
build libsaithrift-dev_1.2.1_amd64.deb  without SAI headers prior installed
**- Description for the changelog**
define sai header dir
**- A picture of a cute animal (not mandatory but encouraged)**
./\.../\
(.'•..•'.)
  =*=﻿
