### PR TITLE
[config-bcm] set bcm_tunnel_term_compatible_mode=1 for all platforms

### DIFF
--- a/device/accton/x86_64-accton_as5712_54x-r0/Accton-AS5712-54X/td2-as5712-72x10G.config.bcm
+++ b/device/accton/x86_64-accton_as5712_54x-r0/Accton-AS5712-54X/td2-as5712-72x10G.config.bcm
@@ -1,5 +1,6 @@
 os=unix
 bcm_stat_flags=0
+bcm_tunnel_term_compatible_mode=1
 parity_enable=0
 parity_correction=0
 

--- a/device/accton/x86_64-accton_as7312_54x-r0/Accton-AS7312-54X/th-as7312-48x25G+6x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7312_54x-r0/Accton-AS7312-54X/th-as7312-48x25G+6x100G.config.bcm
@@ -1,5 +1,6 @@
 # accton_as7312_54x 48x25G+6x100G SDK config
 os=unix
+bcm_tunnel_term_compatible_mode=1
 schan_intr_enable=0
 
 l2_mem_entries=40960

--- a/device/accton/x86_64-accton_as7312_54xs-r0/Accton-AS7312-54XS/th-as7312-48x25G+6x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7312_54xs-r0/Accton-AS7312-54XS/th-as7312-48x25G+6x100G.config.bcm
@@ -1,5 +1,6 @@
 # accton_as7312_54x 48x25G+6x100G SDK config
 os=unix
+bcm_tunnel_term_compatible_mode=1
 schan_intr_enable=0
 
 l2_mem_entries=40960

--- a/device/accton/x86_64-accton_as7712_32x-r0/Accton-AS7712-32X/th-as7712-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7712_32x-r0/Accton-AS7712-32X/th-as7712-32x100G.config.bcm
@@ -1,5 +1,6 @@
 # accton_as7712_32x 32x100G SDK config
 os=unix
+bcm_tunnel_term_compatible_mode=1
 schan_intr_enable=0
 l2_mem_entries=40960
 l2xmsg_mode=1

--- a/device/accton/x86_64-accton_as7716_32x-r0/Accton-AS7716-32X/th-as7716-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7716_32x-r0/Accton-AS7716-32X/th-as7716-32x100G.config.bcm
@@ -1,5 +1,6 @@
 # accton_as7716_32x 32x100G SDK config
 os=unix
+bcm_tunnel_term_compatible_mode=1
 schan_intr_enable=0
 l2_mem_entries=40960
 l2xmsg_mode=1

--- a/device/accton/x86_64-accton_as7716_32xb-r0/Accton-AS7716-32XB/th-as7716-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7716_32xb-r0/Accton-AS7716-32XB/th-as7716-32x100G.config.bcm
@@ -1,5 +1,6 @@
 # accton_as7716_32x 32x100G SDK config
 os=unix
+bcm_tunnel_term_compatible_mode=1
 schan_intr_enable=0
 l2_mem_entries=40960
 l2xmsg_mode=1

--- a/device/accton/x86_64-accton_as7816_64x-r0/Accton-AS7816-64X/th2-as7816-64x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7816_64x-r0/Accton-AS7816-64X/th2-as7816-64x100G.config.bcm
@@ -1,5 +1,6 @@
 # accton_as7816_64x 64x100G SDK config
 os=unix
+bcm_tunnel_term_compatible_mode=1
 schan_intr_enable=0
 l2_mem_entries=40960
 l2xmsg_mode=1

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-Q16S64/td2-a7050-qx32-16x40G+32x10G+8x40G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-Q16S64/td2-a7050-qx32-16x40G+32x10G+8x40G.config.bcm
@@ -1,5 +1,6 @@
 #/******************************************************************************
 # *
+bcm_tunnel_term_compatible_mode=1
 # *      File:   config.bcm.cloverdales (7050-QX32)
 # *      Name:
 # *

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/td2-a7050-qx32-32x40G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/td2-a7050-qx32-32x40G.config.bcm
@@ -1,5 +1,6 @@
 #/******************************************************************************
 # *
+bcm_tunnel_term_compatible_mode=1
 # *      File:   config.bcm.cloverdales (7050-QX32)
 # *      Name:
 # *

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/td2-a7050-qx32s-32x40G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/td2-a7050-qx32s-32x40G.config.bcm
@@ -1,5 +1,6 @@
 #/******************************************************************************
 # *
