### PR TITLE
[config] Do not fail for minigraphs which do not have neighbors listed in <Devices> section

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -40,7 +40,7 @@ def
     {%- set cable_len = [] %}
     {%- for local_port in DEVICE_NEIGHBOR %}
         {%- if local_port == port_name %}
-            {%- if DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[local_port].name] %}
+            {%- if DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[local_port].name] %}
                 {%- set neighbor = DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[local_port].name] %}
                 {%- set neighbor_role = neighbor.type %}
                 {%- set roles1 = switch_role + '_' + neighbor_role %}


### PR DESCRIPTION

Signed-off-by: Nadiya.Stetskovych <nstetskovych@barefootnetworks.com>

**- What I did**
add a check if neighbors metadata exist

**- How I did it**

**- How to verify it**
apply `config load_minigraph -y` upon old minigraph without DEVICE_NEIGHBOR_METADATA
**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
```
__         __
'/  \.-"""-./  \
\    -   -    /
 |   o   o   |
 \  .-'''-.  /
  '-\__Y__/-'
     `---
```
