### PR TITLE
Fix teamd behavior for Warm-reboot mode

### DIFF
--- a/src/libteam/0005-libteam-Add-warm_reboot-mode.patch
+++ b/src/libteam/0005-libteam-Add-warm_reboot-mode.patch
@@ -157,7 +157,7 @@ index 5c2ef56..50e5a08 100644
  			   struct teamd_port *tdport)
  {
 diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
-index 81324de..6087c0d 100644
+index 81324de..519f5e2 100644
 --- a/teamd/teamd_runner_lacp.c
 +++ b/teamd/teamd_runner_lacp.c
 @@ -174,6 +174,8 @@ struct lacp_port {
@@ -258,7 +258,7 @@ index 81324de..6087c0d 100644
 +	strcat(filename, lacp_port->tdport->ifname);
 +
 +	/* check that file is readable. if there is no file, don't do anything */
-+	if (access(ctx->lacp_directory, R_OK) != 0) {
++	if (access(filename, R_OK) != 0) {
 +		return 0;
 +	}
 +

--- a/src/libteam/0005-libteam-Add-warm_reboot-mode.patch
+++ b/src/libteam/0005-libteam-Add-warm_reboot-mode.patch
@@ -157,20 +157,19 @@ index 5c2ef56..50e5a08 100644
  			   struct teamd_port *tdport)
  {
 diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
-index 81324de..829b02f 100644
+index 81324de..6087c0d 100644
 --- a/teamd/teamd_runner_lacp.c
 +++ b/teamd/teamd_runner_lacp.c
-@@ -174,6 +174,9 @@ struct lacp_port {
+@@ -174,6 +174,8 @@ struct lacp_port {
  	struct lacp_port *agg_lead; /* leading port of aggregator.
  				     * NULL in case this port is not selected */
  	enum lacp_port_state state;
 +	bool lacpdu_saved;
 +	struct lacpdu last_pdu;
-+	bool has_read;
  	struct {
  		uint32_t speed;
  		uint8_t	duplex;
-@@ -994,6 +997,13 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
+@@ -994,6 +996,13 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
  		break;
  	}
  
@@ -184,7 +183,7 @@ index 81324de..829b02f 100644
  	teamd_log_info("%s: Changed port state: \"%s\" -> \"%s\"",
  		       lacp_port->tdport->ifname,
  		       lacp_port_state_name[lacp_port->state],
-@@ -1084,26 +1094,23 @@ static int lacpdu_send(struct lacp_port *lacp_port)
+@@ -1084,26 +1093,23 @@ static int lacpdu_send(struct lacp_port *lacp_port)
  	return err;
  }
  
@@ -219,7 +218,7 @@ index 81324de..829b02f 100644
  		err = lacp_port_partner_update(lacp_port);
  		if (err)
  			return err;
-@@ -1118,7 +1125,7 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
+@@ -1118,7 +1124,7 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
  
  	/* Check if the other side has correct info about us */
  	if (!lacp_port->periodic_on &&
@@ -228,7 +227,7 @@ index 81324de..829b02f 100644
  		   sizeof(struct lacpdu_info))) {
  		err = lacpdu_send(lacp_port);
  		if (err)
-@@ -1133,6 +1140,53 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
+@@ -1133,6 +1139,59 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
  	return 0;
  }
  
@@ -257,6 +256,12 @@ index 81324de..829b02f 100644
 +	if (filename[strlen(filename) - 1] != '/')
 +		strcat(filename, "/"); /* Add trailing slash if we don't have one in the filename */
 +	strcat(filename, lacp_port->tdport->ifname);
++
++	/* check that file is readable. if there is no file, don't do anything */
++	if (access(ctx->lacp_directory, R_OK) != 0) {
++		return 0;
++	}
++
 +	fp = fopen(filename, "r");
 +	if (!fp) {
 +		teamd_log_err("Can't open lacp-saved dump from file %s: %s", filename, strerror(errno));
@@ -282,21 +287,20 @@ index 81324de..829b02f 100644
  static int lacp_callback_timeout(struct teamd_context *ctx, int events,
  				 void *priv)
  {
-@@ -1299,6 +1353,13 @@ static int lacp_port_added(struct teamd_context *ctx,
+@@ -1299,6 +1358,12 @@ static int lacp_port_added(struct teamd_context *ctx,
  	lacp_port_actor_init(lacp_port);
  	lacp_port_link_update(lacp_port);
  
 +	/* Read data from file and process it */
-+	if (ctx->warm_start && !lacp_port->has_read && ctx->lacp_directory) {
++	if (ctx->warm_start && ctx->lacp_directory) {
 +		(void)lacpdu_read(lacp_port);
-+		lacp_port->has_read = true;
 +		/* Once started, keep running in normal mode */
 +	}
 +
  	teamd_loop_callback_enable(ctx, LACP_SOCKET_CB_NAME, lacp_port);
  	return 0;
  
-@@ -1321,7 +1382,11 @@ static void lacp_port_removed(struct teamd_context *ctx,
+@@ -1321,7 +1386,11 @@ static void lacp_port_removed(struct teamd_context *ctx,
  {
  	struct lacp_port *lacp_port = priv;
  
@@ -309,7 +313,7 @@ index 81324de..829b02f 100644
  	teamd_loop_callback_del(ctx, LACP_TIMEOUT_CB_NAME, lacp_port);
  	teamd_loop_callback_del(ctx, LACP_PERIODIC_CB_NAME, lacp_port);
  	teamd_loop_callback_del(ctx, LACP_SOCKET_CB_NAME, lacp_port);
-@@ -1413,6 +1478,31 @@ static void lacp_event_watch_refresh(struct teamd_context *ctx, struct teamd_por
+@@ -1413,6 +1482,31 @@ static void lacp_event_watch_refresh(struct teamd_context *ctx, struct teamd_por
  		(void) lacpdu_send(lacp_port);
  }
  
@@ -341,7 +345,7 @@ index 81324de..829b02f 100644
  static const struct teamd_event_watch_ops lacp_event_watch_ops = {
  	.hwaddr_changed = lacp_event_watch_hwaddr_changed,
  	.port_added = lacp_event_watch_port_added,
-@@ -1420,6 +1510,7 @@ static const struct teamd_event_watch_ops lacp_event_watch_ops = {
+@@ -1420,6 +1514,7 @@ static const struct teamd_event_watch_ops lacp_event_watch_ops = {
  	.port_changed = lacp_event_watch_port_changed,
  	.admin_state_changed = lacp_event_watch_admin_state_changed,
  	.refresh = lacp_event_watch_refresh,
@@ -349,7 +353,7 @@ index 81324de..829b02f 100644
  };
  
  static int lacp_carrier_init(struct teamd_context *ctx, struct lacp *lacp)
-@@ -1946,7 +2037,7 @@ static void lacp_fini(struct teamd_context *ctx, void *priv)
+@@ -1946,7 +2041,7 @@ static void lacp_fini(struct teamd_context *ctx, void *priv)
  	teamd_state_val_unregister(ctx, &lacp_state_vg, lacp);
  	teamd_balancer_fini(lacp->tb);
  	teamd_event_watch_unregister(ctx, &lacp_event_watch_ops, lacp);

--- a/src/libteam/0005-libteam-Add-warm_reboot-mode.patch
+++ b/src/libteam/0005-libteam-Add-warm_reboot-mode.patch
@@ -157,19 +157,34 @@ index 5c2ef56..50e5a08 100644
  			   struct teamd_port *tdport)
  {
 diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
-index 81324de..1d908db 100644
+index 81324de..829b02f 100644
 --- a/teamd/teamd_runner_lacp.c
 +++ b/teamd/teamd_runner_lacp.c
-@@ -174,6 +174,8 @@ struct lacp_port {
+@@ -174,6 +174,9 @@ struct lacp_port {
  	struct lacp_port *agg_lead; /* leading port of aggregator.
  				     * NULL in case this port is not selected */
  	enum lacp_port_state state;
 +	bool lacpdu_saved;
 +	struct lacpdu last_pdu;
++	bool has_read;
  	struct {
  		uint32_t speed;
  		uint8_t	duplex;
-@@ -1084,26 +1086,23 @@ static int lacpdu_send(struct lacp_port *lacp_port)
+@@ -994,6 +997,13 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
+ 		break;
+ 	}
+ 
++	if (new_state != PORT_STATE_CURRENT) {
++		/* clean saved lacp pdu up when the current port:
++		   disabled, expired, or defaulted */
++		(void)memset(&lacp_port->last_pdu, 0, sizeof(struct lacpdu));
++		lacp_port->lacpdu_saved = false;
++	}
++
+ 	teamd_log_info("%s: Changed port state: \"%s\" -> \"%s\"",
+ 		       lacp_port->tdport->ifname,
+ 		       lacp_port_state_name[lacp_port->state],
+@@ -1084,26 +1094,23 @@ static int lacpdu_send(struct lacp_port *lacp_port)
  	return err;
  }
  
@@ -204,7 +219,7 @@ index 81324de..1d908db 100644
  		err = lacp_port_partner_update(lacp_port);
  		if (err)
  			return err;
-@@ -1118,7 +1117,7 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
+@@ -1118,7 +1125,7 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
  
  	/* Check if the other side has correct info about us */
  	if (!lacp_port->periodic_on &&
@@ -213,7 +228,7 @@ index 81324de..1d908db 100644
  		   sizeof(struct lacpdu_info))) {
  		err = lacpdu_send(lacp_port);
  		if (err)
-@@ -1133,6 +1132,53 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
+@@ -1133,6 +1140,53 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
  	return 0;
  }
  
@@ -267,21 +282,21 @@ index 81324de..1d908db 100644
  static int lacp_callback_timeout(struct teamd_context *ctx, int events,
  				 void *priv)
  {
-@@ -1299,6 +1345,13 @@ static int lacp_port_added(struct teamd_context *ctx,
+@@ -1299,6 +1353,13 @@ static int lacp_port_added(struct teamd_context *ctx,
  	lacp_port_actor_init(lacp_port);
  	lacp_port_link_update(lacp_port);
  
 +	/* Read data from file and process it */
-+	if (ctx->warm_start && ctx->lacp_directory) {
++	if (ctx->warm_start && !lacp_port->has_read && ctx->lacp_directory) {
 +		(void)lacpdu_read(lacp_port);
-+		ctx->warm_start = false; 
++		lacp_port->has_read = true;
 +		/* Once started, keep running in normal mode */
 +	}
 +
  	teamd_loop_callback_enable(ctx, LACP_SOCKET_CB_NAME, lacp_port);
  	return 0;
  
-@@ -1321,7 +1374,11 @@ static void lacp_port_removed(struct teamd_context *ctx,
+@@ -1321,7 +1382,11 @@ static void lacp_port_removed(struct teamd_context *ctx,
  {
  	struct lacp_port *lacp_port = priv;
  
@@ -294,7 +309,7 @@ index 81324de..1d908db 100644
  	teamd_loop_callback_del(ctx, LACP_TIMEOUT_CB_NAME, lacp_port);
  	teamd_loop_callback_del(ctx, LACP_PERIODIC_CB_NAME, lacp_port);
  	teamd_loop_callback_del(ctx, LACP_SOCKET_CB_NAME, lacp_port);
-@@ -1413,6 +1470,31 @@ static void lacp_event_watch_refresh(struct teamd_context *ctx, struct teamd_por
+@@ -1413,6 +1478,31 @@ static void lacp_event_watch_refresh(struct teamd_context *ctx, struct teamd_por
  		(void) lacpdu_send(lacp_port);
  }
  
@@ -326,7 +341,7 @@ index 81324de..1d908db 100644
  static const struct teamd_event_watch_ops lacp_event_watch_ops = {
  	.hwaddr_changed = lacp_event_watch_hwaddr_changed,
  	.port_added = lacp_event_watch_port_added,
-@@ -1420,6 +1502,7 @@ static const struct teamd_event_watch_ops lacp_event_watch_ops = {
+@@ -1420,6 +1510,7 @@ static const struct teamd_event_watch_ops lacp_event_watch_ops = {
  	.port_changed = lacp_event_watch_port_changed,
  	.admin_state_changed = lacp_event_watch_admin_state_changed,
  	.refresh = lacp_event_watch_refresh,
@@ -334,7 +349,7 @@ index 81324de..1d908db 100644
  };
  
  static int lacp_carrier_init(struct teamd_context *ctx, struct lacp *lacp)
-@@ -1946,7 +2029,7 @@ static void lacp_fini(struct teamd_context *ctx, void *priv)
+@@ -1946,7 +2037,7 @@ static void lacp_fini(struct teamd_context *ctx, void *priv)
  	teamd_state_val_unregister(ctx, &lacp_state_vg, lacp);
  	teamd_balancer_fini(lacp->tb);
  	teamd_event_watch_unregister(ctx, &lacp_event_watch_ops, lacp);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix bugs:
1. Only one port read a saved lacp pdu in the previous teamd patch.
2. teamd kept last received lacp pdu when the port was disabled, or expired

**- How I did it**
1. Add a variable has_read in lacp_port structure. When we read lacp_pdu from the disk, set that variable into true and don't reread already removed file again.
2 When port goes from CURRENT state to any other, clean saved lacp pdu.

**- How to verify it**
Build teamd and run it on your DUT.

To check for the first bug fix - check that teamd removed all lacp pdu files for the LAG
To check for the second - check that teamd will not save anything, if you put a port into disabled state.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
