### PR TITLE
[snmp.service] Make swss.service a requisite for snmp.service

### DIFF
--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -1,6 +1,7 @@
 [Unit]
 Description=SNMP container
-Requires=updategraph.service swss.service
+Requires=updategraph.service
+Requisite=swss.service
 After=updategraph.service swss.service
 Before=ntp-config.service
 


### PR DESCRIPTION
Trying to address #2750 by removing snmp.service required dependency on swss.service and adding it as requisite

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**


**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
