### PR TITLE
Move warm_restart enable/disable config to stateDB WARM_RESTART_ENABL…

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -43,8 +43,8 @@ HWSKU=`sonic-cfggen -d -v "DEVICE_METADATA['localhost']['hwsku']"`
 
 # Don't load json config if system warm start or
 # swss docker warm start is enabled, the data already exists in appDB.
-SYSTEM_WARM_START=`redis-cli -n 4 hget "WARM_RESTART|system" enable`
-SWSS_WARM_START=`redis-cli -n 4 hget "WARM_RESTART|swss" enable`
+SYSTEM_WARM_START=`redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+SWSS_WARM_START=`redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|swss" enable`
 if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; then
   # We have to make sure db data has not been flushed.
   RESTORE_COUNT=`redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restore_count`

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -32,7 +32,7 @@ function copy_config_files_and_directories()
 
 function check_system_warm_boot()
 {
-    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|system" enable`
+    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
     # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
     if [[ x"$SYSTEM_WARM_START" == x"true" ]]; then
         WARM_BOOT="true"
@@ -50,7 +50,7 @@ fi
 . /etc/sonic/updategraph.conf
 
 check_system_warm_boot
-copy_list="minigraph.xml snmp.yml acl.json config_db.json frr" 
+copy_list="minigraph.xml snmp.yml acl.json config_db.json frr"
 if [ -f /tmp/pending_config_migration ]; then
     copy_config_files_and_directories $copy_list
     if [ x"${WARM_BOOT}" == x"true" ]; then
@@ -71,7 +71,7 @@ fi
 
 if [ -f /tmp/pending_config_initialization ]; then
     rm -f /tmp/pending_config_initialization
-    if [ "$enabled" != "true" ]; then 
+    if [ "$enabled" != "true" ]; then
         PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
         PRESET=(`head -n 1 /usr/share/sonic/device/$PLATFORM/default_sku`)
         sonic-cfggen -H -k ${PRESET[0]} --preset ${PRESET[1]} > /etc/sonic/config_db.json

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -29,8 +29,8 @@ function unlock_service_state_change()
 
 function check_warm_boot()
 {
-    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|system" enable`
-    SERVICE_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|${SERVICE}" enable`
+    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SERVICE_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
     if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
         WARM_BOOT="true"
     else

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -29,8 +29,8 @@ function unlock_service_state_change()
 
 function check_warm_boot()
 {
-    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|system" enable`
-    SERVICE_WARM_START=`/usr/bin/redis-cli -n 4 hget "WARM_RESTART|${SERVICE}" enable`
+    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SERVICE_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
     # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
     if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
         WARM_BOOT="true"


### PR DESCRIPTION
…E_TABLE

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


Prerequisite PRs:
https://github.com/Azure/sonic-swss-common/pull/260
https://github.com/Azure/sonic-swss/pull/786
https://github.com/Azure/sonic-sairedis/pull/418
https://github.com/Azure/sonic-utilities/pull/458

**- What I did**

For warm_restart enable/disable configuration, putting them into configDB caused confusion in configuration save and restore. They are not supposed to be persistent across cold boot. Moving them to stateDB which will be saved and restored during warm reboot.

https://github.com/Azure/sonic-swss-common/pull/260

https://github.com/Azure/sonic-swss/pull/786

https://github.com/Azure/sonic-sairedis/pull/418

https://github.com/Azure/sonic-utilities/pull/458

https://github.com/Azure/sonic-buildimage/pull/2538

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
