### PR TITLE
Fixed FW upgrade sequence.

### DIFF
--- a/device/mellanox/x86_64-mlnx_lssn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_lssn2700-r0/platform_reboot
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_reboot

--- a/device/mellanox/x86_64-mlnx_msn2010-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/platform_reboot
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_reboot

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/platform_reboot
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_reboot

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/platform_reboot
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_reboot

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-FW_UPGRADE_SCRIPT="/usr/bin/mlnx-fw-upgrade.sh"
+declare -r EXIT_SUCCESS="0"
+declare -r EXIT_ERROR="1"
 
-NEXT_SONIC_IMAGE="$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)"
-CURRENT_SONIC_IMAGE="$(sonic_installer list | grep "Current: " | cut -d ' ' -f 2)"
+declare -r FW_UPGRADE_SCRIPT="/usr/bin/mlnx-fw-upgrade.sh"
 
 FORCE_REBOOT="no"
 
-ParseArguments() {
+function ParseArguments() {
     while [ $# -ge 1 ]; do
         case "$1" in
             -f|--force)
@@ -18,30 +18,17 @@ ParseArguments() {
     done
 }
 
-ParseArguments $@
+ParseArguments "$@"
 
-if [[ "${CURRENT_SONIC_IMAGE}" != "${NEXT_SONIC_IMAGE}" ]]; then
-    echo "Prepare ASIC to reboot: install new FW if required"
+${FW_UPGRADE_SCRIPT} --upgrade
+EXIT_CODE="$?"
+if [[ "${EXIT_CODE}" != "${EXIT_SUCCESS}" ]]; then
+    echo "Failed to burn MLNX FW: errno=${EXIT_CODE}"
 
-    NEXT_IMAGE_FS_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}/fs.squashfs"
-    FS_MOUNTPOINT="/tmp/image-${NEXT_SONIC_IMAGE#SONiC-OS-}-fs"
-
-    mkdir -p "${FS_MOUNTPOINT}"
-    mount -t squashfs "${NEXT_IMAGE_FS_PATH}" "${FS_MOUNTPOINT}"
-
-    ${FW_UPGRADE_SCRIPT} "${FS_MOUNTPOINT}/etc/mlnx/fw-SPC.mfa"
-    EXIT_CODE=$?
-
-    umount "${FS_MOUNTPOINT}"
-
-    if [[ ${EXIT_CODE} != 0 ]]; then
-        echo "Failed to burn FW: errno=${EXIT_CODE}"
-
-        if [[ ${FORCE_REBOOT} != "yes" ]]; then
-            echo "Reboot is interrupted: use -f|--force to override"
-            exit 1
-        fi
+    if [[ "${FORCE_REBOOT}" != "yes" ]]; then
+        echo "Reboot is interrupted: use -f|--force to override"
+        exit "${EXIT_ERROR}"
     fi
 fi
 
-/sbin/reboot $@
+exec /sbin/reboot $@

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+FW_UPGRADE_SCRIPT="/usr/bin/mlnx-fw-upgrade.sh"
+
+NEXT_SONIC_IMAGE="$(sonic_installer list | grep "Next: " | cut -d ' ' -f 2)"
+CURRENT_SONIC_IMAGE="$(sonic_installer list | grep "Current: " | cut -d ' ' -f 2)"
+
+FORCE_REBOOT="no"
+
+ParseArguments() {
+    while [ $# -ge 1 ]; do
+        case "$1" in
+            -f|--force)
+                FORCE_REBOOT="yes"
+            ;;
+        esac
+        shift
+    done
+}
+
+ParseArguments $@
+
+if [[ "${CURRENT_SONIC_IMAGE}" != "${NEXT_SONIC_IMAGE}" ]]; then
+    echo "Prepare ASIC to reboot: install new FW if required"
+
+    NEXT_IMAGE_FS_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}/fs.squashfs"
+    FS_MOUNTPOINT="/tmp/image-${NEXT_SONIC_IMAGE#SONiC-OS-}-fs"
+
+    mkdir -p "${FS_MOUNTPOINT}"
+    mount -t squashfs "${NEXT_IMAGE_FS_PATH}" "${FS_MOUNTPOINT}"
+
+    ${FW_UPGRADE_SCRIPT} "${FS_MOUNTPOINT}/etc/mlnx/fw-SPC.mfa"
+    EXIT_CODE=$?
+
+    umount "${FS_MOUNTPOINT}"
+
+    if [[ ${EXIT_CODE} != 0 ]]; then
+        echo "Failed to burn FW: errno=${EXIT_CODE}"
+
+        if [[ ${FORCE_REBOOT} != "yes" ]]; then
+            echo "Reboot is interrupted: use -f|--force to override"
+            exit 1
+        fi
+    fi
+fi
+
+/sbin/reboot $@

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/platform_reboot
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_reboot

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -5,11 +5,11 @@ query_retry_count_max="10"
 fw_file=/etc/mlnx/fw-SPC.mfa
 
 run_or_fail() {
-	$1
-	if [[ $? != 0 ]]; then
-		echo $1 failed
-		exit 1
-	fi
+    $1
+    if [[ $? != 0 ]]; then
+        echo $1 failed
+        exit 1
+    fi
 }
 
 # wait until devices will be available
