### PR TITLE
[platform/dx010] Fix issing qsfp_reset sysfs file

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -33,7 +33,6 @@ case "$1" in
 start)
         echo -n "Setting up board... "
 
-        depmod -a
         modprobe i2c-dev
         modprobe i2c-mux-pca954x
         modprobe dx010_wdt

--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.install
@@ -1,2 +1,3 @@
 dx010/scripts/dx010_check_qsfp.sh usr/local/bin
 dx010/cfg/dx010-modules.conf etc/modules-load.d
+dx010/systemd/platform-modules-dx010.service lib/systemd/system

--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.postinst
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.postinst
@@ -1,0 +1,3 @@
+depmod -a
+systemctl enable platform-modules-dx010.service
+systemctl start platform-modules-dx010.service

--- a/platform/broadcom/sonic-platform-modules-cel/dx010/modules/dx010_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-cel/dx010/modules/dx010_cpld.c
@@ -30,6 +30,13 @@
 
 #define DRIVER_NAME "dx010_cpld"
 
+#define RESET0108   0x250
+#define RESET0910   0x251
+#define RESET1118   0x2d0
+#define RESET1921   0x2d1
+#define RESET2229   0x3d0
+#define RESET3032   0x3d1
+
 #define LPMOD0108   0x252
 #define LPMOD0910   0x253
 #define LPMOD1118   0x2d2
@@ -50,6 +57,7 @@
 #define INT1921     0x2d7
 #define INT2229     0x3d6
 #define INT3032     0x3d7
+
 
 #define LENGTH_PORT_CPLD        34
 #define PORT_BANK1_START        1
@@ -105,6 +113,53 @@ struct dx010_cpld_data {
 };
 
 struct dx010_cpld_data *cpld_data;
+
+static ssize_t get_reset(struct device *dev, struct device_attribute *devattr,
+                char *buf)
+{
+        unsigned long reset = 0;
+
+        mutex_lock(&cpld_data->cpld_lock);
+
+        reset =
+                (inb(RESET3032) & 0x07) << (24+5) |
+                inb(RESET2229) << (24-3)  |
+                (inb(RESET1921) & 0x07) << (16 + 2) |
+                inb(RESET1118) << (16-6) |
+                (inb(RESET0910) & 0x03 ) << 8 |
+                inb(RESET0108);
+
+        mutex_unlock(&cpld_data->cpld_lock);
+
+        return sprintf(buf,"0x%8.8lx\n", reset & 0xffffffff);
+}
+
+static ssize_t set_reset(struct device *dev, struct device_attribute *devattr,
+                const char *buf, size_t count)
+{
+        unsigned long reset;
+        int err;
+
+        mutex_lock(&cpld_data->cpld_lock);
+
+        err = kstrtoul(buf, 16, &reset);
+        if (err)
+        {
+                mutex_unlock(&cpld_data->cpld_lock);
+                return err;
+        }
+
+        outb( (reset >> 0)  & 0xFF, RESET0108);
+        outb( (reset >> 8)  & 0x03, RESET0910);
+        outb( (reset >> 10) & 0xFF, RESET1118);
+        outb( (reset >> 18) & 0x07, RESET1921);
+        outb( (reset >> 21) & 0xFF, RESET2229);
+        outb( (reset >> 29) & 0x07, RESET3032);
+
+        mutex_unlock(&cpld_data->cpld_lock);
+
+        return count;
+}
 
 static ssize_t get_lpmode(struct device *dev, struct device_attribute *devattr,
                 char *buf)
@@ -193,11 +248,13 @@ static ssize_t get_modirq(struct device *dev, struct device_attribute *devattr,
         return sprintf(buf,"0x%8.8lx\n", irq  & 0xffffffff);
 }
 
+static DEVICE_ATTR(qsfp_reset, S_IRUGO | S_IWUSR, get_reset, set_reset);
 static DEVICE_ATTR(qsfp_lpmode, S_IRUGO | S_IWUSR, get_lpmode, set_lpmode);
 static DEVICE_ATTR(qsfp_modprs, S_IRUGO, get_modprs, NULL);
 static DEVICE_ATTR(qsfp_modirq, S_IRUGO, get_modirq, NULL);
 
 static struct attribute *dx010_lpc_attrs[] = {
+        &dev_attr_qsfp_reset.attr,
         &dev_attr_qsfp_lpmode.attr,
         &dev_attr_qsfp_modprs.attr,
         &dev_attr_qsfp_modirq.attr,
@@ -247,7 +304,6 @@ static int i2c_read_eeprom(struct i2c_adapter *a, u16 addr,
         short temp;
         short portid, opcode, devaddr, cmdbyte0, ssrr, writedata, readdata;
         __u16 word_data;
-        char read_byte;
         int error = -EIO;
 
         mutex_lock(&cpld_data->cpld_lock);
@@ -465,7 +521,6 @@ static int cel_dx010_lpc_drv_probe(struct platform_device *pdev)
 static int cel_dx010_lpc_drv_remove(struct platform_device *pdev)
 {
         int portid_count;
-        struct dx010_i2c_data *new_data;
 
         sysfs_remove_group(&pdev->dev.kobj, &dx010_lpc_attr_grp);
 

--- a/platform/broadcom/sonic-platform-modules-cel/dx010/systemd/platform-modules-dx010.service
+++ b/platform/broadcom/sonic-platform-modules-cel/dx010/systemd/platform-modules-dx010.service
@@ -1,0 +1,14 @@
+
+[Unit]
+Description=Celestica Seastone dx010 platform modules
+After=local-fs.target
+Before=pmon.service
+
+[Service]
+Type=oneshot
+ExecStart=-/etc/init.d/platform-modules-dx010 start
+ExecStop=-/etc/init.d/platform-modules-dx010 stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 Add qsfp_reset sysfs of dx010 platform.

**- How I did it**
 * Implement sysfs interface for platform transceiver reset.
 * Add systemd unit file for platform init-script.

**- How to verify it**
- Platform module service must be loaded after boot.
- Run sfputil reset ... test on the platform.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fix missing qsfp_reset sysfs interface.
- Add systemd unit file for platform initialize.

