### PR TITLE
Enhanced SupervisorD to exit immediately if one of its managed process get crashed which causes respective docker container to stop.Then container will be restarted gracefully.

### DIFF
--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -45,6 +45,7 @@ RUN mkdir -p /etc/supervisor
 RUN mkdir -p /var/log/supervisor
 
 COPY ["etc/supervisor/supervisord.conf", "/etc/supervisor/"]
+COPY ["etc/supervisor/kill_supervisor.py", "/usr/bin/"]
 
 RUN apt-get -y purge   \
     exim4              \

--- a/dockers/docker-base/etc/supervisor/kill_supervisor.py
+++ b/dockers/docker-base/etc/supervisor/kill_supervisor.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+
+# Please follow the link for documentation: http://supervisord.org/events.html
+# SupervisorD exits immediately if one of its managed process get crashed as it subscribes to "EVENT Listener" process.
+
+import sys
+import os
+import signal
+import subprocess
+
+from supervisor.childutils import listener
+
+def write_stdout(s):
+    # only eventlistener protocol messages may be sent to stdout
+    sys.stdout.write(s)
+    sys.stdout.flush()
+
+def write_stderr(s):
+    sys.stderr.write(s)
+    sys.stderr.flush()
+
+def main():
+    while True:
+        all_service_list = []
+        proc = subprocess.Popen(["supervisorctl avail | cut -d' ' -f1"], shell=True, stdout=subprocess.PIPE)
+        (out, err) = proc.communicate()
+
+        all_service_list = out.split()
+
+        # "exception_service_list" contains all the program excluded  from event listener process.
+        exception_service_list = ["start.sh", "enable_counters", "swssconfig", "arp_update", "ledinit", "fancontrol", "lm-sensors", "ledd", "xcvrd", "configdb-load.sh", "snmpd-config-updater"]
+
+        service_list =  [x for x in all_service_list if x not in exception_service_list]
+        headers, body = listener.wait(sys.stdin, sys.stdout)
+        body = dict([pair.split(":") for pair in body.split(" ")])
+
+        write_stderr("Headers: %r\n" % repr(headers))
+        write_stderr("Body: %r\n" % repr(body))
+
+        process = body["processname"];
+        state = headers["eventname"].split('_')[2];
+        if process in service_list:
+            write_stderr("Process {} got {} !!! Time to kill Supervisord !!!\n".format(process,state))
+            try:
+                pidfile = open('/var/run/supervisord.pid','r')
+                pid = int(pidfile.readline());
+                os.kill(pid, signal.SIGQUIT)
+            except Exception as e:
+                write_stdout('Could not kill supervisor: ' + e.strerror + '\n')
+        else:
+            write_stderr("Process {} got {} !!! But no need to kill Supervisor !!!\n".format(process,state))
+
+        # # transition from READY to ACKNOWLEDGED
+        write_stdout("RESULT 2\nOK")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/dockers/docker-database/supervisord.conf
+++ b/dockers/docker-database/supervisord.conf
@@ -27,3 +27,9 @@ autorestart=false
 startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -65,3 +65,9 @@ stderr_logfile=syslog
 {% endfor %}
 {% endif %}
 {% endif %}
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/dockers/docker-fpm-quagga/supervisord.conf
+++ b/dockers/docker-fpm-quagga/supervisord.conf
@@ -56,3 +56,9 @@ autorestart=false
 startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/dockers/docker-lldp-sv2/supervisord.conf
+++ b/dockers/docker-lldp-sv2/supervisord.conf
@@ -47,3 +47,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -116,3 +116,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/dockers/docker-platform-monitor/supervisord.conf
+++ b/dockers/docker-platform-monitor/supervisord.conf
@@ -54,3 +54,9 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=0
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf
+++ b/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf
@@ -27,3 +27,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/dockers/docker-snmp-sv2/supervisord.conf
+++ b/dockers/docker-snmp-sv2/supervisord.conf
@@ -34,3 +34,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/dockers/docker-sonic-telemetry/supervisord.conf
+++ b/dockers/docker-sonic-telemetry/supervisord.conf
@@ -34,3 +34,9 @@ autostart=false
 autorestart=true
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/dockers/docker-teamd/supervisord.conf
+++ b/dockers/docker-teamd/supervisord.conf
@@ -34,3 +34,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/files/build_templates/database.service.j2
+++ b/files/build_templates/database.service.j2
@@ -9,5 +9,7 @@ ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh attach
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
+Restart=always
+
 [Install]
 WantedBy=multi-user.target

--- a/files/build_templates/dhcp_relay.service.j2
+++ b/files/build_templates/dhcp_relay.service.j2
@@ -9,5 +9,7 @@ ExecStartPre=/usr/bin/{{ docker_container_name }}.sh start
 ExecStart=/usr/bin/{{ docker_container_name }}.sh attach
 ExecStop=/usr/bin/{{ docker_container_name }}.sh stop
 
