### PR TITLE
[minigraph]: Fix gateway address type issue

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -624,7 +624,7 @@ def parse_device_desc_xml(filename):
     mgmt_intf = {}
     mgmtipn = ipaddress.IPNetwork(mgmt_prefix)
     gwaddr = ipaddress.IPAddress(int(mgmtipn.network) + 1)
-    results['MGMT_INTERFACE'] = {('eth0', mgmt_prefix): {'gwaddr': gwaddr}}
+    results['MGMT_INTERFACE'] = {('eth0', mgmt_prefix): {'gwaddr': str(gwaddr)}}
 
     return results
 


### PR DESCRIPTION
Exception:
Invalid input of type: 'IPv6Address'. Convert to a byte, string or number first
Invalid input of type: 'IPv4Address'. Convert to a byte, string or number first

This field needs to be converted into string first.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>