### PR TITLE
Add initial support for keeping track of and displaying reboot cause

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -112,12 +112,12 @@ process_reboot_cause() {
     PREVIOUS_REBOOT_CAUSE_FILE="/var/cache/sonic/previous-reboot-cause.txt"
 
     # Set the previous reboot cause accordingly
-    # If this is the first boot after an image upgrade, state that as the
+    # If this is the first boot after an image install, state that as the
     # cause. Otherwise, move REBOOT_CAUSE_FILE to PREVIOUS_REBOOT_CAUSE_FILE.
     # REBOOT_CAUSE_FILE should always exist, but we add the else case
     # to ensure we always generate PREVIOUS_REBOOT_CAUSE_FILE here
     if [ -f $FIRST_BOOT_FILE ]; then
-        echo "SONiC firmware upgrade" > $PREVIOUS_REBOOT_CAUSE_FILE
+        echo "SONiC image installation" > $PREVIOUS_REBOOT_CAUSE_FILE
     elif [ -f $REBOOT_CAUSE_FILE ]; then
         mv -f $REBOOT_CAUSE_FILE $PREVIOUS_REBOOT_CAUSE_FILE
     else

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -14,9 +14,6 @@
 eval SONIC_VERSION=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
 FIRST_BOOT_FILE="/host/image-${SONIC_VERSION}/platform/firsttime"
 
-echo $SONIC_VERSION
-echo $FIRST_BOOT_FILE
-
 # In case the unit is migrating from another NOS, save the logs
 log_migration() {
     echo $1 >> /host/migration/migration.log
@@ -109,6 +106,32 @@ value_extract() {
     done
 }
 
+# Set up previous and next reboot cause files
+process_reboot_cause() {
+    REBOOT_CAUSE_FILE="/var/cache/sonic/reboot-cause.txt"
+    PREVIOUS_REBOOT_CAUSE_FILE="/var/cache/sonic/previous-reboot-cause.txt"
+
+    # Set the previous reboot cause accordingly
+    # If this is the first boot after an image upgrade, state that as the
+    # cause. Otherwise, move REBOOT_CAUSE_FILE to PREVIOUS_REBOOT_CAUSE_FILE.
+    # REBOOT_CAUSE_FILE should always exist, but we add the else case
+    # to ensure we always generate PREVIOUS_REBOOT_CAUSE_FILE here
+    if [ -f $FIRST_BOOT_FILE ]; then
+        echo "SONiC firmware upgrade" > $PREVIOUS_REBOOT_CAUSE_FILE
+    elif [ -f $REBOOT_CAUSE_FILE ]; then
+        mv -f $REBOOT_CAUSE_FILE $PREVIOUS_REBOOT_CAUSE_FILE
+    else
+        echo "Unknown reboot cause" > $PREVIOUS_REBOOT_CAUSE_FILE
+    fi
+
+    # Set the default cause for the next reboot
+    echo "Unexpected reboot" > $REBOOT_CAUSE_FILE
+}
+
+#### Begin Main Body ####
+
+# Set up previous and next reboot cause files
+process_reboot_cause
 
 # If the machine.conf is absent, it indicates that the unit booted
 # into SONiC from another NOS. Extract the machine.conf from ONIE.

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -11,7 +11,7 @@
 #
 # By default this script does nothing.
 
-eval SONIC_VERSION=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
+SONIC_VERSION=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version)
 FIRST_BOOT_FILE="/host/image-${SONIC_VERSION}/platform/firsttime"
 
 # In case the unit is migrating from another NOS, save the logs

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -11,6 +11,12 @@
 #
 # By default this script does nothing.
 
+eval SONIC_VERSION=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
+FIRST_BOOT_FILE="/host/image-${SONIC_VERSION}/platform/firsttime"
+
+echo $SONIC_VERSION
+echo $FIRST_BOOT_FILE
+
 # In case the unit is migrating from another NOS, save the logs
 log_migration() {
     echo $1 >> /host/migration/migration.log
@@ -84,6 +90,25 @@ update_mgmt_interface_macaddr() {
     log_migration "/etc/udev/rules.d/70-persistent-net.rules : replacing $old_mac with $new_mac for eth0"
     sed -i "/eth0/ s/ATTR{address}==\"$old_mac\"/ATTR{address}==\"$new_mac\"/g" /etc/udev/rules.d/70-persistent-net.rules
 }
+
+firsttime_exit() {
+    rm -rf $FIRST_BOOT_FILE
+    exit 0
+}
+
+# Given a string of tuples of the form field=value, extract the value for a field
+# In : $string, $field
+# Out: $value
+value_extract() {
+    set -- $string
+    for x in "$@"; do
+        case "$x" in
+            $field=*)
+                value="${x#$field=}"
+        esac
+    done
+}
+
 
 # If the machine.conf is absent, it indicates that the unit booted
 # into SONiC from another NOS. Extract the machine.conf from ONIE.
@@ -161,38 +186,16 @@ fi
 
 . /host/machine.conf
 
-echo "install platform dependent packages at the first boot time"
+if [ -f $FIRST_BOOT_FILE ]; then
 
-firsttime_exit()
-{
-    rm /host/image-$sonic_version/platform/firsttime
-    exit 0
-}
-
-# Given a string of tuples of the form field=value, extract the value for a field
-# In : $string, $field
-# Out: $value
-value_extract()
-{
-set -- $string
-for x in "$@"; do
-    case "$x" in
-        $field=*)
-            value="${x#$field=}"
-    esac
-done
-}
-
-eval sonic_version=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
-
-if [ -f /host/image-$sonic_version/platform/firsttime ]; then
+    echo "First boot detected. Performing first boot tasks..."
 
     if [ -n "$aboot_platform" ]; then
         platform=$aboot_platform
     elif [ -n "$onie_platform" ]; then
         platform=$onie_platform
     else
