### PR TITLE
Add warm/fast-boot feature processing for wedge100bf_32x/65x platforms

### DIFF
--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/sai.profile
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/sai.profile
@@ -1,0 +1,3 @@
+SAI_KEY_WARM_BOOT_WRITE_FILE=/var/warmboot/sai-warmboot.bin
+SAI_KEY_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin
+

--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/sai.profile
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/sai.profile
@@ -1,0 +1,3 @@
+SAI_KEY_WARM_BOOT_WRITE_FILE=/var/warmboot/sai-warmboot.bin
+SAI_KEY_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin
+

--- a/platform/barefoot/docker-syncd-bfn-rpc.mk
+++ b/platform/barefoot/docker-syncd-bfn-rpc.mk
@@ -13,3 +13,4 @@ $(DOCKER_SYNCD_BFN_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BFN_RPC)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_SYNCD_BFN_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_BFN_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_SYNCD_BFN_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot

--- a/platform/barefoot/docker-syncd-bfn.mk
+++ b/platform/barefoot/docker-syncd-bfn.mk
@@ -13,3 +13,4 @@ $(DOCKER_SYNCD_BFN)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BFN)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_SYNCD_BFN)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_BFN)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_SYNCD_BFN)_RUN_OPT += -v /host/warmboot:/var/warmboot


### PR DESCRIPTION
**- What I did**
added WARM_BOOT options for Barefoot based platforms including 
* added `sai.profile` file
* mount `/host/warmboot` folder from base system to the `syncd` container

**- How to verify it**
run `sudo warm-reboot` on the hardware box

**- Description for the changelog**
Add warm/fast-boot feature processing for wedge100bf_32x/65x platforms

**- Should be merged together with**
https://github.com/Azure/sonic-sairedis/pull/434
https://github.com/Azure/sonic-utilities/pull/485

@akokhan, @mkbalani FYI

@lguohan: please merge this and 2 others related
