### PR TITLE
Tag the newly built docker as remote latest and push to the remote registry

### DIFF
--- a/push_docker.sh
+++ b/push_docker.sh
@@ -20,11 +20,13 @@ remote_image_name=$REGISTRY_SERVER:$REGISTRY_PORT/$docker_image_name:$DOCKER_IMA
 timestamp="$(date -u +%Y%m%d)"
 build_version="${timestamp}.bld-${BUILD_NUMBER}"
 build_remote_image_name=$REGISTRY_SERVER:$REGISTRY_PORT/$docker_image_name:$build_version
+remote_image_name_latest=$REGISTRY_SERVER:$REGISTRY_PORT/$docker_image_name:latest
 
 ## Add registry information as tag, so will push as latest
 ## Add additional tag with build information
 docker tag $docker_image_name $remote_image_name
 docker tag $docker_image_name $build_remote_image_name
+docker tag $docker_image_name $remote_image_name_latest
 
 ## Login the docker image registry server
 ## Note: user name and password are passed from command line
@@ -39,4 +41,6 @@ echo "Image sha256: $image_sha"
 echo "Pushing $build_remote_image_name"
 docker push $build_remote_image_name
 docker rmi $build_remote_image_name || true
+docker push $remote_image_name_latest
+docker rmi $remote_image_name_latest || true
 docker rmi $docker_image_name || true


### PR DESCRIPTION
<image>
Signed-off-by: Wenda <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Tag latest is not updated with images push to the remote registry. This causes the ptf host to always perceive its local ptf docker image, if present, to be up to date when creating the ptf docker container.

To address this, add tag remote latest to the docker image and push to the remote registry to update

**- How I did it**

Change push_docker.sh

**- How to verify it**
Not fully, but manually tried

docker image tag <remote/image>:latest
docker image push <remote/image>:latest
docker image pull <remote/image>

on ptf host against internal registry. It updates the tag latest on remote registry.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
