### PR TITLE
Add 10% safe margin to pg headroom

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/buffers.json.j2
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/buffers.json.j2
@@ -79,7 +79,7 @@
             "mode": "static"
         },
         "egress_lossy_pool": {
-            "size": "7582515",
+            "size": "7326924",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -88,8 +88,8 @@
         "ingress_lossless_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "xon":"18432",
-            "xoff":"50128",
-            "size":"51376",
+            "xoff":"55120",
+            "size":"56368",
             "dynamic_th":"-3",
             "xon_offset":"2496"
         },

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/buffers.json.j2
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/buffers.json.j2
@@ -79,7 +79,7 @@
             "mode": "static"
         },
         "egress_lossy_pool": {
-            "size": "7582515",
+            "size": "7326924",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -88,8 +88,8 @@
         "ingress_lossless_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "xon":"18432",
-            "xoff":"50128",
-            "size":"51376",
+            "xoff":"55120",
+            "size":"56368",
             "dynamic_th":"-3",
             "xon_offset":"2496"
         },

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers.json.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers.json.j2
@@ -79,7 +79,7 @@
             "mode": "static"
         },
         "egress_lossy_pool": {
-            "size": "7582515",
+            "size": "7326924",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -88,8 +88,8 @@
         "ingress_lossless_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "xon":"18432",
-            "xoff":"50128",
-            "size":"51376",
+            "xoff":"55120",
+            "size":"56368",
             "dynamic_th":"-3",
             "xon_offset":"2496"
         },


### PR DESCRIPTION
Update pg headroom (10% safe margin) & egress service pool for a7050 and s6000

Signed-off-by: Wenda <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
