### PR TITLE
Warm reboot: Add support for swss docker warm restart

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -2,9 +2,28 @@
 
 start() {
     # Wait for redis server start before database clean
-    until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]]; 
+    until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]];
         do sleep 1;
     done
+
+    # Wait for configDB initialization
+    until [[ $(/usr/bin/docker exec database redis-cli -n 4 GET "CONFIG_DB_INITIALIZED") ]];
+        do sleep 1;
+    done
+
+    SYSTEM_WARM_START=`/usr/bin/docker exec database redis-cli -n 4 HGET "WARM_RESTART|system" enable`
+    SWSS_WARM_START=`/usr/bin/docker exec database redis-cli -n 4 HGET "WARM_RESTART|swss" enable`
+    # if warm start enabled, just do swss docker start.
+    # Don't flush DB or try to start other modules.
+    if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; then
+      RESTART_COUNT=`redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restart_count`
+      # We have to make sure db data has not been flushed.
+      if [[ -n "$RESTART_COUNT" ]]; then
+        /usr/bin/swss.sh start
+        /usr/bin/swss.sh attach
+        return 0
+      fi
+    fi
 
     # Flush DB
     /usr/bin/docker exec database redis-cli -n 0 FLUSHDB
@@ -25,14 +44,22 @@ start() {
         /etc/init.d/xpnet.sh start
     fi
 
-    # start swss and syncd docker 
-    /usr/bin/swss.sh start 
+    # start swss and syncd docker
+    /usr/bin/swss.sh start
     /usr/bin/syncd.sh start
     /usr/bin/swss.sh attach
 }
 
 stop() {
     /usr/bin/swss.sh stop
+
+    SYSTEM_WARM_START=`redis-cli -n 4 hget "WARM_RESTART|system" enable`
+    SWSS_WARM_START=`redis-cli -n 4 hget "WARM_RESTART|swss" enable`
+    # if warm start enabled, just stop swss docker, then return
+    if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; then
+        return 0
+    fi
+
     /usr/bin/syncd.sh stop
 
     # platform specific tasks


### PR DESCRIPTION
**- What I did**
Add support for swss docker warm restart

**- How I did it**

**- How to verify it**

Perform system cold restart,  and config reload, system could be started without issue.

Enable swss or system warm start,  do systemctl restart swss , or upgrade_docker
swss got start again without affect data plane traffic.
```
root@sonic:~# sonic_installer upgrade_docker  --cleanup_image swss swss_test_01 ./docker-orchagent-brcm_test_01.gz  
New docker image will be installed, continue? [y/N]: y
Orchagent is in clean state and frozen for warm upgrade
Command: systemctl stop swss

Command: docker rm  swss
swss

Command: docker rmi  docker-orchagent-brcm:latest
Untagged: docker-orchagent-brcm:latest

Command: docker load < ././docker-orchagent-brcm_test_01.gz

Command: docker tag docker-orchagent-brcm:latest docker-orchagent-brcm:swss_test_01

Command: systemctl restart swss

Command: docker rmi -f a5f4711c7e3e
Untagged: docker-orchagent-brcm:warm-reboot.0-dirty-20180823.192608
Deleted: sha256:a5f4711c7e3e349356c5bb0f991bcd318a9f9de560a4bbca9d00e291d815c204
Deleted: sha256:a90f8d8df5e5c20735543dbc92920ba860c186e52320b7ec9cf5cd6de52bece9

Command: sleep 5

Done

127.0.0.1:6379[6]> hgetall  "WARM_RESTART_TABLE|orchagent"
1) "restart_count"
2) "2"
3) "state"
4) "reconciled"
127.0.0.1:6379[6]> hgetall "WARM_RESTART_TABLE|neighsyncd"
1) "restart_count"
2) "2"

```
