### PR TITLE
Allow configuration of platform-specific interfaces

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -165,6 +165,7 @@ sudo cp $IMAGE_CONFIGS/interfaces/*.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATE
 
 # Copy initial interfaces configuration file, will be overwritten on first boot
 sudo cp $IMAGE_CONFIGS/interfaces/init_interfaces $FILESYSTEM_ROOT/etc/network/interfaces
+sudo mkdir -p $FILESYSTEM_ROOT/etc/network/interfaces.d
 
 # Copy hostcfgd files
 sudo cp $IMAGE_CONFIGS/hostcfgd/hostcfgd.service $FILESYSTEM_ROOT/etc/systemd/system/

--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -4,18 +4,6 @@ ifdown --force eth0
 
 sonic-cfggen -d -t /usr/share/sonic/templates/interfaces.j2 > /etc/network/interfaces
 
-# Add usb0 interface for bfn platforms
-platform=$(sonic-cfggen -H -v 'DEVICE_METADATA["localhost"]["platform"]')
-if [[ "$platform" == "x86_64-accton_wedge100bf_32x-r0" || "$platform" == "x86_64-accton_wedge100bf_65x-r0" ]]; then
-cat <<'EOF' >> /etc/network/interfaces
-# BMC interface
-auto usb0
-allow-hotplug usb0
-iface usb0 inet6 auto
-up ifconfig usb0 txqueuelen 64
-EOF
-fi
-
 [ -f /var/run/dhclient.eth0.pid ] && kill `cat /var/run/dhclient.eth0.pid` && rm -f /var/run/dhclient.eth0.pid
 
 systemctl restart networking

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -47,4 +47,6 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
 iface eth0 inet dhcp
 {% endif %}
 #
+source /etc/network/interfaces.d/*
+#
 {% endblock mgmt_interface %}

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/configs/network/interfaces.d/usb0
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/configs/network/interfaces.d/usb0
@@ -1,0 +1,5 @@
+# BMC interface
+auto usb0
+allow-hotplug usb0
+iface usb0 inet6
+up ifconfig usb0 txqueuelen 64

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/debian/rules
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/debian/rules
@@ -2,6 +2,7 @@
 
 PACKAGE_NAME := sonic-platform-modules-bfn-montara
 SCRIPT_SRC := $(shell pwd)/scripts
+CONFIGS_SRC := $(shell pwd)/configs
 
 %:
 	dh $@
@@ -9,6 +10,8 @@ SCRIPT_SRC := $(shell pwd)/scripts
 override_dh_auto_install:
 	dh_installdirs -p$(PACKAGE_NAME) usr/local/bin
 	cp -r $(SCRIPT_SRC)/* debian/$(PACKAGE_NAME)/usr/local/bin
+	dh_installdirs -p$(PACKAGE_NAME) etc/network/interfaces.d/
+	cp -r $(CONFIGS_SRC)/network/interfaces.d/* debian/$(PACKAGE_NAME)/etc/network/interfaces.d/
 
 override_dh_usrlocal:
 

--- a/platform/barefoot/sonic-platform-modules-bfn/configs/network/interfaces.d/usb0
+++ b/platform/barefoot/sonic-platform-modules-bfn/configs/network/interfaces.d/usb0
@@ -1,0 +1,5 @@
+# BMC interface
+auto usb0
+allow-hotplug usb0
+iface usb0 inet6
+up ifconfig usb0 txqueuelen 64

--- a/platform/barefoot/sonic-platform-modules-bfn/debian/rules
+++ b/platform/barefoot/sonic-platform-modules-bfn/debian/rules
@@ -2,6 +2,7 @@
 
 PACKAGE_NAME := sonic-platform-modules-bfn
 SCRIPT_SRC := $(shell pwd)/scripts
+CONFIGS_SRC := $(shell pwd)/configs
 
 %:
 	dh $@
@@ -9,6 +10,8 @@ SCRIPT_SRC := $(shell pwd)/scripts
 override_dh_auto_install:
 	dh_installdirs -p$(PACKAGE_NAME) usr/local/bin
 	cp -r $(SCRIPT_SRC)/* debian/$(PACKAGE_NAME)/usr/local/bin
+	dh_installdirs -p$(PACKAGE_NAME) etc/network/interfaces.d/
+	cp -r $(CONFIGS_SRC)/network/interfaces.d/* debian/$(PACKAGE_NAME)/etc/network/interfaces.d/
 
 override_dh_usrlocal:
 

--- a/src/sonic-config-engine/tests/sample_output/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/interfaces
@@ -47,4 +47,6 @@ iface eth0 inet6 static
     down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
     down ip -6 rule delete from 2603:10e2:0:2902::8/128 table default
 #
+source /etc/network/interfaces.d/*
+#
 


### PR DESCRIPTION
**- Why it is required**
since SONiC master switches `ifupdown` package to the new implementation (`ifupdown2`), it is required to change the configuration of a platform-specific interface for `wedge100bf_32x` and `wedge100bf_65x` platforms (bc of `ifupdown2` doesn't support `auto` mode for `inet6` protocol).

Also, need to make some refactoring and remove `if platform == smth then..` from the system level scripts.

**- What I did**
* removed customization of `/usr/bin/interfaces-config.sh`
* explicitly created directory `/etc/network/interfaces.d`
* added "source" to the `/etc/network/interfaces` generation template (to include platform-specific interfaces processing)
* added platform-specific interfaces config itself (for `wedge100bf_32x` and `wedge100bf_65x`)
* fixed testcase in `sonic-config-engine`

**- How to verify it**
* build image for wedge100bf_32x
* perform `sudo config reload -y` on new installation
* check the correct configuration of `usb0` interface

**- Description for the changelog**
- Allow configuration of platform-specific interfaces

@akokhan, @mkbalani: please review this first

@lguohan: please review and merge this
