### PR TITLE
Use MAC from EEPROM for PortChannels

### DIFF
--- a/dockers/docker-teamd/start.sh
+++ b/dockers/docker-teamd/start.sh
@@ -6,7 +6,12 @@ rm -rf $TEAMD_CONF_PATH
 mkdir -p $TEAMD_CONF_PATH
 
 SONIC_ASIC_TYPE=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
-MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
+
+if [ "$SONIC_ASIC_TYPE" == "mellanox" ]; then
+    MAC_ADDRESS=$(od -vt x1 -An /sys/bus/i2c/devices/8-0051/eeprom | xargs printf "0x%s " | xargs printf "%02x:" | awk 'BEGIN { FS=":"; i=8+1+2+1} {while(i<NF) {type=$i; len=("0x"$(i+1));if(type!="24") {i=i+2+len} else {print substr($0, (i+1)*3+1, len*3-1); break}}}')
+else
+    MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
+fi
 
 # Align last byte
 if [ "$SONIC_ASIC_TYPE" == "mellanox" -o "$SONIC_ASIC_TYPE" == "centec" ]; then


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

**- What I did**
Updated teams start script to pass MAC from EEPROM to the portchannels config template for Mellanox platforms

**- How I did it**
updated start.sh which runs on container 

**- How to verify it**
Start SONiC and make sure MACs on PortChannel (and members) are similar to one returned by command
od -vt x1 -An /sys/bus/i2c/devices/8-0051/eeprom | xargs printf "0x%s " | xargs printf "%02x:" | awk 'BEGIN { FS=":"; i=8+1+2+1} {while(i<NF) {type=$i; len=("0x"$(i+1));if(type!="24") {i=i+2+len} else {print substr($0, (i+1)*3+1, len*3-1); break}}}'

some bits in last byte may differ
