### PR TITLE
Adding setuid permissions to ping binaries, so sudo is no longer needed

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -239,6 +239,12 @@ sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/libwrap0_*.deb || \
 ## Disable kexec supported reboot which was installed by default
 sudo sed -i 's/LOAD_KEXEC=true/LOAD_KEXEC=false/' $FILESYSTEM_ROOT/etc/default/kexec
 
+## Fix ping tools permission so non root user can directly use them
+## Note: this is a workaround since aufs doesn't support extended attributes
+## Ref: https://github.com/moby/moby/issues/5650#issuecomment-303499489
+## TODO: remove workaround when the overlay filesystem support extended attributes
+sudo chmod u+s $FILESYSTEM_ROOT/bin/ping{,6}
+
 ## Remove sshd host keys, and will regenerate on first sshd start
 sudo rm -f $FILESYSTEM_ROOT/etc/ssh/ssh_host_*_key*
 sudo cp files/sshd/host-ssh-keygen.sh $FILESYSTEM_ROOT/usr/local/bin/


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix ping tools permission so non root user can directly use them

**- How I did it**

**- How to verify it**
```
admin@sonic:~$ ls -la /bin/ping*
-rwsr-xr-x 1 root root 44104 Nov  8  2014 /bin/ping
-rwsr-xr-x 1 root root 44552 Nov  8  2014 /bin/ping6

admin@sonic:~$ ping 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.077 ms
64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.106 ms
64 bytes from 127.0.0.1: icmp_seq=3 ttl=64 time=0.091 ms
^C

admin@sonic:~$ ping6 2a01:111:e210:3000:7efe:90ff:fe5e:6a9a
PING 2a01:111:e210:3000:7efe:90ff:fe5e:6a9a(2a01:111:e210:3000:7efe:90ff:fe5e:6a9a) 56 data bytes
64 bytes from 2a01:111:e210:3000:7efe:90ff:fe5e:6a9a: icmp_seq=1 ttl=64 time=0.043 ms
64 bytes from 2a01:111:e210:3000:7efe:90ff:fe5e:6a9a: icmp_seq=2 ttl=64 time=0.070 ms
64 bytes from 2a01:111:e210:3000:7efe:90ff:fe5e:6a9a: icmp_seq=3 ttl=64 time=0.074 ms
^C

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
