### PR TITLE
Set swssconfig.sh startsecs=0 for quick exiting

### DIFF
--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -57,6 +57,7 @@ priority=7
 autostart=false
 autorestart=unexpected
 startretries=0
+startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog
 


### PR DESCRIPTION
The default startsecs is 1 second. However, swssconfig.sh will quickly
exit with expected exit code 0 during warm starting. This case should
not be treated as a failure

Before this fix
```
Oct 22 23:58:45.495722 sonic INFO swss.sh[1688]: 2018-10-22 23:58:45,495 INFO exited: swssconfig (exit status 0; not expected)
Oct 22 23:58:45.496639 sonic INFO swss.sh[1688]: 2018-10-22 23:58:45,496 INFO gave up: swssconfig entered FATAL state, too many start retries too quickly
```

After this fix
```
Oct 23 00:15:52.954857 sonic INFO swss#supervisord 2018-10-23 00:14:50,068 INFO exited: swssconfig (exit status 0; expected)
```
ref: http://supervisord.org/configuration.html