### PR TITLE
[quagga bgp] set quagga graceful restart timeout to 180 seconds

### DIFF
--- a/dockers/docker-fpm-quagga/bgpd.conf.j2
+++ b/dockers/docker-fpm-quagga/bgpd.conf.j2
@@ -27,6 +27,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
+  bgp graceful-restart restart-time 180
   bgp graceful-restart
 {% for (name, prefix) in LOOPBACK_INTERFACE %}
 {% if prefix | ipv4 and name == 'Loopback0' %}

--- a/src/sonic-config-engine/tests/sample_output/bgpd_quagga.conf
+++ b/src/sonic-config-engine/tests/sample_output/bgpd_quagga.conf
@@ -20,6 +20,7 @@ router bgp 65100
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
+  bgp graceful-restart restart-time 180
   bgp graceful-restart
   bgp router-id 10.1.0.32
   network 10.1.0.32/32


### PR DESCRIPTION
**- What I did**
set quagga graceful restart timeout to 180 seconds

We need graceful restart timeout of 180 for warm reboot.