### PR TITLE
[knet driver] don't unload knet drivers during shutdown

### DIFF
--- a/platform/broadcom/saibcm-modules/systemd/opennsl-modules-4.9.0-7-amd64.service
+++ b/platform/broadcom/saibcm-modules/systemd/opennsl-modules-4.9.0-7-amd64.service
@@ -6,7 +6,12 @@ Before=syncd.service
 [Service]
 Type=oneshot
 ExecStart=-/etc/init.d/opennsl-modules-4.9.0-7-amd64 start
-ExecStop=-/etc/init.d/opennsl-modules-4.9.0-7-amd64 stop
+# Don't remove opennsl driver when stopping service. Because
+# removing knet drivers takes ~30 seconds to delete netdevs.
+# This delay cuts too deep into warm reboot time budget.
+# We could skip this step because we don't expect stopping
+# opennsl service in any context other than rebooting.
+# ExecStop=-/etc/init.d/opennsl-modules-4.9.0-7-amd64 stop
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
**- What I did**
knet driver unload takes about 30 seconds to remove netdevs. This cut
into our warm reboot time budget.

therefore, don't unload knet drivers during shutdown

**- How to verify it**
verified with warm reboot test.