+bcm_tunnel_term_compatible_mode=1
 # *      File:   config.bcm.clearlake (7050-QX32S)
 # *      Name:
 # *

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
@@ -1,5 +1,6 @@
 # Arista 7060CX-32S
 
+bcm_tunnel_term_compatible_mode=1
 phy_an_allow_pll_change=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
@@ -1,5 +1,6 @@
 # Arista 7060CX-32S
 
+bcm_tunnel_term_compatible_mode=1
 phy_an_allow_pll_change=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
@@ -1,5 +1,6 @@
 # Arista 7060CX-32S
 
+bcm_tunnel_term_compatible_mode=1
 phy_an_allow_pll_change=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
@@ -1,5 +1,6 @@
 # Arista 7060CX-32S
 
+bcm_tunnel_term_compatible_mode=1
 phy_an_allow_pll_change=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/th2-a7260cx3-64-64x100G.config.bcm
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/th2-a7260cx3-64-64x100G.config.bcm
@@ -1,5 +1,6 @@
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
+bcm_tunnel_term_compatible_mode=1
 asf_mem_profile=2
 bcm_num_cos=8
 bcm_stat_flags=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/th2-a7260cx3-64-112x50G+8x100G.config.bcm
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/th2-a7260cx3-64-112x50G+8x100G.config.bcm
@@ -1,5 +1,6 @@
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
+bcm_tunnel_term_compatible_mode=1
 asf_mem_profile=2
 bcm_num_cos=8
 bcm_stat_flags=1

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/th-seastone-dx010-96x10G-16x50G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/th-seastone-dx010-96x10G-16x50G.config.bcm
@@ -1,5 +1,6 @@
 # Define default OS / SAL
 os=unix
+bcm_tunnel_term_compatible_mode=1
 
 # all XPORTs to XE ports
 #pbmp_xport_xe=0x1fffffffe

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50/th-seastone-dx010-64x50G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50/th-seastone-dx010-64x50G.config.bcm
@@ -1,5 +1,6 @@
 # Define default OS / SAL
 os=unix
+bcm_tunnel_term_compatible_mode=1
 
 # all XPORTs to XE ports
 #pbmp_xport_xe=0x1fffffffe

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/th-seastone-dx010-32x100G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/th-seastone-dx010-32x100G.config.bcm
@@ -1,5 +1,6 @@
 # Define default OS / SAL
 os=unix
+bcm_tunnel_term_compatible_mode=1
 
 # all XPORTs to XE ports
 #pbmp_xport_xe=0x1fffffffe

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/td2-s6000-32x40G.config.bcm
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/td2-s6000-32x40G.config.bcm
@@ -1,5 +1,6 @@
 # Old LPM only configuration
 # l2_mem_entries=163840
+bcm_tunnel_term_compatible_mode=1
 # l3_mem_entries=90112
 # l3_alpm_enable=0
 # ipv6_lpm_128b_enable=0

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t0.config.bcm
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t0.config.bcm
@@ -1,5 +1,6 @@
 #TH S6100 64x40
 l3_alpm_enable=2
+bcm_tunnel_term_compatible_mode=1
 pfc_deadlock_seq_control=1
 bcm_stat_interval=2000000
 bcm_num_cos=8

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t1.config.bcm
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t1.config.bcm
@@ -1,5 +1,6 @@
 #TH S6100 64x40
 l3_alpm_enable=2
+bcm_tunnel_term_compatible_mode=1
 pfc_deadlock_seq_control=1
 bcm_stat_interval=2000000
 bcm_num_cos=8

--- a/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100/th-z9100-32x100G.config.bcm
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100/th-z9100-32x100G.config.bcm
@@ -1,5 +1,6 @@
 #TH Z9100 32x100
 l3_alpm_enable=2
+bcm_tunnel_term_compatible_mode=1
 bcm_num_cos=8
 switch_bypass_mode=0
 mmu_lossless=0

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f/th2-z9264f-64x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f/th2-z9264f-64x100G.config.bcm
@@ -1,5 +1,6 @@
 #TH2 Z9264F 64x100G
 os=unix
+bcm_tunnel_term_compatible_mode=1
 core_clock_frequency=1700
 dpp_clock_ratio=2:3
 pbmp_xport_xe=0x3FFFD0000FFFF40003FFFC0001FFFE

