### PR TITLE
[syncd.sh] Don't stop sxdkernel during warm shutdown on Mellanox plat…

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -155,16 +155,11 @@ stop() {
 
     # platform specific tasks
 
-    # stop mellanox driver regardless of
-    # shutdown type
-    if [ x$sonic_asic_platform == x'mellanox' ]; then
-        /etc/init.d/sxdkernel stop
-        /usr/bin/mst stop
-    fi
-
-
     if [[ x"$WARM_BOOT" != x"true" ]]; then
-        if [ x$sonic_asic_platform == x'cavium' ]; then
+        if [ x$sonic_asic_platform == x'mellanox' ]; then
+            /etc/init.d/sxdkernel stop
+            /usr/bin/mst stop
+        elif [ x$sonic_asic_platform == x'cavium' ]; then
             /etc/init.d/xpnet.sh stop
             /etc/init.d/xpnet.sh start
         fi


### PR DESCRIPTION
…form

/etc/init.d/sxdkernel stop may take up to 20 sec which has impact on
control plane downtime

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Don't stop sxdkernel during warm shutdown on Mellanox platform since it may take 15-20 sec to stop

**- How I did it**
Place sxdkernel stop under ```if [[ x"$WARM_BOOT" != x"warm" ]]``` statement

**- How to verify it**
Run warm reboot 100 times with and without this change:
Without this change: 1 of 10 runs LAG on neighbor may go down
With this change: After 100 reboots LAG never went down

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
