### PR TITLE
[thrift]: change wget download from -nc to -N

### DIFF
--- a/src/thrift/Makefile
+++ b/src/thrift/Makefile
@@ -16,9 +16,9 @@ THRIFT_LINK_PRE = https://sonicstorage.blob.core.windows.net/packages/debian
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf thrift-$(THRIFT_VERSION)
 
-	wget -nc -O "thrift_$(THRIFT_VERSION).orig.tar.gz" "$(THRIFT_LINK_PRE)/thrift_$(THRIFT_VERSION).orig.tar.gz?sv=2015-04-05&sr=b&sig=wM3B01UnZQYYr7ZGXmCvRn6MMeS5hn5Oa5G5%2Btub53g%3D&se=2028-11-11T02%3A20%3A36Z&sp=r"
-	wget -nc -O "thrift_$(THRIFT_VERSION_FULL).debian.tar.xz" "$(THRIFT_LINK_PRE)/thrift_$(THRIFT_VERSION_FULL).debian.tar.xz?sv=2015-04-05&sr=b&sig=76bx%2BN8uxYbuI%2BEq8uK%2B8cTKTzVmjtjsQ9weejWNINk%3D&se=2028-11-11T02%3A19%3A30Z&sp=r"
-	wget -nc -O "thrift_$(THRIFT_VERSION_FULL).dsc" "$(THRIFT_LINK_PRE)/thrift_$(THRIFT_VERSION_FULL).dsc?sv=2015-04-05&sr=b&sig=Vpk1eJ97I5aWrtjAYS8w8AKyLXcJKFGIVFOOBGR3a5I%3D&se=2028-11-11T02%3A20%3A20Z&sp=r"
+	wget -NO "thrift_$(THRIFT_VERSION).orig.tar.gz" "$(THRIFT_LINK_PRE)/thrift_$(THRIFT_VERSION).orig.tar.gz?sv=2015-04-05&sr=b&sig=wM3B01UnZQYYr7ZGXmCvRn6MMeS5hn5Oa5G5%2Btub53g%3D&se=2028-11-11T02%3A20%3A36Z&sp=r"
+	wget -NO "thrift_$(THRIFT_VERSION_FULL).debian.tar.xz" "$(THRIFT_LINK_PRE)/thrift_$(THRIFT_VERSION_FULL).debian.tar.xz?sv=2015-04-05&sr=b&sig=76bx%2BN8uxYbuI%2BEq8uK%2B8cTKTzVmjtjsQ9weejWNINk%3D&se=2028-11-11T02%3A19%3A30Z&sp=r"
+	wget -NO "thrift_$(THRIFT_VERSION_FULL).dsc" "$(THRIFT_LINK_PRE)/thrift_$(THRIFT_VERSION_FULL).dsc?sv=2015-04-05&sr=b&sig=Vpk1eJ97I5aWrtjAYS8w8AKyLXcJKFGIVFOOBGR3a5I%3D&se=2028-11-11T02%3A20%3A20Z&sp=r"
 
 	dpkg-source -x thrift_$(THRIFT_VERSION_FULL).dsc
 	pushd thrift-$(THRIFT_VERSION)


### PR DESCRIPTION
-nc will not download if already here and return error
-N will compare the timestamp and not download the file.

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
