### PR TITLE
Add missing timestamp in docker meta label tag value

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -9,7 +9,7 @@ SHELL = /bin/bash
 USER = $(shell id -un)
 UID = $(shell id -u)
 GUID = $(shell id -g)
-SONIC_GET_VERSION=$(shell . functions.sh && sonic_get_version)
+SONIC_GET_VERSION=$(shell export BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) && . functions.sh && sonic_get_version)
 
 .SECONDEXPANSION:
 

--- a/slave.mk
+++ b/slave.mk
@@ -9,7 +9,7 @@ SHELL = /bin/bash
 USER = $(shell id -un)
 UID = $(shell id -u)
 GUID = $(shell id -g)
-SONIC_GET_VERSION=$(shell export BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) && . functions.sh && sonic_get_version)
+SONIC_GET_VERSION=$(shell export BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) && export BUILD_NUMBER=$(BUILD_NUMBER) && . functions.sh && sonic_get_version)
 
 .SECONDEXPANSION:
 


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


**- What I did**
Timestamp is missing in tag value of docker meta labels


**- How I did it**
Fixed via adding " export BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)" in SONIC_GET_VERSION 
**- How to verify it**

Before the change, build timestamp was missing for teamd which had been upgraded successfully.

Tag value: **warm-reboot.0-dirty-**

```
root@sonic:/home/admin# sonic_installer upgrade_docker teamd /tmp/docker-teamd.gz 
New docker image will be installed, continue? [y/N]: y
Command: systemctl stop teamd

Command: docker rm teamd 
teamd

Command: docker rmi docker-teamd:latest 
Untagged: docker-teamd:latest

Command: docker load < /tmp/docker-teamd.gz

Command: docker tag docker-teamd:latest docker-teamd:warm-reboot.0-dirty-

Command: systemctl restart teamd

Command: sleep 5

Done
root@sonic:/home/admin# docker inspect --format '{{.ContainerConfig.Labels.Tag}}' teamd

Template parsing error: template: :1:18: executing "" at <.ContainerConfig.Lab...>: map has no entry for key "ContainerConfig"
root@sonic:/home/admin# docker images
REPOSITORY                 TAG                                   IMAGE ID            CREATED             SIZE
docker-teamd               latest                                c534cde941bb        6 minutes ago       336 MB
docker-teamd               warm-reboot.0-dirty-                  c534cde941bb        6 minutes ago       336 MB
docker-syncd-brcm          latest                                5209276f92b1        37 hours ago        369.6 MB
docker-syncd-brcm          warm-reboot.0-dirty-20181023.012010   5209276f92b1        37 hours ago        369.6 MB
docker-orchagent-brcm      latest                                2a5d6b0ca076        37 hours ago        340 MB
docker-orchagent-brcm      warm-reboot.0-dirty-20181023.012010   2a5d6b0ca076        37 hours ago        340 MB
docker-lldp-sv2            latest                                f80049704bc9        37 hours ago        293.9 MB
docker-lldp-sv2            warm-reboot.0-dirty-20181023.012010   f80049704bc9        37 hours ago        293.9 MB
docker-dhcp-relay          latest                                49fffa75673a        37 hours ago        258.4 MB
docker-dhcp-relay          warm-reboot.0-dirty-20181023.012010   49fffa75673a        37 hours ago        258.4 MB
docker-database            latest                                c70129c1fe6c        37 hours ago        255.3 MB
docker-database            warm-reboot.0-dirty-20181023.012010   c70129c1fe6c        37 hours ago        255.3 MB
docker-snmp-sv2            latest                                fc1f5ca2491a        37 hours ago        330.3 MB
docker-snmp-sv2            warm-reboot.0-dirty-20181023.012010   fc1f5ca2491a        37 hours ago        330.3 MB
docker-teamd               warm-reboot.0-dirty-20181023.012010   e74a90da2219        37 hours ago        334.8 MB
docker-sonic-telemetry     latest                                005bec383174        37 hours ago        281.8 MB
docker-sonic-telemetry     warm-reboot.0-dirty-20181023.012010   005bec383174        37 hours ago        281.8 MB
docker-router-advertiser   latest                                10ee59b0e81d        38 hours ago        252.9 MB
docker-router-advertiser   warm-reboot.0-dirty-20181023.012010   10ee59b0e81d        38 hours ago        252.9 MB
docker-platform-monitor    latest                                f81245e6ab9b        38 hours ago        297.1 MB
docker-platform-monitor    warm-reboot.0-dirty-20181023.012010   f81245e6ab9b        38 hours ago        297.1 MB
docker-fpm-frr             latest                                67fd027cfdb0        38 hours ago        360.5 MB
docker-fpm-frr             warm-reboot.0-dirty-20181023.012010   67fd027cfdb0        38 hours ago        360.5 MB

root@sonic:/home/admin# docker inspect --format '{{.ContainerConfig.Labels.Tag}}' c534cde941bb
warm-reboot.0-dirty-
```

