### PR TITLE
Separate syncd service from swss service

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -293,8 +293,9 @@ sudo LANG=C chroot $FILESYSTEM_ROOT fuser -km /sys || true
 sudo LANG=C chroot $FILESYSTEM_ROOT umount -lf /sys
 {% endif %}
 
-# Copy swss service script
+# Copy swss and syncd service script
 sudo LANG=C cp $SCRIPTS_DIR/swss.sh $FILESYSTEM_ROOT/usr/local/bin/swss.sh
+sudo LANG=C cp $SCRIPTS_DIR/syncd.sh $FILESYSTEM_ROOT/usr/local/bin/syncd.sh
 
 # Copy systemd timer configuration
 # It implements delayed start of services

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -8,11 +8,6 @@ Requires=nps-modules-4.9.0-7-amd64.service
 {% endif %}
 After=database.service updategraph.service
 After=interfaces-config.service
-{% if sonic_asic_platform == 'broadcom' %}
-After=opennsl-modules-4.9.0-7-amd64.service
-{% elif sonic_asic_platform == 'nephos' %}
-After=nps-modules-4.9.0-7-amd64.service
-{% endif %}
 
 [Service]
 User=root

--- a/files/build_templates/syncd.service.j2
+++ b/files/build_templates/syncd.service.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=syncd service
+Requires=database.service updategraph.service
+{% if sonic_asic_platform == 'broadcom' %}
+Requires=opennsl-modules-4.9.0-7-amd64.service
+{% elif sonic_asic_platform == 'nephos' %}
+Requires=nps-modules-4.9.0-7-amd64.service
+{% endif %}
+After=database.service updategraph.service
+After=interfaces-config.service
+{% if sonic_asic_platform == 'broadcom' %}
+After=opennsl-modules-4.9.0-7-amd64.service
+{% elif sonic_asic_platform == 'nephos' %}
+After=nps-modules-4.9.0-7-amd64.service
+{% endif %}
+
+[Service]
+User=root
+Environment=sonic_asic_platform={{ sonic_asic_platform }}
+ExecStart=/usr/local/bin/syncd.sh start
+ExecStop=/usr/local/bin/syncd.sh stop
+
+[Install]
+WantedBy=multi-user.target

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 SERVICE="swss"
+DEBUGLOG="/tmp/swss-syncd-debug.log"
+
+function debug()
+{
+    /bin/echo `date` "- $1" >> ${DEBUGLOG}
+}
 
 function check_warm_boot()
 {
@@ -38,9 +44,13 @@ function wait_for_database_service()
 }
 
 start() {
+    debug "Starting ${SERVICE} service..."
+
     wait_for_database_service
     check_warm_boot
     validate_restart_count
+
+    debug "Warm boot flag: ${WARM_START}."
 
     # Don't flush DB during warm boot
     if [[ x"$WARM_START" != x"true" ]]; then
@@ -65,6 +75,8 @@ start() {
 
     # start swss and syncd docker
     /usr/bin/swss.sh start
+    debug "Started ${SERVICE} service..."
+
     if [[ x"$WARM_START" != x"true" ]]; then
         /usr/bin/syncd.sh start
     fi
@@ -72,9 +84,13 @@ start() {
 }
 
 stop() {
+    debug "Stopping ${SERVICE} service..."
+
     check_warm_boot
+    debug "Warm boot flag: ${WARM_START}."
 
     /usr/bin/swss.sh stop
+    debug "Stopped ${SERVICE} service..."
 
     # if warm start enabled, just stop swss docker, then return
     if [[ x"$WARM_START" != x"true" ]]; then

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -18,12 +18,12 @@ function lock_service_state_change()
     /usr/bin/flock -x ${LOCKFD}
     trap "/usr/bin/flock -u ${LOCKFD}" 0 2 3 15
 
-    debug "Locked ${LOCKFILE} ($LOCKFD}) from ${SERVICE} service"
+    debug "Locked ${LOCKFILE} (${LOCKFD}) from ${SERVICE} service"
 }
 
 function unlock_service_state_change()
 {
-    debug "Unlocking ${LOCKFILE} ($LOCKFD}) from ${SERVICE} service"
+    debug "Unlocking ${LOCKFILE} (${LOCKFD}) from ${SERVICE} service"
     /usr/bin/flock -u ${LOCKFD}
 }
 

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -1,6 +1,31 @@
 #!/bin/bash
 
-start() {
+SERVICE="swss"
+
+function check_warm_boot()
+{
+    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|system" enable`
+    SERVICE_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|${SERVICE}" enable`
+    if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
+        WARM_START="true"
+    else
+        WARM_START="false"
+    fi
+}
+
+function validate_restart_count()
+{
+    if [[ x"$WARM_START" == x"true" ]]; then
+        RESTART_COUNT=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restart_count`
+        # We have to make sure db data has not been flushed.
+        if [[ -z "$RESTART_COUNT" ]]; then
+            WARM_START="false"
+        fi
+    fi
+}
+
+function wait_for_database_service()
+{
     # Wait for redis server start before database clean
     until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]];
         do sleep 1;
@@ -10,66 +35,60 @@ start() {
     until [[ $(/usr/bin/docker exec database redis-cli -n 4 GET "CONFIG_DB_INITIALIZED") ]];
         do sleep 1;
     done
+}
 
-    SYSTEM_WARM_START=`/usr/bin/docker exec database redis-cli -n 4 HGET "WARM_RESTART|system" enable`
-    SWSS_WARM_START=`/usr/bin/docker exec database redis-cli -n 4 HGET "WARM_RESTART|swss" enable`
-    # if warm start enabled, just do swss docker start.
-    # Don't flush DB or try to start other modules.
-    if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; then
-      RESTART_COUNT=`redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restart_count`
-      # We have to make sure db data has not been flushed.
-      if [[ -n "$RESTART_COUNT" ]]; then
-        /usr/bin/swss.sh start
-        /usr/bin/swss.sh attach
-        return 0
-      fi
-    fi
+start() {
+    wait_for_database_service
+    check_warm_boot
+    validate_restart_count
 
-    # Flush DB
-    /usr/bin/docker exec database redis-cli -n 0 FLUSHDB
-    /usr/bin/docker exec database redis-cli -n 1 FLUSHDB
-    /usr/bin/docker exec database redis-cli -n 2 FLUSHDB
-    /usr/bin/docker exec database redis-cli -n 5 FLUSHDB
-    /usr/bin/docker exec database redis-cli -n 6 FLUSHDB
+    # Don't flush DB during warm boot
+    if [[ x"$WARM_START" != x"true" ]]; then
+        /usr/bin/docker exec database redis-cli -n 0 FLUSHDB
+        /usr/bin/docker exec database redis-cli -n 1 FLUSHDB
+        /usr/bin/docker exec database redis-cli -n 2 FLUSHDB
+        /usr/bin/docker exec database redis-cli -n 5 FLUSHDB
+        /usr/bin/docker exec database redis-cli -n 6 FLUSHDB
 
-    # platform specific tasks
-    if [ x$sonic_asic_platform == x'mellanox' ]; then
-        FAST_BOOT=1
-        /usr/bin/mst start
-        /usr/bin/mlnx-fw-upgrade.sh
-        /etc/init.d/sxdkernel start
-        /sbin/modprobe i2c-dev
-        /etc/mlnx/mlnx-hw-management start
-    elif [ x$sonic_asic_platform == x'cavium' ]; then
-        /etc/init.d/xpnet.sh start
+        # platform specific tasks
+        if [ x$sonic_asic_platform == x'mellanox' ]; then
+            FAST_BOOT=1
+            /usr/bin/mst start
+            /usr/bin/mlnx-fw-upgrade.sh
+            /etc/init.d/sxdkernel start
+            /sbin/modprobe i2c-dev
+            /etc/mlnx/mlnx-hw-management start
+        elif [ x$sonic_asic_platform == x'cavium' ]; then
+            /etc/init.d/xpnet.sh start
+        fi
     fi
 
     # start swss and syncd docker
     /usr/bin/swss.sh start
-    /usr/bin/syncd.sh start
+    if [[ x"$WARM_START" != x"true" ]]; then
+        /usr/bin/syncd.sh start
+    fi
     /usr/bin/swss.sh attach
 }
 
 stop() {
+    check_warm_boot
+
     /usr/bin/swss.sh stop
 
-    SYSTEM_WARM_START=`redis-cli -n 4 hget "WARM_RESTART|system" enable`
-    SWSS_WARM_START=`redis-cli -n 4 hget "WARM_RESTART|swss" enable`
     # if warm start enabled, just stop swss docker, then return
-    if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; then
-        return 0
-    fi
+    if [[ x"$WARM_START" != x"true" ]]; then
+        /usr/bin/syncd.sh stop
 
-    /usr/bin/syncd.sh stop
-
-    # platform specific tasks
-    if [ x$sonic_asic_platform == x'mellanox' ]; then
-        /etc/mlnx/mlnx-hw-management stop
-        /etc/init.d/sxdkernel stop
-        /usr/bin/mst stop
-    elif [ x$sonic_asic_platform == x'cavium' ]; then
-        /etc/init.d/xpnet.sh stop
-        /etc/init.d/xpnet.sh start
+        # platform specific tasks
+        if [ x$sonic_asic_platform == x'mellanox' ]; then
+            /etc/mlnx/mlnx-hw-management stop
+            /etc/init.d/sxdkernel stop
+            /usr/bin/mst stop
+        elif [ x$sonic_asic_platform == x'cavium' ]; then
+            /etc/init.d/xpnet.sh stop
+            /etc/init.d/xpnet.sh start
+        fi
     fi
 }
 

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -27,23 +27,7 @@ function unlock_service_state_change()
 function check_warm_boot()
 {
     SYSTEM_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|system" enable`
-    SERVICE_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|${SERVICE}" enable`
-    if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
-        WARM_BOOT="true"
-    else
-        WARM_BOOT="false"
-    fi
-}
-
-function validate_restart_count()
-{
-    if [[ x"$WARM_BOOT" == x"true" ]]; then
-        RESTART_COUNT=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restart_count`
-        # We have to make sure db data has not been flushed.
-        if [[ -z "$RESTART_COUNT" ]]; then
-            WARM_BOOT="false"
-        fi
-    fi
+    WARM_BOOT=${SYSTEM_WARM_START}
 }
 
 function wait_for_database_service()
@@ -66,7 +50,6 @@ start() {
 
     wait_for_database_service
     check_warm_boot
-    validate_restart_count
 
     debug "Warm boot flag: ${SERVICE} ${WARM_BOOT}."
 

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -18,12 +18,12 @@ function lock_service_state_change()
     /usr/bin/flock -x ${LOCKFD}
     trap "/usr/bin/flock -u ${LOCKFD}" 0 2 3 15
 
-    debug "Locked ${LOCKFILE} ($LOCKFD}) from ${SERVICE} service"
+    debug "Locked ${LOCKFILE} (${LOCKFD}) from ${SERVICE} service"
 }
 
 function unlock_service_state_change()
 {
-    debug "Unlocking ${LOCKFILE} ($LOCKFD}) from ${SERVICE} service"
+    debug "Unlocking ${LOCKFILE} (${LOCKFD}) from ${SERVICE} service"
     /usr/bin/flock -u ${LOCKFD}
 }
 


### PR DESCRIPTION
**- What I did**
1.  Separate syncd service from swss service to become an independent service.
2. Add code to make sure syncd and swss starts/stops/restarts synchronously.
3. syncd and swss starts/stops/restarts independently if warm boot is requested.

**- How to verify it**
- There is not enough warm boot support to validate warm boot behavior yet.
- DUT boots up and syncd/swss both initialized properly.
- Stop/start/restart syncd, validated swss follows the state changes.
- Stop/start/restart swss, validated syncd follows the state changes.
- config load_minigraph works as expected.