### PR TITLE
'show vlan config' is not displaying the VLAN members, after the clear config and reload with default l2 configuration.

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -47,6 +47,10 @@ def generate_l2_config(data):
     if not data['DEVICE_METADATA']['localhost'].has_key('type'):
         data['DEVICE_METADATA']['localhost']['type'] = 'ToRRouter'
     data['VLAN'] = {'Vlan1000': {'vlanid': '1000'}}
+    vp = [] 
+    for port in natsorted(data['PORT'].keys()):
+        vp.append(port)
+    data['VLAN']['Vlan1000'].setdefault('members', vp)
     data['VLAN_MEMBER'] = {}
     for port in natsorted(data['PORT'].keys()):
         data['VLAN_MEMBER']['Vlan1000|{}'.format(port)] = {'tagging_mode': 'untagged'}

--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -47,9 +47,7 @@ def generate_l2_config(data):
     if not data['DEVICE_METADATA']['localhost'].has_key('type'):
         data['DEVICE_METADATA']['localhost']['type'] = 'ToRRouter'
     data['VLAN'] = {'Vlan1000': {'vlanid': '1000'}}
-    vp = [] 
-    for port in natsorted(data['PORT'].keys()):
-        vp.append(port)
+    vp = natsorted(data['PORT'].keys())
     data['VLAN']['Vlan1000'].setdefault('members', vp)
     data['VLAN_MEMBER'] = {}
     for port in natsorted(data['PORT'].keys()):


### PR DESCRIPTION
**- What I did**
To clear configuration and load default l2 configuration, execute below commands.
redis-cli -n 4 flushdb
redis-cli -n 4 SET CONFIG_DB_INITIALIZED true
sonic-cfggen --preset l2 -H -p -k Accton-AS5712-54X  >/etc/sonic/config_db.json
config reload -y

After the clear config with above commands, switch reloaded with l2 default configuration (config_samples.py).
The command 'show vlan brief' displaying the default VLAN (1000) and associated members. 
But 'show vlan config' command not displaying not the VLAN information.
To fix this issue,  to the default l2 configuration(config_samples.py), all ports are added as members of default VLAN. The VLAN dict is updated with members list. 

**- How I did it**
In config_samples.py file, members are added to default Vlan(1000). 
In sonic-utilities/show/main.py the VLAN information displayed correctly. 

**- How to verify it**
Do clear config and reload switch with default l2 configuration.
check the VLAN information displayed correctly.

**- Previous command output (if the output of a command-line utility has changed)**
root@sonic:~# show vlan config
Name    VID    Member    Mode
------  -----  --------  ------
root@sonic:~#

**- New command output (if the output of a command-line utility has changed)**
root@sonic:~# show vlan config
Name        VID  Member      Mode
--------  -----  ----------  --------
Vlan1000   1000  Ethernet0   untagged
Vlan1000   1000  Ethernet1   untagged
Vlan1000   1000  Ethernet2   untagged
Vlan1000   1000  Ethernet3   untagged
Vlan1000   1000  Ethernet4   untagged
Vlan1000   1000  Ethernet5   untagged
.....
Vlan1000   1000  Ethernet67  untagged
Vlan1000   1000  Ethernet68  untagged
Vlan1000   1000  Ethernet69  untagged
Vlan1000   1000  Ethernet70  untagged
Vlan1000   1000  Ethernet71  untagged
root@sonic:~# 