--- a/device/delta/x86_64-delta_ag5648-r0/Delta-ag5648/th-ag5648-48x25G+6x100G.config.bcm
+++ b/device/delta/x86_64-delta_ag5648-r0/Delta-ag5648/th-ag5648-48x25G+6x100G.config.bcm
@@ -1,5 +1,6 @@
 os=unix
 schan_intr_enable=0
+bcm_tunnel_term_compatible_mode=1
 l2_mem_entries=40960
 l2xmsg_mode=1
 l3_mem_entries=40960

--- a/device/delta/x86_64-delta_ag9032v1-r0/Delta-ag9032v1/th-ag9032v1-32x100G.config.bcm
+++ b/device/delta/x86_64-delta_ag9032v1-r0/Delta-ag9032v1/th-ag9032v1-32x100G.config.bcm
@@ -1,5 +1,6 @@
 os=unix
 schan_intr_enable=0
+bcm_tunnel_term_compatible_mode=1
 ctr_evict_enable=0
 l2_mem_entries=40960
 l2xmsg_mode=1

--- a/device/delta/x86_64-delta_ag9064-r0/Delta-ag9064/th2-ag9064-64x100G.config.bcm
+++ b/device/delta/x86_64-delta_ag9064-r0/Delta-ag9064/th2-ag9064-64x100G.config.bcm
@@ -1,5 +1,6 @@
 core_clock_frequency=1700
 dport_map_enable=1
+bcm_tunnel_term_compatible_mode=1
 dport_map_port_102=31
 dport_map_port_103=32
 dport_map_port_104=64

--- a/device/facebook/x86_64-facebook_wedge100-r0/Facebook-W100-C32/th-wedge100-32x100G.config.bcm
+++ b/device/facebook/x86_64-facebook_wedge100-r0/Facebook-W100-C32/th-wedge100-32x100G.config.bcm
@@ -1,5 +1,6 @@
 ctr_evict_enable=0x0
 l2_mem_entries=0x8000
+bcm_tunnel_term_compatible_mode=1
 l3_intf_vlan_split_egress=0x1
 l3_mem_entries=0x4000
 mdio_output_delay=0xb

--- a/device/ingrasys/x86_64-ingrasys_s8810_32q-r0/INGRASYS-S8810-32Q/td2-s8810-32x40G.config.bcm
+++ b/device/ingrasys/x86_64-ingrasys_s8810_32q-r0/INGRASYS-S8810-32Q/td2-s8810-32x40G.config.bcm
@@ -1,5 +1,6 @@
 #2017/09/12
 os=unix
+bcm_tunnel_term_compatible_mode=1
 
 module_64ports=0
 scache_filename=/tmp/scache

--- a/device/ingrasys/x86_64-ingrasys_s8900_54xc-r0/INGRASYS-S8900-54XC/th-s8900-48x25G+6x100G.config.bcm
+++ b/device/ingrasys/x86_64-ingrasys_s8900_54xc-r0/INGRASYS-S8900-54XC/th-s8900-48x25G+6x100G.config.bcm
@@ -1,5 +1,6 @@
 #2017/05/31
 
+bcm_tunnel_term_compatible_mode=1
 os=unix
 
 oversubscribe_mode=1

--- a/device/ingrasys/x86_64-ingrasys_s8900_64xc-r0/INGRASYS-S8900-64XC/th-s8900-48x25G+16x100G.config.bcm
+++ b/device/ingrasys/x86_64-ingrasys_s8900_64xc-r0/INGRASYS-S8900-64XC/th-s8900-48x25G+16x100G.config.bcm
@@ -1,5 +1,6 @@
 #2017/05/31
 
+bcm_tunnel_term_compatible_mode=1
 os=unix
 
 oversubscribe_mode=1

--- a/device/ingrasys/x86_64-ingrasys_s9100-r0/INGRASYS-S9100-C32/th-s9100-32x100G.config.bcm
+++ b/device/ingrasys/x86_64-ingrasys_s9100-r0/INGRASYS-S9100-C32/th-s9100-32x100G.config.bcm
@@ -1,5 +1,6 @@
 #2017/09/12
 
+bcm_tunnel_term_compatible_mode=1
 os=unix
 
 oversubscribe_mode=1

