### PR TITLE
[swss]: sonic-swss submodule update

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.1.3.5-2_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.5-2_amd64.deb?sv=2015-04-05&sr=b&sig=wAXRViJp5SZtlHqEZVeAHZ0b%2F8Cfxw0QIjCaAigWS2s%3D&se=2032-03-19T18%3A25%3A07Z&sp=r"
+BRCM_SAI = libsaibcm_3.1.3.5-3_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm_3.1.3.5-3_amd64.deb?sv=2015-04-05&sr=b&sig=lzB9IHpJuMEENr9N9W0LBFamJ7mpvRVWgigfQmpIrPc%3D&se=2155-06-05T09%3A13%3A41Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.1.3.5-2_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.1.3.5-3_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.5-2_amd64.deb?sv=2015-04-05&sr=b&sig=1LqBLe%2BPNHyVmcaes21TMuZ8VoUS%2FDIuGS5Vzn9N8L4%3D&se=2032-03-19T18%3A25%3A53Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/libsaibcm-dev_3.1.3.5-3_amd64.deb?sv=2015-04-05&sr=b&sig=WoRAz6j8G3Xk%2BT3MOmhp5f%2BvWggw%2BgGgk2JtDJHkKjs%3D&se=2155-06-05T09%3A14%3A46Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI) $(BRCM_SAI_DEV)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
  762e7da 2018-07-11 | Add support for AN and FEC to be specified in port_config.ini (#534)

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add support for AN and FEC in port_config.ini

**- How I did it**
In port_config.ini, you can specify autoneg/fec column

```
# name          lanes   speed   alias   autoneg
Ethernet0       2       1000    etp1    1
Ethernet1       1       1000    etp2    1
Ethernet2       4       1000    etp3    1
Ethernet3       3       1000    etp4    1
```

**- How to verify it**
tested on DUT

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
