### PR TITLE
[sonic-cli] add a new cli to host environment.

### DIFF
--- a/dockers/docker-fpm-quagga/start.sh
+++ b/dockers/docker-fpm-quagga/start.sh
@@ -22,6 +22,9 @@ supervisorctl start bgpcfgd
 
 supervisorctl start rsyslogd
 
+chmod 777 -R /var/run/quagga
+chown -R quagga /var/run/quagga
+chgrp -R quagga /var/run/quagga
 # Start Quagga processes
 supervisorctl start zebra
 supervisorctl start bgpd

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -101,6 +101,8 @@ sudo cp -f $IMAGE_CONFIGS/bash/bash.bashrc $FILESYSTEM_ROOT/etc/
 sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/sonic-device-data_*.deb || \
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
 
+# Install sonic-cli
+sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/sonic-cli*.deb
 # Install pam-tacplus and nss-tacplus
 sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/libtac2_*.deb
 sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/libpam-tacplus_*.deb

--- a/rules/docker-fpm-quagga.mk
+++ b/rules/docker-fpm-quagga.mk
@@ -9,5 +9,6 @@ SONIC_DOCKER_IMAGES += $(DOCKER_FPM_QUAGGA)
 $(DOCKER_FPM_QUAGGA)_CONTAINER_NAME = bgp
 $(DOCKER_FPM_QUAGGA)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_FPM_QUAGGA)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_FPM_QUAGGA)_RUN_OPT += -v /var/run/quagga:/var/run/quagga:rw
 
 $(DOCKER_FPM_QUAGGA)_BASE_IMAGE_FILES += vtysh:/usr/bin/vtysh

--- a/rules/sonic-cli.mk
+++ b/rules/sonic-cli.mk
@@ -1,0 +1,8 @@
+# sonic-cli packages
+
+CLI_VERSION = 1.0.0
+
+SONIC_CLI = sonic-cli-$(CLI_VERSION)-Linux.deb
+$(SONIC_CLI)_DEPENDS += $(LIBTAC_DEV)
+$(SONIC_CLI)_SRC_PATH = $(SRC_PATH)/sonic-utilities/sonic-cli
+SONIC_CMAKE_DEBS += $(SONIC_CLI)

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -55,6 +55,8 @@ RUN apt-get update && apt-get install -y \
         libpcre3-dev \
         gawk \
         chrpath \
+# For sonic-cli
+        libaudit-dev \
 # For frr build
         libc-ares-dev \
         hardening-wrapper \


### PR DESCRIPTION
- What I did
Add a new cli to host environment.
- How I did it
Add related cmake processing.
Make a shared path between host and Quagga. CLI uses this path to connect vtysh server of quagga.
- How to verify it
Type cli on linux.