### PR TITLE
[build]: add build option to use native docker instead of dind for build

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -70,6 +70,12 @@ DOCKER_RUN := docker run --rm=true --privileged \
     -e "https_proxy=$(https_proxy)" \
     -i$(if $(TERM),t,)
 
+include rules/config
+
+ifeq ($(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD), y)
+    DOCKER_RUN += -v /var/run/docker.sock:/var/run/docker.sock
+endif
+
 DOCKER_BASE_BUILD = docker build --no-cache \
 		    -t $(SLAVE_BASE_IMAGE) \
 		    --build-arg http_proxy=$(http_proxy) \

--- a/rules/config
+++ b/rules/config
@@ -16,6 +16,10 @@ SONIC_CONFIG_BUILD_JOBS = 1
 # Corresponding -j argument will be passed to make/dpkg commands that build separate packages
 SONIC_CONFIG_MAKE_JOBS = $(shell nproc)
 
+# SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD - use native dockerd for build.
+# If set to y SONiC build container will use native dockerd instead of dind for faster build
+# SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD = y
+
 # SONIC_CONFIG_ENABLE_COLORS - enable colored output in build system.
 # Comment next line to disable:
 # SONIC_CONFIG_ENABLE_COLORS = y

--- a/slave.mk
+++ b/slave.mk
@@ -389,7 +389,7 @@ $(SONIC_INSTALL_WHEELS) : $(PYTHON_WHEELS_PATH)/%-install : .platform $$(addsuff
 docker-start :
 	@sudo sed -i '/http_proxy/d' /etc/default/docker
 	@sudo bash -c "echo \"export http_proxy=$$http_proxy\" >> /etc/default/docker"
-	@sudo service docker status &> /dev/null || ( sudo service docker start &> /dev/null && sleep 1 )
+	@test $(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) != "y" && sudo service docker status &> /dev/null || ( sudo service docker start &> /dev/null && sleep 1 )
 
 # targets for building simple docker images that do not depend on any debian packages
 $(addprefix $(TARGET_PATH)/, $(SONIC_SIMPLE_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform docker-start $$(addsuffix -load,$$(addprefix $(TARGET_PATH)/,$$($$*.gz_LOAD_DOCKERS)))


### PR DESCRIPTION


Signed-off-by: Wataru Ishida <ishida@nel-america.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add a build option to use native dockerd instead of dind for faster build.

related PR : https://github.com/Azure/sonic-buildimage/pull/2016

Also, I found an issue pointing out the slowness of `vfs` storage driver.
It seems they fixed it by changing the driver to `overlay`.

https://github.com/Azure/draft/issues/181

**- How I did it**

mount /var/run/docker.sock in build container

**- How to verify it**

Add following to `rules/config`

```
SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD = y
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
