### PR TITLE
[mellanox]: Fix sysfs path for PSU devices in psuutil plugin

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/plugins/psuutil.py
@@ -20,10 +20,14 @@ class PsuUtil(PsuBase):
 
     def __init__(self):
         PsuBase.__init__(self)
-
-        self.psu_path = "/bsp/module/"
-        self.psu_presence = "psu{}_pwr_status"
-        self.psu_oper_status = "psu{}_pwr_status"
+        self.psu_path = ""
+        for index in range(0, 100):
+            hwmon_path = "/sys/devices/platform/mlxplat/mlxreg-hotplug/hwmon/hwmon{}/".format(index)
+            if os.path.exists(hwmon_path):
+                self.psu_path = hwmon_path
+                break
+        self.psu_presence = "pwr{}"
+        self.psu_oper_status = "pwr{}"
 
     def get_num_psus(self):
         """

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/plugins/psuutil.py
@@ -21,9 +21,14 @@ class PsuUtil(PsuBase):
     def __init__(self):
         PsuBase.__init__(self)
 
-        self.psu_path = "/bsp/module/"
-        self.psu_presence = "psu{}_status"
-        self.psu_oper_status = "psu{}_pwr_status"
+        self.psu_path = ""
+        for index in range(0, 100):
+            hwmon_path = "/sys/devices/platform/mlxplat/mlxreg-hotplug/hwmon/hwmon{}/".format(index)
+            if os.path.exists(hwmon_path):
+                self.psu_path = hwmon_path
+                break
+        self.psu_presence = "pwr{}"
+        self.psu_oper_status = "pwr{}"
 
     def get_num_psus(self):
         """

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/plugins/psuutil.py
@@ -21,9 +21,14 @@ class PsuUtil(PsuBase):
     def __init__(self):
         PsuBase.__init__(self)
 
-        self.psu_path = "/bsp/module/"
-        self.psu_presence = "psu{}_status"
-        self.psu_oper_status = "psu{}_pwr_status"
+        self.psu_path = ""
+        for index in range(0, 100):
+            hwmon_path = "/sys/devices/platform/mlxplat/mlxreg-hotplug/hwmon/hwmon{}/".format(index)
+            if os.path.exists(hwmon_path):
+                self.psu_path = hwmon_path
+                break
+        self.psu_presence = "psu{}"
+        self.psu_oper_status = "pwr{}"
 
     def get_num_psus(self):
         """

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/psuutil.py
@@ -21,9 +21,14 @@ class PsuUtil(PsuBase):
     def __init__(self):
         PsuBase.__init__(self)
 
-        self.psu_path = "/bsp/module/"
-        self.psu_presence = "psu{}_status"
-        self.psu_oper_status = "psu{}_pwr_status"
+        self.psu_path = ""
+        for index in range(0, 100):
+            hwmon_path = "/sys/devices/platform/mlxplat/mlxreg-hotplug/hwmon/hwmon{}/".format(index)
+            if os.path.exists(hwmon_path):
+                self.psu_path = hwmon_path
+                break
+        self.psu_presence = "psu{}"
+        self.psu_oper_status = "pwr{}"
 
     def get_num_psus(self):
         """

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/plugins/psuutil.py
@@ -20,10 +20,14 @@ class PsuUtil(PsuBase):
 
     def __init__(self):
         PsuBase.__init__(self)
-
-        self.psu_path = "/bsp/module/"
-        self.psu_presence = "psu{}_status"
-        self.psu_oper_status = "psu{}_pwr_status"
+        self.psu_path = ""
+        for index in range(0, 100):
+            hwmon_path = "/sys/devices/platform/mlxplat/mlxreg-hotplug/hwmon/hwmon{}/".format(index)
+            if os.path.exists(hwmon_path):
+                self.psu_path = hwmon_path
+                break
+        self.psu_presence = "psu{}"
+        self.psu_oper_status = "pwr{}"
 
     def get_num_psus(self):
         """


### PR DESCRIPTION
Snmp container needs to access the PSU path, but /bsp doesn't mount
into the container, so need to use the real path rather than a symlink.

Signed-off-by: Kevin Wang <kevinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Just change the sysfs path for psu
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
