### PR TITLE
Migrate brcm platform to use new ECN config

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/qos.json.j2
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/qos.json.j2
@@ -127,35 +127,23 @@
         }
     },
     "WRED_PROFILE": {
-        "AZURE_LOSSY" : {
-            "wred_green_enable":"true",
-            "wred_yellow_enable":"true",
-            "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
-        },
         "AZURE_LOSSLESS" : {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
+            "red_max_threshold":"312000",
+            "red_min_threshold":"104000",
+            "yellow_max_threshold":"312000",
+            "yellow_min_threshold":"104000",
+            "green_max_threshold": "312000",
+            "green_min_threshold": "104000"
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0-1" : {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]"
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
+            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0" : {
             "scheduler"     :   "[SCHEDULER|scheduler.1]"

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/qos.json.j2
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/qos.json.j2
@@ -127,35 +127,23 @@
         }
     },
     "WRED_PROFILE": {
-        "AZURE_LOSSY" : {
-            "wred_green_enable":"true",
-            "wred_yellow_enable":"true",
-            "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
-        },
         "AZURE_LOSSLESS" : {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
+            "red_max_threshold":"312000",
+            "red_min_threshold":"104000",
+            "yellow_max_threshold":"312000",
+            "yellow_min_threshold":"104000",
+            "green_max_threshold": "312000",
+            "green_min_threshold": "104000"
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet2,Ethernet4,Ethernet6,Ethernet8,Ethernet10,Ethernet12,Ethernet14,Ethernet16,Ethernet18,Ethernet20,Ethernet22,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet42,Ethernet44,Ethernet46,Ethernet48,Ethernet50,Ethernet52,Ethernet54,Ethernet56,Ethernet58,Ethernet60,Ethernet62,Ethernet64,Ethernet66,Ethernet68,Ethernet70,Ethernet72,Ethernet74,Ethernet76,Ethernet78,Ethernet80,Ethernet82,Ethernet84,Ethernet86,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet106,Ethernet108,Ethernet110,Ethernet112,Ethernet114,Ethernet116,Ethernet118,Ethernet120,Ethernet122,Ethernet124,Ethernet126|0-1": {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
         "Ethernet0,Ethernet2,Ethernet4,Ethernet6,Ethernet8,Ethernet10,Ethernet12,Ethernet14,Ethernet16,Ethernet18,Ethernet20,Ethernet22,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet42,Ethernet44,Ethernet46,Ethernet48,Ethernet50,Ethernet52,Ethernet54,Ethernet56,Ethernet58,Ethernet60,Ethernet62,Ethernet64,Ethernet66,Ethernet68,Ethernet70,Ethernet72,Ethernet74,Ethernet76,Ethernet78,Ethernet80,Ethernet82,Ethernet84,Ethernet86,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet106,Ethernet108,Ethernet110,Ethernet112,Ethernet114,Ethernet116,Ethernet118,Ethernet120,Ethernet122,Ethernet124,Ethernet126|3-4": {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]"
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
+            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },
         "Ethernet0,Ethernet2,Ethernet4,Ethernet6,Ethernet8,Ethernet10,Ethernet12,Ethernet14,Ethernet16,Ethernet18,Ethernet20,Ethernet22,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet42,Ethernet44,Ethernet46,Ethernet48,Ethernet50,Ethernet52,Ethernet54,Ethernet56,Ethernet58,Ethernet60,Ethernet62,Ethernet64,Ethernet66,Ethernet68,Ethernet70,Ethernet72,Ethernet74,Ethernet76,Ethernet78,Ethernet80,Ethernet82,Ethernet84,Ethernet86,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet106,Ethernet108,Ethernet110,Ethernet112,Ethernet114,Ethernet116,Ethernet118,Ethernet120,Ethernet122,Ethernet124,Ethernet126|0": {
             "scheduler"     :   "[SCHEDULER|scheduler.1]"

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/qos.json.j2
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/qos.json.j2
@@ -127,35 +127,23 @@
         }
     },
     "WRED_PROFILE": {
-        "AZURE_LOSSY" : {
-            "wred_green_enable":"true",
-            "wred_yellow_enable":"true",
-            "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
-        },
         "AZURE_LOSSLESS" : {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
+            "red_max_threshold":"312000",
+            "red_min_threshold":"104000",
+            "yellow_max_threshold":"312000",
+            "yellow_min_threshold":"104000",
+            "green_max_threshold": "312000",
+            "green_min_threshold": "104000"
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0-1" : {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]"
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
+            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0" : {
             "scheduler"     :   "[SCHEDULER|scheduler.1]"

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/qos.json.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/qos.json.j2
@@ -127,35 +127,23 @@
         }
     },
     "WRED_PROFILE": {
-        "AZURE_LOSSY" : {
-            "wred_green_enable":"true",
-            "wred_yellow_enable":"true",
-            "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
-        },
         "AZURE_LOSSLESS" : {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
+            "red_max_threshold":"312000",
+            "red_min_threshold":"104000",
+            "yellow_max_threshold":"312000",
+            "yellow_min_threshold":"104000",
+            "green_max_threshold": "312000",
+            "green_min_threshold": "104000"
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet2,Ethernet4,Ethernet6,Ethernet8,Ethernet10,Ethernet12,Ethernet14,Ethernet16,Ethernet18,Ethernet20,Ethernet22,Ethernet24,Ethernet26,Ethernet28,Ethernet30,Ethernet32,Ethernet34,Ethernet36,Ethernet38,Ethernet40,Ethernet42,Ethernet44,Ethernet46,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet82,Ethernet84,Ethernet86,Ethernet88,Ethernet90,Ethernet92,Ethernet94,Ethernet96,Ethernet98,Ethernet100,Ethernet102,Ethernet104,Ethernet106,Ethernet108,Ethernet110,Ethernet112,Ethernet114,Ethernet116,Ethernet118,Ethernet120,Ethernet122,Ethernet124,Ethernet126,Ethernet128,Ethernet130,Ethernet132,Ethernet134,Ethernet136,Ethernet138,Ethernet140,Ethernet142,Ethernet144,Ethernet146,Ethernet148,Ethernet150,Ethernet152,Ethernet154,Ethernet156,Ethernet158,Ethernet160,Ethernet162,Ethernet164,Ethernet166,Ethernet168,Ethernet170,Ethernet172,Ethernet174,Ethernet176,Ethernet178,Ethernet180,Ethernet182,Ethernet184,Ethernet186,Ethernet188,Ethernet190,Ethernet192,Ethernet194,Ethernet196,Ethernet198,Ethernet200,Ethernet202,Ethernet204,Ethernet206,Ethernet208,Ethernet210,Ethernet212,Ethernet214,Ethernet216,Ethernet218,Ethernet220,Ethernet222,Ethernet224,Ethernet226,Ethernet228,Ethernet230,Ethernet232,Ethernet234,Ethernet236,Ethernet238,Ethernet240,Ethernet242,Ethernet244,Ethernet246,Ethernet248,Ethernet250,Ethernet252,Ethernet254|0-1" : {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
         "Ethernet0,Ethernet2,Ethernet4,Ethernet6,Ethernet8,Ethernet10,Ethernet12,Ethernet14,Ethernet16,Ethernet18,Ethernet20,Ethernet22,Ethernet24,Ethernet26,Ethernet28,Ethernet30,Ethernet32,Ethernet34,Ethernet36,Ethernet38,Ethernet40,Ethernet42,Ethernet44,Ethernet46,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet82,Ethernet84,Ethernet86,Ethernet88,Ethernet90,Ethernet92,Ethernet94,Ethernet96,Ethernet98,Ethernet100,Ethernet102,Ethernet104,Ethernet106,Ethernet108,Ethernet110,Ethernet112,Ethernet114,Ethernet116,Ethernet118,Ethernet120,Ethernet122,Ethernet124,Ethernet126,Ethernet128,Ethernet130,Ethernet132,Ethernet134,Ethernet136,Ethernet138,Ethernet140,Ethernet142,Ethernet144,Ethernet146,Ethernet148,Ethernet150,Ethernet152,Ethernet154,Ethernet156,Ethernet158,Ethernet160,Ethernet162,Ethernet164,Ethernet166,Ethernet168,Ethernet170,Ethernet172,Ethernet174,Ethernet176,Ethernet178,Ethernet180,Ethernet182,Ethernet184,Ethernet186,Ethernet188,Ethernet190,Ethernet192,Ethernet194,Ethernet196,Ethernet198,Ethernet200,Ethernet202,Ethernet204,Ethernet206,Ethernet208,Ethernet210,Ethernet212,Ethernet214,Ethernet216,Ethernet218,Ethernet220,Ethernet222,Ethernet224,Ethernet226,Ethernet228,Ethernet230,Ethernet232,Ethernet234,Ethernet236,Ethernet238,Ethernet240,Ethernet242,Ethernet244,Ethernet246,Ethernet248,Ethernet250,Ethernet252,Ethernet254|3-4" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]"
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
+            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },
         "Ethernet0,Ethernet2,Ethernet4,Ethernet6,Ethernet8,Ethernet10,Ethernet12,Ethernet14,Ethernet16,Ethernet18,Ethernet20,Ethernet22,Ethernet24,Ethernet26,Ethernet28,Ethernet30,Ethernet32,Ethernet34,Ethernet36,Ethernet38,Ethernet40,Ethernet42,Ethernet44,Ethernet46,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet82,Ethernet84,Ethernet86,Ethernet88,Ethernet90,Ethernet92,Ethernet94,Ethernet96,Ethernet98,Ethernet100,Ethernet102,Ethernet104,Ethernet106,Ethernet108,Ethernet110,Ethernet112,Ethernet114,Ethernet116,Ethernet118,Ethernet120,Ethernet122,Ethernet124,Ethernet126,Ethernet128,Ethernet130,Ethernet132,Ethernet134,Ethernet136,Ethernet138,Ethernet140,Ethernet142,Ethernet144,Ethernet146,Ethernet148,Ethernet150,Ethernet152,Ethernet154,Ethernet156,Ethernet158,Ethernet160,Ethernet162,Ethernet164,Ethernet166,Ethernet168,Ethernet170,Ethernet172,Ethernet174,Ethernet176,Ethernet178,Ethernet180,Ethernet182,Ethernet184,Ethernet186,Ethernet188,Ethernet190,Ethernet192,Ethernet194,Ethernet196,Ethernet198,Ethernet200,Ethernet202,Ethernet204,Ethernet206,Ethernet208,Ethernet210,Ethernet212,Ethernet214,Ethernet216,Ethernet218,Ethernet220,Ethernet222,Ethernet224,Ethernet226,Ethernet228,Ethernet230,Ethernet232,Ethernet234,Ethernet236,Ethernet238,Ethernet240,Ethernet242,Ethernet244,Ethernet246,Ethernet248,Ethernet250,Ethernet252,Ethernet254|0" : {
             "scheduler"     :   "[SCHEDULER|scheduler.1]"

--- a/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-T0/qos.json.j2
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-T0/qos.json.j2
@@ -127,35 +127,23 @@
         }
     },
     "WRED_PROFILE": {
-        "AZURE_LOSSY" : {
-            "wred_green_enable":"true",
-            "wred_yellow_enable":"true",
-            "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
-        },
         "AZURE_LOSSLESS" : {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
+            "red_max_threshold":"312000",
+            "red_min_threshold":"104000",
+            "yellow_max_threshold":"312000",
+            "yellow_min_threshold":"104000",
+            "green_max_threshold": "312000",
+            "green_min_threshold": "104000"
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet2,Ethernet4,Ethernet6,Ethernet8,Ethernet10,Ethernet12,Ethernet14,Ethernet16,Ethernet18,Ethernet20,Ethernet22,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet42,Ethernet44,Ethernet46,Ethernet48,Ethernet50,Ethernet52,Ethernet54,Ethernet56,Ethernet58,Ethernet60,Ethernet62,Ethernet64,Ethernet66,Ethernet68,Ethernet70,Ethernet72,Ethernet74,Ethernet76,Ethernet78,Ethernet80,Ethernet82,Ethernet84,Ethernet86,Ethernet88,Ethernet90,Ethernet92,Ethernet94,Ethernet96,Ethernet98,Ethernet100,Ethernet102,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet122,Ethernet124,Ethernet126|0-1": {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
         "Ethernet0,Ethernet2,Ethernet4,Ethernet6,Ethernet8,Ethernet10,Ethernet12,Ethernet14,Ethernet16,Ethernet18,Ethernet20,Ethernet22,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet42,Ethernet44,Ethernet46,Ethernet48,Ethernet50,Ethernet52,Ethernet54,Ethernet56,Ethernet58,Ethernet60,Ethernet62,Ethernet64,Ethernet66,Ethernet68,Ethernet70,Ethernet72,Ethernet74,Ethernet76,Ethernet78,Ethernet80,Ethernet82,Ethernet84,Ethernet86,Ethernet88,Ethernet90,Ethernet92,Ethernet94,Ethernet96,Ethernet98,Ethernet100,Ethernet102,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet122,Ethernet124,Ethernet126|3-4": {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]"
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
+            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },
         "Ethernet0,Ethernet2,Ethernet4,Ethernet6,Ethernet8,Ethernet10,Ethernet12,Ethernet14,Ethernet16,Ethernet18,Ethernet20,Ethernet22,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet42,Ethernet44,Ethernet46,Ethernet48,Ethernet50,Ethernet52,Ethernet54,Ethernet56,Ethernet58,Ethernet60,Ethernet62,Ethernet64,Ethernet66,Ethernet68,Ethernet70,Ethernet72,Ethernet74,Ethernet76,Ethernet78,Ethernet80,Ethernet82,Ethernet84,Ethernet86,Ethernet88,Ethernet90,Ethernet92,Ethernet94,Ethernet96,Ethernet98,Ethernet100,Ethernet102,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet122,Ethernet124,Ethernet126|0": {
             "scheduler"     :   "[SCHEDULER|scheduler.1]"

--- a/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100/qos.json.j2
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100/qos.json.j2
@@ -127,35 +127,23 @@
         }
     },
     "WRED_PROFILE": {
-        "AZURE_LOSSY" : {
-            "wred_green_enable":"true",
-            "wred_yellow_enable":"true",
-            "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
-        },
         "AZURE_LOSSLESS" : {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
-            "red_max_threshold":"512000",
-            "red_min_threshold":"512000",
-            "yellow_max_threshold":"512000",
-            "yellow_min_threshold":"512000",
-            "green_max_threshold": "184320",
-            "green_min_threshold": "184320"
+            "red_max_threshold":"312000",
+            "red_min_threshold":"104000",
+            "yellow_max_threshold":"312000",
+            "yellow_min_threshold":"104000",
+            "green_max_threshold": "312000",
+            "green_min_threshold": "104000"
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0-1" : {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]"
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
+            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0" : {
             "scheduler"     :   "[SCHEDULER|scheduler.1]"


### PR DESCRIPTION
Migrate brcm platform to use new ECN config, which is applied on lossless traffic.

hwsku:
Arista-7060CX-32S-C32
Arista-7060CX-32S-D48C8
Arista-7060CX-32S-Q32
Arista-7260CX3-D108C8
Force10-Z9100-T0
Force10-Z9100

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
Change qos.json

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
