### PR TITLE
Add index column for 7170 port config

### DIFF
--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/port_config.ini
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/port_config.ini
@@ -1,65 +1,65 @@
-# name          lanes             alias             speed 
-Ethernet0       0,1,2,3           Ethernet1/1       100000
-Ethernet4       4,5,6,7           Ethernet2/1       100000
-Ethernet8       8,9,10,11         Ethernet3/1       100000
-Ethernet12      12,13,14,15       Ethernet4/1       100000
-Ethernet16      16,17,18,19       Ethernet5/1       100000
-Ethernet20      20,21,22,23       Ethernet6/1       100000
-Ethernet24      24,25,26,27       Ethernet7/1       100000
-Ethernet28      28,29,30,31       Ethernet8/1       100000
-Ethernet32      32,33,34,35       Ethernet9/1       100000
-Ethernet36      36,37,38,39       Ethernet10/1      100000
-Ethernet40      40,41,42,43       Ethernet11/1      100000
-Ethernet44      44,45,46,47       Ethernet12/1      100000
-Ethernet48      48,49,50,51       Ethernet13/1      100000
-Ethernet52      52,53,54,55       Ethernet14/1      100000
-Ethernet56      56,57,58,59       Ethernet15/1      100000
-Ethernet60      60,61,62,63       Ethernet16/1      100000
-Ethernet64      64,65,66,67       Ethernet17/1      100000
-Ethernet68      68,69,70,71       Ethernet18/1      100000
-Ethernet72      72,73,74,75       Ethernet19/1      100000
-Ethernet76      76,77,78,79       Ethernet20/1      100000
-Ethernet80      80,81,82,83       Ethernet21/1      100000
-Ethernet84      84,85,86,87       Ethernet22/1      100000
-Ethernet88      88,89,90,91       Ethernet23/1      100000
-Ethernet92      92,93,94,95       Ethernet24/1      100000
-Ethernet96      96,97,98,99       Ethernet25/1      100000
-Ethernet100     100,101,102,103   Ethernet26/1      100000
-Ethernet104     104,105,106,107   Ethernet27/1      100000
-Ethernet108     108,109,110,111   Ethernet28/1      100000
-Ethernet112     112,113,114,115   Ethernet29/1      100000
-Ethernet116     116,117,118,119   Ethernet30/1      100000
-Ethernet120     120,121,122,123   Ethernet31/1      100000
-Ethernet124     124,125,126,127   Ethernet32/1      100000
-Ethernet128     128,129,130,131   Ethernet33/1      100000
-Ethernet132     132,133,134,135   Ethernet34/1      100000
-Ethernet136     136,137,138,139   Ethernet35/1      100000
-Ethernet140     140,141,142,143   Ethernet36/1      100000
-Ethernet144     144,145,146,147   Ethernet37/1      100000
-Ethernet148     148,149,150,151   Ethernet38/1      100000
-Ethernet152     152,153,154,155   Ethernet39/1      100000
-Ethernet156     156,157,158,159   Ethernet40/1      100000
-Ethernet160     160,161,162,163   Ethernet41/1      100000
-Ethernet164     164,165,166,167   Ethernet42/1      100000
-Ethernet168     168,169,170,171   Ethernet43/1      100000
-Ethernet172     172,173,174,175   Ethernet44/1      100000
-Ethernet176     176,177,178,179   Ethernet45/1      100000
-Ethernet180     180,181,182,183   Ethernet46/1      100000
-Ethernet184     184,185,186,187   Ethernet47/1      100000
-Ethernet188     188,189,190,191   Ethernet48/1      100000
-Ethernet192     192,193,194,195   Ethernet49/1      100000
-Ethernet196     196,197,198,199   Ethernet50/1      100000
-Ethernet200     200,201,202,203   Ethernet51/1      100000
-Ethernet204     204,205,206,207   Ethernet52/1      100000
-Ethernet208     208,209,210,211   Ethernet53/1      100000
-Ethernet212     212,213,214,215   Ethernet54/1      100000
-Ethernet216     216,217,218,219   Ethernet55/1      100000
-Ethernet220     220,221,222,223   Ethernet56/1      100000
-Ethernet224     224,225,226,227   Ethernet57/1      100000
-Ethernet228     228,229,230,231   Ethernet58/1      100000
-Ethernet232     232,233,234,235   Ethernet59/1      100000
-Ethernet236     236,237,238,239   Ethernet60/1      100000
-Ethernet240     240,241,242,243   Ethernet61/1      100000
-Ethernet244     244,245,246,247   Ethernet62/1      100000
-Ethernet248     248,249,250,251   Ethernet63/1      100000
-Ethernet252     252,253,254,255   Ethernet64/1      100000
+# name          lanes             alias             speed       index
+Ethernet0       0,1,2,3           Ethernet1/1       100000      1
+Ethernet4       4,5,6,7           Ethernet2/1       100000      2
+Ethernet8       8,9,10,11         Ethernet3/1       100000      3
+Ethernet12      12,13,14,15       Ethernet4/1       100000      4
+Ethernet16      16,17,18,19       Ethernet5/1       100000      5
+Ethernet20      20,21,22,23       Ethernet6/1       100000      6
+Ethernet24      24,25,26,27       Ethernet7/1       100000      7
+Ethernet28      28,29,30,31       Ethernet8/1       100000      8
+Ethernet32      32,33,34,35       Ethernet9/1       100000      9
+Ethernet36      36,37,38,39       Ethernet10/1      100000      10
+Ethernet40      40,41,42,43       Ethernet11/1      100000      11
+Ethernet44      44,45,46,47       Ethernet12/1      100000      12
+Ethernet48      48,49,50,51       Ethernet13/1      100000      13
+Ethernet52      52,53,54,55       Ethernet14/1      100000      14
+Ethernet56      56,57,58,59       Ethernet15/1      100000      15
+Ethernet60      60,61,62,63       Ethernet16/1      100000      16
+Ethernet64      64,65,66,67       Ethernet17/1      100000      17
+Ethernet68      68,69,70,71       Ethernet18/1      100000      18
+Ethernet72      72,73,74,75       Ethernet19/1      100000      19
+Ethernet76      76,77,78,79       Ethernet20/1      100000      20
+Ethernet80      80,81,82,83       Ethernet21/1      100000      21
+Ethernet84      84,85,86,87       Ethernet22/1      100000      22
+Ethernet88      88,89,90,91       Ethernet23/1      100000      23
+Ethernet92      92,93,94,95       Ethernet24/1      100000      24
+Ethernet96      96,97,98,99       Ethernet25/1      100000      25
+Ethernet100     100,101,102,103   Ethernet26/1      100000      26
+Ethernet104     104,105,106,107   Ethernet27/1      100000      27
+Ethernet108     108,109,110,111   Ethernet28/1      100000      28
+Ethernet112     112,113,114,115   Ethernet29/1      100000      29
+Ethernet116     116,117,118,119   Ethernet30/1      100000      30
+Ethernet120     120,121,122,123   Ethernet31/1      100000      31
+Ethernet124     124,125,126,127   Ethernet32/1      100000      32
+Ethernet128     128,129,130,131   Ethernet33/1      100000      33
+Ethernet132     132,133,134,135   Ethernet34/1      100000      34
+Ethernet136     136,137,138,139   Ethernet35/1      100000      35
+Ethernet140     140,141,142,143   Ethernet36/1      100000      36
+Ethernet144     144,145,146,147   Ethernet37/1      100000      37
+Ethernet148     148,149,150,151   Ethernet38/1      100000      38
+Ethernet152     152,153,154,155   Ethernet39/1      100000      39
+Ethernet156     156,157,158,159   Ethernet40/1      100000      40
+Ethernet160     160,161,162,163   Ethernet41/1      100000      41
+Ethernet164     164,165,166,167   Ethernet42/1      100000      42
+Ethernet168     168,169,170,171   Ethernet43/1      100000      43
+Ethernet172     172,173,174,175   Ethernet44/1      100000      44
+Ethernet176     176,177,178,179   Ethernet45/1      100000      45
+Ethernet180     180,181,182,183   Ethernet46/1      100000      46
+Ethernet184     184,185,186,187   Ethernet47/1      100000      47
+Ethernet188     188,189,190,191   Ethernet48/1      100000      48
+Ethernet192     192,193,194,195   Ethernet49/1      100000      49
+Ethernet196     196,197,198,199   Ethernet50/1      100000      50
+Ethernet200     200,201,202,203   Ethernet51/1      100000      51
+Ethernet204     204,205,206,207   Ethernet52/1      100000      52
+Ethernet208     208,209,210,211   Ethernet53/1      100000      53
+Ethernet212     212,213,214,215   Ethernet54/1      100000      54
+Ethernet216     216,217,218,219   Ethernet55/1      100000      55
+Ethernet220     220,221,222,223   Ethernet56/1      100000      56
+Ethernet224     224,225,226,227   Ethernet57/1      100000      57
+Ethernet228     228,229,230,231   Ethernet58/1      100000      58
+Ethernet232     232,233,234,235   Ethernet59/1      100000      59
+Ethernet236     236,237,238,239   Ethernet60/1      100000      60
+Ethernet240     240,241,242,243   Ethernet61/1      100000      61
+Ethernet244     244,245,246,247   Ethernet62/1      100000      62
+Ethernet248     248,249,250,251   Ethernet63/1      100000      63
+Ethernet252     252,253,254,255   Ethernet64/1      100000      64


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

sfputilbase isn't very flexible and requires the index column or else it will grab the port number from the speed column.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
