### PR TITLE
[swss]: flush asic db in swss.sh for non warm-boot

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -91,8 +91,9 @@ start() {
 
     # Don't flush DB during warm boot
     if [[ x"$WARM_BOOT" != x"true" ]]; then
-        debug "Flushing databases ..."
+        debug "Flushing APP, ASIC, COUNTER, CONFIG, and partial STATE databases ..."
         /usr/bin/docker exec database redis-cli -n 0 FLUSHDB
+        /usr/bin/docker exec database redis-cli -n 1 FLUSHDB
         /usr/bin/docker exec database redis-cli -n 2 FLUSHDB
         /usr/bin/docker exec database redis-cli -n 5 FLUSHDB
         clean_up_tables 6 "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*'"

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -88,10 +88,6 @@ start() {
         touch /host/warmboot/warm-starting
     else
         rm -f /host/warmboot/warm-starting
-
-        # Flush ASIC DB during non-warm start
-        debug "Flushing ASIC database ..."
-        /usr/bin/docker exec database redis-cli -n 1 FLUSHDB
     fi
 
     # platform specific tasks


### PR DESCRIPTION
need to flush asic db in swss.sh instead of syncd.sh

orchagent might already started in swss.sh and put commands
into asic db before asic db is flushed in syncd.sh. This
causes race condition such as INIT_VIEW not passing to syncd.

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
flush asic db in swss.sh for non warm-boot

In current script, the asic db is flushed after orchagent already started. This causes commands sent by orchagent to syncd lost during asic db flush.

Below is current log with problematic sequencing.

```
Feb 18 09:24:39.323574 vlab-01 NOTICE root: Flushing databases ...
Feb 18 09:24:47.762531 vlab-01 INFO swss.sh[29193]: 2019-02-18 09:24:47,761 INFO spawned: 'orchagent' with pid
 40
Feb 18 09:24:48.707208 vlab-01 NOTICE root: Flushing ASIC database ...
```

**- How I did it**

**- How to verify it**
run ```config load_minigraph -y``` many times and verify no race condition.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
