### PR TITLE
Change VrfMgrd startup order, cleanup VRF_TABLE from state DB

### DIFF
--- a/dockers/docker-orchagent/start.sh
+++ b/dockers/docker-orchagent/start.sh
@@ -27,6 +27,8 @@ supervisorctl start neighsyncd
 
 supervisorctl start swssconfig
 
+supervisorctl start vrfmgrd
+
 supervisorctl start vlanmgrd
 
 supervisorctl start intfmgrd
@@ -36,8 +38,6 @@ supervisorctl start portmgrd
 supervisorctl start buffermgrd
 
 supervisorctl start enable_counters
-
-supervisorctl start vrfmgrd
 
 supervisorctl start nbrmgrd
 

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -93,7 +93,7 @@ start() {
         /usr/bin/docker exec database redis-cli -n 0 FLUSHDB
         /usr/bin/docker exec database redis-cli -n 2 FLUSHDB
         /usr/bin/docker exec database redis-cli -n 5 FLUSHDB
-        clean_up_tables 6 "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*'"
+        clean_up_tables 6 "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*'"
     fi
 
     # start service docker

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -48,6 +48,8 @@ supervisorctl start fpmsyncd
 
 supervisorctl start teammgrd
 
+supervisorctl start vrfmgrd
+
 supervisorctl start portmgrd
 
 supervisorctl start intfmgrd
@@ -57,8 +59,6 @@ supervisorctl start vlanmgrd
 supervisorctl start zebra
 
 supervisorctl start buffermgrd
-
-supervisorctl start vrfmgrd
 
 supervisorctl start nbrmgrd
 


### PR DESCRIPTION
**- What I did**
Start VrfMgrd before IntfMgrd/PortMgrd
Clean up VRF_TABLE from stateDB during config reload

**- How I did it**

**- How to verify it**
Do `config reload -y`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
