### PR TITLE
Added picocom and pexpect to base image for use in consutil

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -226,7 +226,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     hping3                  \
     python-scapy            \
     tcptraceroute           \
-    mtr-tiny
+    mtr-tiny                \
+    picocom
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
     grub-pc-bin

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -96,6 +96,10 @@ sudo rm -rf $FILESYSTEM_ROOT/$PLATFORM_COMMON_PY2_WHEEL_NAME
 sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/python-click*_all.deb || \
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
 
+# Install python pexpect used by sonic-utilities consutil
+# using pip install instead to get a more recent version than is available through debian
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install pexpect
+
 # Install SONiC Utilities (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/python-sonic-utilities_*.deb || \
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f


### PR DESCRIPTION
Signed-off-by: Cayla Wanderman-Milne <t-cawand@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added picocom and pexpect to base image for use in consutil
**- How I did it**
Added picocom to list of fundamental packages in build_debian.sh and added pip install pexpect to sonic_debian_extension.j2
**- How to verify it**
Build and install image and use picocom or pexpect (or consutil connect)
**- Description for the changelog**
Added picocom and pexpect to base image for use in consutil

**- A picture of a cute animal (not mandatory but encouraged)**

![poof](https://user-images.githubusercontent.com/39776867/44174712-cc6d7a00-a098-11e8-8505-64bec4ea3e86.jpg)

