### PR TITLE
[syncd] extend syncd service script to support both warm/cold shutdown

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -96,17 +96,21 @@ stop() {
     debug "Warm boot flag: ${SERVICE} ${WARM_BOOT}."
 
     if [[ x"$WARM_BOOT" == x"true" ]]; then
-        debug "Warm shutdown syncd process ..."
-        /usr/bin/docker exec -i syncd /usr/bin/syncd_request_shutdown --warm
-
-        # wait until syncd quits gracefully
-        while docker top syncd | grep -q /usr/bin/syncd; do
-            sleep 0.1
-        done
-
-        /usr/bin/docker exec -i syncd /bin/sync
-        debug "Finished warm shutdown syncd process ..."
+        TYPE=warm
+    else
+        TYPE=cold
     fi
+
+    debug "${TYPE} shutdown syncd process ..."
+    /usr/bin/docker exec -i syncd /usr/bin/syncd_request_shutdown --${TYPE}
+
+    # wait until syncd quits gracefully
+    while docker top syncd | grep -q /usr/bin/syncd; do
+        sleep 0.1
+    done
+
+    /usr/bin/docker exec -i syncd /bin/sync
+    debug "Finished ${TYPE} shutdown syncd process ..."
 
     /usr/bin/${SERVICE}.sh stop
     debug "Stopped ${SERVICE} service..."


### PR DESCRIPTION
- cold shutdown is used by regular service stop and/or fast reboot
- warm shutdown is used by warm restart and/or warm reboot

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
Move syncd shutdown knowledge to syncd service script. So that there is no more special handling for syncd service in normal/fast-reboot/warm-reboot cases.

**- How to verify it**
Regular service stop:
command: service swss stop

Thu Nov 8 16:50:40 UTC 2018 - Stopping swss service...
Thu Nov 8 16:50:40 UTC 2018 - Locking /tmp/swss-syncd-lock from swss service
Thu Nov 8 16:50:40 UTC 2018 - Locked /tmp/swss-syncd-lock (10) from swss service
Thu Nov 8 16:50:40 UTC 2018 - Warm boot flag: swss false.
Thu Nov 8 16:50:42 UTC 2018 - Stopped swss service...
Thu Nov 8 16:50:42 UTC 2018 - Unlocking /tmp/swss-syncd-lock (10) from swss service
Thu Nov 8 16:50:42 UTC 2018 - Stopping syncd service...
Thu Nov 8 16:50:42 UTC 2018 - Locking /tmp/swss-syncd-lock from syncd service
Thu Nov 8 16:50:42 UTC 2018 - Locked /tmp/swss-syncd-lock (10) from syncd service
Thu Nov 8 16:50:42 UTC 2018 - Warm boot flag: syncd false.
Thu Nov 8 16:50:42 UTC 2018 - cold shutdown syncd process ...
Thu Nov 8 16:50:46 UTC 2018 - Finished cold shutdown syncd process ...
Thu Nov 8 16:50:48 UTC 2018 - Stopped syncd service...
Thu Nov 8 16:50:48 UTC 2018 - Unlocking /tmp/swss-syncd-lock (10) from syncd service

Warm stop syncd (simulating syncd warm restart):
commands:
config warm_restart enable system
service syncd stop

Thu Nov 8 16:53:19 UTC 2018 - Stopping syncd service...
Thu Nov 8 16:53:19 UTC 2018 - Locking /tmp/swss-syncd-lock from syncd service
Thu Nov 8 16:53:19 UTC 2018 - Locked /tmp/swss-syncd-lock (10) from syncd service
Thu Nov 8 16:53:19 UTC 2018 - Warm boot flag: syncd true.
Thu Nov 8 16:53:19 UTC 2018 - warm shutdown syncd process ...
Thu Nov 8 16:53:44 UTC 2018 - Finished warm shutdown syncd process ...
Thu Nov 8 16:53:46 UTC 2018 - Stopped syncd service...
Thu Nov 8 16:53:46 UTC 2018 - Unlocking /tmp/swss-syncd-lock (10) from syncd service

fast-reboot simulation: docker kill swss

Thu Nov 8 16:55:27 UTC 2018 - Stopping swss service...
Thu Nov 8 16:55:27 UTC 2018 - Locking /tmp/swss-syncd-lock from swss service
Thu Nov 8 16:55:27 UTC 2018 - Locked /tmp/swss-syncd-lock (10) from swss service
Thu Nov 8 16:55:27 UTC 2018 - Warm boot flag: swss false.
Thu Nov 8 16:55:27 UTC 2018 - Stopped swss service...
Thu Nov 8 16:55:27 UTC 2018 - Unlocking /tmp/swss-syncd-lock (10) from swss service
Thu Nov 8 16:55:27 UTC 2018 - Stopping syncd service...
Thu Nov 8 16:55:27 UTC 2018 - Locking /tmp/swss-syncd-lock from syncd service
Thu Nov 8 16:55:27 UTC 2018 - Locked /tmp/swss-syncd-lock (10) from syncd service
Thu Nov 8 16:55:28 UTC 2018 - Warm boot flag: syncd false.
Thu Nov 8 16:55:28 UTC 2018 - cold shutdown syncd process ...
Thu Nov 8 16:55:28 UTC 2018 - Finished cold shutdown syncd process ...
Thu Nov 8 16:55:30 UTC 2018 - Stopped syncd service...
Thu Nov 8 16:55:30 UTC 2018 - Unlocking /tmp/swss-syncd-lock (10) from syncd service

full system warm-reboot simulation (swss service left syncd alone, syncd service will be stopped later):
commands:
config warm_restart enable system
docker kill swss

Thu Nov 8 16:56:56 UTC 2018 - Stopping swss service...
Thu Nov 8 16:56:56 UTC 2018 - Locking /tmp/swss-syncd-lock from swss service
Thu Nov 8 16:56:56 UTC 2018 - Locked /tmp/swss-syncd-lock (10) from swss service
Thu Nov 8 16:56:56 UTC 2018 - Warm boot flag: swss true.
Thu Nov 8 16:56:56 UTC 2018 - Stopped swss service...
Thu Nov 8 16:56:56 UTC 2018 - Unlocking /tmp/swss-syncd-lock (10) from swss service
