### PR TITLE
Install ipaddress python package that has deprecated current ipaddr. …

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -356,6 +356,7 @@ set /files/etc/sysctl.conf/net.core.wmem_max 2097152
 ## docker-py is needed by Ansible docker module
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT easy_install pip
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'docker-py==1.6.0'
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'ipaddress'
 ## Note: keep pip installed for maintainance purpose
 
 ## Get gcc and python dev pkgs

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -356,7 +356,6 @@ set /files/etc/sysctl.conf/net.core.wmem_max 2097152
 ## docker-py is needed by Ansible docker module
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT easy_install pip
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'docker-py==1.6.0'
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'ipaddress'
 ## Note: keep pip installed for maintainance purpose
 
 ## Get gcc and python dev pkgs

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -87,6 +87,9 @@ sudo cp {{redis_dump_load_py2_wheel_path}} $FILESYSTEM_ROOT/$REDIS_DUMP_LOAD_PY2
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install $REDIS_DUMP_LOAD_PY2_WHEEL_NAME
 sudo rm -rf $FILESYSTEM_ROOT/$REDIS_DUMP_LOAD_PY2_WHEEL_NAME
 
+# Install Python module for ipaddress
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install ipaddress
+
 # Install SwSS SDK Python 2 package
 SWSSSDK_PY2_WHEEL_NAME=$(basename {{swsssdk_py2_wheel_path}})
 sudo cp {{swsssdk_py2_wheel_path}} $FILESYSTEM_ROOT/$SWSSSDK_PY2_WHEEL_NAME


### PR DESCRIPTION
…ipaddress has backport to python2.7

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Install ipaddress python package.
This is required for the Sonic utility for route check (route_check.py)

**- How I did it**

**- How to verify it**
Run the following lines in a Python script/interpreter, which should succeed.
"
import ipaddress
print str(ipaddress.IPv4Network(u"10.10.10.10/24", False))
"
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
