### PR TITLE
[dockers] Prevent old supervisord messages from gettting re-logged to syslog

### DIFF
--- a/dockers/docker-base/etc/rsyslog.d/supervisor.conf
+++ b/dockers/docker-base/etc/rsyslog.d/supervisor.conf
@@ -5,4 +5,5 @@ $InputFileTag supervisord
 $InputFileStateFile state-supervisor
 $InputFileSeverity info
 $InputFileFacility local0
+$InputFilePersistStateInterval 1
 $InputRunFileMonitor


### PR DESCRIPTION
Upon restarting a Docker container, one would notice that all supervisord log messages from prior runs of that container would be logged to syslog again. This cluttered the log and made it difficult to follow.

I found that the rsyslog imfile module's statefile would not consistently get updated. According to the [documentation](https://www.rsyslog.com/doc/v8-stable/configuration/modules/imfile.html), by default, a new state file is only written when the monitored file is being closed (end of rsyslogd execution). It appears that this was not always happening (possibly a race condition between rsyslog exiting and container shutdown?). This behavior can be modified to update the state file after every `n` number of lines forwarded to the syslog by setting the value of `$InputFilePersistStateInterval`. Note that setting this to a small value can have an impact on performance. However, supervisord logs are very low-volume (we normally only get 10-20 messages when the container starts and stops--none during normal execution), so I decided to set the value to `1` in order to ensure the state file is updated after every supervisord message, thus ensuring that we will never see old messages appear in the syslog.

- Resolves https://github.com/Azure/sonic-buildimage/issues/1652