### PR TITLE
[make file] update make file for initramfs-tools

### DIFF
--- a/rules/initramfs-tools.mk
+++ b/rules/initramfs-tools.mk
@@ -8,6 +8,6 @@ $(INITRAMFS_TOOLS)_SRC_PATH = $(SRC_PATH)/initramfs-tools
 SONIC_MAKE_DEBS += $(INITRAMFS_TOOLS)
 
 INITRAMFS_TOOLS_CORE = initramfs-tools-core_$(INITRAMFS_TOOLS_VERSION)_all.deb
-$(eval $(call add_derived_package,$(INITRAMFS_TOOLS),$(INITRAMFS_TOOLS_CORE)))
+$(eval $(call add_extra_package,$(INITRAMFS_TOOLS),$(INITRAMFS_TOOLS_CORE)))
 
 SONIC_STRETCH_DEBS += $(INITRAMFS_TOOLS) $(INITRAMFS_TOOLS_CORE)


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
Call add_extra_package instead add_derived_package. Because the 'extra'
package doesn't require 'base' package to be installed to be built.

This change enables make stretch with multiple threads.

**- How to verify it**
make SONIC_BUILD_JOBS=20  stretch