### PR TITLE
Remove MAC alignment WA for Mellanox platforms.

### DIFF
--- a/src/sonic-config-engine/sonic_platform.py
+++ b/src/sonic-config-engine/sonic_platform.py
@@ -56,7 +56,7 @@ def get_system_mac():
     mac = mac.strip()
 
     # Align last byte of MAC if necessary
-    if version_info and (version_info['asic_type'] == 'mellanox' or version_info['asic_type'] == 'centec'):
+    if version_info and version_info['asic_type'] == 'centec':
         last_byte = mac[-2:]
         aligned_last_byte = format(int(int(last_byte, 16) & 0b11000000), '02x')
         mac = mac[:-2] + aligned_last_byte


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

These changes are made in terms of propagating new Mellanox platforms: SN3700/SN3700C:
Spectrum-1/Spectrum-2 based devices requires a different MAC alignment and the correct values should be taken directly from system EEPROM.

**- What I did**
* Removed MAC alignment WA for Mellanox platforms

**- How I did it**
* Updated sonic-config-engine

**- How to verify it**
1. make configure PLATFORM=mellanox
2. make target/sonic-mellanox.bin

**- Description for the changelog**
* N/A