### PR TITLE
Set a rate limit on syslog messages from all Docker containers

### DIFF
--- a/dockers/docker-base-stretch/etc/rsyslog.conf
+++ b/dockers/docker-base-stretch/etc/rsyslog.conf
@@ -10,6 +10,13 @@
 #################
 
 $ModLoad imuxsock # provides support for local system logging
+
+#
+# Set a rate limit on messages from the container
+#
+$SystemLogRateLimitInterval 300
+$SystemLogRateLimitBurst 10000
+
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability
 

--- a/dockers/docker-base-stretch/etc/rsyslog.conf
+++ b/dockers/docker-base-stretch/etc/rsyslog.conf
@@ -15,7 +15,7 @@ $ModLoad imuxsock # provides support for local system logging
 # Set a rate limit on messages from the container
 #
 $SystemLogRateLimitInterval 300
-$SystemLogRateLimitBurst 10000
+$SystemLogRateLimitBurst 20000
 
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability

--- a/dockers/docker-base/etc/rsyslog.conf
+++ b/dockers/docker-base/etc/rsyslog.conf
@@ -14,6 +14,13 @@
 #################
 
 $ModLoad imuxsock # provides support for local system logging
+
+#
+# Set a rate limit on messages from the container
+#
+$SystemLogRateLimitInterval 300
+$SystemLogRateLimitBurst 10000
+
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability
 

--- a/dockers/docker-base/etc/rsyslog.conf
+++ b/dockers/docker-base/etc/rsyslog.conf
@@ -19,7 +19,7 @@ $ModLoad imuxsock # provides support for local system logging
 # Set a rate limit on messages from the container
 #
 $SystemLogRateLimitInterval 300
-$SystemLogRateLimitBurst 10000
+$SystemLogRateLimitBurst 20000
 
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability


### PR DESCRIPTION
Enable rate limiting on rsyslog messages originating from each Docker container. Each container is limited to 10,000 messages per 5-minute interval.

I averaged the rates of messages of a few switches configured with 120+ ports. During normal operation, the highest rate of messages occurs at boot. I found with these devices, the average maximum rate of _total_ messages (base image + all containers) is ~12,000 per 5 minute interval. The average maximum rate per container at boot is as follows:

| Container | Max Messages Per 5-Minute Interval |
| --- | --- |
| syncd | 3871 |
| swss | 2761 |
| teamd | 2097 |
| lldp | 415 |
| snmp | 325 |
| pmon | 110 |
| dhcp_relay | 67 |
| bgp | 31 |
| radv | 13 |
| database | 9 |

Thus, setting the per-container rate limit to 10,000 messages per 5-minute interval should not interfere with boot messages. If we are concerned at all, I think we could increase the limit to 20,000 or even a bit higher. The idea here is simply to prevent a rogue process from spamming a remote syslog server, so there is a bit of flexibility.

Note: 3/1/2019 -- Increased threshold to 20,000 messages per 5-minute interval.