@@ -18,12 +18,12 @@ query_cmd="mlxfwmanager --query"
 ${query_cmd} > /dev/null
 
 while [[ (${query_retry_count} -lt ${query_retry_count_max}) && ($? -ne "0") ]]; do
-	sleep 1
-	query_retry_count=$[${query_retry_count}+1]
-	${query_cmd} > /dev/null
+    sleep 1
+    query_retry_count=$[${query_retry_count}+1]
+    ${query_cmd} > /dev/null
 done
 
-function upgrade() {
+upgrade() {
     if [ ! -z "$1" ]; then
         fw_file="$1"
         if [ ! -f "$fw_file" ]; then
@@ -46,17 +46,17 @@ function upgrade() {
         fw_info=$(grep FW /tmp/mlnxfwmanager-query.txt)
         fw_current=$(echo $fw_info | cut -f2 -d' ')
     fi
-    
+
     if [[ -z ${fw_current} ]]; then
         echo "Could not retreive current FW version."
         exit 1
     fi
-    
+
     if [[ -z ${fw_required} ]]; then
         echo "Could not retreive required FW version."
         exit 1
     fi
-    
+
     if [[ ${fw_current} == ${fw_required} ]]; then
         echo "Mellanox firmware is up to date."
     else

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -1,68 +1,143 @@
 #!/bin/bash
 
-fw_required="{{ MLNX_FW_VERSION }}"
-query_retry_count_max="10"
-fw_file=/etc/mlnx/fw-SPC.mfa
+declare -r SCRIPT_NAME="$(basename "$0")"
+declare -r SCRIPT_PATH="$(readlink -f "$0")"
+declare -r SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 
-run_or_fail() {
+declare -r EXIT_SUCCESS="0"
+declare -r EXIT_ERROR="1"
+
+declare -r QUERY_CMD="mlxfwmanager --query"
+declare -r BURN_CMD="mlxfwmanager -u -f -y"
+
+declare -r FW_FILE="/etc/mlnx/fw-SPC.mfa"
+declare -r QUERY_FILE="/tmp/mlnxfwmanager-query.txt"
+
+declare -r FW_REQUIRED="{{ MLNX_FW_VERSION }}"
+
+IMAGE_UPGRADE="no"
+
+function PrintHelp() {
+    echo
+    echo "Usage: ./${SCRIPT_NAME} [OPTIONS]"
+    echo
+    echo "OPTIONS:"
+    echo "  -u, --upgrade  Upgrade MLNX ASIC firmware using next boot image (useful after SONiC-To-SONiC update)"
+    echo "  -h, --help     Print help"
+    echo
+    echo "Examples:"
+    echo "  ./${SCRIPT_NAME}"
+    echo "  ./${SCRIPT_NAME} --upgrade"
+    echo "  ./${SCRIPT_NAME} --help"
+    echo
+}
+
+function ParseArguments() {
+    while [ $# -ge 1 ]; do
+        case "$1" in
+            -u|--upgrade)
+                IMAGE_UPGRADE="yes"
+            ;;
+            -h|--help)
+                PrintHelp
+                exit "${EXIT_SUCCESS}"
+            ;;
+        esac
+        shift
+    done
+}
+
+function WaitForDevice() {
+    local -i QUERY_RETRY_COUNT_MAX="10"
+    local -i QUERY_RETRY_COUNT="0"
+
+    ${QUERY_CMD} > /dev/null
+
+    while [[ ("${QUERY_RETRY_COUNT}" -lt "${QUERY_RETRY_COUNT_MAX}") && ("$?" -ne "0") ]]; do
+        sleep 1s
+        ((QUERY_RETRY_COUNT++))
+        ${QUERY_CMD} > /dev/null
+    done
+}
+
+function RunCmd() {
     $1
     if [[ $? != 0 ]]; then
-        echo $1 failed
-        exit 1
+        echo "Command failed: cmd=$1, errno=$?"
+        exit "${EXIT_ERROR}"
     fi
 }
 
-# wait until devices will be available
-query_retry_count="0"
-query_cmd="mlxfwmanager --query"
-${query_cmd} > /dev/null
+function UpgradeFW() {
+    local _FW_FILE="$1"
 
-while [[ (${query_retry_count} -lt ${query_retry_count_max}) && ($? -ne "0") ]]; do
-    sleep 1
-    query_retry_count=$[${query_retry_count}+1]
-    ${query_cmd} > /dev/null
-done
-
-upgrade() {
-    if [ ! -z "$1" ]; then
-        fw_file="$1"
-        if [ ! -f "$fw_file" ]; then
-            >&2 echo "No such file: $fw_file"
-            exit 1
+    if [ ! -z "${_FW_FILE}" ]; then
+        if [ ! -f "${_FW_FILE}" ]; then
+            echo "No such file: ${_FW_FILE}"
+            exit "${EXIT_ERROR}"
         fi
 
-        run_or_fail "${query_cmd} -i ${fw_file}" > /tmp/mlnxfwmanager-query.txt
+        RunCmd "${QUERY_CMD} -i ${_FW_FILE}" > "${QUERY_FILE}"
 
-        # get current firmware version and available version from $fw_file
-        fw_info=$(grep FW /tmp/mlnxfwmanager-query.txt)
-        fw_current=$(echo $fw_info | cut -f2 -d' ')
-        fw_available=$(echo $fw_info | cut -f3 -d' ')
-
-        fw_required=$fw_available
+        local -r _FW_INFO="$(grep FW ${QUERY_FILE})"
+        local -r _FW_CURRENT="$(echo ${_FW_INFO} | cut -f2 -d' ')"
+        local -r _FW_AVAILABLE="$(echo ${_FW_INFO} | cut -f3 -d' ')"
     else
-        run_or_fail "${query_cmd}" > /tmp/mlnxfwmanager-query.txt
+        RunCmd "${QUERY_CMD}" > "${QUERY_FILE}"
 
-        # get current firmware version and required version
-        fw_info=$(grep FW /tmp/mlnxfwmanager-query.txt)
-        fw_current=$(echo $fw_info | cut -f2 -d' ')
+        local -r _FW_INFO="$(grep FW ${QUERY_FILE})"
+        local -r _FW_CURRENT="$(echo ${_FW_INFO} | cut -f2 -d' ')"
+        local -r _FW_AVAILABLE="${FW_REQUIRED}"
+
+        _FW_FILE="${FW_FILE}"
     fi
 
-    if [[ -z ${fw_current} ]]; then
-        echo "Could not retreive current FW version."
-        exit 1
+    if [[ -z "${_FW_CURRENT}" ]]; then
+        echo "Could not retreive current FW version"
+        exit "${EXIT_ERROR}"
     fi
 
-    if [[ -z ${fw_required} ]]; then
-        echo "Could not retreive required FW version."
-        exit 1
+    if [[ -z "${_FW_AVAILABLE}" ]]; then
+        echo "Could not retreive available FW version"
+        exit "${EXIT_ERROR}"
     fi
 
-    if [[ ${fw_current} == ${fw_required} ]]; then
-        echo "Mellanox firmware is up to date."
+    if [[ "${_FW_CURRENT}" == "${_FW_AVAILABLE}" ]]; then
+        echo "Mellanox firmware is up to date"
     else
-        echo "Mellanox firmware required version is ${fw_required}. Installing compatible version..."
-        run_or_fail "mlxfwmanager -i ${fw_file} -u -f -y"
+        echo "Mellanox firmware upgrade is required. Installing compatible version..."
+        RunCmd "${BURN_CMD} -i ${_FW_FILE}"
     fi
 }
 
-upgrade "$1"
+function UpgradeFWFromImage() {
+    local -r _NEXT_SONIC_IMAGE="$(sonic_installer list | grep "Next: " | cut -f2 -d' ')"
+    local -r _CURRENT_SONIC_IMAGE="$(sonic_installer list | grep "Current: " | cut -f2 -d' ')"
+
+    local -r _FS_PATH="/host/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}/fs.squashfs"
+    local -r _FS_MOUNTPOINT="/tmp/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}-fs"
+
+    if [[ "${_CURRENT_SONIC_IMAGE}" == "${_NEXT_SONIC_IMAGE}" ]]; then
+        echo "Mellanox firmware is up to date"
+    else
+        mkdir -p "${_FS_MOUNTPOINT}"
+        mount -t squashfs "${_FS_PATH}" "${_FS_MOUNTPOINT}"
+
+        UpgradeFW "${_FS_MOUNTPOINT}/etc/mlnx/fw-SPC.mfa"
+
+        umount -rf "${_FS_MOUNTPOINT}"
+        rm -rf "${_FS_MOUNTPOINT}"
+    fi
+}
+
+ParseArguments "$@"
+
+WaitForDevice
+
+if [ "${IMAGE_UPGRADE}" != "yes" ]; then
+    UpgradeFW
+else
+    UpgradeFWFromImage
+fi
+
+exit "${EXIT_SUCCESS}"


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

**- What I did**
Fixed FW upgrade sequence

**- How I did it**
Added logic to start FW upgrade on switch reboot after SONiC-To-SONiC update.
This will solve the issue when FW upgrade can be interrupted by swss restart.

**- How to verify it**
1. Perform SONiC-To-SONiC upgrade (FW versions should be different)
2. Reboot switch
3. Start parallel SSH session and restart swss

**- Description for the changelog**
* N/A

**- External dependencies**
1. https://github.com/Azure/sonic-utilities/pull/333