### PR TITLE
[make] introducing new build option KERNEL_PROCURE_METHOD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 #  * KEEP_SLAVE_ON: Keeps slave container up after building-process concludes.
 #  * SOURCE_FOLDER: host path to be mount as /var/$(USER)/src, only effective when KEEP_SLAVE_ON=yes
 #  * SONIC_BUILD_JOBS: Specifying number of concurrent build job(s) to run
-#  * KERNEL_BUILD_METHOD: Specifying method of building kernel: download or build
+#  * KERNEL_PROCURE_METHOD: Specifying method of obtaining kernel Debian package: download or build
 #
 ###############################################################################
 
@@ -70,7 +70,7 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            PASSWORD=$(PASSWORD) \
                            USERNAME=$(USERNAME) \
                            SONIC_BUILD_JOBS=$(SONIC_BUILD_JOBS) \
-                           KERNEL_BUILD_METHOD=$(KERNEL_BUILD_METHOD) \
+                           KERNEL_PROCURE_METHOD=$(KERNEL_PROCURE_METHOD) \
                            HTTP_PROXY=$(http_proxy) \
                            HTTPS_PROXY=$(https_proxy) \
                            SONIC_ENABLE_SYSTEM_TELEMETRY=$(ENABLE_SYSTEM_TELEMETRY)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@
 #  * PASSWORD: Desired password -- default at rules/config
 #  * KEEP_SLAVE_ON: Keeps slave container up after building-process concludes.
 #  * SOURCE_FOLDER: host path to be mount as /var/$(USER)/src, only effective when KEEP_SLAVE_ON=yes
-#  * SONIC_BUILD_JOB: Specifying number of concurrent build job(s) to run
+#  * SONIC_BUILD_JOBS: Specifying number of concurrent build job(s) to run
+#  * KERNEL_BUILD_METHOD: Specifying method of building kernel: download or build
 #
 ###############################################################################
 
@@ -69,6 +70,7 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            PASSWORD=$(PASSWORD) \
                            USERNAME=$(USERNAME) \
                            SONIC_BUILD_JOBS=$(SONIC_BUILD_JOBS) \
+                           KERNEL_BUILD_METHOD=$(KERNEL_BUILD_METHOD) \
                            HTTP_PROXY=$(http_proxy) \
                            HTTPS_PROXY=$(https_proxy) \
                            SONIC_ENABLE_SYSTEM_TELEMETRY=$(ENABLE_SYSTEM_TELEMETRY)

--- a/rules/config
+++ b/rules/config
@@ -67,7 +67,7 @@ ENABLE_ORGANIZATION_EXTENSIONS = y
 # ENABLE_SYSTEM_TELEMETRY - build docker-sonic-telemetry for system telemetry support
 # ENABLE_SYSTEM_TELEMETRY = y
 
-# DEFAULT_KERNEL_BUILD_METHOD - default method for building kernel
+# DEFAULT_KERNEL_PROCURE_METHOD - default method for obtaining kernel
 #   build:    build kernel from source
-#   download: downlaod built kernel from Azure storage.
-DEFAULT_KERNEL_BUILD_METHOD = build
+#   download: downlaod pre-built kernel from Azure storage.
+DEFAULT_KERNEL_PROCURE_METHOD = build

--- a/rules/config
+++ b/rules/config
@@ -69,5 +69,5 @@ ENABLE_ORGANIZATION_EXTENSIONS = y
 
 # DEFAULT_KERNEL_PROCURE_METHOD - default method for obtaining kernel
 #   build:    build kernel from source
-#   download: downlaod pre-built kernel from Azure storage.
+#   download: download pre-built kernel from Azure storage.
 DEFAULT_KERNEL_PROCURE_METHOD = build

--- a/rules/config
+++ b/rules/config
@@ -66,3 +66,8 @@ ENABLE_ORGANIZATION_EXTENSIONS = y
 
 # ENABLE_SYSTEM_TELEMETRY - build docker-sonic-telemetry for system telemetry support
 # ENABLE_SYSTEM_TELEMETRY = y
+
+# DEFAULT_KERNEL_BUILD_METHOD - default method for building kernel
+#   build:    build kernel from source
+#   download: downlaod built kernel from Azure storage.
+DEFAULT_KERNEL_BUILD_METHOD = build

