### PR TITLE
Remove fan LED initialization from led_control plugins for Arista 7050-QX32, 7050-QX-32S

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/plugins/led_control.py
+++ b/device/arista/x86_64-arista_7050_qx32/plugins/led_control.py
@@ -85,16 +85,6 @@ class LedControl(LedControlBase):
         with open("/sys/class/leds/psu2/brightness", "w") as f:
             f.write("1")
 
-        # Initialize all fan LEDs to green
-        with open("/sys/devices/platform/sb800-fans/hwmon/hwmon1/fan1_led", "w") as f:
-            f.write("3")
-        with open("/sys/devices/platform/sb800-fans/hwmon/hwmon1/fan2_led", "w") as f:
-            f.write("3")
-        with open("/sys/devices/platform/sb800-fans/hwmon/hwmon1/fan3_led", "w") as f:
-            f.write("3")
-        with open("/sys/devices/platform/sb800-fans/hwmon/hwmon1/fan4_led", "w") as f:
-            f.write("3")
-
         # Initialize: Turn all front panel QSFP LEDs off
         for qsfp_index in range(self.QSFP_BREAKOUT_START_IDX, self.QSFP_BREAKOUT_END_IDX + 1):
             for lane in range(1, 5):

--- a/device/arista/x86_64-arista_7050_qx32s/plugins/led_control.py
+++ b/device/arista/x86_64-arista_7050_qx32s/plugins/led_control.py
@@ -80,17 +80,6 @@ class LedControl(LedControlBase):
         with open("/sys/class/leds/psu2/brightness", "w") as f:
             f.write("1")
 
-        # Initialize all fan LEDs to green
-        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon4/fan1_led", "w") as f:
-            f.write("1")
-        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon4/fan2_led", "w") as f:
-            f.write("1")
-        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon4/fan3_led", "w") as f:
-            f.write("1")
-        with open("/sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/i2c-3/3-0060/hwmon/hwmon4/fan4_led", "w") as f:
-            f.write("1")
-
-
         # Initialize: Turn all front panel QSFP LEDs off
         for qsfp_index in range(self.QSFP_BREAKOUT_START_IDX, self.QSFP_BREAKOUT_END_IDX + 1):
             for lane in range(1, 5):


### PR DESCRIPTION
In https://github.com/aristanetworks/sonic/commit/6e35bf5af108df6130fdd61218f04ec355939e35, the mapping of color values changed for the 7050-QX, causing the values in led_control.py to set the LEDs to yellow/orange rather than green as they had previously. However, also in this commit, Arista also began initializing the fan LEDs to green rather than off, as they had previously. Therefore, there is no longer a need to initialize the fan LEDs to green in led_control.py.

Similar changes were implemented for the 7050-QX-32-S here: https://github.com/aristanetworks/sonic/commit/561f785021fc9b56d1b7f1873a66c3dba6774064, however there was no remapping of colors, so these devices were not impacted. I am also removing the fan LED initialization for the SKU because it is now also redundant. #