### PR TITLE
[dhcp_relay] fix #1247 Per Vlan DHCP relay is broken if DHCP server is connected via Vlan interface

### DIFF
--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -53,6 +53,9 @@ command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /t
 {%- for (name, prefix) in PORTCHANNEL_INTERFACE -%}
 {%- if prefix | ipv4 %} -i {{ name }}{% endif -%}
 {%- endfor -%}
+{%- for (name, prefix) in VLAN_INTERFACE -%}
+{%- if (prefix | ipv4) and (name != vlan_name) %} -i {{ name }}{% endif -%}
+{%- endfor -%}
 {%- for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %} {{ dhcp_server }}{% endfor %}
 
 priority=3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Study #1247. Understand how to Manually modified docker-dhcp-relay.supervisord.conf to include the dhcp server VLAN, and dhcp relay is working properly.
* Study the docker designed for dhcp_relay

**- How I did it**
* Add the following code in docker-dhcp-relay.supervisord.conf.j2

{%- for (name, prefix) in VLAN_INTERFACE -%}
{%- if (prefix | ipv4) and (name != vlan_name) %} -i {{ name }}{% endif -%}
{%- endfor -%}

for search the interface listed in VLAN_INTERFACE. 

**- How to verify it**
* Reproduce the issue and then add the code statement to see if it fixes the issue.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[dhcp_relay] fix #1247 Per Vlan DHCP relay is broken if DHCP server is connected via Vlan interface

**- A picture of a cute animal (not mandatory but encouraged)**
