### PR TITLE
[teamd] retry creating team_port after interface info changed

### DIFF
--- a/src/libteam/0008-teamd-register-change-handler-for-TEAM_IFINFO_CHANGE.patch
+++ b/src/libteam/0008-teamd-register-change-handler-for-TEAM_IFINFO_CHANGE.patch
@@ -1,0 +1,34 @@
+From 7dff9798c2c92eb75b0120737efb81febcdb80c1 Mon Sep 17 00:00:00 2001
+From: Ying Xie <ying.xie@microsoft.com>
+Date: Sun, 24 Mar 2019 21:49:59 +0000
+Subject: [PATCH] [teamd] register change handler for TEAM_IFINFO_CHANGE as
+ well
+
+There has been a race condition in the libnal/teamd interation, causing
+TEAM_PORT_CHANGE to report a port with empty device name. Which then
+causes the teamd unable to add the lag members into the lag.
+
+Registering to the TEAM_IFINFO_CHANGE would give teamd another chance to
+add member again.
+
+Signed-off-by: Ying Xie <ying.xie@microsoft.com>
+---
+ teamd/teamd_per_port.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/teamd/teamd_per_port.c b/teamd/teamd_per_port.c
+index 09d1dc7..137da57 100644
+--- a/teamd/teamd_per_port.c
++++ b/teamd/teamd_per_port.c
+@@ -274,7 +274,7 @@ static int port_priv_change_handler_func(struct team_handle *th, void *priv,
+ 
+ static const struct team_change_handler port_priv_change_handler = {
+ 	.func = port_priv_change_handler_func,
+-	.type_mask = TEAM_PORT_CHANGE,
++	.type_mask = TEAM_PORT_CHANGE | TEAM_IFINFO_CHANGE,
+ };
+ 
+ int teamd_per_port_init(struct teamd_context *ctx)
+-- 
+2.7.4
+

--- a/src/libteam/series
+++ b/src/libteam/series
@@ -5,3 +5,4 @@
 0005-libteam-Add-warm_reboot-mode.patch
 0006-Fix-ifinfo_link_with_port-race-condition-with-newlink.patch
 0007-Skip-setting-the-same-hwaddr-to-lag-port-to-avoid-di.patch
+0008-teamd-register-change-handler-for-TEAM_IFINFO_CHANGE.patch


### PR DESCRIPTION
**- What I did**

Race condition has been noticed after warm reboot: sometimes when
port_changed notification was received, the link message didn't
have the device name. Without device name, creating team port
would fail.

Registering to the interface information change notification, so
later when device name becomes available, retry creating team port.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Continuous warm reboot on my DUT. The retry has been verified with debug messages.

Without the change, continuous warm reboot would fail within 20 iterations. With the fix, the test count has gone up to 78 and still running.

for f in `ls *.log`; do cnt=`grep iteration $f | wc -l`; echo $f $cnt; done
wb-test-20190313-0437.log 13
wb-test-20190319-2212.log 2
wb-test-20190319-2307.log 1
wb-test-20190319-2313.log 3
wb-test-20190319-2348.log 6
wb-test-20190320-0119.log 20
wb-test-20190321-0020.log 2
wb-test-20190321-0207.log 10
wb-test-20190321-1733.log 7
wb-test-20190321-1839.log 5
wb-test-20190321-2131.log 7
wb-test-20190322-0133.log 4
wb-test-20190322-0219.log 5
wb-test-20190322-0429.log 3
wb-test-20190322-1656.log 19
wb-test-20190322-2158.log 2
wb-test-20190323-0006.log 7
wb-test-20190323-0650.log 4
wb-test-20190323-0729.log 3
wb-test-20190323-1855.log 2
wb-test-20190323-1911.log 1
wb-test-20190323-1924.log 10
**wb-test-20190324-1911.log 78**