### PR TITLE
Resolve ecn runtime config save conflict with default config

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/qos.json
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/qos.json
@@ -127,7 +127,11 @@
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4" : {
+        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
+            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|4" : {
             "scheduler"     :   "[SCHEDULER|scheduler.0]",
             "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/qos.json
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/qos.json
@@ -127,7 +127,11 @@
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4" : {
+        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
+            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|4" : {
             "scheduler"     :   "[SCHEDULER|scheduler.0]",
             "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers.json.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers.json.j2
@@ -90,7 +90,7 @@
             "xon":"18432",
             "xoff":"40560",
             "size":"41808",
-            "dynamic_th":"-4",
+            "dynamic_th":"-3",
             "xon_offset":"2496"
         },
         "ingress_lossy_profile": {
@@ -115,6 +115,9 @@
         },
         "{{ port_names }}|0-1": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "{{ port_names }}|5": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         }
     },
     "BUFFER_QUEUE": {
@@ -122,6 +125,9 @@
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "{{ port_names }}|0-1": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "{{ port_names }}|5": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         }
     }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/qos.json
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/qos.json
@@ -4,7 +4,8 @@
             "0": "0",
             "1": "1",
             "3": "3",
-            "4": "4"
+            "4": "4",
+            "5": "5"
         }
     },
     "MAP_PFC_PRIORITY_TO_QUEUE": {
@@ -12,7 +13,8 @@
             "0": "0",
             "1": "1",
             "3": "3",
-            "4": "4"
+            "4": "4",
+            "5": "5"
         }
     },
     "TC_TO_QUEUE_MAP": {
@@ -20,7 +22,8 @@
             "0": "0",
             "1": "1",
             "3": "3",
-            "4": "4"
+            "4": "4",
+            "5": "5"
         }
     },
     "DSCP_TO_TC_MAP": {
@@ -71,7 +74,7 @@
             "43":"0",
             "44":"0",
             "45":"0",
-            "46":"0",
+            "46":"5",
             "47":"0",
             "48":"0",
             "49":"0",
@@ -94,14 +97,6 @@
     "SCHEDULER": {
         "scheduler.0" : {
             "type":"DWRR",
-            "weight": "25"
-        },
-        "scheduler.1" : {
-            "type":"DWRR",
-            "weight": "30"
-        },
-        "scheduler.2" : {
-            "type":"DWRR",
             "weight": "20"
         }
     },
@@ -120,29 +115,34 @@
             "wred_yellow_enable":"true",
             "wred_red_enable":"true",
             "ecn":"ecn_all",
-            "red_max_threshold":"312000",
-            "red_min_threshold":"104000",
-            "yellow_max_threshold":"312000",
-            "yellow_min_threshold":"104000",
-            "green_max_threshold":"312000",
-            "green_min_threshold":"104000"
+            "red_max_threshold":"2097152",
+            "red_min_threshold":"1048576",
+            "yellow_max_threshold":"2097152",
+            "yellow_min_threshold":"1048576",
+            "green_max_threshold":"2097152",
+            "green_min_threshold":"1048576",
+            "green_drop_probability":"5",
+            "yellow_drop_probability":"5",
+            "red_drop_probability":"5"
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]"
-        },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
             "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|4" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
             "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+            "scheduler"     :   "[SCHEDULER|scheduler.0]"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|1" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
+            "scheduler"     :   "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|5" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.0]"
         }
     }
 }

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/qos.json
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/qos.json
@@ -136,7 +136,11 @@
         }
     },
     "QUEUE": {
-        "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet49,Ethernet50,Ethernet51,Ethernet52,Ethernet53,Ethernet54,Ethernet55,Ethernet56,Ethernet57,Ethernet58,Ethernet59,Ethernet60,Ethernet61,Ethernet62,Ethernet63|3-4" : {
+        "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet49,Ethernet50,Ethernet51,Ethernet52,Ethernet53,Ethernet54,Ethernet55,Ethernet56,Ethernet57,Ethernet58,Ethernet59,Ethernet60,Ethernet61,Ethernet62,Ethernet63|3" : {
+            "scheduler"     :   "[SCHEDULER|scheduler.0]",
+            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet49,Ethernet50,Ethernet51,Ethernet52,Ethernet53,Ethernet54,Ethernet55,Ethernet56,Ethernet57,Ethernet58,Ethernet59,Ethernet60,Ethernet61,Ethernet62,Ethernet63|4" : {
             "scheduler"     :   "[SCHEDULER|scheduler.0]",
             "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
         },


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1) Resolve ecn runtime config save conflict with default config
2) qos & buffer config change for s6000 (same as 7050 profile)

**- How I did it**

**- How to verify it**
Tested on a7050, s6100, and s6000:
Change ecn on/off, config save, and reboot




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