--- a/device/inventec/x86_64-inventec_d7032q28b-r0/INVENTEC-D7032Q28B-C32/th-d7032q28b-32x100g.config.bcm
+++ b/device/inventec/x86_64-inventec_d7032q28b-r0/INVENTEC-D7032Q28B-C32/th-d7032q28b-32x100g.config.bcm
@@ -1,5 +1,6 @@
 # Redwood BCM Shell config / all 100G 32 ports
 
+bcm_tunnel_term_compatible_mode=1
 # Define default OS / SAL
 os=unix
 

--- a/device/inventec/x86_64-inventec_d7032q28b-r0/INVENTEC-D7032Q28B-C32/th-d7032q28b-32x40g.config.bcm
+++ b/device/inventec/x86_64-inventec_d7032q28b-r0/INVENTEC-D7032Q28B-C32/th-d7032q28b-32x40g.config.bcm
@@ -1,5 +1,6 @@
 # Redwood BCM Shell config / all 100G 32 ports
 
+bcm_tunnel_term_compatible_mode=1
 # Define default OS / SAL
 os=unix
 

--- a/device/inventec/x86_64-inventec_d7054q28b-r0/INVENTEC-D7054Q28B-S48-Q6/th-d7054q28b-48x10g-6x100g.config.bcm
+++ b/device/inventec/x86_64-inventec_d7054q28b-r0/INVENTEC-D7054Q28B-S48-Q6/th-d7054q28b-48x10g-6x100g.config.bcm
@@ -1,5 +1,6 @@
 # Cypress BCM Shell config / 10G * 48 ports; 100G * 6 ports
 
+bcm_tunnel_term_compatible_mode=1
 # Define default OS / SAL
 os=unix
 

--- a/device/inventec/x86_64-inventec_d7054q28b-r0/INVENTEC-D7054Q28B-S48-Q6/th-d7054q28b-48x25g-6x100g.config.bcm
+++ b/device/inventec/x86_64-inventec_d7054q28b-r0/INVENTEC-D7054Q28B-S48-Q6/th-d7054q28b-48x25g-6x100g.config.bcm
@@ -1,5 +1,6 @@
 # Cypress BCM Shell config / 25G * 48 ports; 100G * 6 ports
 
+bcm_tunnel_term_compatible_mode=1
 # Define default OS / SAL
 os=unix
 

--- a/device/inventec/x86_64-inventec_d7264q28b-r0/INVENTEC-D7264Q28B/th2-d7264q28b-64x100g.config.bcm
+++ b/device/inventec/x86_64-inventec_d7264q28b-r0/INVENTEC-D7264Q28B/th2-d7264q28b-64x100g.config.bcm
@@ -1,5 +1,6 @@
 # Sequoia BCM Shell config / 100G * 64 ports
 
+bcm_tunnel_term_compatible_mode=1
 core_clock_frequency=1700
 dpp_clock_ratio=2:3
 load_firmware=1

--- a/device/mitac/x86_64-mitac_ly1200_b32h0_c3-r0/MiTAC-LY1200-B32H0-C3/th-ly1200-32x100G.config.bcm
+++ b/device/mitac/x86_64-mitac_ly1200_b32h0_c3-r0/MiTAC-LY1200-B32H0-C3/th-ly1200-32x100G.config.bcm
@@ -1,5 +1,6 @@
 ### BMS (start)
 ## Global settings
+bcm_tunnel_term_compatible_mode=1
 bcm_num_cos=8
 dport_map_indexed=0
 

--- a/device/quanta/x86_64-quanta_ix1b_32x-r0/Quanta-IX1B-32X/th-ix1b-32x100G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix1b_32x-r0/Quanta-IX1B-32X/th-ix1b-32x100G.config.bcm
@@ -1,5 +1,6 @@
 os=unix
 
+bcm_tunnel_term_compatible_mode=1
 pbmp_xport_xe=0x3fd000000ff4000003fc000001fe
 pbmp_oversubscribe=0x3fd000000ff4000003fc000001fe
 l2xmsg_mode=1


### PR DESCRIPTION
According to Broadcom:
- This setting doesn't affect currently Broadcom SAI 3.1 behavior.
- This setting is required for upcoming SAI version(s).

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
set bcm_tunnel_term_compatible_mode=1 for all platforms

**- How I did it**
This change is done by a bash script. The choice of location to insert might not be the best as result.

**- How to verify it**
I tested this change on a few platforms that I have access to. Did not exhausting all platforms.