### PR TITLE
[services] Ensure swss and syncd services start before dependent services

### DIFF
--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -13,7 +13,8 @@ Before=ntp-config.service
 [Service]
 User=root
 Environment=sonic_asic_platform={{ sonic_asic_platform }}
-ExecStart=/usr/local/bin/swss.sh start
+ExecStartPre=/usr/local/bin/swss.sh start
+ExecStart=/usr/bin/swss.sh attach
 ExecStop=/usr/local/bin/swss.sh stop
 
 [Install]

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -14,7 +14,7 @@ Before=ntp-config.service
 User=root
 Environment=sonic_asic_platform={{ sonic_asic_platform }}
 ExecStartPre=/usr/local/bin/swss.sh start
-ExecStart=/usr/bin/swss.sh attach
+ExecStart=/usr/local/bin/swss.sh attach
 ExecStop=/usr/local/bin/swss.sh stop
 
 [Install]

--- a/files/build_templates/syncd.service.j2
+++ b/files/build_templates/syncd.service.j2
@@ -18,7 +18,8 @@ Before=ntp-config.service
 [Service]
 User=root
 Environment=sonic_asic_platform={{ sonic_asic_platform }}
-ExecStart=/usr/local/bin/syncd.sh start
+ExecStartPre=/usr/local/bin/syncd.sh start
+ExecStart=/usr/bin/syncd.sh attach
 ExecStop=/usr/local/bin/syncd.sh stop
 
 [Install]

--- a/files/build_templates/syncd.service.j2
+++ b/files/build_templates/syncd.service.j2
@@ -19,7 +19,7 @@ Before=ntp-config.service
 User=root
 Environment=sonic_asic_platform={{ sonic_asic_platform }}
 ExecStartPre=/usr/local/bin/syncd.sh start
-ExecStart=/usr/bin/syncd.sh attach
+ExecStart=/usr/local/bin/syncd.sh attach
 ExecStop=/usr/local/bin/syncd.sh stop
 
 [Install]

--- a/files/build_templates/syncd.service.j2
+++ b/files/build_templates/syncd.service.j2
@@ -13,6 +13,7 @@ After=opennsl-modules.service
 {% elif sonic_asic_platform == 'nephos' %}
 After=nps-modules-4.9.0-8-2-amd64.service
 {% endif %}
+After=swss.service
 Before=ntp-config.service
 
 [Service]

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -109,7 +109,6 @@ start() {
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         /bin/systemctl start ${PEER}
     fi
-    /usr/bin/${SERVICE}.sh attach
 }
 
 stop() {

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -111,6 +111,10 @@ start() {
     fi
 }
 
+attach() {
+    /usr/bin/${SERVICE}.sh attach
+}
+
 stop() {
     debug "Stopping ${SERVICE} service..."
 
@@ -133,11 +137,11 @@ stop() {
 }
 
 case "$1" in
-    start|stop)
+    start|attach|stop)
         $1
         ;;
     *)
-        echo "Usage: $0 {start|stop}"
+        echo "Usage: $0 {start|attach|stop}"
         exit 1
         ;;
 esac

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -119,6 +119,10 @@ start() {
     unlock_service_state_change
 }
 
+attach() {
+    /usr/bin/${SERVICE}.sh attach
+}
+
 stop() {
     debug "Stopping ${SERVICE} service..."
 
@@ -164,11 +168,11 @@ stop() {
 }
 
 case "$1" in
-    start|stop)
+    start|attach|stop)
         $1
         ;;
     *)
-        echo "Usage: $0 {start|stop}"
+        echo "Usage: $0 {start|attach|stop}"
         exit 1
         ;;
 esac

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -117,7 +117,6 @@ start() {
     debug "Started ${SERVICE} service..."
 
     unlock_service_state_change
-    /usr/bin/${SERVICE}.sh attach
 }
 
 stop() {


### PR DESCRIPTION
**- What I did**
- Ensure swss and syncd services start before dependent services

**- How I did it**
With the previous solution, systemd would start dependent services simultaneously with swss and syncd. Due to the extra overhead in the swss.sh file, this would cause dependent containers (dhcp_relay, radv, etc.) to get started before swss.

Moving the `/usr/local/bin/syncd.sh start` call to `ExecStartPre` and moving the `/usr/bin/syncd.sh attach` from out of that script and assigning as the `ExecStart` command fixes this issue.

**- How to verify it**

Call `systemctl restart swss` and ensure containers stop and start in proper order as defined in systemd service files.