### PR TITLE
[Mellanox] Use MAC from EEPROM for PortChannels and VLAN Interfaces

### DIFF
--- a/dockers/docker-teamd/start.sh
+++ b/dockers/docker-teamd/start.sh
@@ -8,7 +8,7 @@ mkdir -p $TEAMD_CONF_PATH
 SONIC_ASIC_TYPE=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 
 if [ "$SONIC_ASIC_TYPE" == "mellanox" ]; then
-    MAC_ADDRESS=$(od -vt x1 -An /sys/bus/i2c/devices/8-0051/eeprom | xargs printf "0x%s " | xargs printf "%02x:" | awk 'BEGIN { FS=":"; i=8+1+2+1} {while(i<NF) {type=$i; len=("0x"$(i+1));if(type!="24") {i=i+2+len} else {print substr($0, (i+1)*3+1, len*3-1); break}}}')
+    MAC_ADDRESS=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.mac)
 else
     MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
 fi

--- a/dockers/docker-teamd/start.sh
+++ b/dockers/docker-teamd/start.sh
@@ -6,7 +6,12 @@ rm -rf $TEAMD_CONF_PATH
 mkdir -p $TEAMD_CONF_PATH
 
 SONIC_ASIC_TYPE=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
-MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
+
+if [ "$SONIC_ASIC_TYPE" == "mellanox" ]; then
+    MAC_ADDRESS=$(od -vt x1 -An /sys/bus/i2c/devices/8-0051/eeprom | xargs printf "0x%s " | xargs printf "%02x:" | awk 'BEGIN { FS=":"; i=8+1+2+1} {while(i<NF) {type=$i; len=("0x"$(i+1));if(type!="24") {i=i+2+len} else {print substr($0, (i+1)*3+1, len*3-1); break}}}')
+else
+    MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
+fi
 
 # Align last byte
 if [ "$SONIC_ASIC_TYPE" == "mellanox" -o "$SONIC_ASIC_TYPE" == "centec" ]; then

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -155,7 +155,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable hostname-config.service
 sudo cp $IMAGE_CONFIGS/hostname/hostname-config.sh $FILESYSTEM_ROOT/usr/bin/
 
 # Copy updategraph script and service file
-sudo cp $IMAGE_CONFIGS/updategraph/updategraph.service  $FILESYSTEM_ROOT/etc/systemd/system/
+j2 files/build_templates/updategraph.service.j2 | sudo tee $FILESYSTEM_ROOT/etc/systemd/system/updategraph.service
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable updategraph.service
 sudo cp $IMAGE_CONFIGS/updategraph/updategraph $FILESYSTEM_ROOT/usr/bin/
 {% if enable_dhcp_graph_service == "y" %}

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -32,7 +32,6 @@ ExecStartPre=/usr/bin/mlnx-fw-upgrade.sh
 ExecStartPre=/etc/init.d/sxdkernel start
 ExecStartPre=/sbin/modprobe i2c-dev
 ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)/hw-management start"
-ExecStartPre=/usr/local/bin/sonic-cfggen -H --write-to-db
 {% elif sonic_asic_platform == 'cavium' %}
 ExecStartPre=/etc/init.d/xpnet.sh start
 {% endif %}

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -32,6 +32,7 @@ ExecStartPre=/usr/bin/mlnx-fw-upgrade.sh
 ExecStartPre=/etc/init.d/sxdkernel start
 ExecStartPre=/sbin/modprobe i2c-dev
 ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)/hw-management start"
+ExecStartPre=/usr/local/bin/sonic-cfggen -H --write-to-db
 {% elif sonic_asic_platform == 'cavium' %}
 ExecStartPre=/etc/init.d/xpnet.sh start
 {% endif %}

--- a/files/build_templates/updategraph.service.j2
+++ b/files/build_templates/updategraph.service.j2
@@ -6,6 +6,9 @@ Requires=database.service
 
 [Service]
 Type=oneshot
+{% if sonic_asic_platform == 'mellanox' -%}
+ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)/hw-management start"
+{% endif -%}
 ExecStart=/usr/bin/updategraph
 RemainAfterExit=yes
 

--- a/files/build_templates/updategraph.service.j2
+++ b/files/build_templates/updategraph.service.j2
@@ -7,7 +7,8 @@ Requires=database.service
 [Service]
 Type=oneshot
 {% if sonic_asic_platform == 'mellanox' -%}
-ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)/hw-management start"
+EnvironmentFile=/host/machine.conf
+ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$onie_platform/hw-management start"
 {% endif -%}
 ExecStart=/usr/bin/updategraph
 RemainAfterExit=yes

--- a/files/build_templates/updategraph.service.j2
+++ b/files/build_templates/updategraph.service.j2
@@ -3,13 +3,13 @@ Description=Update minigraph and set configuration based on minigraph
 After=rc-local.service
 After=database.service
 Requires=database.service
+{% if sonic_asic_platform == 'mellanox' -%}
+Requires=hw-management.service
+{% endif -%}
+
 
 [Service]
 Type=oneshot
-{% if sonic_asic_platform == 'mellanox' -%}
-EnvironmentFile=/host/machine.conf
-ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$onie_platform/hw-management start"
-{% endif -%}
 ExecStart=/usr/bin/updategraph
 RemainAfterExit=yes
 

