### PR TITLE
[syncd]: Fix reload flow for Mellanox platforms

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -52,6 +52,24 @@ function wait_for_database_service()
     done
 }
 
+function getBootType()
+{
+    case "$(cat /proc/cmdline | grep -o 'SONIC_BOOT_TYPE=\S*' | cut -d'=' -f2)" in
+    warm*)
+        TYPE='warm'
+        ;;
+    fastfast)
+        TYPE='fastfast'
+        ;;
+    fast*)
+        TYPE='fast'
+        ;;
+    *)
+        TYPE='cold'
+    esac
+    echo "${TYPE}"
+}
+
 start() {
     debug "Starting ${SERVICE} service..."
 
@@ -74,15 +92,21 @@ start() {
         /usr/bin/docker exec database redis-cli -n 1 FLUSHDB
 
         # platform specific tasks
-        if [ x$sonic_asic_platform == x'mellanox' ]; then
-            export FAST_BOOT=1
-            /usr/bin/mst start
-            /usr/bin/mlnx-fw-upgrade.sh
-            /etc/init.d/sxdkernel start
-            /sbin/modprobe i2c-dev
-        elif [ x$sonic_asic_platform == x'cavium' ]; then
+        if [ x$sonic_asic_platform == x'cavium' ]; then
             /etc/init.d/xpnet.sh start
         fi
+    fi
+
+    # platform specific tasks
+    if [ x"$sonic_asic_platform" == x"mellanox" ]; then
+        BOOT_TYPE=`getBootType`
+        if [[ x"$WARM_BOOT" == x"true" || x"$BOOT_TYPE" == x"fast" ]]; then
+            export FAST_BOOT=1
+        fi
+        /usr/bin/mst start
+        /usr/bin/mlnx-fw-upgrade.sh
+        /etc/init.d/sxdkernel start
+        /sbin/modprobe i2c-dev
     fi
 
     # start service docker
@@ -106,16 +130,18 @@ stop() {
         TYPE=cold
     fi
 
-    debug "${TYPE} shutdown syncd process ..."
-    /usr/bin/docker exec -i syncd /usr/bin/syncd_request_shutdown --${TYPE}
+    if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then
+        debug "${TYPE} shutdown syncd process ..."
+        /usr/bin/docker exec -i syncd /usr/bin/syncd_request_shutdown --${TYPE}
 
-    # wait until syncd quits gracefully
-    while docker top syncd | grep -q /usr/bin/syncd; do
-        sleep 0.1
-    done
+        # wait until syncd quits gracefully
+        while docker top syncd | grep -q /usr/bin/syncd; do
+            sleep 0.1
+        done
 
-    /usr/bin/docker exec -i syncd /bin/sync
-    debug "Finished ${TYPE} shutdown syncd process ..."
+        /usr/bin/docker exec -i syncd /bin/sync
+        debug "Finished ${TYPE} shutdown syncd process ..."
+    fi
 
     /usr/bin/${SERVICE}.sh stop
     debug "Stopped ${SERVICE} service..."
@@ -123,13 +149,16 @@ stop() {
     # if warm start enabled, don't stop peer service docker
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         # platform specific tasks
-        if [ x$sonic_asic_platform == x'mellanox' ]; then
-            /etc/init.d/sxdkernel stop
-            /usr/bin/mst stop
-        elif [ x$sonic_asic_platform == x'cavium' ]; then
+        if [ x$sonic_asic_platform == x'cavium' ]; then
             /etc/init.d/xpnet.sh stop
             /etc/init.d/xpnet.sh start
         fi
+    fi
+
+    # platform specific tasks
+    if [ x"$sonic_asic_platform" == x"mellanox" ]; then
+        /etc/init.d/sxdkernel stop
+        /usr/bin/mst stop
     fi
 
     unlock_service_state_change


### PR DESCRIPTION
* Perform stop/start of Mellanox driver tools for all types of reboot
* Don't set Mellanox FAST_BOOT option for "cold" reboot
* Don't send "syncd_request_shutdown" event for "cold" reboot on Mellanox platforms

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed reload flow for syncd on Mellanox platforms.
**- How I did it**
Currently there are problems for syncd stop/start flow on Mellanox platforms which cause errors during switch/config reload and as a result switch is not initialized correctly. It happens due to broken syncd shutdown/start flow on Mellanox platforms.

Below is the list of changes made in order to fix the problem
_**Note:** All changes are relevant only for Mellanox and doesn't change behavior for other platforms._
* On Mellanox platforms stop/start of driver tools should be executed for all types of reboot, so changed ```syncd.sh``` script accordingly.
* On Mellanox platforms ```FAST_BOOT``` option should be set only for ```fast/warm``` start and not for ```cold``` reboot, so changed ```syncd.sh``` script accordingly.
* For now on Mellanox SAI ```remove_switch``` API doesn't have full support and returns an error on ```cold``` reboot (currently need to remove all config and then call switch remove). Changed ```syncd.sh``` stop flow in order to not send ```syncd_request_shutdown``` event for ```cold``` reboot.

**- How to verify it**
Deploy an image and verify that the following is working without any problems and errors during shutdown/start flow:
* ```reboot```
* ```config load_minigraph```
* ```config reload```
* ```systemctl restart swss```
* ```fast-reboot```
* ```warm-reboot```

**- Description for the changelog**
[syncd]: Fix reload flow for Mellanox platforms