### PR TITLE
 depmod fixes for Dell-S6100/Z9100 platform

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -6,4 +6,4 @@ common/fstrim.timer etc/systemd/system
 common/fstrim.service etc/systemd/system
 s6100/scripts/platform_sensors.py usr/local/bin
 s6100/scripts/sensors usr/bin
-s6100/systemd/platform-modules-s6100.service etc/systemd/system/multi-user.target.wants
+s6100/systemd/platform-modules-s6100.service etc/systemd/system

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.postinst
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.postinst
@@ -4,4 +4,8 @@
 systemctl enable fstrim.timer
 systemctl start fstrim.timer
 
+# Enable Dell-S6100-platform-service
+depmod -a 
+systemctl enable platform-modules-s6100.service
+systemctl start platform-modules-s6100.service
 #DEBHELPER#

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9100.install
@@ -6,4 +6,4 @@ common/fstrim.service etc/systemd/system
 z9100/scripts/platform_sensors.py usr/local/bin
 z9100/scripts/sensors usr/bin
 z9100/cfg/z9100-modules.conf etc/modules-load.d
-z9100/systemd/platform-modules-z9100.service etc/systemd/system/multi-user.target.wants
+z9100/systemd/platform-modules-z9100.service etc/systemd/system

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9100.postinst
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9100.postinst
@@ -4,4 +4,10 @@
 systemctl enable fstrim.timer
 systemctl start fstrim.timer
 
+# Enable Dell-Z9100-platform-service
+depmod -a 
+systemctl enable platform-modules-z9100.service
+systemctl start platform-modules-z9100.service
+
+
 #DEBHELPER#


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fresh installation of SONiC in S6100/Z9100 fails to load Dell kernel modules. This happens only at first time installation. While installing platform-modules-[s6100/Z9100]_1.1_amd64.deb package at boot-up  *.postinst file, part of *.deb package is exported with misplaced order of depmod and this interrupts the service startup and box ended up with no Dell modules loaded.

_dh_installmodules_ by default integrate depmod check for debian packages. But, it add the depmod entry after starting the service. Since, depmod is inited after the platform service kernel modules fails to load in the switch.
```
# postinst script for S6100

# Enable fstrim
systemctl enable fstrim.timer
systemctl start fstrim.timer

# Enable Dell-S6100-
depmod -
systemctl enable platform-modules-s6100.service
systemctl start platform-modules-s6100.service

# Automatically added by dh_installmodules
if [ "$1" = "configure" ]; then
        if [ -e /boot/System.map-4.9.0-7-amd64 ]; then
                depmod -a -F /boot/System.map-4.9.0-7-amd64 4.9.0-7-amd64 || true
```

- Additionally changed *.service file startup locations. So, symlinks will be in proper order.

**- How I did it**
Fixed by adding "depmod -a" in platform specific postinst files. Will investigate more and try to order this by default.

**- How to verify it**
lsmod | grep dell

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
