### PR TITLE
Revert "[teamd service] teamd service should start after syncd"

### DIFF
--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=TEAMD container
 Requires=updategraph.service
-After=updategraph.service syncd.service
+After=updategraph.service
 Before=ntp-config.service
 
 [Service]


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#2724

Found an issue with this change in test: this change exposes a race condition in teamd that causes lags unable to get ARP packets served. The result is that even the LAGs are up, we are unable to ping the peer and BGP on top of these LAGs are unable to establish.

I experimented to change teamd start only after swss (to solve the teamd/swss race condition), that seems to be able to avoid the race condition.

The race condition could be platform specific. We need to investigate further before coming back with a proper solution.