### PR TITLE
[Platforms] Add stubs for new API in SfpUtilBase to platforms which haven't added

### DIFF
--- a/device/accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
@@ -226,3 +226,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
         
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/accton/x86_64-accton_as7116_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/plugins/sfputil.py
@@ -148,3 +148,11 @@ class SfpUtil(SfpUtilBase):
     @property 
     def port_to_eeprom_mapping(self):
          return self._port_to_eeprom_mapping
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/accton/x86_64-accton_as7212_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7212_54x-r0/plugins/sfputil.py
@@ -125,3 +125,11 @@ class sfputil(SfpUtilBase):
     @property 
     def port_to_eeprom_mapping(self):
          return self._port_to_eeprom_mapping
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/accton/x86_64-accton_as7312_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/plugins/sfputil.py
@@ -213,3 +213,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
         
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/accton/x86_64-accton_as7312_54xs-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7312_54xs-r0/plugins/sfputil.py
@@ -213,3 +213,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
         
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/accton/x86_64-accton_as7326_56x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/plugins/sfputil.py
@@ -201,3 +201,11 @@ class SfpUtil(SfpUtilBase):
 
     def reset(self, port_num):
         raise NotImplementedError
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/accton/x86_64-accton_as7512_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7512_32x-r0/plugins/sfputil.py
@@ -70,3 +70,11 @@ class SfpUtil(SfpUtilBase):
     @property
     def port_to_eeprom_mapping(self):
         return self._port_to_eeprom_mapping
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
@@ -125,4 +125,10 @@ class SfpUtil(SfpUtilBase):
     def port_to_eeprom_mapping(self):
          return self._port_to_eeprom_mapping
 
-
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/accton/x86_64-accton_as7716_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7716_32x-r0/plugins/sfputil.py
@@ -132,3 +132,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
         
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/accton/x86_64-accton_as7716_32xb-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7716_32xb-r0/plugins/sfputil.py
@@ -135,4 +135,10 @@ class SfpUtil(SfpUtilBase):
         (status, output) = commands.getstatusoutput (mod_rst_cmd)        
         return True
     
- 
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/accton/x86_64-accton_as7816_64x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/plugins/sfputil.py
@@ -152,4 +152,10 @@ class SfpUtil(SfpUtilBase):
     def port_to_eeprom_mapping(self):
          return self._port_to_eeprom_mapping
 
-
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/centec/x86_64-centec_e582_48x6q-r0/plugins/sfputil.py
+++ b/device/centec/x86_64-centec_e582_48x6q-r0/plugins/sfputil.py
@@ -158,3 +158,11 @@ class SfpUtil(SfpUtilBase):
 
         return False
 
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError
+

--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
@@ -173,3 +173,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/dell/x86_64-dell_s6100_c2538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/plugins/sfputil.py
@@ -431,3 +431,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/sfputil.py
@@ -190,3 +190,11 @@ class SfpUtil(SfpUtilBase):
 	status = self.pci_set_value(self.BASE_RES_PATH, reg_value, port_offset)
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/delta/x86_64-delta_ag5648-r0/plugins/sfputil.py
+++ b/device/delta/x86_64-delta_ag5648-r0/plugins/sfputil.py
@@ -201,3 +201,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/delta/x86_64-delta_ag9032v1-r0/plugins/sfputil.py
+++ b/device/delta/x86_64-delta_ag9032v1-r0/plugins/sfputil.py
@@ -173,3 +173,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/delta/x86_64-delta_ag9064-r0/plugins/sfputil.py
+++ b/device/delta/x86_64-delta_ag9064-r0/plugins/sfputil.py
@@ -173,3 +173,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/delta/x86_64-delta_et-6248brb-r0/plugins/sfputil.py
+++ b/device/delta/x86_64-delta_et-6248brb-r0/plugins/sfputil.py
@@ -86,3 +86,11 @@ class SfpUtil(SfpUtilBase):
             return False
 
         return False
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/ingrasys/x86_64-ingrasys_s8810_32q-r0/plugins/sfputil.py
+++ b/device/ingrasys/x86_64-ingrasys_s8810_32q-r0/plugins/sfputil.py
@@ -145,3 +145,11 @@ class SfpUtil(SfpUtilBase):
         val_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/ingrasys/x86_64-ingrasys_s8900_54xc-r0/plugins/sfputil.py
