### PR TITLE
[mellanox]: Fix problem with system EEPROM in "hw-mgmt"

### DIFF
--- a/platform/mellanox/hw-management/Add-modprobe-config-for-at24-module.patch
+++ b/platform/mellanox/hw-management/Add-modprobe-config-for-at24-module.patch
@@ -1,0 +1,21 @@
+From 2f70f5df445820fb86e3bd7f95707e0fb97b553f Mon Sep 17 00:00:00 2001
+From: Volodymyr Samotiy <volodymyrs@mellanox.com>
+Date: Thu, 16 Aug 2018 17:21:37 +0300
+Subject: Add modprobe config for "at24" module
+
+Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>
+---
+ usr/etc/modprobe.d/mellanox-system-whitelist.conf | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 usr/etc/modprobe.d/mellanox-system-whitelist.conf
+
+diff --git a/usr/etc/modprobe.d/mellanox-system-whitelist.conf b/usr/etc/modprobe.d/mellanox-system-whitelist.conf
+new file mode 100644
+index 0000000..a3eef57
+--- /dev/null
++++ b/usr/etc/modprobe.d/mellanox-system-whitelist.conf
+@@ -0,0 +1 @@
++options at24 io_limit=32
+-- 
+1.9.1
+


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed problem with system EEPROM in ```hw-mgmt```
**- How I did it**
Apply patch to ```hw-mgmt``` sub-module in order to add valid ```modprobe``` config for the ```at24``` module
**- How to verify it**
Build an image, deploy to the switch and verify that ```decode-syseeprom``` returns valid output without any errors
**- Description for the changelog**
[mellanox]: Fix problem with system EEPROM in "hw-mgmt"