--- a/slave.mk
+++ b/slave.mk
@@ -98,6 +98,10 @@ ifeq ($(SONIC_BUILD_JOBS),)
 override SONIC_BUILD_JOBS := $(SONIC_CONFIG_BUILD_JOBS)
 endif
 
+ifeq ($(KERNEL_BUILD_METHOD),)
+override KERNEL_BUILD_METHOD := $(DEFAULT_KERNEL_BUILD_METHOD)
+endif
+
 MAKEFLAGS += -j $(SONIC_BUILD_JOBS)
 export SONIC_CONFIG_MAKE_JOBS
 
@@ -126,12 +130,15 @@ $(info "HTTPS_PROXY"                     : "$(HTTPS_PROXY)")
 $(info "ENABLE_SYSTEM_TELEMETRY"         : "$(ENABLE_SYSTEM_TELEMETRY)")
 $(info "SONIC_DEBUGGING_ON"              : "$(SONIC_DEBUGGING_ON)")
 $(info "SONIC_PROFILING_ON"              : "$(SONIC_PROFILING_ON)")
+$(info "KERNEL_BUILD_METHOD"             : "$(KERNEL_BUILD_METHOD)")
 $(info )
 
 ###############################################################################
 ## Generic rules section
 ## All rules must go after includes for propper targets expansion
 ###############################################################################
+
+export kernel_build_method="$(KERNEL_BUILD_METHOD)"
 
 ###############################################################################
 ## Local targets
@@ -147,6 +154,7 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_COPY_DEBS)) : $(DEBS_PATH)/% : .platform
 	$(foreach deb,$* $($*_DERIVED_DEBS), \
 	    { cp $($(deb)_PATH)/$(deb) $(DEBS_PATH)/ $(LOG) || exit 1 ; } ; )
 	$(FOOTER)
+
 
 SONIC_TARGET_LIST += $(addprefix $(DEBS_PATH)/, $(SONIC_COPY_DEBS))
 

--- a/slave.mk
+++ b/slave.mk
@@ -98,8 +98,8 @@ ifeq ($(SONIC_BUILD_JOBS),)
 override SONIC_BUILD_JOBS := $(SONIC_CONFIG_BUILD_JOBS)
 endif
 
-ifeq ($(KERNEL_BUILD_METHOD),)
-override KERNEL_BUILD_METHOD := $(DEFAULT_KERNEL_BUILD_METHOD)
+ifeq ($(KERNEL_PROCURE_METHOD),)
+override KERNEL_PROCURE_METHOD := $(DEFAULT_KERNEL_PROCURE_METHOD)
 endif
 
 MAKEFLAGS += -j $(SONIC_BUILD_JOBS)
@@ -130,7 +130,7 @@ $(info "HTTPS_PROXY"                     : "$(HTTPS_PROXY)")
 $(info "ENABLE_SYSTEM_TELEMETRY"         : "$(ENABLE_SYSTEM_TELEMETRY)")
 $(info "SONIC_DEBUGGING_ON"              : "$(SONIC_DEBUGGING_ON)")
 $(info "SONIC_PROFILING_ON"              : "$(SONIC_PROFILING_ON)")
-$(info "KERNEL_BUILD_METHOD"             : "$(KERNEL_BUILD_METHOD)")
+$(info "KERNEL_PROCURE_METHOD"           : "$(KERNEL_PROCURE_METHOD)")
 $(info )
 
 ###############################################################################
@@ -138,7 +138,7 @@ $(info )
 ## All rules must go after includes for propper targets expansion
 ###############################################################################
 
-export kernel_build_method="$(KERNEL_BUILD_METHOD)"
+export kernel_procure_method="$(KERNEL_PROCURE_METHOD)"
 
 ###############################################################################
 ## Local targets


### PR DESCRIPTION
Note: this PR is best go in before https://github.com/Azure/sonic-linux-kernel/pull/51.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
Introducing the option of downloading pre-built kernel instead of building it every time.

- Kernel could be built from source files with method 'build'
- Kernel could be downloaded from Azure storage with method 'download'


**- How to verify it**
1. The kernel being downloaded was built with make KERNEL_PROCURE_METHOD=build
2. Tried to build image with option "KERNEL_PROCURE_METHOD=download" as well.
