### PR TITLE
[enable_counters]: make enable_counter service depend on swss

### DIFF
--- a/files/build_templates/enable_counters.service
+++ b/files/build_templates/enable_counters.service
@@ -1,8 +1,12 @@
 [Unit]
 Description=Enable SONiC counters
-PartOf=swss.service
+Requires=swss.service
+After=swss.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c 'sleep 60 ; /usr/bin/counterpoll queue enable ; /usr/bin/counterpoll port enable ; /usr/bin/pfcwd counter_poll enable'
+ExecStart=/bin/bash -c '/bin/sleep 60 ; /usr/bin/counterpoll queue enable ; /usr/bin/counterpoll port enable ; /usr/bin/pfcwd counter_poll enable'
 RemainAfterExit=yes
+
+[Install]
+WantedBy=swss.service


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Before the change enable_counter service will not start when using "service swss restart" or "config load_minigraph"

**- How I did it**
Modify the service file to make it depend on swss service 
**- How to verify it**
With the change, run "service swss restart", "config load_minigraph", "systemctl restart swss",
Can see counters in counter db
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
