### PR TITLE
[vm build] force Linux to drop cache before calling kvm

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -27,6 +27,9 @@
 #  *                  make NOSTRETCH=1 KEEP_SLAVE_ON=yes <any jessie target>
 #  * SOURCE_FOLDER: host path to be mount as /var/$(USER)/src, only effective when KEEP_SLAVE_ON=yes
 #  * SONIC_BUILD_JOBS: Specifying number of concurrent build job(s) to run
+#  * VS_PREPARE_MEM: Prepare memory in VS build (drop cache and compact).
+#  *                 Default: yes
+#  *                 Values:  yes, no
 #  * KERNEL_PROCURE_METHOD: Specifying method of obtaining kernel Debian package: download or build
 #
 ###############################################################################
@@ -115,6 +118,7 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            PASSWORD=$(PASSWORD) \
                            USERNAME=$(USERNAME) \
                            SONIC_BUILD_JOBS=$(SONIC_BUILD_JOBS) \
+                           VS_PREPARE_MEM=$(VS_PREPARE_MEM) \
                            KERNEL_PROCURE_METHOD=$(KERNEL_PROCURE_METHOD) \
                            HTTP_PROXY=$(http_proxy) \
                            HTTPS_PROXY=$(https_proxy) \

--- a/build_kvm_image.sh
+++ b/build_kvm_image.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 #  Copyright (C) 2014 Curt Brune <curt@cumulusnetworks.com>
 #
@@ -47,10 +47,14 @@ prepare_installer_disk()
 create_disk
 prepare_installer_disk
 
-# Force o.s. to drop cache so that KVM can get 2G memory
+echo "Prepare memory for KVM build: $vs_build_prepare_mem"
 free -m
-echo 1 | sudo tee /proc/sys/vm/drop_caches
-free -m
+if [[ "$vs_build_prepare_mem" == "yes" ]]; then
+    # Force o.s. to drop cache and compact memory so that KVM can get 2G memory
+    sudo bash -c 'echo 1 > /proc/sys/vm/drop_caches'
+    sudo bash -c 'echo 1 > /proc/sys/vm/compact_memory'
+    free -m
+fi
 
 /usr/bin/kvm -m $MEM \
     -name "onie" \

--- a/build_kvm_image.sh
+++ b/build_kvm_image.sh
@@ -47,6 +47,11 @@ prepare_installer_disk()
 create_disk
 prepare_installer_disk
 
+# Force o.s. to drop cache so that KVM can get 2G memory
+free -m
+echo 1 | sudo tee /proc/sys/vm/drop_caches
+free -m
+
 /usr/bin/kvm -m $MEM \
     -name "onie" \
     -boot "order=cd,once=d" -cdrom "$ONIE_RECOVERY_ISO" \

--- a/rules/config
+++ b/rules/config
@@ -84,3 +84,6 @@ DEFAULT_KERNEL_PROCURE_METHOD = build
 # group during installation.
 FRR_USER_UID = 300
 FRR_USER_GID = 300
+
+# Default VS build memory preparation
+DEFAULT_VS_PREPARE_MEM = yes

--- a/slave.mk
+++ b/slave.mk
@@ -120,6 +120,10 @@ ifeq ($(SONIC_BUILD_JOBS),)
 override SONIC_BUILD_JOBS := $(SONIC_CONFIG_BUILD_JOBS)
 endif
 
+ifeq ($(VS_PREPARE_MEM),)
+override VS_PREPARE_MEM := $(DEFAULT_VS_PREPARE_MEM)
+endif
+
 ifeq ($(KERNEL_PROCURE_METHOD),)
 override KERNEL_PROCURE_METHOD := $(DEFAULT_KERNEL_PROCURE_METHOD)
 endif
@@ -167,6 +171,7 @@ $(info "SONIC_PROFILING_ON"              : "$(SONIC_PROFILING_ON)")
 $(info "KERNEL_PROCURE_METHOD"           : "$(KERNEL_PROCURE_METHOD)")
 $(info "BUILD_TIMESTAMP"                 : "$(BUILD_TIMESTAMP)")
 $(info "BLDENV"                          : "$(BLDENV)")
+$(info "VS_PREPARE_MEM"                  : "$(VS_PREPARE_MEM)")
 $(info )
 
 ###############################################################################
@@ -175,6 +180,7 @@ $(info )
 ###############################################################################
 
 export kernel_procure_method=$(KERNEL_PROCURE_METHOD)
+export vs_build_prepare_mem=$(VS_PREPARE_MEM)
 
 ###############################################################################
 ## Local targets


### PR DESCRIPTION
**- What I did**

KVM need to allocate 2G memory for VS build. The system memory might
be occupied by cache at the moment and doesn't have 2G chunk to give
out. Forcing Kernel to drop cache to boost the chance of getting 2G
memory.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
See if this PR test would pass?