### PR TITLE
Warm reboot: Separate syncd from swss systemd service

### DIFF
--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -1,56 +1,16 @@
 [Unit]
 Description=switch state service
-Requires=database.service updategraph.service
-{% if sonic_asic_platform == 'broadcom' %}
-Requires=opennsl-modules-3.16.0-5-amd64.service
-{% elif sonic_asic_platform == 'nephos' %}
-Requires=nps-modules-3.16.0-5-amd64.service
-{% endif %}
-After=database.service updategraph.service
+Requires=syncd.service
+After=syncd.service
 After=interfaces-config.service
-{% if sonic_asic_platform == 'broadcom' %}
-After=opennsl-modules-3.16.0-5-amd64.service
-{% elif sonic_asic_platform == 'nephos' %}
-After=nps-modules-3.16.0-5-amd64.service
-{% endif %}
 
 [Service]
 User=root
-# Wait for redis server start before database clean
-ExecStartPre=/bin/bash -c 'until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]]; do sleep 1; done'
-ExecStartPre=/usr/bin/docker exec database redis-cli -n 0 FLUSHDB
-ExecStartPre=/usr/bin/docker exec database redis-cli -n 1 FLUSHDB
-ExecStartPre=/usr/bin/docker exec database redis-cli -n 2 FLUSHDB
-ExecStartPre=/usr/bin/docker exec database redis-cli -n 5 FLUSHDB
-ExecStartPre=/usr/bin/docker exec database redis-cli -n 6 FLUSHDB
 
-{% if sonic_asic_platform == 'mellanox' %}
-Environment=FAST_BOOT=1
-TimeoutStartSec=3min
-ExecStartPre=/usr/bin/mst start
-ExecStartPre=/usr/bin/mlnx-fw-upgrade.sh
-ExecStartPre=/etc/init.d/sxdkernel start
-ExecStartPre=/sbin/modprobe i2c-dev
-ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)/hw-management start"
-{% elif sonic_asic_platform == 'cavium' %}
-ExecStartPre=/etc/init.d/xpnet.sh start
-{% endif %}
-
-ExecStartPre=/usr/bin/{{docker_container_name}}.sh start 
-ExecStartPre=/usr/bin/syncd.sh start
+ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh attach
 
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-ExecStopPost=/usr/bin/syncd.sh stop
-
-{% if sonic_asic_platform == 'mellanox' %}
-ExecStopPost=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)/hw-management stop"
-ExecStopPost=/etc/init.d/sxdkernel stop
-ExecStopPost=/usr/bin/mst stop
-{% elif sonic_asic_platform == 'cavium' %}
-ExecStopPost=/etc/init.d/xpnet.sh stop
-ExecStopPost=/etc/init.d/xpnet.sh start
-{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/files/build_templates/syncd.service.j2
+++ b/files/build_templates/syncd.service.j2
@@ -1,0 +1,53 @@
+[Unit]
+Description=syncd service
+Requires=database.service updategraph.service
+{% if sonic_asic_platform == 'broadcom' %}
+Requires=opennsl-modules-3.16.0-5-amd64.service
+{% elif sonic_asic_platform == 'nephos' %}
+Requires=nps-modules-3.16.0-5-amd64.service
+{% endif %}
+After=database.service updategraph.service
+{% if sonic_asic_platform == 'broadcom' %}
+After=opennsl-modules-3.16.0-5-amd64.service
+{% elif sonic_asic_platform == 'nephos' %}
+After=nps-modules-3.16.0-5-amd64.service
+{% endif %}
+
+[Service]
+User=root
+# Wait for redis server start before database clean
+ExecStartPre=/bin/bash -c 'until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]]; do sleep 1; done'
+ExecStartPre=/usr/bin/docker exec database redis-cli -n 0 FLUSHDB
+ExecStartPre=/usr/bin/docker exec database redis-cli -n 1 FLUSHDB
+ExecStartPre=/usr/bin/docker exec database redis-cli -n 2 FLUSHDB
+ExecStartPre=/usr/bin/docker exec database redis-cli -n 5 FLUSHDB
+ExecStartPre=/usr/bin/docker exec database redis-cli -n 6 FLUSHDB
+
+{% if sonic_asic_platform == 'mellanox' %}
+Environment=FAST_BOOT=1
+TimeoutStartSec=3min
+ExecStartPre=/usr/bin/mst start
+ExecStartPre=/usr/bin/mlnx-fw-upgrade.sh
+ExecStartPre=/etc/init.d/sxdkernel start
+ExecStartPre=/sbin/modprobe i2c-dev
+ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)/hw-management start"
+{% elif sonic_asic_platform == 'cavium' %}
+ExecStartPre=/etc/init.d/xpnet.sh start
+{% endif %}
+
+ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
+ExecStart=/usr/bin/{{docker_container_name}}.sh attach
+
+ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+
+{% if sonic_asic_platform == 'mellanox' %}
+ExecStopPost=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)/hw-management stop"
+ExecStopPost=/etc/init.d/sxdkernel stop
+ExecStopPost=/usr/bin/mst stop
+{% elif sonic_asic_platform == 'cavium' %}
+ExecStopPost=/etc/init.d/xpnet.sh stop
+ExecStopPost=/etc/init.d/xpnet.sh start
+{% endif %}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**- What I did**
Separate syncd from swss service
This to prepare docker level warm restart for swss.

**- How I did it**
Separate syncd from swss service and have swss service depending on it.

**- How to verify it**
reboot the system,  system start without problem and traffic resume on vlan and ethernet router interface.

systemctl stop syncd:  all services which have dependency on swss service and swss service itself stopped.

systemctl restart syncd:   all services which have dependency on swss service and swss service itself start again.  
