### PR TITLE
Support TACACS Accounting

### DIFF
--- a/files/image_config/hostcfgd/common-session-sonic.j2
+++ b/files/image_config/hostcfgd/common-session-sonic.j2
@@ -1,0 +1,30 @@
+#
+# /etc/pam.d/common-session - session-related modules common to all services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of modules that define tasks to be performed
+# at the start and end of sessions of *any* kind (both interactive and
+# non-interactive).
+#
+# As of pam 1.0.1-6, this file is managed by pam-auth-update by default.
+# To take advantage of this, it is recommended that you configure any
+# local modules either before or after the default block, and use
+# pam-auth-update to manage selection of other modules.  See
+# pam-auth-update(8) for details.
+
+# here are the per-package modules (the "Primary" block)
+{% if acct['session'] == 'tacacs+' %}
+{% for server in servers %}
+session [success=done new_authtok_reqd=done default=ignore]        pam_tacplus.so server={{ server.ip }}:{{ server.tcp_port }} secret={{ server.passkey }} service=shell 
+{% endfor %}
+{% endif %}
+session	[default=1]			pam_permit.so
+# here's the fallback if no module succeeds
+session	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+session	required			pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+session	required	pam_unix.so 
+# end of pam-auth-update config

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -12,6 +12,8 @@ from swsssdk import ConfigDBConnector
 # FILE
 PAM_AUTH_CONF = "/etc/pam.d/common-auth-sonic"
 PAM_AUTH_CONF_TEMPLATE = "/usr/share/sonic/templates/common-auth-sonic.j2"
+PAM_SESSION_CONF = "/etc/pam.d/common-session-sonic"
+PAM_SESSION_CONF_TEMPLATE = "/usr/share/sonic/templates/common-session-sonic.j2"
 NSS_TACPLUS_CONF = "/etc/tacplus_nss.conf"
 NSS_TACPLUS_CONF_TEMPLATE = "/usr/share/sonic/templates/tacplus_nss.conf.j2"
 NSS_CONF = "/etc/nsswitch.conf"
@@ -45,12 +47,16 @@ class AaaCfg(object):
         self.auth_default = {
             'login': 'local'
         }
+        self.acct_default = {
+            'session': ''
+        }
         self.tacplus_global_default = {
             'auth_type': TACPLUS_SERVER_AUTH_TYPE_DEFAULT,
             'timeout': TACPLUS_SERVER_TIMEOUT_DEFAULT,
             'passkey': TACPLUS_SERVER_PASSKEY_DEFAULT
         }
         self.auth = {}
+        self.acct = {}
         self.tacplus_global = {}
         self.tacplus_servers = {}
         self.debug = False
@@ -72,6 +78,8 @@ class AaaCfg(object):
                 self.auth['failthrough'] = is_true(data['failthrough'])
             if 'debug' in data:
                 self.debug = is_true(data['debug'])
+            if key == 'accounting':
+                self.acct =data
         if modify_conf:
             self.modify_conf_file()
 
@@ -94,6 +102,8 @@ class AaaCfg(object):
     def modify_conf_file(self):
         auth = self.auth_default.copy()
         auth.update(self.auth)
+        acct = self.acct_default.copy()
+        acct.update(self.acct)
         tacplus_global = self.tacplus_global_default.copy()
         tacplus_global.update(self.tacplus_global)
 
@@ -114,6 +124,14 @@ class AaaCfg(object):
         with open(PAM_AUTH_CONF, 'w') as f:
             f.write(pam_conf)
 
+        template_file = os.path.abspath(PAM_SESSION_CONF_TEMPLATE)
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader('/'), trim_blocks=True)
+        env.filters['sub'] = sub
+        template = env.get_template(template_file)
+        pam_conf = template.render(acct=acct, servers=servers_conf)
+        with open(PAM_SESSION_CONF, 'w') as f:
+            f.write(pam_conf)
+
         # Modify common-auth include file in /etc/pam.d/login and sshd
         if os.path.isfile(PAM_AUTH_CONF):
             os.system("sed -i -e '/^@include/s/common-auth$/common-auth-sonic/' /etc/pam.d/sshd")
@@ -121,6 +139,14 @@ class AaaCfg(object):
         else:
             os.system("sed -i -e '/^@include/s/common-auth-sonic$/common-auth/' /etc/pam.d/sshd")
             os.system("sed -i -e '/^@include/s/common-auth-sonic$/common-auth/' /etc/pam.d/login")
+
+        # Modify common-session include file in /etc/pam.d/login and sshd
+        if os.path.isfile(PAM_AUTH_CONF):
+            os.system("sed -i -e '/^@include/s/common-session$/common-session-sonic/' /etc/pam.d/sshd")
+            os.system("sed -i -e '/^@include/s/common-session$/common-session-sonic/' /etc/pam.d/login")
+        else:
+            os.system("sed -i -e '/^@include/s/common-session-sonic$/common-sesssion/' /etc/pam.d/sshd")
+            os.system("sed -i -e '/^@include/s/common-session-sonic$/common-session/' /etc/pam.d/login")
 
         # Add tacplus in nsswitch.conf if TACACS+ enable
         if 'tacacs+' in auth['login']:

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -43,7 +43,7 @@ def obfuscate(data):
 class AaaCfg(object):
     def __init__(self):
         self.auth_default = {
-            'login': 'local',
+            'login': 'local'
         }
         self.tacplus_global_default = {
             'auth_type': TACPLUS_SERVER_AUTH_TYPE_DEFAULT,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Implement TACAS Accounting feature as an enhancement

**- How I did it**
Add "common-session-sonic.j2"
Add accounting in "hostcfgd"

**- How to verify it**
== check aaa accounting command ==
root@SONiC-Inventec-d7054:~# config aaa accounting session tacacs+
root@SONiC-Inventec-d7054:~# config aaa authentication login local tacacs+
root@SONiC-Inventec-d7054:~# config tacacs add 192.168.3.50
root@SONiC-Inventec-d7054:~# config tacacs passkey admin

root@SONiC-Inventec-d7054:~# cat /etc/pam.d/common-session-sonic 
#
# /etc/pam.d/common-session - session-related modules common to all services
#
# This file is included from other service-specific PAM config files,
# and should contain a list of modules that define tasks to be performed
# at the start and end of sessions of *any* kind (both interactive and
# non-interactive).
#
# As of pam 1.0.1-6, this file is managed by pam-auth-update by default.
# To take advantage of this, it is recommended that you configure any
# local modules either before or after the default block, and use
# pam-auth-update to manage selection of other modules.  See
# pam-auth-update(8) for details.

# here are the per-package modules (the "Primary" block)
session [success=done new_authtok_reqd=done default=ignore]        pam_tacplus.so server=192.168.3.50:49 secret=admin service=shell 
session	[default=1]			pam_permit.so
# here's the fallback if no module succeeds
session	requisite			pam_deny.so
# prime the stack with a positive return value if there isn't one already;
# this avoids us returning an error just because nothing sets a success code
# since the modules above will each just jump around
session	required			pam_permit.so
# and here are more per-package modules (the "Additional" block)
session	required	pam_unix.so 

== check /etc/sonic/config_db.json ==

root@SONiC-Inventec-d7054:~# config save
root@SONiC-Inventec-d7054:~# cat /etc/sonic/config_db.json

    "AAA": {
        "accounting": {
            "session": "tacacs+"
        },
        "authentication": {
            "login": "local,tacacs+"
        }
    },

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
