### PR TITLE
[interfaces]: Move IP/MTU information from interfaces file into database

### DIFF
--- a/dockers/docker-orchagent/start.sh
+++ b/dockers/docker-orchagent/start.sh
@@ -26,6 +26,8 @@ supervisorctl start vlanmgrd
 
 supervisorctl start intfmgrd
 
+supervisorctl start portmgrd
+
 supervisorctl start buffermgrd
 
 supervisorctl start enable_counters

--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -84,9 +84,17 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
+[program:portmgrd]
+command=/usr/bin/portmgrd
+priority=11
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+
 [program:buffermgrd]
 command=/usr/bin/buffermgrd -l /usr/share/sonic/hwsku/pg_profile_lookup.ini
-priority=10
+priority=12
 autostart=false
 autorestart=false
 stdout_logfile=syslog
@@ -94,7 +102,7 @@ stderr_logfile=syslog
 
 [program:enable_counters]
 command=/usr/bin/enable_counters.py
-priority=11
+priority=13
 autostart=false
 autorestart=false
 stdout_logfile=syslog

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -49,15 +49,6 @@ iface eth0 inet dhcp
 #
 {% endblock mgmt_interface %}
 {% block front_panel_interfaces %}
-# The switch front panel interfaces
-{% for (name, prefix) in INTERFACE %}
-allow-hotplug {{ name }}
-iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
-    mtu {{ PORT[name]['mtu'] if PORT[name]['mtu'] else 9100 }}
-    address {{ prefix | ip }}
-    netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
-#
-{% endfor %}
 {% if PORTCHANNEL %}
 # "|| true" is added to suppress the error when interface is already a member of LAG
 # "ip link show | grep -q master" is added to ensure interface is enslaved
@@ -73,16 +64,3 @@ iface {{ member }} inet manual
 {% endfor %}
 {% endif %}
 {% endblock front_panel_interfaces %}
-{% block pc_interfaces %}
-{% if PORTCHANNEL_INTERFACE %}
-# Portchannel interfaces
-{% for (name, prefix) in PORTCHANNEL_INTERFACE.keys() | sort %}
-allow-hotplug {{ name }}
-iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
-    mtu {{ PORTCHANNEL[name]['mtu'] if PORTCHANNEL[name]['mtu'] else 9100 }}
-    address {{ prefix | ip }}
-    netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
-#
-{% endfor %}
-{% endif %}
-{% endblock pc_interfaces %}

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -42,6 +42,8 @@ supervisorctl start teamsyncd
 
 supervisorctl start fpmsyncd
 
+supervisorctl start portmgrd
+
 supervisorctl start intfmgrd
 
 supervisorctl start vlanmgrd

--- a/platform/vs/docker-sonic-vs/supervisord.conf
+++ b/platform/vs/docker-sonic-vs/supervisord.conf
@@ -91,9 +91,17 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
+[program:portmgrd]
+command=/usr/bin/portmgrd
+priority=12
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+
 [program:zebra]
 command=/usr/lib/quagga/zebra -A 127.0.0.1
-priority=12
+priority=13
 autostart=false
 autorestart=false
 stdout_logfile=syslog
@@ -101,7 +109,7 @@ stderr_logfile=syslog
 
 [program:bgpd]
 command=/usr/lib/quagga/bgpd -A 127.0.0.1 -F
-priority=13
+priority=14
 autostart=false
 autorestart=false
 stdout_logfile=syslog
@@ -109,7 +117,7 @@ stderr_logfile=syslog
 
 [program:fpmsyncd]
 command=/usr/bin/fpmsyncd
-priority=14
+priority=15
 autostart=false
 autorestart=false
 stdout_logfile=syslog
@@ -117,7 +125,7 @@ stderr_logfile=syslog
 
 [program:arp_update]
 command=/usr/bin/arp_update
-priority=15
+priority=16
 autostart=false
 autorestart=unexpected
 stdout_logfile=syslog
