### PR TITLE
[201803] Set a rate limit on syslog messages from all Docker containers

### DIFF
--- a/dockers/docker-base/etc/rsyslog.conf
+++ b/dockers/docker-base/etc/rsyslog.conf
@@ -14,6 +14,13 @@
 #################
 
 $ModLoad imuxsock # provides support for local system logging
+
+#
+# Set a rate limit on messages from the container
+#
+$SystemLogRateLimitInterval 300
+$SystemLogRateLimitBurst 10000
+
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability
 


### PR DESCRIPTION
Enable rate limiting on rsyslog messages originating from each Docker container. Each container is limited to 10,000 messages per 5-minute interval.