### PR TITLE
[device/Dell] SOSFTDEP to lpc_ich module for dell_ich module

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/installer.conf
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/installer.conf
@@ -1,3 +1,3 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=1
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich,i2c_mux_gpio"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich"

--- a/device/dell/x86_64-dell_z9100_c2538-r0/installer.conf
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/installer.conf
@@ -1,3 +1,3 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=1
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich,i2c_mux_gpio"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich"

--- a/platform/broadcom/sonic-platform-modules-dell/common/dell_ich.c
+++ b/platform/broadcom/sonic-platform-modules-dell/common/dell_ich.c
@@ -1038,5 +1038,6 @@ MODULE_LICENSE("GPL");
 MODULE_ALIAS("platform:"DRV_NAME);
 MODULE_PARM_DESC(force_id, "Override the detected device ID");
 
+MODULE_SOFTDEP("pre: lpc_ich");
 module_init(dell_ich_init);
 module_exit(dell_ich_exit);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- dell_ich module fails to load sometimes due to the failure of pci_get_drvdata().
- This function is responsible for fetching INTEL PCI related memory handle in kernel. This is implemented in lpc_ich kernel module. 
- Due to race in addition/deletion of kernel modules, sometimes lpc_ich loads after dell_ich. 
- Because of this behaviour dell_ich module fails to load.
- Fixed by addding dependency between modules.

- Removed i2c_mux_gpio module from blacklist entry as it is not the original root case of this issue.
  
**- How I did it**

- Introduced MODULE_SOFTDEP("pre: lpc_ich") 
- This add the dependency to to lpc_ich module at the time of startup. 
-  pre indicates lpc_ich will be loaded before dell_ich


**- How to verify it**
root@sonic:/home/admin# modprobe -D dell_ich
insmod /lib/modules/4.9.0-7-amd64/kernel/drivers/mfd/mfd-core.ko
insmod /lib/modules/4.9.0-7-amd64/kernel/drivers/mfd/lpc_ich.ko
insmod /lib/modules/4.9.0-7-amd64/extra/dell_ich.ko
root@sonic:/home/admin#


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
