### PR TITLE
[teamd] avoid using actor port number 0 in teamd config

### DIFF
--- a/src/libteam/0005-libteam-Add-warm_reboot-mode.patch
+++ b/src/libteam/0005-libteam-Add-warm_reboot-mode.patch
@@ -264,7 +264,7 @@ index 81324de..9e88ce0 100644
 +		teamd_log_err("%s: Can't convert from port name to port id. Port id is equal to 0, but this is not expected", name);
 +	}
 +
-+	return htons(port_id);
++	return htons(port_id + 1);
 +}
 +
  static void lacp_port_actor_init(struct lacp_port *lacp_port)


### PR DESCRIPTION
**- What I did**

When using actor port number 0 in lag configuration, IO cannot be sent to
peer. Increase actor port number by 1 to keep uniqueness and at the same
time, avoid using actor port number 0.

Ref. 802.1AX 6.3.4 Port identification

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Boot up on a dut where Ethernet0 is part of a lag. Making sure that the LAG is up and the BGP session on top of this LAG is also up.