### PR TITLE
Disable acpi power saving mode used by some CPUs

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -372,6 +372,10 @@ allow-hotplug eth0
 iface eth0 inet dhcp
 EOF
 
+# Disable acpi power saving mode used by some CPUs
+sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c 'echo "HandleLidSwitch=ignore" >> /etc/systemd/logind.conf'
+sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c 'echo "IdleAction=ignore" >> /etc/systemd/logind.conf'
+
 sudo cp files/dhcp/rfc3442-classless-routes $FILESYSTEM_ROOT/etc/dhcp/dhclient-exit-hooks.d
 sudo cp files/dhcp/sethostname $FILESYSTEM_ROOT/etc/dhcp/dhclient-exit-hooks.d/
 sudo cp files/dhcp/graphserviceurl $FILESYSTEM_ROOT/etc/dhcp/dhclient-exit-hooks.d/

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -374,7 +374,6 @@ EOF
 
 # Disable acpi power saving mode used by some CPUs
 sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c 'echo "HandleLidSwitch=ignore" >> /etc/systemd/logind.conf'
-sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c 'echo "IdleAction=ignore" >> /etc/systemd/logind.conf'
 
 sudo cp files/dhcp/rfc3442-classless-routes $FILESYSTEM_ROOT/etc/dhcp/dhclient-exit-hooks.d
 sudo cp files/dhcp/sethostname $FILESYSTEM_ROOT/etc/dhcp/dhclient-exit-hooks.d/


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
On some CPUs, the system will go immediately into power saving mode. This patch disable this feature.

**- How I did it**
This can be prevented by adding a few options into the file /etc/systemd/logind.conf
 - HandleLidSwitch=ignore
 - IdleAction=ignore

**- How to verify it**
I verified that on this particular CPU, the system will not go into power saving mode. On other CPUs which do not already go into power saving mode, these additions do not anything.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Disable acpi power saving mode used by some CPUs

**- A picture of a cute animal (not mandatory but encouraged)**
