### PR TITLE
[sonic-cli] add a new cli to host environment.

### DIFF
--- a/rules/sonic-cli.mk
+++ b/rules/sonic-cli.mk
@@ -1,0 +1,8 @@
+# sonic-cli packages
+
+CLI_VERSION = 1.0.0
+
+SONIC_CLI = sonic-cli-$(CLI_VERSION)-Linux.deb
+$(SONIC_CLI)_DEPENDS += $(LIBTAC_DEV)
+$(SONIC_CLI)_SRC_PATH = $(SRC_PATH)/sonic-utilities/sonic-cli
+SONIC_CMAKE_DEBS += $(SONIC_CLI)


### PR DESCRIPTION
**- What I did**
Add a new cli to host environment.
**- How I did it**
Add related cmake processing.
Make a shared path between host and Quagga. CLI uses this path to connect vtysh server of quagga.
**- How to verify it**
Type cli on linux.