### PR TITLE
Set the default mac ageing time to 600 seconds

### DIFF
--- a/dockers/docker-orchagent/switch.json.j2
+++ b/dockers/docker-orchagent/switch.json.j2
@@ -13,7 +13,7 @@
         "SWITCH_TABLE:switch": {
             "ecmp_hash_seed": "{{ hash_seed }}",
             "lag_hash_seed": "{{ hash_seed }}",
-            "fdb_aging_time": "300"
+            "fdb_aging_time": "600"
         },
         "OP": "SET"
     }

--- a/dockers/docker-orchagent/switch.json.j2
+++ b/dockers/docker-orchagent/switch.json.j2
@@ -12,7 +12,8 @@
     {
         "SWITCH_TABLE:switch": {
             "ecmp_hash_seed": "{{ hash_seed }}",
-            "lag_hash_seed": "{{ hash_seed }}"
+            "lag_hash_seed": "{{ hash_seed }}",
+            "fdb_aging_time": "300"
         },
         "OP": "SET"
     }


### PR DESCRIPTION
The current mac ageing was disabled, this could lead the mac address
table to increase over time and lead to resource and performance issues.

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Set mac ageing time default to 300 seconds
 
**- How I did it**
set the ageing time in switch.json generated by switch.j2,  it will be loaded during the init or service restart.

**- How to verify it**
Before the fix, macs learnt were never aged out.
After the fix,  after ~5 minutes, the macs learnt but inactive were aged out. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
