### PR TITLE
[sudoers] Add 'SONIC_CLI_IFACE_MODE' to env_keep to ensure variable is made available to sudo calls

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -9,6 +9,7 @@
 Defaults        env_reset
 #Defaults        mail_badpass
 Defaults        secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults        env_keep += "SONIC_CLI_IFACE_MODE"
 Defaults        env_keep += "VTYSH_PAGER"
 Defaults        lecture_file = /etc/sudoers.lecture
 


### PR DESCRIPTION
Calling `config` commands requires elevated privileges. This change ensures that the `SONIC_CLI_IFACE_MODE` environment variable is kept in the environment when calling commands using `sudo`.