+Restart=always
+
 [Install]
 WantedBy=multi-user.target teamd.service

--- a/files/build_templates/lldp.service.j2
+++ b/files/build_templates/lldp.service.j2
@@ -9,5 +9,7 @@ ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh attach
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
+Restart=always
+
 [Install]
 WantedBy=multi-user.target

--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -9,5 +9,7 @@ ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh attach
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
+Restart=always
+
 [Install]
 WantedBy=multi-user.target

--- a/files/build_templates/radv.service.j2
+++ b/files/build_templates/radv.service.j2
@@ -9,5 +9,7 @@ ExecStartPre=/usr/bin/{{ docker_container_name }}.sh start
 ExecStart=/usr/bin/{{ docker_container_name }}.sh attach
 ExecStop=/usr/bin/{{ docker_container_name }}.sh stop
 
+Restart=always
+
 [Install]
 WantedBy=multi-user.target

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -7,3 +7,5 @@ After=updategraph.service swss.service
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh attach
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+
+Restart=always

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -15,5 +15,7 @@ Environment=sonic_asic_platform={{ sonic_asic_platform }}
 ExecStart=/usr/local/bin/swss.sh start
 ExecStop=/usr/local/bin/swss.sh stop
 
+Restart=always
+
 [Install]
 WantedBy=multi-user.target

--- a/files/build_templates/syncd.service.j2
+++ b/files/build_templates/syncd.service.j2
@@ -20,5 +20,7 @@ Environment=sonic_asic_platform={{ sonic_asic_platform }}
 ExecStart=/usr/local/bin/syncd.sh start
 ExecStop=/usr/local/bin/syncd.sh stop
 
+Restart=always
+
 [Install]
 WantedBy=multi-user.target

--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -9,5 +9,7 @@ ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh attach
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
+Restart=always
+
 [Install]
 WantedBy=multi-user.target

--- a/files/build_templates/telemetry.service.j2
+++ b/files/build_templates/telemetry.service.j2
@@ -9,5 +9,7 @@ ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh attach
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
+Restart=always
+
 [Install]
 WantedBy=multi-user.target

--- a/platform/barefoot/docker-syncd-bfn/supervisord.conf
+++ b/platform/barefoot/docker-syncd-bfn/supervisord.conf
@@ -27,3 +27,8 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/platform/broadcom/docker-syncd-brcm/supervisord.conf
+++ b/platform/broadcom/docker-syncd-brcm/supervisord.conf
@@ -34,3 +34,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/platform/cavium/docker-syncd-cavm/supervisord.conf
+++ b/platform/cavium/docker-syncd-cavm/supervisord.conf
@@ -26,3 +26,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/platform/centec/docker-syncd-centec/supervisord.conf
+++ b/platform/centec/docker-syncd-centec/supervisord.conf
@@ -26,3 +26,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/platform/marvell/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell/docker-syncd-mrvl/supervisord.conf
@@ -27,3 +27,8 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/platform/mellanox/docker-syncd-mlnx/supervisord.conf
+++ b/platform/mellanox/docker-syncd-mlnx/supervisord.conf
@@ -34,3 +34,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/platform/nephos/docker-syncd-nephos/supervisord.conf
+++ b/platform/nephos/docker-syncd-nephos/supervisord.conf
@@ -26,3 +26,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/platform/vs/docker-sonic-vs/supervisord.conf
+++ b/platform/vs/docker-sonic-vs/supervisord.conf
@@ -154,3 +154,9 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/src/sonic-config-engine/tests/sample_output/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/docker-dhcp-relay.supervisord.conf
@@ -31,3 +31,8 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 
+[eventlistener:kill_supervisor]
+command=/usr/bin/kill_supervisor.py
+events=PROCESS_STATE_STOPPED, PROCESS_STATE_EXITED, PROCESS_STATE_FATAL
+stdout_logfile=syslog
+stderr_logfile=syslog


### PR DESCRIPTION
**- What I did**

- Enhanced SupervisorD to exit immediately if one of its managed process get crashed which causes 
 respective docker container to stop.Then container will be restarted gracefully.

**- Little Background**
 
Supervisor provides a way for a specially written program (which it runs as a subprocess) called an “event listener” to subscribe to “event notifications”. An event notification implies that something happened related to a subprocess controlled by supervisord or to supervisord itself.  

**-How I did it**

SupervisorD now subscribes to "EVENT Listener" process. A Python implementation of a “long-running” event listener which accepts an event notification and kill the supervisord if one of its managed process get crashed. 

**- Some Disclaimer**
- Modified supervisord.conf under syncd docker folder for every platform. Though, I tested it only on Broadcom Platform.

**- How to verify it**

