### PR TITLE
Add index and speed for port_config.ini on Celestica platform

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/port_config.ini
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/port_config.ini
@@ -1,113 +1,113 @@
-# name          lanes        alias
-Ethernet0       65           Eth1/1
-Ethernet1       66           Eth1/2
-Ethernet2       67           Eth1/3
-Ethernet3       68           Eth1/4
-Ethernet4       69           Eth2/1
-Ethernet5       70           Eth2/2
-Ethernet6       71           Eth2/3
-Ethernet7       72           Eth2/4
-Ethernet8       73           Eth3/1
-Ethernet9       74           Eth3/2
-Ethernet10      75           Eth3/3
-Ethernet11      76           Eth3/4
-Ethernet12      77           Eth4/1
-Ethernet13      78           Eth4/2
-Ethernet14      79           Eth4/3
-Ethernet15      80           Eth4/4
-Ethernet16      33           Eth5/1
-Ethernet17      34           Eth5/2
-Ethernet18      35           Eth5/3
-Ethernet19      36           Eth5/4
-Ethernet20      37           Eth6/1
-Ethernet21      38           Eth6/2
-Ethernet22      39           Eth6/3
-Ethernet23      40           Eth6/4
-Ethernet24      41           Eth7/1
-Ethernet25      42           Eth7/2
-Ethernet26      43           Eth7/3
-Ethernet27      44           Eth7/4
-Ethernet28      45           Eth8/1
-Ethernet29      46           Eth8/2
-Ethernet30      47           Eth8/3
-Ethernet31      48           Eth8/4
-Ethernet32      49           Eth9/1
-Ethernet33      50           Eth9/2
-Ethernet34      51           Eth9/3
-Ethernet35      52           Eth9/4
-Ethernet36      53           Eth10/1
-Ethernet37      54           Eth10/2
-Ethernet38      55           Eth10/3
-Ethernet39      56           Eth10/4
-Ethernet40      57           Eth11/1
-Ethernet41      58           Eth11/2
-Ethernet42      59           Eth11/3
-Ethernet43      60           Eth11/4
-Ethernet44      61           Eth12/1
-Ethernet45      62           Eth12/2
-Ethernet46      63           Eth12/3
-Ethernet47      64           Eth12/4
-Ethernet48      81           Eth13/1
-Ethernet49      82           Eth13/2
-Ethernet50      83           Eth13/3
-Ethernet51      84           Eth13/4
-Ethernet52      85           Eth14/1
-Ethernet53      86           Eth14/2
-Ethernet54      87           Eth14/3
-Ethernet55      88           Eth14/4
-Ethernet56      89           Eth15/1
-Ethernet57      90           Eth15/2
-Ethernet58      91           Eth15/3
-Ethernet59      92           Eth15/4
-Ethernet60      93           Eth16/1
-Ethernet61      94           Eth16/2
-Ethernet62      95           Eth16/3
-Ethernet63      96           Eth16/4
-Ethernet64      97           Eth17/1
-Ethernet65      98           Eth17/2
-Ethernet66      99           Eth17/3
-Ethernet67      100          Eth17/4
-Ethernet68      101          Eth18/1
-Ethernet69      102          Eth18/2
-Ethernet70      103          Eth18/3
-Ethernet71      104          Eth18/4
-Ethernet72      105          Eth19/1
-Ethernet73      106          Eth19/2
-Ethernet74      107          Eth19/3
-Ethernet75      108          Eth19/4
-Ethernet76      109          Eth20/1
-Ethernet77      110          Eth20/2
-Ethernet78      111          Eth20/3
-Ethernet79      112          Eth20/4
-Ethernet80      1            Eth21/1
-Ethernet81      2            Eth21/2
-Ethernet82      3            Eth21/3
-Ethernet83      4            Eth21/4
-Ethernet84      5            Eth22/1
-Ethernet85      6            Eth22/2
-Ethernet86      7            Eth22/3
-Ethernet87      8            Eth22/4
-Ethernet88      9            Eth23/1
-Ethernet89      10           Eth23/2
-Ethernet90      11           Eth23/3
-Ethernet91      12           Eth23/4
-Ethernet92      13           Eth24/1
-Ethernet93      14           Eth24/2
-Ethernet94      15           Eth24/3
-Ethernet95      16           Eth24/4
-Ethernet96      17,18        Eth25/1
-Ethernet98      19,20        Eth25/2
-Ethernet100     21,22        Eth26/1
-Ethernet102     23,24        Eth26/2
-Ethernet104     25,26        Eth27/1
-Ethernet106     27,28        Eth27/2
-Ethernet108     29,30        Eth28/1
-Ethernet110     31,32        Eth28/2
-Ethernet112     113,114      Eth29/1
-Ethernet114     115,116      Eth29/2
-Ethernet116     117,118      Eth30/1
-Ethernet118     119,120      Eth30/2
-Ethernet120     121,122      Eth31/1
-Ethernet122     123,124      Eth31/2
-Ethernet124     125,126      Eth32/1
-Ethernet126     127,128      Eth32/2
+# name          lanes        alias      index   speed
+Ethernet0       65           Eth1/1     0       10000
+Ethernet1       66           Eth1/2     0       10000
+Ethernet2       67           Eth1/3     0       10000
+Ethernet3       68           Eth1/4     0       10000
+Ethernet4       69           Eth2/1     1       10000
+Ethernet5       70           Eth2/2     1       10000
+Ethernet6       71           Eth2/3     1       10000
+Ethernet7       72           Eth2/4     1       10000
+Ethernet8       73           Eth3/1     2       10000
+Ethernet9       74           Eth3/2     2       10000
+Ethernet10      75           Eth3/3     2       10000
+Ethernet11      76           Eth3/4     2       10000
+Ethernet12      77           Eth4/1     3       10000
+Ethernet13      78           Eth4/2     3       10000
+Ethernet14      79           Eth4/3     3       10000
+Ethernet15      80           Eth4/4     3       10000
+Ethernet16      33           Eth5/1     4       10000
+Ethernet17      34           Eth5/2     4       10000
+Ethernet18      35           Eth5/3     4       10000
+Ethernet19      36           Eth5/4     4       10000
+Ethernet20      37           Eth6/1     5       10000
+Ethernet21      38           Eth6/2     5       10000
+Ethernet22      39           Eth6/3     5       10000
+Ethernet23      40           Eth6/4     5       10000
+Ethernet24      41           Eth7/1     6       10000
+Ethernet25      42           Eth7/2     6       10000
+Ethernet26      43           Eth7/3     6       10000
+Ethernet27      44           Eth7/4     6       10000
+Ethernet28      45           Eth8/1     7       10000
+Ethernet29      46           Eth8/2     7       10000
+Ethernet30      47           Eth8/3     7       10000
+Ethernet31      48           Eth8/4     7       10000
+Ethernet32      49           Eth9/1     8       10000
+Ethernet33      50           Eth9/2     8       10000
+Ethernet34      51           Eth9/3     8       10000
+Ethernet35      52           Eth9/4     8       10000
+Ethernet36      53           Eth10/1    9       10000
+Ethernet37      54           Eth10/2    9       10000
+Ethernet38      55           Eth10/3    9       10000
+Ethernet39      56           Eth10/4    9       10000
+Ethernet40      57           Eth11/1    10      10000
+Ethernet41      58           Eth11/2    10      10000
+Ethernet42      59           Eth11/3    10      10000
+Ethernet43      60           Eth11/4    10      10000
+Ethernet44      61           Eth12/1    11      10000
+Ethernet45      62           Eth12/2    11      10000
+Ethernet46      63           Eth12/3    11      10000
+Ethernet47      64           Eth12/4    11      10000
+Ethernet48      81           Eth13/1    12      10000
+Ethernet49      82           Eth13/2    12      10000
+Ethernet50      83           Eth13/3    12      10000
+Ethernet51      84           Eth13/4    12      10000
+Ethernet52      85           Eth14/1    13      10000
+Ethernet53      86           Eth14/2    13      10000
+Ethernet54      87           Eth14/3    13      10000
+Ethernet55      88           Eth14/4    13      10000
+Ethernet56      89           Eth15/1    14      10000
+Ethernet57      90           Eth15/2    14      10000
+Ethernet58      91           Eth15/3    14      10000
+Ethernet59      92           Eth15/4    14      10000
+Ethernet60      93           Eth16/1    15      10000
+Ethernet61      94           Eth16/2    15      10000
+Ethernet62      95           Eth16/3    15      10000
+Ethernet63      96           Eth16/4    15      10000
+Ethernet64      97           Eth17/1    16      10000
+Ethernet65      98           Eth17/2    16      10000
+Ethernet66      99           Eth17/3    16      10000
+Ethernet67      100          Eth17/4    16      10000
+Ethernet68      101          Eth18/1    17      10000
+Ethernet69      102          Eth18/2    17      10000
+Ethernet70      103          Eth18/3    17      10000
+Ethernet71      104          Eth18/4    17      10000
+Ethernet72      105          Eth19/1    18      10000
+Ethernet73      106          Eth19/2    18      10000
+Ethernet74      107          Eth19/3    18      10000
+Ethernet75      108          Eth19/4    18      10000
+Ethernet76      109          Eth20/1    19      10000
+Ethernet77      110          Eth20/2    19      10000
+Ethernet78      111          Eth20/3    19      10000
+Ethernet79      112          Eth20/4    19      10000
+Ethernet80      1            Eth21/1    20      10000
+Ethernet81      2            Eth21/2    20      10000
+Ethernet82      3            Eth21/3    20      10000
+Ethernet83      4            Eth21/4    20      10000
+Ethernet84      5            Eth22/1    21      10000
+Ethernet85      6            Eth22/2    21      10000
+Ethernet86      7            Eth22/3    21      10000
+Ethernet87      8            Eth22/4    21      10000
+Ethernet88      9            Eth23/1    22      10000
+Ethernet89      10           Eth23/2    22      10000
+Ethernet90      11           Eth23/3    22      10000
+Ethernet91      12           Eth23/4    22      10000
+Ethernet92      13           Eth24/1    23      10000
+Ethernet93      14           Eth24/2    23      10000
+Ethernet94      15           Eth24/3    23      10000
+Ethernet95      16           Eth24/4    23      10000
+Ethernet96      17,18        Eth25/1    24      50000
+Ethernet98      19,20        Eth25/2    24      50000
+Ethernet100     21,22        Eth26/1    25      50000
+Ethernet102     23,24        Eth26/2    25      50000
+Ethernet104     25,26        Eth27/1    26      50000
+Ethernet106     27,28        Eth27/2    26      50000
+Ethernet108     29,30        Eth28/1    27      50000
+Ethernet110     31,32        Eth28/2    27      50000
+Ethernet112     113,114      Eth29/1    28      50000
+Ethernet114     115,116      Eth29/2    28      50000
+Ethernet116     117,118      Eth30/1    29      50000
+Ethernet118     119,120      Eth30/2    29      50000
+Ethernet120     121,122      Eth31/1    30      50000
+Ethernet122     123,124      Eth31/2    30      50000
+Ethernet124     125,126      Eth32/1    31      50000
+Ethernet126     127,128      Eth32/2    31      50000

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50/port_config.ini
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50/port_config.ini
@@ -1,65 +1,65 @@
-# name          lanes           alias
-Ethernet0       65,66           Eth1/1
-Ethernet2       67,68           Eth1/2
-Ethernet4       69,70           Eth2/1
-Ethernet6       71,72           Eth2/2
-Ethernet8       73,74           Eth3/1
-Ethernet10      75,76           Eth3/2
-Ethernet12      77,78           Eth4/1
-Ethernet14      79,80           Eth4/2
-Ethernet16      33,34           Eth5/1
-Ethernet18      35,36           Eth5/2
-Ethernet20      37,38           Eth6/1
-Ethernet22      39,40           Eth6/2
-Ethernet24      41,42           Eth7/1
-Ethernet26      43,44           Eth7/2
-Ethernet28      45,46           Eth8/1
-Ethernet30      47,48           Eth8/2
-Ethernet32      49,50           Eth9/1
-Ethernet34      51,52           Eth9/2
-Ethernet36      53,54           Eth10/1
-Ethernet38      55,56           Eth10/2
-Ethernet40      57,58           Eth11/1
-Ethernet42      59,60           Eth11/2
-Ethernet44      61,62           Eth12/1
-Ethernet46      63,64           Eth12/2
-Ethernet48      81,82           Eth13/1
-Ethernet50      83,84           Eth13/2
-Ethernet52      85,86           Eth14/1
-Ethernet54      87,88           Eth14/2
-Ethernet56      89,90           Eth15/1
-Ethernet58      91,92           Eth15/2
-Ethernet60      93,94           Eth16/1
-Ethernet62      95,96           Eth16/2
-Ethernet64      97,98           Eth17/1
-Ethernet66      99,100          Eth17/2
-Ethernet68      101,102         Eth18/1
-Ethernet70      103,104         Eth18/2
-Ethernet72      105,106         Eth19/1
-Ethernet74      107,108         Eth19/2
-Ethernet76      109,110         Eth20/1
-Ethernet78      111,112         Eth20/2
-Ethernet80      1,2             Eth21/1
-Ethernet82      3,4             Eth21/2
-Ethernet84      5,6             Eth22/1
-Ethernet86      7,8             Eth22/2
-Ethernet88      9,10            Eth23/1
-Ethernet90      11,12           Eth23/2
-Ethernet92      13,14           Eth24/1
-Ethernet94      15,16           Eth24/2
-Ethernet96      17,18           Eth25/1
-Ethernet98      19,20           Eth25/2
-Ethernet100     21,22           Eth26/1
-Ethernet102     23,24           Eth26/2
-Ethernet104     25,26           Eth27/1
-Ethernet106     27,28           Eth27/2
-Ethernet108     29,30           Eth28/1
-Ethernet110     31,32           Eth28/2
-Ethernet112     113,114         Eth29/1
-Ethernet114     115,116         Eth29/2
-Ethernet116     117,118         Eth30/1
-Ethernet118     119,120         Eth30/2
-Ethernet120     121,122         Eth31/1
-Ethernet122     123,124         Eth31/2
-Ethernet124     125,126         Eth32/1
-Ethernet126     127,128         Eth32/2
+# name          lanes           alias       index       speed
+Ethernet0       65,66           Eth1/1      0           50000
+Ethernet2       67,68           Eth1/2      0           50000
+Ethernet4       69,70           Eth2/1      1           50000
+Ethernet6       71,72           Eth2/2      1           50000
+Ethernet8       73,74           Eth3/1      2           50000
+Ethernet10      75,76           Eth3/2      2           50000
+Ethernet12      77,78           Eth4/1      3           50000
+Ethernet14      79,80           Eth4/2      3           50000
+Ethernet16      33,34           Eth5/1      4           50000
+Ethernet18      35,36           Eth5/2      4           50000
+Ethernet20      37,38           Eth6/1      5           50000
+Ethernet22      39,40           Eth6/2      5           50000
+Ethernet24      41,42           Eth7/1      6           50000
+Ethernet26      43,44           Eth7/2      6           50000
+Ethernet28      45,46           Eth8/1      7           50000
+Ethernet30      47,48           Eth8/2      7           50000
+Ethernet32      49,50           Eth9/1      8           50000
+Ethernet34      51,52           Eth9/2      8           50000
+Ethernet36      53,54           Eth10/1     9           50000
+Ethernet38      55,56           Eth10/2     9           50000
+Ethernet40      57,58           Eth11/1     10          50000
+Ethernet42      59,60           Eth11/2     10          50000
+Ethernet44      61,62           Eth12/1     11          50000
+Ethernet46      63,64           Eth12/2     11          50000
+Ethernet48      81,82           Eth13/1     12          50000
+Ethernet50      83,84           Eth13/2     12          50000
+Ethernet52      85,86           Eth14/1     13          50000
+Ethernet54      87,88           Eth14/2     13          50000
+Ethernet56      89,90           Eth15/1     14          50000
+Ethernet58      91,92           Eth15/2     14          50000
+Ethernet60      93,94           Eth16/1     15          50000
+Ethernet62      95,96           Eth16/2     15          50000
+Ethernet64      97,98           Eth17/1     16          50000
+Ethernet66      99,100          Eth17/2     16          50000
+Ethernet68      101,102         Eth18/1     17          50000
+Ethernet70      103,104         Eth18/2     17          50000
+Ethernet72      105,106         Eth19/1     18          50000
+Ethernet74      107,108         Eth19/2     18          50000
+Ethernet76      109,110         Eth20/1     19          50000
+Ethernet78      111,112         Eth20/2     19          50000
+Ethernet80      1,2             Eth21/1     20          50000
+Ethernet82      3,4             Eth21/2     20          50000
+Ethernet84      5,6             Eth22/1     21          50000
+Ethernet86      7,8             Eth22/2     21          50000
+Ethernet88      9,10            Eth23/1     22          50000
+Ethernet90      11,12           Eth23/2     22          50000
+Ethernet92      13,14           Eth24/1     23          50000
+Ethernet94      15,16           Eth24/2     23          50000
+Ethernet96      17,18           Eth25/1     24          50000
+Ethernet98      19,20           Eth25/2     24          50000
+Ethernet100     21,22           Eth26/1     25          50000
+Ethernet102     23,24           Eth26/2     25          50000
+Ethernet104     25,26           Eth27/1     26          50000
+Ethernet106     27,28           Eth27/2     26          50000
+Ethernet108     29,30           Eth28/1     27          50000
+Ethernet110     31,32           Eth28/2     27          50000
+Ethernet112     113,114         Eth29/1     28          50000
+Ethernet114     115,116         Eth29/2     28          50000
+Ethernet116     117,118         Eth30/1     29          50000
+Ethernet118     119,120         Eth30/2     29          50000
+Ethernet120     121,122         Eth31/1     30          50000
+Ethernet122     123,124         Eth31/2     30          50000
+Ethernet124     125,126         Eth32/1     31          50000
+Ethernet126     127,128         Eth32/2     31          50000

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/port_config.ini
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes                 alias
-Ethernet0       65,66,67,68           Eth1
-Ethernet4       69,70,71,72           Eth2
-Ethernet8       73,74,75,76           Eth3
-Ethernet12      77,78,79,80           Eth4
-Ethernet16      33,34,35,36           Eth5
-Ethernet20      37,38,39,40           Eth6
-Ethernet24      41,42,43,44           Eth7
-Ethernet28      45,46,47,48           Eth8
-Ethernet32      49,50,51,52           Eth9
-Ethernet36      53,54,55,56           Eth10
-Ethernet40      57,58,59,60           Eth11
-Ethernet44      61,62,63,64           Eth12
-Ethernet48      81,82,83,84           Eth13
-Ethernet52      85,86,87,88           Eth14
-Ethernet56      89,90,91,92           Eth15
-Ethernet60      93,94,95,96           Eth16
-Ethernet64      97,98,99,100          Eth17
-Ethernet68      101,102,103,104       Eth18
-Ethernet72      105,106,107,108       Eth19
-Ethernet76      109,110,111,112       Eth20
-Ethernet80      1,2,3,4               Eth21
-Ethernet84      5,6,7,8               Eth22
-Ethernet88      9,10,11,12            Eth23
-Ethernet92      13,14,15,16           Eth24
-Ethernet96      17,18,19,20           Eth25
-Ethernet100     21,22,23,24           Eth26
-Ethernet104     25,26,27,28           Eth27
-Ethernet108     29,30,31,32           Eth28
-Ethernet112     113,114,115,116       Eth29
-Ethernet116     117,118,119,120       Eth30
-Ethernet120     121,122,123,124       Eth31
-Ethernet124     125,126,127,128       Eth32
+# name          lanes                 alias     index   speed
+Ethernet0       65,66,67,68           Eth1      0       100000
+Ethernet4       69,70,71,72           Eth2      1       100000
+Ethernet8       73,74,75,76           Eth3      2       100000
+Ethernet12      77,78,79,80           Eth4      3       100000
+Ethernet16      33,34,35,36           Eth5      4       100000
+Ethernet20      37,38,39,40           Eth6      5       100000
+Ethernet24      41,42,43,44           Eth7      6       100000
+Ethernet28      45,46,47,48           Eth8      7       100000
+Ethernet32      49,50,51,52           Eth9      8       100000
+Ethernet36      53,54,55,56           Eth10     9       100000
+Ethernet40      57,58,59,60           Eth11     10      100000
+Ethernet44      61,62,63,64           Eth12     11      100000
+Ethernet48      81,82,83,84           Eth13     12      100000
+Ethernet52      85,86,87,88           Eth14     13      100000
+Ethernet56      89,90,91,92           Eth15     14      100000
+Ethernet60      93,94,95,96           Eth16     15      100000
+Ethernet64      97,98,99,100          Eth17     16      100000
+Ethernet68      101,102,103,104       Eth18     17      100000
+Ethernet72      105,106,107,108       Eth19     18      100000
+Ethernet76      109,110,111,112       Eth20     19      100000
+Ethernet80      1,2,3,4               Eth21     20      100000
+Ethernet84      5,6,7,8               Eth22     21      100000
+Ethernet88      9,10,11,12            Eth23     22      100000
+Ethernet92      13,14,15,16           Eth24     23      100000
+Ethernet96      17,18,19,20           Eth25     24      100000
+Ethernet100     21,22,23,24           Eth26     25      100000
+Ethernet104     25,26,27,28           Eth27     26      100000
+Ethernet108     29,30,31,32           Eth28     27      100000
+Ethernet112     113,114,115,116       Eth29     28      100000
+Ethernet116     117,118,119,120       Eth30     29      100000
+Ethernet120     121,122,123,124       Eth31     30      100000
+Ethernet124     125,126,127,128       Eth32     31      100000


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add index and port-speed on port_config.ini

