### PR TITLE
[caclmgrd] Translation of ACL Control Plane rules into iptables comman…

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -88,6 +88,32 @@ class ControlPlaneAclManager(object):
             if proc.returncode != 0:
                 log_error("Error running command '{}'".format(cmd))
 
+    def parse_int_to_tcp_flags(self, hex_value):
+        tcp_flags_str = ""
+        if hex_value & 0x01:
+            tcp_flags_str += "FIN,"
+        if hex_value & 0x02:
+            tcp_flags_str += "SYN,"
+        if hex_value & 0x04:
+            tcp_flags_str += "RST,"
+        if hex_value & 0x08:
+            tcp_flags_str += "PSH,"
+        if hex_value & 0x10:
+            tcp_flags_str += "ACK,"
+        if hex_value & 0x20:
+            tcp_flags_str += "URG,"
+        # iptables doesn't handle the flags below now. It has some special keys for it:
+        #   --ecn-tcp-cwr   This matches if the TCP ECN CWR (Congestion Window Received) bit is set.
+        #   --ecn-tcp-ece   This matches if the TCP ECN ECE (ECN Echo) bit is set.
+        # if hex_value & 0x40:
+        #     tcp_flags_str += "ECE,"
+        # if hex_value & 0x80:
+        #     tcp_flags_str += "CWR,"
+
+        # Delete the trailing comma
+        tcp_flags_str = tcp_flags_str[:-1]
+        return tcp_flags_str
+
     def get_acl_rules_and_translate_to_iptables_commands(self):
         """
         Retrieves current ACL tables and rules from Config DB, translates
@@ -162,32 +188,15 @@ class ControlPlaneAclManager(object):
 
                             rule_cmd += " --dport {}".format(dst_port)
 
-                            # If there are TCP flags present, append them
-                            if "TCP_FLAGS" in rule_props and rule_props["TCP_FLAGS"]:
-                                tcp_flags = int(rule_props["TCP_FLAGS"], 16)
+                            # If there are TCP flags present and ip protocol is TCP, append them
+                            if ip_protocol == "tcp" and "TCP_FLAGS" in rule_props and rule_props["TCP_FLAGS"]:
+                                tcp_flags, tcp_flags_mask = rule_props["TCP_FLAGS"].split("/")
 
-                                if tcp_flags > 0:
-                                    rule_cmd += " --tcp-flags "
+                                tcp_flags = int(tcp_flags, 16)
+                                tcp_flags_mask = int(tcp_flags_mask, 16)
 
-                                    if tcp_flags & 0x01:
-                                        rule_cmd += "FIN,"
-                                    if tcp_flags & 0x02:
-                                        rule_cmd += "SYN,"
-                                    if tcp_flags & 0x04:
-                                        rule_cmd += "RST,"
-                                    if tcp_flags & 0x08:
-                                        rule_cmd += "PSH,"
-                                    if tcp_flags & 0x10:
-                                        rule_cmd += "ACK,"
-                                    if tcp_flags & 0x20:
-                                        rule_cmd += "URG,"
-                                    if tcp_flags & 0x40:
-                                        rule_cmd += "ECE,"
-                                    if tcp_flags & 0x80:
-                                        rule_cmd += "CWR,"
-
-                                    # Delete the trailing comma
-                                    rule_cmd = rule_cmd[:-1]
+                                if tcp_flags_mask > 0:
+                                    rule_cmd += " --tcp-flags {mask} {flags}".format(mask = self.parse_int_to_tcp_flags(tcp_flags_mask), flags =  self.parse_int_to_tcp_flags(tcp_flags))
 
                             # Append the packet action as the jump target
                             rule_cmd += " -j {}".format(rule_props["PACKET_ACTION"])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
*The problem*
ACL control plane rules were not being translated into iptables rules
The config_db.json fragment with ACL configuration:
```json
    "ACL_TABLE": {
        "TEST_ACL_TABLE": {
            "policy_desc": "Forward/Drop/Redirect Traffic",
            "type": "CTRLPLANE",
            "services": [
                "SNMP"
            ],
            "ports": [
                "Ethernet101",
                "Ethernet102",
                "Ethernet103",
                "Ethernet104"
            ]
        }
    }, 
    "ACL_RULE": {
        "TEST_ACL_TABLE|DROP_ON_ETH101": {
            "PRIORITY": "1011",
            "SRC_IP": "10.1.1.2/32",
            "DST_IP": "10.2.2.2/32",
            "ETHER_TYPE": "0x0800",
            "TCP_FLAGS": "0x30/0xFF",
            "IP_TYPE": "IP",
            "PACKET_ACTION": "DROP"
        }
    }, 
```

**- How I did it**
*The causes*
1. There were no check if the ip protocol is "tcp" before adding --tcp-flags argument into iptables command
1. It is necessary to set both mask and flags fields with --tcp-flags argument. But there were no parsing of the mask field from configuration db.

**- How to verify it**
1. Add the fragment above into config_db.json and apply new configuration
1. Check if ACL rules are created:
    ```
    admin@sonic:~$ acl-loader show rule
    Rule ID         Rule Name       Priority    Action    Match
    --------------  --------------  ----------  --------  --------------------
    TEST_ACL_TABLE  DROP_ON_ETH101  1011        DROP      DST_IP: 10.2.2.2/32
                                                          ETHER_TYPE: 0x0800
                                                          IP_TYPE: IP
                                                          SRC_IP: 10.1.1.2/32
                                                          TCP_FLAGS: 0x30/0xFF
    admin@sonic:~$ acl-loader show table
    Name            Type       Binding    Description
    --------------  ---------  ---------  -----------------------------
    TEST_ACL_TABLE  CTRLPLANE  SNMP       Forward/Drop/Redirect Traffic
    ```
1. Check if ACL rules are translated into iptables
    ```
    admin@sonic:~$ sudo iptables -L
    Chain INPUT (policy ACCEPT)
    target     prot opt source               destination         
    DROP       tcp  --  10.1.1.2             anywhere             tcp dpt:snmp flags:FIN,SYN,RST,PSH,ACK,URG/ACK,URG
    DROP       udp  --  10.1.1.2             anywhere             udp dpt:snmp
    
    Chain FORWARD (policy ACCEPT)
    target     prot opt source               destination         
    
    Chain OUTPUT (policy ACCEPT)
    target     prot opt source               destination    
    ```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Translation of ACL Control Plane rules into iptables commands fixed


**- A picture of a cute animal (not mandatory but encouraged)**
```
  __________
 / ___  ___ \
/ / @ \/ @ \ \
\ \___/\___/ /\
 \____\/____/||
 /     /\\\\\//
|     |\\\\\\
 \      \\\\\\
   \______/\\\\
    _||_||_
```