### PR TITLE
Treat bcmcmd as a supervisor task so we could collect stdout/stderr

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/start.sh
+++ b/platform/broadcom/docker-syncd-brcm/start.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 PLATFORM_DIR=/usr/share/sonic/platform
 HWSKU_DIR=/usr/share/sonic/hwsku
@@ -18,6 +18,7 @@ else
     fi
 fi
 
+rm -f /var/run/sswsyncd/sswsyncd.socket
 supervisorctl start syncd
 
 # Function: wait until syncd has created the socket for bcmcmd to connect to
@@ -33,5 +34,5 @@ wait_syncd() {
 # If this platform has an initialization file for the Broadcom LED microprocessor, load it
 if [ -r ${PLATFORM_DIR}/led_proc_init.soc ]; then
     wait_syncd
-    /usr/bin/bcmcmd -t 60 "rcload ${PLATFORM_DIR}/led_proc_init.soc"
+    supervisorctl start bcmcmd
 fi

--- a/platform/broadcom/docker-syncd-brcm/start.sh
+++ b/platform/broadcom/docker-syncd-brcm/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PLATFORM_DIR=/usr/share/sonic/platform
 HWSKU_DIR=/usr/share/sonic/hwsku
@@ -34,5 +34,5 @@ wait_syncd() {
 # If this platform has an initialization file for the Broadcom LED microprocessor, load it
 if [ -r ${PLATFORM_DIR}/led_proc_init.soc ]; then
     wait_syncd
-    supervisorctl start bcmcmd
+    supervisorctl start ledinit
 fi

--- a/platform/broadcom/docker-syncd-brcm/supervisord.conf
+++ b/platform/broadcom/docker-syncd-brcm/supervisord.conf
@@ -26,3 +26,11 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[program:bcmcmd]
+command=/usr/bin/bcmcmd -t 60 "rcload /usr/share/sonic/platform/led_proc_init.soc"
+priority=4
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/platform/broadcom/docker-syncd-brcm/supervisord.conf
+++ b/platform/broadcom/docker-syncd-brcm/supervisord.conf
@@ -27,7 +27,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
-[program:bcmcmd]
+[program:ledinit]
 command=/usr/bin/bcmcmd -t 60 "rcload /usr/share/sonic/platform/led_proc_init.soc"
 priority=4
 autostart=false


### PR DESCRIPTION
Also clean the unix socket file before dsserve