### PR TITLE
[tmpfs var/log] mount /var/log as tmpfs for some platforms

### DIFF
--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -11,6 +11,31 @@ case $1 in
     ;;
 esac
 
+set_tmpfs_log_partition_size()
+{
+  varlogsize=128
+
+  # NOTE: certain platforms, when reaching initramfs stage, have a small
+  #       limit of mounting tmpfs partition, potentially due to amount
+  #       of RAM available in this stage. e.g. Arista 7050 QX32
+  [ X"$aboot_platform" = X"x86_64-arista_7050_qx32"  ] && return
+
+  # set varlogsize to existing var-log.ext4 size
+  if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
+    varlogsize=$(ls -l ${rootmnt}/host/disk-img/var-log.ext4 | awk '{print $5}')
+    varlogsize=$(($varlogsize/1024/1024))
+  fi
+
+  # make sure varlogsize is between 5% to 10% of total memory size
+  memkb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+  memmb=$(($memkb/1024))
+  minsize=$(($memmb*5/100))
+  maxsize=$(($memmb*10/100))
+
+  [ $minsize -ge $varlogsize ] && varlogsize=$minsize
+  [ $maxsize -le $varlogsize ] && varlogsize=$maxsize
+}
+
 ## Mount the overlay file system: rw layer over squashfs
 image_dir=$(cat /proc/cmdline | sed -e 's/.*loop=\(\S*\)\/.*/\1/')
 mkdir -p ${rootmnt}/host/$image_dir/rw
@@ -26,5 +51,16 @@ mount --bind ${rootmnt}/host/$image_dir/{{ DOCKERFS_DIR }} ${rootmnt}/var/lib/do
 ## Mount the boot directory in the raw partition, bypass the overlay
 mkdir -p ${rootmnt}/boot
 mount --bind ${rootmnt}/host/$image_dir/boot ${rootmnt}/boot
-## Mount loop device for /var/log
-[ -f ${rootmnt}/host/disk-img/var-log.ext4 ] && mount -t ext4 -o loop,rw ${rootmnt}/host/disk-img/var-log.ext4 ${rootmnt}/var/log
+## Mount loop device or tmpfs for /var/log
+onie_platform=""
+aboot_platform=""
+. ${rootmnt}/host/machine.conf
+if [ X"$aboot_platform" = X"x86_64-arista_7050_qx32"  ] ||
+   [ X"$aboot_platform" = X"x86_64-arista_7050_qx32s" ]
+then
+  set_tmpfs_log_partition_size
+  mount -t tmpfs -o rw,nosuid,nodev,size=${varlogsize}M tmpfs ${rootmnt}/var/log
+  [ -f ${rootmnt}/host/disk-img/var-log.ext4 ] && rm -rf ${rootmnt}/host/disk-img/var-log.ext4
+else
+  [ -f ${rootmnt}/host/disk-img/var-log.ext4 ] && mount -t ext4 -o loop,rw ${rootmnt}/host/disk-img/var-log.ext4 ${rootmnt}/var/log
+fi


### PR DESCRIPTION
**- What I did**

SONiC is a heavy writer to /var/log partition, we noticed that this
behavior causes certain flash drive to become read-only over time.
To avoid this issue, we mount /var/log parition on these devices as
tmpfs.

- Mount /var/log as tmpfs
- /var/log default size is 128M
- Adjust size according to existing var-log.ext4 file size.
- Adjust size to between 5% to 10% of total memory size.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