@@ -125,7 +133,7 @@ stderr_logfile=syslog
 
 [program:buffermgrd]
 command=/usr/bin/buffermgrd -l /usr/share/sonic/device/vswitch/pg_profile_lookup.ini
-priority=10
+priority=17
 autostart=false
 autorestart=false
 stdout_logfile=syslog

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -91,7 +91,7 @@ def parse_png(png, hname):
                             'flow_control': flowcontrol
                             }
                     continue
-                     
+
                 if linktype != "DeviceInterfaceLink" and linktype != "UnderlayInterfaceLink":
                     continue
 
@@ -516,6 +516,15 @@ def parse_xml(filename, platform=None, port_config_file=None):
 
         ports.setdefault(port_name, {})['description'] = port_descriptions[port_name]
 
+    # set default port MTU as 9100
+    for port in ports.itervalues():
+        port['mtu'] = '9100'
+
+    # set physical port default admin status up
+    for port in phyport_intfs:
+        if port[0] in ports:
+            ports.get(port[0])['admin_status'] = 'up'
+
     results['PORT'] = ports
     results['CONSOLE_PORT'] = console_ports
 
@@ -527,6 +536,11 @@ def parse_xml(filename, platform=None, port_config_file=None):
             if not set(mbr_map['members']).issubset(port_set):
                 print >> sys.stderr, "Warning: ignore '%s' as part of its member interfaces is not in the port_config.ini" % pc_name
                 del pcs[pc_name]
+
+    # set default port channel MTU as 9100 and admin status up
+    for pc in pcs.itervalues():
+        pc['mtu'] = '9100'
+        pc['admin_status'] = 'up'
 
     results['PORTCHANNEL'] = pcs
 

--- a/src/sonic-config-engine/tests/sample_output/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/interfaces
@@ -47,7 +47,6 @@ iface eth0 inet6 static
     down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
     down ip -6 rule delete from 2603:10e2:0:2902::8/128 table default
 #
-# The switch front panel interfaces
 # "|| true" is added to suppress the error when interface is already a member of LAG
 # "ip link show | grep -q master" is added to ensure interface is enslaved
 allow-hotplug fortyGigE0/112
@@ -73,54 +72,5 @@ iface fortyGigE0/124 inet manual
     pre-up teamdctl PortChannel04 port add fortyGigE0/124 || true
     post-up ip link show fortyGigE0/124 | grep -q master && ifconfig fortyGigE0/124 up
     post-down ifconfig fortyGigE0/124 down
-#
-# Portchannel interfaces
-allow-hotplug PortChannel01
-iface PortChannel01 inet static
-    mtu 9100
-    address 10.0.0.56
-    netmask 255.255.255.254
-#
-allow-hotplug PortChannel01
-iface PortChannel01 inet6 static
-    mtu 9100
-    address fc00::71
-    netmask 126
-#
-allow-hotplug PortChannel02
-iface PortChannel02 inet static
-    mtu 9100
-    address 10.0.0.58
-    netmask 255.255.255.254
-#
-allow-hotplug PortChannel02
-iface PortChannel02 inet6 static
-    mtu 9100
-    address fc00::75
-    netmask 126
-#
-allow-hotplug PortChannel03
-iface PortChannel03 inet static
-    mtu 9100
-    address 10.0.0.60
-    netmask 255.255.255.254
-#
-allow-hotplug PortChannel03
-iface PortChannel03 inet6 static
-    mtu 9100
-    address fc00::79
-    netmask 126
-#
-allow-hotplug PortChannel04
-iface PortChannel04 inet static
-    mtu 9100
-    address 10.0.0.62
-    netmask 255.255.255.254
-#
-allow-hotplug PortChannel04
-iface PortChannel04 inet6 static
-    mtu 9100
-    address fc00::7d
-    netmask 126
 #
 

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -115,12 +115,12 @@ class TestCfgGen(TestCase):
     def test_minigraph_portchannels(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v PORTCHANNEL'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'PortChannel01': {'members': ['Ethernet4']}}")
+        self.assertEqual(output.strip(), "{'PortChannel01': {'admin_status': 'up', 'members': ['Ethernet4'], 'mtu': '9100'}}")
 
     def test_minigraph_portchannels_more_member(self):
         argument = '-m "' + self.sample_graph_pc_test + '" -p "' + self.port_config + '" -v PORTCHANNEL'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'PortChannel01': {'members': ['Ethernet112', 'Ethernet116', 'Ethernet120', 'Ethernet124']}}")
