### PR TITLE
[Dell] sensors.conf files for S6100/Z9100

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/sensors.conf
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/sensors.conf
@@ -1,0 +1,9 @@
+chip "SMF_S6100_ON-isa-0000"
+label power1 "PSU1 Input  Power"
+label power2 "PSU1 Output Power"
+label power3 "PSU2 Input  Power"
+label power4 "PSU2 Output Power"
+label temp14 "PSU1 Temp"
+label temp15 "PSU1 Temp"
+ignore temp12
+ignore temp13

--- a/device/dell/x86_64-dell_z9100_c2538-r0/sensors.conf
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/sensors.conf
@@ -1,0 +1,12 @@
+chip "SMF_Z9100_ON-isa-0000"
+label power1 "PSU1 Input  Power"
+label power2 "PSU1 Output Power"
+label power3 "PSU2 Input  Power"
+label power4 "PSU2 Output Power"
+label temp14 "PSU1 Temp"
+label temp15 "PSU1 Temp"
+ignore temp12
+ignore temp13
+ignore temp5
+ignore temp7
+ignore temp8

--- a/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
+++ b/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
@@ -28,6 +28,7 @@
 #define SIO_DRVNAME             "SMF"
 #define DEBUG                   1
 #define LABELS                  1
+#define SMF_VERSION_ADDR        0x0000
 
 #define FANIN_MAX               12  /* Counted from 1 */
 #define VSEN_MAX                48  /* VSEN1.. */
@@ -471,6 +472,32 @@ static int smf_read_reg16(struct smf_data *data, u16 reg)
         return res;
 }
 
+/* SMF Version */
+static ssize_t show_smf_version(struct device *dev,
+                struct device_attribute *devattr, char *buf)
+{
+    int              index = to_sensor_dev_attr(devattr)->index;
+    unsigned int     ret = 0;
+    unsigned int     smf_version = 0;
+    unsigned int     smf_firmware_major_ver = 0;
+    unsigned int     smf_firmware_minor_ver = 0;
+    struct smf_data *data = dev_get_drvdata(dev);
+
+    ret = smf_read_reg(data, (SMF_VERSION_ADDR + index*2));
+
+    if (index > 0) {
+        smf_firmware_major_ver = ((ret & (0xC0)) >> 6);
+        smf_firmware_minor_ver = (ret & (0x3F));
+        ret = sprintf(buf, "%u.%u\n", smf_firmware_major_ver,
+                                      smf_firmware_minor_ver);
+    } else {
+        smf_version = ret;
+        ret = sprintf(buf, "%u\n", smf_version);
+    }
+
+    return ret;
+}
+
 
 /* FANIN ATTR */
 static ssize_t
