### PR TITLE
[boot] Start ntp-config service after all Docker containers are started

### DIFF
--- a/files/image_config/ntp/ntp-config.service
+++ b/files/image_config/ntp/ntp-config.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Update NTP configuration
 Requires=updategraph.service
-After=updategraph.service
+After=updategraph.service bgp.service dhcp_relay.service lldp.service pmon.service radv.service snmp.service swss.service syncd.service teamd.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Docker containers in SONiC rely on supervisord to manage running processes. However, supervisord currently has the following issue: If the system clock rolls backwards (e.g., due to NTP correcting system time) after supervisor has marked a process as being in the STARTING state but before it has entered the RUNNING state, when supervisor goes to change the process' state to RUNNING, supervisor will crash if the current system time precedes the timestamp when it marked the process as STARTING.

Until supervisor is made to work nicely when the system clock rolls backward, this PR will wait to configure and restart the NTP service until after all services which start Docker containers have started.