### PR TITLE
[docker-syncd-brcm] Add 'startsecs=0' to ledinit process

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/supervisord.conf
+++ b/platform/broadcom/docker-syncd-brcm/supervisord.conf
@@ -32,5 +32,6 @@ command=/usr/bin/bcmcmd -t 60 "rcload /usr/share/sonic/platform/led_proc_init.so
 priority=4
 autostart=false
 autorestart=false
+startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog


### PR DESCRIPTION
ledinit process can complete successfully in < 1 second. This prevents suprevisor from logging a "not expected" message in that case.