### PR TITLE
Add autoneg to 7170-Q59S20

### DIFF
--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/port_config.ini
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/port_config.ini
@@ -1,80 +1,80 @@
-# name          lanes             alias             speed       index
-Ethernet0       0,1,2,3           Ethernet1/1       40000      1
-Ethernet4       4,5,6,7           Ethernet2/1       40000      2
-Ethernet8       8,9,10,11         Ethernet3/1       40000      3
-Ethernet12      12,13,14,15       Ethernet4/1       40000      4
-Ethernet16      16,17,18,19       Ethernet5/1       40000      5
-Ethernet20      20,21,22,23       Ethernet6/1       40000      6
-Ethernet24      24,25,26,27       Ethernet7/1       40000      7
-Ethernet28      28,29,30,31       Ethernet8/1       40000      8
-Ethernet32      32,33,34,35       Ethernet9/1       40000      9
-Ethernet36      36,37,38,39       Ethernet10/1      40000      10
-Ethernet40      40,41,42,43       Ethernet11/1      40000      11
-Ethernet44      44,45,46,47       Ethernet12/1      40000      12
-Ethernet48      48,49,50,51       Ethernet13/1      40000      13
-Ethernet52      52,53,54,55       Ethernet14/1      40000      14
-Ethernet56      56,57,58,59       Ethernet15/1      40000      15
-Ethernet60      60,61,62,63       Ethernet16/1      40000      16
-Ethernet64      64,65,66,67       Ethernet17/1      40000      17
-Ethernet68      68,69,70,71       Ethernet18/1      40000      18
-Ethernet72      72,73,74,75       Ethernet19/1      40000      19
-Ethernet76      76,77,78,79       Ethernet20/1      40000      20
-Ethernet80      80                Ethernet21/1      10000      21
-Ethernet81      81                Ethernet21/2      10000      21
-Ethernet82      82                Ethernet21/3      10000      21
-Ethernet83      83                Ethernet21/4      10000      21
-Ethernet84      84                Ethernet22/1      10000      22
-Ethernet85      85                Ethernet22/2      10000      22
-Ethernet86      86                Ethernet22/3      10000      22
-Ethernet87      87                Ethernet22/4      10000      22
-Ethernet88      88,89,90,91       Ethernet23/1      40000      23
-Ethernet92      92,93,94,95       Ethernet24/1      40000      24
-Ethernet96      96,97,98,99       Ethernet25/1      40000      25
-Ethernet100     100,101,102,103   Ethernet26/1      40000      26
-Ethernet104     104,105,106,107   Ethernet27/1      40000      27
-Ethernet108     108,109,110,111   Ethernet28/1      40000      28
-Ethernet112     112,113,114,115   Ethernet29/1      40000      29
-Ethernet116     116,117,118,119   Ethernet30/1      40000      30
-Ethernet120     120,121,122,123   Ethernet31/1      40000      31
-Ethernet124     124,125,126,127   Ethernet32/1      40000      32
-Ethernet128     128               Ethernet33/1      10000      33
-Ethernet129     129               Ethernet33/2      10000      33
-Ethernet130     130               Ethernet33/3      10000      33
-Ethernet131     131               Ethernet33/4      10000      33
-Ethernet132     132               Ethernet34/1      10000      34
-Ethernet133     133               Ethernet34/2      10000      34
-Ethernet134     134               Ethernet34/3      10000      34
-Ethernet135     135               Ethernet34/4      10000      34
-Ethernet136     136               Ethernet35/1      10000      35
-Ethernet137     137               Ethernet35/2      10000      35
-Ethernet138     138               Ethernet35/3      10000      35
-Ethernet139     139               Ethernet35/4      10000      35
-Ethernet140     140,141,142,143   Ethernet36/1      40000      36
-Ethernet144     144,145,146,147   Ethernet37/1      40000      37
-Ethernet148     148,149,150,151   Ethernet38/1      40000      38
-Ethernet152     152,153,154,155   Ethernet39/1      40000      39
-Ethernet156     156,157,158,159   Ethernet40/1      40000      40
-Ethernet160     160,161,162,163   Ethernet41/1      40000      41
-Ethernet164     164,165,166,167   Ethernet42/1      40000      42
-Ethernet168     168,169,170,171   Ethernet43/1      40000      43
-Ethernet172     172,173,174,175   Ethernet44/1      40000      44
-Ethernet176     176,177,178,179   Ethernet45/1      40000      45
-Ethernet180     180,181,182,183   Ethernet46/1      40000      46
-Ethernet184     184,185,186,187   Ethernet47/1      40000      47
-Ethernet188     188,189,190,191   Ethernet48/1      40000      48
-Ethernet192     192,193,194,195   Ethernet49/1      40000      49
-Ethernet196     196,197,198,199   Ethernet50/1      40000      50
-Ethernet200     200,201,202,203   Ethernet51/1      40000      51
-Ethernet204     204,205,206,207   Ethernet52/1      40000      52
-Ethernet208     208,209,210,211   Ethernet53/1      40000      53
-Ethernet212     212,213,214,215   Ethernet54/1      40000      54
-Ethernet216     216,217,218,219   Ethernet55/1      40000      55
-Ethernet220     220,221,222,223   Ethernet56/1      40000      56
-Ethernet224     224,225,226,227   Ethernet57/1      40000      57
-Ethernet228     228,229,230,231   Ethernet58/1      40000      58
-Ethernet232     232,233,234,235   Ethernet59/1      40000      59
-Ethernet236     236,237,238,239   Ethernet60/1      40000      60
-Ethernet240     240,241,242,243   Ethernet61/1      40000      61
-Ethernet244     244,245,246,247   Ethernet62/1      40000      62
-Ethernet248     248,249,250,251   Ethernet63/1      40000      63
-Ethernet252     252,253,254,255   Ethernet64/1      40000      64
+# name          lanes             alias             speed      index    autoneg
+Ethernet0       0,1,2,3           Ethernet1/1       40000      1        0
+Ethernet4       4,5,6,7           Ethernet2/1       40000      2        0
+Ethernet8       8,9,10,11         Ethernet3/1       40000      3        0
+Ethernet12      12,13,14,15       Ethernet4/1       40000      4        0
+Ethernet16      16,17,18,19       Ethernet5/1       40000      5        0
+Ethernet20      20,21,22,23       Ethernet6/1       40000      6        0
+Ethernet24      24,25,26,27       Ethernet7/1       40000      7        0
+Ethernet28      28,29,30,31       Ethernet8/1       40000      8        0
+Ethernet32      32,33,34,35       Ethernet9/1       40000      9        1
+Ethernet36      36,37,38,39       Ethernet10/1      40000      10       1
+Ethernet40      40,41,42,43       Ethernet11/1      40000      11       1
+Ethernet44      44,45,46,47       Ethernet12/1      40000      12       1
+Ethernet48      48,49,50,51       Ethernet13/1      40000      13       1
+Ethernet52      52,53,54,55       Ethernet14/1      40000      14       1
+Ethernet56      56,57,58,59       Ethernet15/1      40000      15       1
+Ethernet60      60,61,62,63       Ethernet16/1      40000      16       1
+Ethernet64      64,65,66,67       Ethernet17/1      40000      17       1
+Ethernet68      68,69,70,71       Ethernet18/1      40000      18       1
+Ethernet72      72,73,74,75       Ethernet19/1      40000      19       1
+Ethernet76      76,77,78,79       Ethernet20/1      40000      20       1
+Ethernet80      80                Ethernet21/1      10000      21       0
+Ethernet81      81                Ethernet21/2      10000      21       0
+Ethernet82      82                Ethernet21/3      10000      21       0
+Ethernet83      83                Ethernet21/4      10000      21       0
+Ethernet84      84                Ethernet22/1      10000      22       0
+Ethernet85      85                Ethernet22/2      10000      22       0
+Ethernet86      86                Ethernet22/3      10000      22       0
+Ethernet87      87                Ethernet22/4      10000      22       0
+Ethernet88      88,89,90,91       Ethernet23/1      40000      23       0
+Ethernet92      92,93,94,95       Ethernet24/1      40000      24       0
+Ethernet96      96,97,98,99       Ethernet25/1      40000      25       0
+Ethernet100     100,101,102,103   Ethernet26/1      40000      26       0
+Ethernet104     104,105,106,107   Ethernet27/1      40000      27       0
+Ethernet108     108,109,110,111   Ethernet28/1      40000      28       0
+Ethernet112     112,113,114,115   Ethernet29/1      40000      29       0
+Ethernet116     116,117,118,119   Ethernet30/1      40000      30       0
+Ethernet120     120,121,122,123   Ethernet31/1      40000      31       0
+Ethernet124     124,125,126,127   Ethernet32/1      40000      32       0
+Ethernet128     128               Ethernet33/1      10000      33       0
+Ethernet129     129               Ethernet33/2      10000      33       0
+Ethernet130     130               Ethernet33/3      10000      33       0
+Ethernet131     131               Ethernet33/4      10000      33       0
+Ethernet132     132               Ethernet34/1      10000      34       0
+Ethernet133     133               Ethernet34/2      10000      34       0
+Ethernet134     134               Ethernet34/3      10000      34       0
+Ethernet135     135               Ethernet34/4      10000      34       0
+Ethernet136     136               Ethernet35/1      10000      35       0
+Ethernet137     137               Ethernet35/2      10000      35       0
+Ethernet138     138               Ethernet35/3      10000      35       0
+Ethernet139     139               Ethernet35/4      10000      35       0
+Ethernet140     140,141,142,143   Ethernet36/1      40000      36       0
+Ethernet144     144,145,146,147   Ethernet37/1      40000      37       0
+Ethernet148     148,149,150,151   Ethernet38/1      40000      38       0
+Ethernet152     152,153,154,155   Ethernet39/1      40000      39       0
+Ethernet156     156,157,158,159   Ethernet40/1      40000      40       0
+Ethernet160     160,161,162,163   Ethernet41/1      40000      41       1
+Ethernet164     164,165,166,167   Ethernet42/1      40000      42       1
+Ethernet168     168,169,170,171   Ethernet43/1      40000      43       1
+Ethernet172     172,173,174,175   Ethernet44/1      40000      44       1
+Ethernet176     176,177,178,179   Ethernet45/1      40000      45       1
+Ethernet180     180,181,182,183   Ethernet46/1      40000      46       1
+Ethernet184     184,185,186,187   Ethernet47/1      40000      47       1
+Ethernet188     188,189,190,191   Ethernet48/1      40000      48       1
+Ethernet192     192,193,194,195   Ethernet49/1      40000      49       1
+Ethernet196     196,197,198,199   Ethernet50/1      40000      50       1
+Ethernet200     200,201,202,203   Ethernet51/1      40000      51       1
+Ethernet204     204,205,206,207   Ethernet52/1      40000      52       1
+Ethernet208     208,209,210,211   Ethernet53/1      40000      53       1
+Ethernet212     212,213,214,215   Ethernet54/1      40000      54       1
+Ethernet216     216,217,218,219   Ethernet55/1      40000      55       1
+Ethernet220     220,221,222,223   Ethernet56/1      40000      56       1
+Ethernet224     224,225,226,227   Ethernet57/1      40000      57       1
+Ethernet228     228,229,230,231   Ethernet58/1      40000      58       1
+Ethernet232     232,233,234,235   Ethernet59/1      40000      59       1
+Ethernet236     236,237,238,239   Ethernet60/1      40000      60       1
+Ethernet240     240,241,242,243   Ethernet61/1      40000      61       1
+Ethernet244     244,245,246,247   Ethernet62/1      40000      62       1
+Ethernet248     248,249,250,251   Ethernet63/1      40000      63       1
+Ethernet252     252,253,254,255   Ethernet64/1      40000      64       1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added to copper ports, 9-20 and 41-64


**- A picture of a cute animal (not mandatory but encouraged)**
