### PR TITLE
[swss service] don't clear WARM_RESTART table

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -93,7 +93,7 @@ start() {
         /usr/bin/docker exec database redis-cli -n 0 FLUSHDB
         /usr/bin/docker exec database redis-cli -n 2 FLUSHDB
         /usr/bin/docker exec database redis-cli -n 5 FLUSHDB
-        clean_up_tables 6 "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'WARM_RESTART_TABLE*'"
+        clean_up_tables 6 "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*'"
     fi
 
     # start service docker


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
Clear WARM_RESTART table could cause component level warm restart to
fail due to missing WARM_RESTART state.

**- How to verify it**
Cold boot up a system with the change. Check output of "show warm_restart state" output, making sure that teammgrd's state and syncd's state are there.