### PR TITLE
[snmp] Configure snmp docker hostname from config DB

### DIFF
--- a/dockers/docker-snmp-sv2/start.sh
+++ b/dockers/docker-snmp-sv2/start.sh
@@ -12,11 +12,13 @@ echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status
 CURRENT_HOSTNAME=`hostname`
 HOSTNAME=`sonic-cfggen -d -v DEVICE_METADATA[\'localhost\'][\'hostname\']`
 
-echo $HOSTNAME > /etc/hostname
-hostname -F /etc/hostname
+if [ "$?" == "0" ] && [ "$HOSTNAME" != "" ]; then
+    echo $HOSTNAME > /etc/hostname
+    hostname -F /etc/hostname
 
-sed -i "/\s$CURRENT_HOSTNAME$/d" /etc/hosts
-echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
+    sed -i "/\s$CURRENT_HOSTNAME$/d" /etc/hosts
+    echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
+fi
 
 rm -f /var/run/rsyslogd.pid
 

--- a/dockers/docker-snmp-sv2/start.sh
+++ b/dockers/docker-snmp-sv2/start.sh
@@ -9,6 +9,15 @@ sonic-cfggen -d -y /etc/sonic/snmp.yml -t /usr/share/sonic/templates/snmpd.conf.
 mkdir -p /var/sonic
 echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status
 
+CURRENT_HOSTNAME=`hostname`
+HOSTNAME=`sonic-cfggen -d -v DEVICE_METADATA[\'localhost\'][\'hostname\']`
+
+echo $HOSTNAME > /etc/hostname
+hostname -F /etc/hostname
+
+sed -i "/\s$CURRENT_HOSTNAME$/d" /etc/hosts
+echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
+
 rm -f /var/run/rsyslogd.pid
 
 supervisorctl start rsyslogd


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

**- What I did**
Configure snmp docker hostname with the value received from the config DB in order to fix SNMP CT which failed because the "sonic" sysName was always received.

**- How I did it**
Configure snmp docker hostname in the same way as this is done in hostname-config.sh

**- How to verify it**
Run snmp CT and verify it will pass

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
