### PR TITLE
[vs]: Add option to specify platform name for DVS orchagent

### DIFF
--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-export platform=vs
+if [[ -z "$fake_platform"  ]]; then
+    export platform=vs
+else
+    export platform=$fake_platform
+fi
 
 MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added possibility to specify platform name for DVS orchagent.
It is needed in order to be able to enable platform specific "orchagent" code for testing purposes.

**- How I did it**
Added new ```fake_platform``` environment variable to specify platfom name for DVS orchagent.
If ```fake_platform``` is passed to the ```vs``` docker container then run orchangent with ```platform``` set to specified value.
If ```fake_platform``` is not defined then behavior is not changed and ```platform``` is set to ```vs```.

**- How to verify it**
- Run ```vs``` container with the ```-e``` option and define ```fake_platform``` (e.g. ```-e fake_platform=mellanox```).
- Go to ```vs``` container console and check that ```fake_platform``` is set: ```cat $fakeplatform```.
- Check that orchagent was started with the ```platform``` set to specified value: ```cat /proc/`pidof orchagent`/environ```.

**- Description for the changelog**
[vs]: Add option to specify platform name for DVS orchagent