**- How I did it**
Add index and port-speed on port_config.ini

**- How to verify it**
$show interface transceiver eeprom
$ show interfaces transceiver eep
Command: sudo sfputil show eeprom
Ethernet0: SFP EEPROM detected
        Connector: MPOx12
        Encoding: NRZ
        Extended Identifier: Power Class 4(3.5W max), CDR present in Rx Tx
        Extended RateSelect Compliance: QSFP+ Rate Select Version 1
        Identifier: QSFP28
        Length(km): 2
        Nominal Bit Rate(100Mbs): 255
        Specification compliance:
        ...

Ethernet4: SFP EEPROM not detected

$ show interfaces status 
Command: intfutil status
  Interface    Admin    Oper    Alias            Lanes    Speed    MTU
-----------  -------  ------  -------  ---------------  -------  -----
  Ethernet0       up    down     Eth1      65,66,67,68     100G   9100
  Ethernet4       up    down     Eth2      69,70,71,72     100G   9100
  Ethernet8       up    down     Eth3      73,74,75,76     100G   9100
 Ethernet12       up    down     Eth4      77,78,79,80     100G   9100
 Ethernet16       up    down     Eth5      33,34,35,36     100G   9100
 Ethernet20       up    down     Eth6      37,38,39,40     100G   9100
 Ethernet24       up    down     Eth7      41,42,43,44     100G   9100

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add index and speed in port_config.ini on celestica platform

**- A picture of a cute animal (not mandatory but encouraged)**
