### PR TITLE
[aaa] Fix common-auth-sonic.j2 template issue

### DIFF
--- a/files/image_config/hostcfgd/common-auth-sonic.j2
+++ b/files/image_config/hostcfgd/common-auth-sonic.j2
@@ -19,7 +19,7 @@ auth	[success=done new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not
 {% endfor %}
 {% if servers | count %}
 {% set last_server = servers | last %}
-auth	[success=1 default=ignore]	pam_tacplus.so server={{ last_server.ip }}:{{ last_server.tcp_port }} secret={{ last_server.passkey }} login={{ last_server.auth_type }} timeout={{ last_server.timeout }} {% if server.vrf %} vrf={{ last_server.vrf }} {% endif %} try_first_pass
+auth	[success=1 default=ignore]	pam_tacplus.so server={{ last_server.ip }}:{{ last_server.tcp_port }} secret={{ last_server.passkey }} login={{ last_server.auth_type }} timeout={{ last_server.timeout }} {% if last_server.vrf %} vrf={{ last_server.vrf }} {% endif %} try_first_pass
 
 {% endif %}
 {% elif auth['login'] == 'tacacs+' or auth['login'] == 'tacacs+,local' %}


### PR DESCRIPTION
 **- What I did**
To select AAA authentication as local and tacacs+ executed the below CLI command. 
"config aaa  authentication login local tacacs+" 
After executing the command, the common-auth-sonic file is not updated with list of authentication modules.
Also with the above selection, hostcfgd enforcer is closed due to UndefinedError exception.
The crash logs are shown below.

```
Feb 24 10:34:41.563298 sonic INFO hostcfgd[1382]:   File "/usr/bin/hostcfgd", line 155, in aaa_handler
Feb 24 10:34:41.564132 sonic INFO hostcfgd[1382]:     self.aaacfg.aaa_update(key, data)
Feb 24 10:34:41.564872 sonic INFO hostcfgd[1382]:   File "/usr/bin/hostcfgd", line 78, in aaa_update
Feb 24 10:34:41.565641 sonic INFO hostcfgd[1382]:     self.modify_conf_file()
Feb 24 10:34:41.566395 sonic INFO hostcfgd[1382]:   File "/usr/bin/hostcfgd", line 115, in modify_conf_file
Feb 24 10:34:41.567131 sonic INFO hostcfgd[1382]:     pam_conf = template.render(auth=auth, servers=servers_conf)
Feb 24 10:34:41.567969 sonic INFO hostcfgd[1382]:   File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 1008, in render
Feb 24 10:34:41.568747 sonic INFO hostcfgd[1382]:     return self.environment.handle_exception(exc_info, True)
Feb 24 10:34:41.569478 sonic INFO hostcfgd[1382]:   File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 780, in handle_exception
Feb 24 10:34:41.570227 sonic INFO hostcfgd[1382]:     reraise(exc_type, exc_value, tb)
Feb 24 10:34:41.570945 sonic INFO hostcfgd[1382]:   File "/usr/share/sonic/templates/common-auth-sonic.j2", line 22, in top-level template code
Feb 24 10:34:41.571683 sonic INFO hostcfgd[1382]:     auth#011[success=1 default=ignore]#011pam_tacplus.so server={{ last_server.ip }}:{{ last_server.tcp_port }} secret={{ last_server.passkey }} login={{ last_server.auth_type }} timeout={{ last_server.timeout }} {% if server.vrf %} vrf={{ last_server.vrf }} {% endif %} try_first_pass
Feb 24 10:34:41.572397 sonic INFO hostcfgd[1382]:   File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 430, in getattr
Feb 24 10:34:41.573128 sonic INFO hostcfgd[1382]:     return getattr(obj, attribute)
Feb 24 10:34:41.573860 sonic INFO hostcfgd[1382]: jinja2.exceptions.UndefinedError: 'server' is undefined
Feb 24 10:34:41.580348 sonic NOTICE systemd[1]: hostcfgd.service: Main process exited, code=exited, status=1/FAILURE
Feb 24 10:34:41.582178 sonic NOTICE systemd[1]: hostcfgd.service: Unit entered failed state.
Feb 24 10:34:41.582921 sonic WARNING systemd[1]: hostcfgd.service: Failed with result 'exit-code'.
```
 
**- How I did it**

Fixed the UndefinedError exception. User the last_server as server for VRF configuration.
The variable name server is changed to last_server in the below file 
files/image_config/hostcfgd/common-auth-sonic.j2

**- How to verify it**
Configure AAA login authentication methods as local and tacacs+. 
Check the /etc/pam.d/common-auth-sonic is updated correctly.
Check AAA authentication works as expected. 