### PR TITLE
[console speed] Inherit console speed from install environment

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -64,10 +64,6 @@ fi
 
 echo "onie_platform: $onie_platform"
 
-# default console settings
-CONSOLE_PORT=0x3f8
-CONSOLE_DEV=0
-
 # Get platform specific linux kernel command line arguments
 ONIE_PLATFORM_EXTRA_CMDLINE_LINUX=""
 
@@ -76,11 +72,34 @@ VAR_LOG_SIZE=4096
 
 [ -r platforms/$onie_platform ] && . platforms/$onie_platform
 
-# Pick up console speed from install enviroment if not defined yet.
-# Console speed setting in cmdline is like "console=ttyS0,9600n",
-# so we can use pattern 'console=ttyS[0-9]+,[0-9]+' to match it
+# Pick up console port and speed from install enviroment if not defined yet.
+# Console port and speed setting in cmdline is like "console=ttyS0,9600n",
+# so we can use pattern 'console=ttyS[0-9]+,[0-9]+' to match it.
+# If failed to get the speed and ttyS from cmdline then set them to default: ttyS0 and 9600
+if [ -z "$CONSOLE_PORT" ]; then
+    console_ttys=$(cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+' | cut -d "=" -f2)
+    if [ -z "$console_ttys" -o "$console_ttys" = "ttyS0" ]; then
+        CONSOLE_PORT=0x3f8
+        CONSOLE_DEV=0
+    elif [ "$console_ttys" = "ttyS1" ]; then
+        CONSOLE_PORT=0x2f8
+        CONSOLE_DEV=1
+    elif [ "$console_ttys" = "ttyS2" ]; then
+        CONSOLE_PORT=0x3e8
+        CONSOLE_DEV=2
+    elif [ "$console_ttys" = "ttyS3" ]; then
+        CONSOLE_PORT=0x2e8
+        CONSOLE_DEV=3
+    fi
+fi
+
 if [ -z "$CONSOLE_SPEED" ]; then
-    CONSOLE_SPEED=$(cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d "," -f2)
+    speed=$(cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d "," -f2)
+    if [ -z "$speed" ]; then
+        CONSOLE_SPEED=9600
+    else
+        CONSOLE_SPEED=$speed
+    fi
 fi
 
 # Install demo on same block device as ONIE

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -67,7 +67,12 @@ echo "onie_platform: $onie_platform"
 # default console settings
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
-CONSOLE_SPEED=9600
+
+# Pick up console speed from install enviroment, if failed, set it to 9600
+CONSOLE_SPEED=$(stty -F /dev/ttyS0 | grep speed | cut -d " " -f2)
+if [ -z "$CONSOLE_SPEED" ]; then
+    CONSOLE_SPEED=9600
+fi
 
 # Get platform specific linux kernel command line arguments
 ONIE_PLATFORM_EXTRA_CMDLINE_LINUX=""

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -68,12 +68,6 @@ echo "onie_platform: $onie_platform"
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 
-# Pick up console speed from install enviroment, if failed, set it to 9600
-CONSOLE_SPEED=$(stty -F /dev/ttyS0 | grep speed | cut -d " " -f2)
-if [ -z "$CONSOLE_SPEED" ]; then
-    CONSOLE_SPEED=9600
-fi
-
 # Get platform specific linux kernel command line arguments
 ONIE_PLATFORM_EXTRA_CMDLINE_LINUX=""
 
@@ -81,6 +75,13 @@ ONIE_PLATFORM_EXTRA_CMDLINE_LINUX=""
 VAR_LOG_SIZE=4096
 
 [ -r platforms/$onie_platform ] && . platforms/$onie_platform
+
+# Pick up console speed from install enviroment if not defined yet.
+# Console speed setting in cmdline is like "console=ttyS0,9600n",
+# so we can use pattern 'console=ttyS[0-9]+,[0-9]+' to match it
+if [ -z "$CONSOLE_SPEED" ]; then
+    CONSOLE_SPEED=$(cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d "," -f2)
+fi
 
 # Install demo on same block device as ONIE
 if [ "$install_env" != "build" ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In the current installer the console speed is set to 9600 regardless the original value of the install enviroment. If the install enviroment was using another value,  eg. 115200, after installed SONiC, user have to make some chage to adapt the new console speed.  To give user a more smooth experience, suggest to keep using the original console speed instead of overwrite it.

**- How I did it**
in the install.sh add code to pick up console speed from install enviroment instead of hardcode to 9600.

**- How to verify it**
tested by installing SONiC from ONIE and SONiC itself.

**- Description for the changelog**

installer/x86_64/install.sh

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
