### PR TITLE
[minigraph parser] add basic support for MGMT_PORT

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -474,9 +474,16 @@ def parse_xml(filename, platform=None, port_config_file=None):
         mgmt_intf.itervalues().next()['forced_mgmt_routes'] = mgmt_routes
     results['MGMT_PORT'] = {}
     results['MGMT_INTERFACE'] = {}
+    mgmt_intf_count = 0
+    mgmt_alias_reverse_mapping = {}
     for key in mgmt_intf:
         alias = key[0]
-        name = 'eth' + alias[-1]
+        if mgmt_alias_reverse_mapping.has_key(alias):
+            name = mgmt_alias_reverse_mapping[alias]
+        else:
+            name = 'eth' + str(mgmt_intf_count)
+            mgmt_intf_count += 1
+            mgmt_alias_reverse_mapping[alias] = name
         results['MGMT_PORT'][name] = {'alias': alias, 'admin_status': 'up'}
         results['MGMT_INTERFACE'][(name, key[1])] = mgmt_intf[key]
     results['LOOPBACK_INTERFACE'] = lo_intfs

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -472,7 +472,13 @@ def parse_xml(filename, platform=None, port_config_file=None):
     if mgmt_routes:
         # TODO: differentiate v4 and v6
         mgmt_intf.itervalues().next()['forced_mgmt_routes'] = mgmt_routes
-    results['MGMT_INTERFACE'] = mgmt_intf
+    results['MGMT_PORT'] = {}
+    results['MGMT_INTERFACE'] = {}
+    for key in mgmt_intf:
+        alias = key[0]
+        name = 'eth' + alias[-1]
+        results['MGMT_PORT'][name] = {'alias': alias, 'admin_status': 'up'}
+        results['MGMT_INTERFACE'][(name, key[1])] = mgmt_intf[key]
     results['LOOPBACK_INTERFACE'] = lo_intfs
 
     phyport_intfs = {}

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -92,6 +92,11 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '2.2.2.2'}}")
 
+    def test_minigraph_mgmt_ports(self):
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v MGMT_PORT'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), "{'eth0': {'alias': 'Management0', 'admin_status': 'up'}}")
+
     def test_minigraph_interfaces(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "INTERFACE.keys()"'
         output = self.run_script(argument)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Create parsing minigraph for MGMT_PORT table according to design in
 https://github.com/Azure/SONiC/wiki/SONiC-SMMP-Design-on-Management-Ports

Currently support `alias` and `admin_status` field.

**- How to verify it**
```
localadmin@taoyl-vm0:~$ ./sonic-cfggen -m tests/sample_graph.xml -v MGMT_PORT
{'eth0': {'alias': 'Management0', 'admin_status': 'up' }} 
```
