### PR TITLE
[docker-snmp] Install pyyaml in the container

### DIFF
--- a/dockers/docker-snmp-sv2/Dockerfile.j2
+++ b/dockers/docker-snmp-sv2/Dockerfile.j2
@@ -35,6 +35,9 @@ RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
 RUN python3.6 -m pip install --no-cache-dir hiredis
 
+# Install pyyaml dependency for use by some plugins
+RUN python3.6 -m pip install --no-cache-dir pyyaml
+
 {% if docker_snmp_sv2_whls.strip() -%}
 # Copy locally-built Python wheel dependencies
 {%- for whl in docker_snmp_sv2_whls.split(' ') %}


### PR DESCRIPTION
This dependency is needed for arista plugins to properly work.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Installed pyyaml via pip in snmp Dockerfile

**- How to verify it**

snmpwalk -v2c -c public 10.3.147.241 1.3.6.1.4.1.9.9.117
