### PR TITLE
Fix a bug that default graph might be missing when generating minimal config

### DIFF
--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -106,6 +106,9 @@ if [ "$src" = "dhcp" ]; then
     fi
     if [ "`cat /tmp/dhcp_graph_url`" = "N/A" ]; then
         echo "'N/A' found in DHCP response. Skipping graph update and generating an empty configuration."
+        if [ ! -f /etc/sonic/minigraph.xml ]; then
+            copy_default_minigraph
+        fi
         echo '{"DEVICE_METADATA":' > /tmp/device_meta.json
         sonic-cfggen -H -m /etc/sonic/minigraph.xml --var-json DEVICE_METADATA >> /tmp/device_meta.json
         echo '}' >> /tmp/device_meta.json


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When "N/A" is received from DHCP response, updategraph service will try to generate a minimal configuration which contains only HWSKU and other device metadata. However this process will fail when there is no minigraph in /etc/sonic/ folder. This PR fix the bug.

**- How I did it**
Copy default minigraph when there is no minigraph in /etc/sonic/ before generating minimal configuration.
