### PR TITLE
[sonic-slave]: install openjdk-8 for jenkins slave

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -237,6 +237,9 @@ RUN apt-get update && apt-get install -y \
         qemu-kvm \
         libvirt-bin
 
+# For jenkins slave
+RUN apt-get -y install ca-certificates-java=20161107~bpo8+1 openjdk-8-jdk
+
 # For linux build
 RUN apt-get -y build-dep linux
 


### PR DESCRIPTION
new jenkins requires jdk-8 to be installed

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
