### PR TITLE
[boot] Delay ntp-config service to start after 5 minutes

### DIFF
--- a/files/build_templates/ntp-config.timer
+++ b/files/build_templates/ntp-config.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Delays NTP configuration service until SONiC has started
+
+[Timer]
+OnBootSec=5min
+Unit=ntp-config.service
+
+[Install]
+WantedBy=timers.target

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -296,7 +296,9 @@ sudo LANG=C cp $SCRIPTS_DIR/syncd.sh $FILESYSTEM_ROOT/usr/local/bin/syncd.sh
 # Copy systemd timer configuration
 # It implements delayed start of services
 sudo cp $BUILD_TEMPLATES/snmp.timer $FILESYSTEM_ROOT/etc/systemd/system/
+sudo cp $BUILD_TEMPLATES/ntp-config.timer $FILESYSTEM_ROOT/etc/systemd/system/
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable snmp.timer
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable ntp-config.timer
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get remove -y python-dev
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get clean -y


### PR DESCRIPTION
This is an addendum to PR https://github.com/Azure/sonic-buildimage/pull/2335, to ensure that the supervisor processes in all Docker containers have finished starting up all processes in the respective containers.