### PR TITLE
Fixing get_transceiver_change_event

### DIFF
--- a/device/dell/x86_64-dell_z9100_c2538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/plugins/sfputil.py
@@ -406,11 +406,11 @@ class SfpUtil(SfpUtilBase):
 
             port = self.port_start
             while port <= self.port_end:
-                if interrupt_reg & (1 << port):
+                if interrupt_reg & (1 << (port-1)):
                     # update only if atleast one port has generated
                     # interrupt
                     is_port_dict_updated = True
-                    if status_reg & (1 << port):
+                    if status_reg & (1 << (port-1)):
                         # status reg 1 => optics is removed
                         port_dict[port] = '0'
                     else:


### PR DESCRIPTION
Signed-off-by: Sudharsan sudharsan_gopalarath@dell.com

**- What I did**
Fixing get_transceiver_change_event in Z9100 sfputil

**- How I did it**
The pull request https://github.com/Azure/sonic-buildimage/pull/2496 addressed to have the port index numbers starting from 1. However the hardware interrupt registers have bitmaps starting from index 0. Thus proper translation is done from the port set in hardware portmap to the port index number in port_config.ini. While checking the hardware portbitmap use port index -1 to map tp correct port.

Without this change, the TRANSCEIVER_INFO_TABLE and TRANSCEIVER_DOM_SENSOR would be updated with wrong index.

**- How to verify it**
Perform an OIR and check if proper port is updated on the tables listed above.

**- Description for the changelog**
<!--
Fixing get_transceiver_change_event in Z9100 sfputil
-->


**- A picture of a cute animal (not mandatory but encouraged)**
