### PR TITLE
[mellanox]: Update hw-mgmt service with the stop action

### DIFF
--- a/platform/mellanox/hw-management/Add-systemd-service-config.patch
+++ b/platform/mellanox/hw-management/Add-systemd-service-config.patch
@@ -29,7 +29,7 @@ new file mode 100644
 index 0000000..d18916d
 --- /dev/null
 +++ b/debian/hw-management.service
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,11 @@
 +[Unit]
 +Description=Mellanox Hardware Management
 +
@@ -37,6 +37,7 @@ index 0000000..d18916d
 +Type=oneshot
 +EnvironmentFile=/host/machine.conf
 +ExecStart=/bin/bash -c "/etc/mlnx/mlnx-hw-management start"
++ExecStop=/bin/bash -c "/etc/mlnx/mlnx-hw-management stop"
 +
 +[Install]
 +WantedBy=multi-user.target


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated hw-mgmt service with the stop action
**- How I did it**
Modified patch for the hw-mgmt sub-module  in order to add stop action in systemd config file
(Later on hw-mgmt will be correctly started by SWSS service)
**- How to verify it**
Build and image, deploy to the switch and verify that all is up and running
**- Description for the changelog**
[mellanox]: Update hw-mgmt service with the stop action
