### PR TITLE
[build]: support specifying builder mount point and workdir

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -63,9 +63,17 @@ OVERLAY_MODULE_CHECK := lsmod | grep "^overlay " > /dev/null 2>&1 || (echo "ERRO
 
 BUILD_TIMESTAMP := $(shell date +%Y%m%d\.%H%M%S)
 
+ifeq ($(DOCKER_BUILDER_MOUNT),)
+override DOCKER_BUILDER_MOUNT := "$(PWD):/sonic"
+endif
+
+ifeq ($(DOCKER_BUILDER_WORKDIR),)
+override DOCKER_BUILDER_WORKDIR := "/sonic"
+endif
+
 DOCKER_RUN := docker run --rm=true --privileged \
-    -v $(PWD):/sonic \
-    -w /sonic \
+    -v $(DOCKER_BUILDER_MOUNT) \
+    -w $(DOCKER_BUILDER_WORKDIR) \
     -e "http_proxy=$(http_proxy)" \
     -e "https_proxy=$(https_proxy)" \
     -i$(if $(TERM),t,)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

support buildimage repo to be a git submodule

**- How I did it**

If we put this repo as a git submodule of other git repo, `make all` fails because `sonic_get_version()` doesn't work inside a build container.

Inside `sonic_get_version()`, `git describe` commands are executed. To make these command work, `git` command need to access the `.git` directory which is not mounted in a build container.

This commit makes a build container mount a parent git directory to give access to the `.git` directory if this repo is a git submodule.

**- How to verify it**

make this repo git submodule and run `make all`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
