### PR TITLE
Fix for KeyError: 'DEVICE_NEIGHBOR' when executing 'show interfaces neighbor expected' command

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -244,7 +244,10 @@ def main():
         print(template.render(data))
 
     if args.var_json != None:
-        print(json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder))
+        try :
+            print(json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder))
+        except KeyError:
+            return
 
     if args.write_to_db:
         configdb = ConfigDBConnector(**db_kwargs)


### PR DESCRIPTION
**- What I did**
Handle exceptions (KeyError and ValueError), when user issued 'show interfaces neighbor expected' command and DEVICE_NEIGHBOR data is not present in the configuration file.
 
**- How I did it**
In the src/sonic-config-engine/sonic-cfggen file 'KeyError' exception handled, when DEVICE_NEIGHBOR or DEVICE_NEUGHBOR_METADATA information is not present.
In the sonic-utilities/show/main.py utility, 'ValueError' exception handled.

**- How to verify it**
Issue 'show interfaces neighbor expected' command and observe no exceptions. 
If DEVICE_NEIGHBOR data present in configuration file, data will be displayed. 

**- Previous command output (if the output of a command-line utility has changed)**

root@sonic-testing:/home/admin# show interfaces neighbor expected 
Traceback (most recent call last): 
  File "/usr/local/bin/sonic-cfggen", line 263, in <module> 
    main() 
  File "/usr/local/bin/sonic-cfggen", line 247, in main 
    print(json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder)) 
KeyError: 'DEVICE_NEIGHBOR' 
Traceback (most recent call last): 
  File "/usr/bin/show", line 9, in <module> 
    load_entry_point('sonic-utilities==1.2', 'console_scripts', 'show')() 
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__ 
    return self.main(*args, **kwargs) 
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main 
    rv = self.invoke(ctx) 
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke 
    return _process_result(sub_ctx.command.invoke(sub_ctx)) 
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke 
    return _process_result(sub_ctx.command.invoke(sub_ctx)) 
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke 
    return _process_result(sub_ctx.command.invoke(sub_ctx)) 
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke 
    return ctx.invoke(self.callback, **ctx.params) 
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke 
    return callback(*args, **kwargs) 
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 426, in expected 
    neighbor_dict = json.loads(p1.stdout.read()) 
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads 
    return _default_decoder.decode(s) 
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode 
    obj, end = self.raw_decode(s, idx=_w(s, 0).end()) 
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode 
    raise ValueError("No JSON object could be decoded") 
ValueError: No JSON object could be decoded 
root@sonic-testing:/home/admin# 

**- New command output (if the output of a command-line utility has changed)**

root@sonic-testing:/home/admin# show interfaces neighbor expected
DEVICE_NEIGHBOR information is not present.

root@sonic-testing:/home/admin# 