### PR TITLE
[docker/snmp] Allow snmp container to use python smbus

### DIFF
--- a/dockers/docker-snmp-sv2/Dockerfile.j2
+++ b/dockers/docker-snmp-sv2/Dockerfile.j2
@@ -17,7 +17,7 @@ RUN apt-get update
 RUN apt-get install -y curl ca-certificates
 
 # Install gcc which is required for installing hiredis
-RUN apt-get install -y gcc
+RUN apt-get install -y gcc make
 
 {% if docker_snmp_sv2_debs.strip() -%}
 # Copy locally-built Debian package dependencies
@@ -38,6 +38,9 @@ RUN python3.6 -m pip install --no-cache-dir hiredis
 # Install pyyaml dependency for use by some plugins
 RUN python3.6 -m pip install --no-cache-dir pyyaml
 
+# Install smbus dependency for use by some plugins
+RUN python3.6 -m pip install --no-cache-dir smbus
+
 {% if docker_snmp_sv2_whls.strip() -%}
 # Copy locally-built Python wheel dependencies
 {%- for whl in docker_snmp_sv2_whls.split(' ') %}
@@ -53,7 +56,7 @@ RUN pip install /python-wheels/{{ whl }}
 RUN python3.6 -m sonic_ax_impl install
 
 # Clean up
-RUN apt-get -y purge libpython3.6-dev curl gcc
+RUN apt-get -y purge libpython3.6-dev curl gcc make
 RUN apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y --purge
 RUN find / | grep -E "__pycache__" | xargs rm -rf
 RUN rm -rf /debs /python-wheels ~/.cache


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The python3-smbus module is installed on the host and shared to the snmp
container via a docker mount.
This is a hack to prevent snmp from installing build-essential to build
a single cpython module.
Once the snmp docker image uses stretch, the python3-smbus should be available there directly. 

**- How I did it**

Installed python3-smbus in the host.
Added a mountpoint for the cpython lib in snmp.
