### PR TITLE
Mellanox platform: Attach queues 2 and 6 to lossy profile for the tc …

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t0.j2
@@ -81,10 +81,10 @@
         "{{ port_names }}|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "{{ port_names }}|0-1": {
+        "{{ port_names }}|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "{{ port_names }}|5": {
+        "{{ port_names }}|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         }
     }

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t1.j2
@@ -81,10 +81,10 @@
         "{{ port_names }}|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "{{ port_names }}|0-1": {
+        "{{ port_names }}|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "{{ port_names }}|5": {
+        "{{ port_names }}|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         }
     }


### PR DESCRIPTION
…to queue mapping update: 2 -> 2, 6 -> 6

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