--- a/platform/mellanox/.gitignore
+++ b/platform/mellanox/.gitignore
@@ -3,6 +3,7 @@ mlnx-sai/*
 !mlnx-sai/Makefile
 hw-management/*
 !hw-management/Makefile
+!hw-management/*.patch
 mft/*
 !mft/Makefile
 

--- a/platform/mellanox/hw-management/Add-systemd-service-config.patch
+++ b/platform/mellanox/hw-management/Add-systemd-service-config.patch
@@ -1,0 +1,58 @@
+From 22fef644b1150677353ab0559828ea45a982d901 Mon Sep 17 00:00:00 2001
+From: Andriy Moroz <c_andriym@mellanox.com>
+Date: Wed, 11 Jul 2018 16:51:07 +0300
+Subject: [PATCH] Add systemd service config
+
+Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>
+---
+ debian/control               |  2 +-
+ debian/hw-management.service | 10 ++++++++++
+ debian/rules                 |  2 +-
+ 3 files changed, 12 insertions(+), 2 deletions(-)
+ create mode 100644 debian/hw-management.service
+
+diff --git a/debian/control b/debian/control
+index 048cd61..7e3a545 100644
+--- a/debian/control
++++ b/debian/control
+@@ -1,7 +1,7 @@
+ Source: hw-management
+ Priority: extra
+ Maintainer: Adir Atias <adira@dev-r-vrt-128-008>
+-Build-Depends:
++Build-Depends: dh-systemd
+ Standards-Version:
+ Section: libs
+ Homepage: http://www.mellanox.com
+diff --git a/debian/hw-management.service b/debian/hw-management.service
+new file mode 100644
+index 0000000..d18916d
+--- /dev/null
++++ b/debian/hw-management.service
+@@ -0,0 +1,10 @@
++[Unit]
++Description=Mellanox Hardware Management
++
++[Service]
++Type=oneshot
++EnvironmentFile=/host/machine.conf
++ExecStart=/bin/bash -c "/usr/share/sonic/device/$onie_platform/hw-management start"
++
++[Install]
++WantedBy=multi-user.target
+diff --git a/debian/rules b/debian/rules
+index fc38817..fba4150 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -8,7 +8,7 @@ K_SRC ?= "/lib/modules/$(KVERSION)/build"
+ pwd=$(shell pwd)
+ 
+ %:
+-	dh $@
++	dh $@ --with systemd
+ 
+ override_dh_auto_configure:
+ 
+-- 
+1.9.1
+

--- a/platform/mellanox/hw-management/Makefile
+++ b/platform/mellanox/hw-management/Makefile
@@ -10,6 +10,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# build
 	pushd hw-management
+	git am ../*.patch
 	sed "s~@SED_VERSION@~$(MLNX_HW_MANAGEMENT_VERSION)~" -i debian/changelog
 	chmod +x ./debian/rules
 	sudo ./debian/rules binary KVERSION=$(KVERSION)

--- a/slave.mk
+++ b/slave.mk
@@ -481,6 +481,8 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	j2 -f env files/initramfs-tools/union-mount.j2 onie-image.conf > files/initramfs-tools/union-mount
 	j2 -f env files/initramfs-tools/arista-convertfs.j2 onie-image.conf > files/initramfs-tools/arista-convertfs
 
+	j2 files/build_templates/updategraph.service.j2 > updategraph.service
+
 	$(if $($*_DOCKERS),
 		j2 files/build_templates/sonic_debian_extension.j2 > sonic_debian_extension.sh
 		chmod +x sonic_debian_extension.sh,

--- a/src/sonic-config-engine/sonic_platform.py
+++ b/src/sonic-config-engine/sonic_platform.py
@@ -41,13 +41,12 @@ def get_sonic_version_info():
     return data
 
 def get_system_mac():
-    get_mac_cmd = "ip link show eth0 | grep ether | awk '{print $2}'"
     version_info = get_sonic_version_info()
 
     if (version_info['asic_type'] == 'mellanox'):
-        eeprom_file = "/sys/bus/i2c/devices/8-0051/eeprom"
-        if (os.access(eeprom_file, os.R_OK)):
-            get_mac_cmd = "od -vt x1 -An " + eeprom_file + "| xargs printf \"0x%s \" | xargs printf \"%02x:\" | awk 'BEGIN { FS=\":\"; i=8+1+2+1} {while(i<NF) {type=$i; len=(\"0x\"$(i+1));if(type!=\"24\") {i=i+2+len} else {print substr($0, (i+1)*3+1, len*3-1); break}}}'"
+        get_mac_cmd = "sudo decode-syseeprom -m"
+    else:
+        get_mac_cmd = "ip link show eth0 | grep ether | awk '{print $2}'"
 
     proc = subprocess.Popen(get_mac_cmd, shell=True, stdout=subprocess.PIPE)
     (mac, err) = proc.communicate()

--- a/src/sonic-config-engine/sonic_platform.py
+++ b/src/sonic-config-engine/sonic_platform.py
@@ -48,8 +48,11 @@ def get_system_mac():
     else:
         get_mac_cmd = "ip link show eth0 | grep ether | awk '{print $2}'"
 
-    proc = subprocess.Popen(get_mac_cmd, shell=True, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(get_mac_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (mac, err) = proc.communicate()
+    if err:
+        return None
+
     mac = mac.strip()
     
     # Align last byte of MAC if necessary


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

**- What I did**
Updated teams start script to pass MAC from EEPROM to the portchannels config template

**- How I did it**
updated start.sh which runs in teamd container 

**- How to verify it**
Start SONiC and make sure MACs on PortChannel (and members) or Vlan interface are similar to one returned by command
od -vt x1 -An /sys/bus/i2c/devices/8-0051/eeprom | xargs printf "0x%s " | xargs printf "%02x:" | awk 'BEGIN { FS=":"; i=8+1+2+1} {while(i<NF) {type=$i; len=("0x"$(i+1));if(type!="24") {i=i+2+len} else {print substr($0, (i+1)*3+1, len*3-1); break}}}'

some bits in last byte may differ
