### PR TITLE
[ipinip config] Add v6 ip and peering ip besides currect v4 loopback

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -1,16 +1,68 @@
-{# only IPv4 decapsulation is supported #}
+{% set ipv4_addresses = [] %}
+{% set ipv6_addresses = [] %}
 {% set ipv4_loopback_addresses = [] %}
+{% set ipv6_loopback_addresses = [] %}
 {% for (name, prefix) in LOOPBACK_INTERFACE %}
     {%- if prefix | ipv4 and name == 'Loopback0' %}
+        {%- set ipv4_addresses = ipv4_addresses.append(prefix) %}
         {%- set ipv4_loopback_addresses = ipv4_loopback_addresses.append(prefix) %}
+    {%- endif %}
+    {%- if prefix | ipv6 and name == 'Loopback0' %}
+        {%- set ipv6_addresses = ipv6_addresses.append(prefix) %}
+        {%- set ipv6_loopback_addresses = ipv6_loopback_addresses.append(prefix) %}
+    {%- endif %}
+{% endfor %}
+{% for (name, prefix) in INTERFACE %}
+    {%- if prefix | ipv4 %}
+        {%- set ipv4_addresses = ipv4_addresses.append(prefix) %}
+    {%- endif %}
+    {%- if prefix | ipv6 %}
+        {%- set ipv6_addresses = ipv6_addresses.append(prefix) %}
+    {%- endif %}
+{% endfor %}
+{% for (name, prefix) in PORTCHANNEL_INTERFACE %}
+    {%- if prefix | ipv4 %}
+        {%- set ipv4_addresses = ipv4_addresses.append(prefix) %}
+    {%- endif %}
+    {%- if prefix | ipv6 %}
+        {%- set ipv6_addresses = ipv6_addresses.append(prefix) %}
+    {%- endif %}
+{% endfor %}
+{% for (name, prefix) in VLAN_INTERFACE %}
+    {%- if prefix | ipv4 %}
+        {%- set ipv4_addresses = ipv4_addresses.append(prefix) %}
+    {%- endif %}
+    {%- if prefix | ipv6 %}
+        {%- set ipv6_addresses = ipv6_addresses.append(prefix) %}
     {%- endif %}
 {% endfor %}
 [
+{% if ipv6_loopback_addresses %}
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
             "src_ip":"{{ ipv4_loopback_addresses | first | ip }}",
-            "dst_ip":"{% for prefix in ipv4_loopback_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
+            "dst_ip":"{% for prefix in ipv4_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
+{% if "mlnx" in DEVICE_METADATA.localhost.platform %}
+            "dscp_mode":"uniform",
+            "ecn_mode":"standard",
+{% else %}
+            "dscp_mode":"pipe",
+            "ecn_mode":"copy_from_outer",
+{% endif %}
+            "ttl_mode":"pipe"
+        },
+        "OP": "SET"
+    } 
+{% endif %}
+{% if ipv4_loopback_addresses and ipv6_loopback_addresses %}    ,
+{% endif %}
+{% if ipv6_loopback_addresses %}
+    {
+        "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+            "tunnel_type":"IPINIP",
+            "src_ip":"{{ ipv6_loopback_addresses | first | ip }}",
+            "dst_ip":"{% for prefix in ipv6_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
 {% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "dscp_mode":"uniform",
             "ecn_mode":"standard",
@@ -22,4 +74,5 @@
         },
         "OP": "SET"
     }
+{% endif %}
 ]

--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -37,7 +37,7 @@
     {%- endif %}
 {% endfor %}
 [
-{% if ipv6_loopback_addresses %}
+{% if ipv4_loopback_addresses %}
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",

--- a/src/sonic-config-engine/tests/sample_output/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/ipinip.json
@@ -3,7 +3,19 @@
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
             "src_ip":"10.1.0.32",
-            "dst_ip":"10.1.0.32",
+            "dst_ip":"10.1.0.32,10.0.0.56,10.0.0.58,10.0.0.60,10.0.0.62,192.168.0.1",
+            "dscp_mode":"pipe",
+            "ecn_mode":"copy_from_outer",
+            "ttl_mode":"pipe"
+        },
+        "OP": "SET"
+    } 
+    ,
+    {
+        "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+            "tunnel_type":"IPINIP",
+            "src_ip":"fc00:1::32",
+            "dst_ip":"fc00:1::32,fc00::71,fc00::75,fc00::79,fc00::7d",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Originally only IPv4 loopback address is configured for IP decap. This change add IPv6 support, as well as extend the decap to front panel port IP, port channel IP and vlan IP as well.
