### PR TITLE
[make file] building management docker doesn't need to build stretch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ ifeq ($(NOSTRETCH), 0)
 	BLDENV=stretch make -f Makefile.work stretch
 endif
 
-clean reset init configure showtag sonic-slave-build sonic-slave-bash :
+clean reset init configure showtag sonic-slave-build sonic-slave-bash target/docker-sonic-mgmt.gz :
 	@echo "+++ Making $@ +++"
 	make -f Makefile.work $@


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
add management docker to pass through target.

**- How to verify it**
make target/docker-sonic-mgmt.gz