### PR TITLE
[201811][service] add warmboot finializer service

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -144,6 +144,11 @@ sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable ntp-config.service
 sudo cp $IMAGE_CONFIGS/ntp/ntp-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/ntp/ntp.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 
+# Copy warmboot-finalizer files
+sudo LANG=C cp $IMAGE_CONFIGS/warmboot-finalizer/finalize-warmboot.sh $FILESYSTEM_ROOT/usr/local/bin/finalize-warmboot.sh
+sudo LANG=C cp $IMAGE_CONFIGS/warmboot-finalizer/warmboot-finalizer.service $FILESYSTEM_ROOT/etc/systemd/system/
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable warmboot-finalizer.service
+
 # Copy rsyslog configuration files and templates
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog-config.service  $FILESYSTEM_ROOT/etc/systemd/system/
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable rsyslog-config.service

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -1,0 +1,96 @@
+#! /bin/bash
+
+VERBOSE=no
+
+# Check components
+COMP_LIST="orchagent neighsyncd bgp"
+EXP_STATE="reconciled"
+
+ASSISTANT_SCRIPT="/usr/bin/neighbor_advertiser"
+
+
+function debug()
+{
+    /usr/bin/logger "WARMBOOT_FINALIZER : $1"
+    if [[ x"${VERBOSE}" == x"yes" ]]; then
+        echo `date` "- $1"
+    fi
+}
+
+
+function check_warm_boot()
+{
+    WARM_BOOT=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+}
+
+
+function wait_for_database_service()
+{
+    debug "Wait for database to become ready..."
+
+    # Wait for redis server start before database clean
+    until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]];
+        do sleep 1;
+    done
+
+    # Wait for configDB initialization
+    until [[ $(/usr/bin/docker exec database redis-cli -n 4 GET "CONFIG_DB_INITIALIZED") ]];
+        do sleep 1;
+    done
+
+    debug "Database is ready..."
+}
+
+
+function get_component_state()
+{
+    /usr/bin/redis-cli -n 6 hget "WARM_RESTART_TABLE|$1" state
+}
+
+
+function check_list()
+{
+    RET_LIST=''
+    for comp in $@; do
+        state=`get_component_state ${comp}`
+	if [[ x"${state}" != x"${EXP_STATE}" ]]; then
+            RET_LIST="${RET_LIST} ${comp}"
+	fi
+    done
+
+    echo ${RET_LIST}
+}
+
+
+function finalize_warm_boot()
+{
+    debug "Finalizing warmboot..."
+    sudo config warm_restart disable
+}
+
+
+wait_for_database_service
+
+check_warm_boot
+
+if [[ x"${WARM_BOOT}" != x"true" ]]; then
+    debug "warmboot is not enabled ..."
+    exit 0
+fi
+
+list=${COMP_LIST}
+
+# Wait up to 5 minutes
+for i in `seq 60`; do
+    list=`check_list ${list}`
+    if [[ -z "${list}" ]]; then
+	break
+    fi
+    sleep 5
+done
+
+if [[ -n "${list}" ]]; then
+    debug "Some components didn't finish reconcile: ${list} ..."
+fi
+
+finalize_warm_boot

--- a/files/image_config/warmboot-finalizer/warmboot-finalizer.service
+++ b/files/image_config/warmboot-finalizer/warmboot-finalizer.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monitor warm recovery and disable warmboot when done
+Requires=database.service
+After=database.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/finalize-warmboot.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
**- What I did**

#2715 is approved but cannot merge because waiting for utilities sub-module to be updated. And utilities sub module is currently blocked due to another change waiting for yet another dependency. Creating this PR to get the change in 201811 where it is needed.

After warm reboot is done, we need to disable warm reboot flag and
tear down anything setup for warm reboot and persisted across.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
