### PR TITLE
Manually send SIGHUP to vtysh when the current session was disconnected

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/vtysh
+++ b/dockers/docker-fpm-frr/base_image_files/vtysh
@@ -3,12 +3,11 @@
 # Determine whether stdout is on a terminal
 if [ -t 1 ] ; then
   # Prepare a function to send HUP signal to vtysh in the container
-  # we mark the new instance of vtysh with current tty as a tag
+  # we mark the new instance of vtysh with the current tty as a tag
   TTY=$(tty)
   function cleanup
   {
-    PID_FOR_HUP=$(docker exec -i bgp ps a | grep "vtysh $TTY" | awk '{print $1; }')
-    docker exec -i bgp kill -HUP $PID_FOR_HUP
+    docker exec -i bgp pkill -HUP -f "vtysh $TTY"
   }
   trap cleanup HUP
   docker exec -ti bgp vtysh "$TTY" "$@"

--- a/dockers/docker-fpm-frr/base_image_files/vtysh
+++ b/dockers/docker-fpm-frr/base_image_files/vtysh
@@ -1,3 +1,17 @@
 #!/bin/bash
 
-docker exec -i bgp vtysh "$@"
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+  # Prepare a function to send HUP signal to vtysh in the container
+  # we mark the new instance of vtysh with current tty as a tag
+  TTY=$(tty)
+  function cleanup
+  {
+    PID_FOR_HUP=$(docker exec -i bgp ps a | grep "vtysh $TTY" | awk '{print $1; }')
+    docker exec -i bgp kill -HUP $PID_FOR_HUP
+  }
+  trap cleanup HUP
+  docker exec -ti bgp vtysh "$TTY" "$@"
+else
+  docker exec -i bgp vtysh "$@"
+fi

--- a/dockers/docker-fpm-quagga/base_image_files/vtysh
+++ b/dockers/docker-fpm-quagga/base_image_files/vtysh
@@ -3,12 +3,11 @@
 # Determine whether stdout is on a terminal
 if [ -t 1 ] ; then
   # Prepare a function to send HUP signal to vtysh in the container
-  # we mark the new instance of vtysh with current tty as a tag
+  # we mark the new instance of vtysh with the current tty as a tag
   TTY=$(tty)
   function cleanup
   {
-    PID_FOR_HUP=$(docker exec -i bgp ps a | grep "vtysh $TTY" | awk '{print $1; }')
-    docker exec -i bgp kill -HUP $PID_FOR_HUP
+    docker exec -i bgp pkill -HUP -f "vtysh $TTY"
   }
   trap cleanup HUP
   docker exec -ti bgp vtysh "$TTY" "$@"

--- a/dockers/docker-fpm-quagga/base_image_files/vtysh
+++ b/dockers/docker-fpm-quagga/base_image_files/vtysh
@@ -1,3 +1,17 @@
 #!/bin/bash
 
-docker exec -i bgp vtysh "$@"
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+  # Prepare a function to send HUP signal to vtysh in the container
+  # we mark the new instance of vtysh with current tty as a tag
+  TTY=$(tty)
+  function cleanup
+  {
+    PID_FOR_HUP=$(docker exec -i bgp ps a | grep "vtysh $TTY" | awk '{print $1; }')
+    docker exec -i bgp kill -HUP $PID_FOR_HUP
+  }
+  trap cleanup HUP
+  docker exec -ti bgp vtysh "$TTY" "$@"
+else
+  docker exec -i bgp vtysh "$@"
+fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I added a logic to send SIGHUP to running vtysh in bgp container. Otherwise it will run in the container indefinitely long. This PR is fix for the previous https://github.com/Azure/sonic-buildimage/pull/1792:  which broke autocompletion in vtysh.

**- How I did it**
1. Get current tty for the session.
2. Register signal handler for bash running in host os
3. Send SIGHUP to the vtysh process which was run by current TTY session

**- How to verify it**
Run vtysh and disconnect from the console. When you connect back, you'll not find any vtysh instances.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
