### PR TITLE
Download newer version (8.23.0-2) of rsyslog from jessie-backports in hopes of eliminating memory leaks

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -200,7 +200,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     openssh-server          \
     python                  \
     python-setuptools       \
-    rsyslog                 \
     monit                   \
     python-apt              \
     traceroute              \
@@ -227,6 +226,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     python-scapy            \
     tcptraceroute           \
     mtr-tiny
+
+# Install a newer version of rsyslog from jessie-backports in hopes of
+# eliminating memory leaks
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y -t jessie-backports install rsyslog
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
     grub-pc-bin

--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -25,11 +25,14 @@ RUN apt-get update
 
 # Pre-install fundamental packages
 RUN apt-get -y install \
-    rsyslog            \
     vim-tiny           \
     perl               \
     python             \
     less
+
+# Install a newer version of rsyslog from jessie-backports in hopes of
+# eliminating memory leaks
+RUN apt-get -y -t jessie-backports install rsyslog
 
 # Pre-install troubleshooting packages
 RUN apt-get -y install socat

--- a/dockers/docker-base/sources.list
+++ b/dockers/docker-base/sources.list
@@ -5,3 +5,4 @@ deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-fre
 deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free
 deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
 deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
+deb http://debian-archive.trafficmanager.net/debian/ jessie-backports main contrib non-free

--- a/files/apt/sources.list
+++ b/files/apt/sources.list
@@ -5,3 +5,4 @@ deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-fre
 deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free
 deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
 deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
+deb http://debian-archive.trafficmanager.net/debian/ jessie-backports main contrib non-free

--- a/files/image_config/apt/sources.list.d/debian_archive_trafficmanager_net_debian.list
+++ b/files/image_config/apt/sources.list.d/debian_archive_trafficmanager_net_debian.list
@@ -1,2 +1,3 @@
 deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free
 deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
+deb http://debian-archive.trafficmanager.net/debian/ jessie-backports main contrib non-free

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -6,7 +6,7 @@ RUN echo "deb http://debian-archive.trafficmanager.net/debian/ jessie main contr
         echo "deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo 'deb http://debian-archive.trafficmanager.net/debian jessie-backports main' >> /etc/apt/sources.list
+        echo "deb http://debian-archive.trafficmanager.net/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The latest version of rsyslog from the stable Debian Jessie repo (version 8.4.2-1) has a memory leak issue that takes a couple months to consume all system RAM on 4GB systems.

The changelog for rsyslog shows multiple memory leak fixes since 8.4.2. However, the latest package compatible with Debian Jessie (available from jessie-backports) is 8.23.0, which is still behind current upstream version of 8.37.0, so it may still have some memory leaks, but hopefully enough bug fixes are in 8.23.0 to fix this issue presented in SONiC.

This PR updates the version of rsyslog in both the base image and all Docker containers.