### PR TITLE
[device] Misc fixes for Arista platforms

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/sensors.conf
+++ b/device/arista/x86_64-arista_7050_qx32/sensors.conf
@@ -2,11 +2,11 @@
 # ------------------------------------------------
 #
 
-bus "i2c-2" "SCD SMBus master 0 bus 0"
-bus "i2c-3" "SCD SMBus master 0 bus 1"
-bus "i2c-5" "SCD SMBus master 0 bus 3"
-bus "i2c-6" "SCD SMBus master 0 bus 4"
-bus "i2c-7" "SCD SMBus master 0 bus 5"
+bus "i2c-2" "SCD 0000:04:00.0 SMBus master 0 bus 0"
+bus "i2c-3" "SCD 0000:04:00.0 SMBus master 0 bus 1"
+bus "i2c-5" "SCD 0000:04:00.0 SMBus master 0 bus 3"
+bus "i2c-6" "SCD 0000:04:00.0 SMBus master 0 bus 4"
+bus "i2c-7" "SCD 0000:04:00.0 SMBus master 0 bus 5"
 
 chip "k10temp-pci-00c3"
     label temp1 "Cpu temp sensor"

--- a/device/arista/x86_64-arista_7050_qx32s/minigraph.xml
+++ b/device/arista/x86_64-arista_7050_qx32s/minigraph.xml
@@ -2,623 +2,8 @@
   <CpgDec>
     <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
     <PeeringSessions>
-      <BGPSession>
-        <StartRouter>ARISTA01T0</StartRouter>
-        <StartPeer>10.0.0.33</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.32</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.0</StartPeer>
-        <EndRouter>ARISTA01T2</EndRouter>
-        <EndPeer>10.0.0.1</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA02T0</StartRouter>
-        <StartPeer>10.0.0.35</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.34</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.2</StartPeer>
-        <EndRouter>ARISTA02T2</EndRouter>
-        <EndPeer>10.0.0.3</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA03T0</StartRouter>
-        <StartPeer>10.0.0.37</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.36</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.4</StartPeer>
-        <EndRouter>ARISTA03T2</EndRouter>
-        <EndPeer>10.0.0.5</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA04T0</StartRouter>
-        <StartPeer>10.0.0.39</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.38</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.6</StartPeer>
-        <EndRouter>ARISTA04T2</EndRouter>
-        <EndPeer>10.0.0.7</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA05T0</StartRouter>
-        <StartPeer>10.0.0.41</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.40</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.8</StartPeer>
-        <EndRouter>ARISTA05T2</EndRouter>
-        <EndPeer>10.0.0.9</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA06T0</StartRouter>
-        <StartPeer>10.0.0.43</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.42</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.10</StartPeer>
-        <EndRouter>ARISTA06T2</EndRouter>
-        <EndPeer>10.0.0.11</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA07T0</StartRouter>
-        <StartPeer>10.0.0.45</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.44</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.12</StartPeer>
-        <EndRouter>ARISTA07T2</EndRouter>
-        <EndPeer>10.0.0.13</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA08T0</StartRouter>
-        <StartPeer>10.0.0.47</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.46</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.14</StartPeer>
-        <EndRouter>ARISTA08T2</EndRouter>
-        <EndPeer>10.0.0.15</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA09T0</StartRouter>
-        <StartPeer>10.0.0.49</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.48</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.16</StartPeer>
-        <EndRouter>ARISTA09T2</EndRouter>
-        <EndPeer>10.0.0.17</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA10T0</StartRouter>
-        <StartPeer>10.0.0.51</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.50</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.18</StartPeer>
-        <EndRouter>ARISTA10T2</EndRouter>
-        <EndPeer>10.0.0.19</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA11T0</StartRouter>
-        <StartPeer>10.0.0.53</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.52</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.20</StartPeer>
-        <EndRouter>ARISTA11T2</EndRouter>
-        <EndPeer>10.0.0.21</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA12T0</StartRouter>
-        <StartPeer>10.0.0.55</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.54</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.22</StartPeer>
-        <EndRouter>ARISTA12T2</EndRouter>
-        <EndPeer>10.0.0.23</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA13T0</StartRouter>
-        <StartPeer>10.0.0.57</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.56</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.24</StartPeer>
-        <EndRouter>ARISTA13T2</EndRouter>
-        <EndPeer>10.0.0.25</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA14T0</StartRouter>
-        <StartPeer>10.0.0.59</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.58</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.26</StartPeer>
-        <EndRouter>ARISTA14T2</EndRouter>
-        <EndPeer>10.0.0.27</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA15T0</StartRouter>
-        <StartPeer>10.0.0.61</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.60</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.28</StartPeer>
-        <EndRouter>ARISTA15T2</EndRouter>
-        <EndPeer>10.0.0.29</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>ARISTA16T0</StartRouter>
-        <StartPeer>10.0.0.63</StartPeer>
-        <EndRouter>sonic</EndRouter>
-        <EndPeer>10.0.0.62</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
-      <BGPSession>
-        <StartRouter>sonic</StartRouter>
-        <StartPeer>10.0.0.30</StartPeer>
-        <EndRouter>ARISTA16T2</EndRouter>
-        <EndPeer>10.0.0.31</EndPeer>
-        <Multihop>1</Multihop>
-        <HoldTime>180</HoldTime>
-        <KeepAliveTime>60</KeepAliveTime>
-      </BGPSession>
     </PeeringSessions>
     <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-      <a:BGPRouterDeclaration>
