### PR TITLE
Add index column to Mellanox-SN2700-D48C8/port_config.ini

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/port_config.ini
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/port_config.ini
@@ -1,57 +1,57 @@
-# name          lanes                  speed        alias
-Ethernet0       0,1                    50000        etp1a
-Ethernet2       2,3                    50000        etp1b
-Ethernet4       4,5                    50000        etp2a
-Ethernet6       6,7                    50000        etp2b
-Ethernet8       8,9                    50000        etp3a
-Ethernet10      10,11                  50000        etp3b
-Ethernet12      12,13                  50000        etp4a
-Ethernet14      14,15                  50000        etp4b
-Ethernet16      16,17                  50000        etp5a
-Ethernet18      18,19                  50000        etp5b
-Ethernet20      20,21                  50000        etp6a
-Ethernet22      22,23                  50000        etp6b
-Ethernet24      24,25,26,27            100000       etp7
-Ethernet28      28,29,30,31            100000       etp8
-Ethernet32      32,33,34,35            100000       etp9
-Ethernet36      36,37,38,39            100000       etp10
-Ethernet40      40,41                  50000        etp11a
-Ethernet42      42,43                  50000        etp11b
-Ethernet44      44,45                  50000        etp12a
-Ethernet46      46,47                  50000        etp12b
-Ethernet48      48,49                  50000        etp13a
-Ethernet50      50,51                  50000        etp13b
-Ethernet52      52,53                  50000        etp14a
-Ethernet54      54,55                  50000        etp14b
-Ethernet56      56,57                  50000        etp15a
-Ethernet58      58,59                  50000        etp15b
-Ethernet60      60,61                  50000        etp16a
-Ethernet62      62,63                  50000        etp16b
-Ethernet64      64,65                  50000        etp17a
-Ethernet66      66,67                  50000        etp17b
-Ethernet68      68,69                  50000        etp18a
-Ethernet70      70,71                  50000        etp18b
-Ethernet72      72,73                  50000        etp19a
-Ethernet74      74,75                  50000        etp19b
-Ethernet76      76,77                  50000        etp20a
-Ethernet78      78,79                  50000        etp20b
-Ethernet80      80,81                  50000        etp21a
-Ethernet82      82,83                  50000        etp21b
-Ethernet84      84,85                  50000        etp22a
-Ethernet86      86,87                  50000        etp22b
-Ethernet88      88,89,90,91           100000        etp23
-Ethernet92      92,93,94,95           100000        etp24
-Ethernet96      96,97,98,99           100000        etp25
-Ethernet100     100,101,102,103       100000        etp26
-Ethernet104     104,105                50000        etp27a
-Ethernet106     106,107                50000        etp27b
-Ethernet108     108,109                50000        etp28a
-Ethernet110     110,111                50000        etp28b
-Ethernet112     112,113                50000        etp29a
-Ethernet114     114,115                50000        etp29b
-Ethernet116     116,117                50000        etp30a
-Ethernet118     118,119                50000        etp30b
-Ethernet120     120,121                50000        etp31a
-Ethernet122     122,123                50000        etp31b
-Ethernet124     124,125                50000        etp32a
-Ethernet126     126,127                50000        etp32b
+# name          lanes                  speed        alias       index
+Ethernet0       0,1                    50000        etp1a       1
+Ethernet2       2,3                    50000        etp1b       1
+Ethernet4       4,5                    50000        etp2a       2
+Ethernet6       6,7                    50000        etp2b       2
+Ethernet8       8,9                    50000        etp3a       3
+Ethernet10      10,11                  50000        etp3b       3
+Ethernet12      12,13                  50000        etp4a       4
+Ethernet14      14,15                  50000        etp4b       4
+Ethernet16      16,17                  50000        etp5a       5
+Ethernet18      18,19                  50000        etp5b       5
+Ethernet20      20,21                  50000        etp6a       6
+Ethernet22      22,23                  50000        etp6b       6
+Ethernet24      24,25,26,27            100000       etp7        7
+Ethernet28      28,29,30,31            100000       etp8        8
+Ethernet32      32,33,34,35            100000       etp9        9
+Ethernet36      36,37,38,39            100000       etp10       10
+Ethernet40      40,41                  50000        etp11a      11
+Ethernet42      42,43                  50000        etp11b      11
+Ethernet44      44,45                  50000        etp12a      12
+Ethernet46      46,47                  50000        etp12b      12
+Ethernet48      48,49                  50000        etp13a      13
+Ethernet50      50,51                  50000        etp13b      13
+Ethernet52      52,53                  50000        etp14a      14
+Ethernet54      54,55                  50000        etp14b      14
+Ethernet56      56,57                  50000        etp15a      15
+Ethernet58      58,59                  50000        etp15b      15
+Ethernet60      60,61                  50000        etp16a      16
+Ethernet62      62,63                  50000        etp16b      16
+Ethernet64      64,65                  50000        etp17a      17
+Ethernet66      66,67                  50000        etp17b      17
+Ethernet68      68,69                  50000        etp18a      18
+Ethernet70      70,71                  50000        etp18b      18
+Ethernet72      72,73                  50000        etp19a      19
+Ethernet74      74,75                  50000        etp19b      19
+Ethernet76      76,77                  50000        etp20a      20
+Ethernet78      78,79                  50000        etp20b      20
+Ethernet80      80,81                  50000        etp21a      21
+Ethernet82      82,83                  50000        etp21b      21
+Ethernet84      84,85                  50000        etp22a      22
+Ethernet86      86,87                  50000        etp22b      22
+Ethernet88      88,89,90,91           100000        etp23       23
+Ethernet92      92,93,94,95           100000        etp24       24
+Ethernet96      96,97,98,99           100000        etp25       25
+Ethernet100     100,101,102,103       100000        etp26       26
+Ethernet104     104,105                50000        etp27a      27
+Ethernet106     106,107                50000        etp27b      27
+Ethernet108     108,109                50000        etp28a      28
+Ethernet110     110,111                50000        etp28b      28
+Ethernet112     112,113                50000        etp29a      29
+Ethernet114     114,115                50000        etp29b      29
+Ethernet116     116,117                50000        etp30a      30
+Ethernet118     118,119                50000        etp30b      30
+Ethernet120     120,121                50000        etp31a      31
+Ethernet122     122,123                50000        etp31b      31
+Ethernet124     124,125                50000        etp32a      32
+Ethernet126     126,127                50000        etp32b      32


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Try to fix a bug
```
$ show platform summary
Platform: x86_64-mlnx_msn2700-r0
HwSKU: Mellanox-SN2700-D48C8
ASIC: mellanox

$ sudo sfputil show presence
Error reading port info (invalid literal for int() with base 10: 'etp1a')
```

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
