### PR TITLE
Adjusting bgp jinja template and quagga's supervisord.conf

### DIFF
--- a/dockers/docker-fpm-quagga/bgpd.conf.j2
+++ b/dockers/docker-fpm-quagga/bgpd.conf.j2
@@ -27,10 +27,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
-{# Advertise graceful restart capability for ToR #}
-{% if DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
   bgp graceful-restart
-{% endif %}
 {% for (name, prefix) in LOOPBACK_INTERFACE %}
 {% if prefix | ipv4 and name == 'Loopback0' %}
   bgp router-id {{ prefix | ip }}

--- a/dockers/docker-fpm-quagga/supervisord.conf
+++ b/dockers/docker-fpm-quagga/supervisord.conf
@@ -42,6 +42,7 @@ stderr_logfile=syslog
 [program:bgpd]
 command=/usr/lib/quagga/bgpd -A 127.0.0.1 -F
 priority=5
+stopsignal=KILL
 autostart=false
 autorestart=false
 startsecs=0


### PR DESCRIPTION
There are two minor changes in this PR:

* Adjust quagga's jinja template to enable bgp-gr functionality by default. Currently is only applicable to those devices tagged as TOR/T0.

* Ensure that no bgp-notification is sent out to remote-peers during bgpd shutdown events. The goal here is to make sure that remote-peers kick off bgp-gr-helper logic (i.e. retain restarting-router state), which can be only achieved if an ungraceful-shutdown (tcp pipe/socket down) is perceived. There are other approaches to accomplish this goal, such as draft-ietf-idr-bgp-gr-notification, but this one hasn't been implemented yet by Quagga/FRR.

To enforce this behavior i'm adjusting supervisord.conf to generate a SIGKILL signal during bgpd shutdown events.

Signed-off-by: Rodny Molina <rmolina@linkedin.com>
