### PR TITLE
Prefix docker container name to syslog syslogtag (program name)

### DIFF
--- a/dockers/docker-base/etc/rsyslog.conf
+++ b/dockers/docker-base/etc/rsyslog.conf
@@ -29,8 +29,10 @@ $ModLoad imuxsock # provides support for local system logging
 ###########################
 #### GLOBAL DIRECTIVES ####
 ###########################
-#Set remote syslog server
-*.* @127.0.0.1:514
+
+# Set remote syslog server
+template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
+*.* action(type="omfwd" target="127.0.0.1" port="514" protocol="udp" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.

--- a/dockers/docker-database/Dockerfile.j2
+++ b/dockers/docker-database/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockers/docker-dhcp-relay/Dockerfile.j2
+++ b/dockers/docker-dhcp-relay/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockers/docker-fpm-quagga/Dockerfile.j2
+++ b/dockers/docker-fpm-quagga/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockers/docker-lldp-sv2/Dockerfile.j2
+++ b/dockers/docker-lldp-sv2/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockers/docker-router-advertiser/Dockerfile.j2
+++ b/dockers/docker-router-advertiser/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockers/docker-snmp-sv2/Dockerfile.j2
+++ b/dockers/docker-snmp-sv2/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 # Enable -O for all Python calls
 ENV PYTHONOPTIMIZE 1
 

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/platform/cavium/docker-syncd-cavm/Dockerfile.j2
+++ b/platform/cavium/docker-syncd-cavm/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/platform/centec/docker-syncd-centec/Dockerfile.j2
+++ b/platform/centec/docker-syncd-centec/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/platform/marvell/docker-syncd-mrvl/Dockerfile.j2
+++ b/platform/marvell/docker-syncd-mrvl/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/platform/nephos/docker-syncd-nephos/Dockerfile.j2
+++ b/platform/nephos/docker-syncd-nephos/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/platform/p4/docker-sonic-p4/Dockerfile.j2
+++ b/platform/p4/docker-sonic-p4/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM docker-config-engine
 
+ARG docker_container_name
+RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name\/%syslogtag%/;" /etc/rsyslog.conf
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/slave.mk
+++ b/slave.mk
@@ -382,6 +382,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_SIMPLE_DOCKER_IMAGES)) : $(TARGET_PATH)/%.g
 		--build-arg user=$(USER) \
 		--build-arg uid=$(UID) \
 		--build-arg guid=$(GUID) \
+		--build-arg docker_container_name=$($*.gz_CONTAINER_NAME) \
 		-t $* $($*.gz_PATH) $(LOG)
 	docker save $* | gzip -c > $@
 	# Clean up
@@ -412,6 +413,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .pl
 		--build-arg user=$(USER) \
 		--build-arg uid=$(UID) \
 		--build-arg guid=$(GUID) \
+		--build-arg docker_container_name=$($*.gz_CONTAINER_NAME) \
 		-t $* $($*.gz_PATH) $(LOG)
 	docker save $* | gzip -c > $@
 	# Clean up


### PR DESCRIPTION
Refine syslog in host system file and forwarded message to remote server
Before:
```
Jun 23 06:00:41.207694 sonic INFO snmp-subagent [ax_interface] INFO: OID registration complete. Waiting to receive PDUs...
Jun 23 06:00:44.800044 sonic INFO supervisord 2018-06-23 06:00:35,789 INFO success: rsyslogd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
```

After:
```
Jun 23 06:00:41.207694 sonic INFO snmp/snmp-subagent [ax_interface] INFO: OID registration complete. Waiting to receive PDUs...
Jun 23 06:00:44.800044 sonic INFO snmp/supervisord 2018-06-23 06:00:35,789 INFO success: rsyslogd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
```
