### PR TITLE
[swss]: simplify swss systemd service file

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -27,6 +27,7 @@ set -x -e
 . functions.sh
 BUILD_TEMPLATES=files/build_templates
 IMAGE_CONFIGS=files/image_config
+SCRIPTS_DIR=files/scripts
 
 # Define target fold macro
 FILESYSTEM_ROOT_USR="$FILESYSTEM_ROOT/usr"
@@ -291,6 +292,9 @@ fi
 sudo LANG=C chroot $FILESYSTEM_ROOT fuser -km /sys || true
 sudo LANG=C chroot $FILESYSTEM_ROOT umount -lf /sys
 {% endif %}
+
+# Copy swss service script
+sudo LANG=C cp $SCRIPTS_DIR/swss.sh $FILESYSTEM_ROOT/usr/local/bin/swss.sh
 
 # Copy systemd timer configuration
 # It implements delayed start of services

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -16,41 +16,9 @@ After=nps-modules-4.9.0-7-amd64.service
 
 [Service]
 User=root
-# Wait for redis server start before database clean
-ExecStartPre=/bin/bash -c 'until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]]; do sleep 1; done'
-ExecStartPre=/usr/bin/docker exec database redis-cli -n 0 FLUSHDB
-ExecStartPre=/usr/bin/docker exec database redis-cli -n 1 FLUSHDB
-ExecStartPre=/usr/bin/docker exec database redis-cli -n 2 FLUSHDB
-ExecStartPre=/usr/bin/docker exec database redis-cli -n 5 FLUSHDB
-ExecStartPre=/usr/bin/docker exec database redis-cli -n 6 FLUSHDB
-
-{% if sonic_asic_platform == 'mellanox' %}
-Environment=FAST_BOOT=1
-TimeoutStartSec=3min
-ExecStartPre=/usr/bin/mst start
-ExecStartPre=/usr/bin/mlnx-fw-upgrade.sh
-ExecStartPre=/etc/init.d/sxdkernel start
-ExecStartPre=/sbin/modprobe i2c-dev
-ExecStartPre=/bin/bash -c "/etc/mlnx/mlnx-hw-management start"
-{% elif sonic_asic_platform == 'cavium' %}
-ExecStartPre=/etc/init.d/xpnet.sh start
-{% endif %}
-
-ExecStartPre=/usr/bin/{{docker_container_name}}.sh start 
-ExecStartPre=/usr/bin/syncd.sh start
-ExecStart=/usr/bin/{{docker_container_name}}.sh attach
-
-ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-ExecStopPost=/usr/bin/syncd.sh stop
-
-{% if sonic_asic_platform == 'mellanox' %}
-ExecStopPost=/bin/bash -c "/etc/mlnx/mlnx-hw-management stop"
-ExecStopPost=/etc/init.d/sxdkernel stop
-ExecStopPost=/usr/bin/mst stop
-{% elif sonic_asic_platform == 'cavium' %}
-ExecStopPost=/etc/init.d/xpnet.sh stop
-ExecStopPost=/etc/init.d/xpnet.sh start
-{% endif %}
+Environment=sonic_asic_platform={{ sonic_asic_platform }}
+ExecStart=/usr/local/bin/swss.sh start
+ExecStop=/usr/local/bin/swss.sh stop
 
 [Install]
 WantedBy=multi-user.target

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+start() {
+    # Wait for redis server start before database clean
+    until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]]; 
+        do sleep 1;
+    done
+
+    # Flush DB
+    /usr/bin/docker exec database redis-cli -n 0 FLUSHDB
+    /usr/bin/docker exec database redis-cli -n 1 FLUSHDB
+    /usr/bin/docker exec database redis-cli -n 2 FLUSHDB
+    /usr/bin/docker exec database redis-cli -n 5 FLUSHDB
+    /usr/bin/docker exec database redis-cli -n 6 FLUSHDB
+
+    # platform specific tasks
+    if [ x$sonic_asic_platform == x'mellanox' ]; then
+        FAST_BOOT=1
+        /usr/bin/mst start
+        /usr/bin/mlnx-fw-upgrade.sh
+        /etc/init.d/sxdkernel start
+        /sbin/modprobe i2c-dev
+        /etc/mlnx/mlnx-hw-management start
+    elif [ x$sonic_asic_platform == x'cavium' ]; then
+        /etc/init.d/xpnet.sh start
+    fi
+
+    # start swss and syncd docker 
+    /usr/bin/swss.sh start 
+    /usr/bin/syncd.sh start
+    /usr/bin/swss.sh attach
+}
+
+stop() {
+    /usr/bin/swss.sh stop
+    /usr/bin/syncd.sh stop
+
+    # platform specific tasks
+    if [ x$sonic_asic_platform == x'mellanox' ]; then
+        /etc/mlnx/mlnx-hw-management stop
+        /etc/init.d/sxdkernel stop
+        /usr/bin/mst stop
+    elif [ x$sonic_asic_platform == x'cavium' ]; then
+        /etc/init.d/xpnet.sh stop
+        /etc/init.d/xpnet.sh start
+    fi
+}
+
+case "$1" in
+    start|stop)
+        $1
+        ;;
+    *)
+        echo "Usage: $0 {start|stop}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
move the swss service start/stop logic into /usr/local/bin/swss.sh

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
move the swss service start/stop logic into /usr/local/bin/swss.sh

**- How I did it**

**- How to verify it**
test on DUT
```
sudo systemctl restart swss
sudo systemctl stop swss
sudo systemctl start swss
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