> killed "portmgrd" . As a result of it, swss docker got stopped.

```
admin@lnos-x1-a-asw01:~$ docker exec -it swss bash
root@lnos-x1-a-asw01:/# supervisorctl  status
arp_update                       STOPPED   Not started
buffermgrd                       RUNNING   pid 338, uptime 5:54:06
enable_counters                  EXITED    Oct 29 05:13 PM
intfmgrd                         RUNNING   pid 157, uptime 5:54:09
intfsyncd                        RUNNING   pid 128, uptime 5:54:14
kill_supervisor                  RUNNING   pid 18, uptime 5:54:20
neighsyncd                       RUNNING   pid 131, uptime 5:54:12
orchagent                        RUNNING   pid 47, uptime 5:54:16
portmgrd                         RUNNING   pid 168, uptime 5:54:07
portsyncd                        RUNNING   pid 59, uptime 5:54:15
rsyslogd                         RUNNING   pid 42, uptime 5:54:17
start.sh                         EXITED    Oct 29 05:12 PM
swssconfig                       EXITED    Oct 29 05:12 PM
vlanmgrd                         RUNNING   pid 145, uptime 5:54:10
vrfmgrd                          RUNNING   pid 369, uptime 5:54:04
root@lnos-x1-a-asw01:/# kill 168
root@lnos-x1-a-asw01:/# admin@lnos-x1-a-asw01:~$ 
```
```
admin@lnos-x1-a-asw01:~$ docker ps -a
CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS                     PORTS               NAMES
42ff33678e91        docker-snmp-sv2:latest            "/usr/bin/supervisord"   3 days ago          Up 5 hours                                     snmp
bb88aacbaa88        docker-orchagent-brcm:latest      "/usr/bin/supervisord"   3 days ago          Exited (0) 5 seconds ago                       swss
4070498c4996        docker-syncd-brcm:latest          "/usr/bin/supervisord"   3 days ago          Exited (0) 3 seconds ago                       syncd
b52ea3733065        docker-dhcp-relay:latest          "/usr/bin/docker_init"   3 days ago          Exited (0) 2 seconds ago                       dhcp_relay
41c9bad718e0        docker-router-advertiser:latest   "/usr/bin/supervisord"   3 days ago          Exited (0) 1 seconds ago                       radv
19eefe013033        docker-sonic-telemetry:latest     "/usr/bin/supervisord"   3 days ago          Exited (0) 3 seconds ago                       telemetry
9ef5a032d189        docker-fpm-quagga:latest          "/usr/bin/supervisord"   3 days ago          Up 3 days                                      bgp
ca18b2d768f0        docker-lldp-sv2:latest            "/usr/bin/supervisord"   3 days ago          Up 3 days                                      lldp
5235acdf79d8        docker-platform-monitor:latest    "/usr/bin/supervisord"   3 days ago          Up 3 days                                      pmon
b2ccf545ba86        docker-teamd:latest               "/usr/bin/supervisord"   3 days ago          Up 3 days                                      teamd
b6da9b2fe970        docker-database:latest            "/usr/bin/supervisord"   3 days ago          Up 3 days                                      database
```

> With "restart" features in every service,  swss container got restarted gracefully.
```

admin@lnos-x1-a-asw01:~$ docker ps -a
CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS              PORTS               NAMES
42ff33678e91        docker-snmp-sv2:latest            "/usr/bin/supervisord"   3 days ago          Up 47 seconds                           snmp
bb88aacbaa88        docker-orchagent-brcm:latest      "/usr/bin/supervisord"   3 days ago          Up 45 seconds                           swss
4070498c4996        docker-syncd-brcm:latest          "/usr/bin/supervisord"   3 days ago          Up 42 seconds                           syncd
b52ea3733065        docker-dhcp-relay:latest          "/usr/bin/docker_init"   3 days ago          Up 47 seconds                           dhcp_relay
41c9bad718e0        docker-router-advertiser:latest   "/usr/bin/supervisord"   3 days ago          Up 47 seconds                           radv
19eefe013033        docker-sonic-telemetry:latest     "/usr/bin/supervisord"   3 days ago          Up 47 seconds                           telemetry
9ef5a032d189        docker-fpm-quagga:latest          "/usr/bin/supervisord"   3 days ago          Up 3 days                               bgp
ca18b2d768f0        docker-lldp-sv2:latest            "/usr/bin/supervisord"   3 days ago          Up 3 days                               lldp
5235acdf79d8        docker-platform-monitor:latest    "/usr/bin/supervisord"   3 days ago          Up 3 days                               pmon
b2ccf545ba86        docker-teamd:latest               "/usr/bin/supervisord"   3 days ago          Up 3 days                               teamd
b6da9b2fe970        docker-database:latest            "/usr/bin/supervisord"   3 days ago          Up 3 days                               database
```