### PR TITLE
[libteam] LACP should not work after shutdown port-channel via ifconfig down

### DIFF
--- a/src/libteam/0005-when-port-status-is-disabled-it-could-not-handle-lacpdu-frame.patch
+++ b/src/libteam/0005-when-port-status-is-disabled-it-could-not-handle-lacpdu-frame.patch
@@ -1,0 +1,15 @@
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 9c77fae..276b3b0 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -1091,6 +1112,10 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
+ 			return err;
+ 	}
+ 
++	/* Bug, if lacp_port status is PORT_STATE_DISABLED, We should not handle any LACPDU */
++	if ( lacp_port->state == PORT_STATE_DISABLED )
++		return 0;
++
+ 	err = lacp_port_set_state(lacp_port, PORT_STATE_CURRENT);
+ 	if (err)
+ 		return err;

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -19,6 +19,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git apply ../0002-libteam-Temporarily-remove-redundant-debug-mes.patch
 	git apply ../0003-teamd-lacp-runner-will-send-lacp-update-right-after-.patch
 	git apply ../0004-libteam-Add-lacp-fallback-support-for-single-member-.patch
+	git apply ../0005-when-port-status-is-disabled-it-could-not-handle-lacpdu-frame.patch
 	popd
 
 	# Obtain debian packaging


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Add a patch in libteam for solving this issue. 

The sympthon of this issue is. 
Step1: Config PortChannel01 in config_db.json and check PortChannel01 is up via 'show interface portchannel'
Step2: Shutdown PortChannel01 via 'config portchannel shutdown PortChannel01'
Step3: Check PortChannel01 status again to make sure it is down 
Step4: Send traffic to make sure it is down => STILL can forward the traffic 

**- How I did it**
* Check LACP design document (https://github.com/Azure/SONiC/tree/gh-pages/doc/lag) to understand its state machine and do the modification described as follows:

According to the LACP state machine process, the status of port is changed to CURRENT only when the status of the port is EXPIRED or DEFAULTED. We should check the status of the port when receive LACPDU to see if it is EXPIRED or DEFAULTED before changing the status to CURRENT.  

**- How to verify it**
* Follow the steps mentioned previously to test. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[libteam] LACP should not work after shutdown port-channel manually

**- A picture of a cute animal (not mandatory but encouraged)**
