### PR TITLE
[docker-fpm-frr]: Fix build with frr used for routing stack

### DIFF
--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -1,26 +1,31 @@
 FROM docker-config-engine
 
-## Make apt-get non-interactive
+# Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Update apt's cache of available packages
 RUN apt-get update
 
+# Install required packages
 RUN apt-get install -y libdbus-1-3 libdaemon0 libjansson4 libc-ares2 iproute
 
-COPY \
-{% for deb in docker_fpm_frr_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
-
-RUN dpkg -i \
-{% for deb in docker_fpm_frr_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
+{% if docker_fpm_frr_debs.strip() -%}
+# Copy locally-built Debian package dependencies
+{%- for deb in docker_fpm_frr_debs.split(' ') %}
+COPY debs/{{ deb }} /debs/
 {%- endfor %}
 
-## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+# Install locally-built Debian packages and implicitly install their dependencies
+{%- for deb in docker_fpm_frr_debs.split(' ') %}
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt /debs/{{ deb }}
+{%- endfor %}
+{%- endif %}
+
+# Clean up
+RUN apt-get clean -y
+RUN apt-get autoclean -y
+RUN apt-get autoremove -y
+RUN rm -rf /debs ~/.cache
 
 COPY ["*.j2", "/usr/share/sonic/templates/"]
 COPY ["start.sh", "config.sh", "/usr/bin/"]


### PR DESCRIPTION
After commit 832be7b8f4c3 ("[dockers] Prevent apt-get from installing
suggested and recommended packages by default (#1666)") SONiC fails
to build when FRR is used for routing stack (e.g. SONIC_ROUTING_STACK
is set to frr in rules/config).

To fix issue just replicate changes from docker-fpm-quagga to
docker-fpm-frr to make dependencies installed correctly after above
change to package installing behaviour.

Signed-off-by: Sergey Popovich <sergey.popovich@ordnance.co>

