### PR TITLE
Enable WRED red color profile on mellanox platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/qos.json.j2
@@ -154,6 +154,7 @@
         "AZURE_LOSSY": {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"516096",
             "red_min_threshold":"516096",
@@ -165,6 +166,7 @@
         "AZURE_LOSSLESS": {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"516096",
             "red_min_threshold":"516096",

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/qos.json.j2
@@ -154,6 +154,7 @@
         "AZURE_LOSSY": {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"516096",
             "red_min_threshold":"516096",
@@ -165,6 +166,7 @@
         "AZURE_LOSSLESS": {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"516096",
             "red_min_threshold":"516096",

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json.j2
@@ -154,6 +154,7 @@
         "AZURE_LOSSY": {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"516096",
             "red_min_threshold":"516096",
@@ -165,6 +166,7 @@
         "AZURE_LOSSLESS": {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"516096",
             "red_min_threshold":"516096",

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/qos.json.j2
@@ -154,6 +154,7 @@
         "AZURE_LOSSY": {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"516096",
             "red_min_threshold":"516096",
@@ -165,6 +166,7 @@
         "AZURE_LOSSLESS": {
             "wred_green_enable":"true",
             "wred_yellow_enable":"true",
+            "wred_red_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"516096",
             "red_min_threshold":"516096",


### PR DESCRIPTION
Signed-off-by: Wenda <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
Tested on msn2700

$ ps aux | grep orchagent
root     24026  0.1  0.0 183512  7784 pts/2    Sl   17:38   0:01 /usr/bin/orchagent -d /var/log/swss -b 8192

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
