### PR TITLE
[caclmgrd] Don't crash if we find empty/null rule_props

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -182,12 +182,16 @@ class ControlPlaneAclManager(object):
                 acl_rules = {}
 
                 for ((rule_table_name, rule_id), rule_props) in self._rules_db_info.iteritems():
-                    if not rule_props:
-                        log_warning("rule_props for rule_id {} empty or null!".format(rule_id))
-                        continue
-
                     if rule_table_name == table_name:
-                        acl_rules[rule_props["PRIORITY"]] = rule_props
+                        if not rule_props:
+                            log_warning("rule_props for rule_id {} empty or null!".format(rule_id))
+                            continue
+
+                        try:
+                            acl_rules[rule_props["PRIORITY"]] = rule_props
+                        except KeyError:
+                            log_error("rule_props for rule_id {} does not have key 'PRIORITY'!".format(rule_id))
+                            continue
 
                         # If we haven't determined the IP version for this ACL table yet,
                         # try to do it now. We determine heuristically based on whether the

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -182,6 +182,10 @@ class ControlPlaneAclManager(object):
                 acl_rules = {}
 
                 for ((rule_table_name, rule_id), rule_props) in self._rules_db_info.iteritems():
+                    if not rule_props:
+                        log_warning("rule_props for rule_id {} empty or null!".format(rule_id))
+                        continue
+
                     if rule_table_name == table_name:
                         acl_rules[rule_props["PRIORITY"]] = rule_props
 


### PR DESCRIPTION
**- What I did**

Make caclmgrd more robust. In case we find an empty or null `rule_props`, don't crash, just log a warning message to the syslog.

**- How to verify it**

This is the old backtrace from the crash that should now be prevented:

```
Jan 20 14:20:11.435602 str-msn2700-06 INFO caclmgrd-start.sh[1108]: Traceback (most recent call last):
Jan 20 14:20:11.435965 str-msn2700-06 INFO caclmgrd-start.sh[1108]: File "/usr/bin/caclmgrd", line 280, in <module>
Jan 20 14:20:11.436304 str-msn2700-06 INFO caclmgrd-start.sh[1108]: main()
Jan 20 14:20:11.436631 str-msn2700-06 INFO caclmgrd-start.sh[1108]: File "/usr/bin/caclmgrd", line 276, in main
Jan 20 14:20:11.436948 str-msn2700-06 INFO caclmgrd-start.sh[1108]: caclmgr.run()
Jan 20 14:20:11.437271 str-msn2700-06 INFO caclmgrd-start.sh[1108]: File "/usr/bin/caclmgrd", line 261, in run
Jan 20 14:20:11.437590 str-msn2700-06 INFO caclmgrd-start.sh[1108]: self.config_db.listen()
Jan 20 14:20:11.437899 str-msn2700-06 INFO caclmgrd-start.sh[1108]: File "/usr/local/lib/python2.7/dist-packages/swsssdk/configdb.py", line 97, in listen
Jan 20 14:20:11.438214 str-msn2700-06 INFO caclmgrd-start.sh[1108]: self.__fire(table, row, data)
Jan 20 14:20:11.438521 str-msn2700-06 INFO caclmgrd-start.sh[1108]: File "/usr/local/lib/python2.7/dist-packages/swsssdk/configdb.py", line 82, in __fire
Jan 20 14:20:11.439440 str-msn2700-06 INFO caclmgrd-start.sh[1108]: handler(table, key, data)
Jan 20 14:20:11.439831 str-msn2700-06 INFO caclmgrd-start.sh[1108]: File "/usr/bin/caclmgrd", line 258, in <lambda>
Jan 20 14:20:11.440201 str-msn2700-06 INFO caclmgrd-start.sh[1108]: lambda table, key, data: self.notification_handler(key, data))
Jan 20 14:20:11.440569 str-msn2700-06 INFO caclmgrd-start.sh[1108]: File "/usr/bin/caclmgrd", line 248, in notification_handler
Jan 20 14:20:11.440935 str-msn2700-06 INFO caclmgrd-start.sh[1108]: self.update_control_plane_acls()
Jan 20 14:20:11.443090 str-msn2700-06 INFO caclmgrd-start.sh[1108]: File "/usr/bin/caclmgrd", line 238, in update_control_plane_acls
Jan 20 14:20:11.443506 str-msn2700-06 INFO caclmgrd-start.sh[1108]: iptables_cmds = self.get_acl_rules_and_translate_to_iptables_commands()
Jan 20 14:20:11.443887 str-msn2700-06 INFO caclmgrd-start.sh[1108]: File "/usr/bin/caclmgrd", line 160, in get_acl_rules_and_translate_to_iptables_commands
Jan 20 14:20:11.444263 str-msn2700-06 INFO caclmgrd-start.sh[1108]: acl_rules[rule_props["PRIORITY"]] = rule_props
Jan 20 14:20:11.444642 str-msn2700-06 INFO caclmgrd-start.sh[1108]: KeyError: 'PRIORITY'
Jan 20 14:20:11.453502 str-msn2700-06 NOTICE systemd[1]: caclmgrd.service: main process exited, code=exited, status=1/FAILURE
```

In its place, this is the new output to the syslog:
```
Jan 22 23:37:11.250132 str-msn2700-06 WARNING caclmgrd: rule_props for rule_id RULE_1 empty or null!
```