### PR TITLE
Fix potential blackholing/looping traffic when link-local was used and refresh ipv6 neighbor to avoid CPU hit

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -302,6 +302,7 @@ set /files/etc/sysctl.conf/net.ipv4.conf.all.arp_notify 1
 set /files/etc/sysctl.conf/net.ipv4.conf.all.arp_ignore 2
 
 set /files/etc/sysctl.conf/net.ipv4.neigh.default.base_reachable_time_ms 1800000
+set /files/etc/sysctl.conf/net.ipv6.neigh.default.base_reachable_time_ms 1800000
 
 set /files/etc/sysctl.conf/net.ipv6.conf.default.forwarding 1
 set /files/etc/sysctl.conf/net.ipv6.conf.all.forwarding 1

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -10,6 +10,7 @@ RUN apt-get update
 
 RUN apt-get install -f -y ifupdown arping libdbus-1-3 libdaemon0 libjansson4
 
+RUN apt-get install -f -y ndisc6
 ## Install redis-tools dependencies
 ## TODO: implicitly install dependencies
 RUN apt-get -y install libjemalloc1

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -11,17 +11,11 @@ while /bin/true; do
   # find L3 interfaces which are UP, send ipv6 multicast pings
   echo "{% for (name, prefix) in INTERFACE %} {{name}} {% endfor %}" > /tmp/intf_tmp.j2
   INTERFACE=`sonic-cfggen -d -t /tmp/intf_tmp.j2`
-  for intf in $INTERFACE; do
-      ping6cmd="ping6 -I $intf -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
-      intf_up=$(ip link show $intf | grep "state UP")
-      if [[ -n "$intf_up" ]]; then
-          eval $ping6cmd
-      fi
-  done
-
   echo "{% for (name, prefix) in PORTCHANNEL_INTERFACE %} {{name}} {% endfor %}" > /tmp/pc_intf_tmp.j2
   PC_INTERFACE=`sonic-cfggen -d -t /tmp/pc_intf_tmp.j2`
-  for intf in $PC_INTERFACE; do
+
+  ALL_INTERFACE="$INTERFACE $PC_INTERFACE"
+  for intf in $ALL_INTERFACE; do
       ping6cmd="ping6 -I $intf -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
       intf_up=$(ip link show $intf | grep "state UP")
       if [[ -n "$intf_up" ]]; then

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -1,10 +1,24 @@
 #!/bin/bash
 #
 # usage:
-# arp_update: Send gratuitous ARP requests to VLAN member neighbors to refresh
-# the neighbors state.
+# arp_update:
+# Send ipv6 multicast pings to all "UP" L3 interfaces including vlan interfaces to
+# refresh link-local addresses from neighbors.
+# Send gratuitous ARP/NDP requests to VLAN member neighbors to refresh
+# the ipv4/ipv6 neighbors state.
 
 while /bin/true; do
+  # find L3 interfaces which are UP, send ipv6 multicast pings
+  echo "{% for (name, prefix) in INTERFACE %} {{name}} {% endfor %}" > /tmp/intf_tmp.j2
+  INTERFACE=`sonic-cfggen -d -t /tmp/intf_tmp.j2`
+  for intf in $INTERFACE; do
+      ping6cmd="ping6 -I $intf -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
+      intf_up=$(ip link show $intf | grep "state UP")
+      if [[ -n "$intf_up" ]]; then
+	  eval $ping6cmd
+      fi
+  done
+
   VLAN=`sonic-cfggen -d -v 'VLAN.keys() | join(" ") if VLAN'`
   for vlan in $VLAN; do
       # generate a list of arping commands:
@@ -15,6 +29,18 @@ while /bin/true; do
       ipcmd="ip -4 neigh show | grep $vlan | cut -d ' ' -f 1,3 | $arpingcmd"
 
       eval `eval $ipcmd`
+
+      # send ipv6 multicast pings to Vlan interfaces to get/refresh link-local addrs
+      ping6cmd="ping6 -I $vlan -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
+      eval $ping6cmd
+
+      # generate a list of ndisc6 commands (exclude link-local addrs since it is done above):
+      #   ndisc6 -q -w 0 -1 <IP 1> <VLAN interface>;
+      #   ndisc6 -q -w 0 -1 <IP 2> <VLAN interface>;
+      #   ...
+      ndisc6cmd="sed -e 's/^/ndisc6 -q -w 0 -1 /' -e 's/$/;/'"
+      ip6cmd="ip -6 neigh show | grep -v fe80 | grep $vlan | cut -d ' ' -f 1,3 | $ndisc6cmd"
+      eval `eval $ip6cmd`
   done
   sleep 300
 done

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -15,7 +15,17 @@ while /bin/true; do
       ping6cmd="ping6 -I $intf -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
       intf_up=$(ip link show $intf | grep "state UP")
       if [[ -n "$intf_up" ]]; then
-	  eval $ping6cmd
+          eval $ping6cmd
+      fi
+  done
+
+  echo "{% for (name, prefix) in PORTCHANNEL_INTERFACE %} {{name}} {% endfor %}" > /tmp/pc_intf_tmp.j2
+  PC_INTERFACE=`sonic-cfggen -d -t /tmp/pc_intf_tmp.j2`
+  for intf in $PC_INTERFACE; do
+      ping6cmd="ping6 -I $intf -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
+      intf_up=$(ip link show $intf | grep "state UP")
+      if [[ -n "$intf_up" ]]; then
+          eval $ping6cmd
       fi
   done
 

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -13,6 +13,7 @@ RUN apt-get update
 
 RUN apt-get install -y net-tools \
                        arping \
