### PR TITLE
Optimize ipv4/ipv6 neighbor timers

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -334,8 +334,11 @@ set /files/etc/sysctl.conf/net.ipv4.conf.all.arp_filter 0
 set /files/etc/sysctl.conf/net.ipv4.conf.all.arp_notify 1
 set /files/etc/sysctl.conf/net.ipv4.conf.all.arp_ignore 2
 
-set /files/etc/sysctl.conf/net.ipv4.neigh.default.base_reachable_time_ms 1800000
-set /files/etc/sysctl.conf/net.ipv6.neigh.default.base_reachable_time_ms 1800000
+set /files/etc/sysctl.conf/net.ipv4.neigh.default.base_reachable_time_ms 60000
+set /files/etc/sysctl.conf/net.ipv4.neigh.default.gc_stale_time 1800
+
+set /files/etc/sysctl.conf/net.ipv6.neigh.default.base_reachable_time_ms 60000
+set /files/etc/sysctl.conf/net.ipv6.neigh.default.gc_stale_time 1800
 
 set /files/etc/sysctl.conf/net.ipv6.conf.default.forwarding 1
 set /files/etc/sysctl.conf/net.ipv6.conf.all.forwarding 1


### PR DESCRIPTION
Optimize ipv4/ipv6 neighbor timers

SONiC currently has 30m reachable timer and 60s stale timer for
both ipv4 and ipv6.
In case the peer has updated the mac due to system migration or
replace of the device. It is possible that the neighbor entry
will be at REACHABLE state for long (~30mins), and the traffic is
blackholed. This is especially for L3 interface where we rely on
BGP etc protocol to check peers. The protocol won't prob the MAC
when the neighbor is at REACHABLE state with the old MAC.

The fix is to change the REACHABLE timer to 60s, and keep the stale
timer to 30mins. So when we have protocol running, it will refresh the
MAC when the neighbor is at STALE state.
We rely on arping/ndisc6 for VLAN interfaces neighbor MAC update since
there might not be protocol running.

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Optimize the ipv4/ipv6 REACHABLE timer and STALE timer.

**- How I did it**
Change the default settings of ipv4/ipv6 REACHABLE timer and STALE timer.

**- How to verify it**
Build image and new image has the updated timer value.

Before the fix, if the peer changed MAC address, we can see ipv6 pinging to the peer are blocked and no MAC updated for ~30mins (could be 45mins).  Ipv4 seems to be ok since the peer usually sends GARP when it come up.

After fix, if the peer changed MAC address,  ipv6 pinging traffic to peer address will be resumed in ~1min.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
