### PR TITLE
Update to debian python-scapy (2.4.0-2) to fix scapy crash seen with 2.3.3-1

### DIFF
--- a/dockers/docker-base-stretch/sources.list
+++ b/dockers/docker-base-stretch/sources.list
@@ -6,3 +6,4 @@ deb-src http://debian-archive.trafficmanager.net/debian/ stretch main contrib no
 deb http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
 deb-src http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
 deb http://debian-archive.trafficmanager.net/debian/ stretch-backports main contrib non-free
+deb http://debian-archive.trafficmanager.net/debian/ unstable main contrib non-free

--- a/dockers/docker-base-stretch/sources.list
+++ b/dockers/docker-base-stretch/sources.list
@@ -6,4 +6,3 @@ deb-src http://debian-archive.trafficmanager.net/debian/ stretch main contrib no
 deb http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
 deb-src http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free
 deb http://debian-archive.trafficmanager.net/debian/ stretch-backports main contrib non-free
-deb http://debian-archive.trafficmanager.net/debian/ unstable main contrib non-free

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -10,14 +10,15 @@ RUN apt-get update
 
 RUN apt-get install -f -y ifupdown arping libdbus-1-3 libdaemon0 libjansson4 libpython2.7 iproute2
 
-RUN apt-get install -f -y ndisc6 tcpdump python-scapy=2.4.0-2
+RUN apt-get install -f -y ndisc6 tcpdump
+RUN pip install scapy==2.4.2
 ## Install redis-tools dependencies
 ## TODO: implicitly install dependencies
 RUN apt-get -y install libjemalloc1
 
 RUN apt-get install -y libelf1 libmnl0 bridge-utils
 
-RUN pip install setuptools 
+RUN pip install setuptools
 RUN pip install pyroute2==0.5.3 netifaces==0.10.7
 RUN pip install monotonic==1.5
 

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -10,7 +10,7 @@ RUN apt-get update
 
 RUN apt-get install -f -y ifupdown arping libdbus-1-3 libdaemon0 libjansson4 libpython2.7 iproute2
 
-RUN apt-get install -f -y ndisc6 tcpdump python-scapy
+RUN apt-get install -f -y ndisc6 tcpdump python-scapy=2.4.0-2
 ## Install redis-tools dependencies
 ## TODO: implicitly install dependencies
 RUN apt-get -y install libjemalloc1


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**- What I did**
A try to fix https://github.com/Azure/sonic-buildimage/issues/2735

https://packages.debian.org/sid/python-scapy

**- How I did it**

**- How to verify it**
```
# apt-cache policy python-scapy
python-scapy:
  Installed: 2.4.0-2
  Candidate: 2.4.0-2
  Version table:
 *** 2.4.0-2 500
        500 http://debian-archive.trafficmanager.net/debian unstable/main amd64 Packages
        100 /var/lib/dpkg/status
     2.3.3-1 500
        500 http://debian-archive.trafficmanager.net/debian stretch/main amd64 Packages
```
restore_neighbors.py works well now.

```
root@ASW:/# cat /proc//net/if_inet6
20000000000001000000000000000001 01 80 00 80       lo
20000000000001000000000000000001 8e 38 00 80 Ethernet2
00010000000000000000000100010001 01 80 00 80       lo
fe80000000000000505400fffed3419e 02 40 20 80     eth0
20000000000005000000000000000001 92 38 00 80 Ethernet6
20000000000003000000000000000001 90 38 00 80 Ethernet4
fc020000000000000000000000000001 8a 40 00 80   Vlan12
20000000000007000000000000000001 94 38 00 80 Ethernet8
00000000000000000000000000000001 01 80 10 80       lo
fc010000000000000000000000000001 89 40 00 80   Vlan11
20000000000002000000000000000001 8f 38 00 80 Ethernet3
20000000000000000000000000000001 8d 38 00 80 Ethernet1
fc000000000000000000000000000001 89 40 00 80   Vlan11
20000000000004000000000000000001 91 38 00 80 Ethernet5
20000000000006000000000000000001 93 38 00 80 Ethernet7
fe8000000000000090bdf9fffee6c2b6 86 40 20 80   Bridge
fe800000000000000000000000000002 8a 40 20 80   Vlan12
fe800000000000000000000000000002 89 40 20 80   Vlan11
fd000000000000000000000000000001 8a 38 00 80   Vlan12

root@ASW:/# ip add show lo
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet 1.1.1.1/32 scope global lo
       valid_lft forever preferred_lft forever
    inet6 2000:0:0:100::1/128 scope global 
       valid_lft forever preferred_lft forever
    inet6 1::1:1:1/128 scope global 
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
```
```
# /usr/bin/restore_neighbors.py
restore_neighbors service is started
restore_neighbors service is skipped as warm restart not enabled

:/# /usr/bin/restore_neighbors.py
restore_neighbors service is started
restore_neighbor service is done for system warmreboot
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
