### PR TITLE
Blacklist i2c_mux_gpio driver for DellEMC S6100/Z9100 

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/installer.conf
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/installer.conf
@@ -1,3 +1,3 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=1
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich,i2c_mux_gpio"

--- a/device/dell/x86_64-dell_z9100_c2538-r0/installer.conf
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/installer.conf
@@ -1,3 +1,3 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=1
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich,i2c_mux_gpio"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Blacklisting i2c_mux_gpio driver. 
Melanox added new gpio driver and that holds GPIO entry and as a result dell_ich driver fails to load.

**- How I did it**
Added blacklisting entry in installer.conf

**- How to verify it**
Verifty the above entry in grub.cfg

