### PR TITLE
[aaa/sudoer] Modify sudo lecture message to be more informational

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -179,6 +179,7 @@ sudo cp $IMAGE_CONFIGS/asn/deployment_id_asn_map.yml $FILESYSTEM_ROOT/etc/sonic/
 
 # Copy sudoers configuration file
 sudo cp $IMAGE_CONFIGS/sudoers/sudoers $FILESYSTEM_ROOT/etc/
+sudo cp $IMAGE_CONFIGS/sudoers/sudoers.lecture $FILESYSTEM_ROOT/etc/
 
 # Copy control plane ACL management daemon files
 sudo cp $IMAGE_CONFIGS/caclmgrd/caclmgrd.service  $FILESYSTEM_ROOT/etc/systemd/system/

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -10,6 +10,7 @@ Defaults        env_reset
 #Defaults        mail_badpass
 Defaults        secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 Defaults        env_keep += "VTYSH_PAGER"
+Defaults        lecture_file = /etc/sudoers.lecture
 
 # Host alias specification
 

--- a/files/image_config/sudoers/sudoers.lecture
+++ b/files/image_config/sudoers/sudoers.lecture
@@ -1,0 +1,4 @@
+
+Make sure your account has RW permission to current device.
+Otherwise sudo requests will be rejected.
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Currently, when a user with RO permission tries to sudo, the Linux default sudo lecture message will be prompted as following:

> user_ro@sonic-9:/home/admin$ sudo ls
>
> We trust you have received the usual lecture from the local System
> Administrator. It usually boils down to these three things:
>
>    #1) Respect the privacy of others.
>    #2) Think before you type.
>    #3) With great power comes great responsibility.
>
> [sudo] password for user_ro: 
> Sorry, try again.

This PR changes it into a more sonic-specific one:
> user_ro@sonic-9:/home/admin$ sudo ls
>
> Make sure your account has RW permission to current device.
> Otherwise sudo requests will be rejected.
>
> [sudo] password for user_ro: 
> Sorry, try again.

