### PR TITLE
[mellanox]: Fix sysfs path for PSU devices in psuutil plugin

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2100-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/plugins/psuutil.py
@@ -21,9 +21,9 @@ class PsuUtil(PsuBase):
     def __init__(self):
         PsuBase.__init__(self)
 
-        self.psu_path = "/sys/bus/i2c/devices/2-0060/"
+        self.psu_path = "/bsp/module/"
         self.psu_presence = "psu{}_status"
-        self.psu_oper_status = "psu{}_pg_status"
+        self.psu_oper_status = "psu{}_pwr_status"
 
     def get_num_psus(self):
         """

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/plugins/psuutil.py
@@ -21,9 +21,9 @@ class PsuUtil(PsuBase):
     def __init__(self):
         PsuBase.__init__(self)
 
-        self.psu_path = "/sys/bus/i2c/devices/2-0060/"
+        self.psu_path = "/bsp/module/"
         self.psu_presence = "psu{}_status"
-        self.psu_oper_status = "psu{}_pg_status"
+        self.psu_oper_status = "psu{}_pwr_status"
 
     def get_num_psus(self):
         """

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/psuutil.py
@@ -21,9 +21,9 @@ class PsuUtil(PsuBase):
     def __init__(self):
         PsuBase.__init__(self)
 
-        self.psu_path = "/sys/bus/i2c/devices/2-0060/"
+        self.psu_path = "/bsp/module/"
         self.psu_presence = "psu{}_status"
-        self.psu_oper_status = "psu{}_pg_status"
+        self.psu_oper_status = "psu{}_pwr_status"
 
     def get_num_psus(self):
         """

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/plugins/psuutil.py
@@ -21,9 +21,9 @@ class PsuUtil(PsuBase):
     def __init__(self):
         PsuBase.__init__(self)
 
-        self.psu_path = "/sys/bus/i2c/devices/2-0060/"
+        self.psu_path = "/bsp/module/"
         self.psu_presence = "psu{}_status"
-        self.psu_oper_status = "psu{}_pg_status"
+        self.psu_oper_status = "psu{}_pwr_status"
 
     def get_num_psus(self):
         """


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed ```psuutil``` plugin.
**- How I did it**
```sysfs``` path for PSU devices was changed in MLNX ```hw-mgmt``` implementation for kernel 4.9, as a result ```psuutil``` doesn't show correct PSU status.
To fix the issue changed ```sysfs``` path for PSU devices in ```psuutil``` plugin in order to use common symbol links under ```/bsp/``` directory and avoid using direct ```sysfs``` path.
**- How to verify it**
Build and image, deploy to the switch and verify that ```psuutil status``` shows correct values:
```
root@sonic:/home/admin# psuutil status
PSU    Status
-----  --------
PSU 1  OK
PSU 2  OK
```
**- Description for the changelog**
[mellanox]: Fix sysfs path for PSU devices in psuutil plugin
