### PR TITLE
[arista] Align flash partition at 1M

### DIFF
--- a/files/initramfs-tools/arista-convertfs.j2
+++ b/files/initramfs-tools/arista-convertfs.j2
@@ -175,7 +175,7 @@ umount "$root_mnt"
 if [ $(echo -n "$root_dev" | tail -c 1) == "1" ]; then
     # Create a new partition table (content in flash_dev will be deleted)
     err_msg="Error: repartitioning $flash_dev failed"
-    cmd="echo ';' | sfdisk $flash_dev || (sleep 3; blockdev --rereadpt $flash_dev && fdisk -l $flash_dev | grep -q ${root_dev}.*Linux)"
+    cmd="echo '2048' | sfdisk $flash_dev || (sleep 3; blockdev --rereadpt $flash_dev && fdisk -l $flash_dev | grep -q ${root_dev}.*Linux)"
     run_cmd "$cmd" "$err_msg"
 fi
 


### PR DESCRIPTION
Flashes used for the 7050QX-32 and 7050QX-32S have a fw issue.
The best option to solve the problem is to upgrade to a newer firmware.
However this can only be done while in memory and takes 10 seconds.
Adding an upgrade mechanism is possible but would need more
consideration as flashing the firmware and reformatting the flash will
exceed fast-reboot requirements.

A quick mitigation is to align the ext4 partition that we create on
these vfat based system on a 4k boundary.
Here we chose 1M instead but it's the same.
Newer version of sfdisk do this automatically but the one in debian
today doesn't have this behavior.

This workaround will only reduce the pace of the flash health
degradation. The only long term fix is to upgrade the firmware.