+                       ndisc6 \
                        ethtool \
                        tcpdump \
                        ifupdown \


### PR DESCRIPTION
Fix potential blackholing/looping traffic and refresh ipv6 neighbor to avoid CPU hit

In case ipv6 global addresses were configured on L3 interfaces and used for peering,
and routing protocol was using link-local addresses on the same interfaces as prefered nexthops,
the link-local addresses could be aged out after a while due to no activities towards the link-local
addresses themselves. And when we receive new routes with the link-local nexthops, SONiC won't insert
them to the HW, and thus cause looping or blackholing traffic.

Global ipv6 addresses on L3 interfaces between switches are refreshed by BGP keeplive and other messages.

On server facing side, traffic may hit fowarding plane only, and no refresh for the ipv6 neighbor entries regularly.
This could age-out the linux kernel ipv6 neighbor entries, and HW neighbor table entries could be removed,
and thus traffic going to those neighbors would hit CPU, and cause traffic drop and temperary CPU high load.

Also, if link-local addresses were not learned, we may not get them at all later.

It is intended to fix all above issues.

Changes:
Add ndisc6 package in swss docker and use it for ipv6 ndp ping to update the neighbors' state on Vlan interfaces
Change the default ipv6 neighbor reachable timer to 30mins
Add periodical ipv6 multicast ping to ff02::11 to get/refresh link-local neighbor info.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix potential blackholing/looping traffic when ipv6 link-local was used, and refresh ipv6 neighbor to avoid CPU hit

**- How I did it**
Add ndisc6 package in swss docker and use it for ipv6 ndp ping to update the neighbors' state on Vlan interfaces
Change the default ipv6 neighbor reachable timer to 30mins
Add periodical ipv6 multicast ping to ff02::11 to get/refresh link-local neighbor info.

**- How to verify it**
-- ipv6 neighbors now stay at REACHABLE state for 30mins instead of 30seconds.


admin@lnos-x1-a-asw03:~$ clear arp
fe80::a83c:309a:5ca3:6593 dev Vlan100 lladdr 04:62:73:c4:eb:59 ref 1 used 2470/2470/39 probes 1 REACHABLE
2100::7 dev Vlan100 lladdr 04:62:73:8c:fd:6a ref 1 used 95/9/56 probes 4 REACHABLE
fe80::2a6f:7fff:feba:1cff dev eth0 lladdr 28:6f:7f:ba:1c:ff router used 30606/27426/22 probes 1 STALE
fe80::662:73ff:fe8c:fd6a dev Vlan100 lladdr 04:62:73:8c:fd:6a ref 1 used 85/85/5 probes 1 REACHABLE
fe80::2e0:ecff:fe3b:d6ac dev Ethernet122 lladdr 00:e0:ec:3b:d6:ac router ref 1 used 651/651/52 probes 1 REACHABLE
172.25.11.1 dev eth0 lladdr 28:6f:7f:ba:1c:ff ref 1 used 857/0/852 probes 1 REACHABLE
172.18.1.7 dev Vlan100 lladdr 04:62:73:8c:fd:6a ref 1 used 39523/56/56 probes 6 REACHABLE
172.25.11.46 dev eth0 lladdr 00:e0:ec:3c:09:9a ref 1 used 2475/2472/20 probes 1 REACHABLE


Round 1, deleting 8 entries 
Flush is complete after 1 round


admin@lnos-x1-a-asw03:~$ ip neighbor show | grep -v FAILED
172.25.11.1 dev eth0 lladdr 28:6f:7f:ba:1c:ff REACHABLE
172.25.11.46 dev eth0 lladdr 00:e0:ec:3c:09:9a REACHABLE


admin@lnos-x1-a-asw03:~$ docker exec -it swss bash -c "/usr/bin/arp_update"



admin@lnos-x1-a-asw03:~$ ip neighbor show | grep -v FAILED
fe80::662:73ff:fe8c:fd6a dev Vlan100 lladdr 04:62:73:8c:fd:6a DELAY
fe80::2e0:ecff:fe3b:d6ac dev Ethernet122 lladdr 00:e0:ec:3b:d6:ac router DELAY
172.25.11.1 dev eth0 lladdr 28:6f:7f:ba:1c:ff REACHABLE
172.18.1.7 dev Vlan100 lladdr 04:62:73:8c:fd:6a REACHABLE
172.25.11.46 dev eth0 lladdr 00:e0:ec:3c:09:9a REACHABLE


admin@lnos-x1-a-asw03:~$ ip neighbor show | grep -v FAILED
fe80::662:73ff:fe8c:fd6a dev Vlan100 lladdr 04:62:73:8c:fd:6a REACHABLE
fe80::2e0:ecff:fe3b:d6ac dev Ethernet122 lladdr 00:e0:ec:3b:d6:ac router REACHABLE
172.25.11.1 dev eth0 lladdr 28:6f:7f:ba:1c:ff REACHABLE
172.18.1.7 dev Vlan100 lladdr 04:62:73:8c:fd:6a REACHABLE
172.25.11.46 dev eth0 lladdr 00:e0:ec:3c:09:9a REACHABLE

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
