### PR TITLE
dhcp-relay: dhcrelay daemon is permantly blocked and not starting

### DIFF
--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -30,9 +30,12 @@ function wait_until_iface_ready
 }
 
 
-# Wait for all interfaces to come up and have IPv4 addresses assigned
+# Wait for all interfaces to come up and have IPv4 addresses assigned. Skip
+# waiting on interfaces that are not configured with an IPv4 address.
 {% for (name, prefix) in INTERFACE %}
+{% if prefix != '0.0.0.0/0' %}
 wait_until_iface_ready {{ name }}
+{% endif %}
 {% endfor %}
 {% for (name, prefix) in VLAN_INTERFACE %}
 wait_until_iface_ready {{ name }}

--- a/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
@@ -31,13 +31,4 @@ function wait_until_iface_ready
 
 
 # Wait for all interfaces to come up and have IPv4 addresses assigned
-wait_until_iface_ready Vlan1000
-wait_until_iface_ready PortChannel01
-wait_until_iface_ready PortChannel01
-wait_until_iface_ready PortChannel02
-wait_until_iface_ready PortChannel02
-wait_until_iface_ready PortChannel03
-wait_until_iface_ready PortChannel03
-wait_until_iface_ready PortChannel04
-wait_until_iface_ready PortChannel04
 


### PR DESCRIPTION
Fixes #2092 

Problem:
An admin status up interface in config_db.json without an IP address will cause dhcrelay daemon to block permanently and not start.

Fix and verification:
Reproduced and verified manually by running sonic-cfggen -d -t /usr/share/sonic/templates/wait_for_intf.sh.j2 > /usr/bin/wait_for_intf.sh and then running /usr/bin/wait_for_intf.sh.

Regards,

Nikos.-

**- A picture of a cute animal (not mandatory but encouraged)**
┈┈╭━╱▔▔▔▔╲━╮┈┈┈
┈┈╰╱╭▅╮╭▅╮╲╯┈┈┈
╳┈┈▏╰┈▅▅┈╯▕┈┈┈┈
┈┈┈╲┈╰━━╯┈╱┈┈╳┈
┈┈┈╱╱▔╲╱▔╲╲┈┈┈┈
┈╭━╮▔▏┊┊▕▔╭━╮┈╳
┈┃┊┣▔╲┊┊╱▔┫┊┃┈┈
┈╰━━━━╲╱━━━━╯┈╳