+++ b/device/ingrasys/x86_64-ingrasys_s8900_54xc-r0/plugins/sfputil.py
@@ -277,3 +277,11 @@ class SfpUtil(SfpUtilBase):
         val_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/ingrasys/x86_64-ingrasys_s8900_64xc-r0/plugins/sfputil.py
+++ b/device/ingrasys/x86_64-ingrasys_s8900_64xc-r0/plugins/sfputil.py
@@ -254,3 +254,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/ingrasys/x86_64-ingrasys_s9100-r0/plugins/sfputil.py
+++ b/device/ingrasys/x86_64-ingrasys_s9100-r0/plugins/sfputil.py
@@ -280,3 +280,11 @@ class SfpUtil(SfpUtilBase):
         val_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/ingrasys/x86_64-ingrasys_s9130_32x-r0/plugins/sfputil.py
+++ b/device/ingrasys/x86_64-ingrasys_s9130_32x-r0/plugins/sfputil.py
@@ -185,3 +185,11 @@ class SfpUtil(SfpUtilBase):
         gpio_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/ingrasys/x86_64-ingrasys_s9180_32x-r0/plugins/sfputil.py
+++ b/device/ingrasys/x86_64-ingrasys_s9180_32x-r0/plugins/sfputil.py
@@ -288,3 +288,11 @@ class SfpUtil(SfpUtilBase):
         val_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/ingrasys/x86_64-ingrasys_s9200_64x-r0/plugins/sfputil.py
+++ b/device/ingrasys/x86_64-ingrasys_s9200_64x-r0/plugins/sfputil.py
@@ -258,3 +258,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/ingrasys/x86_64-ingrasys_s9230_64x-r0/plugins/sfputil.py
+++ b/device/ingrasys/x86_64-ingrasys_s9230_64x-r0/plugins/sfputil.py
@@ -291,3 +291,11 @@ class SfpUtil(SfpUtilBase):
 
         return True
 
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError
+

--- a/device/ingrasys/x86_64-ingrasys_s9280_64x-r0/plugins/sfputil.py
+++ b/device/ingrasys/x86_64-ingrasys_s9280_64x-r0/plugins/sfputil.py
@@ -298,3 +298,11 @@ class SfpUtil(SfpUtilBase):
 
         return True
 
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError
+

--- a/device/inventec/x86_64-inventec_d7032q28b-r0/plugins/sfputil.py
+++ b/device/inventec/x86_64-inventec_d7032q28b-r0/plugins/sfputil.py
@@ -177,3 +177,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/inventec/x86_64-inventec_d7054q28b-r0/plugins/sfputil.py
+++ b/device/inventec/x86_64-inventec_d7054q28b-r0/plugins/sfputil.py
@@ -207,3 +207,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/inventec/x86_64-inventec_d7264q28b-r0/plugins/sfputil.py
+++ b/device/inventec/x86_64-inventec_d7264q28b-r0/plugins/sfputil.py
@@ -217,3 +217,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/marvell/x86_64-marvell_slm5401_54x-r0/plugins/sfputil.py
+++ b/device/marvell/x86_64-marvell_slm5401_54x-r0/plugins/sfputil.py
@@ -125,3 +125,11 @@ class sfputil(SfpUtilBase):
     @property 
     def port_to_eeprom_mapping(self):
          return self._port_to_eeprom_mapping
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/mitac/x86_64-mitac_ly1200_b32h0_c3-r0/plugins/sfputil.py
+++ b/device/mitac/x86_64-mitac_ly1200_b32h0_c3-r0/plugins/sfputil.py
@@ -180,3 +180,11 @@ class SfpUtil(SfpUtilBase):
         reg_file.close()
 
         return True
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError

--- a/device/quanta/x86_64-quanta_ix1b_32x-r0/plugins/sfputil.py
+++ b/device/quanta/x86_64-quanta_ix1b_32x-r0/plugins/sfputil.py
@@ -168,4 +168,12 @@ class SfpUtil(SfpUtilBase):
     def port_to_eeprom_mapping(self):
          return self._port_to_eeprom_mapping
 
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError
+
 

