### PR TITLE
Watchdog Support for DellEMC s6100

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -5,5 +5,7 @@ common/io_rd_wr.py usr/local/bin
 common/fstrim.timer etc/systemd/system
 common/fstrim.service etc/systemd/system
 s6100/scripts/platform_sensors.py usr/local/bin
+s6100/scripts/platform_watchdog_enable.sh usr/local/bin
+s6100/scripts/platform_watchdog_disable.sh usr/local/bin
 s6100/scripts/sensors usr/bin
 s6100/systemd/platform-modules-s6100.service etc/systemd/system

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_watchdog_disable.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_watchdog_disable.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#This script is used to disable SMF Watchdog Timer
+
+wd_status=-1
+enabled=0
+
+# Disable Watchdog if enabled
+wd_status=$(io_rd_wr.py  --get --offset 0x207 | cut -d " " -f3)
+
+if [[ $wd_status -eq $enabled ]]; then
+    echo "Disabling Watchdog Timer.."
+    io_rd_wr.py --set --val 1 --offset 0x207
+fi

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_watchdog_enable.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_watchdog_enable.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#This script is used to enable SMF Watchdog Timer
+
+# Set watchdog to 180 seconds
+io_rd_wr.py --set --val 3 --offset 0x206
+
+# Enable watchdog timer
+io_rd_wr.py --set --val 0 --offset 0x207

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -205,6 +205,11 @@ if [[ "$1" == "init" ]]; then
     modprobe dell_s6100_iom_cpld
     modprobe dell_s6100_lpc
 
+    # Disable Watcdog Timer
+    if [[ -e /usr/local/bin/platform_watchdog_disable.sh ]]; then
+        exec /usr/local/bin/platform_watchdog_disable.sh
+    fi
+
     cpu_board_mux "new_device"
     switch_board_mux "new_device"
     sys_eeprom "new_device"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Added two scripts platform_watchdog_enable.sh and platform_watchdog_disable.sh.

**- How I did it**
- Before upgrading the box please do execute platform_watchdog_enable.sh. This enable the SMF Watchdog bit. Also, configure the watchdog timer to 180 seconds.
- Upgrade the box with new image.
- During upgrade or in the middle of upgrade, if the box hangs in middle, watchdog kicks-in at 180 seconds interval and perform a warm-reboot.
- This will avoid manual power-cycle interruption at the time of issue state.
- Instead, if there is no any issues with the box we disablemwatchdog in startup script s6100_platform.sh]
- Enabling watchdog is not a in-build one. The user have to manually trigger the script to enable watchdog.

**- How to verify it**
- execute platform_watchdog_enable.sh
- Upgrade the box with latest image.

