### PR TITLE
Fix LLDP netlink buffer size issue

### DIFF
--- a/rules/lldpd.mk
+++ b/rules/lldpd.mk
@@ -1,6 +1,6 @@
 # lldpd package
 
-LLDPD_VERSION = 0.9.5
+LLDPD_VERSION = 0.9.6
 
 LLDPD = lldpd_$(LLDPD_VERSION)-0_amd64.deb
 $(LLDPD)_DEPENDS += $(LIBSNMP_DEV)

--- a/src/lldpd/Makefile
+++ b/src/lldpd/Makefile
@@ -23,7 +23,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	stg import -s ../patch/series
 
 	# Build source and Debian packages
-	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
+	env "with_netlink_receive_bufsize=1024*1024" dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
 	# Move the newly-built .deb packages to the destination directory


### PR DESCRIPTION
LLDP is misbehaving if netlink messages were lost due to timing/buffer size issue.

The behavior could be that we are sending LLDP message but not using
lldpcli configured properties if netlink delete messages were lost.

It also could be that some interfaces do not sending messages at all.
"lldpcli show statistics" could see duplicated or missing interfaces.

Changes:
Upgrade lldpd to 0.9.6 (which introduced the adjustable netlink buffer size)
Change the netlink receive buffer size to 1MB

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the llpd netlink buffer size issue

**- How I did it**
Upgrade lldp to 0.9.6
Increase the netlink receive buffer size to 1MB.

**- How to verify it**
Before fix, if I repeat doing "service swss restart",  I could see the interfaces numbers from "lldpcli show statistics" sometimes do not match the expected one, it can be reproduced very often (one out of a few of times).

After fix, tried "service swss restart" 100+ times, no mismatch were noticed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
