### PR TITLE
Enable bgp soft-reconfiguration inbound for quagga templates

### DIFF
--- a/dockers/docker-fpm-quagga/bgpd.conf.j2
+++ b/dockers/docker-fpm-quagga/bgpd.conf.j2
@@ -78,6 +78,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
     neighbor {{ neighbor_addr }} allowas-in 1
 {% endif %}
     neighbor {{ neighbor_addr }} activate
+    neighbor {{ neighbor_addr }} soft-reconfiguration inbound
     maximum-paths 64
   exit-address-family
 {% endif %}
@@ -87,6 +88,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
     neighbor {{ neighbor_addr }} allowas-in 1
 {% endif %}
     neighbor {{ neighbor_addr }} activate
+    neighbor {{ neighbor_addr }} soft-reconfiguration inbound
     maximum-paths 64
   exit-address-family
 {% endif %}

--- a/src/sonic-config-engine/tests/sample_output/bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/bgpd.conf
@@ -32,6 +32,7 @@ router bgp 65100
   address-family ipv4
     neighbor 10.0.0.57 allowas-in 1
     neighbor 10.0.0.57 activate
+    neighbor 10.0.0.57 soft-reconfiguration inbound
     maximum-paths 64
   exit-address-family
   neighbor 10.0.0.59 remote-as 64600
@@ -39,6 +40,7 @@ router bgp 65100
   address-family ipv4
     neighbor 10.0.0.59 allowas-in 1
     neighbor 10.0.0.59 activate
+    neighbor 10.0.0.59 soft-reconfiguration inbound
     maximum-paths 64
   exit-address-family
   neighbor 10.0.0.61 remote-as 64600
@@ -46,6 +48,7 @@ router bgp 65100
   address-family ipv4
     neighbor 10.0.0.61 allowas-in 1
     neighbor 10.0.0.61 activate
+    neighbor 10.0.0.61 soft-reconfiguration inbound
     maximum-paths 64
   exit-address-family
   neighbor 10.0.0.63 remote-as 64600
@@ -53,6 +56,7 @@ router bgp 65100
   address-family ipv4
     neighbor 10.0.0.63 allowas-in 1
     neighbor 10.0.0.63 activate
+    neighbor 10.0.0.63 soft-reconfiguration inbound
     maximum-paths 64
   exit-address-family
   neighbor fc00::7a remote-as 64600
@@ -60,6 +64,7 @@ router bgp 65100
   address-family ipv6
     neighbor fc00::7a allowas-in 1
     neighbor fc00::7a activate
+    neighbor fc00::7a soft-reconfiguration inbound
     maximum-paths 64
   exit-address-family
   neighbor fc00::7e remote-as 64600
@@ -67,6 +72,7 @@ router bgp 65100
   address-family ipv6
     neighbor fc00::7e allowas-in 1
     neighbor fc00::7e activate
+    neighbor fc00::7e soft-reconfiguration inbound
     maximum-paths 64
   exit-address-family
   neighbor fc00::72 remote-as 64600
@@ -74,6 +80,7 @@ router bgp 65100
   address-family ipv6
     neighbor fc00::72 allowas-in 1
     neighbor fc00::72 activate
+    neighbor fc00::72 soft-reconfiguration inbound
     maximum-paths 64
   exit-address-family
   neighbor fc00::76 remote-as 64600
@@ -81,6 +88,7 @@ router bgp 65100
   address-family ipv6
     neighbor fc00::76 allowas-in 1
     neighbor fc00::76 activate
+    neighbor fc00::76 soft-reconfiguration inbound
     maximum-paths 64
   exit-address-family
 !


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I turn on bgp inbound soft reconfiguration for both ipv4 and ipv6 neighbors in the quagga bgp template.

**- How I did it**
Adding configuration commands to the template

**- How to verify it**
`sh ip bgp neighbors 10.0.0.1 received-routes` must show list of received routes if the soft reconfiguration is enabled. Otherwise it will show
```
# sh ip bgp neighbors 10.0.0.1 received-routes  
% Inbound soft reconfiguration not enabled
```
Also `sh ip bgp neighbors 10.0.0.5` should include following:
```
 For address family: IPv4 Unicast
  Inbound soft reconfiguration allowed
  Community attribute sent to this neighbor(both)
  6402 accepted prefixes
```
In case of ipv6 `sh ip bgp neighbors fc00::a`
```
For address family: IPv6 Unicast
  Inbound soft reconfiguration allowed
  Community attribute sent to this neighbor(both)
  6402 accepted prefixes
```

**- Description for the changelog**
Enable  bgp inbound soft reconfiguration for both ipv4 and ipv6 neighbors
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
