### PR TITLE
Don't load json conifg like copp, ininip, ports and switch again upon…

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -41,6 +41,18 @@ fast_reboot
 
 HWSKU=`sonic-cfggen -d -v "DEVICE_METADATA['localhost']['hwsku']"`
 
+# Don't load json config if system warm start or
+# swss docker warm start is enabled, the data already exists in appDB.
+WARM_START=`redis-cli -n 4 hget "WARM_RESTART|system" enable`
+if [ "$WARM_START" == "true" ]; then
+  exit 0
+fi
+
+WARM_START=`redis-cli -n 4 hget "WARM_RESTART|swss" enable`
+if [ "$WARM_START" == "true" ]; then
+  exit 0
+fi
+
 SWSSCONFIG_ARGS="00-copp.config.json ipinip.json ports.json switch.json "
 
 for file in $SWSSCONFIG_ARGS; do


### PR DESCRIPTION
… swss warm start

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**- What I did**
Some of the configurations in copp, ininip, ports and switch are create only, they should be applied once only.  
For swss warm start, same configurations already exist in appDB and have been restored. 

**- How I did it**
Skip swss json load upon warm start.

**- How to verify it**
cold start,
enable warm start, start again.

**- Description for the changelog**
