### PR TITLE
[syncd] warn shutdown syncd process when warm boot is enabled

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -56,6 +56,8 @@ start() {
 
     lock_service_state_change
 
+    mkdir -p /host/warmboot
+
     wait_for_database_service
     check_warm_boot
 

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -93,6 +93,19 @@ stop() {
     check_warm_boot
     debug "Warm boot flag: ${SERVICE} ${WARM_BOOT}."
 
+    if [[ x"$WARM_BOOT" == x"true" ]]; then
+        debug "Warm shutdown syncd process ..."
+        /usr/bin/docker exec -i syncd /usr/bin/syncd_request_shutdown --warm
+
+        # wait until syncd quits gracefully
+        while docker top syncd | grep -q /usr/bin/syncd; do
+            sleep 0.1
+        done
+
+        /usr/bin/docker exec -i syncd /bin/sync
+        debug "Finihsed warm shutdown syncd process ..."
+    fi
+
     /usr/bin/${SERVICE}.sh stop
     debug "Stopped ${SERVICE} service..."
 

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -105,7 +105,7 @@ stop() {
         done
 
         /usr/bin/docker exec -i syncd /bin/sync
-        debug "Finihsed warm shutdown syncd process ..."
+        debug "Finished warm shutdown syncd process ..."
     fi
 
     /usr/bin/${SERVICE}.sh stop

--- a/platform/broadcom/docker-syncd-brcm.mk
+++ b/platform/broadcom/docker-syncd-brcm.mk
@@ -15,6 +15,7 @@ $(DOCKER_SYNCD_BRCM)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_SYNCD_BRCM)_RUN_OPT += -v /host/warmboot:/var/warmboot
 
 $(DOCKER_SYNCD_BRCM)_BASE_IMAGE_FILES += bcmcmd:/usr/bin/bcmcmd
 $(DOCKER_SYNCD_BRCM)_BASE_IMAGE_FILES += bcmsh:/usr/bin/bcmsh


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
When syncd service is stopping during warm reboot. Give syncd enough time to gracefully shutdown and save states.

**- How to verify it**
Set global warm shutdown flag, shutdown syncd service, make sure that the SAI state has been saved to specified file.

(However, full verification will have to wait until warm recover is in place).

Also what missing from this PR is definition of follow sample entries in sai.profile:
  SAI_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin
  SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/sai-warmboot.bin
