### PR TITLE
Only keep most recent one in old_config

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -226,6 +226,7 @@ if [ -f $FIRST_BOOT_FILE ]; then
     # and create a flag in /tmp/ to let updategraph service know
     if [ -d /host/old_config ]; then
         mv -f /host/old_config /etc/sonic/
+        rm -rf /etc/sonic/old_config/old_config
         touch /tmp/pending_config_migration
     elif [ -f /host/minigraph.xml ]; then
         mkdir -p /etc/sonic/old_config


### PR DESCRIPTION
**- What I did**
Per request, remove the configuration history in cascaded old_config folder and keep only the most recent one.
