### PR TITLE
[sub module] move sairedis and swss to 201811 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,11 @@
 [submodule "sonic-sairedis"]
 	path = src/sonic-sairedis
 	url = https://github.com/Azure/sonic-sairedis
+	branch = 201811
 [submodule "sonic-swss"]
 	path = src/sonic-swss
 	url = https://github.com/Azure/sonic-swss
+	branch = 201811
 [submodule "src/p4c-bm/p4c-bm"]
 	path = platform/p4/p4c-bm/p4c-bm
 	url = https://github.com/krambn/p4c-bm


### PR DESCRIPTION
**- What I did**
Move sairedis and swss submodule to 201811 branch of each repo. These 2 sub modules' heads have diverged.

With this change, sairedis and swss submodule head didn't change.