### PR TITLE
Filesystems - eMMC wearout mitigation

### DIFF
--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -12,8 +12,7 @@ case $1 in
 esac
 
 # Extract kernel parameters
-set -- $(cat /proc/cmdline)
-for x in "$@"; do
+for x in $(cat /proc/cmdline); do
     case "$x" in
         loop=*)
             image_dir=`echo $x | sed -e 's/.*loop=\(\S*\)\/.*/\1/'`

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -11,8 +11,22 @@ case $1 in
     ;;
 esac
 
+# Extract kernel parameters
+set -- $(cat /proc/cmdline)
+for x in "$@"; do
+    case "$x" in
+        loop=*)
+            image_dir=`echo $x | sed -e 's/.*loop=\(\S*\)\/.*/\1/'`
+        ;;
+        varlog_size=*)
+            varlog_size="${x#varlog_size=}"
+        ;;
+        *mmc_host*)
+             eMMC=1
+    esac
+done
+
 ## Mount the overlay file system: rw layer over squashfs
-image_dir=$(cat /proc/cmdline | sed -e 's/.*loop=\(\S*\)\/.*/\1/')
 mkdir -p ${rootmnt}/host/$image_dir/rw
 mkdir -p ${rootmnt}/host/$image_dir/work
 mount -n -o lowerdir=${rootmnt},upperdir=${rootmnt}/host/$image_dir/rw,workdir=${rootmnt}/host/$image_dir/work -t overlay root-overlay ${rootmnt}
@@ -26,5 +40,9 @@ mount --bind ${rootmnt}/host/$image_dir/{{ DOCKERFS_DIR }} ${rootmnt}/var/lib/do
 ## Mount the boot directory in the raw partition, bypass the overlay
 mkdir -p ${rootmnt}/boot
 mount --bind ${rootmnt}/host/$image_dir/boot ${rootmnt}/boot
-## Mount loop device for /var/log
-[ -f ${rootmnt}/host/disk-img/var-log.ext4 ] && mount -t ext4 -o loop,rw ${rootmnt}/host/disk-img/var-log.ext4 ${rootmnt}/var/log
+## Mount loop device for /var/log or a tmpfs device if the flash is eMMC
+if [ -z ${eMMC+1} ]; then
+    [ -f ${rootmnt}/host/disk-img/var-log.ext4 ] && mount -t ext4 -o loop,rw ${rootmnt}/host/disk-img/var-log.ext4 ${rootmnt}/var/log
+else
+    mount -t tmpfs -o size=${varlog_size}M,mode=0755 tmpfs ${rootmnt}/var/log
+fi

--- a/files/initramfs-tools/varlog
+++ b/files/initramfs-tools/varlog
@@ -17,6 +17,9 @@ for x in "$@"; do
     case "$x" in
         varlog_size=*)
             varlog_size="${x#varlog_size=}"
+	;;
+	*mmc_host*)
+	    eMMC=1
     esac
 done
 
@@ -32,5 +35,7 @@ if [ -e "${rootmnt}/host/disk-img/var-log.ext4" ]; then
     fi
 fi
 
-# create varlog disk
-mkdir -p ${rootmnt}/host/disk-img && ${rootmnt}/usr/bin/fallocate -l "$varlog_size"M ${rootmnt}/host/disk-img/var-log.ext4 && mkfs.ext4 -q -F ${rootmnt}/host/disk-img/var-log.ext4
+# create varlog disk only if we are not running eMMC flash
+if [ -z ${eMMC+1} ]; then
+    mkdir -p ${rootmnt}/host/disk-img && ${rootmnt}/usr/bin/fallocate -l "$varlog_size"M ${rootmnt}/host/disk-img/var-log.ext4 && mkfs.ext4 -q -F ${rootmnt}/host/disk-img/var-log.ext4
+fi


### PR DESCRIPTION
Some platform's flash is eMMC, this can be ok for some NOS but SONiC is
very write intensive, especially logging. This patch aims to
prolong the life of these eMMC flash drives by moving the /var/log
filesystem from a loop device to a tmpfs RAMdrive

The patch checks the kernel boot variables for the presence of an MMC
module string and modifies the initramfs build to mount the /var/log
filesystem as a ramdisk. The check is crude and has only been tested on
our only known affected platform, we are not sure it may work on all
eMMC based flash storage.

Caveat: you lose all stored logs at each reboot on eMMC platforms so
configure your rsyslogs to log outside the box

Signed-off-by: Michel Moriniaux <m.moriniaux@criteo.com>