### PR TITLE
[Daemon-base] fix load board class of eeprom module issue

### DIFF
--- a/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
+++ b/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
@@ -18,6 +18,9 @@ SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 HWSKU_KEY = 'DEVICE_METADATA.localhost.hwsku'
 PLATFORM_KEY = 'DEVICE_METADATA.localhost.platform'
 
+EEPROM_MODULE_NAME = 'eeprom'
+EEPROM_CLASS_NAME = 'board'
+
 class DaemonBase(object):
     # Redis DB information
     redis_hostname = "localhost"
@@ -127,7 +130,11 @@ class DaemonBase(object):
 
         try:
             platform_util_class = getattr(module, class_name)
-            platform_util = platform_util_class()
+            # board class of eeprom requires 4 paramerters, need special treatment here.
+            if module_name == EEPROM_MODULE_NAME and class_name == EEPROM_CLASS_NAME:
+                platform_util = platform_util_class('','','','')
+            else:
+                platform_util = platform_util_class()
         except AttributeError, e:
             self.log_error("Failed to instantiate '%s' class: %s" % (class_name, str(e)))
             return None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fix issue in function "load_platform_util".
unlike PSU or SFP, 'board' class __init__ function of 'eeprom' module need 5 parameters, current implementation only cover PSU and SFP which require 1 parameter.  
  
**- How I did it**
Add judgment in function "load_platform_util" for eeprom module to pass extra parameters.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
