### PR TITLE
[eeprom] modify output of decode-syseprom for mellanox platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/eeprom.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/eeprom.py
@@ -17,6 +17,7 @@ try:
     import warnings
     import os
     import sys
+    from cStringIO import StringIO
     from sonic_eeprom import eeprom_base
     from sonic_eeprom import eeprom_tlvinfo
     import subprocess
@@ -30,3 +31,11 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
     def __init__(self, name, path, cpld_root, ro):
         self.eeprom_path = "/bsp/eeprom/vpd_info"
         super(board, self).__init__(self.eeprom_path, 0, '', True)
+
+    def decode_eeprom(self, e):
+        original_stdout = sys.stdout
+        sys.stdout = StringIO()
+        eeprom_tlvinfo.TlvInfoDecoder.decode_eeprom(self, e)
+        decode_output = sys.stdout.getvalue()
+        sys.stdout = original_stdout
+        print(decode_output.replace('\0', ''))


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes 
https://github.com/Azure/sonic-utilities/issues/371

**- What I did**
Remove '\0' characters from decode syseeprom output.
**- How I did it**
In a way that will not affect other platforms)
**- How to verify it**
on mlnx plaform:
show platform syseeprom > file.txt
cat -A file.txt
make sure there are no '^@' in the output

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
 modify output of decode-syseprom for mellanox platform

**- A picture of a cute animal (not mandatory but encouraged)**
