### PR TITLE
[mellanox] Fix in mlnx-ffb.sh

### DIFF
--- a/platform/mellanox/mlnx-ffb.sh
+++ b/platform/mellanox/mlnx-ffb.sh
@@ -42,8 +42,13 @@ check_sdk_upgrade()
 
         ISSU_VERSION_FILE_PATH="/etc/mlnx/issu-version"
 
-        [ -f "${SDK_VERSION_FILE_PATH}" ] || {
+        [ -f "${ISSU_VERSION_FILE_PATH}" ] || {
             >&2 echo "No ISSU version file found ${ISSU_VERSION_FILE_PATH}"
+            break
+        }
+
+        [ -f "${FS_MOUNTPOINT}/${ISSU_VERSION_FILE_PATH}" ] || {
+            >&2 echo "No ISSU version file found ${ISSU_VERSION_FILE_PATH} in ${NEXT_SONIC_IMAGE}"
             break
         }
 


### PR DESCRIPTION
Fixes "No ISSU version file found /etc/mlnx/issu-version"
when rebooting to different image;
Add aditional check condition.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix warm rebooting to different image

**- How I did it**

**- How to verify it**
Run warm reboot to a different sonic image

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
