### PR TITLE
[Pmon] dynamically load pmon daemons

### DIFF
--- a/device/mellanox/x86_64-mlnx_lssn2700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_lssn2700-r0/pmon_daemon_control.json
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/pmon_daemon_control.json

--- a/device/mellanox/x86_64-mlnx_msn2010-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/pmon_daemon_control.json
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/pmon_daemon_control.json

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/pmon_daemon_control.json
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/pmon_daemon_control.json

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/pmon_daemon_control.json
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/pmon_daemon_control.json

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
@@ -1,0 +1,5 @@
+{
+    "skip_ledd": true
+}
+
+

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
@@ -2,4 +2,3 @@
     "skip_ledd": true
 }
 
-

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/pmon_daemon_control.json
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/pmon_daemon_control.json

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/pmon_daemon_control.json
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/pmon_daemon_control.json

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/pmon_daemon_control.json
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/pmon_daemon_control.json

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -55,7 +55,7 @@ RUN apt-get autoclean -y
 RUN apt-get autoremove -y
 RUN rm -rf /debs /python-wheels ~/.cache
 
-COPY ["start.sh", "lm-sensors.sh", "/usr/bin/"]
-COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
+COPY ["docker_init.sh", "lm-sensors.sh", "/usr/bin/"]
+COPY ["docker-pmon.supervisord.conf.j2", "start.sh.j2", "/usr/share/sonic/templates/"]
 
-ENTRYPOINT ["/usr/bin/supervisord"]
+ENTRYPOINT ["/usr/bin/docker_init.sh"]

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -37,6 +37,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
+{% if not skip_ledd %}
 [program:ledd]
 command=/usr/bin/ledd
 priority=5
@@ -45,7 +46,9 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=0
+{% endif %}
 
+{% if not skip_xcvrd %}
 [program:xcvrd]
 command=/usr/bin/xcvrd
 priority=6
@@ -54,7 +57,9 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=0
+{% endif %}
 
+{% if not skip_psud %}
 [program:psud]
 command=/usr/bin/psud
 priority=7
@@ -63,4 +68,4 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=0
-
+{% endif %}

--- a/dockers/docker-platform-monitor/docker_init.sh
+++ b/dockers/docker-platform-monitor/docker_init.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Generate supervisord config file and the start.sh scripts
+mkdir -p /etc/supervisor/conf.d/
+
+if [ -e /usr/share/sonic/platform/pmon_daemon_control.json ]; then
+sonic-cfggen -j /usr/share/sonic/platform/pmon_daemon_control.json -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
+sonic-cfggen -j /usr/share/sonic/platform/pmon_daemon_control.json -t /usr/share/sonic/templates/start.sh.j2 > /usr/bin/start.sh
+chmod +x /usr/bin/start.sh
+else
+sonic-cfggen -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
+sonic-cfggen -t /usr/share/sonic/templates/start.sh.j2 > /usr/bin/start.sh
+chmod +x /usr/bin/start.sh
+fi
+
+exec /usr/bin/supervisord

--- a/dockers/docker-platform-monitor/docker_init.sh
+++ b/dockers/docker-platform-monitor/docker_init.sh
@@ -3,14 +3,16 @@
 # Generate supervisord config file and the start.sh scripts
 mkdir -p /etc/supervisor/conf.d/
 
-if [ -e /usr/share/sonic/platform/pmon_daemon_control.json ]; then
-sonic-cfggen -j /usr/share/sonic/platform/pmon_daemon_control.json -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
-sonic-cfggen -j /usr/share/sonic/platform/pmon_daemon_control.json -t /usr/share/sonic/templates/start.sh.j2 > /usr/bin/start.sh
-chmod +x /usr/bin/start.sh
+if [ -e /usr/share/sonic/platform/pmon_daemon_control.json ]; 
+then
+    sonic-cfggen -j /usr/share/sonic/platform/pmon_daemon_control.json -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
+    sonic-cfggen -j /usr/share/sonic/platform/pmon_daemon_control.json -t /usr/share/sonic/templates/start.sh.j2 > /usr/bin/start.sh
+    chmod +x /usr/bin/start.sh
 else
-sonic-cfggen -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
-sonic-cfggen -t /usr/share/sonic/templates/start.sh.j2 > /usr/bin/start.sh
-chmod +x /usr/bin/start.sh
+    sonic-cfggen -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
+    sonic-cfggen -t /usr/share/sonic/templates/start.sh.j2 > /usr/bin/start.sh
+    chmod +x /usr/bin/start.sh
 fi
 
 exec /usr/bin/supervisord
+

--- a/dockers/docker-platform-monitor/start.sh.j2
+++ b/dockers/docker-platform-monitor/start.sh.j2
@@ -37,8 +37,14 @@ if [ -e /usr/share/sonic/platform/fancontrol ]; then
     supervisorctl start fancontrol
 fi
 
+{% if not skip_ledd %}
 supervisorctl start ledd
+{% endif %}
 
+{% if not skip_xcvrd %}
 supervisorctl start xcvrd
+{% endif %}
 
+{% if not skip_psud %}
 supervisorctl start psud
+{% endif %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Make the pmon container daemons(ledd, xcvrd, psud) can be selectively loaded according to the platform configuration.
Add a pmon daemon control configuration file to all Mellanox platform to skip load ledd on all of them.

design doc in this link: https://github.com/Azure/SONiC/blob/master/doc/pmon/pmon-enhancement-design.md#4-pmon-daemons-dynamically-loading

**- How I did it**
1. Change the pmon container starting entry from "start.sh" to "docker_init.sh", in this new script will generate "supervisord.conf" and "start.sh" according to the platform configuration file, if this configuration file not exist, it will generate a config and start.sh for starting all the daemons.

2. Add jinja templates for supervisord.conf and start.sh generation.

3. Add pmon daemon control configuration file to Mellaox platform to skip ledd and also as an example.
**- How to verify it**
compile a pmon docker image and test it with a configuration file, to check whether the started daemons inside pmon is as expected.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
