### PR TITLE
[sonic-buildimage] New feature managementVRF(L3mdev)

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -205,6 +205,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install      \
 ## Note: don't install python-apt by pip, older than Debian repo one
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \
     file                    \
+    ifmetric                \
     iproute2                \
     bridge-utils            \
     isc-dhcp-client         \

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -5,6 +5,11 @@
 # file: /etc/network/interfaces
 #
 {% endblock banner %}
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
+auto mgmt
+iface mgmt
+    vrf-table 5000
+{% endif %}
 {% block loopback %}
 # The loopback network interface
 auto lo
@@ -26,25 +31,44 @@ auto eth0
 iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     address {{ prefix | ip }}
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
+{%     set vrf_table = 'default' %}
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
+{%     set vrf_table = '5000' %}
+    vrf mgmt
+{% endif %}
     ########## management network policy routing rules
     # management port up rules
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table default
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table default
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table default
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }} metric 201
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
+    up cgcreate -g l3mdev:mgmt
+    up cgset -r l3mdev.master-device=mgmt mgmt
+{% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    up ip rule add to {{ route }} table default
+    up ip rule add to {{ route }} table {{ vrf_table }}
 {% endfor %}
     # management port down rules
-    down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table default
-    down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table default
-    down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table default
+    down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }}
+    down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
+    down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
+    down cgdelete -g l3mdev:mgmt
+{% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    down ip rule delete to {{ route }} table default
+    down ip rule delete to {{ route }} table {{ vrf_table }}
 {% endfor %}
 {# TODO: COPP policy type rules #}
 {% endfor %}
 {% else %}
 iface eth0 inet dhcp
+    metric 202
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
+    vrf mgmt
+    up cgcreate -g l3mdev:mgmt
+    up cgset -r l3mdev.master-device=mgmt mgmt
+    down cgdelete -g l3mdev:mgmt
+{% endif %}
 {% endif %}
 #
 source /etc/network/interfaces.d/*

--- a/src/sonic-config-engine/tests/sample_output/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/interfaces
@@ -27,7 +27,7 @@ iface eth0 inet static
     netmask 255.255.255.0
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table default
     up ip -4 rule add from 10.0.0.100/32 table default
     # management port down rules
@@ -39,7 +39,7 @@ iface eth0 inet6 static
     netmask 64
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
     up ip -6 rule add from 2603:10e2:0:2902::8/128 table default
     # management port down rules


### PR DESCRIPTION
This commit adds support for New feature management VRF using L3mdev.
Added commands to enable/disable management VRF. Config vrf add mgmt
will enable management VRF, enslave the eth0 device to the master
device mgmt, stop ntp service in default, restart interfaces-configs
and restart ntp service in mgmt-vrf context.
management interface (eth0) can be configured using config interface eth0 ip add
command and removed using config interface eth0 ip remove command.
Requirement and design are covered in mgmt vrf design document.
Currently show command displays Linux command output, will update show
command display in next PR after concluding what would be the output for the
show commands. Added metric for default routes in dhcp and static, any changes
for metric will be addressed subsequently after discussing.

Signed-off-by: Harish Venkatraman <harish_venkatraman@dell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added support for new feature management VRF using l3mdev.
**- How I did it**
Added commands to enable and disable management VRF using config commands and displays the management VRF information using show commands.
Added support to configure eth0 (management interface) ip address 

**- How to verify it**
Verified by running the below commands for configuring management VRF and delete management VRF
config vrf add mgmt
config vrf del mgmt
Use the below command to configure eth0 ip address.
config interface eth0 ip add ip/mask gatewayIP
Ex: config interface eth0 ip add 10.11.100.11/24 10.11.100.1
config interface eth0 ip remove ip/mask
config interface eth0 ip remove10.11.100.11/24
Verified NTP using below steps
- Added NTP_SERVERS in config_db.json
- Load config_db.json 
- restart ntp.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
