### PR TITLE
ALPM is not working on AS5712/TD2 platforms.

### DIFF
--- a/device/accton/x86_64-accton_as5712_54x-r0/Accton-AS5712-54X/td2-as5712-72x10G.config.bcm
+++ b/device/accton/x86_64-accton_as5712_54x-r0/Accton-AS5712-54X/td2-as5712-72x10G.config.bcm
@@ -3,8 +3,12 @@ bcm_stat_flags=0
 parity_enable=0
 parity_correction=0
 
-l2_mem_entries=163840
-l3_mem_entries=81920
+bcm_num_cos=8
+l2_mem_entries=32768
+l3_mem_entries=16384
+l3_alpm_enable=2
+ipv6_lpm_128b_enable=1
+
 mmu_lossless=0
 lls_num_l2uc=12
 module_64ports=0


### PR DESCRIPTION
ALPM is not working on AS5712/TD2 platforms.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
   Enable ALPM on AS5712 platform.

**- How I did it**
Enable alpm settings in the platform config file for AS5712.
With the current values of l2_mem_entries (163840) and l3_mem_entries (81920), the memory is not sufficient and the box doesn't come up if alpm is enabled in the config. Scale them down to the values that work for ALPM in as5712 [l2_mem_entries = 32768, l3_mem_entries = 16384].

Also initialized the number of cos queues in AS5712 to 8.
Else the interfaces are not coming up due to a lower default value of cos queues in AS5712.

**- How to verify it**
Ensure the interfaces are coming up fine 'show interface status'.
Also, send in routes via BGP, to the ALPM capacity (like 32K IPv4 + 24K IPv6) and ensure the routes are added into hardware.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
