### PR TITLE
[Mellanox] Update hw-management service config

### DIFF
--- a/platform/mellanox/hw-management/Add-systemd-service-config.patch
+++ b/platform/mellanox/hw-management/Add-systemd-service-config.patch
@@ -29,7 +29,7 @@ new file mode 100644
 index 0000000..d18916d
 --- /dev/null
 +++ b/debian/hw-management.service
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,11 @@
 +[Unit]
 +Description=Mellanox Hardware Management
 +
@@ -37,6 +37,7 @@ index 0000000..d18916d
 +Type=oneshot
 +EnvironmentFile=/host/machine.conf
 +ExecStart=/bin/bash -c "/usr/share/sonic/device/$onie_platform/hw-management start"
++ExecStop=/bin/bash -c "/usr/share/sonic/device/$onie_platform/hw-management stop"
 +
 +[Install]
 +WantedBy=multi-user.target


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

**- What I did**
Added service stop command to the hw-management

**- How I did it**
Updated hw-management service config

**- How to verify it**
start/stop service, check presence of /sys/bus/i2c/devices/2-0048/hwmon

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
