### PR TITLE
[update graph] adapt to warm reboot scenario

### DIFF
--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -18,6 +18,26 @@ reload_minigraph()
     pfcwd start_default
 }
 
+function copy_config_files()
+{
+    for file in $@; do
+        if [ -f /etc/sonic/old_config/${file} ]; then
+            cp /etc/sonic/old_config/${file} /etc/sonic/
+        fi
+    done
+}
+
+function check_system_warm_boot()
+{
+    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|system" enable`
+    # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
+    if [[ x"$SYSTEM_WARM_START" == x"true" ]]; then
+        WARM_BOOT="true"
+    else
+        WARM_BOOT="false"
+    fi
+}
+
 
 if [ ! -f /etc/sonic/updategraph.conf ]; then
     echo "No updategraph.conf found, generating a default one."
@@ -26,21 +46,18 @@ fi
 
 . /etc/sonic/updategraph.conf
 
+check_system_warm_boot
+
 if [ -f /tmp/pending_config_migration ]; then
-    if [ "$enabled" = "true" ]; then
+    copy_config_files minigraph.xml snmp.yml acl.json config_db.json
+    if [ x"${WARM_BOOT}" == x"true" ]; then
+        echo "Warm reboot detected..."
+    elif [ "$enabled" = "true" ]; then
         echo "Use minigraph.xml from old system..."
-        cp /etc/sonic/old_config/minigraph.xml /etc/sonic/
-        if [ -f /etc/sonic/old_config/snmp.yml ]; then
-            cp /etc/sonic/old_config/snmp.yml /etc/sonic/
-        fi
-        if [ -f /etc/sonic/old_config/acl.json ]; then
-            cp /etc/sonic/old_config/acl.json /etc/sonic/
-        fi
         reload_minigraph
         sonic-cfggen -d --print-data > /etc/sonic/config_db.json
     else
         echo "Use config_db.json from old system..."
-        cp /etc/sonic/old_config/config_db.json /etc/sonic/
         sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
     fi
     rm -f /tmp/pending_config_migration


### PR DESCRIPTION
**- What I did**
When migrating configuration, always copy config files from old_config
to /etc/sonic. But if warm reboot is detected, then skip configuration
operations.

**- How to verify it**
warm reboot into another newly installed image with the fix.

Before the fix, when warm reboot into a new image, warm boot flag would be lost and the boot up path would execute cold boot; with the fix, the boot up path executes warm boot.