### PR TITLE
[teamd]: Add teamd.sh start script to clean up STATE database

### DIFF
--- a/dockers/docker-teamd/start.sh
+++ b/dockers/docker-teamd/start.sh
@@ -3,6 +3,12 @@
 rm -f /var/run/rsyslogd.pid
 rm -f /var/run/teamd/*
 
+if [[ x"$WARM_BOOT" != x"true" ]]; then
+    for pc in `ip link show | grep PortChannel | awk -F "[ :]" '{print $3}'`;
+        do ip link delete dev $pc
+    done
+fi
+
 mkdir -p /var/warmboot/teamd
 
 supervisorctl start rsyslogd

--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -5,9 +5,8 @@ After=updategraph.service
 
 [Service]
 User={{ sonicadmin_user }}
-ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
-ExecStart=/usr/bin/{{docker_container_name}}.sh attach
-ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+ExecStart=/usr/local/bin/{{docker_container_name}}.sh attach
+ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop
 
 [Install]
 WantedBy=multi-user.target

--- a/files/scripts/teamd.sh
+++ b/files/scripts/teamd.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+SERVICE="teamd"
+DEBUGLOG="/tmp/teamd-debug.log"
+
+function debug()
+{
+    /bin/echo `date` "- $1" >> ${DEBUGLOG}
+}
+
+function wait_for_database_service()
+{
+    # Wait for redis server start before database clean
+    until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]];
+        do sleep 1;
+    done
+
+    # Wait for configDB initialization
+    until [[ $(/usr/bin/docker exec database redis-cli -n 4 GET "CONFIG_DB_INITIALIZED") ]];
+        do sleep 1;
+    done
+}
+
+function clean_up_tables()
+{
+    redis-cli -n $1 EVAL "
+    local tables = {$2}
+    for i = 1, table.getn(tables) do
+        local matches = redis.call('KEYS', tables[i])
+        for j,name in ipairs(matches) do
+            redis.call('DEL', name)
+        end
+    end" 0
+}
+
+start() {
+    debug "Starting ${SERVICE} service..."
+
+    wait_for_database_service
+
+    clean_up_tables 6 "LAG_TABLE*"
+
+    /usr/bin/${SERVICE}.sh start
+    /usr/bin/${SERVICE}.sh attach
+}
+
+
+stop() {
+    debug "Stopping ${SERVICE} service..."
+    /usr/bin/${SERVICE}.sh stop
+}
+
+case "$1" in
+    start|stop)
+        $1
+        ;;
+    *)
+        echo "Usage: $0 {start|stop}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
To align the startup approach same with syncd and swss docker.
Clean up the state database for LAGs when starting the docker.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>