### PR TITLE
[zebra.conf] Avoid zebra crash upon empty configuration

### DIFF
--- a/dockers/docker-fpm-quagga/zebra.conf.j2
+++ b/dockers/docker-fpm-quagga/zebra.conf.j2
@@ -52,7 +52,7 @@ ip route 0.0.0.0/0 {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} 200
 {%   endfor %}
 {% endif %}
 ! Set ip source to loopback for bgp learned routes
-{% if lo_ipv4_addrs|length > 0 %} 
+{% if lo_ipv4_addrs|length > 0 -%} 
 route-map RM_SET_SRC permit 10
     set src {{ lo_ipv4_addrs[0] | ip }}
 !

--- a/dockers/docker-fpm-quagga/zebra.conf.j2
+++ b/dockers/docker-fpm-quagga/zebra.conf.j2
@@ -52,9 +52,11 @@ ip route 0.0.0.0/0 {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} 200
 {%   endfor %}
 {% endif %}
 ! Set ip source to loopback for bgp learned routes
+{% if lo_ipv4_addrs|length > 0 %} 
 route-map RM_SET_SRC permit 10
     set src {{ lo_ipv4_addrs[0] | ip }}
 !
+{% endif %}
 {% if lo_ipv6_addrs|length > 0 %} 
 route-map RM_SET_SRC6 permit 10
     set src {{ lo_ipv6_addrs[0] | ip }}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Current zebra.conf template will generate an invalid configuration file and crash zebra process, when no ipv4 loopback address is defined. Though this will not happen during normal use case, it could cause unexpected zebra crash log when applying 'empty' preset configurations. This change intends to fix this problem.

**- How I did it**
Add check in zebra.conf template similar to what we are doing for ipv6 loopback addresses

