### PR TITLE
S6100/Z9100 : Make the get_transceiver_change_event's epoll blocking

### DIFF
--- a/device/dell/x86_64-dell_z9100_c2538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/plugins/sfputil.py
@@ -119,11 +119,6 @@ class SfpUtil(SfpUtilBase):
                 self.port_to_i2c_mapping[x][0],
                 self.port_to_i2c_mapping[x][1])
 
-        self.oir_fd = open(self.OIR_FD_PATH, "r")
-        self.epoll = select.epoll()
-        if self.oir_fd != -1:
-                self.epoll.register(self.oir_fd.fileno(), select.EPOLLIN)
-
         SfpUtilBase.__init__(self)
 
     def __del__(self):
@@ -428,13 +423,40 @@ class SfpUtil(SfpUtilBase):
             port_dict = {}
             try:
                 # We get notified when there is an SCI interrupt from GPIO SUS6
+                # Open the sysfs file and register the epoll object
+                self.oir_fd = open(self.OIR_FD_PATH, "r")
+                if self.oir_fd != -1:
+                    # Do a dummy read before epoll register
+                    self.oir_fd.read()
+                    self.epoll = select.epoll()
+                    self.epoll.register(self.oir_fd.fileno(),
+                                        select.EPOLLIN & select.EPOLLET)
+                else:
+                    print("get_transceiver_change_event : unable to create fd")
+                    return False, {}
+
                 # Check for missed interrupts by invoking self.check_interrupts
-                # it will update the port_dict.
-                # Then poll for new xcvr insertion/removal and
-                # call self.check_interrupts again and return
-                retval, is_port_dict_updated = self.check_interrupts(port_dict)
-                if ((retval == 0) and (is_port_dict_updated is True)):
-                    return True, port_dict
+                # which will update the port_dict.
+                while True:
+                    interrupt_count_start = self.get_register(self.OIR_FD_PATH)
+
+                    retval, is_port_dict_updated = \
+                        self.check_interrupts(port_dict)
+                    if ((retval == 0) and (is_port_dict_updated is True)):
+                        return True, port_dict
+
+                    interrupt_count_end = self.get_register(self.OIR_FD_PATH)
+
+                    if (interrupt_count_start == 'ERR' or
+                            interrupt_count_end == 'ERR'):
+                        print("get_transceiver_change_event : \
+                            unable to retrive interrupt count")
+                        break
+
+                    # check_interrupts() itself may take upto 100s of msecs.
+                    # We detect a missed interrupt based on the count
+                    if interrupt_count_start == interrupt_count_end:
+                        break
 
                 # Block until an xcvr is inserted or removed with timeout = -1
                 events = self.epoll.poll(
@@ -445,8 +467,17 @@ class SfpUtil(SfpUtilBase):
                                               self.check_interrupts(port_dict)
                     if (retval != 0):
                         return False, {}
+
                 return True, port_dict
             except:
                 return False, {}
+            finally:
+                if self.oir_fd != -1:
+                    self.epoll.unregister(self.oir_fd.fileno())
+                    self.epoll.close()
+                    self.oir_fd.close()
+                    self.oir_fd = -1
+                    self.epoll = -1
+
             return False, {}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
An optimization was attempted earlier to open the fd and epoll.register during sfputil class instantiation so that only epoll.poll is needed in get_transceiver_change_event(). However, this makes the epoll non-blocking.. (resulting in xcvrd hogging CPU).

**- How I did it**

1. Create the fd and epoll register during every get_transceiver_change_entry(). 
2. Do a dummy read so flush outstanding events to prepare for epoll
3. Change the flags to include EPOLLET
4. Check outstanding interrupts that we may have missed (after previous return). Note that since several registers need to be queried, check_interrupts() itself may take 100s of msecs (on S6100, it takes about 350 msecs). In order to ensure that we don't miss interrupts during check_interrupts(), we read the interrupt count before and after check_interrupts(). If there are no fresh interrupts, we block on epoll.poll().

There is still an outstanding race (an interrupt may come after reading the interrupt count but just before epoll.poll() blocks). This time window is about 300 usecs on a S6100. The current workaround is in place until either the fd is made blocking (during class init) or we move to a better mechanism.

**- How to verify it**

1. Added debug prints and checked that OIR xcvrd blocks and get_transceiver_change_events() is able to construct the dict as expected
2. Checked top output.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

S6100/Z9100 : Make the get_transceiver_change_event's epoll blocking

**- A picture of a cute animal (not mandatory but encouraged)**
