### PR TITLE
frr: staticd terminating due to inadequate permissions

### DIFF
--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 
 # Install required packages
-RUN apt-get install -y libdbus-1-3 libdaemon0 libjansson4 libc-ares2 iproute libpython2.7 libjson-c2 logrotate
+RUN apt-get install -y libdbus-1-3 libdaemon0 libjansson4 libc-ares2 iproute2 libpython2.7 libjson-c2 logrotate
 
 {% if docker_fpm_frr_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -326,6 +326,6 @@ sudo touch $FILESYSTEM_ROOT/etc/sonic/frr/vtysh.conf
 sudo cp dockers/docker-fpm-frr/daemons.conf $FILESYSTEM_ROOT/etc/sonic/frr/
 sudo cp dockers/docker-fpm-frr/daemons $FILESYSTEM_ROOT/etc/sonic/frr/
 sudo chown -R $FRR_USER_UID:$FRR_USER_GID $FILESYSTEM_ROOT/etc/sonic/frr
-sudo chmod 750 $FILESYSTEM_ROOT/etc/sonic/frr
 sudo chmod -R 640 $FILESYSTEM_ROOT/etc/sonic/frr/
+sudo chmod 750 $FILESYSTEM_ROOT/etc/sonic/frr
 {%- endif %}


### PR DESCRIPTION
Also updating pkg to match latest iproute2 dependancy.

Signed-off-by: nikos <ntriantafillis@gmail.com>
