### PR TITLE
[build]: add libssl1.0-dev to build snmpd in sonic slave stretch docker

### DIFF
--- a/sonic-slave-stretch/Dockerfile
+++ b/sonic-slave-stretch/Dockerfile
@@ -168,7 +168,7 @@ RUN apt-get update && apt-get install -y \
         python-parse \
 # For snmpd
         default-libmysqlclient-dev \
-        libssl-dev \
+        libssl1.0-dev \
         libperl-dev \
         libpci-dev \
         libpci3 \


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
add libssl1.0-dev package in sonic-slave-stretch docker

**- How I did it**

**- How to verify it**
```
lgh@5d01c701873c:/data2/sonic/stretch/sonic-buildimage$ BLDENV=stretch make -f slave.mk target/debs/stretch/libsnmp-base_5.7.3+dfsg-1.5_all.deb
SONiC Build System

Build Configuration
"CONFIGURED_PLATFORM"             : "broadcom"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "1"
"SONIC_CONFIG_MAKE_JOBS"          : "8"
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "quagga"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_SYSTEM_TELEMETRY"         : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : ""
"BLDENV"                          : "stretch"

[ 01 ] [ target/debs/stretch/libsnmp-base_5.7.3+dfsg-1.5_all.deb ]
lgh@5d01c701873c:/data2/sonic/stretch/sonic-buildimage$
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
