### PR TITLE
[swss/syncd] log swss/syncd service script activities

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -7,6 +7,7 @@ LOCKFILE="/tmp/swss-syncd-lock"
 
 function debug()
 {
+    /usr/bin/logger $1
     /bin/echo `date` "- $1" >> ${DEBUGLOG}
 }
 
@@ -90,6 +91,7 @@ start() {
 
     # Don't flush DB during warm boot
     if [[ x"$WARM_BOOT" != x"true" ]]; then
+        debug "Flushing databases ..."
         /usr/bin/docker exec database redis-cli -n 0 FLUSHDB
         /usr/bin/docker exec database redis-cli -n 2 FLUSHDB
         /usr/bin/docker exec database redis-cli -n 5 FLUSHDB

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -7,6 +7,7 @@ LOCKFILE="/tmp/swss-syncd-lock"
 
 function debug()
 {
+    /usr/bin/logger $1
     /bin/echo `date` "- $1" >> ${DEBUGLOG}
 }
 
@@ -88,7 +89,8 @@ start() {
     else
         rm -f /host/warmboot/warm-starting
 
-        # Flush DB during non-warm start
+        # Flush ASIC DB during non-warm start
+        debug "Flushing ASIC database ..."
         /usr/bin/docker exec database redis-cli -n 1 FLUSHDB
     fi
 


### PR DESCRIPTION
**- What I did**
Log syncd/swss service starting/stopping progress to syslog to help debug.
Log when syncd/swss clears the databases.