-        <a:ASN>65100</a:ASN>
-        <a:Hostname>sonic</a:Hostname>
-        <a:Peers>
-          <BGPPeer>
-            <Address>10.0.0.33</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.1</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.35</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.3</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.37</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.5</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.39</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.7</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.41</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.9</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.43</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.11</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.45</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.13</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.47</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.15</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.49</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.17</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.51</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.19</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.53</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.21</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.55</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.23</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.57</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.25</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.59</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.27</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.61</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.29</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.63</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-          <BGPPeer>
-            <Address>10.0.0.31</Address>
-            <RouteMapIn i:nil="true"/>
-            <RouteMapOut i:nil="true"/>
-          </BGPPeer>
-        </a:Peers>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64001</a:ASN>
-        <a:Hostname>ARISTA01T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA01T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64002</a:ASN>
-        <a:Hostname>ARISTA02T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA02T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64003</a:ASN>
-        <a:Hostname>ARISTA03T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA03T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64004</a:ASN>
-        <a:Hostname>ARISTA04T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA04T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64005</a:ASN>
-        <a:Hostname>ARISTA05T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA05T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64006</a:ASN>
-        <a:Hostname>ARISTA06T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA06T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64007</a:ASN>
-        <a:Hostname>ARISTA07T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA07T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64008</a:ASN>
-        <a:Hostname>ARISTA08T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA08T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64009</a:ASN>
-        <a:Hostname>ARISTA09T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA09T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64010</a:ASN>
-        <a:Hostname>ARISTA10T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA10T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64011</a:ASN>
-        <a:Hostname>ARISTA11T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA11T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64012</a:ASN>
-        <a:Hostname>ARISTA12T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA12T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64013</a:ASN>
-        <a:Hostname>ARISTA13T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA13T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64014</a:ASN>
-        <a:Hostname>ARISTA14T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA14T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64015</a:ASN>
-        <a:Hostname>ARISTA15T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA15T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>64016</a:ASN>
-        <a:Hostname>ARISTA16T0</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
-      <a:BGPRouterDeclaration>
-        <a:ASN>65200</a:ASN>
-        <a:Hostname>ARISTA16T2</a:Hostname>
-        <a:RouteMaps/>
-      </a:BGPRouterDeclaration>
     </Routers>
   </CpgDec>
   <DpgDec>
@@ -645,162 +30,162 @@
       <IPInterfaces>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet1/1</AttachTo>
+          <AttachTo>Ethernet5/1</AttachTo>
           <Prefix>10.0.0.0/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet2/1</AttachTo>
+          <AttachTo>Ethernet6/1</AttachTo>
           <Prefix>10.0.0.2/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet3/1</AttachTo>
+          <AttachTo>Ethernet7/1</AttachTo>
           <Prefix>10.0.0.4/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet4/1</AttachTo>
+          <AttachTo>Ethernet8/1</AttachTo>
           <Prefix>10.0.0.6/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet5/1</AttachTo>
+          <AttachTo>Ethernet9/1</AttachTo>
           <Prefix>10.0.0.8/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet6/1</AttachTo>
+          <AttachTo>Ethernet10/1</AttachTo>
           <Prefix>10.0.0.10/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet7/1</AttachTo>
+          <AttachTo>Ethernet11/1</AttachTo>
           <Prefix>10.0.0.12/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet8/1</AttachTo>
+          <AttachTo>Ethernet12/1</AttachTo>
           <Prefix>10.0.0.14/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet9/1</AttachTo>
+          <AttachTo>Ethernet13/1</AttachTo>
           <Prefix>10.0.0.16/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet10/1</AttachTo>
