### PR TITLE
[docker] Update docker package version for CVE-2019-5736 fix

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -29,7 +29,7 @@
 set -x -e
 
 ## docker engine version (with platform)
-DOCKER_VERSION=5:18.09.0~3-0~debian-stretch
+DOCKER_VERSION=5:18.09.2~3-0~debian-stretch
 LINUX_KERNEL_VERSION=4.9.0-8-2
 
 ## Working directory to prepare the file system


### PR DESCRIPTION
ref: https://docs.docker.com/engine/release-notes/#18092

For debian jessie, we will use `18.06.2~ce~3-0~debian`
ref: https://docs.docker.com/engine/release-notes/#18062