### PR TITLE
Upgrade azure-keyvault to known compatible version

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -101,7 +101,7 @@ RUN azure-cli_bundle_*/installer
 
 # Known bug: azure keyvault cannot work behind a proxy
 # Temporary fix: upgrade the azure-keyvault package within az cli
-# TODO: if azure-cli containers newer version azure-keyvault, remove this
+# TODO: if azure-cli contains newer version azure-keyvault, remove this
 RUN ~/lib/azure-cli/bin/python -m pip install azure-keyvault==0.3.7 -U
 
 RUN git clone https://github.com/Azure/sonic-mgmt

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -101,6 +101,7 @@ RUN azure-cli_bundle_*/installer
 
 # Known bug: azure keyvault cannot work behind a proxy
 # Temporary fix: upgrade the azure-keyvault package within az cli
-RUN ~/lib/azure-cli/bin/python -m pip install azure-keyvault -U
+# TODO: if azure-cli containers newer version azure-keyvault, remove this
+RUN ~/lib/azure-cli/bin/python -m pip install azure-keyvault==0.3.7 -U
 
 RUN git clone https://github.com/Azure/sonic-mgmt


### PR DESCRIPTION
In sonic-mgmt docker
Recent https://pypi.org/project/azure-keyvault/#history versions are not compatible with latest azure-cli