### PR TITLE
Increase syncd start timeout

### DIFF
--- a/files/build_templates/syncd.service.j2
+++ b/files/build_templates/syncd.service.j2
@@ -22,6 +22,9 @@ Environment=sonic_asic_platform={{ sonic_asic_platform }}
 ExecStartPre=/usr/local/bin/syncd.sh start
 ExecStart=/usr/local/bin/syncd.sh wait
 ExecStop=/usr/local/bin/syncd.sh stop
+{% if sonic_asic_platform == 'mellanox' %}
+TimeoutSec=150
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/files/build_templates/syncd.service.j2
+++ b/files/build_templates/syncd.service.j2
@@ -23,7 +23,7 @@ ExecStartPre=/usr/local/bin/syncd.sh start
 ExecStart=/usr/local/bin/syncd.sh wait
 ExecStop=/usr/local/bin/syncd.sh stop
 {% if sonic_asic_platform == 'mellanox' %}
-TimeoutSec=150
+TimeoutStartSec=150
 {% endif %}
 
 [Install]


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

**- What I did**
Increased syncd start timeout to let post-boot FW update on Mellanox platform finish successfully. 

**- How I did it**
Added TimeoutSec field to the syncd service config
 
**- How to verify it**
Verified upgrade from 201803 to 201811 or master finishes successfully

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
