### PR TITLE
[teamd]: Update hwaddr_orig unconditionally.

### DIFF
--- a/src/libteam/0005-libteam-Add-warm_reboot-mode.patch
+++ b/src/libteam/0005-libteam-Add-warm_reboot-mode.patch
@@ -1,3 +1,25 @@
+diff --git a/libteam/ifinfo.c b/libteam/ifinfo.c
+index 72155ae..44de4ca 100644
+--- a/libteam/ifinfo.c
++++ b/libteam/ifinfo.c
+@@ -105,15 +105,13 @@ static void update_hwaddr(struct team_ifinfo *ifinfo, struct rtnl_link *link)
+ 	hwaddr_len = nl_addr_get_len(nl_addr);
+ 	if (ifinfo->hwaddr_len != hwaddr_len) {
+ 		ifinfo->hwaddr_len = hwaddr_len;
+-		if (!ifinfo->master_ifindex)
+-			ifinfo->orig_hwaddr_len = hwaddr_len;
++		ifinfo->orig_hwaddr_len = hwaddr_len;
+ 		set_changed(ifinfo, CHANGED_HWADDR_LEN);
+ 	}
+ 	hwaddr = nl_addr_get_binary_addr(nl_addr);
+ 	if (memcmp(ifinfo->hwaddr, hwaddr, hwaddr_len)) {
+ 		memcpy(ifinfo->hwaddr, hwaddr, hwaddr_len);
+-		if (!ifinfo->master_ifindex)
+-			memcpy(ifinfo->orig_hwaddr, hwaddr, hwaddr_len);
++		memcpy(ifinfo->orig_hwaddr, hwaddr, hwaddr_len);
+ 		set_changed(ifinfo, CHANGED_HWADDR);
+ 	}
+ }
 diff --git a/teamd/teamd.c b/teamd/teamd.c
 index c987333..53aec1d 100644
 --- a/teamd/teamd.c


### PR DESCRIPTION
SONiC uses same mac address for both phy ports and LAGs

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Forced teamd to use current mac address on physical interfaces as original.

**- How I did it**
Remove master_ifindex check

**- How to verify it**
Build teamd, install it on your dut, restart dut, check that all lags are up, then restart teamd docker, and check that teamd is still able to send lacp.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
