### PR TITLE
[image config] Install Python tabulate library v0.8.2 via pip

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -102,6 +102,9 @@ sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/python-click*_all.deb || \
 # using pip install instead to get a more recent version than is available through debian
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install pexpect
 
+# Install tabulate >= 0.8.1 via pip in order to support multi-line row output for sonic-utilities
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install tabulate==0.8.2
+
 # Install SONiC Utilities (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i target/debs/python-sonic-utilities_*.deb || \
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f


### PR DESCRIPTION
Version 0.8.1 of Python tabulate package added support for properly displaying multi-line content in a cell. This is required for the new "show vlan" command in sonic-utilities, and will most likely be used more in the future. This needs to be installed via pip as the latest version available as a Debian package for Stretch is 0.7.7. The latest version available via pip is v0.8.2.

https://bitbucket.org/astanin/python-tabulate/issues/28/feature-request-multiline-cells-and