### PR TITLE
Add static route

### DIFF
--- a/dockers/docker-fpm-quagga/zebra.conf.j2
+++ b/dockers/docker-fpm-quagga/zebra.conf.j2
@@ -35,6 +35,11 @@ ip route 0.0.0.0/0 {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} 200
 {% endfor %}
 {% endblock default_route %}
 !
+! set static route for the device
+{% for (route, exit) in ROUTE_TABLE.keys() | sort %}
+ip route {{route}} {{exit}} {{ ROUTE_TABLE[(route, exit)]['ad'] }}
+{% endfor %}
+!
 {% block source_loopback %}
 {% set lo_ipv4_addrs = [] %}
 {% set lo_ipv6_addrs = [] %}


### PR DESCRIPTION
I found that sonic does not have anywhere to save the static route. However I think this is a fundamental function for a router or switch. Every time I reboot or reload the switch, I need to add the static route again, 

**- What I did**
- Add the static route for the device through quagga. The ad number also has been added

**- How I did it**
- Using the template.

**- How to verify it** 
- Add the static route to the config_db.json file:
    "ROUTE_TABLE": {
        "1.1.1.0/24|192.168.111.2": {
            "ad": "1"
        },
        "1.1.1.0/24|192.168.111.3": {
            "ad": "2"
        },
        "2.3.4.0/24|192.168.111.1": {
            "ad": "1"
        }
    },
- Check any syntax: sonic-cfggen -j /etc/sonic/config_db.json --print-data
- Reload the device: config reload -y
- Check the route table: show ip route


**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
