### PR TITLE
Sample graph master

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -414,7 +414,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
             (port_speeds_default, port_descriptions) = parse_deviceinfo(child, hwsku)
 
     current_device = [devices[key] for key in devices if key.lower() == hostname.lower()][0]
-    results = {}    
+    results = {}
     results['DEVICE_METADATA'] = {'localhost': {
         'bgp_asn': bgp_asn,
         'deployment_id': deployment_id,
@@ -456,9 +456,10 @@ def parse_xml(filename, platform=None, port_config_file=None):
         ports.setdefault(port_name, {})['speed'] = port_speeds_default[port_name]
 
     for port_name in port_speed_png:
-        # if port_name is not in port_config.ini, still consider it.
-        # and later swss will pick up and behave on-demand port break-up.
-        # if on-deman port break-up is not supported on a specific platform, swss will return error.
+        # not consider port not in port_config.ini
+        if port_name not in ports:
+            continue
+
         ports.setdefault(port_name, {})['speed'] = port_speed_png[port_name]
 
     for port_name, port in ports.items():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

1. Update test cases to consider misconfig in minigraph.xml
* PortChannelInterfaces that can leak into PORTCHANNEL in config_db.json
* EthernetInterface that can leak into PORT in config_db.json
* portchannel IPInterface that can leak into PORTCHANNEL_INTERFACE in config_db.json
* DeviceInterfaceLinks that can leak into DEVICE_NEIGHBOR and PORT in config_db.json

2. Add one test case to assert that DEVICE_NEIGHBOR does not have non-port_config.ini port

3. Disallow non-port_config.ini port to get into PORT list even if it has non-zero Bandwidth attribute in DeviceInterfaceLink

4. remove non-port_config.ini port from PORTCHANNEL, PORTCHANNEL_INTERFACE, and DEVICE_NEIGHBOR

**- How I did it**

**- How to verify it**

1. pytest tests/test_cfggen.py

2. load minigraph.py on DUT and confirm that config_db.json generated from a misconfig minigraph.xml does not have the false config.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
