### PR TITLE
[console speed] lock console speed to start up speed

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -85,6 +85,19 @@ update_mgmt_interface_macaddr() {
     sed -i "/eth0/ s/ATTR{address}==\"$old_mac\"/ATTR{address}==\"$new_mac\"/g" /etc/udev/rules.d/70-persistent-net.rules
 }
 
+program_console_speed()
+{
+    speed=$(cat /proc/cmdline | grep -Eo 'console=ttyS[0-9]+,[0-9]+' | cut -d "," -f2)
+    if [ -z "$speed" ]; then
+        CONSOLE_SPEED=9600
+    else
+        CONSOLE_SPEED=$speed
+    fi
+
+    sed -i "s|\-\-keep\-baud .* %I| $CONSOLE_SPEED %I|g" /lib/systemd/system/serial-getty@.service
+    systemctl daemon-reload
+}
+
 # If the machine.conf is absent, it indicates that the unit booted
 # into SONiC from another NOS. Extract the machine.conf from ONIE.
 if [ ! -e /host/machine.conf ]; then
@@ -184,6 +197,8 @@ done
 }
 
 eval sonic_version=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
+
+program_console_speed
 
 if [ -f /host/image-$sonic_version/platform/firsttime ]; then
 


### PR DESCRIPTION

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
Auto negotiating console speed could cause sonic to lock on a wrong
speed under rare conditions. The only way to come out of the wrong
speed is to issue line break or restart console service with forced
speed, or reboot sonic.

Lock down the console speed to avoid these situations.

**- How to verify it**
Boot up and check console service is using fixed baud rate.
Passed continuous reboot test.