### PR TITLE
[Libnl] Always report LINK_ATTR_IFINDEX when available

### DIFF
--- a/src/libnl3/0001-libnl-always-report-link-interface-name.patch
+++ b/src/libnl3/0001-libnl-always-report-link-interface-name.patch
@@ -1,0 +1,39 @@
+From 72fc79b2695004ce172583ac670df7b5c7dfec23 Mon Sep 17 00:00:00 2001
+From: Ying Xie <ying.xie@microsoft.com>
+Date: Tue, 26 Mar 2019 16:23:43 +0000
+Subject: [PATCH] [libnl] always report link interface name
+
+Signed-off-by: Ying Xie <ying.xie@microsoft.com>
+---
+ lib/route/link.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/lib/route/link.c b/lib/route/link.c
+index 5c32550..05fe04f 100644
+--- a/lib/route/link.c
++++ b/lib/route/link.c
+@@ -1486,12 +1486,21 @@ int rtnl_link_build_change_request(struct rtnl_link *orig,
+ 		return -NLE_IMMUTABLE;
+ 	}
+ 
++#if 0 // Disable optimization
++    /* Justifications: some client (libteamd) experienced issue, if they
++     *   didn't get interface name from libnl upon receiving the
++     *   first notification after LINK_ATTR_IFNAME is set, with the
++     *   following code in place, these client wouldn't be able to query
++     *   interface name later because libnl won't return interface name
++     *   after LINK_ATTR_IFNAME flag is removed.
++     */
+ 	/* Avoid unnecessary name change requests */
+ 	if (orig->ce_mask & LINK_ATTR_IFINDEX &&
+ 	    orig->ce_mask & LINK_ATTR_IFNAME &&
+ 	    changes->ce_mask & LINK_ATTR_IFNAME &&
+ 	    !strcmp(orig->l_name, changes->l_name))
+ 		changes->ce_mask &= ~LINK_ATTR_IFNAME;
++#endif
+ 
+ 	if ((err = build_link_msg(RTM_NEWLINK, &ifi, changes, flags, result)) < 0)
+ 		goto errout;
+-- 
+2.7.4
+

--- a/src/libnl3/Makefile
+++ b/src/libnl3/Makefile
@@ -22,7 +22,15 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-source -x libnl3_$(LIBNL3_VERSION).dsc
 
 	pushd ./libnl3-$(LIBNL3_VERSION_BASE)
+	git init
+	git add -f *
+	git commit -qm "check in all loose files and diffs"
+
+	stg init
+	# When patches are ready: stg import -s ../series
+
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
+
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/libnl3/Makefile
+++ b/src/libnl3/Makefile
@@ -27,7 +27,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git commit -qm "check in all loose files and diffs"
 
 	stg init
-	# When patches are ready: stg import -s ../series
+	stg import -s ../series
 
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 

--- a/src/libnl3/series
+++ b/src/libnl3/series
@@ -1,0 +1,1 @@
+0001-libnl-always-report-link-interface-name.patch


### PR DESCRIPTION
**- What I did**
Justifications: some client (libteamd) experienced issue, if they didn't get interface name from libnl upon receiving the first notification after LINK_ATTR_IFNAME is set, (before this change) these client wouldn't be able to query interface name later because libnl won't return interface name after LINK_ATTR_IFNAME flag is removed.

This PR complements https://github.com/Azure/sonic-buildimage/pull/2699

**- How to verify it**
This issue was original discovered in continuous warm-reboot test at 182nd iteration. It is not super repeatable. With the fix, now the test passed that iteration. The test will go on for another day or 2 until we can safely say it is good. Putting up this review for early discussions.