### PR TITLE
ASIC temperature sensors support

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -14,6 +14,7 @@ def enable_counters():
     enable_counter_group(db, 'PORT')
     enable_counter_group(db, 'QUEUE')
     enable_counter_group(db, 'PFCWD')
+    enable_counter_group(db, 'SENSORS')
 
 def get_uptime():
     with open('/proc/uptime') as fp:

--- a/platform/broadcom/sonic-platform-modules-dell/common/asic_sensors.py
+++ b/platform/broadcom/sonic-platform-modules-dell/common/asic_sensors.py
@@ -1,0 +1,117 @@
+#! /usr/bin/python
+# Retrieve the maximum number of thermal sensors supported on
+# the ASIC from the flex counter DB and print the readings
+# along wtih the average.
+
+import swsssdk
+import json
+import sys
+import os
+import pickle
+from subprocess import Popen, PIPE
+
+# temp files to cache constants
+SENSORS_DIR = "/tmp/dell/sensors"
+SWITCH_OID = "switch_oid"
+MAX_SENSORS = "max_sensors"
+
+# Load a value from a given file
+def load_from_file(file):
+    if os.path.isfile(file):
+        try:
+            value = pickle.load(open(file, 'r'))
+        except IOError as e:
+            print e.errno, e
+            sys.exit(e.errno)
+    return value
+
+# Dump a value into a given file
+def dump_to_file(file, value):
+    if value:
+        try:
+            pickle.dump(value, open(file, 'w'))
+        except IOError as e:
+            print e.errno, e
+            sys.exit(e.errno)
+
+# Get the switch OID should the ASIC support sensors
+def get_switch_sensors_oid():
+    switch_oid_file = SENSORS_DIR + "/" + SWITCH_OID
+
+    # Check if we saved it in the tmp file already
+    if os.path.isfile(switch_oid_file):
+        return load_from_file(switch_oid_file)
+
+    if not os.path.exists(SENSORS_DIR):
+        try:
+            os.makedirs(SENSORS_DIR)
+        except IOError as e:
+            print e.errno, e
+            sys.exit(1)
+
+    # Retrieve the switch oid from the flex counter DB
+    # and save it in the file cache
+    proc = Popen("docker exec -i database redis-cli \
+                 --raw -n 5 KEYS FLEX_COUNTER_TABLE:SWITCH_SENSORS*", \
+                 stdout=PIPE, stderr=PIPE, shell=True)
+    out, err = proc.communicate()
+
+    for key in out.splitlines() or [None]:
+        if key:
+            id = key.replace('FLEX_COUNTER_TABLE:SWITCH_SENSORS:oid:', '')
+            if id:
+                dump_to_file(switch_oid_file, id)
+                return id
+    return None
+
+# Get the number of sensor values that will be dumped to counters DB
+def get_switch_max_sensors(sensors):
+    max_sensors_file = SENSORS_DIR + "/" + MAX_SENSORS
+
+    if os.path.isfile(max_sensors_file):
+        return load_from_file(max_sensors_file)
+
+    temp_list = [sensors[key] for key in sensors
+                 if key.startswith('SAI_SWITCH_ATTR_TEMP_')]
+    max_sensors = len(temp_list)
+    if max_sensors:
+        dump_to_file(max_sensors_file, max_sensors)
+        return max_sensors
+
+    return 0
+
+# Print the ASIC sensors from the counter DB
+def print_asic_sensors():
+
+    countersdb = swsssdk.SonicV2Connector(host='127.0.0.1')
+    countersdb.connect(countersdb.COUNTERS_DB)
+
+    id = get_switch_sensors_oid()
+    if id:
+        sensors = countersdb.get_all(countersdb.COUNTERS_DB,
+                                     'COUNTERS:oid:' + id)
+        max_sensors = get_switch_max_sensors(sensors)
+
+        average_temp = sensors.get('SAI_SWITCH_ATTR_AVERAGE_TEMP')
+        max_temp = sensors.get('SAI_SWITCH_ATTR_MAX_TEMP')
+        temp_list = []
+
+        # Retrieve the list of individual sensor values
+        for i in range(max_sensors):
+            temp_list.append(sensors.get('SAI_SWITCH_ATTR_TEMP_%d' % i))
+
+        if (average_temp is not None) and \
+           (max_temp is not None) and \
+           (temp_list is not None):
+            print '\nBCM Internal: ' \
+                + str(average_temp) + ' C' \
+                + ' (max ' + str(max_temp) + ' C)' \
+                + ' (' + ' '.join(str(x) for x in temp_list) + ' C)'
+        else:
+            print '\nBCM Internal: ' + 'NA'
+
+    else:
+        print '\nBCM Internal: ' + 'NA'
+
+    countersdb.close(countersdb.COUNTERS_DB)
+

