### PR TITLE
Adapt to the new WARM_RESTART_TABLE table schema: change from restart…

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -47,8 +47,8 @@ SYSTEM_WARM_START=`redis-cli -n 4 hget "WARM_RESTART|system" enable`
 SWSS_WARM_START=`redis-cli -n 4 hget "WARM_RESTART|swss" enable`
 if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; then
   # We have to make sure db data has not been flushed.
-  RESTART_COUNT=`redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restore_count`
-  if [[ -n "$RESTART_COUNT" ]] && [[ "$RESTART_COUNT" != "0" ]]; then
+  RESTORE_COUNT=`redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restore_count`
+  if [[ -n "$RESTORE_COUNT" ]] && [[ "$RESTORE_COUNT" != "0" ]]; then
     exit 0
   fi
 fi

--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -47,7 +47,7 @@ SYSTEM_WARM_START=`redis-cli -n 4 hget "WARM_RESTART|system" enable`
 SWSS_WARM_START=`redis-cli -n 4 hget "WARM_RESTART|swss" enable`
 if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; then
   # We have to make sure db data has not been flushed.
-  RESTART_COUNT=`redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restart_count`
+  RESTART_COUNT=`redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restore_count`
   if [[ -n "$RESTART_COUNT" ]] && [[ "$RESTART_COUNT" != "0" ]]; then
     exit 0
   fi

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -38,12 +38,12 @@ function check_warm_boot()
     fi
 }
 
-function validate_restart_count()
+function validate_restore_count()
 {
     if [[ x"$WARM_BOOT" == x"true" ]]; then
-        RESTART_COUNT=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restore_count`
+        RESTORE_COUNT=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restore_count`
         # We have to make sure db data has not been flushed.
-        if [[ -z "$RESTART_COUNT" ]]; then
+        if [[ -z "$RESTORE_COUNT" ]]; then
             WARM_BOOT="false"
         fi
     fi
@@ -69,7 +69,7 @@ start() {
 
     wait_for_database_service
     check_warm_boot
-    validate_restart_count
+    validate_restore_count
 
     debug "Warm boot flag: ${SERVICE} ${WARM_BOOT}."
 

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -41,7 +41,7 @@ function check_warm_boot()
 function validate_restart_count()
 {
     if [[ x"$WARM_BOOT" == x"true" ]]; then
-        RESTART_COUNT=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restart_count`
+        RESTART_COUNT=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restore_count`
         # We have to make sure db data has not been flushed.
         if [[ -z "$RESTART_COUNT" ]]; then
             WARM_BOOT="false"


### PR DESCRIPTION
…_count to restore_count

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


**- What I did**
With changes introduced in Azure/sonic-swss#600
WARM_RESTART_TABLE:restart_count got changed to WARM_RESTART_TABLE:restore_count

The swss related check for WARM_RESTART_TABLE:restart_count should be updated.

**- How I did it**

**- How to verify it**

docker upgrade and systemctl restart.

*Don't merge the change until swss submodule updated*