+          <AttachTo>Ethernet14/1</AttachTo>
           <Prefix>10.0.0.18/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet11/1</AttachTo>
+          <AttachTo>Ethernet15/1</AttachTo>
           <Prefix>10.0.0.20/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet12/1</AttachTo>
+          <AttachTo>Ethernet16/1</AttachTo>
           <Prefix>10.0.0.22/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet13/1</AttachTo>
+          <AttachTo>Ethernet17/1</AttachTo>
           <Prefix>10.0.0.24/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet14/1</AttachTo>
+          <AttachTo>Ethernet18/1</AttachTo>
           <Prefix>10.0.0.26/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet15/1</AttachTo>
+          <AttachTo>Ethernet19/1</AttachTo>
           <Prefix>10.0.0.28/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet16/1</AttachTo>
+          <AttachTo>Ethernet20/1</AttachTo>
           <Prefix>10.0.0.30/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet17/1</AttachTo>
+          <AttachTo>Ethernet21/1</AttachTo>
           <Prefix>10.0.0.32/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet18/1</AttachTo>
+          <AttachTo>Ethernet22/1</AttachTo>
           <Prefix>10.0.0.34/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet19/1</AttachTo>
+          <AttachTo>Ethernet23/1</AttachTo>
           <Prefix>10.0.0.36/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet20/1</AttachTo>
+          <AttachTo>Ethernet24/1</AttachTo>
           <Prefix>10.0.0.38/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet21/1</AttachTo>
+          <AttachTo>Ethernet25/1</AttachTo>
           <Prefix>10.0.0.40/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet22/1</AttachTo>
+          <AttachTo>Ethernet26/1</AttachTo>
           <Prefix>10.0.0.42/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet23/1</AttachTo>
+          <AttachTo>Ethernet27/1</AttachTo>
           <Prefix>10.0.0.44/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet24/1</AttachTo>
+          <AttachTo>Ethernet28/1</AttachTo>
           <Prefix>10.0.0.46/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet25</AttachTo>
+          <AttachTo>Ethernet29</AttachTo>
           <Prefix>10.0.0.48/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet26</AttachTo>
+          <AttachTo>Ethernet30</AttachTo>
           <Prefix>10.0.0.50/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet27</AttachTo>
+          <AttachTo>Ethernet31</AttachTo>
           <Prefix>10.0.0.52/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet28</AttachTo>
+          <AttachTo>Ethernet32</AttachTo>
           <Prefix>10.0.0.54/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet29</AttachTo>
+          <AttachTo>Ethernet33</AttachTo>
           <Prefix>10.0.0.56/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet30</AttachTo>
+          <AttachTo>Ethernet34</AttachTo>
           <Prefix>10.0.0.58/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet31</AttachTo>
+          <AttachTo>Ethernet35</AttachTo>
           <Prefix>10.0.0.60/31</Prefix>
         </IPInterface>
         <IPInterface>
           <Name i:Name="true"/>
-          <AttachTo>Ethernet32</AttachTo>
+          <AttachTo>Ethernet36</AttachTo>
           <Prefix>10.0.0.62/31</Prefix>
         </IPInterface>
       </IPInterfaces>
@@ -812,230 +197,6 @@
   </DpgDec>
   <PngDec>
     <DeviceInterfaceLinks>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet1/1</EndPort>
