### PR TITLE
[interface-config] Force eth0 before reconfiguration

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ifdown eth0
+ifdown --force eth0
 
 sonic-cfggen -d -t /usr/share/sonic/templates/interfaces.j2 > /etc/network/interfaces
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Force `ifdown` `eth0` before reconfig `/etc/network/interfaces' file, to make sure the changes to the file would be applied by `ifup` in the later `systemctl restart networking`.

**- More information**
What was triggered by `systemctl restart networking` is actually an `ifdown && ifup` for every interfaces except `lo`. If `eth0` is in a wrong state before reconfiguration (we see that several times because of manual configuration), this `if down` could fail and result in `ifup` script not correctly executed.