### PR TITLE
Add carrier change (oper state) for bf_tun tap intf

### DIFF
--- a/platform/barefoot/bfn-modules/modules/bf_tun.c
+++ b/platform/barefoot/bfn-modules/modules/bf_tun.c
@@ -1073,6 +1073,7 @@ static const struct net_device_ops tap_netdev_ops = {
 	.ndo_features_check	= passthru_features_check,
 	.ndo_set_rx_headroom	= tun_set_headroom,
 	.ndo_get_stats64	= tun_net_get_stats64,
+	.ndo_change_carrier	= tun_change_carrier,
 };
 
 static void tun_flow_init(struct tun_struct *tun)


### PR DESCRIPTION
**- What I did**
Fix bf tun driver to allow changing oper state for tap devices

**- How I did it**
Add carrier change method for tap devices

**- How to verify it**
ip link show <EthernetXX> for unconnected ports should not show LOWER_UP

**- Description for the changelog**
Modify bf_tun driver to allow oper state change for tap interfaces


**- A picture of a cute animal (not mandatory but encouraged)**
