### PR TITLE
[minigraph.py] add support to parse deployment id of neighbor devices

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -41,6 +41,7 @@ def parse_device(device):
     d_type = None   # don't shadow type()
     hwsku = None
     name = None
+    deployment_id = None
     if str(QName(ns3, "type")) in device.attrib:
         d_type = device.attrib[str(QName(ns3, "type"))]
 
@@ -53,7 +54,9 @@ def parse_device(device):
             name = node.text
         elif node.tag == str(QName(ns, "HwSku")):
             hwsku = node.text
-    return (lo_prefix, mgmt_prefix, name, hwsku, d_type)
+        elif node.tag == str(QName(ns, "DeploymentId")):
+            deployment_id = node.text
+    return (lo_prefix, mgmt_prefix, name, hwsku, d_type, deployment_id)
 
 def parse_png(png, hname):
     neighbors = {}
@@ -92,8 +95,10 @@ def parse_png(png, hname):
 
         if child.tag == str(QName(ns, "Devices")):
             for device in child.findall(str(QName(ns, "Device"))):
-                (lo_prefix, mgmt_prefix, name, hwsku, d_type) = parse_device(device)
+                (lo_prefix, mgmt_prefix, name, hwsku, d_type, deployment_id) = parse_device(device)
                 device_data = {'lo_addr': lo_prefix, 'type': d_type, 'mgmt_addr': mgmt_prefix, 'hwsku': hwsku }
+                if deployment_id:
+                    device_data['deployment_id'] = deployment_id
                 devices[name] = device_data
 
         if child.tag == str(QName(ns, "DeviceInterfaceLinks")):
@@ -546,7 +551,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
 
 def parse_device_desc_xml(filename):
     root = ET.parse(filename).getroot()
-    (lo_prefix, mgmt_prefix, hostname, hwsku, d_type) = parse_device(root)
+    (lo_prefix, mgmt_prefix, hostname, hwsku, d_type, _) = parse_device(root)
 
     results = {}
     results['DEVICE_METADATA'] = {'localhost': {

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -181,27 +181,33 @@
     </DeviceDataPlaneInfo>
   </DpgDec>
   <PngDec>
-    <DeviceInterfaceLinks/>
+    <DeviceInterfaceLinks>
+      <DeviceLinkBase i:type="DeviceInterfaceLink">
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <AutoNegotiation>true</AutoNegotiation>
+        <Bandwidth>10000</Bandwidth>
+        <EndDevice>switch-t0</EndDevice>
+        <EndPort>fortyGigE0/0</EndPort>
+        <StartDevice>switch-01t1</StartDevice>
+        <StartPort>port1</StartPort>
+      </DeviceLinkBase>
+    </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="ToRRouter">
         <Hostname>switch-t0</Hostname>
         <HwSku>Force10-S6000</HwSku>
       </Device>
       <Device i:type="LeafRouter">
-        <Hostname>ARISTA01T1</Hostname>
-        <HwSku>Arista</HwSku>
-      </Device>
-      <Device i:type="LeafRouter">
-        <Hostname>ARISTA02T1</Hostname>
-        <HwSku>Arista</HwSku>
-      </Device>
-      <Device i:type="LeafRouter">
-        <Hostname>ARISTA03T1</Hostname>
-        <HwSku>Arista</HwSku>
-      </Device>
-      <Device i:type="LeafRouter">
-        <Hostname>ARISTA04T1</Hostname>
-        <HwSku>Arista</HwSku>
+        <Hostname>switch-01t1</Hostname>
+        <Address xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>10.1.0.186/32</a:IPPrefix>
+        </Address>
+        <DeploymentId>2</DeploymentId>
+        <DeviceLocation i:nil="true"/>
+        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>10.7.0.196/26</a:IPPrefix>
+        </ManagementAddress> 
+        <HwSku>Force10-S6000</HwSku>
       </Device>
     </Devices>
   </PngDec>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -94,6 +94,11 @@ class TestCfgGenCaseInsensitive(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "1")
 
+    def test_minigraph_deployment_id(self):
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "DEVICE_NEIGHBOR_METADATA"'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), "{'switch-01t1': {'lo_addr': '10.1.0.186/32', 'mgmt_addr': '10.7.0.196/26', 'hwsku': 'Force10-S6000', 'type': 'LeafRouter', 'deployment_id': '2'}}")
+
     def test_metadata_everflow(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "MIRROR_SESSION"'
         output = self.run_script(argument)

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -94,7 +94,7 @@ class TestCfgGenCaseInsensitive(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "1")
 
-    def test_minigraph_deployment_id(self):
+    def test_minigraph_neighbor_metadata(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "DEVICE_NEIGHBOR_METADATA"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'switch-01t1': {'lo_addr': '10.1.0.186/32', 'mgmt_addr': '10.7.0.196/26', 'hwsku': 'Force10-S6000', 'type': 'LeafRouter', 'deployment_id': '2'}}")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
`DEVICE_NEIGHBOR_METADATA` table now contains an optional `deployment_id` attribute.

```
   "DEVICE_NEIGHBOR_METADATA": {
       "switch1": {
           "lo_addr": "10.15.1.0/24",
           "mgmt_addr": "10.15.8.0/24",
           "hwsku": "Mellanox-SN2700",
           "type": "ToRRouter",
           "deployment_id": "1"
       },
    ...
```