### PR TITLE
[vs]: Add missing packages to speed up build process

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -42,7 +42,10 @@ RUN apt-get install -y net-tools \
                        python-tabulate \
                        bash-completion \
                        libelf1 \
-                       libmnl0
+                       libmnl0 \
+                       logrotate \
+                       apt-utils \
+                       psmisc
 
 RUN pip install setuptools
 RUN pip install py2_ipaddress


### PR DESCRIPTION
Add logrotate, apt-utils, psmics packages to speed up
build process.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>