### PR TITLE
[snmp.service] remove snmp.timer unit

### DIFF
--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -8,3 +8,6 @@ Before=ntp-config.service
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+
+[Install]
+WantedBy=multi-user.target

--- a/files/build_templates/snmp.timer
+++ b/files/build_templates/snmp.timer
@@ -1,9 +1,0 @@
-[Unit]
-Description=Delays snmp container until SONiC has started
-
-[Timer]
-OnBootSec=3min 30 sec
-Unit=snmp.service
-
-[Install]
-WantedBy=timers.target

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -297,11 +297,6 @@ sudo LANG=C chroot $FILESYSTEM_ROOT umount -lf /sys
 sudo LANG=C cp $SCRIPTS_DIR/swss.sh $FILESYSTEM_ROOT/usr/local/bin/swss.sh
 sudo LANG=C cp $SCRIPTS_DIR/syncd.sh $FILESYSTEM_ROOT/usr/local/bin/syncd.sh
 
-# Copy systemd timer configuration
-# It implements delayed start of services
-sudo cp $BUILD_TEMPLATES/snmp.timer $FILESYSTEM_ROOT/etc/systemd/system/
-sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable snmp.timer
-
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get remove -y python-dev
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get clean -y
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get autoremove -y


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed snmp.timer unit. Trying to address Azure/sonic-buildimage#2750 by removing snmp.timer systemd unit and adding synchronization between counters and SNMP counter dependent MIBs

<b>NOTE:</b> This change depends on https://github.com/Azure/sonic-snmpagent/pull/105

**- How I did it**
Removed snmp.timer unit

**- How to verify it**
SNMP ansible test;
Mannual test:
 - system cold reboot
 - system warm reboot
 - snmp service restart
 - swss service restart

**- Description for the changelog**
Removed snmp.timer unit
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
