### PR TITLE
[Devices] Dell Reset I2C MUX in S6000 while invoking platform reboot

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/installer.conf
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/installer.conf
@@ -7,8 +7,10 @@ echo "Replace ONIE reboot with Dell reset commands"
 # set I2C GPIO mux
 [ -d /sys/class/gpio/gpio1 ] || echo 1 > /sys/class/gpio/export
 [ -d /sys/class/gpio/gpio2 ] || echo 2 > /sys/class/gpio/export
+[ -d /sys/class/gpio/gpio10 ] || echo 10 > /sys/class/gpio/export
 echo out > /sys/class/gpio/gpio1/direction
 echo out > /sys/class/gpio/gpio2/direction
+echo out > /sys/class/gpio/gpio10/direction
 echo 0 > /sys/class/gpio/gpio1/value
 echo 0 > /sys/class/gpio/gpio2/value
 

--- a/device/dell/x86_64-dell_s6000_s1220-r0/platform_reboot
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/platform_reboot
@@ -1,3 +1,13 @@
 #!/bin/sh
 
+# Export GPIO10 if needed
+[ -d /sys/class/gpio/gpio10 ] || echo 10 > /sys/class/gpio/export
+echo out > /sys/class/gpio/gpio10/direction
+
+#Toggle GPIO10 pin (to reset MUX)
+echo 1 > /sys/class/gpio/gpio10/value
+echo 0 > /sys/class/gpio/gpio10/value
+
+
+#Power Reset
 echo 1 > /sys/devices/platform/dell-s6000-cpld.0/power_reset

--- a/platform/broadcom/sonic-platform-modules-s6000/modules/dell_s6000_platform.c
+++ b/platform/broadcom/sonic-platform-modules-s6000/modules/dell_s6000_platform.c
@@ -419,7 +419,14 @@ static ssize_t set_power_reset(struct device *dev, struct device_attribute *deva
 
 static ssize_t get_power_reset(struct device *dev, struct device_attribute *devattr, char *buf)
 {
-    return sprintf(buf, "0\n");
+    uint8_t ret = 0;
+    struct cpld_platform_data *pdata = dev->platform_data;
+
+    ret = i2c_smbus_read_byte_data(pdata[system_cpld].client, 0x1);
+    if (ret < 0)
+        return sprintf(buf, "read error");
+
+    return sprintf(buf, "0x%x\n", ret);
 }
 
 static ssize_t get_fan_prs(struct device *dev, struct device_attribute *devattr, char *buf)
@@ -1006,6 +1013,55 @@ static ssize_t set_fan2_led(struct device *dev, struct device_attribute *devattr
     return count;
 }
 
+static ssize_t get_system_cpld_ver(struct device *dev,
+                                   struct device_attribute *devattr, char *buf)
+{
+    uint8_t ret;
+    u32 data = 0;
+    struct cpld_platform_data *pdata = dev->platform_data;
+
+    ret = i2c_smbus_read_byte_data(pdata[system_cpld].client, 0x0);
+    if (ret < 0)
+        return sprintf(buf, "read error");
+
+    data = ret & (0x0f);
+
+    return sprintf(buf, "0x%x\n", data);
+}
+
+static ssize_t get_master_cpld_ver(struct device *dev,
+                                   struct device_attribute *devattr, char *buf)
+{
+    uint8_t ret;
+    u32 data = 0;
+    struct cpld_platform_data *pdata = dev->platform_data;
+
+    ret = i2c_smbus_read_byte_data(pdata[master_cpld].client, 0x1);
+    if (ret < 0)
+        return sprintf(buf, "read error");
+
+    data = ret & (0x0f);
+
+    return sprintf(buf, "0x%x\n", data);
+}
+
+static ssize_t get_slave_cpld_ver(struct device *dev,
+                                   struct device_attribute *devattr, char *buf)
+{
+    uint8_t ret;
+    u32 data = 0;
+    struct cpld_platform_data *pdata = dev->platform_data;
+
+    ret = i2c_smbus_read_byte_data(pdata[slave_cpld].client, 0xa);
+    if (ret < 0)
+        return sprintf(buf, "read error");
+
+    data = ret & (0x0f);
+
+    return sprintf(buf, "0x%x\n", data);
+}
+
+
 static DEVICE_ATTR(qsfp_modsel, S_IRUGO, get_modsel, NULL);
 static DEVICE_ATTR(qsfp_modprs, S_IRUGO, get_modprs, NULL);
 static DEVICE_ATTR(qsfp_lpmode, S_IRUGO | S_IWUSR, get_lpmode, set_lpmode);
@@ -1024,6 +1080,9 @@ static DEVICE_ATTR(fan_led, S_IRUGO | S_IWUSR, get_fan_led, set_fan_led);
 static DEVICE_ATTR(fan0_led, S_IRUGO | S_IWUSR, get_fan0_led, set_fan0_led);
 static DEVICE_ATTR(fan1_led, S_IRUGO | S_IWUSR, get_fan1_led, set_fan1_led);
 static DEVICE_ATTR(fan2_led, S_IRUGO | S_IWUSR, get_fan2_led, set_fan2_led);
+static DEVICE_ATTR(system_cpld_ver, S_IRUGO, get_system_cpld_ver, NULL);
+static DEVICE_ATTR(master_cpld_ver, S_IRUGO, get_master_cpld_ver, NULL);
+static DEVICE_ATTR(slave_cpld_ver,  S_IRUGO, get_slave_cpld_ver,  NULL);
 
 static struct attribute *s6000_cpld_attrs[] = {
     &dev_attr_qsfp_modsel.attr,
@@ -1044,6 +1103,9 @@ static struct attribute *s6000_cpld_attrs[] = {
     &dev_attr_fan0_led.attr,
     &dev_attr_fan1_led.attr,
     &dev_attr_fan2_led.attr,
+    &dev_attr_system_cpld_ver.attr,
+    &dev_attr_master_cpld_ver.attr,
+    &dev_attr_slave_cpld_ver.attr,
     NULL,
 };
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Reset i2c Mux in S6000 before invoking platform reboot using system cpld.
Also added code to export the system, master and slave cpld version 
**- How I did it**
Toggle GPIO pin 10 before invoking power_reset in system_cpld
**- How to verify it**
Reboot will work seamlessly
**- Description for the changelog**
<!--
In S6000, implemented the  CPLD based reset with GPIO fix for recovering hung mux.
It is achieved by toggling the gpio10 value. Exported the GPIO ping 10 and toggled the 
value.
Also added code to export the system, master and slave cpld version
-->


**- A picture of a cute animal (not mandatory but encouraged)**
