### PR TITLE
[docker] Upgrade docker engine to docker-ce 18.09.0~3-0

### DIFF
--- a/ThirdPartyLicenses.txt
+++ b/ThirdPartyLicenses.txt
@@ -977,7 +977,7 @@ Microsoft is offering you a license to use the following components, to the exte
  * <http://www.gnu.org/philosophy/why-not-lgpl.html>.
  */
 
-4. apt-clean, apt-gzip-indexes, apt-no-languages imported from docker v1.11.1
+4. apt-clean, apt-gzip-indexes, apt-no-languages imported from docker ce 18.09.0~3-0
 /*
  *                                 Apache License
  *                           Version 2.0, January 2004

--- a/ThirdPartyLicenses.txt
+++ b/ThirdPartyLicenses.txt
@@ -977,7 +977,7 @@ Microsoft is offering you a license to use the following components, to the exte
  * <http://www.gnu.org/philosophy/why-not-lgpl.html>.
  */
 
-4. apt-clean, apt-gzip-indexes, apt-no-languages imported from docker ce 18.09.0~3-0
+4. apt-clean, apt-gzip-indexes, apt-no-languages imported from docker v1.11.1
 /*
  *                                 Apache License
  *                           Version 2.0, January 2004

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -31,7 +31,7 @@ function upgrade_docker_deb()
 
 function prepare_docker_upgrade()
 {
-    ## This upgrade preparation is very verion speific. Because we are chroot'ing
+    ## This upgrade preparation is very verion specific. Because we are chroot'ing
     ## to create installer image. The docker service is not really running in the
     ## target file system root. Removing docker-engine.prerm will avoid stopping
     ## the never-started service and failing.

--- a/files/docker/docker.service.conf
+++ b/files/docker/docker.service.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay --bip=240.127.1.1/24  --iptables=false
+ExecStart=/usr/bin/dockerd -H unix:// --storage-driver=overlay --bip=240.127.1.1/24  --iptables=false


### PR DESCRIPTION
This change requires https://github.com/Azure/sonic-utilities/pull/423 in place, otherwise, reboot takes about 10 minutes and that will surely fail nightly tests.

**- What I did**
- Initially install docker 1.11.1 for docker image loading. 1.11.1
  doesn't require docker service running in target filesystem root
  to load images. The latest version supports so is 1.12.2-0.
- After all docker images have been loaded, upgrade docker engine to
  docker ce 18.09.0~3-0. Also due to the complicity of chroot
  installation. Removing docker-engine.prerm is needed for successful
  uninstall of version 1.11.1.
- New version deprecated docker daemon sub-command, using dockerd
  instead. (Deprecated 1.13.0 and removed in 17.12).
- dockerd -H fd:// doesn't work. Change to -H unix://.

**- How to verify it**
- Rolling warm-reboot between 2 images for 392 iterations:
================ iteration 392 ===================
 18:02:54 up 8 min,  0 users,  load average: 1.61, 1.41, 0.77
Candidates: 1230.01 1230.02
Removing image SONiC-OS-wb-20181230.02
Removing image root filesystem...
Image removed
Image 1230.01 is installed
Image 1230.02 is not installed, installing...
Wed Jan 2 18:04:01 UTC 2019 Pausing orchagent ...
RESTARTCHECK succeeded
Wed Jan 2 18:04:01 UTC 2019 Stopping bgp ...
Wed Jan 2 18:04:01 UTC 2019 Stopped bgp ...
swss
Wed Jan 2 18:04:04 UTC 2019 Initialize pre-shutdown ...
0
Wed Jan 2 18:04:05 UTC 2019 Requesting pre-shutdown ...
requested PRE-SHUTDOWN shutdown
Wed Jan 2 18:04:05 UTC 2019 Waiting for pre-shutdown ...
Wed Jan 2 18:04:13 UTC 2019 Pre-shutdown succeeded ...
Wed Jan 2 18:04:13 UTC 2019 Backing up database ...

OK
Wed Jan 2 18:04:14 UTC 2019 Stopping teamd ...
Wed Jan 2 18:04:14 UTC 2019 Stopped teamd ...
Wed Jan 2 18:04:14 UTC 2019 Stopping syncd ...
Wed Jan 2 18:04:25 UTC 2019 Stopped syncd ...
Wed Jan 2 18:04:27 UTC 2019 Rebooting with /sbin/reboot to SONiC-OS-wb-20181230.02 ...