-        <StartDevice>ARISTA01T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet2/1</EndPort>
-        <StartDevice>ARISTA02T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet3/1</EndPort>
-        <StartDevice>ARISTA03T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet4/1</EndPort>
-        <StartDevice>ARISTA04T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet5/1</EndPort>
-        <StartDevice>ARISTA05T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet6/1</EndPort>
-        <StartDevice>ARISTA06T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet7/1</EndPort>
-        <StartDevice>ARISTA07T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet8/1</EndPort>
-        <StartDevice>ARISTA08T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet9/1</EndPort>
-        <StartDevice>ARISTA09T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet10/1</EndPort>
-        <StartDevice>ARISTA10T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet11/1</EndPort>
-        <StartDevice>ARISTA11T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet12/1</EndPort>
-        <StartDevice>ARISTA12T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet13/1</EndPort>
-        <StartDevice>ARISTA13T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet14/1</EndPort>
-        <StartDevice>ARISTA14T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet15/1</EndPort>
-        <StartDevice>ARISTA15T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet16/1</EndPort>
-        <StartDevice>ARISTA16T2</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet17/1</EndPort>
-        <StartDevice>ARISTA01T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet18/1</EndPort>
-        <StartDevice>ARISTA02T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet19/1</EndPort>
-        <StartDevice>ARISTA03T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet20/1</EndPort>
-        <StartDevice>ARISTA04T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet21/1</EndPort>
-        <StartDevice>ARISTA05T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet22/1</EndPort>
-        <StartDevice>ARISTA06T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet23/1</EndPort>
-        <StartDevice>ARISTA07T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet24/1</EndPort>
-        <StartDevice>ARISTA08T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet25</EndPort>
-        <StartDevice>ARISTA09T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet26</EndPort>
-        <StartDevice>ARISTA10T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet27</EndPort>
-        <StartDevice>ARISTA11T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet28</EndPort>
-        <StartDevice>ARISTA12T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet29</EndPort>
-        <StartDevice>ARISTA13T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet30</EndPort>
-        <StartDevice>ARISTA14T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet31</EndPort>
-        <StartDevice>ARISTA15T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
-      <DeviceLinkBase>
-        <ElementType>DeviceInterfaceLink</ElementType>
-        <EndDevice>sonic</EndDevice>
-        <EndPort>Ethernet32</EndPort>
-        <StartDevice>ARISTA16T0</StartDevice>
-        <StartPort>Ethernet1</StartPort>
-      </DeviceLinkBase>
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="LeafRouter">

--- a/device/arista/x86_64-arista_7050_qx32s/sensors.conf
+++ b/device/arista/x86_64-arista_7050_qx32s/sensors.conf
@@ -2,11 +2,11 @@
 # ------------------------------------------------
 #
 
-bus "i2c-2" "SCD SMBus master 0 bus 0"
-bus "i2c-3" "SCD SMBus master 0 bus 1"
-bus "i2c-5" "SCD SMBus master 0 bus 3"
-bus "i2c-6" "SCD SMBus master 0 bus 4"
-bus "i2c-7" "SCD SMBus master 0 bus 5"
+bus "i2c-2" "SCD 0000:02:00.0 SMBus master 0 bus 0"
+bus "i2c-3" "SCD 0000:02:00.0 SMBus master 0 bus 1"
+bus "i2c-5" "SCD 0000:02:00.0 SMBus master 0 bus 3"
+bus "i2c-6" "SCD 0000:02:00.0 SMBus master 0 bus 4"
+bus "i2c-7" "SCD 0000:02:00.0 SMBus master 0 bus 5"
 
 chip "k10temp-pci-00c3"
     label temp1 "Cpu temp sensor"

--- a/files/initramfs-tools/arista-convertfs.j2
+++ b/files/initramfs-tools/arista-convertfs.j2
@@ -105,6 +105,7 @@ for x in "$@"; do
         loop=*)
             x1="${x#loop=}"
             image_dir="${x1%/*}"
+            ;;
     esac
 done
 root_dev="$ROOT"
@@ -168,12 +169,14 @@ umount "$root_mnt"
 
 #### Lines below will modify the root file system, so any failure will be trapped to shell for manual interventions.
 
-# Create a new partition table (content in flash_dev will be deleted)
-err_msg="Error: repartitioning $flash_dev failed"
-cmd="echo ';' | sfdisk $flash_dev || (sleep 3; blockdev --rereadpt $flash_dev && fdisk -l $flash_dev | grep -q ${root_dev}.*Linux)"
-run_cmd "$cmd" "$err_msg"
+if [ $(echo -n "$root_dev" | tail -c 1) == "1" ]; then
+    # Create a new partition table (content in flash_dev will be deleted)
+    err_msg="Error: repartitioning $flash_dev failed"
+    cmd="echo ';' | sfdisk $flash_dev || (sleep 3; blockdev --rereadpt $flash_dev && fdisk -l $flash_dev | grep -q ${root_dev}.*Linux)"
+    run_cmd "$cmd" "$err_msg"
+fi
 
-sleep 5
+sleep 2
 err_msg="Error: timeout in waiting for $root_dev after repartition"
 cmd="wait_for_root_dev"
 run_cmd "$cmd" "$err_msg"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix the i2c bus names for 7050QX-32 and 7050QX-32S after the recent submodule update.
Fix the default minigraph.xml for the 7050QX-32S that prevented it from properly starting.
Allow the image to be booted from another partition which does not affect default behavior.

**- How to verify it**

Boot an image on 7050QX-32S from vfat to verify that the initramfs script is still working.
Starting without minigraph.xml and verifying that syncd does not crash verifies the default minigraph.xml
Verify that the sensors names are properly set up.

**- Description for the changelog**

Miscellaneous fixes for Arista devices.
