### PR TITLE
[vs]: Add time.sleep(1) to make test stable

### DIFF
--- a/platform/vs/tests/teamd/test_portchannel.py
+++ b/platform/vs/tests/teamd/test_portchannel.py
@@ -23,6 +23,7 @@ def test_PortChannel(dvs, testlog):
 
     # create the lag member
     dvs.runcmd("config portchannel member add PortChannel0001 Ethernet112")
+    time.sleep(1)
 
     # test lag member table in appl db
     tbl = swsscommon.Table(appldb, "LAG_MEMBER_TABLE")


### PR DESCRIPTION
time.sleep(1) after running the command to enslave member port

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>