### PR TITLE
[docker_image_ctl]: Add --force while removing obsolete dockers

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -52,7 +52,7 @@ start() {
 
         # docker created with a different HWSKU, remove and recreate
         echo "Removing obsolete {{docker_container_name}} container with HWSKU $DOCKERMOUNT"
-        docker rm {{docker_container_name}}
+        docker rm -f {{docker_container_name}}
     fi
 
 {%- if docker_container_name == "database" %}


### PR DESCRIPTION
```
You cannot remove a running container 4018a005a31e951cf5062d82e568ed2704bd82b6089e72327ecaeadfc3101b12. Stop the container before attempting removal or use -f"

```