### PR TITLE
[mellanox]: Fix symlink to QOS config file for MSN2740 platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2740-r0/ACS-MSN2740/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/ACS-MSN2740/qos.json.j2
@@ -1,1 +1,1 @@
-../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json.j2


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed issue when ports are not UP after SONiC start.

**- How I did it**
Problem is that updategraph cannot find QOS config file (qos.json.j2) and as a result bufferorch cannot fill the ``` m_port_ready_list_ref``` list.
```
# systemctl status updategraph.service
...
QoS definition template not found at /usr/share/sonic/device/x86_64-mlnx_msn2740-r0/ACS-MSN2740/qos.json.j2
...
```
Fixed symlink to QOS config file for MSN2740 platform in order to point to correct config file.

**- How to verify it**
1. Build and install SONiC image to the switch.
2. Verify that all interfaces are up after boot.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix symlink to QOS config file for MSN2740 platform
