### PR TITLE
[console] use fixed console baud rate

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -128,6 +128,19 @@ process_reboot_cause() {
     echo "Unexpected reboot" > $REBOOT_CAUSE_FILE
 }
 
+program_console_speed()
+{
+    speed=$(cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d "," -f2)
+    if [ -z "$speed" ]; then
+        CONSOLE_SPEED=9600
+    else
+        CONSOLE_SPEED=$speed
+    fi
+
+    sed -i "s|\-\-keep\-baud .* %I| $CONSOLE_SPEED %I|g" /lib/systemd/system/serial-getty@.service
+    systemctl daemon-reload
+}
+
 #### Begin Main Body ####
 
 # Set up previous and next reboot cause files
@@ -208,6 +221,8 @@ if [ ! -e /host/machine.conf ]; then
 fi
 
 . /host/machine.conf
+
+program_console_speed
 
 if [ -f $FIRST_BOOT_FILE ]; then
 


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
When CONSOLE_SPEED is defined in <device>/installer.conf, use the defined
speed. Otherwise, use 9600.

**- How I did it**
Check installer.conf at each boot up time and set baudrate accordingly.

**- How to verify it**
Tested on my dut with following scenarios:
1. Without installer.conf: the console baudrate is fixed to 9600 after boot up.
2. With installer.conf specifying a baudrate: the console baudrate is set to the expected value after boot up.
3. Editing the baudrate in installer.conf in device folder to a different value. reboot the dut and the baudrate changes accordingly.