### PR TITLE
[eeprom] check if source exists before reading eeprom on Mellanox platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/eeprom.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/eeprom.py
@@ -24,12 +24,32 @@ try:
 except ImportError, e:
     raise ImportError (str(e) + "- required module not found")
 
+SYSLOG_IDENTIFIER = "eeprom.py"
+EEPROM_SYMLINK = "/bsp/eeprom/vpd_info"
+CACHE_FILE = "/var/cache/sonic/decode-syseeprom/syseeprom_cache"
+
+def log_error(msg):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_ERR, msg)
+    syslog.closelog()
+
 class board(eeprom_tlvinfo.TlvInfoDecoder):
 
     _TLV_INFO_MAX_LEN = 256
+    RETRIES = 5
 
     def __init__(self, name, path, cpld_root, ro):
-        self.eeprom_path = "/bsp/eeprom/vpd_info"
+        for attempt in range(self.RETRIES):
+            if not os.path.islink(EEPROM_SYMLINK):
+                time.sleep(1)
+            else:
+                break  
+                      
+        if not (os.path.islink(EEPROM_SYMLINK) or os.isfile(CACHE_FILE)):
+            log_error("Nowhere to read syseeprom from! No symlink or cache file found")
+            raise RuntimeError("No syseeprom symlink or cache file found")
+
+        self.eeprom_path = EEPROM_SYMLINK
         super(board, self).__init__(self.eeprom_path, 0, '', True)
 
     def decode_eeprom(self, e):


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added additional check  to make sure that decode syseeprom will have something to read from.
**- How I did it**

**- How to verify it**
run 'show platform syseeprom'
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add additional check in Mellanox specific eeprom.py plugin

**- A picture of a cute animal (not mandatory but encouraged)**
