### PR TITLE
Update go version to 1.11.2 for gobgp and telemetry

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -250,7 +250,7 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get -y build-dep linux
 
 # For gobgp build
-RUN export VERSION=1.8.3 \
+RUN export VERSION=1.11.2 \
  && wget https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz \
  && tar -C /usr/local -xzf go$VERSION.linux-amd64.tar.gz \
  && echo 'export GOROOT=/usr/local/go' >> /etc/bash.bashrc \

--- a/src/gobgp/Makefile
+++ b/src/gobgp/Makefile
@@ -5,10 +5,10 @@ INSTALL := /usr/bin/install
 all: gobgp gobgpd
 
 gobgpd:
-	go get -v github.com/osrg/gobgp/gobgpd
+	/usr/local/go/bin/go get -v github.com/osrg/gobgp/cmd/gobgpd
 
 gobgp:
-	go get -v github.com/osrg/gobgp/gobgp
+	/usr/local/go/bin/go get -v github.com/osrg/gobgp/cmd/gobgp
 
 install:
 	$(INSTALL) -D ${GOPATH}/bin/gobgp $(DESTDIR)/usr/bin/gobgp


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


**- What I did**

Address issue: https://github.com/Azure/sonic-buildimage/issues/2229

Update go version to 1.11.1  and fix gobgp build

gobgp requires go 1.10 or newer. 
```
To start developing GoBGP
You need a working Go environment (1.10 or newer).
```

Eventually we need go package version control like glide.
May extract this change with one PR: https://github.com/Azure/sonic-telemetry/pull/14/commits/c079dbd37cf66ba8fb12f345642c186ee35a466f

**- How I did it**


**- How to verify it**
make  target/debs/gobgp_1.16-01_amd64.deb
make target/debs/sonic-telemetry_0.1_amd64.deb
**- Description for the changelog**
