### PR TITLE
[slave.mk] Fix DEB_BUILD_OPTIONS passing

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -98,11 +98,11 @@ $(warning PASSWORD given on command line: could be visible to other users)
 endif
 
 ifeq ($(SONIC_DEBUGGING_ON),y)
-DEB_BUILD_OPTIONS_GENERIC := "nostrip"
+DEB_BUILD_OPTIONS_GENERIC := nostrip
 endif
 
 ifeq ($(SONIC_PROFILING_ON),y)
-DEB_BUILD_OPTIONS_GENERIC := "nostrip noopt"
+DEB_BUILD_OPTIONS_GENERIC := nostrip noopt
 endif
 
 ifeq ($(SONIC_BUILD_JOBS),)


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Image build with SONIC_PROFILING_ON=y fails, this commit tries to fix this

**- How I did it**
Don't quote "nostrip noopt", it is quoted when passing to make.

**- How to verify it**
What I observed before:
```bash
$ make ... SONIC_PROFILING_ON=y target/debs/<some-deb>
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "mellanox"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "24"
"SONIC_CONFIG_MAKE_JOBS"          : "48"
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : "y"
"ROUTING_STACK"                   : "quagga"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : "y"
[ FAIL LOG START ] [ target/debs/applibs_1.mlnx.4.3.0132_amd64.deb ]
/bin/bash: line 9: noopt: command not found
[  FAIL LOG END  ] [ target/debs/applibs_1.mlnx.4.3.0132_amd64.deb ]
slave.mk:266: recipe for target 'target/debs/applibs_1.mlnx.4.3.0132_amd64.deb' failed
make: *** [target/debs/applibs_1.mlnx.4.3.0132_amd64.deb] Error 1
```

Why it happened:
Running make with '-n'
```bash
...
DEB_BUILD_OPTIONS=""nostrip noopt"" make DEST=/sonic/target/debs ...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
