### PR TITLE
[vs]: Create /var/warmboot/teamd folder for teammgrd

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -97,4 +97,7 @@ RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
 RUN echo "docker-sonic-vs" > /etc/hostname
 RUN touch /etc/quagga/zebra.conf
 
+# Create /var/warmboot/teamd folder for teammgrd
+RUN mkdir -p /var/warmboot/teamd
+
 ENTRYPOINT ["/usr/bin/supervisord"]


### PR DESCRIPTION
To suppress the error message:
INFO #supervisord: teammgrd Can't write to the lacp directory
'/var/warmboot/teamd/': No such file or directory

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