-        echo "Unknown sonic platform"
+        echo "Unknown SONiC platform"
         firsttime_exit
     fi
 
@@ -216,15 +219,15 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         touch /tmp/pending_config_initialization
     fi
 
-    if [ -d /host/image-$sonic_version/platform/$platform ]; then
-        dpkg -i /host/image-$sonic_version/platform/$platform/*.deb
+    if [ -d /host/image-$SONIC_VERSION/platform/$platform ]; then
+        dpkg -i /host/image-$SONIC_VERSION/platform/$platform/*.deb
     fi
 
     # If the unit booted into SONiC from another NOS's grub,
     # we now install a grub for SONiC.
     if [ -n "$onie_platform" ] && [ -n "$migration" ]; then
 
-        grub_bin=$(ls /host/image-$sonic_version/platform/x86_64-grub/grub-pc-bin*.deb 2> /dev/null)
+        grub_bin=$(ls /host/image-$SONIC_VERSION/platform/x86_64-grub/grub-pc-bin*.deb 2> /dev/null)
         if [ -z "$grub_bin" ]; then
             log_migration "Unable to locate grub package !"
             firsttime_exit
@@ -302,7 +305,7 @@ if [ -f /host/image-$sonic_version/platform/firsttime ]; then
         mv /host/grub.cfg /host/grub/grub.cfg
     fi
 
-    rm /host/image-$sonic_version/platform/firsttime
+    firsttime_exit
 fi
 
 exit 0


### PR DESCRIPTION
**- What I did**

Add initial support for keeping track of and displaying reboot cause

**- How I did it**

- Upon boot, rc.local determines the cause of the previous reboot and generates `/var/cache/sonic/previous-reboot-cause.txt` to contain the cause. This is determined as follows:
  - If this is the first boot after an image upgrade, it writes `SONiC firmware upgrade`
  - Otherwise it moves `/var/cache/sonic/reboot-cause.txt` (which should contain the cause of the previous reboot -- see below) to `/var/cache/sonic/previous-reboot-cause.txt`
  - In the unlikely event `/var/cache/sonic/reboot-cause.txt` does not exist, it writes `Unknown reboot cause`
- rc.local then generates a new `/var/cache/sonic/reboot-cause.txt` file containing the default cause of `Unexpected reboot`. This file should be updated before going down for reboot if the cause is known. This is currently only done in the reboot wrapper script in sonic-utilities, which updates the file when a user issues the `reboot` command.

- The new command `show reboot-cause` can be used to display the previous reboot cause. Sample output:

```
admin@sonic:~$ show reboot-cause 
User issued reboot command [User: admin, Time: Sat Jun 23 01:30:43 UTC 2018]
```

```
admin@sonic:~$ show reboot-cause 
Unexpected reboot
```

- Also reorganized rc.local such that the file contains (in order) constant declarations, function definitions, main body

- Also renamed constants using all caps

**- How to verify it**
- Try rebooting the device by both command and by hard power cycle. Once booted, run `show reboot-cause` and confirm the output is expected.

**- For the future**

- We can abstract a platform-agnostic way to determine whether the device rebooted due to a hard power-cycle, and possibly other reboot causes.