### PR TITLE
Avoid removing localhost entry from /etc/hosts file

### DIFF
--- a/files/image_config/hostname/hostname-config.sh
+++ b/files/image_config/hostname/hostname-config.sh
@@ -6,6 +6,11 @@ HOSTNAME=`sonic-cfggen -d -v DEVICE_METADATA[\'localhost\'][\'hostname\']`
 echo $HOSTNAME > /etc/hostname
 hostname -F /etc/hostname
 
-sed -i "/\s$CURRENT_HOSTNAME$/d" /etc/hosts
+# Remove the old hostname entry from hosts file.
+# But, 'localhost' entry is used by multiple applications. Don't remove it altogether.
+if [ $CURRENT_HOSTNAME  != "localhost" ] || [ $CURRENT_HOSTNAME == $HOSTNAME ] ;  then
+ sed -i "/\s$CURRENT_HOSTNAME$/d" /etc/hosts
+fi
+
 echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This fix removes the possibility of 'localhost' entry getting removed from /etc/hosts file by  hostname-config service. 

Without this change, whenever we change the hostname from 'localhost' to any other name on the config_db.json and reload the config, /etc/hosts file will only have the new hostname on it. But there are multiple sonic utilities (eg: swssconfig) which relies on the hard coded 'localhost' name and they tend to stop working.

**- How I did it**
Added a new check on hostname-config.sh script to avid blindly deleting the line containing the old hostname from /etc/hosts file. Now it will delete the old hostname only if its not `localhost` or when the hostname is not changing.

**- How to verify it**
1. Bring up SONiC on a device with hostname as `localhost`
2. Edit `/etc/sonic/config_db.json` to update the 'hostname' filed under `DEVICE_METADATA` from `"hostname" : "localhost"` --> `"hostname" : "sonic"`
4. run `config reload -y` to reflect the hostname change done  on config_db.json file.
5. `cat /etc/hosts` and check whether both `127.0.0.1 localhost` and `127.0.0.1 sonic` entry are present on the file.
6. `ping localhost` should work fine.

**- Description for the changelog**
Make hostname-config service more robust in handling SONiC hostname change from `localhost` to anything else.


**- A picture of a cute animal (not mandatory but encouraged)**
