### PR TITLE
[teamd service] teamd service should start after syncd

### DIFF
--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -1,8 +1,7 @@
 [Unit]
 Description=TEAMD container
 Requires=updategraph.service
-After=updategraph.service
-After=syncd.service
+After=updategraph.service syncd.service
 Before=ntp-config.service
 
 [Service]

--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -2,6 +2,7 @@
 Description=TEAMD container
 Requires=updategraph.service
 After=updategraph.service
+After=syncd.service
 Before=ntp-config.service
 
 [Service]


### PR DESCRIPTION
**- What I did**
- Let teamd service starting after syncd. Teamd has some dependencies on syncd:
1. teamd requires netdevs created by syncd. (this change doesn't guarantee satisfying this dependency, listing here for completeness).
2. teamd and swss shares a same table in app_db, swss script clears the table upon cold start and teamd would populate this table. Letting teamd starting after syncd (which is after swss) would avoid teamd coming up first, started to populate the table, then cleared by swss service script.

**- How to verify it**
Have tested this change with recent continuous warm reboot tests, and some nightly tests.