### PR TITLE
Disable SNMPv1

### DIFF
--- a/src/snmpd/patch-5.7.3+dfsg/0004-Disable-SNMPv1.patch
+++ b/src/snmpd/patch-5.7.3+dfsg/0004-Disable-SNMPv1.patch
@@ -1,0 +1,25 @@
+From db633987abf1ea093cb1785b3cd37adfdb55e4cc Mon Sep 17 00:00:00 2001
+From: Qi Luo <qiluo-msft@users.noreply.github.com>
+Date: Mon, 15 Oct 2018 22:30:28 +0000
+Subject: [PATCH] Disable SNMPv1
+
+Signed-off-by: Qi Luo <qiluo-msft@users.noreply.github.com>
+---
+ debian/rules | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/debian/rules b/debian/rules
+index 9eb8d2d..4c3b5b6 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -42,6 +42,7 @@ endif
+ override_dh_auto_configure:
+ 	dh_auto_configure -- --prefix=/usr --sysconfdir=/etc --mandir=/usr/share/man \
+ 	  --with-persistent-directory=/var/lib/snmp \
++	  --disable-snmpv1 \
+ 	  --enable-ucd-snmp-compatibility \
+ 	  --enable-shared --with-cflags="$(CFLAGS) -DNETSNMP_USE_INLINE" \
+ 	  --with-ldflags="$(LDFLAGS)" \
+-- 
+2.18.0
+

--- a/src/snmpd/patch-5.7.3+dfsg/series
+++ b/src/snmpd/patch-5.7.3+dfsg/series
@@ -1,3 +1,4 @@
 0001-SNMP-Stop-spamming-logs-with-statfs-permission-denie.patch
 0002-at.c-properly-check-return-status-from-realloc.-Than.patch
 0003-CHANGES-BUG-2743-snmpd-crashes-when-receiving-a-GetN.patch
+0004-Disable-SNMPv1.patch


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Disable SNMPv1 when building snmpd, because it is considered old school and obsoleted.

**- How I did it**
Change debian auto config

**- How to verify it**
Build log shows:
```
---------------------------------------------------------
            Net-SNMP configuration summary:
---------------------------------------------------------

  UCD-SNMP compatability:     enabled
  SNMP Versions Supported:    2c 3
  Building for:               linux
  Net-SNMP Version:           5.7.3
  Network transport support:  Callback Unix Alias TCP UDP IPv4Base SocketBase TCPBase UDPIPv4Base UDPBase
  SNMPv3 Security Modules:     usm
  Agent MIB code:            default_modules disman/event-mib host mibII/mta_sendmail smux ucd-snmp/dlmod =>  snmpv3mibs mibII ucd_snmp notification notification-log-mib target agent_mibs agentx disman/event disman/schedule utilities host disman/event host/hrh_storage host/hrh_filesys host/hrSWInstalledTable host/hrSWRunTable host/hr_system host/hr_device host/hr_other host/hr_proc host/hr_network host/hr_print host/hr_disk host/hr_partition smux/smux
  MYSQL Trap Logging:         enabled
  Embedded Perl support:      enabled
  SNMP Perl modules:          building -- embeddable
  SNMP Python modules:        disabled
  Crypto support from:        crypto
  Authentication support:     MD5 SHA1
  Encryption support:         DES AES
  Local DNSSEC validation:    disabled
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
