### PR TITLE
[sonic boot] disable dhcp during boot up, until updategraph service is running

### DIFF
--- a/files/image_config/interfaces/init_interfaces
+++ b/files/image_config/interfaces/init_interfaces
@@ -5,6 +5,4 @@
 auto lo
 iface lo inet loopback
 #
-# The management network interface
-auto eth0
-iface eth0 inet dhcp
+# Disable the management network interface during boot up

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -77,6 +77,10 @@ fi
 ACL_URL=$acl_src
 
 if [ "$src" = "dhcp" ]; then
+    # Enable dhcp client on management port eth0
+    /sbin/dhclient -4 -v -pf /run/dhclient.eth0.pid -lf /var/lib/dhcp/dhclient.eth0.leases -I -df /var/lib/dhcp/dhclient6.eth0.leases eth0 &
+    disown
+
     while [ ! -f /tmp/dhcp_graph_url ]; do
         echo "Waiting for DHCP response..."
         sleep 1


### PR DESCRIPTION
**- What I did**
A freshly installed sonic image could take 65 more seconds to boot up, waiting for dhcp offer on the management port if there is no dhcp server to send an offer.

That could add 65 seconds of delay during warm boot or fast boot. Either case, it delays the returning of the control plane.

This change delays enabling management port dhcp request until the updategraph service is running and dhcp is enabled.