### PR TITLE
Update sample graph for unit test against minigraph misconfig leaking into config_db.json

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -447,7 +447,6 @@ def parse_xml(filename, platform=None, port_config_file=None):
 
     results['INTERFACE'] = phyport_intfs
     results['VLAN_INTERFACE'] = vlan_intfs
-    results['PORTCHANNEL_INTERFACE'] = pc_intfs
 
     for port_name in port_speeds_default:
         # ignore port not in port_config.ini
@@ -482,6 +481,14 @@ def parse_xml(filename, platform=None, port_config_file=None):
             del pcs[pc_name]
 
     results['PORTCHANNEL'] = pcs
+
+
+    for pc_intf in pc_intfs.keys():
+        # remove portchannels not in PORTCHANNEL dictionary
+        if pc_intf[0] not in pcs:
+            del pc_intfs[pc_intf]
+
+    results['PORTCHANNEL_INTERFACE'] = pc_intfs
 
     results['VLAN'] = vlans
     results['VLAN_MEMBER'] = vlan_members

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -493,7 +493,13 @@ def parse_xml(filename, platform=None, port_config_file=None):
     results['VLAN'] = vlans
     results['VLAN_MEMBER'] = vlan_members
 
+    for nghbr in neighbors.keys():
+        # remove port not in port_config.ini
+        if nghbr not in ports:
+            del neighbors[nghbr]
+
     results['DEVICE_NEIGHBOR'] = neighbors
+
     results['DEVICE_NEIGHBOR_METADATA'] = { key:devices[key] for key in devices if key.lower() != hostname.lower() }
     results['SYSLOG_SERVER'] = dict((item, {}) for item in syslog_servers)
     results['DHCP_SERVER'] = dict((item, {}) for item in dhcp_servers)

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -474,7 +474,15 @@ def parse_xml(filename, platform=None, port_config_file=None):
         ports.setdefault(port_name, {})['description'] = port_descriptions[port_name]
 
     results['PORT'] = ports
+
+    port_set = set(ports.keys())
+    for (pc_name, mbr_map) in pcs.items():
+        # remove portchannels that contain ports not existing in port_config.ini
+        if not set(mbr_map['members']).issubset(port_set):
+            del pcs[pc_name]
+
     results['PORTCHANNEL'] = pcs
+
     results['VLAN'] = vlans
     results['VLAN_MEMBER'] = vlan_members
 

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -154,6 +154,16 @@
         </IPInterface>
         <IPInterface>
           <Name i:nil="true"/>
+          <AttachTo>PortChannel1001</AttachTo>
+          <Prefix>10.0.0.57/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel1001</AttachTo>
+          <Prefix>FC00::72/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
           <AttachTo>fortyGigE0/0</AttachTo>
           <Prefix>10.0.0.58/31</Prefix>
         </IPInterface>

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -213,9 +213,20 @@
         <AutoNegotiation>true</AutoNegotiation>
         <Bandwidth>10000</Bandwidth>
         <EndDevice>switch-t0</EndDevice>
-        <EndPort>Ethernet2</EndPort>
+        <EndPort>Ethernet1</EndPort>
         <FlowControl>true</FlowControl>
         <StartDevice>ARISTA05T1</StartDevice>
+        <StartPort>Ethernet1/32</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <AutoNegotiation>true</AutoNegotiation>
+        <Bandwidth>10000</Bandwidth>
+        <EndDevice>switch-t0</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ARISTA06T1</StartDevice>
         <StartPort>Ethernet1/33</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -125,6 +125,11 @@
           <AttachTo>fortyGigE0/4</AttachTo>
           <SubInterface/>
         </PortChannel>
+        <PortChannel>
+          <Name>PortChannel1001</Name>
+          <AttachTo>Ethernet1;Ethernet2</AttachTo>
+          <SubInterface/>
+        </PortChannel>
       </PortChannelInterfaces>
       <VlanInterfaces>
         <VlanInterface>
@@ -240,7 +245,20 @@
           <EnableAutoNegotiation>true</EnableAutoNegotiation>
           <EnableFlowControl>true</EnableFlowControl>
           <Index>1</Index>
-          <InterfaceName>fortyGigE0/1</InterfaceName>
+          <InterfaceName>Ethernet1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>10000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet2</InterfaceName>
           <InterfaceType i:nil="true"/>
           <MultiPortsInterface>false</MultiPortsInterface>
           <PortName>0</PortName>

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -208,6 +208,17 @@
         <StartPort>fortyGigE0/8</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <AutoNegotiation>true</AutoNegotiation>
+        <Bandwidth>10000</Bandwidth>
+        <EndDevice>switch-t0</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ARISTA05T1</StartDevice>
+        <StartPort>Ethernet1/33</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="ToRRouter">

--- a/src/sonic-config-engine/tests/t0-sample-graph.xml
+++ b/src/sonic-config-engine/tests/t0-sample-graph.xml
@@ -338,6 +338,15 @@
         <StartDevice>switch-t0</StartDevice>
         <StartPort>fortyGigE0/124</StartPort>
       </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>switch-t0</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>ARISTA05T1</StartDevice>
+        <StartPort>Ethernet1/33</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="ToRRouter">

--- a/src/sonic-config-engine/tests/t0-sample-graph.xml
+++ b/src/sonic-config-engine/tests/t0-sample-graph.xml
@@ -340,6 +340,8 @@
       </DeviceLinkBase>
       <DeviceLinkBase>
         <ElementType>DeviceInterfaceLink</ElementType>
+        <AutoNegotiation>true</AutoNegotiation>
+        <Bandwidth>10000</Bandwidth>
         <EndDevice>switch-t0</EndDevice>
         <EndPort>Ethernet2</EndPort>
         <FlowControl>true</FlowControl>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -130,6 +130,15 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'name': 'ARISTA04T1', 'port': 'Ethernet1/1'}")
 
+    def test_minigraph_extra_neighbors(self):
+        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v DEVICE_NEIGHBOR'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), \
+                "{'Ethernet116': {'name': 'ARISTA02T1', 'port': 'Ethernet1/1'}, "
+                "'Ethernet124': {'name': 'ARISTA04T1', 'port': 'Ethernet1/1'}, "
+                "'Ethernet112': {'name': 'ARISTA01T1', 'port': 'Ethernet1/1'}, "
+                "'Ethernet120': {'name': 'ARISTA03T1', 'port': 'Ethernet1/1'}}")
+
     def test_minigraph_bgp(self):
         argument = '-m "' + self.sample_graph_bgp_speaker + '" -p "' + self.port_config + '" -v "BGP_NEIGHBOR[\'10.0.0.59\']"'
         output = self.run_script(argument)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

1. Update test cases to consider misconfig in minigraph.xml
* PortChannelInterfaces that can leak into PORTCHANNEL in config_db.json
* EthernetInterface that can leak into PORT in config_db.json
* portchannel IPInterface that can leak into PORTCHANNEL_INTERFACE in config_db.json
* DeviceInterfaceLinks that can leak into DEVICE_NEIGHBOR and PORT in config_db.json

2. Add one test case to assert that DEVICE_NEIGHBOR does not have non-port_config.ini port

3. Disallow non-port_config.ini port to get into PORT list even if it has non-zero Bandwidth attribute in DeviceInterfaceLink

4. remove non-port_config.ini port from PORTCHANNEL, PORTCHANNEL_INTERFACE, and DEVICE_NEIGHBOR

**- How I did it**

**- How to verify it**

1. pytest tests/test_cfggen.py

2. load minigraph.py on DUT and confirm that config_db.json generated from a misconfig minigraph.xml does not have the false config.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
