### PR TITLE
[hostcfgd]: Promote logs for update-notifications-from-DB from DEBUG to INFO

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -166,7 +166,7 @@ class HostConfigDaemon:
         log_data = copy.deepcopy(data)
         if log_data.has_key('passkey'):
             log_data['passkey'] = obfuscate(log_data['passkey'])
-        syslog.syslog(syslog.LOG_DEBUG, 'value of {} changed to {}'.format(key, log_data))
+        syslog.syslog(syslog.LOG_INFO, 'value of {} changed to {}'.format(key, log_data))
 
     def start(self):
         self.config_db.subscribe('AAA', lambda table, key, data: self.aaa_handler(key, data))

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -159,7 +159,7 @@ class HostConfigDaemon:
         log_data = copy.deepcopy(data)
         if log_data.has_key('passkey'):
             log_data['passkey'] = obfuscate(log_data['passkey'])
-        syslog.syslog(syslog.LOG_DEBUG, 'value of {} changed to {}'.format(key, log_data))
+        syslog.syslog(syslog.LOG_INFO, 'value of {} changed to {}'.format(key, log_data))
 
     def tacacs_global_handler(self, key, data):
         self.aaacfg.tacacs_global_update(key, data)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed syslog severity level of two log messages, from DEBUG to INFO. This is to help with getting insight into inputs received by hostcfgd at runtime.

**- How I did it**
Changed the severity level in the code.

**- How to verify it**
On a sonic switch with updated hostcfgd, use "config tacacs add <IP>" and/or  "config tacacs delete <IP>" to add/remove an IP. Look for these updates in /var/log/syslog.

**- Description for the changelog**
<N/A>

**- A picture of a cute animal (not mandatory but encouraged)**
