### PR TITLE
Feature to run an option platform specific script on the first boot

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -351,6 +351,10 @@ if [ -f $FIRST_BOOT_FILE ]; then
         mv /host/grub.cfg /host/grub/grub.cfg
     fi
 
+    # If there is a platform dependant script, execute it
+    if [ -x /usr/share/sonic/device/${onie_platform}/platform_setup ]; then
+        /usr/share/sonic/device/${onie_platform}/platform_setup
+    fi
     firsttime_exit
 fi
 

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -352,8 +352,8 @@ if [ -f $FIRST_BOOT_FILE ]; then
     fi
 
     # If there is a platform dependant script, execute it
-    if [ -x /usr/share/sonic/device/${onie_platform}/platform_setup ]; then
-        /usr/share/sonic/device/${onie_platform}/platform_setup
+    if [ -x /usr/share/sonic/device/${platform}/platform_setup ]; then
+        /usr/share/sonic/device/${platform}/platform_setup
     fi
     firsttime_exit
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I added the ability to run an optional platform specific script on the first boot. This will be useful in the case of doing some switch specific setup and initialization.

**- How I did it**
Add a few lines in the files/image_config/platform/rc.local in the section which is run only on the first boot. We test for the existence of a file named platform_setup, and this file has execute flag set, the script will be executed.

**- How to verify it**
Create a shell script named platform_setup,. store it in the device directory, under the onie platform directory.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added the feature to run an option platform specific script on the first boot

**- A picture of a cute animal (not mandatory but encouraged)**
