### PR TITLE
[mellanox] Block the select function by default in get_transceiver_ch…

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -176,7 +176,11 @@ class SfpUtil(SfpUtilBase):
         if 'LIVENESS' not in keys:
             return False, phy_port_dict
 
-        (state, c) = self.db_sel.select(timeout)
+        if timeout:
+            (state, c) = self.db_sel.select(timeout)
+        else:
+            (state, c) = self.db_sel.select()
+
         if state == self.db_sel_timeout:
             status = True
         elif state != self.db_sel_object:


### PR DESCRIPTION
…ange_event()

* Use default timeout value which will block the select function
* Submodule update for argument type issue in Select class

Submodule update sonic-swss-common:

e8caaea - Align the argument type with epoll_wait() (#255)
3ea133d - [selectable]: Update throw message (#253)

Signed-off-by: Kevin Wang <kevinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Xcvrd daemon will always use more than 50% CPU utilization in Mellanox platform. The root cause is Xcvrd will loop to get the change_event information using function get_transceiver_change_event(timeout) which is implemented in sfputil.py per platform. On Mellanox platform, get_transceiver_change_event() will return immediately by default even there is no SFP change event happened. So the Xcvrd daemon will always busy.

**- How I did it**
What I fixed is to change the default behavior to block the select function if the timeout is the default value zero in get_transceiver_change_event(),
**- How to verify it**
Check the CPU utilization of Xcvrd process, before this change, this process's CPU utilization is always around 50%. After this change, CPU utilization will decrease to nearly 0% at the most time.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
