### PR TITLE
[docker script] skip docker mount point checking for database container

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -103,9 +103,17 @@ start() {
 
     DOCKERCHECK=`docker inspect --type container {{docker_container_name}} 2>/dev/null`
     if [ "$?" -eq "0" ]; then
+        {%- if docker_container_name == "database" %}
+        DOCKERMOUNT=""
+        {%- else %}
         DOCKERMOUNT=`getMountPoint "$DOCKERCHECK"`
-        if [ "$DOCKERMOUNT" == "$HWSKU" ]; then
+        {%- endif %}
+        if [ x"$DOCKERMOUNT" == x"$HWSKU" ]; then
+            {%- if docker_container_name == "database" %}
+            echo "Starting existing {{docker_container_name}} container"
+            {%- else %}
             echo "Starting existing {{docker_container_name}} container with HWSKU $HWSKU"
+            {%- endif %}
             preStartAction
             docker start {{docker_container_name}}
             postStartAction


### PR DESCRIPTION
**- What I did**
Fixing issue https://github.com/Azure/sonic-buildimage/issues/2260

**- How I did it**
Change wording for database container.

**- How to verify it**
root@str-7260cx3-acs-2:/var/log# zgrep "database container" syslog
Mar 19 21:07:42.679939 str-7260cx3-acs-2 INFO database.sh[1068]: Starting existing database container