### PR TITLE
[bcm config test] allowing ext_sram_freq and ext_tcam_freq

### DIFF
--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -19,6 +19,8 @@ dport_map_enable
 dport_map_indexed
 dport_map_port
 dpp_clock_ratio
+ext_sram_freq
+ext_tcam_freq
 force_core_pll
 fpem_mem_entries
 higig2_hdr_mode


### PR DESCRIPTION
Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- What I did**
Enabling a couple Broadcom config file entries for public consumption with approval from Broadcom.
