### PR TITLE
DellEMC S6000 xcvrd support

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
@@ -196,7 +196,7 @@ class SfpUtil(SfpUtilBase):
 
         return True
 
-    def get_transceiver_change_event(self):
+    def get_transceiver_change_event(self, timeout=0):
 
         port_dict = {}
         port = self.port_start

--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
@@ -201,7 +201,7 @@ class SfpUtil(SfpUtilBase):
         port_dict = {}
         port = self.port_start
 
-        # Sleep for a minute
+        # Sleep for a second
         if self.modprs_register == self.get_transceiver_status:
             time.sleep(1)
             if self.modprs_register == self.get_transceiver_status:

--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
@@ -204,15 +204,9 @@ class SfpUtil(SfpUtilBase):
         # Sleep for a second
         if self.modprs_register == self.get_transceiver_status:
             time.sleep(1)
-            if self.modprs_register == self.get_transceiver_status:
-                state_change = 0
-            else:
-                state_change = 1
-
-        # Check OIR change events
-        if not state_change:
             return True, {}
         else:
+            reg_value = self.get_transceiver_status
             changed_ports = self.modprs_register ^ reg_value
             while port >= self.port_start and port <= self.port_end:
 

--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
@@ -41,14 +41,6 @@ class SfpUtil(SfpUtilBase):
     @property
     def get_transceiver_status(self):
 
-    def __init__(self):
-        port = self.port_start
-        eeprom_path = "/sys/class/i2c-adapter/i2c-{0}/{0}-0050/eeprom"
-
-        for x in range(0, self.port_end + 1):
-            self._port_to_eeprom_mapping[x] = eeprom_path.format(x + self.EEPROM_OFFSET)
-
-        # Get Transceiver status
         try:
             reg_file = open("/sys/devices/platform/dell-s6000-cpld.0/qsfp_modprs")
 
@@ -65,7 +57,6 @@ class SfpUtil(SfpUtilBase):
 
     def __init__(self):
 
-        port = self.port_start
         eeprom_path = "/sys/class/i2c-adapter/i2c-{0}/{0}-0050/eeprom"
 
         for x in range(0, self.port_end + 1):

--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
@@ -201,28 +201,27 @@ class SfpUtil(SfpUtilBase):
         port_dict = {}
         port = self.port_start
 
-        # Sleep for a second
-        if self.modprs_register == self.get_transceiver_status:
-            time.sleep(1)
-            return True, {}
-        else:
+        while True:
             reg_value = self.get_transceiver_status
-            changed_ports = self.modprs_register ^ reg_value
-            while port >= self.port_start and port <= self.port_end:
+            if reg_value != self.modprs_register:
+                changed_ports = self.modprs_register ^ reg_value
+                while port >= self.port_start and port <= self.port_end:
 
-                # Mask off the bit corresponding to our port
-                mask = (1 << port)
+                    # Mask off the bit corresponding to our port
+                    mask = (1 << port)
 
-                if changed_ports & mask:
-                    # ModPrsL is active low
-                    if reg_value & mask == 0:
-                        port_dict[port] = '1'
-                    else:
-                        port_dict[port] = '0'
+                    if changed_ports & mask:
+                        # ModPrsL is active low
+                        if reg_value & mask == 0:
+                            port_dict[port] = '1'
+                        else:
+                            port_dict[port] = '0'
 
-                port += 1
+                    port += 1
 
-            # Update reg value
-            self.modprs_register = reg_value
+                # Update reg value
+                self.modprs_register = reg_value
+                return True, port_dict
 
-            return True, port_dict
+            # Sleep for a second
+            time.sleep(1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Added xcvrd support for DellEMC S600 switches.

**- How I did it**
- get_transceiver_change_event() in spfputil.py check for default presence registers and if any state-change happens on ports, the difference is updated and propgrated to xcvrd.

**- How to verify it**
- sfputil show eeprom

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
