### PR TITLE
[warm boot] restore log level DB during warm reboot

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -48,6 +48,8 @@ function postStartAction()
         redisLoadAndDelete 6 $WARM_DIR/state_db.json
         # Load asicDB from /host/warm-reboot/asic_db.json
         redisLoadAndDelete 1 $WARM_DIR/asic_db.json
+        # Load loglevelDB from /host/warm-reboot/loglevel_db.json
+        redisLoadAndDelete 3 $WARM_DIR/loglevel_db.json
     fi
 {%- elif docker_container_name == "swss" %}
     docker exec swss rm -f /ready   # remove cruft


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
Restore log level DB during warm boot.

**- How to verify it**
In system level warm boot test, change a component log to different level before initiating warm boot, after warm boot, the same level of logging are observed from syslog and the level was persisted across the warm boot.

(Full test requires sonic-utilities PR 369)