### PR TITLE
Fix FRR config script to render frr.conf

### DIFF
--- a/dockers/docker-fpm-frr/config.sh
+++ b/dockers/docker-fpm-frr/config.sh
@@ -5,7 +5,7 @@ mkdir -p /etc/frr
 CONFIG_TYPE=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["docker_routing_config_mode"]'`
 
 if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "unified" ]; then
-    sonic-cfggen -d -t /usr/share/sonic/templates/frr.conf.j2 >/etc/frr/frr.conf
+    sonic-cfggen -d -y /etc/sonic/deployment_id_asn_map.yml -t /usr/share/sonic/templates/frr.conf.j2 >/etc/frr/frr.conf
 fi
 
 sonic-cfggen -d -t /usr/share/sonic/templates/isolate.j2 >/usr/sbin/bgp-isolate


### PR DESCRIPTION
The original error is like below.
```
# sonic-cfggen -d -t /usr/share/sonic/templates/frr.conf.j2
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 263, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 240, in main
    print(template.render(sort_data(data)))
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/share/sonic/templates/frr.conf.j2", line 169, in top-level template code
    {% block bgp_peers_with_range %}
  File "/usr/share/sonic/templates/frr.conf.j2", line 174, in block "bgp_peers_with_range"
    neighbor {{ bgp_peer['name'] }} remote-as {{ deployment_id_asn_map[DEVICE_METADATA['localhost']['deployment_id']] }}
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 411, in getitem
    return obj[argument]
jinja2.exceptions.UndefinedError: 'deployment_id_asn_map' is undefined
```