### PR TITLE
[updategraph] Use empty configuration when DHCP graphurl option is missing

### DIFF
--- a/files/dhcp/graphserviceurl
+++ b/files/dhcp/graphserviceurl
@@ -3,7 +3,7 @@ case $reason in
         if [ -n "$new_minigraph_url" ]; then
             echo $new_minigraph_url > /tmp/dhcp_graph_url
         else
-            echo "default" > /tmp/dhcp_graph_url
+            echo "N/A" > /tmp/dhcp_graph_url
         fi
         if [ -n "$new_acl_url" ]; then
             echo $new_acl_url > /tmp/dhcp_acl_url

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -81,16 +81,8 @@ if [ "$src" = "dhcp" ]; then
         sleep 1
     done
 
-    if [ "`cat /tmp/dhcp_graph_url`" = "default" ]; then
-        echo "No graph_url option in DHCP response. Skipping graph update and using existing minigraph."
-        if [ "$dhcp_as_static" = "true" ]; then
-            sed -i "/enabled=/d" /etc/sonic/updategraph.conf
-            echo "enabled=false" >> /etc/sonic/updategraph.conf
-        fi
-        exit 0
-    fi
     if [ "`cat /tmp/dhcp_graph_url`" = "N/A" ]; then
-        echo "'N/A' found in DHCP response. Skipping graph update and generating an empty configuration."
+        echo "No graph_url option in DHCP response. Skipping graph update and generating an empty configuration."
         PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
         if [ -f /etc/sonic/minigraph.xml ]; then
             sonic-cfggen -H -m /etc/sonic/minigraph.xml --preset empty > /tmp/device_meta.json


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
As we no longer use default minigraph now, change the behavior of updategraph service when DHCP server returns no graphurl option from using default minigraph to generate empty configuration.

**- How I did it**
dhclient plugin now write 'N/A' instead of 'default' to /tmp/dhcp_graph_url file when no graphurl option is indicated.
