### PR TITLE
[jessie based docker] remove dependency on some retired jessie repos

### DIFF
--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -28,11 +28,8 @@ RUN apt-get -y install \
     vim-tiny           \
     perl               \
     python             \
+    rsyslog            \
     less
-
-# Install a newer version of rsyslog from jessie-backports in hopes of
-# eliminating memory leaks
-RUN apt-get -y -t jessie-backports install rsyslog
 
 COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
 COPY ["etc/rsyslog.d/*", "/etc/rsyslog.d/"]

--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -1,5 +1,8 @@
 FROM debian:jessie
 
+## Remove retired jessie-updates repo
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+
 # Clean documentation in FROM image
 RUN find /usr/share/doc -depth \( -type f -o -type l \) ! -name copyright | xargs rm || true
 

--- a/dockers/docker-base/sources.list
+++ b/dockers/docker-base/sources.list
@@ -5,4 +5,3 @@ deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-fre
 deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free
 deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
 deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
-deb http://debian-archive.trafficmanager.net/debian/ jessie-backports main contrib non-free

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -2,6 +2,9 @@ FROM debian:jessie
 
 MAINTAINER Pavel Shirshov
 
+## Remove retired jessie-updates repo
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+
 ## Copy dependencies
 COPY \
 {% for deb in docker_ptf_debs.split(' ') -%}

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -2,6 +2,9 @@ FROM debian:jessie
 
 MAINTAINER johnar@microsoft.com
 
+## Remove retired jessie-updates repo
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+
 RUN echo "deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
@@ -9,9 +12,6 @@ RUN echo "deb http://debian-archive.trafficmanager.net/debian/ jessie main contr
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
-
-## Remove retired jessie-updates repo
-RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y \
         apt-utils \

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -5,11 +5,13 @@ MAINTAINER johnar@microsoft.com
 RUN echo "deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb http://debian-archive.trafficmanager.net/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list
+        echo "deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
+
+## Remove retried jessie-updates repo
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y \
         apt-utils \

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "deb http://debian-archive.trafficmanager.net/debian/ jessie main contr
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-## Remove retried jessie-updates repo
+## Remove retired jessie-updates repo
 RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
**- What I did**
Some Jessie repo were retired recently. This PR addresses following 2 issues:

1. Jessie-backports has been retired. we need to use the rsyslog comes with Jessie.
    The SONiC base image is running stretch already. We believe running older version of rsyslog in dockers is safe.

2. Jessie base container downloaded from docker repo still references jessie-updates under main repo. We need to remove it from sources.list.

**- How to verify it**
build a sonic image.