@@ -513,6 +540,9 @@ static ssize_t show_fan(struct device *dev,
 
         if (ret < 0)
                 return ret;
+
+        if (ret & 0x8000)
+                ret = - (ret & 0x7fff);
 
         rpm = ret;
 
@@ -1327,23 +1357,28 @@ static ssize_t show_temp_crit(struct device *dev,
 }
 
 
-/*static ssize_t show_temp_alarm(struct device *dev,
+static ssize_t show_temp_alarm(struct device *dev,
                 struct device_attribute *devattr, char *buf)
 {
         int index = to_sensor_dev_attr(devattr)->index;
         struct smf_data *data = dev_get_drvdata(dev);
-        int ret;
-        int temp;
+        int ret = 0;
+        int temp = 0;
 
-        ret = smf_read_reg16(data, TEMP_SENSOR_1_STATUS + index * 2);
+        ret = smf_read_reg(data, TEMP_SENSOR_1_STATUS + index);
 
-        if (ret < 0)
-                return ret;
+        if (ret < 0) {
+            return ret;
+        }
+
+        if (ret == 0xff) {
+            ret = 0;
+        }
 
         temp = ret;
 
         return sprintf(buf, "%d\n", temp);
-}*/
+}
 
 
 static umode_t smf_tcpu_is_visible(struct kobject *kobj,
@@ -1432,6 +1467,25 @@ static SENSOR_DEVICE_ATTR(temp13_max,       S_IRUGO, show_temp_crit, NULL, 50);
 static SENSOR_DEVICE_ATTR(temp14_max,       S_IRUGO, show_temp_crit, NULL, 46);
 static SENSOR_DEVICE_ATTR(temp15_max,       S_IRUGO, show_temp_crit, NULL, 50);
 
+static SENSOR_DEVICE_ATTR(temp1_alarm,      S_IRUGO, show_temp_alarm, NULL, 0);
+static SENSOR_DEVICE_ATTR(temp2_alarm,      S_IRUGO, show_temp_alarm, NULL, 1);
+static SENSOR_DEVICE_ATTR(temp3_alarm,      S_IRUGO, show_temp_alarm, NULL, 2);
+static SENSOR_DEVICE_ATTR(temp4_alarm,      S_IRUGO, show_temp_alarm, NULL, 3);
+static SENSOR_DEVICE_ATTR(temp5_alarm,      S_IRUGO, show_temp_alarm, NULL, 4);
+static SENSOR_DEVICE_ATTR(temp6_alarm,      S_IRUGO, show_temp_alarm, NULL, 5);
+static SENSOR_DEVICE_ATTR(temp7_alarm,      S_IRUGO, show_temp_alarm, NULL, 6);
+static SENSOR_DEVICE_ATTR(temp8_alarm,      S_IRUGO, show_temp_alarm, NULL, 7);
+static SENSOR_DEVICE_ATTR(temp9_alarm,      S_IRUGO, show_temp_alarm, NULL, 8);
+static SENSOR_DEVICE_ATTR(temp10_alarm,     S_IRUGO, show_temp_alarm, NULL, 9);
+static SENSOR_DEVICE_ATTR(temp11_alarm,     S_IRUGO, show_temp_alarm, NULL, 10);
+static SENSOR_DEVICE_ATTR(temp12_alarm,     S_IRUGO, show_temp_alarm, NULL, 11);
+static SENSOR_DEVICE_ATTR(temp13_alarm,     S_IRUGO, show_temp_alarm, NULL, 12);
+
+static SENSOR_DEVICE_ATTR(temp14_alarm,     S_IRUGO, show_temp_alarm, NULL, 13);
+static SENSOR_DEVICE_ATTR(temp15_alarm,     S_IRUGO, show_temp_alarm, NULL, 14);
+
+
+
 
 static struct attribute *smf_tcpu_attrs[] = {
         &sensor_dev_attr_temp1_input.dev_attr.attr,
@@ -1498,6 +1552,23 @@ static struct attribute *smf_tcpu_attrs[] = {
         &sensor_dev_attr_temp14_max.dev_attr.attr,
         &sensor_dev_attr_temp15_max.dev_attr.attr,
 
+        &sensor_dev_attr_temp1_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp2_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp3_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp4_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp5_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp6_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp7_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp8_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp9_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp10_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp11_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp12_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp13_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp14_alarm.dev_attr.attr,
+        &sensor_dev_attr_temp15_alarm.dev_attr.attr,
+
+
         NULL
 };  
 
@@ -1525,26 +1596,37 @@ static ssize_t show_psu(struct device *dev,
         struct smf_data *data = dev_get_drvdata(dev);
         int ret=0, export_hex=0;
         int psu_status=0, pow;
+        int pow_val = 0;
 
         switch (index) {
 
                 case 0:
                         pow = smf_read_reg16(data, PSU_1_MAX_POWER);
-			/* TODO Fix */
-			if (data->kind == s6100smf)			
-				ret = 1000000 * 1100;
-			else
-				ret = 1000000 * 750;
+			            /* TODO Fix */
+			            if (data->kind == s6100smf)
+                            ret = 1000000 * 1100;
+			            else
+                            ret = 1000000 * 750;
                         break;
                 case 1:
                         ret = smf_read_reg(data, PSU_1_STATUS);
                         export_hex=1;
                         break;
                 case 2:
-                        ret = 100000 * smf_read_reg16(data, PSU_1_INPUT_POWER);
+                        pow_val = smf_read_reg16(data, PSU_1_INPUT_POWER);
+                        /* In case of absent psu, pow_val will be 0xffff */
+                        if (pow_val == 0xffff) {
+                            pow_val = 0;
+                        }
+                        ret = 100000 * pow_val;
                         break;
                 case 3:
-                        ret = 100000 * smf_read_reg16(data, PSU_1_OUTPUT_POWER);
+                        pow_val = smf_read_reg16(data, PSU_1_OUTPUT_POWER);
+                        /* In case of absent psu, pow_val will be 0xffff */
+                        if (pow_val == 0xffff) {
+                            pow_val = 0;
+                        }
+                        ret = 100000 * pow_val;
                         break;
                 case 4:
                         psu_status = smf_read_reg(data, PSU_1_STATUS);
@@ -1554,21 +1636,31 @@ static ssize_t show_psu(struct device *dev,
                 case 5:
                         pow = smf_read_reg16(data, PSU_2_MAX_POWER);
                         ret = 1000000 * pow;
-			/* TODO Fix */
-			if (data->kind == s6100smf)			
-				ret = 1000000 * 1100;
-			else
-				ret = 1000000 * 750;
+			            /* TODO Fix */
+			            if (data->kind == s6100smf)
+                            ret = 1000000 * 1100;
+			            else
+                            ret = 1000000 * 750;
                         break;
                 case 6:
                         ret = smf_read_reg(data, PSU_2_STATUS);
                         export_hex=1;
                         break;
                 case 7:
-                        ret = 100000 * smf_read_reg16(data, PSU_2_INPUT_POWER);
+                        pow_val = smf_read_reg16(data, PSU_2_INPUT_POWER);
+                        /* In case of absent psu, pow_val will be 0xffff */
+                        if (pow_val == 0xffff) {
+                            pow_val = 0;
+                        }
+                        ret = 100000 * pow_val;
                         break;
                 case 8:
-                        ret = 100000 * smf_read_reg16(data, PSU_2_OUTPUT_POWER);
+                        pow_val = smf_read_reg16(data, PSU_2_OUTPUT_POWER);
+                        /* In case of absent psu, pow_val will be 0xffff */
+                        if (pow_val == 0xffff) {
+                            pow_val = 0;
+                        }
+                        ret = 100000 * pow_val;
                         break;
                 case 9:
                         psu_status = smf_read_reg(data, PSU_2_STATUS);
@@ -1577,6 +1669,10 @@ static ssize_t show_psu(struct device *dev,
                         break;
                 case 10:
                         pow = smf_read_reg16(data, CURRENT_TOTAL_POWER);
+                        /* In case of both psu absent, pow will be 0xffff */
+                        if (pow == 0xffff) {
+                            pow = 0;
+                        }
                         ret = pow/10;
                         break;
                 default:
@@ -1678,7 +1774,13 @@ static SENSOR_DEVICE_ATTR(psu1_presence, S_IRUGO, show_psu, NULL, 1);
 static SENSOR_DEVICE_ATTR(psu2_presence, S_IRUGO, show_psu, NULL, 6);
 static SENSOR_DEVICE_ATTR(current_total_power, S_IRUGO, show_psu, NULL, 10);
 
+/* SMF Version */
+static SENSOR_DEVICE_ATTR(smf_version, S_IRUGO, show_smf_version, NULL, 0);
+static SENSOR_DEVICE_ATTR(smf_firmware_ver, S_IRUGO, show_smf_version, NULL, 1);
+
 static struct attribute *smf_dell_attrs[] = {
+        &sensor_dev_attr_smf_version.dev_attr.attr,
+        &sensor_dev_attr_smf_firmware_ver.dev_attr.attr,
         &sensor_dev_attr_fan_tray_presence.dev_attr.attr,
         &sensor_dev_attr_fan1_airflow.dev_attr.attr,
         &sensor_dev_attr_fan3_airflow.dev_attr.attr,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
**- What I did**
- Addded sensors.conf file for S6100/Z9100 switches.
- sensorsd daemon can able to write syslogs when alarms are raised for any specific attribute.
- Added alarm supprot for onboard sensors.
- Tuned return values of attributes to avoid "Bad Adddress" proc errors.
- Exported SMF version.

**- How I did it**
- Exported attributes in dell_pmc.c which is common for both switches.

**- How to verify it**
- Execute sensors command

