### PR TITLE
[sonic-cfggen] Multi-key should be in form of (a,b) instead of 'a|b'

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -60,8 +60,7 @@ def
     {%- else %}
         {%- if switch_role.lower() == 'torrouter' %}
             {%- for local_port in VLAN_MEMBER %}
-                {%- set vlan_port = local_port.split("|") %}
-                {%- if vlan_port[1] == port_name %}
+                {%- if local_port[1] == port_name %}
                     {%- set roles3 = switch_role + '_' + 'server' %}
                     {%- set roles3 = roles3 | lower %}
                     {%- if roles3 in ports2cable %}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -25,7 +25,6 @@ ns = "Microsoft.Search.Autopilot.Evolution"
 ns1 = "http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"
 ns2 = "Microsoft.Search.Autopilot.NetMux"
 ns3 = "http://www.w3.org/2001/XMLSchema-instance"
-KEY_SEPARATOR = '|'
 
 class minigraph_encoder(json.JSONEncoder):
     def default(self, obj):
@@ -187,7 +186,7 @@ def parse_dpg(dpg, hname):
             for i, member in enumerate(pcmbr_list):
                 pcmbr_list[i] = port_alias_map.get(member, member)
                 intfs_inpc.append(pcmbr_list[i])
-                pc_members[pcintfname + KEY_SEPARATOR + pcmbr_list[i]] = {'NULL': 'NULL'}
+                pc_members[(pcintfname, pcmbr_list[i])] = {'NULL': 'NULL'}
             if pcintf.find(str(QName(ns, "Fallback"))) != None:
                 pcs[pcintfname] = {'members': pcmbr_list, 'fallback': pcintf.find(str(QName(ns, "Fallback"))).text, 'min_links': str(int(math.ceil(len() * 0.75)))}
             else:
@@ -204,8 +203,8 @@ def parse_dpg(dpg, hname):
             vmbr_list = vintfmbr.split(';')
             for i, member in enumerate(vmbr_list):
                 vmbr_list[i] = port_alias_map.get(member, member)
-                sonic_vlan_member_name = "Vlan%s%s%s" % (vlanid, KEY_SEPARATOR, vmbr_list[i])
-                vlan_members[sonic_vlan_member_name] = {'tagging_mode': 'untagged'}
+                sonic_vlan_member_name = "Vlan%s" % (vlanid)
+                vlan_members[(sonic_vlan_member_name, vmbr_list[i])] = {'tagging_mode': 'untagged'}
 
             vlan_attributes = {'vlanid': vlanid}
 
@@ -543,7 +542,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
             ports.get(port[0])['admin_status'] = 'up'
 
     for member in pc_members.keys() + vlan_members.keys():
-        port = ports.get(member.split(KEY_SEPARATOR)[1])
+        port = ports.get(member[1])
         if port:
             port['admin_status'] = 'up'
 

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -110,7 +110,7 @@ class TestCfgGen(TestCase):
     def test_minigraph_vlan_members(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v VLAN_MEMBER'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'Vlan1000|Ethernet8': {'tagging_mode': 'untagged'}}")
+        self.assertEqual(output.strip(), "{('Vlan1000', 'Ethernet8'): {'tagging_mode': 'untagged'}}")
 
     def test_minigraph_vlan_interfaces(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "VLAN_INTERFACE.keys()"'
@@ -130,7 +130,7 @@ class TestCfgGen(TestCase):
     def test_minigraph_portchannel_members(self):
         argument = '-m "' + self.sample_graph_pc_test + '" -p "' + self.port_config + '" -v "PORTCHANNEL_MEMBER.keys()"'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "['PortChannel01|Ethernet112', 'PortChannel01|Ethernet124', 'PortChannel01|Ethernet116', 'PortChannel01|Ethernet120']")
+        self.assertEqual(output.strip(), "[('PortChannel01', 'Ethernet120'), ('PortChannel01', 'Ethernet116'), ('PortChannel01', 'Ethernet124'), ('PortChannel01', 'Ethernet112')]")
 
     def test_minigraph_portchannel_interfaces(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v "PORTCHANNEL_INTERFACE.keys()"'

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -77,7 +77,7 @@ class TestCfgGenCaseInsensitive(TestCase):
     def test_minigraph_vlan_members(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v VLAN_MEMBER'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'Vlan1000|Ethernet8': {'tagging_mode': 'untagged'}}")
+        self.assertEqual(output.strip(), "{('Vlan1000', 'Ethernet8'): {'tagging_mode': 'untagged'}}")
 
     def test_minigraph_vlan_interfaces(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "VLAN_INTERFACE.keys()"'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The design of sonic-cfggen is that multi-key should be in the form of `('key1', 'key2')` in memory data structure. In this way, the template will be able to utilize one of the keys with simply `key[0]`. Only when writing into DB, we serialize the keys into format of `'key1|key2'`. `LOOPBACK_INTERFACE` acts as an example.

Please do not use format `'key1|key2'` directly in `sonic-cfggen` as that will cause the `-d` and `-m` behaviors to be different. Here's the output in current version:

```
admin@sonic-7:~$ sonic-cfggen -d -v VLAN_MEMBER
{('Vlan1000', 'Ethernet96'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet40'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet72'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet4'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet80'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet92'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet32'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet84'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet52'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet36'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet56'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet16'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet68'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet64'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet12'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet60'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet8'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet48'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet20'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet88'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet44'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet76'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet24'): {'tagging_mode': 'untagged'}, ('Vlan1000', 'Ethernet28'): {'tagging_mode': 'untagged'}}
admin@sonic-7:~$ sonic-cfggen -m -v VLAN_MEMBER
{'Vlan1000|Ethernet4': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet8': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet32': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet16': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet36': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet12': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet76': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet72': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet44': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet40': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet48': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet80': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet84': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet28': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet88': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet20': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet24': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet64': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet60': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet52': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet56': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet96': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet92': {'tagging_mode': 'untagged'}, 'Vlan1000|Ethernet68': {'tagging_mode': 'untagged'}}
admin@sonic-7:~$ sonic-cfggen -m -v LOOPBACK_INTERFACE
{('Loopback0', '10.1.0.32/32'): {}, ('Loopback0', 'FC00:1::32/128'): {}}
admin@sonic-7:~$ sonic-cfggen -d -v LOOPBACK_INTERFACE 
{('Loopback0', 'FC00:1::32/128'): {}, ('Loopback0', '10.1.0.32/32'): {}}
admin@sonic-7:~$ 
```

This PR fixes the issue and unify the result from `-d` and `-m` into 
`{('Vlan1000', 'Ethernet96'): {'tagging_mode': 'untagged'}` format.

