### PR TITLE
Routing application split config support

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -177,6 +177,13 @@ sudo LANG=C chroot $FILESYSTEM_ROOT useradd -G sudo,docker $USERNAME -c "$DEFAUL
 ## Create password for the default user
 echo "$USERNAME:$PASSWORD" | sudo LANG=C chroot $FILESYSTEM_ROOT chpasswd
 
+if [ "$SONIC_ROUTING_STACK" == "frr" ]; then
+    sudo LANG=C chroot $FILESYSTEM_ROOT groupadd -g $FRR_USER_GID frr
+    sudo LANG=C chroot $FILESYSTEM_ROOT groupadd -g $FRR_VTY_GID frrvty
+    sudo LANG=C chroot $FILESYSTEM_ROOT useradd -u $FRR_USER_UID -g $FRR_USER_GID -M -s /bin/false frr
+    sudo LANG=C chroot $FILESYSTEM_ROOT usermod -a -G frr,frrvty frr
+fi
+
 ## Pre-install hardware drivers
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install      \
     firmware-linux-nonfree

--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -1,6 +1,10 @@
 FROM docker-config-engine
 
 ARG docker_container_name
+ARG frr_user_uid
+ARG frr_user_gid
+ARG frr_vty_gid
+
 RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%syslogtag%/;" /etc/rsyslog.conf
 
 # Make apt-get non-interactive
@@ -17,6 +21,11 @@ RUN apt-get install -y libdbus-1-3 libdaemon0 libjansson4 libc-ares2 iproute lib
 {%- for deb in docker_fpm_frr_debs.split(' ') %}
 COPY debs/{{ deb }} /debs/
 {%- endfor %}
+
+RUN groupadd -g ${frr_user_gid} frr
+RUN groupadd -g ${frr_vty_gid} frrvty
+RUN useradd -u ${frr_user_uid} -g ${frr_user_gid} -M -s /bin/false frr
+RUN usermod -a -G frr,frrvty frr
 
 # Install locally-built Debian packages and implicitly install their dependencies
 {%- for deb in docker_fpm_frr_debs.split(' ') %}

--- a/dockers/docker-fpm-frr/config.sh
+++ b/dockers/docker-fpm-frr/config.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 mkdir -p /etc/frr
-sonic-cfggen -d -t /usr/share/sonic/templates/frr.conf.j2 >/etc/frr/frr.conf
+
+CONFIG_TYPE=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["docker_routing_config_mode"]'`
+
+if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "unified" ]; then
+    sonic-cfggen -d -t /usr/share/sonic/templates/frr.conf.j2 >/etc/frr/frr.conf
+fi
 
 sonic-cfggen -d -t /usr/share/sonic/templates/isolate.j2 >/usr/sbin/bgp-isolate
 chown root:root /usr/sbin/bgp-isolate

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -310,3 +310,14 @@ sudo cp target/files/$MLNX_FW_FILE $FILESYSTEM_ROOT/etc/mlnx/fw-SPC.mfa
 j2 platform/mellanox/mlnx-fw-upgrade.j2 | sudo tee $FILESYSTEM_ROOT/usr/bin/mlnx-fw-upgrade.sh
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/mlnx-fw-upgrade.sh
 {% endif %}
+
+{%- if SONIC_ROUTING_STACK == "frr" %}
+sudo mkdir $FILESYSTEM_ROOT/etc/sonic/frr
+sudo touch $FILESYSTEM_ROOT/etc/sonic/frr/frr.conf
+sudo touch $FILESYSTEM_ROOT/etc/sonic/frr/vtysh.conf
+sudo cp dockers/docker-fpm-frr/daemons.conf $FILESYSTEM_ROOT/etc/sonic/frr/
+sudo cp dockers/docker-fpm-frr/daemons $FILESYSTEM_ROOT/etc/sonic/frr/
+sudo chown -R $FRR_USER_UID:$FRR_USER_GID $FILESYSTEM_ROOT/etc/sonic/frr
+sudo chmod 750 $FILESYSTEM_ROOT/etc/sonic/frr
+sudo chmod -R 640 $FILESYSTEM_ROOT/etc/sonic/frr/
+{%- endif %}

--- a/rules/config
+++ b/rules/config
@@ -75,3 +75,8 @@ ENABLE_ORGANIZATION_EXTENSIONS = y
 #   build:    build kernel from source
 #   download: download pre-built kernel from Azure storage.
 DEFAULT_KERNEL_PROCURE_METHOD = build
+
+# FRR user and group id values. These only take effect when SONIC_ROUTING_STACK is frr.
+FRR_USER_UID = 300
+FRR_USER_GID = 300
+FRR_VTY_GID = 301

