### PR TITLE
[mlnx] Fix fast reboot

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -70,7 +70,7 @@ start() {
 
         # platform specific tasks
         if [ x$sonic_asic_platform == x'mellanox' ]; then
-            FAST_BOOT=1
+            export FAST_BOOT=1
             /usr/bin/mst start
             /usr/bin/mlnx-fw-upgrade.sh
             /etc/init.d/sxdkernel start


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed fast reboot

**- How I did it**
```sxdkernel start``` will reset ASIC if no FAST_BOOT=1 in environment and will cause longer DP disruption.

From fast reboot test log:
```Downtime must be less then 30 seconds. It was 0:00:34.221790```

**- How to verify it**
Run fast reboot ansible test. Measure downtime

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
