### PR TITLE
Deleting stretch-branch pointer from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,6 @@
 [submodule "sonic-linux-kernel"]
 	path = src/sonic-linux-kernel
 	url = https://github.com/Azure/sonic-linux-kernel
-	branch = stretch
 [submodule "sonic-sairedis"]
 	path = src/sonic-sairedis
 	url = https://github.com/Azure/sonic-sairedis


### PR DESCRIPTION
Removing .gitmodules pointer to inexistent linux-kernel branch.

rmolina-mn1:sonic-buildimage rmolina$ git submodule update --recursive --remote
..
fatal: Needed a single revision
Unable to find current origin/stretch revision in submodule path 'src/sonic-linux-kernel'
...

Signed-off-by: Rodny Molina <rodny@linkedin.com>


