### PR TITLE
[201803] Modify Debian apt repos to reflect changes made by maintainers

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -91,7 +91,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT mount proc /proc -t proc
 
 ## Pointing apt to public apt mirrors and getting latest packages, needed for latest security updates
 sudo cp files/apt/sources.list $FILESYSTEM_ROOT/etc/apt/
-sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages}} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
+sudo cp files/apt/apt.conf.d/* $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
 sudo LANG=C chroot $FILESYSTEM_ROOT bash -c 'apt-mark auto `apt-mark showmanual`'
 
 ## Note: set lang to prevent locale warnings in your chroot

--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -23,6 +23,7 @@ RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt
 # Configure data sources for apt/dpkg
 COPY ["sources.list", "/etc/apt/sources.list"]
 COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 RUN apt-get update
 
 # Pre-install fundamental packages

--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -17,6 +17,9 @@ RUN rm -rf               \
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Remove retired jessie-updates repo
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+
 # Configure data sources for apt/dpkg
 COPY ["sources.list", "/etc/apt/sources.list"]
 COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]

--- a/dockers/docker-base/no-check-valid-until
+++ b/dockers/docker-base/no-check-valid-until
@@ -1,0 +1,1 @@
+Acquire::Check-Valid-Until "false";

--- a/dockers/docker-base/sources.list
+++ b/dockers/docker-base/sources.list
@@ -5,4 +5,4 @@ deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-fre
 deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free
 deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
 deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
-deb http://debian-archive.trafficmanager.net/debian/ jessie-backports main contrib non-free
+deb http://archive.debian.org/debian/ jessie-backports main contrib non-free

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -12,6 +12,9 @@ debs/
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Remove retired jessie-updates repo
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+
 ## Set the apt source, update package cache and install necessary packages
 RUN sed --in-place 's/httpredir.debian.org/debian-archive.trafficmanager.net/' /etc/apt/sources.list \
     && apt-get update          \

--- a/files/apt/apt.conf.d/no-check-valid-until
+++ b/files/apt/apt.conf.d/no-check-valid-until
@@ -1,0 +1,1 @@
+Acquire::Check-Valid-Until "false";

--- a/files/apt/sources.list
+++ b/files/apt/sources.list
@@ -5,4 +5,4 @@ deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-fre
 deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free
 deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
 deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
-deb http://debian-archive.trafficmanager.net/debian/ jessie-backports main contrib non-free
+deb http://archive.debian.org/debian/ jessie-backports main contrib non-free

--- a/files/image_config/apt/sources.list.d/debian_archive_trafficmanager_net_debian.list
+++ b/files/image_config/apt/sources.list.d/debian_archive_trafficmanager_net_debian.list
@@ -1,3 +1,3 @@
 deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free
 deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free
-deb http://debian-archive.trafficmanager.net/debian/ jessie-backports main contrib non-free
+deb http://archive.debian.org/debian/ jessie-backports main contrib non-free

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -2,11 +2,14 @@ FROM debian:jessie
 
 MAINTAINER johnar@microsoft.com
 
+# Remove retired jessie-updates repo
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+
 RUN echo "deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb http://debian-archive.trafficmanager.net/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list
+        echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -8,8 +8,7 @@ RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt
 RUN echo "deb http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src http://debian-archive.trafficmanager.net/debian/ jessie main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list && \
-        echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list
+        echo "deb-src http://debian-archive.trafficmanager.net/debian-security/ jessie/updates main contrib non-free" >> /etc/apt/sources.list
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
As of yesterday, 3/25/19, the Debian folks archived the "jessie-backports" repo and removed the "jessie-updates" repo altogether (it seems they might have made a mistake, as it probably should have also moved to archive.debian.org as well). These changes broke the SONiC image build.

This pull request fixes the build by:
1. Removing all references to the "jessie-updates" repo (we were not using it)
2. Redirecting the "jessie-backports" repo to archive.debian.org
3. Setting the global Apt setting, `Acquire::Check-Valid-Until "false"` because apparently the "valid-until" date will never be updated once a repo is archived.

More info can be found here: https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository