### PR TITLE
Select dst-ip based on platform

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -1,11 +1,15 @@
 {% set ipv4_addresses = [] %}
 {% set ipv6_addresses = [] %}
+{% set ipv4_loopback_addresses = [] %}
+{% set ipv6_loopback_addresses = [] %}
 {% for (name, prefix) in LOOPBACK_INTERFACE %}
     {%- if prefix | ipv4 and name == 'Loopback0' %}
         {%- set ipv4_addresses = ipv4_addresses.append(prefix) %}
+        {%- set ipv4_loopback_addresses = ipv4_loopback_addresses.append(prefix) %}
     {%- endif %}
     {%- if prefix | ipv6 and name == 'Loopback0' %}
         {%- set ipv6_addresses = ipv6_addresses.append(prefix) %}
+        {%- set ipv6_loopback_addresses = ipv6_loopback_addresses.append(prefix) %}
     {%- endif %}
 {% endfor %}
 {% for (name, prefix) in INTERFACE %}
@@ -33,15 +37,16 @@
     {%- endif %}
 {% endfor %}
 [
-{% if ipv4_addresses %}
+{% if ipv4_loopback_addresses %}
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"{% for prefix in ipv4_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
 {% if "mlnx" in DEVICE_METADATA.localhost.platform %}
+            "dst_ip":"{% for prefix in ipv4_loopback_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %},
             "dscp_mode":"uniform",
             "ecn_mode":"standard",
 {% else %}
+            "dst_ip":"{% for prefix in ipv4_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
 {% endif %}
@@ -50,17 +55,18 @@
         "OP": "SET"
     } 
 {% endif %}
-{% if ipv4_addresses and ipv6_addresses %}    ,
+{% if ipv4_loopback_addresses and ipv6_loopback_addresses %}    ,
 {% endif %}
-{% if ipv6_addresses %}
+{% if ipv6_loopback_addresses %}
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"{% for prefix in ipv6_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
 {% if "mlnx" in DEVICE_METADATA.localhost.platform %}
+            "dst_ip":"{% for prefix in ipv6_loopback_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %},
             "dscp_mode":"uniform",
             "ecn_mode":"standard",
 {% else %}
+            "dst_ip":"{% for prefix in ipv6_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
 {% endif %}


### PR DESCRIPTION
**- What I did**
For tunnel decap, select the dst_ip for tunnel termination based on platform

**- How I did it**
Reverted to original change. PR https://github.com/Azure/sonic-buildimage/pull/2145

**- How to verify it**
-

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
