### PR TITLE
Update URL for bfn SDE to 8.5.0 on Azure/SONiC master

### DIFF
--- a/platform/barefoot/bfn-platform.mk
+++ b/platform/barefoot/bfn-platform.mk
@@ -1,5 +1,5 @@
 BFN_PLATFORM = bfnplatform_1.0.0_amd64.deb
-$(BFN_PLATFORM)_URL =	"https://github.com/barefootnetworks/sonic-release-pkgs/raw/sde-sai1.3.3/bfnplatform_1.0.0_amd64.deb"
+$(BFN_PLATFORM)_URL =   "https://github.com/barefootnetworks/sonic-release-pkgs/raw/rel_8_5/bfnplatform_1.0.0_amd64.deb"
 
 SONIC_ONLINE_DEBS += $(BFN_PLATFORM) # $(BFN_SAI_DEV)
 $(BFN_SAI_DEV)_DEPENDS += $(BFN_PLATFORM)

--- a/platform/barefoot/bfn-sai.mk
+++ b/platform/barefoot/bfn-sai.mk
@@ -1,5 +1,5 @@
 BFN_SAI = bfnsdk_1.0.0_amd64.deb
-$(BFN_SAI)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/sde-sai1.3.3/bfnsdk_1.0.0_amd64.deb"
+$(BFN_SAI)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/rel_8_5/bfnsdk_1.0.0_amd64.deb"
 
 SONIC_ONLINE_DEBS += $(BFN_SAI) # $(BFN_SAI_DEV)
 $(BFN_SAI_DEV)_DEPENDS += $(BFN_SAI)


### PR DESCRIPTION
- What I did
Update URL for bfn SDE to 8.5.0 on Azure/SONiC master

- How I did it
Updated bfn sde sai and platform package url

- How to verify it
Build sde for platform=barefoot

- Description for the changelog
Update URL for bfn SDE to 8.5.0 on Azure/SONiC master

- A picture of a cute animal (not mandatory but encouraged)