### PR TITLE
[broadcom]: fix delay to load led proc init

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/start.sh
+++ b/platform/broadcom/docker-syncd-brcm/start.sh
@@ -29,11 +29,13 @@ wait_syncd() {
         fi
         sleep 1
     done
+
+    # wait until bcm sdk is ready to get a request
+    sleep 3
 }
 
 # If this platform has an initialization file for the Broadcom LED microprocessor, load it
 if [ -r ${PLATFORM_DIR}/led_proc_init.soc ]; then
     wait_syncd
-    sleep 60 # wait until bcm sdk is ready to get a request
     supervisorctl start ledinit
 fi


### PR DESCRIPTION
led start bcm cmd triggers link state notifications.
This is quick fix to avoid such fake link state notifications.

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
led start bcm cmd triggers link state notifications.
This is quick fix to avoid such fake link state notifications.

**- How I did it**
change the sleep time to 3 seconds

**- How to verify it**
10 times reload swss to verify led status are loaded while no start.sh error return on multiple DUT.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
