### PR TITLE
Fix bug: if all container killed, service stop will throw exception because no redis

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -39,18 +39,18 @@ function postStartAction()
 {%- endif %}
 }
 
-# Obtain our platform as we will mount directories with these names in each docker
-PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
-
-{%- if docker_container_name == "database" %}
-# Don't mount HWSKU in {{docker_container_name}} container.
-HWSKU=""
-{%- else %}
-# Obtain our HWSKU as we will mount directories with these names in each docker
-HWSKU=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`
-{%- endif %}
-
 start() {
+    # Obtain our platform as we will mount directories with these names in each docker
+    PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+
+    {%- if docker_container_name == "database" %}
+    # Don't mount HWSKU in {{docker_container_name}} container.
+    HWSKU=""
+    {%- else %}
+    # Obtain our HWSKU as we will mount directories with these names in each docker
+    HWSKU=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`
+    {%- endif %}
+
     DOCKERCHECK=`docker inspect --type container {{docker_container_name}} 2>/dev/null`
     if [ "$?" -eq "0" ]; then
         DOCKERMOUNT=`getMountPoint "$DOCKERCHECK"`


### PR DESCRIPTION
It will happen during warm-reboot or fast-reboot.