### PR TITLE
[mellanox] Fix qos.json.j2: apply qos config for active ports

### DIFF
--- a/device/mellanox/x86_64-mlnx_lssn2700-r0/LS-SN2700/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_lssn2700-r0/LS-SN2700/qos.json.j2
@@ -1,3 +1,30 @@
+{%- set PORT_ALL  = [] %}
+
+{%- if PORT is not defined %}
+    {%- for port_idx in range(0,64) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- else %}
+    {%- for port in PORT %}
+        {%- if PORT_ALL.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set PORT_ACTIVE  = [] %}
+{%- if DEVICE_NEIGHBOR is not defined %}
+    {%- set PORT_ACTIVE = PORT_ALL %}
+{%- else %}
+    {%- for port in DEVICE_NEIGHBOR.keys() %}
+        {%- if PORT_ACTIVE.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set port_names_list_active  = [] %}
+{%- for port in PORT_ACTIVE %}
+    {%- if port_names_list_active.append(port) %}{%- endif %}
+{%- endfor %}
+{%- set port_names_active  = port_names_list_active  | join(',') %}
+
 {
     "TC_TO_PRIORITY_GROUP_MAP": {
         "AZURE": {
@@ -114,7 +141,7 @@
         }
     },
     "PORT_QOS_MAP": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124": {
+        "{{ port_names_active }}": {
             "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
             "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
             "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
@@ -148,19 +175,15 @@
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0": {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|1": {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0-1": {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4": {
+        "{{ port_names_active }}|3-4" : {
             "scheduler"     :   "[SCHEDULER|scheduler.0]",
             "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "{{ port_names_active }}|0" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+        },
+        "{{ port_names_active }}|1" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.2]"
         }
     }
 }
-

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/qos.json.j2
@@ -1,3 +1,30 @@
+{%- set PORT_ALL  = [] %}
+
+{%- if PORT is not defined %}
+    {%- for port_idx in range(0,64) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- else %}
+    {%- for port in PORT %}
+        {%- if PORT_ALL.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set PORT_ACTIVE  = [] %}
+{%- if DEVICE_NEIGHBOR is not defined %}
+    {%- set PORT_ACTIVE = PORT_ALL %}
+{%- else %}
+    {%- for port in DEVICE_NEIGHBOR.keys() %}
+        {%- if PORT_ACTIVE.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set port_names_list_active  = [] %}
+{%- for port in PORT_ACTIVE %}
+    {%- if port_names_list_active.append(port) %}{%- endif %}
+{%- endfor %}
+{%- set port_names_active  = port_names_list_active  | join(',') %}
+
 {
     "TC_TO_PRIORITY_GROUP_MAP": {
         "AZURE": {
@@ -114,7 +141,7 @@
         }
     },
     "PORT_QOS_MAP": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60": {
+        "{{ port_names_active }}": {
             "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
             "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
             "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
@@ -148,18 +175,15 @@
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60|0": {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60|1": {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60|0-1": {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60|3-4": {
+        "{{ port_names_active }}|3-4" : {
             "scheduler"     :   "[SCHEDULER|scheduler.0]",
             "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "{{ port_names_active }}|0" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+        },
+        "{{ port_names_active }}|1" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.2]"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/qos.json.j2
@@ -1,3 +1,30 @@
+{%- set PORT_ALL  = [] %}
+
+{%- if PORT is not defined %}
+    {%- for port_idx in range(0,64) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- else %}
+    {%- for port in PORT %}
+        {%- if PORT_ALL.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set PORT_ACTIVE  = [] %}
+{%- if DEVICE_NEIGHBOR is not defined %}
+    {%- set PORT_ACTIVE = PORT_ALL %}
+{%- else %}
+    {%- for port in DEVICE_NEIGHBOR.keys() %}
+        {%- if PORT_ACTIVE.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set port_names_list_active  = [] %}
+{%- for port in PORT_ACTIVE %}
+    {%- if port_names_list_active.append(port) %}{%- endif %}
+{%- endfor %}
+{%- set port_names_active  = port_names_list_active  | join(',') %}
+
 {
     "TC_TO_PRIORITY_GROUP_MAP": {
         "AZURE": {
@@ -114,7 +141,7 @@
         }
     },
     "PORT_QOS_MAP": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124,Ethernet128,Ethernet132,Ethernet136,Ethernet140,Ethernet144,Ethernet148,Ethernet152,Ethernet156,Ethernet160,Ethernet164,Ethernet168,Ethernet172,Ethernet176,Ethernet180,Ethernet184,Ethernet188,Ethernet192,Ethernet196,Ethernet200,Ethernet204,Ethernet208,Ethernet212,Ethernet216,Ethernet220": {
+        "{{ port_names_active }}": {
             "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
             "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
             "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
@@ -148,18 +175,15 @@
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124,Ethernet128,Ethernet132,Ethernet136,Ethernet140,Ethernet144,Ethernet148,Ethernet152,Ethernet156,Ethernet160,Ethernet164,Ethernet168,Ethernet172,Ethernet176,Ethernet180,Ethernet184,Ethernet188,Ethernet192,Ethernet196,Ethernet200,Ethernet204,Ethernet208,Ethernet212,Ethernet216,Ethernet220|0": {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124,Ethernet128,Ethernet132,Ethernet136,Ethernet140,Ethernet144,Ethernet148,Ethernet152,Ethernet156,Ethernet160,Ethernet164,Ethernet168,Ethernet172,Ethernet176,Ethernet180,Ethernet184,Ethernet188,Ethernet192,Ethernet196,Ethernet200,Ethernet204,Ethernet208,Ethernet212,Ethernet216,Ethernet220|1": {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124,Ethernet128,Ethernet132,Ethernet136,Ethernet140,Ethernet144,Ethernet148,Ethernet152,Ethernet156,Ethernet160,Ethernet164,Ethernet168,Ethernet172,Ethernet176,Ethernet180,Ethernet184,Ethernet188,Ethernet192,Ethernet196,Ethernet200,Ethernet204,Ethernet208,Ethernet212,Ethernet216,Ethernet220|0-1": {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124,Ethernet128,Ethernet132,Ethernet136,Ethernet140,Ethernet144,Ethernet148,Ethernet152,Ethernet156,Ethernet160,Ethernet164,Ethernet168,Ethernet172,Ethernet176,Ethernet180,Ethernet184,Ethernet188,Ethernet192,Ethernet196,Ethernet200,Ethernet204,Ethernet208,Ethernet212,Ethernet216,Ethernet220|3-4": {
+        "{{ port_names_active }}|3-4" : {
             "scheduler"     :   "[SCHEDULER|scheduler.0]",
             "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "{{ port_names_active }}|0" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+        },
+        "{{ port_names_active }}|1" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.2]"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json.j2
@@ -1,3 +1,30 @@
+{%- set PORT_ALL  = [] %}
+
+{%- if PORT is not defined %}
+    {%- for port_idx in range(0,64) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- else %}
+    {%- for port in PORT %}
+        {%- if PORT_ALL.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set PORT_ACTIVE  = [] %}
+{%- if DEVICE_NEIGHBOR is not defined %}
+    {%- set PORT_ACTIVE = PORT_ALL %}
+{%- else %}
+    {%- for port in DEVICE_NEIGHBOR.keys() %}
+        {%- if PORT_ACTIVE.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set port_names_list_active  = [] %}
+{%- for port in PORT_ACTIVE %}
+    {%- if port_names_list_active.append(port) %}{%- endif %}
+{%- endfor %}
+{%- set port_names_active  = port_names_list_active  | join(',') %}
+
 {
     "TC_TO_PRIORITY_GROUP_MAP": {
         "AZURE": {
@@ -114,7 +141,7 @@
         }
     },
     "PORT_QOS_MAP": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124": {
+        "{{ port_names_active }}": {
             "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
             "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
             "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
@@ -148,19 +175,15 @@
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0": {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|1": {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0-1": {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4": {
+        "{{ port_names_active }}|3-4" : {
             "scheduler"     :   "[SCHEDULER|scheduler.0]",
             "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "{{ port_names_active }}|0" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+        },
+        "{{ port_names_active }}|1" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.2]"
         }
     }
 }
-

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/qos.json.j2
@@ -1,3 +1,30 @@
+{%- set PORT_ALL  = [] %}
+
+{%- if PORT is not defined %}
+    {%- for port_idx in range(0,64) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- else %}
+    {%- for port in PORT %}
+        {%- if PORT_ALL.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set PORT_ACTIVE  = [] %}
+{%- if DEVICE_NEIGHBOR is not defined %}
+    {%- set PORT_ACTIVE = PORT_ALL %}
+{%- else %}
+    {%- for port in DEVICE_NEIGHBOR.keys() %}
+        {%- if PORT_ACTIVE.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set port_names_list_active  = [] %}
+{%- for port in PORT_ACTIVE %}
+    {%- if port_names_list_active.append(port) %}{%- endif %}
+{%- endfor %}
+{%- set port_names_active  = port_names_list_active  | join(',') %}
+
 {
     "TC_TO_PRIORITY_GROUP_MAP": {
         "AZURE": {
@@ -114,7 +141,7 @@
         }
     },
     "PORT_QOS_MAP": {
-        "Ethernet8,Ethernet2,Ethernet0,Ethernet6,Ethernet4,Ethernet108,Ethernet100,Ethernet104,Ethernet106,Ethernet58,Ethernet126,Ethernet96,Ethernet124,Ethernet122,Ethernet92,Ethernet120,Ethernet50,Ethernet52,Ethernet54,Ethernet56,Ethernet76,Ethernet74,Ethernet18,Ethernet70,Ethernet32,Ethernet72,Ethernet16,Ethernet36,Ethernet78,Ethernet60,Ethernet28,Ethernet62,Ethernet14,Ethernet88,Ethernet118,Ethernet24,Ethernet116,Ethernet82,Ethernet114,Ethernet80,Ethernet112,Ethernet86,Ethernet110,Ethernet84,Ethernet48,Ethernet10,Ethernet44,Ethernet42,Ethernet40,Ethernet64,Ethernet66,Ethernet12,Ethernet46,Ethernet20,Ethernet22,Ethernet68": {
+        "{{ port_names_active }}": {
             "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
             "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
             "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
@@ -148,19 +175,15 @@
         }
     },
     "QUEUE": {
-        "Ethernet8,Ethernet2,Ethernet0,Ethernet6,Ethernet4,Ethernet108,Ethernet100,Ethernet104,Ethernet106,Ethernet58,Ethernet126,Ethernet96,Ethernet124,Ethernet122,Ethernet92,Ethernet120,Ethernet50,Ethernet52,Ethernet54,Ethernet56,Ethernet76,Ethernet74,Ethernet18,Ethernet70,Ethernet32,Ethernet72,Ethernet16,Ethernet36,Ethernet78,Ethernet60,Ethernet28,Ethernet62,Ethernet14,Ethernet88,Ethernet118,Ethernet24,Ethernet116,Ethernet82,Ethernet114,Ethernet80,Ethernet112,Ethernet86,Ethernet110,Ethernet84,Ethernet48,Ethernet10,Ethernet44,Ethernet42,Ethernet40,Ethernet64,Ethernet66,Ethernet12,Ethernet46,Ethernet20,Ethernet22,Ethernet68|0": {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
-        },
-        "Ethernet8,Ethernet2,Ethernet0,Ethernet6,Ethernet4,Ethernet108,Ethernet100,Ethernet104,Ethernet106,Ethernet58,Ethernet126,Ethernet96,Ethernet124,Ethernet122,Ethernet92,Ethernet120,Ethernet50,Ethernet52,Ethernet54,Ethernet56,Ethernet76,Ethernet74,Ethernet18,Ethernet70,Ethernet32,Ethernet72,Ethernet16,Ethernet36,Ethernet78,Ethernet60,Ethernet28,Ethernet62,Ethernet14,Ethernet88,Ethernet118,Ethernet24,Ethernet116,Ethernet82,Ethernet114,Ethernet80,Ethernet112,Ethernet86,Ethernet110,Ethernet84,Ethernet48,Ethernet10,Ethernet44,Ethernet42,Ethernet40,Ethernet64,Ethernet66,Ethernet12,Ethernet46,Ethernet20,Ethernet22,Ethernet68|1": {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
-        },
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0-1": {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
-        },
-        "Ethernet8,Ethernet2,Ethernet0,Ethernet6,Ethernet4,Ethernet108,Ethernet100,Ethernet104,Ethernet106,Ethernet58,Ethernet126,Ethernet96,Ethernet124,Ethernet122,Ethernet92,Ethernet120,Ethernet50,Ethernet52,Ethernet54,Ethernet56,Ethernet76,Ethernet74,Ethernet18,Ethernet70,Ethernet32,Ethernet72,Ethernet16,Ethernet36,Ethernet78,Ethernet60,Ethernet28,Ethernet62,Ethernet14,Ethernet88,Ethernet118,Ethernet24,Ethernet116,Ethernet82,Ethernet114,Ethernet80,Ethernet112,Ethernet86,Ethernet110,Ethernet84,Ethernet48,Ethernet10,Ethernet44,Ethernet42,Ethernet40,Ethernet64,Ethernet66,Ethernet12,Ethernet46,Ethernet20,Ethernet22,Ethernet68|3-4": {
+        "{{ port_names_active }}|3-4" : {
             "scheduler"     :   "[SCHEDULER|scheduler.0]",
             "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "{{ port_names_active }}|0" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+        },
+        "{{ port_names_active }}|1" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.2]"
         }
     }
 }
-


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This is related to https://github.com/Azure/sonic-buildimage/pull/1787;
Render qos.json.j2 file with active ports only.
This also fixes issue that some of ports does not have qos configuration on DUT with split ports, since port names in qos.json.j2 where hardcoded.

**- How I did it**
Render qos.json.j2 file with active ports only.

**- How to verify it**
Build an image and test on DUT

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
