### PR TITLE
Adding some sanity-checking to configdb.json parsing logic

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -78,6 +78,87 @@ def unique_name(l):
             new_list.append(item)
     return new_list
 
+def valid_config(data):
+    """Verifies that proposed config-state (data) is semantically
+    correct/consistent.
+
+    Args:
+    data: config-data in dictionary form
+
+    Returns:
+    'true' if valid configuration, 'false' otherwise
+    """
+
+    # Verifies that there is a valid entry in PORT table for every entry
+    # present in INTERFACE table. See that there's no need to verify the
+    # opposite direction as it's perfectly valid to have PORT entries with
+    # no matching entry in INTERFACE table.
+    #
+    #  "INTERFACE": {
+    #     "Ethernet112|10.1.2.2/24": {},
+    #     "Ethernet112|fc00:1:2::2/64": {},
+    #  }
+    #
+    if 'INTERFACE' in data and 'PORT' in data:
+        interface_table = data['INTERFACE']
+
+        for key in interface_table:
+            if key[0] not in data['PORT']:
+                print("Interface", key[0], "not found in PORT table.")
+                return False
+
+    # Verifies that VLAN_INTERFACE entries are relying on existing VLAN entities.
+    #
+    #  "VLAN_INTERFACE": {
+    #      "Vlan100|172.18.1.1/24": {
+    #      "scope": "global",
+    #      }
+    #   }
+    if 'VLAN_INTERFACE' in data and 'VLAN' in data:
+        vlan_interface_table = data['VLAN_INTERFACE']
+
+        for key in vlan_interface_table:
+            if key[0] not in data['VLAN']:
+                print("Vlan interface", key[0], "not found in VLAN table.")
+                return False
+
+    # Verifies that VLAN table holds members that are present in PORT table.
+    #
+    #  "VLAN": {
+    #      "Vlan100": {
+    #      ...
+    #      "members": [
+    #           "Ethernet16",
+    #           "Ethernet17"
+    #       }
+    #   }
+    if 'VLAN' in data and 'PORT' in data:
+        vlan_table = data['VLAN']
+
+        for key, value in vlan_table.iteritems():
+            for member in value['members']:
+                if member not in data['PORT']:
+                    print("VLAN member", member, "not found in PORT table.")
+                    return False
+
+    # Verifies that each DEVICE_NEIGHBOR key matches a valid entry in PORT table.
+    #
+    #  "DEVICE_NEIGHBOR": {
+    #      "Ethernet112": {
+    #      "name": "lnos-x1-a-csw01",
+    #      "port": "Ethernet1"
+    #      }
+    #   }
+    if 'DEVICE_NEIGHBOR' in data and 'PORT' in data:
+        devnbr_table = data['DEVICE_NEIGHBOR']
+
+        for key in devnbr_table:
+            if key not in data['PORT']:
+                print("DEVICE_NEIGHBOR port", key, "not found in PORT table.")
+                return False
+
+    return True
+
 
 class FormatConverter:
     """Convert config DB based schema to legacy minigraph based schema for backward capability.
@@ -154,6 +235,7 @@ def main():
     group.add_argument("-t", "--template", help="render the data with the template file")
     group.add_argument("-v", "--var", help="print the value of a variable, support jinja2 expression")
     group.add_argument("--var-json", help="print the value of a variable, in json format")
+    group.add_argument("--check-json", help="check passed config -- to be used with -j", action='store_true')
     group.add_argument("--write-to-db", help="write config into configdb", action='store_true')
     group.add_argument("--print-data", help="print all data", action='store_true')
     args = parser.parse_args()
@@ -240,6 +322,11 @@ def main():
         configdb = ConfigDBConnector(**db_kwargs)
         configdb.connect(False)
         configdb.mod_config(FormatConverter.output_to_db(data))
+
+    if args.check_json:
+        if valid_config(FormatConverter.output_to_db(data)) == False:
+            print("\nInvalid configuration detected. No configuration changes processed. Exiting...\n")
+            sys.exit(1)
 
     if args.print_data:
         print(json.dumps(FormatConverter.to_serialized(data), indent=4, cls=minigraph_encoder))


### PR DESCRIPTION
I'm adding some sanity-checking logic to prevent semantically-incorrect entries, present in any given config_db.json file, from being able to make it to sonic backends. This should tackle various issues observed in the past where a user could easily bring a system down or to an inconsistent state by introducing erroneous configuration while manually editing a config_db.json file.

To exercise this logic, user can either make use of the "--check-json" parameter offered by 'sonic-cfggen' (see examples below), or rely on the typical "config load/reload" CLI instructions. The changes associated to the second option will come as part of a different PR (in sonic-utilities repo).

Find some examples below of how this code operates:

<—- Tescase 1) Adding ‘interface’ associated to invalid ‘port’:

        "INTERFACE": {
             "Ethernet0|10.2.2.1/24": {},
                 "Ethernet0|fc00:2:1::1/64": {},
                 "Ethernet4|10.2.1.1/24": {},
                 "Ethernet4|fc00:2:2::1/64": {},
                 "Ethernet121|20.20.20.1/24": {}           <<<<——— inexistent interface
    },

    admin@lnos-x1-a-csw02:~$ /usr/local/bin/sonic-cfggen -j ~/config_db.json --check-json
    Interface Ethernet121 not found in PORT table.

    Invalid configuration detected. No configuration changes processed. Exiting...

<—- Problem fixed after eliminating invalid config entry:

    admin@lnos-x1-a-csw02:~$ /usr/local/bin/sonic-cfggen -j ~/config_db.json --check-json
    admin@lnos-x1-a-csw02:~$

<-— Testcase 2) Adding an inexistent port as a VLAN member:

        "VLAN": {
                "Vlan100": {
                    "vlanid": "100",
                    "admin_status": "up",
                    "description": "Data Traffic",
                    "members": [
                          "Ethernet16",
                          "Ethernet17"          <<<<—— inexistent port
                    ],
                    "mtu": "9100"
                }
         },

    admin@lnos-x1-a-csw02:~$ /usr/local/bin/sonic-cfggen -j ~/config_db.json --check-json
    VLAN member Ethernet17 not found in PORT table.

    Invalid configuration detected. No configuration changes processed. Exiting...

<—- Problem fixed after eliminating invalid config entry:

    admin@lnos-x1-a-csw02:~$ /usr/local/bin/sonic-cfggen -j ~/config_db.json --check-json
    admin@lnos-x1-a-csw02:~$

<—- Testcase 3) Adding a VLAN_INTERFACE for an inexistent VLAN:

        "VLAN_INTERFACE": {
            "Vlan100|9.1.1.2/24": {
                   "scope": "global",
                   "family": "IPv4"
            },
            "Vlan100|fc00:9:2::2/64": {
                   "scope": "global",
                   "family": "IPv6"

            },
            "Vlan101|9.1.1.2/24": {          <<<<—— VLAN101 not defined in VLANS section
                   "scope": "global",
                   "family": "IPv4"
            }
    },

    admin@lnos-x1-a-csw02:~$ /usr/local/bin/sonic-cfggen -j ~/config_db.json --check-json
    Vlan interface Vlan101 not found in VLAN table.

    Invalid configuration detected. No configuration changes processed. Exiting...

<—- Problem fixed after eliminating invalid config entry:

    admin@lnos-x1-a-csw02:~$ /usr/local/bin/sonic-cfggen -j ~/config_db.json --check-json
    admin@lnos-x1-a-csw02:~$

<—- Testcase 4) Adding inexistent port for an neighbor entry:

        "DEVICE_NEIGHBOR": {
                "Ethernet0": {
                   "name": "ARISTA01T2",
                   "port": "Ethernet1"

            },
            "Ethernet2": {
                  "name": "ARISTA02T2",
                  "port": "Ethernet1"

            },
            "Ethernet4": {
                  "name": "ARISTA03T2",
                  "port": "Ethernet1"

            },
            "Ethernet5": {                        <<<<—— Inexistent port
                   "name": "ARISTA04T2",
                   "port": "Ethernet1"
            }
        },

    admin@lnos-x1-a-csw02:~$ /usr/local/bin/sonic-cfggen -j ~/config_db.json --check-json
    DEVICE_NEIGHBOR port Ethernet5 not found in PORT table.

    Invalid configuration detected. No configuration changes processed. Exiting...

<—- Problem fixed after eliminating invalid config entry:

    admin@lnos-x1-a-csw02:~$ /usr/local/bin/sonic-cfggen -j ~/config_db.json --check-json
    admin@lnos-x1-a-csw02:~$

