### PR TITLE
Don't create a pty to run vtysh inside of the docker container

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/vtysh
+++ b/dockers/docker-fpm-frr/base_image_files/vtysh
@@ -1,10 +1,3 @@
 #!/bin/bash
 
-DOCKER_EXEC_FLAGS="i"
-
-# Determine whether stdout is on a terminal
-if [ -t 1 ] ; then
-    DOCKER_EXEC_FLAGS+="t"
-fi
-
-docker exec -$DOCKER_EXEC_FLAGS bgp vtysh "$@"
+docker exec -i bgp vtysh "$@"

--- a/dockers/docker-fpm-quagga/base_image_files/vtysh
+++ b/dockers/docker-fpm-quagga/base_image_files/vtysh
@@ -1,10 +1,3 @@
 #!/bin/bash
 
-DOCKER_EXEC_FLAGS="i"
-
-# Determine whether stdout is on a terminal
-if [ -t 1 ] ; then
-    DOCKER_EXEC_FLAGS+="t"
-fi
-
-docker exec -$DOCKER_EXEC_FLAGS bgp vtysh "$@"
+docker exec -i bgp vtysh "$@"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Previously, when user run vtysh from the base system and disconnected from the terminal, the pty where vtysh was running in the container was left used. It is because of SIGHUP which is not passed inside of the docker. See https://github.com/moby/moby/issues/28872 This patch don't create new pty to run vtysh in the container.

**- How I did it**
I changed command line option for docker exec.

**- How to verify it**
Build DUT and check
Or change /usr/bin/vtysh on DUT, run vtysh, disconnect from the terminal, connect back and check vtysh in the list of processes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
