### PR TITLE
Fix bug: stop/kill swss container will drag down syncd

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -106,7 +106,8 @@ start() {
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         /bin/systemctl start ${PEER}
     fi
-    /usr/bin/${SERVICE}.sh attach
+    /usr/bin/${SERVICE}.sh attach || debug "Docker ${SERVICE} exited with $?"
+    /usr/bin/${PEER}.sh attach || debug "Docker ${PEER} exited with $?"
 }
 
 stop() {


### PR DESCRIPTION
Signed-off-by: Qi Luo <qiluo-msft@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The swss service include two docker container: swss and syncd. In below situations,
- docker kill swss
- docker stop swss

We should treat the service as 'active (running)' state. Currently it will drag down syncd container, and mark the service as 'failed (Result: exit-code)' state with '(code=exited, status=137)'.

PS. 137 is the killing return value.
ref: http://tldp.org/LDP/abs/html/exitcodes.html

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
