### PR TITLE
[vs-test]: not forward routes with no-export community

### DIFF
--- a/platform/vs/tests/bounce/files/bgpd.conf
+++ b/platform/vs/tests/bounce/files/bgpd.conf
@@ -1,0 +1,13 @@
+router bgp 65501
+  bgp router-id 1.1.1.1
+  no bgp default ipv4-unicast
+  neighbor 10.0.0.1 remote-as 65502
+  address-family ipv4
+    neighbor 10.0.0.1 activate
+    maximum-paths 64
+  exit-address-family
+  neighbor 10.0.0.3 remote-as 65503
+  address-family ipv4
+    neighbor 10.0.0.3 activate
+    maximum-paths 64
+  exit-address-family

--- a/platform/vs/tests/bounce/files/exabgp1.conf
+++ b/platform/vs/tests/bounce/files/exabgp1.conf
@@ -1,0 +1,21 @@
+neighbor 10.0.0.0 {
+    router-id 1.1.1.2;
+    local-address 10.0.0.1;
+    local-as 65502;
+    peer-as 65501;
+    group-updates false;
+
+    family{
+        ipv4 unicast;
+    }
+
+    static {
+        route 1.1.1.1/32{
+            next-hop 10.0.0.1;
+            community no-export;
+        }
+        route 2.2.2.2/32{
+            next-hop 10.0.0.1;
+        }
+    }
+}

--- a/platform/vs/tests/bounce/files/exabgp2.conf
+++ b/platform/vs/tests/bounce/files/exabgp2.conf
@@ -1,0 +1,11 @@
+neighbor 10.0.0.2 {
+    router-id 1.1.1.3;
+    local-address 10.0.0.3;
+    local-as 65503;
+    peer-as 65501;
+    group-updates false;
+
+    family {
+        ipv4 unicast;
+    }
+}

--- a/platform/vs/tests/bounce/test_bounce.py
+++ b/platform/vs/tests/bounce/test_bounce.py
@@ -1,0 +1,45 @@
+from swsscommon import swsscommon
+import os
+import re
+import time
+import json
+
+def test_bounce(dvs):
+    dvs.servers[0].runcmd("pkill -f exabgp")
+    dvs.copy_file("/etc/quagga/", "bounce/files/bgpd.conf")
+    dvs.runcmd("supervisorctl start bgpd")
+    dvs.runcmd("ip addr add 10.0.0.0/31 dev Ethernet0") 
+    dvs.runcmd("ifconfig Ethernet0 up")
+
+    dvs.runcmd("ip addr add 10.0.0.2/31 dev Ethernet4")
+    dvs.runcmd("ifconfig Ethernet4 up")
+
+    dvs.servers[0].runcmd("ip addr add 10.0.0.1/31 dev eth0")
+    dvs.servers[0].runcmd("ifconfig eth0 up")
+
+    dvs.servers[1].runcmd("ip addr add 10.0.0.3/31 dev eth0")
+    dvs.servers[1].runcmd("ifconfig eth0 up")
+
+    time.sleep(5)
+
+    p1 = dvs.servers[0].runcmd_async("exabgp -d bounce/files/exabgp1.conf")
+    p2 = dvs.servers[1].runcmd_async("exabgp -d bounce/files/exabgp2.conf")
+
+    time.sleep(20)
+
+    sum_res =  dvs.runcmd(["vtysh", "-c", "show ip bgp sum"])
+    all_route = dvs.runcmd(["vtysh", "-c", "show ip bgp"])
+    announce_route = dvs.runcmd(["vtysh", "-c", "show ip bgp neighbors 10.0.0.3 advertised-routes"])
+ 
+    p1.terminate()
+    p1 = p1.wait()
+
+    p2.terminate()
+    p2 = p2.wait()
+
+    print sum_res
+    print announce_route
+    assert "1.1.1.1/32" in all_route
+    assert "1.1.1.1/32" not in announce_route
+    assert "2.2.2.2/32" in all_route
+    assert "2.2.2.2/32" in announce_route


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add vs test to verify that the device doesn't forward routes with no-export community.
**- How I did it**
Establish two exabgp neighbors, and let one neighbor announce two routes, 1.1.1.1/32 (with no-export community) and 2.2.2.2/32 (without no-export community). The DUT should only announce 2.2.2.2/32 to the other neighbor
**- How to verify it**
Run the test.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
