### PR TITLE
Encap src_ip is not required for the IPinIP decap tunnels

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -1,15 +1,11 @@
 {% set ipv4_addresses = [] %}
 {% set ipv6_addresses = [] %}
-{% set ipv4_loopback_addresses = [] %}
-{% set ipv6_loopback_addresses = [] %}
 {% for (name, prefix) in LOOPBACK_INTERFACE %}
     {%- if prefix | ipv4 and name == 'Loopback0' %}
         {%- set ipv4_addresses = ipv4_addresses.append(prefix) %}
-        {%- set ipv4_loopback_addresses = ipv4_loopback_addresses.append(prefix) %}
     {%- endif %}
     {%- if prefix | ipv6 and name == 'Loopback0' %}
         {%- set ipv6_addresses = ipv6_addresses.append(prefix) %}
-        {%- set ipv6_loopback_addresses = ipv6_loopback_addresses.append(prefix) %}
     {%- endif %}
 {% endfor %}
 {% for (name, prefix) in INTERFACE %}
@@ -37,7 +33,7 @@
     {%- endif %}
 {% endfor %}
 [
-{% if ipv4_loopback_addresses %}
+{% if ipv4_addresses %}
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
@@ -54,9 +50,9 @@
         "OP": "SET"
     } 
 {% endif %}
-{% if ipv4_loopback_addresses and ipv6_loopback_addresses %}    ,
+{% if ipv4_addresses and ipv6_addresses %}    ,
 {% endif %}
-{% if ipv6_loopback_addresses %}
+{% if ipv6_addresses %}
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",

--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -41,7 +41,6 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "src_ip":"{{ ipv4_loopback_addresses | first | ip }}",
             "dst_ip":"{% for prefix in ipv4_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
 {% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "dscp_mode":"uniform",
@@ -61,7 +60,6 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "src_ip":"{{ ipv6_loopback_addresses | first | ip }}",
             "dst_ip":"{% for prefix in ipv6_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
 {% if "mlnx" in DEVICE_METADATA.localhost.platform %}
             "dscp_mode":"uniform",

--- a/src/sonic-config-engine/tests/sample_output/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/ipinip.json
@@ -2,7 +2,6 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "src_ip":"10.1.0.32",
             "dst_ip":"10.1.0.32,10.0.0.56,10.0.0.58,10.0.0.60,10.0.0.62,192.168.0.1",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
@@ -14,7 +13,6 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "src_ip":"fc00:1::32",
             "dst_ip":"fc00:1::32,fc00::71,fc00::75,fc00::79,fc00::7d",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",


### PR DESCRIPTION
**- What I did**
Removed `src_ip` attribute from Decap tunnel

**- How I did it**
Modified the j2 file

**- How to verify it**
`src_ip` not present in the tunnel

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
