### PR TITLE
[201803] [apt] Instruct apt-get to NOT check the "Valid Until" date in Release files 

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -91,7 +91,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT mount proc /proc -t proc
 
 ## Pointing apt to public apt mirrors and getting latest packages, needed for latest security updates
 sudo cp files/apt/sources.list $FILESYSTEM_ROOT/etc/apt/
-sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages}} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
+sudo cp files/apt/apt.conf.d/* $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
 sudo LANG=C chroot $FILESYSTEM_ROOT bash -c 'apt-mark auto `apt-mark showmanual`'
 
 ## Note: set lang to prevent locale warnings in your chroot

--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -20,6 +20,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Configure data sources for apt/dpkg
 COPY ["sources.list", "/etc/apt/sources.list"]
 COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
 RUN apt-get update
 
 # Pre-install fundamental packages

--- a/dockers/docker-base/no-check-valid-until
+++ b/dockers/docker-base/no-check-valid-until
@@ -1,0 +1,3 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+
+Acquire::Check-Valid-Until "0";

--- a/files/apt/apt.conf.d/no-check-valid-until
+++ b/files/apt/apt.conf.d/no-check-valid-until
@@ -1,0 +1,3 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+
+Acquire::Check-Valid-Until "0";

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -47,6 +47,7 @@ sudo chroot $FILESYSTEM_ROOT service docker start
 # Apply apt configuration files
 sudo cp $IMAGE_CONFIGS/apt/sources.list $FILESYSTEM_ROOT/etc/apt/
 sudo cp -R $IMAGE_CONFIGS/apt/sources.list.d/ $FILESYSTEM_ROOT/etc/apt/
+sudo cp $IMAGE_CONFIGS/apt/apt.conf.d/no-check-valid-until $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
 cat $IMAGE_CONFIGS/apt/sonic-dev.gpg.key | sudo LANG=C chroot $FILESYSTEM_ROOT apt-key add -
 
 # Update apt's snapshot of its repos

--- a/files/image_config/apt/apt.conf.d/no-check-valid-until
+++ b/files/image_config/apt/apt.conf.d/no-check-valid-until
@@ -1,0 +1,3 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+
+Acquire::Check-Valid-Until "0";

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -2,6 +2,8 @@ FROM debian:jessie
 
 MAINTAINER johnar@microsoft.com
 
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+
 RUN echo "deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \

--- a/sonic-slave/no-check-valid-until
+++ b/sonic-slave/no-check-valid-until
@@ -1,0 +1,3 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+
+Acquire::Check-Valid-Until "0";


### PR DESCRIPTION
**- What I did**

SONiC image builds were failing due to expired "Valid Until" date in jessie-backports/InRelease and stretch-backports/InRelease files in Debian repo, causing the SONiC build to fail with a message like the following:

```
Step 9/27 : RUN apt-get update
 ---> Running in 7e733c41d938
Ign:1 http://debian-archive.trafficmanager.net/debian stretch InRelease
Get:2 http://debian-archive.trafficmanager.net/debian-security stretch/updates InRelease [94.3 kB]
Get:3 http://debian-archive.trafficmanager.net/debian stretch-backports InRelease [91.9 kB]
Get:4 http://debian-archive.trafficmanager.net/debian stretch Release [118 kB]
Get:5 http://debian-archive.trafficmanager.net/debian stretch Release.gpg [2434 B]
Get:6 http://debian-archive.trafficmanager.net/debian-security stretch/updates/contrib Sources [1384 B]
Get:7 http://debian-archive.trafficmanager.net/debian-security stretch/updates/non-free Sources [1216 B]
Get:8 http://debian-archive.trafficmanager.net/debian-security stretch/updates/main Sources [193 kB]
Get:9 http://debian-archive.trafficmanager.net/debian-security stretch/updates/contrib amd64 Packages [1760 B]
Get:10 http://debian-archive.trafficmanager.net/debian-security stretch/updates/non-free amd64 Packages [1600 B]
Get:11 http://debian-archive.trafficmanager.net/debian-security stretch/updates/main amd64 Packages [474 kB]
Get:12 http://debian-archive.trafficmanager.net/debian stretch/non-free Sources [79.4 kB]
Get:13 http://debian-archive.trafficmanager.net/debian stretch/main Sources [6746 kB]
Get:14 http://debian-archive.trafficmanager.net/debian stretch/contrib Sources [44.7 kB]
Get:15 http://debian-archive.trafficmanager.net/debian stretch/contrib amd64 Packages [50.9 kB]
Get:16 http://debian-archive.trafficmanager.net/debian stretch/non-free amd64 Packages [78.3 kB]
Get:17 http://debian-archive.trafficmanager.net/debian stretch/main amd64 Packages [7084 kB]
Reading package lists...
Release file for http://debian-archive.trafficmanager.net/debian/dists/stretch-backports/InRelease is expired (invalid since 7h 33min 52s). Updates for this repository will not be applied.
The command '/bin/sh -c apt-get update' returned a non-zero code: 100
[  FAIL LOG END  ] [ target/docker-base-stretch.gz ]
```

This change prevents the build from failing under these circumstances.

**- How I did it**

Instruct apt-get to NOT check the "Valid Until" date in Release files by adding a new file inside base image and Docker images, `/etc/apt/apt.conf.d/no-check-valid-until`. The change was applied to the base image, docker-base and sonic-slave.

**- How to verify it**

Ensure build succeeds even if the "Valid Until" date in some Debian Release/InRelease files is expired.