### PR TITLE
Save build timestamp to local tmp file at the start of build

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -59,6 +59,8 @@ SLAVE_DIR = sonic-slave
 endif
 
 OVERLAY_MODULE_CHECK := lsmod | grep "^overlay " > /dev/null 2>&1 || (echo "ERROR: Module 'overlay' not loaded. Try running 'sudo modprobe overlay'."; exit 1)
+SONIC_SET_BUILD_TIMESTAMP = . functions.sh && sonic_set_build_timestamp
+SONIC_CLEAR_BUILD_TIMESTAMP = . functions.sh && sonic_clear_build_timestamp
 
 DOCKER_RUN := docker run --rm=true --privileged \
     -v $(PWD):/sonic \
@@ -114,12 +116,12 @@ SONIC_BUILD_INSTRUCTION :=  make \
 	    $(DOCKER_BUILD) ; }
 ifeq "$(KEEP_SLAVE_ON)" "yes"
     ifdef SOURCE_FOLDER
-		@$(DOCKER_RUN) -v $(SOURCE_FOLDER):/var/$(USER)/src $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_BUILD_INSTRUCTION) $@; /bin/bash"
+		@$(DOCKER_RUN) -v $(SOURCE_FOLDER):/var/$(USER)/src $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_SET_BUILD_TIMESTAMP); $(SONIC_BUILD_INSTRUCTION) $@; $(SONIC_CLEAR_BUILD_TIMESTAMP); /bin/bash"
     else
-		@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_BUILD_INSTRUCTION) $@; /bin/bash"
+		@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_SET_BUILD_TIMESTAMP); $(SONIC_BUILD_INSTRUCTION) $@; $(SONIC_CLEAR_BUILD_TIMESTAMP); /bin/bash"
     endif
 else
-	@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) $(SONIC_BUILD_INSTRUCTION) $@
+	@$(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_SET_BUILD_TIMESTAMP); $(SONIC_BUILD_INSTRUCTION) $@"
 endif
 
 sonic-slave-build :

--- a/functions.sh
+++ b/functions.sh
@@ -50,8 +50,29 @@ docker_try_rmi() {
     }
 }
 
