### PR TITLE
[sonic-mgmt]: Install the latest Microsoft Azure Kusto Library for Python

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -43,11 +43,11 @@ RUN pip install ipaddr \
                 pysnmp==4.2.5 \
                 jinja2==2.7.2 \
                 cffi==1.10.0 \
-                paramiko==2.1.2 \
-                adal
+                paramiko==2.1.2
 
-# Install Azure Storage package
-RUN pip install azure-storage
+# Install Microsoft Azure Kusto Library for Python
+RUN pip install azure-kusto-data \
+                azure-kusto-ingest
 
 ## Copy and install sonic-mgmt docker dependencies
 COPY \


### PR DESCRIPTION
https://github.com/Azure/azure-kusto-python

azure-kusto-data Package provides the capability to query Kusto clusters with Python.
azure-kusto-ingest Package allows sending data to Kusto service - i.e. ingest data.

The removed package adal is a dependent of the Azure Kusto Library.
The removed azure-storage is deprecated and being replaced with new packages that are
also the dependents of the Azure Kusto Library. (https://github.com/Azure/azure-storage-python)

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