--- a/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
+++ b/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
@@ -208,8 +208,8 @@ static const char *const s6100_temp_label[] = {
         "U2 Switch board?",
         "Front GE",
         "Front SFP+",
-        "BCM Internal",
-        "CPU Internal",
+        "Unused",
+        "Unused",
         "",
 	"PSU 1",
 	"PSU 2"

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -5,5 +5,6 @@ common/dell_i2c_utils.sh usr/local/bin
 common/fstrim.timer etc/systemd/system
 common/fstrim.service etc/systemd/system
 s6100/scripts/platform_sensors.py usr/local/bin
+common/asic_sensors.py usr/local/bin
 s6100/scripts/sensors usr/bin
 s6100/systemd/platform-modules-s6100.service etc/systemd/system

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9100.install
@@ -4,6 +4,7 @@ common/dell_i2c_utils.sh usr/local/bin
 common/fstrim.timer etc/systemd/system
 common/fstrim.service etc/systemd/system
 z9100/scripts/platform_sensors.py usr/local/bin
+common/asic_sensors.py usr/local/bin
 z9100/scripts/sensors usr/bin
 z9100/cfg/z9100-modules.conf etc/modules-load.d
 z9100/systemd/platform-modules-z9100.service etc/systemd/system

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_sensors.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_sensors.py
@@ -11,6 +11,7 @@
 import os
 import sys
 import logging
+from asic_sensors import *
 
 S6100_MAX_FAN_TRAYS = 4
 S6100_MAX_PSUS = 2
@@ -319,4 +320,4 @@ print('\nIO Modules:')
 for iom in range(1, S6100_MAX_IOMS+1):
     print '  IOM ' + str(iom) + ' :' + iom_status_list[iom - 1]
 
-print '\n'
+print_asic_sensors()

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/platform_sensors.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/platform_sensors.py
@@ -11,10 +11,10 @@
 import os
 import sys
 import logging
+from asic_sensors import *
 
 Z9100_MAX_FAN_TRAYS = 5
 Z9100_MAX_PSUS = 2
-S6100_MAX_IOMS = 4
 
 MAILBOX_DIR = "/sys/devices/platform/SMF.512/hwmon/hwmon0"
 
@@ -322,3 +322,6 @@ for psu in range(1, Z9100_MAX_PSUS + 1):
         logging.error('Unable to check PSU presence')
 
 print '\n  Total Power:      ', get_pmc_register('current_total_power'), 'W'
+
+print_asic_sensors()
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
**Please do not merge yet.**

Recently (https://github.com/opencomputeproject/SAI/pull/880), new switch attributes were added to retrieve the temperature readings from the ASIC's internal sensors. 

This is a preliminary commit (pending SAI support from vendors) for temperature monitoring. The max, average and the entire list of temperatures are now added to the flex counters DB so that platform sensors scripts may query and use these values in thermal control algorithms.

**- What I did**

Added support to retrieve the ASIC internal temperature measurements from flex counters.

**- How I did it**

1. Added a new script to retrieve the ASIC temperatures from the flex counter DB
2. Enabled the sensors group in the flex table of configDB.

**- How to verify it**

Checked using stubs. Awaiting testing based on vendor implementation.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
ASIC temperature sensors support

**- A picture of a cute animal (not mandatory but encouraged)**
