### PR TITLE
Revert "[boot] Delay ntp-config service to start after 5 minutes"

### DIFF
--- a/files/build_templates/ntp-config.timer
+++ b/files/build_templates/ntp-config.timer
@@ -1,9 +1,0 @@
-[Unit]
-Description=Delays NTP configuration service until SONiC has started
-
-[Timer]
-OnBootSec=5min
-Unit=ntp-config.service
-
-[Install]
-WantedBy=timers.target

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -296,9 +296,7 @@ sudo LANG=C cp $SCRIPTS_DIR/syncd.sh $FILESYSTEM_ROOT/usr/local/bin/syncd.sh
 # Copy systemd timer configuration
 # It implements delayed start of services
 sudo cp $BUILD_TEMPLATES/snmp.timer $FILESYSTEM_ROOT/etc/systemd/system/
-sudo cp $BUILD_TEMPLATES/ntp-config.timer $FILESYSTEM_ROOT/etc/systemd/system/
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable snmp.timer
-sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable ntp-config.timer
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get remove -y python-dev
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get clean -y


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#2494

Turns out that what harmful to supervisord is the ntpd initial jump when ntpd started and received the NTP time the first time.

https://github.com/Azure/sonic-buildimage/pull/2589 addresses the initial jump issue. With that, we would like to have the correct configuration earlier.