### PR TITLE
[teamd] Take over the LAG device if it already exists

### DIFF
--- a/dockers/docker-teamd/teamd.sh
+++ b/dockers/docker-teamd/teamd.sh
@@ -6,7 +6,7 @@ function start_app {
     rm -f /var/run/teamd/*
     if [ "$(ls -A $TEAMD_CONF_PATH)" ]; then
         for f in $TEAMD_CONF_PATH/*; do
-            teamd -f $f -d
+            teamd -f $f -d -o
         done
     fi
     teamsyncd &


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I've added an option to allow teamd to reuse LAG interface if it already exist. Usually we need this if teamd crashed and didn't remove the LAG interface.

**- How I did it**
Added `-o` option for teamd start.

**- How to verify it**
1. go inside teamd docker
2.. `kill -9 $teamd_pid'
3. restart teamd - /usr/bin/teamd.sh.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
