### PR TITLE
[updategraph] After system upgrade, restore files/directories with original attributes etc.

### DIFF
--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -18,14 +18,14 @@ reload_minigraph()
     pfcwd start_default
 }
 
-function copy_config_files()
+function copy_config_files_and_directories()
 {
-    for file in $@; do
-        if [ -f /etc/sonic/old_config/${file} ]; then
-            logger "Copying SONiC configuration ${file} ..."
-            cp /etc/sonic/old_config/${file} /etc/sonic/
+    for file_dir in $@; do
+        if [ -f /etc/sonic/old_config/${file_dir} ] || [ -d /etc/sonic/old_config/${file_dir} ]; then
+            logger "Copying SONiC configuration ${file_dir} ..."
+            cp -ar /etc/sonic/old_config/${file_dir} /etc/sonic/
         else
-            logger "Missing SONiC configuration ${file} ..."
+            logger "Missing SONiC configuration ${file_dir} ..."
         fi
     done
 }
@@ -50,9 +50,9 @@ fi
 . /etc/sonic/updategraph.conf
 
 check_system_warm_boot
-
+copy_list="minigraph.xml snmp.yml acl.json config_db.json deployment_id_asn_map.yml frr" 
 if [ -f /tmp/pending_config_migration ]; then
-    copy_config_files minigraph.xml snmp.yml acl.json config_db.json
+    copy_config_files_and_directories $copy_list
     if [ x"${WARM_BOOT}" == x"true" ]; then
         echo "Warm reboot detected..."
     elif [ "$enabled" = "true" ]; then

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -50,7 +50,7 @@ fi
 . /etc/sonic/updategraph.conf
 
 check_system_warm_boot
-copy_list="minigraph.xml snmp.yml acl.json config_db.json deployment_id_asn_map.yml frr" 
+copy_list="minigraph.xml snmp.yml acl.json config_db.json frr" 
 if [ -f /tmp/pending_config_migration ]; then
     copy_config_files_and_directories $copy_list
     if [ x"${WARM_BOOT}" == x"true" ]; then


### PR DESCRIPTION
[updategraph] After system upgrade, restore files/directories with original attributes etc.
Restore a few more files that was missed before.
Restore FRR configuration directory if exists on old system

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

This depends on https://github.com/Azure/sonic-utilities/pull/410


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Restore files/directories with original attributes.
Restore some missed configurations.

**- How I did it**
added missing files.  use "cp -ar"

**- How to verify it**
build image with frr, and after "sonic_installer" and reboot into the new image,  frr is restored with old attributes. 


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
