### PR TITLE
[swss/syncd] cold start syncd service by swss in attach method

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -78,6 +78,14 @@ function clean_up_tables()
     end" 0
 }
 
+startPeerService() {
+    check_warm_boot
+
+    if [[ x"$WARM_BOOT" != x"true" ]]; then
+        /bin/systemctl start ${PEER}
+    fi
+}
+
 start() {
     debug "Starting ${SERVICE} service..."
 
@@ -105,13 +113,10 @@ start() {
 
     # Unlock has to happen before reaching out to peer service
     unlock_service_state_change
-
-    if [[ x"$WARM_BOOT" != x"true" ]]; then
-        /bin/systemctl start ${PEER}
-    fi
 }
 
 attach() {
+    startPeerService
     /usr/bin/${SERVICE}.sh attach
 }
 


### PR DESCRIPTION
**- What I did**

start() is called by service startPre method, which is blocking. Starting syncd service here is causing deadlock.

attach() is called by service start method, which is non-blocking. Starting syncd service here is fine.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Tested following scenarios:
- cold reboot
- cold restart swss (including config load_minigraph)
- warm restart swss
- warm restart syncd
- warm reboot
(Note that we don't support cold restart syncd).