### PR TITLE
Do not generate ssh server keys for non RSA protocols

### DIFF
--- a/files/sshd/host-ssh-keygen.sh
+++ b/files/sshd/host-ssh-keygen.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
+set -e
+
 [ -r /etc/ssh/ssh_host_rsa_key ] || {
     rm -f /etc/ssh/ssh_host_*_key*
     /usr/bin/ssh-keygen -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
-    /usr/bin/ssh-keygen -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key
-    /usr/bin/ssh-keygen -t rsa1 -N '' -f /etc/ssh/ssh_host_key
-    /usr/bin/ssh-keygen -t ecdsa -N '' -f /etc/ssh/ssh_host_ecdsa_key
-    /usr/bin/ssh-keygen -t ed25519 -N '' -f /etc/ssh/ssh_host_ed25519_key
 }


### PR DESCRIPTION
Because other keys' length < 2048