### PR TITLE
[ntp] disable ntp time jump

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -266,6 +266,10 @@ sudo mv $FILESYSTEM_ROOT/grub-pc-bin*.deb $FILESYSTEM_ROOT/$PLATFORM_DIR/x86_64-
 ## Disable kexec supported reboot which was installed by default
 sudo sed -i 's/LOAD_KEXEC=true/LOAD_KEXEC=false/' $FILESYSTEM_ROOT/etc/default/kexec
 
+## Modifty ntp default configuration: disable initial jump (add -x), and disable
+## jump when time difference is greater than 1000 seconds (remove -g).
+sudo sed -i "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/" $FILESYSTEM_ROOT/etc/default/ntp
+
 ## Fix ping tools permission so non root user can directly use them
 ## Note: this is a workaround since aufs doesn't support extended attributes
 ## Ref: https://github.com/moby/moby/issues/5650#issuecomment-303499489


### PR DESCRIPTION
**- What I did**
This change is added to address the supervisord issue with clock setting back.

- removing -g to disable jump when time difference is greater than 1000s
- add -x to disable initial jump

**- How to verify it**
Set a dut with some clock difference with NTP and sync to CMOS. Then boot up an image with the fix. Confirming that the initial jump didn't happen when ntpd starts with a few reboots and ntpd restarts. And leave the system up and watch the clock slowly drift back towards the correct NTP time (ntpstats).