### PR TITLE
Set proper hostname on containers startup

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -5,6 +5,15 @@ function getMountPoint()
     echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.basename(mnts[0]['Source'])" 2>/dev/null
 }
 
+function updateHostName()
+{
+    HOSTNAME=`hostname`
+
+    echo "Set hostname in {{docker_container_name}} container"
+    docker exec -i {{docker_container_name}} bash -c "hostname $HOSTNAME"
+    docker exec -i {{docker_container_name}} bash -c "echo \"$HOSTNAME\" > /etc/host"
+}
+
 function getBootType()
 {
     local BOOT_TYPE
@@ -81,9 +90,8 @@ function postStartAction()
     fi
 {%- elif docker_container_name == "snmp" %}
     docker exec -i database redis-cli -n 6 HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
-{%- else %}
-    : # nothing
 {%- endif %}
+    updateHostName
 }
 
 start() {


### PR DESCRIPTION

From my investigation currently there is no way to set `hostname` defined in `config_db.json` to containers in automatic mode. 
`hostname` inside container can be updated in case restarting the container (by `docker rm -f`) however we're runing this only in case `hwsku` change. So, `sudo config reload -y` wil not affect hostname inside containers.
Need to pay an attention that some containers (like dhcp_relay) strongly required to have correct `hostname` as its use it for services runing inside.

If I'm wrong - please point me to the correct way on how to set hostname for containers and simple decline this PR.

**- What I did**
Set `hostname` inside each container from `<docker-name>.service`

**- How I did it**
Extended existing post-run hook `postStartAction`

**- How to verify it**
- manually change 'hostname' in `config_db.json`
- run `sudo config reload -y`
- check hostname inside any container

**- Description for the changelog**
 Set proper hostname on containers startup

@lguohan @jleveque: please review this

