### PR TITLE
Dell SMF driver hwmon number reorder fix for Dell S6100/Z9100

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/plugins/psuutil.py
@@ -11,6 +11,8 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
+HWMON_NODE = ', '.join(os.listdir(HWMON_DIR))
 
 class PsuUtil(PsuBase):
     """Platform-specific PSUutil class"""
@@ -20,7 +22,7 @@ class PsuUtil(PsuBase):
 
     # Get a mailbox register
     def get_pmc_register(self, reg_name):
-        mailbox_dir = "/sys/devices/platform/SMF.512/hwmon/hwmon1"
+        mailbox_dir = HWMON_DIR + HWMON_NODE
         retval = 'ERR'
         mb_reg_file = mailbox_dir+'/' + reg_name
         if (not os.path.isfile(mb_reg_file)):

--- a/device/dell/x86_64-dell_s6100_c2538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/plugins/psuutil.py
@@ -12,7 +12,7 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
-HWMON_NODE = ', '.join(os.listdir(HWMON_DIR))
+HWMON_NODE = os.listdir(HWMON_DIR)[0]
 
 class PsuUtil(PsuBase):
     """Platform-specific PSUutil class"""

--- a/device/dell/x86_64-dell_z9100_c2538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/plugins/psuutil.py
@@ -11,6 +11,8 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
+HWMON_NODE = ', '.join(os.listdir(HWMON_DIR))
 
 class PsuUtil(PsuBase):
     """Platform-specific PSUutil class"""
@@ -20,7 +22,7 @@ class PsuUtil(PsuBase):
 
     # Get a mailbox register
     def get_pmc_register(self, reg_name):
-        mailbox_dir = "/sys/devices/platform/SMF.512/hwmon/hwmon1"
+        mailbox_dir = HWMON_DIR + HWMON_NODE
         retval = 'ERR'
         mb_reg_file = mailbox_dir+'/' + reg_name
         if (not os.path.isfile(mb_reg_file)):

--- a/device/dell/x86_64-dell_z9100_c2538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/plugins/psuutil.py
@@ -12,7 +12,7 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
-HWMON_NODE = ', '.join(os.listdir(HWMON_DIR))
+HWMON_NODE = os.listdir(HWMON_DIR)[0]
 
 class PsuUtil(PsuBase):
     """Platform-specific PSUutil class"""

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_sensors.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_sensors.py
@@ -17,7 +17,7 @@ S6100_MAX_PSUS = 2
 S6100_MAX_IOMS = 4
 
 HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
-HWMON_NODE = ', '.join(os.listdir(HWMON_DIR))
+HWMON_NODE = os.listdir(HWMON_DIR)[0]
 MAILBOX_DIR = HWMON_DIR + HWMON_NODE
 iom_status_list = []
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_sensors.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_sensors.py
@@ -16,7 +16,9 @@ S6100_MAX_FAN_TRAYS = 4
 S6100_MAX_PSUS = 2
 S6100_MAX_IOMS = 4
 
-MAILBOX_DIR = "/sys/devices/platform/SMF.512/hwmon/hwmon1"
+HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
+HWMON_NODE = ', '.join(os.listdir(HWMON_DIR))
+MAILBOX_DIR = HWMON_DIR + HWMON_NODE
 iom_status_list = []
 
 # Get a mailbox register

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/platform_sensors.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/platform_sensors.py
@@ -16,7 +16,9 @@ Z9100_MAX_FAN_TRAYS = 5
 Z9100_MAX_PSUS = 2
 S6100_MAX_IOMS = 4
 
-MAILBOX_DIR = "/sys/devices/platform/SMF.512/hwmon/hwmon0"
+HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
+HWMON_NODE = ', '.join(os.listdir(HWMON_DIR))
+MAILBOX_DIR = HWMON_DIR + HWMON_NODE
 
 # Get a mailbox register
 

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/platform_sensors.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/platform_sensors.py
@@ -17,7 +17,7 @@ Z9100_MAX_PSUS = 2
 S6100_MAX_IOMS = 4
 
 HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
-HWMON_NODE = ', '.join(os.listdir(HWMON_DIR))
+HWMON_NODE = os.listdir(HWMON_DIR)[0]
 MAILBOX_DIR = HWMON_DIR + HWMON_NODE
 
 # Get a mailbox register


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Dell SMF driver initialiation with hwmon support changes from hwmon0 to hwmon1. This happens when Ingrasys enabled coretemp kernel driver. At the time of coretemp initalization with hwmon it allocates handle [hwmon0] to intel coretemp. Due to non-availablity next order [hwmon1] is alloted to SMF driver. 

- This order changes affects the existing scripts which rely on existing numerbing scheme.

```
root@sonic-s6100-01:/sys/class/hwmon# ls -lart
total 0
drwxr-xr-x  2 root root 0 Nov 26 05:03 .
lrwxrwxrwx  1 root root 0 Nov 26 05:03 hwmon1 -> ../../devices/platform/SMF.512/hwmon/hwmon1
lrwxrwxrwx  1 root root 0 Nov 26 05:03 hwmon0 -> ../../devices/platform/coretemp.0/hwmon/hwmon0
drwxr-xr-x 40 root root 0 Nov 26 05:03 ..
root@sonic-s6100-01:/sys/class/hwmon# cd ../../dev
```

**- How I did it**

- So, fixed scripts psuutil.py and platform_sensors.py to detect the numbering scheme dynamically from sysfs and construct the valid path accordingly.

**- How to verify it**

1. Execute platform_sensors.py
2. Execute psuutil status