### PR TITLE
mgmt_vrf_namespace2: Repeating management vrf using namespace solutio…

### DIFF
--- a/dockers/docker-snmp-sv2/snmpd.conf.j2
+++ b/dockers/docker-snmp-sv2/snmpd.conf.j2
@@ -90,11 +90,23 @@ load   12 10 5
 # Note: disabled snmp traps due to side effect of causing snmpd to listen on all ports (0.0.0.0)
 #
 #   send SNMPv1  traps
+{%if v1_trap_dest != 'default' %}
+trapsink {{ v1_trap_dest }} public
+{% else %}
 #trapsink     localhost public
+{% endif %}
 #   send SNMPv2c traps
+{%if v2_trap_dest != 'default' %}
+trap2sink {{ v2_trap_dest }} public
+{% else %}
 #trap2sink    localhost public
+{% endif %}
 #   send SNMPv2c INFORMs
+{%if v3_trap_dest != 'default' %}
+informsink {{ v3_trap_dest }} public
+{% else %}
 #informsink   localhost public
+{% endif %}
 
 #  Note that you typically only want *one* of these three lines
 #  Uncommenting two (or all three) will result in multiple copies of each notification.

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -36,6 +36,62 @@ function preStartAction()
         echo -n > /tmp/dump.rdb
         docker cp /tmp/dump.rdb database:/var/lib/redis/
     fi
