### PR TITLE
bfn intf: allow-hotplug for usb0 interface

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -10,6 +10,7 @@ if [[ "$platform" == "x86_64-accton_wedge100bf_32x-r0" || "$platform" == "x86_64
 cat <<'EOF' >> /etc/network/interfaces
 # BMC interface
 auto usb0
+allow-hotplug usb0
 iface usb0 inet6 auto
 up ifconfig usb0 txqueuelen 64
 EOF


### PR DESCRIPTION
**- What I did**
Add hotplug option for usb0 interface on bfn montara and mavericks
**- How I did it**

**- How to verify it**
Build and verify bmc interface come on bmc reboot

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**