+sonic_set_build_timestamp() {
+    local timestamp="$(date +%Y%m%d\.%H%M%S)"
+    echo "${timestamp}" > /tmp/sonic_build_timestamp
+}
+
+sonic_clear_build_timestamp() {
+    rm /tmp/sonic_build_timestamp
+}
+
+## Get build time stamp from temporary file if exists,
+## otherwise get it in real time.
+sonic_get_build_timestamp() {
+    local timestamp="invalid"
+    if [ ! -f /tmp/sonic_build_timestamp ]; then
+        timestamp="$(date +%Y%m%d\.%H%M%S)"
+    else
+        timestamp="$(cat /tmp/sonic_build_timestamp)"
+    fi
+    echo "${timestamp}"
+}
+
 sonic_get_version() {
-    DIRTY_SUFFIX="$(date +%Y%m%d\.%H%M%S)"
+    DIRTY_SUFFIX=$(sonic_get_build_timestamp)
     local describe=$(git describe --tags)
     local latest_tag=$(git describe --tags --abbrev=0)
     local branch_name=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**- What I did**
To fix issue https://github.com/Azure/sonic-buildimage/issues/2081

**- How I did it**
Save timestamp at the beginning of image build, and use the time stamp for all following module version.
**- How to verify it**
```
root@sonic:~# docker images
REPOSITORY                 TAG                                   IMAGE ID            CREATED             SIZE
docker-lldp-sv2            latest                                1d79abdadf07        49 minutes ago      332.9 MB
docker-lldp-sv2            warm-reboot.0-dirty-20181001.230229   1d79abdadf07        49 minutes ago      332.9 MB
docker-snmp-sv2            latest                                8689dc20bc23        49 minutes ago      373.4 MB
docker-snmp-sv2            warm-reboot.0-dirty-20181001.230229   8689dc20bc23        49 minutes ago      373.4 MB
docker-platform-monitor    latest                                746a266c43d7        52 minutes ago      336.2 MB
docker-platform-monitor    warm-reboot.0-dirty-20181001.230229   746a266c43d7        52 minutes ago      336.2 MB
docker-fpm-quagga          latest                                1859f6cd846f        52 minutes ago      389 MB
docker-fpm-quagga          warm-reboot.0-dirty-20181001.230229   1859f6cd846f        52 minutes ago      389 MB
docker-orchagent-brcm      warm-reboot.0-dirty-20181001.230229   e795108b9484        54 minutes ago      370.5 MB
docker-syncd-brcm          latest                                e7a4efbc84a0        56 minutes ago      411.7 MB
docker-syncd-brcm          warm-reboot.0-dirty-20181001.230229   e7a4efbc84a0        56 minutes ago      411.7 MB
docker-database            latest                                578f5d2d96ed        About an hour ago   298.5 MB
docker-database            warm-reboot.0-dirty-20181001.230229   578f5d2d96ed        About an hour ago   298.5 MB
docker-teamd               latest                                11a7f0b8ea65        About an hour ago   370.7 MB
docker-teamd               warm-reboot.0-dirty-20181001.230229   11a7f0b8ea65        About an hour ago   370.7 MB
docker-dhcp-relay          latest                                ded595fb1be5        About an hour ago   301.6 MB
docker-dhcp-relay          warm-reboot.0-dirty-20181001.230229   ded595fb1be5        About an hour ago   301.6 MB
docker-sonic-telemetry     latest                                44f029e11a68        About an hour ago   324.8 MB
docker-sonic-telemetry     warm-reboot.0-dirty-20181001.230229   44f029e11a68        About an hour ago   324.8 MB
docker-router-advertiser   latest                                b01d9e542317        About an hour ago   296.1 MB
docker-router-advertiser   warm-reboot.0-dirty-20181001.230229   b01d9e542317        About an hour ago   296.1 MB
root@sonic:~# show version
SONiC Software Version: SONiC.warm-reboot.0-dirty-20181001.230229
Distribution: Debian 9.5
Kernel: 4.9.0-7-amd64
Build commit: b22b992
Build date: Mon Oct  1 23:38:52 UTC 2018
Built by: jipan@sonicvm1

Docker images:
REPOSITORY                 TAG                                   IMAGE ID            SIZE
docker-lldp-sv2            latest                                1d79abdadf07        332.9 MB
docker-lldp-sv2            warm-reboot.0-dirty-20181001.230229   1d79abdadf07        332.9 MB
docker-snmp-sv2            latest                                8689dc20bc23        373.4 MB
docker-snmp-sv2            warm-reboot.0-dirty-20181001.230229   8689dc20bc23        373.4 MB
docker-platform-monitor    latest                                746a266c43d7        336.2 MB
docker-platform-monitor    warm-reboot.0-dirty-20181001.230229   746a266c43d7        336.2 MB
docker-fpm-quagga          latest                                1859f6cd846f        389 MB
docker-fpm-quagga          warm-reboot.0-dirty-20181001.230229   1859f6cd846f        389 MB
docker-orchagent-brcm      warm-reboot.0-dirty-20181001.230229   e795108b9484        370.5 MB
docker-syncd-brcm          latest                                e7a4efbc84a0        411.7 MB
docker-syncd-brcm          warm-reboot.0-dirty-20181001.230229   e7a4efbc84a0        411.7 MB
docker-database            latest                                578f5d2d96ed        298.5 MB
docker-database            warm-reboot.0-dirty-20181001.230229   578f5d2d96ed        298.5 MB
docker-teamd               latest                                11a7f0b8ea65        370.7 MB
docker-teamd               warm-reboot.0-dirty-20181001.230229   11a7f0b8ea65        370.7 MB
docker-dhcp-relay          latest                                ded595fb1be5        301.6 MB
docker-dhcp-relay          warm-reboot.0-dirty-20181001.230229   ded595fb1be5        301.6 MB
docker-sonic-telemetry     latest                                44f029e11a68        324.8 MB
docker-sonic-telemetry     warm-reboot.0-dirty-20181001.230229   44f029e11a68        324.8 MB
docker-router-advertiser   latest                                b01d9e542317        296.1 MB
docker-router-advertiser   warm-reboot.0-dirty-20181001.230229   b01d9e542317        296.1 MB
```
root@sonic:~# 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
