### PR TITLE
[build] When generating image version, handle case where current commit has no reachable tags

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -60,7 +60,7 @@ sonic_get_version() {
     BUILD_NUMBER=${BUILD_NUMBER:-0}
     ## Check if we are on tagged commit
     ## Note: escape the version string by sed: / -> _
-    if [ "$describe" == "$latest_tag" ]; then
+    if [ -n "$latest_tag" ] && [ "$describe" == "$latest_tag" ]; then
         echo "${latest_tag}${dirty}" | sed 's/\//_/g'
     else
         echo "${branch_name}.${BUILD_NUMBER}${dirty:--$(git rev-parse --short HEAD)}" | sed 's/\//_/g'


### PR DESCRIPTION
**- What I did**

If building a SONiC image from a commit with no reachable parent tag (i.e., `git describe --tags` returns an empty string), `sonic_get_version()` would return an empty string, which would then be passed to `docker tag` which would fail because an empty string is not considered a valid tag.

This fix now also checks if `git describe --tags` returns an empty string. If so, we will create the version string based on branch and commit rather than tag.

**- How to verify it**

Build a SONiC image from a commit that has no reachable tag. Ensure the build succeeds and verify that the image version is based on current branch and commit.