### PR TITLE
[build] Remove sudo calls from build process

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -48,7 +48,8 @@ SLAVE_IMAGE = sonic-slave-$(USER)
 SLAVE_DIR = sonic-slave
 endif
 
-INSMOD_OVERLAY := sudo modprobe overlay
+OVERLAY_MODULE_CHECK := lsmod | grep "^overlay" > /dev/null 2>&1 || (echo "ERROR: Module 'overlay' not loaded. Try running 'sudo modprobe overlay'."; exit 1)
+
 DOCKER_RUN := docker run --rm=true --privileged \
     -v $(PWD):/sonic \
     -w /sonic \
@@ -94,13 +95,13 @@ SONIC_BUILD_INSTRUCTION :=  make \
 .DEFAULT_GOAL :=  all
 
 %::
+	@$(OVERLAY_MODULE_CHECK)
 	@docker inspect --type image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) &> /dev/null || \
 	    { echo Image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Building... ; \
 	    $(DOCKER_BASE_BUILD) ; }
 	@docker inspect --type image $(SLAVE_IMAGE):$(SLAVE_TAG) &> /dev/null || \
 	    { echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
 	    $(DOCKER_BUILD) ; }
-	@$(INSMOD_OVERLAY)
 ifeq "$(KEEP_SLAVE_ON)" "yes"
     ifdef SOURCE_FOLDER
 		@$(DOCKER_RUN) -v $(SOURCE_FOLDER):/var/$(USER)/src $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_BUILD_INSTRUCTION) $@; /bin/bash"
@@ -116,13 +117,13 @@ sonic-slave-build :
 	$(DOCKER_BUILD)
 
 sonic-slave-bash :
+	@$(OVERLAY_MODULE_CHECK)
 	@docker inspect --type image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) &> /dev/null || \
 	    { echo Image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Building... ; \
 	    $(DOCKER_BASE_BUILD) ; }
 	@docker inspect --type image $(SLAVE_IMAGE):$(SLAVE_TAG) &> /dev/null || \
 	    { echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
 	    $(DOCKER_BUILD) ; }
-	@$(INSMOD_OVERLAY)
 	@$(DOCKER_RUN) -t $(SLAVE_IMAGE):$(SLAVE_TAG) bash
 
 showtag:

--- a/Makefile.work
+++ b/Makefile.work
@@ -48,7 +48,7 @@ SLAVE_IMAGE = sonic-slave-$(USER)
 SLAVE_DIR = sonic-slave
 endif
 
-OVERLAY_MODULE_CHECK := lsmod | grep "^overlay" > /dev/null 2>&1 || (echo "ERROR: Module 'overlay' not loaded. Try running 'sudo modprobe overlay'."; exit 1)
+OVERLAY_MODULE_CHECK := lsmod | grep "^overlay " > /dev/null 2>&1 || (echo "ERROR: Module 'overlay' not loaded. Try running 'sudo modprobe overlay'."; exit 1)
 
 DOCKER_RUN := docker run --rm=true --privileged \
     -v $(PWD):/sonic \

--- a/README.md
+++ b/README.md
@@ -47,21 +47,25 @@ To clone the code repository recursively, assuming git version 1.9 or newer:
 
 To build SONiC installer image and docker images, run the following commands:
 
+    # Ensure the 'overlay' module is loaded on your development system
+    sudo modprobe overlay
+
+    # Enter the source directory
     cd sonic-buildimage
 
     # (Optional) Checkout a specific branch. By default, it uses master branch
     git checkout [branch_name]
 
-    # Execute make init once after cloning the repo, or fetched remote repo with submodule updates
+    # Execute make init once after cloning the repo, or after fetching remote repo with submodule updates
     make init
 
     # Execute make configure once to configure ASIC
     make configure PLATFORM=[ASIC_VENDOR]
 
-    # build debian stretch required targets (optional)
+    # Build Debian Stretch required targets (Manual execution optional; will also be executed as part of the build)
     BLDENV=stretch make stretch
 
-    # build SONiC image
+    # Build SONiC image
     make all
 
  **NOTE**:


### PR DESCRIPTION
**- What I did/How I did it**
 
- Remove `sudo modprobe overlay` calls from Makefile.work. If user had not configured passwordless sudo on their build system, running `make` would result in the build stopping to prompt for sudo password multiple times.

- In lieu of explicitly calling `sudo modprobe overlay`, I have added a check to determine whether the overlay module is loaded and will fail the build if not, printing the message, `ERROR: Module 'overlay' not loaded. Try running 'sudo modprobe overlay'.` I have also added an instruction to README.md to notify the user to manually run `sudo modprobe overlay` when setting up his/her build environment.

**- How to verify it**

- Try building a SONiC image and verify there are no sudo password prompts.