### PR TITLE
[boot] Refactor: All services which start Docker containers start before ntp-config service

### DIFF
--- a/files/build_templates/bgp.service.j2
+++ b/files/build_templates/bgp.service.j2
@@ -2,6 +2,7 @@
 Description=BGP container
 Requires=updategraph.service
 After=updategraph.service
+Before=ntp-config.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/dhcp_relay.service.j2
+++ b/files/build_templates/dhcp_relay.service.j2
@@ -2,6 +2,7 @@
 Description=DHCP relay container
 Requires=updategraph.service swss.service teamd.service
 After=updategraph.service swss.service teamd.service
+Before=ntp-config.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/lldp.service.j2
+++ b/files/build_templates/lldp.service.j2
@@ -2,6 +2,7 @@
 Description=LLDP container
 Requires=updategraph.service
 After=updategraph.service
+Before=ntp-config.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -2,6 +2,7 @@
 Description=Platform monitor container
 Requires=updategraph.service
 After=updategraph.service
+Before=ntp-config.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/radv.service.j2
+++ b/files/build_templates/radv.service.j2
@@ -2,6 +2,7 @@
 Description=Router advertiser container
 Requires=updategraph.service swss.service
 After=updategraph.service swss.service
+Before=ntp-config.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -2,6 +2,7 @@
 Description=SNMP container
 Requires=updategraph.service swss.service
 After=updategraph.service swss.service
+Before=ntp-config.service
 
 [Service]
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -8,6 +8,7 @@ Requires=nps-modules-4.9.0-7-amd64.service
 {% endif %}
 After=database.service updategraph.service
 After=interfaces-config.service
+Before=ntp-config.service
 
 [Service]
 User=root

--- a/files/build_templates/syncd.service.j2
+++ b/files/build_templates/syncd.service.j2
@@ -13,6 +13,7 @@ After=opennsl-modules-4.9.0-7-amd64.service
 {% elif sonic_asic_platform == 'nephos' %}
 After=nps-modules-4.9.0-7-amd64.service
 {% endif %}
+Before=ntp-config.service
 
 [Service]
 User=root

--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -2,6 +2,7 @@
 Description=TEAMD container
 Requires=updategraph.service
 After=updategraph.service
+Before=ntp-config.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/build_templates/telemetry.service.j2
+++ b/files/build_templates/telemetry.service.j2
@@ -2,6 +2,7 @@
 Description=Telemetry container
 Requires=swss.service
 After=swss.service
+Before=ntp-config.service
 
 [Service]
 User={{ sonicadmin_user }}

--- a/files/image_config/ntp/ntp-config.service
+++ b/files/image_config/ntp/ntp-config.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Update NTP configuration
 Requires=updategraph.service
-After=updategraph.service bgp.service dhcp_relay.service lldp.service pmon.service radv.service snmp.service swss.service syncd.service teamd.service
+After=updategraph.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This PR inverts the logic of https://github.com/Azure/sonic-buildimage/pull/2303 for a cleaner approach. Each service which starts a Docker container specifies that it should be started before ntp-config, rather than specifying that ntp-config.service should be started after multiple services.