### PR TITLE
[services] Services which start containers now use 'docker wait' instead of 'docker attach'

### DIFF
--- a/files/build_templates/bgp.service.j2
+++ b/files/build_templates/bgp.service.j2
@@ -7,7 +7,7 @@ Before=ntp-config.service
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
-ExecStart=/usr/bin/{{docker_container_name}}.sh attach
+ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
 [Install]

--- a/files/build_templates/database.service.j2
+++ b/files/build_templates/database.service.j2
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 User=root
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
-ExecStart=/usr/bin/{{docker_container_name}}.sh attach
+ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
 [Install]

--- a/files/build_templates/dhcp_relay.service.j2
+++ b/files/build_templates/dhcp_relay.service.j2
@@ -7,7 +7,7 @@ Before=ntp-config.service
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{ docker_container_name }}.sh start
-ExecStart=/usr/bin/{{ docker_container_name }}.sh attach
+ExecStart=/usr/bin/{{ docker_container_name }}.sh wait
 ExecStop=/usr/bin/{{ docker_container_name }}.sh stop
 
 [Install]

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -150,8 +150,8 @@ start() {
     postStartAction
 }
 
-attach() {
-    docker attach --no-stdin {{docker_container_name}}
+wait() {
+    docker wait {{docker_container_name}}
 }
 
 stop() {
@@ -159,11 +159,11 @@ stop() {
 }
 
 case "$1" in
-    start|stop|attach)
+    start|wait|stop)
         $1
         ;;
     *)
-        echo "Usage: $0 {start|stop|attach}"
+        echo "Usage: $0 {start|wait|stop}"
         exit 1
         ;;
 esac

--- a/files/build_templates/lldp.service.j2
+++ b/files/build_templates/lldp.service.j2
@@ -7,7 +7,7 @@ Before=ntp-config.service
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
-ExecStart=/usr/bin/{{docker_container_name}}.sh attach
+ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
 [Install]

--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -7,7 +7,7 @@ Before=ntp-config.service
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
-ExecStart=/usr/bin/{{docker_container_name}}.sh attach
+ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
 [Install]

--- a/files/build_templates/radv.service.j2
+++ b/files/build_templates/radv.service.j2
@@ -7,7 +7,7 @@ Before=ntp-config.service
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{ docker_container_name }}.sh start
-ExecStart=/usr/bin/{{ docker_container_name }}.sh attach
+ExecStart=/usr/bin/{{ docker_container_name }}.sh wait
 ExecStop=/usr/bin/{{ docker_container_name }}.sh stop
 
 [Install]

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -6,5 +6,5 @@ Before=ntp-config.service
 
 [Service]
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
-ExecStart=/usr/bin/{{docker_container_name}}.sh attach
+ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -14,7 +14,7 @@ Before=ntp-config.service
 User=root
 Environment=sonic_asic_platform={{ sonic_asic_platform }}
 ExecStartPre=/usr/local/bin/swss.sh start
-ExecStart=/usr/local/bin/swss.sh attach
+ExecStart=/usr/local/bin/swss.sh wait
 ExecStop=/usr/local/bin/swss.sh stop
 
 [Install]

--- a/files/build_templates/syncd.service.j2
+++ b/files/build_templates/syncd.service.j2
@@ -20,7 +20,7 @@ Before=ntp-config.service
 User=root
 Environment=sonic_asic_platform={{ sonic_asic_platform }}
 ExecStartPre=/usr/local/bin/syncd.sh start
-ExecStart=/usr/local/bin/syncd.sh attach
+ExecStart=/usr/local/bin/syncd.sh wait
 ExecStop=/usr/local/bin/syncd.sh stop
 
 [Install]

--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -7,7 +7,7 @@ Before=ntp-config.service
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
-ExecStart=/usr/bin/{{docker_container_name}}.sh attach
+ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
 [Install]

--- a/files/build_templates/telemetry.service.j2
+++ b/files/build_templates/telemetry.service.j2
@@ -7,7 +7,7 @@ Before=ntp-config.service
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
-ExecStart=/usr/bin/{{docker_container_name}}.sh attach
+ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
 [Install]

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -115,9 +115,9 @@ start() {
     unlock_service_state_change
 }
 
-attach() {
+wait() {
     startPeerService
-    /usr/bin/${SERVICE}.sh attach
+    /usr/bin/${SERVICE}.sh wait
 }
 
 stop() {
@@ -142,11 +142,11 @@ stop() {
 }
 
 case "$1" in
-    start|attach|stop)
+    start|wait|stop)
         $1
         ;;
     *)
-        echo "Usage: $0 {start|attach|stop}"
+        echo "Usage: $0 {start|wait|stop}"
         exit 1
         ;;
 esac

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -119,8 +119,8 @@ start() {
     unlock_service_state_change
 }
 
-attach() {
-    /usr/bin/${SERVICE}.sh attach
+wait() {
+    /usr/bin/${SERVICE}.sh wait
 }
 
 stop() {
@@ -168,11 +168,11 @@ stop() {
 }
 
 case "$1" in
-    start|attach|stop)
+    start|wait|stop)
         $1
         ;;
     *)
-        echo "Usage: $0 {start|attach|stop}"
+        echo "Usage: $0 {start|wait|stop}"
         exit 1
         ;;
 esac


### PR DESCRIPTION
**- What I did**
- Replace `ExecStart=` calls to `docker attach` with calls to the more appropriate `docker wait` in all services which start a container and need to run for the lifetime of the container.