### PR TITLE
Build python-click Debian package from version 6.7-4 source to fix CLI autocomplete/suggest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ src/lldpd/*
 !src/lldpd/patch/
 src/mpdecimal/*
 !src/mpdecimal/Makefile
+src/python-click/*
+!src/python-click/Makefile
 src/python3/*
 !src/python3/Makefile
 src/redis/*

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -89,6 +89,12 @@ sudo cp {{platform_common_py2_wheel_path}} $FILESYSTEM_ROOT/$PLATFORM_COMMON_PY2
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install $PLATFORM_COMMON_PY2_WHEEL_NAME
 sudo rm -rf $FILESYSTEM_ROOT/$PLATFORM_COMMON_PY2_WHEEL_NAME
 
+# Install built Python Click package (and its dependencies via 'apt-get -y install -f')
+# Do this before installing sonic-utilities so that it doesn't attempt to install
+# an older version as part of its dependencies
+sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/python-click*_all.deb || \
+    sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
+
 # Install SONiC Utilities (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/python-sonic-utilities_*.deb || \
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f

--- a/rules/python-click.mk
+++ b/rules/python-click.mk
@@ -1,0 +1,16 @@
+# python-click package
+#
+# Python Click versions < 6.7 have a bug which causes bash completion
+# functionality to stop working after two sublevels. sonic-utilities depends
+# on this package, and the most recent version provided by Debian Jessie and
+# Stretch is v6.6. We build version 6.7 from source in order to fix this bug.
+# TODO: If we upgrade to a distro which provides a version >= 6.7 we will no
+# longer need to build this.
+
+PYTHON_CLICK_VERSION = 6.7-4
+
+export PYTHON_CLICK_VERSION
+
+PYTHON_CLICK = python-click_$(PYTHON_CLICK_VERSION)_all.deb
+$(PYTHON_CLICK)_SRC_PATH = $(SRC_PATH)/python-click
+SONIC_MAKE_DEBS += $(PYTHON_CLICK)

--- a/slave.mk
+++ b/slave.mk
@@ -447,6 +447,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
                 $(IGB_DRIVER) \
                 $(IXGBE_DRIVER) \
                 $(SONIC_DEVICE_DATA) \
+                $(PYTHON_CLICK) \
                 $(SONIC_UTILS) \
                 $(LIBWRAP) \
                 $(LIBPAM_TACPLUS) \

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -193,8 +193,6 @@ RUN apt-get update && apt-get install -y \
         python-netaddr \
         python-ipaddr \
         python-yaml \
-# For sonic utilities
-        python3-netaddr \
 # For lockfile
         procmail \
 # For gtest
@@ -213,7 +211,17 @@ RUN apt-get update && apt-get install -y \
         linuxdoc-tools \
         lynx \
         texlive-latex-extra \
-        texlive-latex-recommended
+        texlive-latex-recommended\
+# For python-click build
+        python-sphinx \
+        python-docutils \
+        python3-all \
+        python3-setuptools \
+        python3-sphinx \
+        python3-docutils \
+        python3-requests \
+        python3-pytest \
+        python3-colorama
 
 # For linux build
 RUN apt-get -y build-dep linux

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -211,7 +211,7 @@ RUN apt-get update && apt-get install -y \
         linuxdoc-tools \
         lynx \
         texlive-latex-extra \
-        texlive-latex-recommended\
+        texlive-latex-recommended \
 # For python-click build
         python-sphinx \
         python-docutils \

--- a/src/python-click/Makefile
+++ b/src/python-click/Makefile
@@ -1,0 +1,26 @@
+.ONESHELL:
+SHELL = /bin/bash
+.SHELLFLAGS += -e
+
+MAIN_TARGET = python-click_$(PYTHON_CLICK_VERSION)_all.deb
+
+$(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
+	# Remove any stale files
+	rm -rf ./python-click
+
+	# Clone python-click Debian repo
+	git clone https://salsa.debian.org/debian/python-click
+
+	pushd ./python-click
+
+	# Reset HEAD to the commit of the proper tag
+	# NOTE: Using "git checkout <tag_name>" here detaches our HEAD,
+	# which stg doesn't like, so we use this method instead
+	git reset --hard debian/$(PYTHON_CLICK_VERSION)
+
+	# Build source and Debian packages
+	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
+	popd
+
+	# Move the newly-built .deb package to the destination directory
+	mv $* $(DEST)/


### PR DESCRIPTION
- Resolves https://github.com/Azure/sonic-utilities/issues/243

**- What I did**

- Download python-click source from Debian repos and build .deb package using v6.7-4 tag.
- There exists a bug in versions of Click < 6.7 in which bash completion (tab-to-autocomplete/tab-to-suggest) only works for the first two levels of subcommands. The bug was fixed in v6.7, however, the most recent package available via apt for Debian Jessie and Stretch is currently v6.6-1. so to get the fix, we must build our own package.

**- How to verify it**

- Try pressing Tab once to autocomplete commands at >= 3 levels of subgroups/subcommands

- Example:

    ```
    admin@sonic:~$ show interfaces transceiver ee
    ```

    *Press Tab once...*

    ```
    admin@sonic:~$ show interfaces transceiver eeprom
    ```

- Try pressing Tab twice to suggest subcommands at >= 3 levels of subgroups/subcommands

    ```
    admin@sonic:~$ show interfaces transceiver
    ```

    *Press Tab twice...*

    ```
    admin@sonic:~$ show interfaces transceiver 
    eeprom    lpmode    presence  
    ```

- Try pressing Tab twice to suggest options at >= 3 levels of subgroups/subcommands

    ```
    admin@sonic:~$ show interfaces transceiver eeprom -
    ```

    *Press Tab twice...*

    ```
    admin@sonic:~$ show interfaces transceiver eeprom -
    --dom      --verbose  -d 
    ```

**- Unrelated**
- Remove Python3 dependency for sonic-utilities, as we are no longer building a Python3 version of that package.
