### PR TITLE
[build]: print error message when use root or sudo to build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ SHELL = /bin/bash
 USER := $(shell id -un)
 PWD := $(shell pwd)
 
+ifeq ($(USER), root)
+$(error Add your user account to docker group and use your user account to make. root or sudo are not supported!)
+endif
+
 # Remove lock file in case previous run was forcefully stopped
 $(shell rm -f .screen)
 


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
print error message when use root or sudo to build.

**- How I did it**

**- How to verify it**
```
lgh@gulv-vm1:/data2/sonic/stretch/sonic-buildimage$ sudo make
Makefile:29: *** Add your user account to docker group and use your user account to make. root or sudo are not supported!.  Stop.
lgh@gulv-vm1:/data2/sonic/stretch/sonic-buildimage$ sudo bash
root@gulv-vm1:/data2/sonic/stretch/sonic-buildimage# make
Makefile:29: *** Add your user account to docker group and use your user account to make. root or sudo are not supported!.  Stop.
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
