### PR TITLE
[lldp] For MGMT port, if port alias is available, use it for Port ID subtype; otherwise use port name

### DIFF
--- a/dockers/docker-lldp-sv2/lldpd.conf.j2
+++ b/dockers/docker-lldp-sv2/lldpd.conf.j2
@@ -1,3 +1,9 @@
 {% if MGMT_INTERFACE %}
-configure ports eth0 lldp portidsubtype local {{ MGMT_INTERFACE.keys()[0][0] }}
+{# If MGMT port alias is available, use it for port ID subtype, otherwise use port name #}
+{% set mgmt_port_name = MGMT_INTERFACE.keys()[0][0] %}
+{% if MGMT_PORT and MGMT_PORT[mgmt_port_name] and MGMT_PORT[mgmt_port_name].alias %}
+configure ports eth0 lldp portidsubtype local {{ MGMT_PORT[mgmt_port_name].alias }}
+{% else %}
+configure ports eth0 lldp portidsubtype local {{ mgmt_port_name }}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
When configuring the management port in LLDP, if the management port has a port alias available, we use it as the Port ID subtype. If an alias does not exist, we simply use the management port name.