--- a/device/wnc/x86_64-wnc_osw1800-r0/plugins/sfputil.py
+++ b/device/wnc/x86_64-wnc_osw1800-r0/plugins/sfputil.py
@@ -203,3 +203,11 @@ class SfpUtil(SfpUtilBase):
                 sfp_data['dom'] = sfpd_obj.get_data_pretty()
 
         return sfp_data
+
+    def get_transceiver_change_event(self):
+        """
+        TODO: This function need to be implemented
+        when decide to support monitoring SFP(Xcvrd)
+        on this platform.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
to fix  issue https://github.com/Azure/sonic-buildimage/issues/2017
New API get_transceiver_change_event() introduced to SfpUtilBase, need add stubs to the sfputil plugin of the platforms which haven't implement this methond yet.

**- How I did it**
add a definiton of  get_transceiver_change_event() to the sfputil plugin, in the function it will raise NotImplementedError.

**- How to verify it**

need each platform to run command to check sfp presence.

**- Description for the changelog**

Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        modified:   accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
        modified:   accton/x86_64-accton_as7116_54x-r0/plugins/sfputil.py
        modified:   accton/x86_64-accton_as7212_54x-r0/plugins/sfputil.py
        modified:   accton/x86_64-accton_as7312_54x-r0/plugins/sfputil.py
        modified:   accton/x86_64-accton_as7312_54xs-r0/plugins/sfputil.py
        modified:   accton/x86_64-accton_as7326_56x-r0/plugins/sfputil.py
        modified:   accton/x86_64-accton_as7512_32x-r0/plugins/sfputil.py
        modified:   accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
        modified:   accton/x86_64-accton_as7716_32x-r0/plugins/sfputil.py
        modified:   accton/x86_64-accton_as7716_32xb-r0/plugins/sfputil.py
        modified:   accton/x86_64-accton_as7816_64x-r0/plugins/sfputil.py
        modified:   centec/x86_64-centec_e582_48x6q-r0/plugins/sfputil.py
        modified:   dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
        modified:   dell/x86_64-dell_s6100_c2538-r0/plugins/sfputil.py
        modified:   dell/x86_64-dellemc_z9264f_c3538-r0/plugins/sfputil.py
        modified:   delta/x86_64-delta_ag5648-r0/plugins/sfputil.py
        modified:   delta/x86_64-delta_ag9032v1-r0/plugins/sfputil.py
        modified:   delta/x86_64-delta_ag9064-r0/plugins/sfputil.py
        modified:   delta/x86_64-delta_et-6248brb-r0/plugins/sfputil.py
        modified:   ingrasys/x86_64-ingrasys_s8810_32q-r0/plugins/sfputil.py
        modified:   ingrasys/x86_64-ingrasys_s8900_54xc-r0/plugins/sfputil.py
        modified:   ingrasys/x86_64-ingrasys_s8900_64xc-r0/plugins/sfputil.py
        modified:   ingrasys/x86_64-ingrasys_s9100-r0/plugins/sfputil.py
        modified:   ingrasys/x86_64-ingrasys_s9130_32x-r0/plugins/sfputil.py
        modified:   ingrasys/x86_64-ingrasys_s9180_32x-r0/plugins/sfputil.py
        modified:   ingrasys/x86_64-ingrasys_s9200_64x-r0/plugins/sfputil.py
        modified:   ingrasys/x86_64-ingrasys_s9230_64x-r0/plugins/sfputil.py
        modified:   ingrasys/x86_64-ingrasys_s9280_64x-r0/plugins/sfputil.py
        modified:   inventec/x86_64-inventec_d7032q28b-r0/plugins/sfputil.py
        modified:   inventec/x86_64-inventec_d7054q28b-r0/plugins/sfputil.py
        modified:   inventec/x86_64-inventec_d7264q28b-r0/plugins/sfputil.py
        modified:   marvell/x86_64-marvell_slm5401_54x-r0/plugins/sfputil.py
        modified:   mitac/x86_64-mitac_ly1200_b32h0_c3-r0/plugins/sfputil.py
        modified:   quanta/x86_64-quanta_ix1b_32x-r0/plugins/sfputil.py
        modified:   wnc/x86_64-wnc_osw1800-r0/plugins/sfputil.py
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
