### PR TITLE
[libteam]: Add patch to update orig_hwaddr unconditionally

### DIFF
--- a/src/libteam/0005-update-hwaddr-orig-unconditionally.patch
+++ b/src/libteam/0005-update-hwaddr-orig-unconditionally.patch
@@ -1,0 +1,22 @@
+diff --git a/libteam/ifinfo.c b/libteam/ifinfo.c
+index 72155ae..44de4ca 100644
+--- a/libteam/ifinfo.c
++++ b/libteam/ifinfo.c
+@@ -105,15 +105,13 @@ static void update_hwaddr(struct team_ifinfo *ifinfo, struct rtnl_link *link)
+ 	hwaddr_len = nl_addr_get_len(nl_addr);
+ 	if (ifinfo->hwaddr_len != hwaddr_len) {
+ 		ifinfo->hwaddr_len = hwaddr_len;
+-		if (!ifinfo->master_ifindex)
+-			ifinfo->orig_hwaddr_len = hwaddr_len;
++		ifinfo->orig_hwaddr_len = hwaddr_len;
+ 		set_changed(ifinfo, CHANGED_HWADDR_LEN);
+ 	}
+ 	hwaddr = nl_addr_get_binary_addr(nl_addr);
+ 	if (memcmp(ifinfo->hwaddr, hwaddr, hwaddr_len)) {
+ 		memcpy(ifinfo->hwaddr, hwaddr, hwaddr_len);
+-		if (!ifinfo->master_ifindex)
+-			memcpy(ifinfo->orig_hwaddr, hwaddr, hwaddr_len);
++		memcpy(ifinfo->orig_hwaddr, hwaddr, hwaddr_len);
+ 		set_changed(ifinfo, CHANGED_HWADDR);
+ 	}
+ }

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -19,6 +19,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git apply ../0002-libteam-Temporarily-remove-redundant-debug-mes.patch
 	git apply ../0003-teamd-lacp-runner-will-send-lacp-update-right-after-.patch
 	git apply ../0004-libteam-Add-lacp-fallback-support-for-single-member-.patch
+	git apply ../0005-update-hwaddr-orig-unconditionally.patch
 	popd
 
 	# Obtain debian packaging


### PR DESCRIPTION
This is to fix the racing issue between the interface orig_hwaddr variable initialization and master value setting.