### PR TITLE
[devices]: Fix arista-convertfs for aligning flash via sfdisk in Jessie

### DIFF
--- a/files/initramfs-tools/arista-convertfs.j2
+++ b/files/initramfs-tools/arista-convertfs.j2
@@ -172,7 +172,7 @@ umount "$root_mnt"
 if [ $(echo -n "$root_dev" | tail -c 1) == "1" ]; then
     # Create a new partition table (content in flash_dev will be deleted)
     err_msg="Error: repartitioning $flash_dev failed"
-    cmd="echo '2048' | sfdisk $flash_dev || (sleep 3; blockdev --rereadpt $flash_dev && fdisk -l $flash_dev | grep -q ${root_dev}.*Linux)"
+    cmd="echo '2048' | sfdisk -u S --force $flash_dev || (sleep 3; blockdev --rereadpt $flash_dev && fdisk -l $flash_dev | grep -q ${root_dev}.*Linux)"
     run_cmd "$cmd" "$err_msg"
 fi
 


### PR DESCRIPTION
The sfdisk in Jessie use unit Cylinder by default. To perform 1M
aligning partition, 2048 sector unit is desirable instead.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Use "-u S --force" option to perform flash repartitioning so that 1M aligning is achieved with start=2048 sectors. "--force" is needed otherwise old sfdisk in Jessie will complain the aligning
scheme.

**- How I did it**

**- How to verify it**
Install the image on arista 7050 then reboot the box to verify the repartitioning of flash is fine. The first partition in the table should start with 2048 sectors.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