+{%- elif docker_container_name == "snmp" %}
+    localhost="localhost"
+    snmpUdpPort=162
+    vrfenabled=`/usr/bin/redis-cli -n 4 hget "MGMT_VRF_CONFIG|vrf_global" mgmtVrfEnabled`
+    v1SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestIp`
+    v1SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestPort`
+    v1MgmtVrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" vrf`
+    v2SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" DestIp`
+    v2SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" DestPort`
+    v2MgmtVrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" vrf`
+    v3SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestIp`
+    v3SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestPort`
+    v3MgmtVrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" vrf`
+
+    if [ "$v1MgmtVrf" == "mgmt" ]
+    then
+        ip netns exec mgmt iptables -t nat -D PREROUTING -i if1 -p udp -d 127.100.100.1 --dport 62101 -j DNAT --to-destination $v1SnmpTrapIp:$v1SnmpTrapPort
+        ip netns exec mgmt iptables -t nat -A PREROUTING -i if1 -p udp -d 127.100.100.1 --dport 62101 -j DNAT --to-destination $v1SnmpTrapIp:$v1SnmpTrapPort
+        sed -i 's/v1_trap_dest:.*/v1_trap_dest: 127.100.100.1:62101/' "/etc/sonic/snmp.yml"
+    elif [ "${v1SnmpTrapIp}" != "" ] && [ "${v1SnmpTrapIp}" != "${localhost}" ] && [ "${v1SnmpTrapIp}" != "default" ]
+    then
+        sed -i "s/v1_trap_dest:.*/v1_trap_dest: ${v1SnmpTrapIp}:${v1SnmpTrapPort}/" "/etc/sonic/snmp.yml"
+    elif [ "${v1SnmpTrapIp}" == "${localhost}" ]
+    then
+        sed -i "s/v1_trap_dest:.*/v1_trap_dest: ${localhost}:${snmpUdpPort}/" "/etc/sonic/snmp.yml"
+    else
+        sed -i "s/v1_trap_dest:.*/v1_trap_dest: default/" "etc/sonic/snmp.yml"
+    fi
+    if [ "$v2MgmtVrf" == "mgmt" ]
+    then
+        ip netns exec mgmt iptables -t nat -D PREROUTING -i if1 -p udp -d 127.100.100.1 --dport 62102 -j DNAT --to-destination $v2SnmpTrapIp:$v2SnmpTrapPort
+        ip netns exec mgmt iptables -t nat -A PREROUTING -i if1 -p udp -d 127.100.100.1 --dport 62102 -j DNAT --to-destination $v2SnmpTrapIp:$v2SnmpTrapPort
+        sed -i 's/v2_trap_dest:.*/v2_trap_dest: 127.100.100.1:62102/' "/etc/sonic/snmp.yml"
+    elif [ "${v2SnmpTrapIp}" != "" ] && [ "${v2SnmpTrapIp}" != "${localhost}" ] && [ "${v2SnmpTrapIp}" != "default" ]
+    then
+        sed -i "s/v2_trap_dest:.*/v2_trap_dest: ${v2SnmpTrapIp}:${v2SnmpTrapPort}/" "/etc/sonic/snmp.yml"
+    elif [ "${v2SnmpTrapIp}" == "${localhost}" ]
+    then
+        sed -i "s/v2_trap_dest:.*/v2_trap_dest: ${localhost}:${snmpUdpPort}/" "/etc/sonic/snmp.yml"
+    else
+        sed -i "s/v2_trap_dest:.*/v2_trap_dest: default/" "etc/sonic/snmp.yml"
+    fi
+    if [ "$v3MgmtVrf" == "mgmt" ]
+    then
+        ip netns exec mgmt iptables -t nat -D PREROUTING -i if1 -p udp -d 127.100.100.1 --dport 62103 -j DNAT --to-destination $v3SnmpTrapIp:$v3SnmpTrapPort
+        ip netns exec mgmt iptables -t nat -A PREROUTING -i if1 -p udp -d 127.100.100.1 --dport 62103 -j DNAT --to-destination $v3SnmpTrapIp:$v3SnmpTrapPort
+        sed -i 's/v3_trap_dest:.*/v3_trap_dest: 127.100.100.1:62103/' "/etc/sonic/snmp.yml"
+    elif [ "${v3SnmpTrapIp}" != "" ] && [ "${v3SnmpTrapIp}" != "${localhost}" ] && [ "${v3SnmpTrapIp}" != "default" ]
+    then
+        sed -i "s/v3_trap_dest:.*/v3_trap_dest: ${v3SnmpTrapIp}:${v3SnmpTrapPort}/" "/etc/sonic/snmp.yml"
+    elif [ "${v3SnmpTrapIp}" == "${localhost}" ]
+    then
+        sed -i "s/v3_trap_dest:.*/v3_trap_dest: ${localhost}:${snmpUdpPort}/" "etc/sonic/snmp.yml"
+    else
+        sed -i "s/v3_trap_dest:.*/v3_trap_dest: default/" "etc/sonic/snmp.yml"
+    fi
 {%- else %}
     : # nothing
 {%- endif %}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -172,6 +172,18 @@ sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable hostcfgd.service
 sudo cp $IMAGE_CONFIGS/hostcfgd/hostcfgd $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/hostcfgd/*.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 
+# Copy the management VRF related scripts
+sudo cp $IMAGE_CONFIGS/interfaces/if_pre_up_netns $FILESYSTEM_ROOT/usr/bin/
+sudo cp $IMAGE_CONFIGS/interfaces/if_up_netns $FILESYSTEM_ROOT/usr/bin/
+sudo cp $IMAGE_CONFIGS/interfaces/if_down_netns $FILESYSTEM_ROOT/usr/bin/
+sudo cp $IMAGE_CONFIGS/interfaces/create-mgmt-vrf-iptables.sh $FILESYSTEM_ROOT/usr/bin/
+sudo cp $IMAGE_CONFIGS/interfaces/delete-mgmt-vrf-iptables.sh $FILESYSTEM_ROOT/usr/bin/
+
+# Copy vrfcfgd files
+sudo cp $IMAGE_CONFIGS/vrfcfgd/vrfcfgd.service $FILESYSTEM_ROOT/etc/systemd/system/
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable vrfcfgd.service
+sudo cp $IMAGE_CONFIGS/vrfcfgd/vrfcfgd $FILESYSTEM_ROOT/usr/bin/
+
 # Copy the buffer configuration template
 sudo cp $BUILD_TEMPLATES/buffers_config.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -21,6 +21,10 @@ TACPLUS_SERVER_PASSKEY_DEFAULT = ""
 TACPLUS_SERVER_TIMEOUT_DEFAULT = "5"
 TACPLUS_SERVER_AUTH_TYPE_DEFAULT = "pap"
 
+MAX_TACPLUS_SERVERS=10
+TACPLUS_SERVER_LOCAL_IP="127.100.100.1"
+TACPLUS_LOCAL_PORT_START=62000
+
 
 def is_true(val):
     if val == 'True' or val == 'true':
@@ -55,7 +59,30 @@ class AaaCfg(object):
         self.auth = {}
         self.tacplus_global = {}
         self.tacplus_servers = {}
+        # Maintain the mapping between user configured tacacs server publicIP to localport
+        self.localport_for_server_publicip = {}
+        # Maintain the mapping between user configured tacacs server publicPort for the serverIP
+        self.publicport_for_server_publicip = {}
+        # Maintain the local_port_status for all 10 servers as either "free" or "used"
+        self.local_port_status = {}
         self.debug = False
+        # next_free_local_port shows the next least numbered free port between 62000 and 62009
+        #Initializing next_free_PORT as 62000
+        self.next_free_local_port = TACPLUS_LOCAL_PORT_START
+        for x in range (MAX_TACPLUS_SERVERS):
+            #Initializing all the available 10 ports as "free"
+            self.local_port_status[x]="free"
+
+
+    def update_next_free_local_port(self):
+        # Check all the status of 10 ports and find the next available free port
+        for x in range (MAX_TACPLUS_SERVERS):
+            local_port = TACPLUS_LOCAL_PORT_START + x
+            if self.local_port_status[x]=='free':
+                #Chaning the next free port to this free local port
+                self.next_free_local_port = local_port
+                break
+
 
     # Load conf from ConfigDb
     def load(self, aaa_conf, tac_global_conf, tacplus_conf):
@@ -86,8 +113,47 @@ class AaaCfg(object):
     def tacacs_server_update(self, key, data, modify_conf=True):
         if data == {}:
             if key in self.tacplus_servers:
+                #Deleting tacplus_server
+                if (self.tacplus_servers[key]['vrf'] == "mgmt"):
+                    #Tacacs Server in Management VRF has to be deleted
+                    local_port_used = self.localport_for_server_publicip[key]
+                    user_configured_port = self.publicport_for_server_publicip[key]
+                    # Compose the ip netns command to remove the previously created DNAT rule from management VRF iptables.
+                    cmd2 = "ip netns exec mgmt iptables -t nat -D PREROUTING -i if1 -p tcp -d {0} --dport {1} -j DNAT --to-destination {2}:{3}".format(TACPLUS_SERVER_LOCAL_IP, local_port_used, key, user_configured_port)
+                    os.system(cmd2) 
+                    # Marking local_port as free
+                    self.local_port_status[local_port_used-TACPLUS_LOCAL_PORT_START] = "free"
+                    # If the self.next_free_local_port is greater than the currently freed port, update it with this least port number
+                    if (self.next_free_local_port > local_port_used):
+                        #Changing next free from old value to new value
+                        self.next_free_local_port = self.localport_for_server_publicip[key]
+
+                # Irrespectie of server in management VRF or default VRF, delete it from our tacplus_server list.
                 del self.tacplus_servers[key]
+
         else:
+            if (data['vrf'] == "mgmt") :
+                # tacplus_server need to be added in management VRF.
+                # Save the user configured publicPort that is required later while adding DNAT rule.
+                data['user_configured_server_port'] = data['tcp_port']
+                # set the tcp_port in data to the local port to be used in the tacacs config file.
+                data['tcp_port'] = str(self.next_free_local_port)
+
+                # Compose the iptables rule to be added to in management namespace.
+                cmd = "ip netns exec mgmt iptables -t nat -A PREROUTING -i if1 -p tcp -d {0} --dport {1} -j DNAT --to-destination {2}:{3}".format(TACPLUS_SERVER_LOCAL_IP, self.next_free_local_port, key, data['user_configured_server_port'])
+                os.system(cmd)
+
+                #Update the mapping table with the local port that is used and the actual publicIP configured by user.
+                # mapping table is index using the tacplus server publicIP (which is the "key").
+                self.localport_for_server_publicip[key] = self.next_free_local_port
+                self.publicport_for_server_publicip[key] = data['user_configured_server_port']
+
+                # Mark the local_port array element as "used"
+                self.local_port_status[self.next_free_local_port-TACPLUS_LOCAL_PORT_START]="used"
+                # Call the function to update the next available free port.
+                self.update_next_free_local_port()
+
+            # Update internal data structure tacplus_servers with the data.
             self.tacplus_servers[key] = data
 
         if modify_conf:
@@ -103,7 +169,16 @@ class AaaCfg(object):
         if self.tacplus_servers:
             for addr in self.tacplus_servers:
                 server = tacplus_global.copy()
-                server['ip'] = addr
+                # It is expected that user configured ports are less than 62000. Value about 62000 until 62009 are local ports
+                # used for NAT that is requried for supporting management VRF.
+                # If localport has been assigned as part of NAT, use that local IP & local port instead of publicIP and publicPort.
+                # This will update the tacplus server configuration file with local IP and local port if the server is reachable via the management VRF.
+                if (int(self.tacplus_servers[addr]['tcp_port']) >= TACPLUS_LOCAL_PORT_START):
+                    if (int(self.tacplus_servers[addr]['tcp_port']) < TACPLUS_LOCAL_PORT_START+MAX_TACPLUS_SERVERS):
+                        # This means that the publicIP is already mapped to local IP and local port
+                        server['ip'] = TACPLUS_SERVER_LOCAL_IP
+                else :
+                    server['ip'] = addr
                 server.update(self.tacplus_servers[addr])
                 servers_conf.append(server)
             sorted(servers_conf, key=lambda t: t['priority'], reverse=True)

--- a/files/image_config/interfaces/create-mgmt-vrf-iptables.sh
+++ b/files/image_config/interfaces/create-mgmt-vrf-iptables.sh
@@ -1,0 +1,27 @@
+#!/bin//bash
+
+set -e
+
+VRFNAME="mgmt"
+
+ip netns exec $VRFNAME iptables -t nat -A PREROUTING -i eth0 -j $IF_MGMT_VRF_CHAIN
+
+ip netns exec $VRFNAME iptables -t nat -A POSTROUTING -p tcp -o $IF_PEER_IFACE -j SNAT --to-source $IF_IF1_IP:62000-65000
+ip netns exec $VRFNAME iptables -t nat -A POSTROUTING -p udp -o $IF_PEER_IFACE -j SNAT --to-source $IF_IF1_IP:62000-65000
+
+ip netns exec $VRFNAME iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+
+ip netns exec $VRFNAME iptables -t nat -A $IF_MGMT_VRF_CHAIN -p tcp --dport 22 -j DNAT --to-destination $IF_IF2_IP
+
+ip netns exec $VRFNAME iptables -t nat -A $IF_MGMT_VRF_CHAIN -p tcp --dport 20 -j DNAT --to-destination $IF_IF2_IP
+
+ip netns exec $VRFNAME iptables -t nat -A $IF_MGMT_VRF_CHAIN -p tcp --dport 21 -j DNAT --to-destination $IF_IF2_IP
+
+ip netns exec $VRFNAME iptables -t nat -A $IF_MGMT_VRF_CHAIN -p udp --dport 161 -j DNAT --to-destination $IF_IF2_IP
+
+ip netns exec $VRFNAME iptables -t nat -A $IF_MGMT_VRF_CHAIN -p udp --dport 69 -j DNAT --to-destination ${IF_IF2_IP}
+
+ip netns exec $VRFNAME iptables -t nat -A $IF_MGMT_VRF_CHAIN -p tcp --dport 80 -j DNAT --to-destination $IF_IF2_IP
+
+ip netns exec $VRFNAME iptables -t nat -A $IF_MGMT_VRF_CHAIN -p tcp --dport 443 -j DNAT --to-destination $IF_IF2_IP
+

--- a/files/image_config/interfaces/delete-mgmt-vrf-iptables.sh
+++ b/files/image_config/interfaces/delete-mgmt-vrf-iptables.sh
@@ -1,0 +1,32 @@
+#!/bin//bash
+
+set -e
+
+VRFNAME="mgmt"
+
+ip netns exec $VRFNAME iptables -t nat -D PREROUTING -i eth0 -j $IF_MGMT_VRF_CHAIN
+
+ip netns exec $VRFNAME iptables -t nat -D POSTROUTING -p tcp -o ${IF_PEER_IFACE} -j SNAT --to-source ${IF_IF1_IP}:62000-65000
+ip netns exec $VRFNAME iptables -t nat -D POSTROUTING -p udp -o ${IF_PEER_IFACE} -j SNAT --to-source ${IF_IF1_IP}:62000-65000
+
+ip netns exec $VRFNAME iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
+
+ip netns exec $VRFNAME iptables -t nat -D $IF_MGMT_VRF_CHAIN -p tcp --dport 22 -j DNAT --to-destination ${IF_IF2_IP}
+
+ip netns exec $VRFNAME iptables -t nat -D $IF_MGMT_VRF_CHAIN -p tcp --dport 20 -j DNAT --to-destination ${IF_IF2_IP}
+
+ip netns exec $VRFNAME iptables -t nat -D $IF_MGMT_VRF_CHAIN -p tcp --dport 21 -j DNAT --to-destination ${IF_IF2_IP}
+
+ip netns exec $VRFNAME iptables -t nat -D $IF_MGMT_VRF_CHAIN -p udp --dport 161 -j DNAT --to-destination ${IF_IF2_IP}
+
+ip netns exec $VRFNAME iptables -t nat -D $IF_MGMT_VRF_CHAIN -p udp --dport 69 -j DNAT --to-destination ${IF_IF2_IP}
+
+ip netns exec $VRFNAME iptables -t nat -D $IF_MGMT_VRF_CHAIN -p tcp --dport 80 -j DNAT --to-destination ${IF_IF2_IP}
+
+ip netns exec $VRFNAME iptables -t nat -D $IF_MGMT_VRF_CHAIN -p tcp --dport 443 -j DNAT --to-destination ${IF_IF2_IP}
+
+ip netns exec $VRFNAME sysctl -w net.ipv4.conf.eth0.route_localnet=0
+
+ip netns exec $VRFNAME sysctl -w net.ipv4.conf.${IF_PEER_IFACE}.route_localnet=0
+
+sysctl -w net.ipv4.conf.${IFACE}.route_localnet=0

--- a/files/image_config/interfaces/if_down_netns
+++ b/files/image_config/interfaces/if_down_netns
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+if [ -n "${IF_PEER_NETNS}" -a -n "${IF_PEER_IFACE}" ]
+then
+	if OUTPUT=$(ip netns list | grep -w ${IF_PEER_NETNS})
+	then
+		# Take down the remote end of the veth
+		ip netns exec ${IF_PEER_NETNS} ip link set ${IF_PEER_IFACE} down
+
+		case "${IF_CONFIGURE_INTERFACES}" in
+			true|yes|on)
+				# Ifdown the interfaces inside the netns and inside
+				# a mount namespace with /run/network.nsname mounted
+				# on /run/network
+				unshare -m /bin/sh <<-EOF
+					mount --make-rprivate /
+					mount --bind /run/network.${IF_PEER_NETNS} /run/network
+					/usr/bin/delete-mgmt-vrf-iptables.sh
+
+            	    logger "if_down_netns: Doing ifdown for the interfaces present in management namespace."
+					ip netns exec ${IF_PEER_NETNS} ifdown -i /etc/network/interfaces.${IF_PEER_NETNS} -a
+				EOF
+				;;
+		esac
+	fi
+fi

--- a/files/image_config/interfaces/if_pre_up_netns
+++ b/files/image_config/interfaces/if_pre_up_netns
@@ -1,0 +1,54 @@
+#!/bin/sh
+# filename: 
+
+set -e
+
+if [ -n "${IF_PEER_NETNS}" -a -n "${IF_PEER_IFACE}" ]
+then
+    logger "if_pre_up_netns: User is enabling management VRF. interfaces.j2 has set the required variables. Create the management namespace if not already present."
+	# Create netns if it doesn't already exist, and bring up the loopback
+	if ! OUTPUT=$(ip netns list | grep -w ${IF_PEER_NETNS})
+	then
+        logger "if_pre_up_netns: management vrf does not exist. Create it now."
+		mkdir -p /run/network.${IF_PEER_NETNS}
+		rm -rf /run/network.${IF_PEER_NETNS}/*
+		ip netns add ${IF_PEER_NETNS}
+		ip netns exec ${IF_PEER_NETNS} ip link set lo up
+	else
+        logger "if_pre_up_netns: management vrf already exists. No need to create it."
+	fi
+	
+	if OUTPUT=$(ifconfig eth0)
+	then
+        logger "if_pre_up_netns: eth0 is in default VRF. Move it to management VRF"
+		# Move the management interface eth0 from default namespace to management namespace
+		ip link set dev eth0 netns ${IF_PEER_NETNS}
+	else
+        logger "if_pre_up_netns: eth0 is NOT in default VRF. No need to move it."
+	fi
+	
+	# if veth pair is already existing, there will be a link by name if1@if2
+	if ! OUTPUT=$(ethtool -S if2)
+	then
+		logger "if_pre_up_netns: if1 & if2 are NOT in eth pair. Connect them via eth pair now"
+		# Add the veth pair for if2 with peer as if1
+		ip link add name ${IFACE} type veth peer name ${IF_PEER_IFACE}
+	else
+		logger "if_pre_up_netns: if1 & if2 are already in eth pair. NO need to connect them via eth pair now"
+	fi
+	
+	# if if1 is already  part of management namespace, nothing to do. Else move it to the management namespace
+	if ! OUTPUT=$(ip netns exec ${IF_PEER_NETNS} ifconfig if1)
+	then
+		logger "if_pre_up_netns: if1 is not in management VRF. Move it now"
+		# Put the remote end interface if1 into the netns
+		ip link set dev ${IF_PEER_IFACE} netns ${IF_PEER_NETNS}
+	else
+		logger "if_pre_up_netns: if1 is alerady in management VRF. no need to move it"
+	fi
+
+	# Set if2 as UP
+    logger "if_pre_up_netns: Bringing up the if2"
+	ip link set ${IFACE} up
+
+fi

--- a/files/image_config/interfaces/if_up_netns
+++ b/files/image_config/interfaces/if_up_netns
@@ -1,0 +1,76 @@
+#!/bin/sh
+# filename: 
+
+set -e
+
+
+if [ -n "${IF_PEER_NETNS}" -a -n "${IF_PEER_IFACE}" ]
+then
+    logger "if_up_netns: User is enabling management VRF. interfaces.j2 has set the required variables. management namespace was already created and eth0 is already moved to management namespace in if_pre_up_netns."
+
+	# Bring up the remote end of the veth
+	ip netns exec ${IF_PEER_NETNS} ip link set ${IF_PEER_IFACE} up
+
+	case "${IF_CONFIGURE_INTERFACES}" in
+		true|yes|on)
+            logger "if_up_netns: Configuring the veth pair and internal IP addresses for the internal interfaces."
+			ip netns exec ${IF_PEER_NETNS} ifconfig ${IF_PEER_IFACE} ${IF_IF1_IP}/${IF_IF1_PREFIXLEN}
+			ifconfig ${IFACE} ${IF_IF2_IP}/${IF_IF2_PREFIXLEN}
+
+			# Ifup the interfaces in the netns and inside
+			# a mount namespace with /run/network.nsname mounted
+			# on /run/network
+			unshare -m /bin/sh <<-EOF
+				mount --make-rprivate /
+				mount --bind /run/network.${IF_PEER_NETNS} /run/network
+            	logger "if_up_netns: Doing ifup for the interfaces present in management namespace."
+				ip netns exec ${IF_PEER_NETNS} ifup -i /etc/network/interfaces.${IF_PEER_NETNS} -a
+			EOF
+			;;
+	esac
+
+	logger "if_up_netns: flushing rules from MgmtVrfChain"
+	ip netns exec ${IF_PEER_NETNS} iptables -t nat -F ${IF_MGMT_VRF_CHAIN} >/dev/null 2>&1 || true
+    # In case if the MgmtVrfChain exists, creating it again will result in the script failing & exiting. Delete is before creating.
+	logger "if_up_netns: Deleting MgmtVrfChain before creating it"
+	ip netns exec ${IF_PEER_NETNS} iptables -t nat -X ${IF_MGMT_VRF_CHAIN} >/dev/null 2>&1 || true 
+	logger "if_up_netns: Creating MgmtVrfChain in management VRF."
+	ip netns exec ${IF_PEER_NETNS} iptables -t nat -N ${IF_MGMT_VRF_CHAIN}
+	logger "if_up_netns: Creating iptables rules in management VRF into MgmtVrfChain"
+	/usr/bin/create-mgmt-vrf-iptables.sh
+	
+    	# When 127 NW is used, default NS does not reply for the ARP request sent from management NS when default NS
+    	# loopback interface netmask is 255.0.0.0. Change it to 255.255.255.0 in both namespaces.
+
+    	ifconfig lo 127.0.0.1 netmask 255.255.255.0
+    	ip netns exec ${IF_PEER_NETNS} ifconfig lo 127.0.0.1 netmask 255.255.255.0
+
+	# route_localnet should be set to 1 to force the linux to route packets for IP addresses 127.100.100.x
+	logger "if_up_netns: Setting route_localnet for if2 in default VRF."
+	sysctl -w net.ipv4.conf.$IFACE.route_localnet=1
+
+	logger "if_up_netns: Setting route_localnet for all interfaces in management VRF."
+	ip netns exec ${IF_PEER_NETNS} sysctl -w net.ipv4.conf.all.route_localnet=1
+fi
+
+if [ $IFACE = "lo" ];
+then
+        logger "if_up_netns: ifup for lo is executed."
+	EXIST=`ip address show lo | grep "127.0.0.1/8" | wc -l`
+	if [ $EXIST -eq 1 ]
+	then
+		logger "if_up_netns: 8 bit 127 address is there."
+		EXIST2=`ip address show lo | grep "127.0.0.1/24" | wc -l`
+		if [ $EXIST2 -eq 1 ]
+		then
+			logger "if_up_netns: 24 bit 127 address is also there."
+			logger "if_up_netns: ifup for lo is executed. Deleting the 8 bit address which is conflicting with 24 bit mask"
+			ip address del 127.0.0.1/8 dev lo
+		else
+			logger "if_up_netns: 24 bit 127 address is NOT there."
+		fi
+	else
+		logger "if_up_netns: ifup for lo is executed. 8 bit address doe not exist and hence nothing to delete"
+	fi
+fi
+

--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -1,8 +1,64 @@
 #!/bin/bash
 
-ifdown --force eth0
+VRFNAME="mgmt"
+
+vrfenabled=`/usr/bin/redis-cli -n 4 hget "MGMT_VRF_CONFIG|vrf_global" mgmtVrfEnabled`
+
+if [ ! -f /var/run/netns/$VRFNAME ]
+then
+    logger "interfaces-config: management vrf is not enabled. Bringing down eth0 in default VRF."
+	ifdown --force eth0
+else
+    logger "interfaces-config: management vrf is enabled. Bringing down eth0 in management VRF."
+	ip netns exec $VRFNAME ifdown --force eth0
+
+fi
 
 sonic-cfggen -d -t /usr/share/sonic/templates/interfaces.j2 > /etc/network/interfaces
+
+	if [ "$vrfenabled" == "true" ]
+	then  
+	
+	    # Copy the respective netns file to the respective directories
+	    logger "interfaces-config: vrfenabled is true. copying the netns scripts & generating interfaces.mgmt file"
+	
+	    cp /usr/bin/if_pre_up_netns /etc/network/if-pre-up.d/netns
+	    cp /usr/bin/if_up_netns /etc/network/if-up.d/netns
+	    cp /usr/bin/if_down_netns /etc/network/if-down.d/netns
+	    
+	    # create management namespace interfaces file which contains the eth0 and 
+	    #  other management namespace interfaces.
+	
+	    sonic-cfggen -d -t /usr/share/sonic/templates/interfaces_mgmt.j2 > /etc/network/interfaces.$VRFNAME
+	
+	
+	 #Following "elif" condition will be exceuted in two conditions. 1. First time fresh boot when vrfenabled variable itself is not there. 2. vrfenabled variable exists, but the value is not true (which is nothing but vrf is disabled.)
+
+    	elif [ -f /var/run/netns/$VRFNAME ]
+	then
+        		logger "interfaces-config: vrfenabled flag is false. Removing netns files, deleting iptables from management vrf and deleting the management VRF"
+	
+	    if [ -f /etc/network/if-up.d/netns ]
+	    then
+		    rm /etc/network/if-up.d/netns
+	    fi
+	    if [ -f /etc/network/if-pre-up.d/netns ]
+	    then
+		    rm /etc/network/if-pre-up.d/netns
+	    fi
+	    if [ -f /etc/network/if-down.d/netns ]
+	    then
+		    rm /etc/network/if-down.d/netns
+	    fi
+	    if [ -f /etc/network/interfaces.$VRFNAME ]
+	    then
+		    rm /etc/network/interfaces.$VRFNAME
+	    fi
+        logger "interfaces-config: Deleting the management VRF"
+	    ip netns del $VRFNAME
+	fi
+
+logger "interfaces-config: Adding usb0 interface for bfn platforms."
 
 # Add usb0 interface for bfn platforms
 platform=$(sonic-cfggen -H -v 'DEVICE_METADATA["localhost"]["platform"]')
@@ -16,8 +72,11 @@ up ifconfig usb0 txqueuelen 64
 EOF
 fi
 
+logger "interfaces-config: Killing dhcp client."
 [ -f /var/run/dhclient.eth0.pid ] && kill `cat /var/run/dhclient.eth0.pid` && rm -f /var/run/dhclient.eth0.pid
 
+logger "interfaces-config: Restarting networking service."
 systemctl restart networking
 
+logger "interfaces-config: Bringing down loopback interfaces and bringing it back to up."
 ifdown lo && ifup lo

--- a/files/image_config/interfaces/interfaces_mgmt.j2
+++ b/files/image_config/interfaces/interfaces_mgmt.j2
@@ -1,36 +1,20 @@
 #
 {% block banner %}
 # =============== Managed by SONiC Config Engine DO NOT EDIT! ===============
-# generated from /usr/share/sonic/templates/interfaces.j2 using sonic-cfggen
-# file: /etc/network/interfaces
+# generated from /usr/share/sonic/templates/interfaces_mgmt.j2 using sonic-cfggen
+# file: /etc/network/interfaces.management
 #
 {% endblock banner %}
+
 {% block loopback %}
 # The loopback network interface
 auto lo
 iface lo inet loopback
-# Use command 'ip addr list dev lo' to check all addresses
-{% for (name, prefix) in LOOPBACK_INTERFACE %}
-iface lo {{ 'inet' if prefix | ipv4 else 'inet6' }} static
-    address {{ prefix | ip }}
-    netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
-#
-{% endfor %}
 {% endblock loopback %}
+
 {% block mgmt_interface %}
 
-{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-auto if2
-iface if2 inet manual
-   peer-netns mgmt
-   peer-iface if1
-   configure-interfaces yes
-   if1-ip 127.100.100.1
-   if1-prefixlen 24
-   if2-ip 127.100.100.2
-   if2-prefixlen 24
-   mgmt-vrf-chain MgmtVrfChain
-{% else %}
+{% if MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true" %}
 # The management network interface
 auto eth0
 {% if MGMT_INTERFACE %}
@@ -40,7 +24,8 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
     ########## management network policy routing rules
     # management port up rules
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table default
+	up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table default
+	#up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table default
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table default
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
@@ -61,4 +46,3 @@ iface eth0 inet dhcp
 {% endif %}
 #
 {% endblock mgmt_interface %}
-

--- a/files/image_config/snmp/snmp.yml
+++ b/files/image_config/snmp/snmp.yml
@@ -1,2 +1,5 @@
 snmp_rocommunity: public
 snmp_location: public
+v1_trap_dest: default
+v2_trap_dest: default
+v3_trap_dest: default

--- a/files/image_config/vrfcfgd/vrfcfgd
+++ b/files/image_config/vrfcfgd/vrfcfgd
@@ -1,0 +1,144 @@
+#!/usr/bin/python -u
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import subprocess
+from subprocess import Popen, PIPE
+import shlex
+import time
+import syslog
+import copy
+import jinja2
+from swsssdk import ConfigDBConnector
+
+
+class VrfCfg(object):
+    def __init__(self):
+        self.vrfconfig = {
+            'mgmtVrfEnabled': 'false',
+        }
+        self.debug = False
+        self.mgmt_vrfname = "mgmt"
+
+
+    # Delete preexisting namespace during reboot/init. It will be created when the configuration from configDB is played.
+    def delete_preexisting_mgmt_namespace(self):
+        cmd = "ip netns list"
+        out2 = subprocess.Popen(cmd, shell=True, stdout = subprocess.PIPE)
+        for line in out2.stdout:
+            namespace=line.split()[0]
+            syslog.syslog (syslog.LOG_INFO, 'VrfCfg: INIT: Deleting pre-existing namespace = {0} after killing all processes running inside it'.format(namespace))
+            # Kill running processes before deleting NS. Otherwise, eth0 wont go back to default VRF. 
+            # kill will succeed if any process is running. Or else kill will fail which means that there is no process to kill; 
+            # this is not an error and hence silently ignore the error output.
+            cmd = "ip netns pids {0} | xargs kill".format (namespace)
+            with open(os.devnull, 'w') as shutup:    
+                 return_code = subprocess.call (cmd, stdout=shutup, stderr=shutup, shell=True)
+            # Delete the namespace now.
+            cmd = "ip netns del {0}".format (namespace)
+            return_code = subprocess.call (cmd, shell=True)
+
+
+
+    # Load conf from ConfigDb
+    def load(self, vrf_conf):
+        syslog.syslog(syslog.LOG_INFO, 'VrfCfg:INIT: Loading config from ConfigDb')
+        for row in vrf_conf:
+            syslog.syslog(syslog.LOG_INFO, 'VrfCfg:INIT: Calling config update with key as: {0}: Data={1}'.format(row, vrf_conf[row]))
+            self.vrf_config_update(row, vrf_conf[row], modify_conf=False)
+
+    def vrf_config_update(self, key, data, modify_conf=True):
+        if data.has_key('mgmtVrfEnabled'):
+            syslog.syslog(syslog.LOG_DEBUG, 'VrfCfg: ConfigUpdate: data has the mgmtVrfEnabled key. Check the value.')
+            if (self.vrfconfig['mgmtVrfEnabled'] != data['mgmtVrfEnabled']):
+                syslog.syslog(syslog.LOG_DEBUG, 'VrfCfg: ConfigUpdate: Current value of mgmtVrfEnabled:{0} is not same as user configured value:{1}. Take action.'.format(self.vrfconfig['mgmtVrfEnabled'], data['mgmtVrfEnabled']))
+
+                # Check if management vrf is currently enabled. If so, explicitly remove the namespace.
+                if (self.vrfconfig['mgmtVrfEnabled'] == "true"):
+                        # User is disabling the already enabled management VRF.
+                        #Check if management namespace is already running and delete all processes running in it.
+                        syslog.syslog(syslog.LOG_INFO, 'VrfCfg: ConfigUpdate: User is disabling the currently enabled management VRF.')
+                        cmd = "ip netns list | grep -w {0}".format (self.mgmt_vrfname)
+                        return_code = subprocess.call (cmd, shell=True)
+                        if (return_code ==0):
+                            syslog.syslog (syslog.LOG_DEBUG, 'VrfCfgd: management vrf is running. Delete the processes running in it')
+                            # Kill running processes before deleting NS. Otherwise, eth0 wont go back to default VRF. 
+                            # kill will succeed if any process is running. Or else kill will fail which means that there is no 
+                            # process to kill; this is not an error and hence silently ignore the error output.
+                            with open(os.devnull, 'w') as shutup:    
+                                 return_code = subprocess.call (cmd, stdout=shutup, stderr=shutup, shell=True)
+                            # Delete the namespace now.
+                            #cmd = "ip netns del {0}".format (self.mgmt_vrfname)
+                            #return_code = subprocess.call (cmd, shell=True)
+                            # Deletion of namespace is done in interfaces-config.sh script and hence it is commented here.
+
+                else:
+                    syslog.syslog(syslog.LOG_INFO, 'VrfCfg: ConfigUpdate: User is enabling the management VRF that is currently  disabled')
+                    # User is enabling the management VRF that is currently disabled.
+                    # Kill if any dhcp client is already running in eth0 and kill it.
+                    cmd = "cat /var/run/dhclient.eth0.pid"
+                    return_code = subprocess.call (cmd, shell=True)
+                    if return_code == 0 :
+                        syslog.syslog (syslog.LOG_DEBUG, 'VrfCfgd: dhclient is running in default VRF. command to be executed to kill it = {0}'.format(cmd))
+                        cmd = "kill -9 $(cat /var/run/dhclient.eth0.pid)"
+                        return_code = subprocess.call (cmd, shell=True)
+                    else:
+                        syslog.syslog (syslog.LOG_DEBUG, 'VrfCfgd: dhclient is not running in default VRF. Nothing to kill')
+
+
+                # In both cases, set the local database with new value 
+                self.vrfconfig['mgmtVrfEnabled'] = data['mgmtVrfEnabled']
+                
+                syslog.syslog(syslog.LOG_INFO, 'VrfCfg: ConfigUpdate: Restarting the interfaces-config  service')
+                #Restart the "interfaces-config" service that creates the /etc/network/interfaces based on enable flag value.
+                # If it is restarted for enabling management vrf, the service 
+                # will place eth0 in /etc/network/interfaces.management and 
+                # triggers the interface configurion on management namespace
+                # using "ip netns exec management" using the script from
+                # /etc/network/if-pre-up.d/netns and /etc/network/if-up.d/netns.
+                # If it is restarted with enable flag as false, the service
+                # places the eth0 in /etc/network/interfaces and triggers the
+                # interface configuration on default VRF.
+                return_code = subprocess.call ("systemctl restart interfaces-config", shell=True)
+            else:
+                syslog.syslog(syslog.LOG_DEBUG, 'VrfCfg: ConfigUpdate: Current value is same as user configured value. No action')
+        else:
+            syslog.syslog(syslog.LOG_DEBUG, 'VrfCfg: ConfigUpdate: mgmtVrfEnabled key itself not available. No action for enabling/disabling management VRF.')
+
+
+
+class VrfConfigDaemon:
+    def __init__(self):
+        self.config_db = ConfigDBConnector()
+        self.config_db.connect(wait_for_init=True, retry_on=True)
+        syslog.syslog(syslog.LOG_INFO, 'VrfCfg:INIT: ConfigDB connect success from VRF config manager')
+        vc1 = self.config_db.get_table('MGMT_VRF_CONFIG')
+        self.vrfconfig = VrfCfg()
+        syslog.syslog(syslog.LOG_DEBUG, 'VrfCfg:INIT: Calling Load Config')
+        # Clear preexisting management namespace that linux might have created  as part of regular boot process. 
+        # After deleting, "load" will take care of creating the management namespace if user has enabled it in ConfigDB.
+	    # If user has not enabled management namespace, everything will come up without namespace.
+        self.vrfconfig.delete_preexisting_mgmt_namespace()
+        self.vrfconfig.load(vc1)
+
+    def vrf_config_handler(self, key, data):
+        syslog.syslog(syslog.LOG_DEBUG, 'VrfCfg: vrf_config_handler calling with key as:{} and data as: {}'.format(key, data))
+        self.vrfconfig.vrf_config_update(key, data)
+
+
+    def start(self):
+        syslog.syslog(syslog.LOG_DEBUG, 'VrfCfg: START.')
+        self.config_db.subscribe('MGMT_VRF_CONFIG', lambda table, key, data: self.vrf_config_handler(key, data))
+        self.config_db.listen()
+
+
+def main():
+    daemon = VrfConfigDaemon()
+    syslog.syslog(syslog.LOG_DEBUG, 'VrfCfg: MAIN: VrfConfigDaemon completed. Calling Start.')
+    daemon.start()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/files/image_config/vrfcfgd/vrfcfgd.service
+++ b/files/image_config/vrfcfgd/vrfcfgd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=VRF config enforcer daemon
+Wants=network-online.target updategraph.service networking.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/vrfcfgd
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
**- What I did**
Added support for management VRF using namespace solution.
Requirements that are covered are explained in the design document. Enhancements required to support tacacs and snmptrap are also added. Enhanced the configuration for using --use-mgmt-vrf for tacacs server & snmptrap server configuration on top of namespace based solution for management VRF to configure the required rules for namespace solution.
Two PRs are raised, one for sonic-buildimage (this PR#2431) and other for sonic-utilities (https://github.com/Azure/sonic-utilities/pull/431).
**- How I did it**
Added commands to enable/disable the management VRF. On enabling, it creates the management namespace, attached eth0 to management namespace, creates the required iptables rules and restarts the networking service. Detailed design is explained in the design document https://github.com/kannankvs/mvrf_namespace/blob/master/Management%20VRF%20Design%20Document%20Namespace.md. Namespace solution requires DNAT as explained in the design document. hostcfgd is enhanced to support maximum of 10 tacacs servers. Mapping between the user configured tacacs server IP/port and internally used local IP/port are maintained in this file for adding and deleting those NAT rules. For supporting snmptrap configuration, enhanced main.py & created sonic_snmp_trap_conf.py to configure the snmptrap server IP address/port and enhanced the file docker_image_ctl.j2 to create the required /usr/bin/snmp.sh script that adds the required DNAT rules during snmp service restart process.
**- How to verify it**
Use the following commands to enable/disable mgmt vrf and test the basic management VRF features.
config vrf add mgmt
config vrf del mgmt
config interface eth0 ip add ip/mask gatewayIP
Ex: config interface eth0 ip add 10.16.206.11/24 10.16.206.1
Using the above configuration, all applications like Ping, SSH, SCP, apt-get, etc., can be tested on management VRF using “ip netns exec mgmt COMMAND” as explained in the design document.
Use the following steps to test tacacs.
1.	First, checkout all the modified files and build an image with these changes.
2.	With the new image, enable mgmt vrf using command "config vrf add mgmt" and configure tacacs client using following commands.
(a) config aaa authentication login tacacs+
(b) config tacacs authtype login
(c) config tacacs passkey testing123
(d) config tacacs add --use-mgmt-vrf serveripaddress
3.	Configure the tacacs server accordingly.
4.	Then, do SSH to the device and verify that the user is authenticated using tacacs server via the management VRF port eth0.
Use the following steps to test snmptrap.
1.	First, checkout all the modified files and build an image with these changes.
2.	Use the command “config snmptrap modify snmp_version snmptrapserver_ipaddress” (ex: config snmptrap modify 2 10.11.150.7) and listen for the traps in the trapserver.
3.	When the above command is configured, it restarts the snmp service. Netsnmp service sends few traps during bootup sequence that can be viewed in the trapserver.