--- a/rules/docker-fpm-frr.mk
+++ b/rules/docker-fpm-frr.mk
@@ -9,5 +9,6 @@ SONIC_DOCKER_IMAGES += $(DOCKER_FPM_FRR)
 $(DOCKER_FPM_FRR)_CONTAINER_NAME = bgp
 $(DOCKER_FPM_FRR)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/sonic/frr:/etc/frr:rw
 
 $(DOCKER_FPM_FRR)_BASE_IMAGE_FILES += vtysh:/usr/bin/vtysh

--- a/slave.mk
+++ b/slave.mk
@@ -117,6 +117,15 @@ MAKEFLAGS += -j $(SONIC_BUILD_JOBS)
 export SONIC_CONFIG_MAKE_JOBS
 
 ###############################################################################
+## Routing stack related exports
+###############################################################################
+
+export SONIC_ROUTING_STACK
+export FRR_USER_UID
+export FRR_USER_GID
+export FRR_VTY_GID
+
+###############################################################################
 ## Dumping key config attributes associated to current building exercise
 ###############################################################################
 
@@ -134,6 +143,11 @@ $(info "SHUTDOWN_BGP_ON_START"           : "$(SHUTDOWN_BGP_ON_START)")
 $(info "ENABLE_PFCWD_ON_START"           : "$(ENABLE_PFCWD_ON_START)")
 $(info "INSTALL_DEBUG_TOOLS"             : "$(INSTALL_DEBUG_TOOLS)")
 $(info "ROUTING_STACK"                   : "$(SONIC_ROUTING_STACK)")
+ifeq ($(SONIC_ROUTING_STACK),frr)
+$(info "FRR_USER_UID"                    : "$(FRR_USER_UID)")
+$(info "FRR_USER_GID"                    : "$(FRR_USER_GID)")
+$(info "FRR_VTY_GID"                     : "$(FRR_VTY_GID)")
+endif
 $(info "ENABLE_SYNCD_RPC"                : "$(ENABLE_SYNCD_RPC)")
 $(info "ENABLE_ORGANIZATION_EXTENSIONS"  : "$(ENABLE_ORGANIZATION_EXTENSIONS)")
 $(info "HTTP_PROXY"                      : "$(HTTP_PROXY)")
@@ -437,6 +451,9 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .pl
 		--build-arg uid=$(UID) \
 		--build-arg guid=$(GUID) \
 		--build-arg docker_container_name=$($*.gz_CONTAINER_NAME) \
+		--build-arg frr_user_uid=$(FRR_USER_UID) \
+		--build-arg frr_user_gid=$(FRR_USER_GID) \
+		--build-arg frr_vty_gid=$(FRR_VTY_GID) \
 		--label Tag=$(SONIC_GET_VERSION) \
 		-t $* $($*.gz_PATH) $(LOG)
 	docker save $* | gzip -c > $@

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -422,6 +422,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
     neighbors = None
     devices = None
     hostname = None
+    docker_routing_config_mode = "unified"
     port_speeds_default = {}
     port_speed_png = {}
     port_descriptions = {}
@@ -437,11 +438,14 @@ def parse_xml(filename, platform=None, port_config_file=None):
 
     hwsku_qn = QName(ns, "HwSku")
     hostname_qn = QName(ns, "Hostname")
+    docker_routing_config_mode_qn = QName(ns, "DockerRoutingConfigMode")
     for child in root:
         if child.tag == str(hwsku_qn):
             hwsku = child.text
         if child.tag == str(hostname_qn):
             hostname = child.text
+        if child.tag == str(docker_routing_config_mode_qn):
+            docker_routing_config_mode = child.text
 
     (ports, alias_map) = get_port_config(hwsku, platform, port_config_file)
     port_alias_map.update(alias_map)
@@ -464,6 +468,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
     results['DEVICE_METADATA'] = {'localhost': {
         'bgp_asn': bgp_asn,
         'deployment_id': deployment_id,
+        'docker_routing_config_mode': docker_routing_config_mode,
         'hostname': hostname,
         'hwsku': hwsku,
         'type': current_device['type']


### PR DESCRIPTION
Enabling support for routing application (frr) split configuration.

The changes are backwards compatible with existing configurations.

To enable split configuration, the following field needs to be added to the device metadata, followed by a config reload -y:

    "DEVICE_METADATA": {
        "localhost": {
            "hwsku": "Force10-Z9100", 
            "hostname": "sonic", 
            "platform": "x86_64-dell_z9100_c2538-r0", 
            "mac": "54:bf:64:ce:c0:40",
            "docker_routing_config_mode": "split",          <===== new field 
            "bgp_asn": "65100", 
            "type": "LeafRouter"
        }
    }, 

The field is optional and can take two values: unified and split. The absence of the field, implicitly means the value is unified. Changes to the field must be followed by a config reload -y at this point.

Signed-off-by: nikos <ntriantafillis@gmail.com>
