### PR TITLE
[sonic-telemetry]: Enable docker cmd inside sonic-telemetry

### DIFF
--- a/rules/docker-telemetry.mk
+++ b/rules/docker-telemetry.mk
@@ -13,3 +13,10 @@ $(DOCKER_TELEMETRY)_CONTAINER_NAME = telemetry
 $(DOCKER_TELEMETRY)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_TELEMETRY)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
+$(DOCKER_TELEMETRY)_RUN_OPT += -v /var/log/wtmp:/var/log/wtmp:ro
+
+# enable docker cmd inside the telemetry container
+$(DOCKER_TELEMETRY)_RUN_OPT += -v /var/run/docker.sock:/var/run/docker.sock:rw
+$(DOCKER_TELEMETRY)_RUN_OPT += -v /usr/bin/docker:/usr/bin/docker
+$(DOCKER_TELEMETRY)_RUN_OPT += -v /usr/lib/x86_64-linux-gnu/libapparmor.so.1:/usr/lib/x86_64-linux-gnu/libapparmor.so.1
+$(DOCKER_TELEMETRY)_RUN_OPT += -v /usr/lib/x86_64-linux-gnu/libltdl.so.7:/usr/lib/x86_64-linux-gnu/libltdl.so.7


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Enable docker cmd inside sonic-telemetry
2. Enable 'last' command inside sonic-telemetry

**- How I did it**
1. Mount docker sock and the related files
2. Mount /var/log/wtmp

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
