### PR TITLE
[Mellanox] Update hw-management service config

### DIFF
--- a/platform/mellanox/hw-management/Add-systemd-service-config.patch
+++ b/platform/mellanox/hw-management/Add-systemd-service-config.patch
@@ -36,11 +36,38 @@ index 0000000..d18916d
 +[Service]
 +Type=oneshot
 +EnvironmentFile=/host/machine.conf
-+ExecStart=/bin/bash -c "/usr/share/sonic/device/$onie_platform/hw-management start"
-+ExecStop=/bin/bash -c "/usr/share/sonic/device/$onie_platform/hw-management stop"
++ExecStart=/bin/bash -c "/usr/bin/hw-management-service.sh $onie_platform start"
++ExecStop=/bin/bash -c "/usr/bin/hw-management-service.sh $onie_platform stop"
 +
 +[Install]
 +WantedBy=multi-user.target
+diff --git a/usr/usr/bin/hw-management-service.sh b/usr/usr/bin/hw-management-service.sh
+new file mode 100755
+index 0000000..e3774e5
+--- /dev/null
++++ b/usr/usr/bin/hw-management-service.sh
+@@ -0,0 +1,21 @@
++#!/bin/bash
++
++if [ $# -ne 2 ]
++then
++    echo "Error: Invalid parameters"
++    exit 1
++fi
++
++if [ -f /etc/sonic/config_db.json ]
++then
++    mac_exist=$(grep -c "\"mac\"" /etc/sonic/config_db.json)
++    mac_is_none=$(grep "\"mac\"" /etc/sonic/config_db.json | grep -c "\"None\"")
++    if [ "$mac_exist" == "0" ] || [ "$mac_is_none" == "1" ]
++    then
++        echo "No MAC address, need hw-management service in updategraph"
++        exec /usr/share/sonic/device/$1/hw-management $2
++        exit 0
++    fi
++fi
++
++echo "MAC address already exists in config_db.json, do nothing"
 diff --git a/debian/rules b/debian/rules
 index fc38817..fba4150 100755
 --- a/debian/rules


### PR DESCRIPTION
Signed-off-by: Kevin Wang <kevinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
To fix a potential issue during system boot up. If the duration is too short, then it may fail at the boot up stage.
**- How I did it**
Updategraph.service need to start hw-management to get the MAC address at the first boot. But if there is a MAC address in config_db, then it doesn't need to start hw-management service anymore. So this patch is to deal with that condition. Just start hw-management in updategraph service if the config_db.json doesn't exist or the mac is None.
**- How to verify it**
Repeat reboot the system, no error found.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
