### PR TITLE
[serial watchdog] remove serial watchdog service dependency to rc.local

### DIFF
--- a/files/image_config/serial-port-watchdog/serial-port-watchdog.service
+++ b/files/image_config/serial-port-watchdog/serial-port-watchdog.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Monitor serial port processes, kill stuck ones
 Requires=
-After=rc.local.Service
+After=
 
 [Service]
 ExecStart=/usr/bin/serial-port-watchdog.py -t ttyS0

--- a/files/image_config/serial-port-watchdog/serial-port-watchdog.service
+++ b/files/image_config/serial-port-watchdog/serial-port-watchdog.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Monitor serial port processes, kill stuck ones
-Requires=
-After=
 
 [Service]
 ExecStart=/usr/bin/serial-port-watchdog.py -t ttyS0


### PR DESCRIPTION
**- What I did**
When restarting this service in rc.local, the dependency causes an error
in syslog. Removing the dependency to mute the error log entry.

**- How to verify it**
Tested with the change, the error entry is gone and the service is still running.

This following entry is no longer there:
May 30 13:53:01.672596 str-7260cx3-acs-1 ERR systemd[1]: [/etc/systemd/system/serial-port-watchdog.service:4] Failed to add dependency on rc.local.Service, ignoring: Invalid argument

Good syslog:
May 30 22:25:10.093548 str-7260cx3-acs-1 INFO systemd[1]: Starting Monitor serial port processes, kill stuck ones...
May 30 22:25:10.093562 str-7260cx3-acs-1 INFO serial-port-watchdog.py[657]: INFO: Attaching to syslog
May 30 22:25:10.093572 str-7260cx3-acs-1 INFO systemd[1]: Started Monitor serial port processes, kill stuck ones.
May 30 22:25:10.093783 str-7260cx3-acs-1 INFO rc.local[660]: + program_serial_port
May 30 22:25:10.093792 str-7260cx3-acs-1 INFO rc.local[660]: + sed -i s|ttyS.|ttyS0|g /etc/systemd/system/serial-port-watchdog.service
May 30 22:25:10.094187 str-7260cx3-acs-1 INFO kernel: [    0.554314] serial8250: ttyS0 at I/O 0x3f8 (irq = 4, base_baud = 115200) is a 16550A
May 30 22:25:10.778167 str-7260cx3-acs-1 INFO rc.local[660]: + systemctl restart serial-port-watchdog.service
May 30 22:25:10.786660 str-7260cx3-acs-1 INFO systemd[1]: Stopping Monitor serial port processes, kill stuck ones...
May 30 22:25:11.157015 str-7260cx3-acs-1 INFO systemd[1]: Starting Monitor serial port processes, kill stuck ones...
May 30 22:25:11.285533 str-7260cx3-acs-1 INFO serial-port-watchdog.py[732]: INFO: Attaching to syslog
May 30 22:25:11.310412 str-7260cx3-acs-1 INFO systemd[1]: Started Monitor serial port processes, kill stuck ones.
root@str-7260cx3-acs-1:/var/log# ps -ef | grep serial
root       732     1  0 22:25 ?        00:00:00 python /usr/bin/serial-port-watchdog.py -t ttyS0