After the fix, timestamp is available
Tag value: **warm-reboot.0-dirty-20181024.161252**
```
root@sonic:/home/admin# sonic_installer upgrade_docker teamd /tmp/docker-teamd.gz --cleanup_image  
New docker image will be installed, continue? [y/N]: y
Command: systemctl stop teamd

Command: docker rm teamd 
teamd

Command: docker rmi docker-teamd:latest 
Untagged: docker-teamd:latest

Command: docker load < /tmp/docker-teamd.gz

Command: docker tag docker-teamd:latest docker-teamd:warm-reboot.0-dirty-20181024.161252

Command: systemctl restart teamd

Command: docker rmi -f e74a90da2219
Untagged: docker-teamd:warm-reboot.0-dirty-20181023.012010
Deleted: sha256:e74a90da22194a2d646f74e7367ca02b28273e66c83dd25a2215d97b39255b21
Deleted: sha256:1ac813878856c4e1e9e19242610e740867cf4f31d3c69d854ab91def9afe441e

Command: docker rmi -f c534cde941bb
Untagged: docker-teamd:warm-reboot.0-dirty-
Deleted: sha256:c534cde941bbf0f8e26601fd2de255ac828c24c891c5b0e81d9a2f8fe47a112b
Deleted: sha256:b0951154b2d1ecff2babb76e35605280ad456a31ab46cb641ae575324141778a

Command: sleep 5

Done
root@sonic:/home/admin# 
root@sonic:/home/admin# 
root@sonic:/home/admin# show version
SONiC Software Version: SONiC.warm-reboot.0-dirty-20181023.012010
Distribution: Debian 9.5
Kernel: 4.9.0-7-amd64
Build commit: 58cd733
Build date: Tue Oct 23 09:42:59 UTC 2018
Built by: jipan@sonicvm1

Docker images:
REPOSITORY                 TAG                                   IMAGE ID            SIZE
docker-teamd               latest                                bc751f7593f4        336 MB
docker-teamd               warm-reboot.0-dirty-20181024.161252   bc751f7593f4        336 MB
docker-syncd-brcm          latest                                5209276f92b1        369.6 MB
docker-syncd-brcm          warm-reboot.0-dirty-20181023.012010   5209276f92b1        369.6 MB
docker-orchagent-brcm      latest                                2a5d6b0ca076        340 MB
docker-orchagent-brcm      warm-reboot.0-dirty-20181023.012010   2a5d6b0ca076        340 MB
docker-lldp-sv2            latest                                f80049704bc9        293.9 MB
docker-lldp-sv2            warm-reboot.0-dirty-20181023.012010   f80049704bc9        293.9 MB
docker-dhcp-relay          latest                                49fffa75673a        258.4 MB
docker-dhcp-relay          warm-reboot.0-dirty-20181023.012010   49fffa75673a        258.4 MB
docker-database            latest                                c70129c1fe6c        255.3 MB
docker-database            warm-reboot.0-dirty-20181023.012010   c70129c1fe6c        255.3 MB
docker-snmp-sv2            latest                                fc1f5ca2491a        330.3 MB
docker-snmp-sv2            warm-reboot.0-dirty-20181023.012010   fc1f5ca2491a        330.3 MB
docker-sonic-telemetry     latest                                005bec383174        281.8 MB
docker-sonic-telemetry     warm-reboot.0-dirty-20181023.012010   005bec383174        281.8 MB
docker-router-advertiser   latest                                10ee59b0e81d        252.9 MB
docker-router-advertiser   warm-reboot.0-dirty-20181023.012010   10ee59b0e81d        252.9 MB
docker-platform-monitor    latest                                f81245e6ab9b        297.1 MB
docker-platform-monitor    warm-reboot.0-dirty-20181023.012010   f81245e6ab9b        297.1 MB
docker-fpm-frr             latest                                67fd027cfdb0        360.5 MB
docker-fpm-frr             warm-reboot.0-dirty-20181023.012010   67fd027cfdb0        360.5 MB

root@sonic:/home/admin# docker images
REPOSITORY                 TAG                                   IMAGE ID            CREATED             SIZE
docker-teamd               latest                                bc751f7593f4        2 minutes ago       336 MB
docker-teamd               warm-reboot.0-dirty-20181024.161252   bc751f7593f4        2 minutes ago       336 MB
docker-syncd-brcm          latest                                5209276f92b1        37 hours ago        369.6 MB
docker-syncd-brcm          warm-reboot.0-dirty-20181023.012010   5209276f92b1        37 hours ago        369.6 MB
docker-orchagent-brcm      latest                                2a5d6b0ca076        37 hours ago        340 MB
docker-orchagent-brcm      warm-reboot.0-dirty-20181023.012010   2a5d6b0ca076        37 hours ago        340 MB
docker-lldp-sv2            latest                                f80049704bc9        37 hours ago        293.9 MB
docker-lldp-sv2            warm-reboot.0-dirty-20181023.012010   f80049704bc9        37 hours ago        293.9 MB
docker-dhcp-relay          latest                                49fffa75673a        37 hours ago        258.4 MB
docker-dhcp-relay          warm-reboot.0-dirty-20181023.012010   49fffa75673a        37 hours ago        258.4 MB
docker-database            latest                                c70129c1fe6c        37 hours ago        255.3 MB
docker-database            warm-reboot.0-dirty-20181023.012010   c70129c1fe6c        37 hours ago        255.3 MB
docker-snmp-sv2            latest                                fc1f5ca2491a        37 hours ago        330.3 MB
docker-snmp-sv2            warm-reboot.0-dirty-20181023.012010   fc1f5ca2491a        37 hours ago        330.3 MB
docker-sonic-telemetry     latest                                005bec383174        38 hours ago        281.8 MB
docker-sonic-telemetry     warm-reboot.0-dirty-20181023.012010   005bec383174        38 hours ago        281.8 MB
docker-router-advertiser   latest                                10ee59b0e81d        38 hours ago        252.9 MB
docker-router-advertiser   warm-reboot.0-dirty-20181023.012010   10ee59b0e81d        38 hours ago        252.9 MB
docker-platform-monitor    latest                                f81245e6ab9b        38 hours ago        297.1 MB
docker-platform-monitor    warm-reboot.0-dirty-20181023.012010   f81245e6ab9b        38 hours ago        297.1 MB
docker-fpm-frr             latest                                67fd027cfdb0        38 hours ago        360.5 MB
docker-fpm-frr             warm-reboot.0-dirty-20181023.012010   67fd027cfdb0        38 hours ago        360.5 MB


root@sonic:/home/admin# docker inspect --format '{{.ContainerConfig.Labels.Tag}}' docker-teamd 
warm-reboot.0-dirty-20181024.161252

```