### PR TITLE
[baseimage]: add commonly used network tools

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -222,7 +222,11 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     sysfsutils              \
     grub2-common            \
     ethtool                 \
-    screen
+    screen                  \
+    hping3                  \
+    python-scapy            \
+    tcptraceroute           \
+    nmap
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
     grub-pc-bin

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -226,7 +226,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     hping3                  \
     python-scapy            \
     tcptraceroute           \
-    nmap
+    nmap                    \
+    mtr-tiny
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
     grub-pc-bin

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -226,7 +226,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     hping3                  \
     python-scapy            \
     tcptraceroute           \
-    nmap                    \
     mtr-tiny
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

```
hping3: Active Network Smashing Tool
https://packages.debian.org/stretch/hping3
Installed Size 69.0 kB

python-scapy: Package: python-scapy (2.2.0-1)
Packet generator/sniffer and network scanner/discovery
https://packages.debian.org/jessie/python-scapy
Installed Size: 1,348.0 kB

tcptraceroute: traceroute implementation using TCP packets
https://packages.debian.org/jessie/tcptraceroute
Installed Size: 120.0 kB

nmap: The Network Mapper
https://packages.debian.org/jessie/nmap
Installed Size: 17,602.0 kB
```




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
