### PR TITLE
[sonic_debian_extension.j2] Create /var/cache/sonic/ directory at image build time

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -58,6 +58,7 @@ sudo cp $IMAGE_CONFIGS/environment/motd $FILESYSTEM_ROOT/etc/
 
 # Create all needed directories
 sudo mkdir -p $FILESYSTEM_ROOT/etc/sonic/
+sudo mkdir -p $FILESYSTEM_ROOT/var/cache/sonic/
 sudo mkdir -p $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 
 # Install dependencies for SONiC config engine 


### PR DESCRIPTION
This directory is currently used to track reboot cause and also by decode-syseeprom. Create it at image build time to prevent checking for its existence in multiple places.