### PR TITLE
[submodule]: update broadcom SAI to 3.1.3.5-11

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.1.3.5-10_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/libsaibcm_3.1.3.5-10_amd64.deb?sv=2015-04-05&sr=b&sig=knKdBT4t%2B%2F8JvPe5wfCJPsJ1JU1kSsCBzMBFQHtXoAg%3D&se=2032-05-30T19%3A33%3A41Z&sp=r"
+BRCM_SAI = libsaibcm_3.1.3.5-11_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/libsaibcm_3.1.3.5-11_amd64.deb?sv=2015-04-05&sr=b&sig=gATwARdB%2FH42%2FUYDirrHcqXzGfSDq79IP4LMVgjUuo0%3D&se=2155-09-02T04%3A33%3A51Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.1.3.5-10_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.1.3.5-11_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/libsaibcm-dev_3.1.3.5-10_amd64.deb?sv=2015-04-05&sr=b&sig=aYTN5yyq9dy4uz%2FctVXhuG9qqLs%2FefT4lJFmheRAk7I%3D&se=2032-05-30T19%3A34%3A34Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/libsaibcm-dev_3.1.3.5-11_amd64.deb?sv=2015-04-05&sr=b&sig=YE%2BCpURwLGSzE8qBVandbERncFUkm5CEvCdMB9YrKZM%3D&se=2155-09-02T02%3A43%3A51Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI) $(BRCM_SAI_DEV)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
disable vxlan init for helix4

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
