### PR TITLE
[debian]: Enable keep_addr_on_down to keep IPv6 addresses

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -318,6 +318,10 @@ set /files/etc/sysctl.conf/net.ipv6.conf.default.accept_dad 0
 set /files/etc/sysctl.conf/net.ipv6.conf.all.accept_dad 0
 set /files/etc/sysctl.conf/net.ipv6.conf.eth0.accept_dad 0
 
+set /files/etc/sysctl.conf/net.ipv6.conf.default.keep_addr_on_down 1
+set /files/etc/sysctl.conf/net.ipv6.conf.all.keep_addr_on_down 1
+set /files/etc/sysctl.conf/net.ipv6.conf.eth0.keep_addr_on_down 1
+
 set /files/etc/sysctl.conf/net.ipv6.conf.eth0.accept_ra_defrtr 0
 
 set /files/etc/sysctl.conf/net.core.rmem_max 2097152


### PR DESCRIPTION
Starting from kernel 4.6, this new attribute keep_addr_on_down
is introduced (https://kernelnewbies.org/Linux_4.6).

If set, static global addresses with no expiration time are not
flushed.

Ref:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f1705ec197e705b79ea40fe7a2cc5acfa1d3bfac

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>