### PR TITLE
[make reset] Also remove fsroot directory

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -166,12 +166,15 @@ init :
 reset :
 	@echo && echo -n "Warning! All local changes will be lost. Proceed? [y/N]: "
 	@read ans && \
-	 if [ $$ans == y ]; then \
-	     git clean -xfdf; \
-	     git reset --hard; \
-	     git submodule foreach --recursive git clean -xfdf; \
-	     git submodule foreach --recursive git reset --hard; \
-	     git submodule update --init --recursive;\
-	 else \
-	     echo "Reset aborted"; \
-	 fi
+	    if [ $$ans == y ]; then \
+	        echo "Resetting local repository. Please wait..."; \
+	        $(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) sudo rm -rf fsroot; \
+	        git clean -xfdf; \
+	        git reset --hard; \
+	        git submodule foreach --recursive git clean -xfdf; \
+	        git submodule foreach --recursive git reset --hard; \
+	        git submodule update --init --recursive; \
+			echo "Reset complete!"; \
+	    else \
+	        echo "Reset aborted"; \
+	    fi


### PR DESCRIPTION
**- What I did**

Eliminate multiple `warning: failed to remove fsroot/var/lib/dpkg/info/<filename> Permission denied` warning messages when calling `make reset`. These messages were caused because the directory is created inside the slave Docker container by superuser, so a standard user calling `make reset` doesn't have proper permissions to delete the directory.



**- How I did it**

Now we first enter the slave Docker container and remove the fsroot directory before preforming other cleanup of the repo outside the slave Docker.

**- How to verify it**

Run `make reset` and:
1. Ensure there are no `warning: failed to remove fsroot/var/lib/dpkg/info/<filename> Permission denied` warning messages
2. After the command completes, ensure the fsroot directory was removed