### PR TITLE
[vs]: only send lldp over eth0 (management port)

### DIFF
--- a/dockers/docker-lldp-sv2/supervisord.conf
+++ b/dockers/docker-lldp-sv2/supervisord.conf
@@ -25,7 +25,7 @@ stderr_logfile=syslog
 # - `-dd` means to stay in foreground, log warnings to console
 # - `-ddd` means to stay in foreground, log warnings and info to console
 # - `-dddd` means to stay in foreground, log all to console
-command=/usr/sbin/lldpd -d -I Ethernet*,eth* -C eth0
+command=/usr/sbin/lldpd -d -I Ethernet*,eth0 -C eth0
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
In vs platform, eth[n] where n > 0 is physical port,
we should not send lldp over those ports

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
tested on vs kvm image on T0 topology.

```
admin@vlab-01:~$ show lldp table
Capability codes: (R) Router, (B) Bridge, (O) Other
LocalPort    RemoteDevice    RemotePortID    Capability    RemotePortDescr
-----------  --------------  --------------  ------------  -----------------
Ethernet112  ARISTA01T1      Ethernet1       BR
Ethernet116  ARISTA02T1      Ethernet1       BR
Ethernet120  ARISTA03T1      Ethernet1       BR
Ethernet124  ARISTA04T1      Ethernet1       BR
--------------------------------------------------
Total entries displayed:  4
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
