### PR TITLE
[bgp quagga] increase BGP graceful restart timeout to 240 seconds

### DIFF
--- a/dockers/docker-fpm-quagga/bgpd.conf.j2
+++ b/dockers/docker-fpm-quagga/bgpd.conf.j2
@@ -27,7 +27,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
-  bgp graceful-restart restart-time 180
+  bgp graceful-restart restart-time 240
   bgp graceful-restart
 {% for (name, prefix) in LOOPBACK_INTERFACE %}
 {% if prefix | ipv4 and name == 'Loopback0' %}

--- a/src/sonic-config-engine/tests/sample_output/bgpd_quagga.conf
+++ b/src/sonic-config-engine/tests/sample_output/bgpd_quagga.conf
@@ -20,7 +20,7 @@ router bgp 65100
   bgp log-neighbor-changes
   bgp bestpath as-path multipath-relax
   no bgp default ipv4-unicast
-  bgp graceful-restart restart-time 180
+  bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp router-id 10.1.0.32
   network 10.1.0.32/32


### PR DESCRIPTION
**- What I did**

There are some platforms with less powerful CPU/hard-drive could take
longer to get ready for BGP. For these platforms, 240 seconds would be
a safer threshold.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
