### PR TITLE
[Mellanox] fix sfp lpmode set failure caused by extra nv port

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
@@ -18,6 +18,14 @@ PMAOS_RST = 0
 PMAOS_ENABLE = 1
 PMAOS_DISABLE = 2
 
+PORT_TYPE_NVE = 8
+PORT_TYPE_OFFSET = 28
+PORT_TYPE_MASK = 0xF0000000
+
+def check_nve(port):
+    port_type = (port & PORT_TYPE_MASK) >> PORT_TYPE_OFFSET
+    return port_type & PORT_TYPE_NVE
+
 def get_port_admin_status_by_log_port(log_port):
     oper_state_p = new_sx_port_oper_state_t_p()
     admin_state_p = new_sx_port_admin_state_t_p()
@@ -48,6 +56,9 @@ def get_log_ports(handle, sfp_module):
     log_port_list = []
     for i in range(0, port_cnt):
         port_attributes = sx_port_attributes_t_arr_getitem(port_attributes_list, i)
+        is_nve = check_nve(int(port_attributes.log_port))
+        if is_nve:
+            continue
         if port_attributes.port_mapping.module_port == sfp_module:
             if get_port_admin_status_by_log_port(port_attributes.log_port):
                 log_port_list.append(port_attributes.log_port)

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
@@ -21,12 +21,12 @@ PMAOS_DISABLE = 2
 PORT_TYPE_NVE = 8
 PORT_TYPE_OFFSET = 28
 PORT_TYPE_MASK = 0xF0000000
+NVE_MASK = PORT_TYPE_MASK & (PORT_TYPE_NVE << PORT_TYPE_OFFSET)
 
-def check_nve(port):
-    port_type = (port & PORT_TYPE_MASK) >> PORT_TYPE_OFFSET
-    return port_type & PORT_TYPE_NVE
+def is_nve(port):
+    return (port & NVE_MASK) != 0
 
-def get_port_admin_status_by_log_port(log_port):
+def is_port_admin_status_up(log_port):
     oper_state_p = new_sx_port_oper_state_t_p()
     admin_state_p = new_sx_port_admin_state_t_p()
     module_state_p = new_sx_port_module_state_t_p()
@@ -56,12 +56,10 @@ def get_log_ports(handle, sfp_module):
     log_port_list = []
     for i in range(0, port_cnt):
         port_attributes = sx_port_attributes_t_arr_getitem(port_attributes_list, i)
-        is_nve = check_nve(int(port_attributes.log_port))
-        if is_nve:
-            continue
-        if port_attributes.port_mapping.module_port == sfp_module:
-            if get_port_admin_status_by_log_port(port_attributes.log_port):
-                log_port_list.append(port_attributes.log_port)
+        if is_nve(int(port_attributes.log_port)) == False \
+           and port_attributes.port_mapping.module_port == sfp_module \
+           and is_port_admin_status_up(port_attributes.log_port):
+            log_port_list.append(port_attributes.log_port)
 
     return log_port_list
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a bug that causes set sfp lpmode failure on some port.

**- How I did it**
When getting all front panel ports from SDK it will return an nv port alongside with the front panel ports, this port needs to be skipped or will cause an issue when trying to set lpmode for it.  Add some logic to skip the nv port.

**- How to verify it**
Run "sfputil lpmode on/off EthernetX" on Mellanox platform.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
# Changes to be committed:
#   (use "git reset HEAD <file>..." to unstage)
#
#       modified:   device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
#
```

**- A picture of a cute animal (not mandatory but encouraged)**
```
                 .
             /\ /l
            ((.Y(!
             \ |/
             /  6~6,
             \ _    +-.
              \`-=--^-'
               \ \
              _/  \
             (  .  Y
            /"\ `--^--v--.
           / _ `--"T~\/~\/
          / " ~\.  !
    _    Y      Y./'
   Y^|   |      |~~7
   | l   |     / ./'
   | `L  | Y .^/~T
   |  l  ! | |/| |          -Row
   | .`\/' | Y | !
   l  "~   j l j_L______
    \,____{ __"~ __ ,\_,\_
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```