+        self.assertEqual(output.strip(), "{'PortChannel01': {'admin_status': 'up', 'members': ['Ethernet112', 'Ethernet116', 'Ethernet120', 'Ethernet124'], 'mtu': '9100'}}")
 
     def test_minigraph_portchannel_interfaces(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "PORTCHANNEL_INTERFACE.keys()"'
@@ -159,47 +159,47 @@ class TestCfgGen(TestCase):
     def test_minigraph_ethernet_interfaces(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet8\']"'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'alias': 'fortyGigE0/8', 'lanes': '37,38,39,40', 'description': 'Interface description', 'speed': '1000'}")
+        self.assertEqual(output.strip(), "{'alias': 'fortyGigE0/8', 'lanes': '37,38,39,40', 'description': 'Interface description', 'speed': '1000', 'mtu': '9100'}")
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "PORT[\'Ethernet12\']"'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'alias': 'fortyGigE0/12', 'lanes': '33,34,35,36', 'fec': 'rs', 'speed': '100000', 'description': 'Interface description'}")
+        self.assertEqual(output.strip(), "{'lanes': '33,34,35,36', 'description': 'Interface description', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'speed': '100000', 'fec': 'rs'}")
 
     def test_minigraph_extra_ethernet_interfaces(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "PORT"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), \
-                "{'Ethernet8': {'alias': 'fortyGigE0/8', 'lanes': '37,38,39,40', 'description': 'Interface description', 'speed': '1000'}, "
-                "'Ethernet0': {'alias': 'fortyGigE0/0', 'lanes': '29,30,31,32', 'speed': '10000'}, "
-                "'Ethernet4': {'alias': 'fortyGigE0/4', 'lanes': '25,26,27,28', 'speed': '25000'}, "
-                "'Ethernet108': {'alias': 'fortyGigE0/108', 'lanes': '81,82,83,84'}, "
-                "'Ethernet100': {'alias': 'fortyGigE0/100', 'lanes': '125,126,127,128'}, "
-                "'Ethernet104': {'alias': 'fortyGigE0/104', 'lanes': '85,86,87,88'}, "
-                "'Ethernet68': {'alias': 'fortyGigE0/68', 'lanes': '69,70,71,72'}, "
-                "'Ethernet96': {'alias': 'fortyGigE0/96', 'lanes': '121,122,123,124'}, "
-                "'Ethernet124': {'alias': 'fortyGigE0/124', 'lanes': '101,102,103,104'}, "
-                "'Ethernet92': {'alias': 'fortyGigE0/92', 'lanes': '113,114,115,116'}, "
-                "'Ethernet120': {'alias': 'fortyGigE0/120', 'lanes': '97,98,99,100'}, "
-                "'Ethernet52': {'alias': 'fortyGigE0/52', 'lanes': '53,54,55,56'}, "
-                "'Ethernet56': {'alias': 'fortyGigE0/56', 'lanes': '61,62,63,64'}, "
-                "'Ethernet76': {'alias': 'fortyGigE0/76', 'lanes': '73,74,75,76'}, "
-                "'Ethernet72': {'alias': 'fortyGigE0/72', 'lanes': '77,78,79,80'}, "
-                "'Ethernet64': {'alias': 'fortyGigE0/64', 'lanes': '65,66,67,68'}, "
-                "'Ethernet32': {'alias': 'fortyGigE0/32', 'lanes': '9,10,11,12'}, "
-                "'Ethernet16': {'alias': 'fortyGigE0/16', 'lanes': '41,42,43,44'}, "
-                "'Ethernet36': {'alias': 'fortyGigE0/36', 'lanes': '13,14,15,16'}, "
-                "'Ethernet12': {'alias': 'fortyGigE0/12', 'lanes': '33,34,35,36', 'fec': 'rs', 'speed': '100000', 'description': 'Interface description'}, "
-                "'Ethernet88': {'alias': 'fortyGigE0/88', 'lanes': '117,118,119,120'}, "
-                "'Ethernet116': {'alias': 'fortyGigE0/116', 'lanes': '93,94,95,96'}, "
-                "'Ethernet80': {'alias': 'fortyGigE0/80', 'lanes': '105,106,107,108'}, "
-                "'Ethernet112': {'alias': 'fortyGigE0/112', 'lanes': '89,90,91,92'}, "
-                "'Ethernet84': {'alias': 'fortyGigE0/84', 'lanes': '109,110,111,112'}, "
-                "'Ethernet48': {'alias': 'fortyGigE0/48', 'lanes': '49,50,51,52'}, "
-                "'Ethernet44': {'alias': 'fortyGigE0/44', 'lanes': '17,18,19,20'}, "
-                "'Ethernet40': {'alias': 'fortyGigE0/40', 'lanes': '21,22,23,24'}, "
-                "'Ethernet28': {'alias': 'fortyGigE0/28', 'lanes': '1,2,3,4'}, "
-                "'Ethernet60': {'alias': 'fortyGigE0/60', 'lanes': '57,58,59,60'}, "
-                "'Ethernet20': {'alias': 'fortyGigE0/20', 'lanes': '45,46,47,48'}, "
-                "'Ethernet24': {'alias': 'fortyGigE0/24', 'lanes': '5,6,7,8'}}")
+                "{'Ethernet8': {'alias': 'fortyGigE0/8', 'lanes': '37,38,39,40', 'description': 'Interface description', 'speed': '1000', 'mtu': '9100'}, "
+                "'Ethernet0': {'alias': 'fortyGigE0/0', 'admin_status': 'up', 'lanes': '29,30,31,32', 'speed': '10000', 'mtu': '9100'}, "
+                "'Ethernet4': {'alias': 'fortyGigE0/4', 'lanes': '25,26,27,28', 'speed': '25000', 'mtu': '9100'}, "
+                "'Ethernet108': {'alias': 'fortyGigE0/108', 'lanes': '81,82,83,84', 'mtu': '9100'}, "
+                "'Ethernet100': {'alias': 'fortyGigE0/100', 'lanes': '125,126,127,128', 'mtu': '9100'}, "
+                "'Ethernet104': {'alias': 'fortyGigE0/104', 'lanes': '85,86,87,88', 'mtu': '9100'}, "
+                "'Ethernet68': {'alias': 'fortyGigE0/68', 'lanes': '69,70,71,72', 'mtu': '9100'}, "
+                "'Ethernet96': {'alias': 'fortyGigE0/96', 'lanes': '121,122,123,124', 'mtu': '9100'}, "
+                "'Ethernet124': {'alias': 'fortyGigE0/124', 'lanes': '101,102,103,104', 'mtu': '9100'}, "
+                "'Ethernet92': {'alias': 'fortyGigE0/92', 'lanes': '113,114,115,116', 'mtu': '9100'}, "
+                "'Ethernet120': {'alias': 'fortyGigE0/120', 'lanes': '97,98,99,100', 'mtu': '9100'}, "
+                "'Ethernet52': {'alias': 'fortyGigE0/52', 'lanes': '53,54,55,56', 'mtu': '9100'}, "
+                "'Ethernet56': {'alias': 'fortyGigE0/56', 'lanes': '61,62,63,64', 'mtu': '9100'}, "
+                "'Ethernet76': {'alias': 'fortyGigE0/76', 'lanes': '73,74,75,76', 'mtu': '9100'}, "
+                "'Ethernet72': {'alias': 'fortyGigE0/72', 'lanes': '77,78,79,80', 'mtu': '9100'}, "
+                "'Ethernet64': {'alias': 'fortyGigE0/64', 'lanes': '65,66,67,68', 'mtu': '9100'}, "
+                "'Ethernet32': {'alias': 'fortyGigE0/32', 'lanes': '9,10,11,12', 'mtu': '9100'}, "
+                "'Ethernet16': {'alias': 'fortyGigE0/16', 'lanes': '41,42,43,44', 'mtu': '9100'}, "
+                "'Ethernet36': {'alias': 'fortyGigE0/36', 'lanes': '13,14,15,16', 'mtu': '9100'}, "
+                "'Ethernet12': {'lanes': '33,34,35,36', 'description': 'Interface description', 'mtu': '9100', 'alias': 'fortyGigE0/12', 'speed': '100000', 'fec': 'rs'}, "
+                "'Ethernet88': {'alias': 'fortyGigE0/88', 'lanes': '117,118,119,120', 'mtu': '9100'}, "
+                "'Ethernet116': {'alias': 'fortyGigE0/116', 'lanes': '93,94,95,96', 'mtu': '9100'}, "
+                "'Ethernet80': {'alias': 'fortyGigE0/80', 'lanes': '105,106,107,108', 'mtu': '9100'}, "
+                "'Ethernet112': {'alias': 'fortyGigE0/112', 'lanes': '89,90,91,92', 'mtu': '9100'}, "
+                "'Ethernet84': {'alias': 'fortyGigE0/84', 'lanes': '109,110,111,112', 'mtu': '9100'}, "
+                "'Ethernet48': {'alias': 'fortyGigE0/48', 'lanes': '49,50,51,52', 'mtu': '9100'}, "
+                "'Ethernet44': {'alias': 'fortyGigE0/44', 'lanes': '17,18,19,20', 'mtu': '9100'}, "
+                "'Ethernet40': {'alias': 'fortyGigE0/40', 'lanes': '21,22,23,24', 'mtu': '9100'}, "
+                "'Ethernet28': {'alias': 'fortyGigE0/28', 'lanes': '1,2,3,4', 'mtu': '9100'}, "
+                "'Ethernet60': {'alias': 'fortyGigE0/60', 'lanes': '57,58,59,60', 'mtu': '9100'}, "
+                "'Ethernet20': {'alias': 'fortyGigE0/20', 'lanes': '45,46,47,48', 'mtu': '9100'}, "
+                "'Ethernet24': {'alias': 'fortyGigE0/24', 'lanes': '5,6,7,8', 'mtu': '9100'}}")
 
     def test_metadata_everflow(self):
         argument = '-m "' + self.sample_graph_metadata + '" -p "' + self.port_config + '" -v "MIRROR_SESSION"'

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -87,7 +87,7 @@ class TestCfgGenCaseInsensitive(TestCase):
     def test_minigraph_portchannels(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v PORTCHANNEL'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'PortChannel01': {'members': ['Ethernet4']}}")
+        self.assertEqual(output.strip(), "{'PortChannel01': {'admin_status': 'up', 'members': ['Ethernet4'], 'mtu': '9100'}}")
 
     def test_minigraph_console_port(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v CONSOLE_PORT'


### PR DESCRIPTION
- Move front panel ports and port channels MTU and IP configurations out of
the current /etc/network/interfaces file and store them in the configuration
database.

- The default MTU value for both front panel ports and the port channels is
9100. Add the option to indicate the desired MTU settings in the port_config.ini
file.

- Introduce portmgrd which will pick up the MTU configurations from the
configuration database.

- The updated intfmgrd will pick up IP address changes from the configuration
database.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>