### PR TITLE
interface_status.sh to add entry for each sessions

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -136,6 +136,7 @@ sudo cp $IMAGE_CONFIGS/interfaces/interfaces-config.service  $FILESYSTEM_ROOT/et
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable interfaces-config.service
 sudo cp $IMAGE_CONFIGS/interfaces/interfaces-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/interfaces/*.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
+sudo cp $IMAGE_CONFIGS/interfaces/interface_mode.sh  $FILESYSTEM_ROOT/etc/profile.d/
 
 # Copy initial interfaces configuration file, will be overwritten on first boot
 sudo cp $IMAGE_CONFIGS/interfaces/init_interfaces $FILESYSTEM_ROOT/etc/network

--- a/files/image_config/environment/environment
+++ b/files/image_config/environment/environment
@@ -1,2 +1,2 @@
 VTYSH_PAGER=more
-IFMODE=default
+SONIC_CLI_IFACE_MODE=default

--- a/files/image_config/environment/environment
+++ b/files/image_config/environment/environment
@@ -1,1 +1,2 @@
 VTYSH_PAGER=more
+IFMODE=default

--- a/files/image_config/interfaces/interface_mode.sh
+++ b/files/image_config/interfaces/interface_mode.sh
@@ -1,0 +1,14 @@
+pts=$(tty | cut -d '/' -f4)
+
+#For console session
+if [ -z "$pts" ]; then
+  pts=$(tty | cut -d '/' -f3 | cut -d 'S' -f2)
+fi
+
+filename="pts"$pts".cfg"
+
+#remove stale entries
+rm -rf /tmp/pts$pts.cfg
+
+#Create unique file entry for each tty
+echo "interface_mode=DEFAULT" > /tmp/$filename

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -10,7 +10,8 @@ Defaults        env_reset
 #Defaults        mail_badpass
 Defaults        secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 Defaults        env_keep += "VTYSH_PAGER"
-Defaults        env_keep += "IFMODE"
+Defaults        lecture_file = /etc/sudoers.lecture
+Defaults        env_keep += "SONIC_CLI_IFACE_MODE"
 
 # Host alias specification
 

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -10,6 +10,7 @@ Defaults        env_reset
 #Defaults        mail_badpass
 Defaults        secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 Defaults        env_keep += "VTYSH_PAGER"
+Defaults        env_keep += "IFMODE"
 
 # Host alias specification
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Introduced a new file interface_status.sh as part of: https://github.com/Azure/sonic-utilities/pull/260




**- How I did it**
1. Introduced interface_status.sh which creates a config file for interface mode selection.
2. This file is unique for each session. Created at login.
3. Works for both console and multiple ssh sessions.

**- How to verify it**
Refer: https://github.com/Azure/sonic-utilities/pull/260


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
