### PR TITLE
Enable Debugs in BCM Kernel-bde and Knet Modules

### DIFF
--- a/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
+++ b/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
@@ -25,6 +25,11 @@ function create_devices()
     mknod /dev/linux-kernel-bde c 127 0
 }
 
+# linux-kernel-bde debug=4    ==> Verbose level debug
+#              dma_debug=1    ==> Enable DMA debug
+# linux-bcm-knet debug=0x5020 ==> Enable KNET Warning(0x1000),
+#                                 Events(0x20) and Instance(0x4000)
+#                                 level logs
 function load_kernel_modules()
 {
     modprobe linux-kernel-bde dmasize=32M maxpayload=128 debug=4 dma_debug=1

--- a/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
+++ b/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
@@ -27,9 +27,9 @@ function create_devices()
 
 function load_kernel_modules()
 {
-    modprobe linux-kernel-bde dmasize=32M maxpayload=128
+    modprobe linux-kernel-bde dmasize=32M maxpayload=128 debug=4 dma_debug=1
     modprobe linux-user-bde
-    modprobe linux-bcm-knet use_rx_skb=1 rx_buffer_size=9238
+    modprobe linux-bcm-knet use_rx_skb=1 rx_buffer_size=9238 debug=0x5020
     modprobe linux-knet-cb
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add code change to enable debugs in Kernel-bde and KNET module
**- How I did it**
    modprobe linux-kernel-bde dmasize=32M maxpayload=128 debug=4 dma_debug=1
    modprobe linux-user-bde
    modprobe linux-bcm-knet use_rx_skb=1 rx_buffer_size=9238 debug=0x5020
    modprobe linux-knet-cb

**- How to verify it**
Load the image and check dmesg output.
Send traffic and verify if dmesg output is not chatty.

Unit Testing
-------------

In Debian8 :-

1)  Save dmesg output to a file
1)  Edit file /etc/init.d/opennsl-modules-3.16.0-6-amd64
2)  modprobe linux-kernel-bde dmasize=32M maxpayload=128 dma_debug=1 debug=4
3)  modprobe linux-bcm-knet use_rx_skb=1 rx_buffer_size=9238 debug=0x5020
4)  Save and reboot the box
5)  Now, save dmesg to another file
6)  vimdiff the 2 files
7)  It will show the new bde and knet logs in dmesg
8)  Execute the dmesg command  multiple times and check the logs for knet/bde messages
8)  Send CPU bound traffic (This will show if the dmesg are chatty or not)
9)  Verify the dmesg output for new logs on sending cpu bound traffic. (ARP request/ BGP protocol)
10) Verify port shut/no shut and check dmesg logs 
11) Verify vlan configuration and check dmesg logs
12) Verify port channel configuration and check dmesg logs

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Enable Debugs in BCM Kernel-bde and Knet Modules

**- A picture of a cute animal (not mandatory but encouraged)**
