### PR TITLE
[lldpd]: Use kernel autoprobe for netlink socket .nl_pid portion of the address

### DIFF
--- a/src/lldpd/patch/0002-Let-linux-kernel-to-find-appropriate-nl_pid-automa.patch
+++ b/src/lldpd/patch/0002-Let-linux-kernel-to-find-appropriate-nl_pid-automa.patch
@@ -1,0 +1,25 @@
+From 2ee8585e8b716719a11235ab5c291b2f6ac9ce1a Mon Sep 17 00:00:00 2001
+From: Pavel Shirshov <pavelsh@microsoft.com>
+Date: Wed, 17 Oct 2018 21:05:58 +0000
+Subject: [PATCH] Let linux kernel to find appropriate nl_pid automatically
+
+---
+ src/daemon/netlink.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/daemon/netlink.c b/src/daemon/netlink.c
+index 1a64a23..f4227b8 100644
+--- a/src/daemon/netlink.c
++++ b/src/daemon/netlink.c
+@@ -93,7 +93,7 @@ netlink_connect(struct lldpd *cfg, int protocol, unsigned groups)
+ 	int s;
+ 	struct sockaddr_nl local = {
+ 		.nl_family = AF_NETLINK,
+-		.nl_pid = getpid(),
++		.nl_pid = 0,
+ 		.nl_groups = groups
+ 	};
+ 
+-- 
+2.7.4
+

--- a/src/lldpd/patch/series
+++ b/src/lldpd/patch/series
@@ -1,2 +1,3 @@
 # This series applies on GIT commit 396961a038a38675d46f96eaa7b430b2a1f8701b
 0001-return-error-when-port-does-not-exist.patch
+0002-Let-linux-kernel-to-find-appropriate-nl_pid-automa.patch


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I added a patch to fix lldpd issue `lldpd[24]: unable to bind netlink socket: Address already in use`.

**- How I did it**
Netlink sockets doesn't support Linux kernel namespaces. So every netlink socket is created in a global namespace. 
Traditionally, when netlink socket is created, the current process pid is used in nl_pid portion of the socket address. When we use docker environment, we could have a lot of processes with the same pid number, but in different docker containers. When we have two processes which create a netlink socket with get_pid() as its address it will create "Address already in use error" error for the second process. To avoid it, it's better to use `.nl_pid = 0` which allows us to avoid such error by autoprobing the most appropriate address.

**- How to verify it**
Build lldp with the patch. Start one lldp process in one docker and another lldp process in another docker. Please make sure that both processes uses the same pid.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
