### PR TITLE
[sonic-device-data] Fix config symlinks dereference

### DIFF
--- a/src/sonic-device-data/Makefile
+++ b/src/sonic-device-data/Makefile
@@ -12,7 +12,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Create a new dir and copy all ONIE-platform-string-named dirs into it
 	mkdir ./device
-	cp -r -H ../../../device/*/* ./device/
+	cp -r -L ../../../device/*/* ./device/
 
 	# Build the package
 	dpkg-buildpackage -rfakeroot -b -us -uc


### PR DESCRIPTION
('cp -H' -> 'cp -L')
'-L' does what we need in this case

From man cp
...
-H     follow command-line symbolic links in SOURCE
...
-L, --dereference
              always follow symbolic links in SOURCE

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
