### PR TITLE
[broadcom sai] update Broadcom SDK/SAI version

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.1.3.5-1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.5-1_amd64.deb?sv=2015-04-05&sr=b&sig=iakBOA9VRsMmdbZWDEsQNLix%2B41gnnVX75YV%2F7VGqNU%3D&se=2155-05-31T10%3A05%3A28Z&sp=r"
+BRCM_SAI = libsaibcm_3.1.3.5-2_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.5-2_amd64.deb?sv=2015-04-05&sr=b&sig=wAXRViJp5SZtlHqEZVeAHZ0b%2F8Cfxw0QIjCaAigWS2s%3D&se=2032-03-19T18%3A25%3A07Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.1.3.5-1_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.1.3.5-2_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.5-1_amd64.deb?sv=2015-04-05&sr=b&sig=XipVKYmbKC%2BjrKc67BPoqhXiVSU5IF6PiF37P%2BxRxMk%3D&se=2155-05-31T10%3A07%3A38Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.5-2_amd64.deb?sv=2015-04-05&sr=b&sig=1LqBLe%2BPNHyVmcaes21TMuZ8VoUS%2FDIuGS5Vzn9N8L4%3D&se=2032-03-19T18%3A25%3A53Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI) $(BRCM_SAI_DEV)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)

--- a/platform/broadcom/sdk.mk
+++ b/platform/broadcom/sdk.mk
@@ -1,4 +1,4 @@
-BRCM_OPENNSL_KERNEL = opennsl-modules-3.16.0-5-amd64_3.4.1.11-2_amd64.deb
-$(BRCM_OPENNSL_KERNEL)_URL = "https://sonicstorage.blob.core.windows.net/packages/opennsl-modules-3.16.0-5-amd64_3.4.1.11-2_amd64.deb?sv=2015-04-05&sr=b&sig=xtf8nafmS1pcqx5hhBsfmLNSx2BeqmwN4Dwq5uwM1bo%3D&se=2031-11-16T21%3A54%3A27Z&sp=r"
+BRCM_OPENNSL_KERNEL = opennsl-modules-3.16.0-5-amd64_3.4.1.11-5_amd64.deb
+$(BRCM_OPENNSL_KERNEL)_URL = "https://sonicstorage.blob.core.windows.net/packages/opennsl-modules-3.16.0-5-amd64_3.4.1.11-5_amd64.deb?sv=2015-04-05&sr=b&sig=VefDUeIdEvgV1007LX9P3aRmMAeO4hnMcIAyXkOBEp8%3D&se=2032-03-19T18%3A23%3A58Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_OPENNSL_KERNEL)


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
- upgrade Broadcom sdk to version 3.4.1.11-5
  - added support for 56340 and PHY542XX
  - SDK-136932 update EGR_IM_MTP_INDEXm when replace mirror destination
  - Include Broadcom parity error fix for TH2 and TD2
- upgrade Broadcom sai to version 3.1.3.5-2
  - No SAI change, bump up version to pick up SDK changes.