### PR TITLE
dockers/docker-orchagent: Add bridge-utils to orchagent image

### DIFF
--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -15,7 +15,7 @@ RUN apt-get install -f -y ndisc6 tcpdump python-scapy
 ## TODO: implicitly install dependencies
 RUN apt-get -y install libjemalloc1
 
-RUN apt-get install -y libelf1 libmnl0
+RUN apt-get install -y libelf1 libmnl0 bridge-utils
 
 RUN pip install setuptools 
 RUN pip install pyroute2==0.5.3 netifaces==0.10.7


### PR DESCRIPTION
* Add bridge-utils package to Dockerfile of docker-orchagent, Because Vxlan need the brctl tool to manage bridge for it

Signed-off-by: Ze Gan <zegan@microsoft.com>