### PR TITLE
Remove unused packages in docker images and host

### DIFF
--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -73,6 +73,10 @@ RUN apt-get -y install {{ dbg_pkg }}
 RUN ln /usr/bin/vim.tiny /usr/bin/vim
 {%- endif %}
 
+# Remove python3.4
+# Note: if later python3 is required by more docker images, consider install homebrew python3 here instead of in SNMP image only
+RUN apt-get purge -y libpython3.4-minimal
+
 # Clean up apt
 # Remove /var/lib/apt/lists/*, could be obsoleted for derived images
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y

--- a/dockers/docker-config-engine-stretch/Dockerfile.j2
+++ b/dockers/docker-config-engine-stretch/Dockerfile.j2
@@ -43,5 +43,5 @@ python-wheels/{{ whl }}{{' '}}
 {%- endif -%}
 
 ## Clean up
-RUN apt-get remove -y python-pip python-dev; apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN apt-get purge -y python-pip python-dev; apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs /python-wheels

--- a/dockers/docker-config-engine/Dockerfile.j2
+++ b/dockers/docker-config-engine/Dockerfile.j2
@@ -43,5 +43,5 @@ python-wheels/{{ whl }}{{' '}}
 {%- endif -%}
 
 ## Clean up
-RUN apt-get remove -y python-pip python-dev; apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
+RUN apt-get purge -y python-pip python-dev; apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs /python-wheels

--- a/dockers/docker-lldp-sv2/Dockerfile.j2
+++ b/dockers/docker-lldp-sv2/Dockerfile.j2
@@ -35,7 +35,7 @@ RUN pip install /python-wheels/{{ whl }}
 {% endif %}
 
 # Clean up
-RUN apt-get remove -y python-pip
+RUN apt-get purge -y python-pip
 RUN apt-get clean -y
 RUN apt-get autoclean -y
 RUN apt-get autoremove -y

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -46,7 +46,7 @@ RUN pip install /python-wheels/{{ whl }}
 {% endif %}
 
 # Clean up
-RUN apt-get remove -y python-pip
+RUN apt-get purge -y python-pip
 RUN apt-get clean -y
 RUN apt-get autoclean -y
 RUN apt-get autoremove -y

--- a/dockers/docker-snmp-sv2/Dockerfile.j2
+++ b/dockers/docker-snmp-sv2/Dockerfile.j2
@@ -60,7 +60,7 @@ RUN pip install /python-wheels/{{ whl }}
 RUN python3.6 -m sonic_ax_impl install
 
 # Clean up
-RUN apt-get -y purge libpython3.6-dev curl gcc make libdpkg-perl
+RUN apt-get -y purge libpython3.6-dev libpython3.6 curl gcc make libdpkg-perl
 # Note: these packages should be removed with autoremove but actually not, so explicitly purged
 RUN apt-get -y purge libldap-2.4-2 libsasl2-2 libsasl2-modules libsasl2-modules-db
 RUN apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y --purge

--- a/dockers/docker-snmp-sv2/Dockerfile.j2
+++ b/dockers/docker-snmp-sv2/Dockerfile.j2
@@ -61,6 +61,8 @@ RUN python3.6 -m sonic_ax_impl install
 
 # Clean up
 RUN apt-get -y purge libpython3.6-dev curl gcc make libdpkg-perl
+# Note: these packages should be removed with autoremove but actually not, so explicitly purged
+RUN apt-get -y purge libldap-2.4-2 libsasl2-2 libsasl2-modules libsasl2-modules-db
 RUN apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y --purge
 RUN find / | grep -E "__pycache__" | xargs rm -rf
 RUN rm -rf /debs /python-wheels ~/.cache

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -29,9 +29,9 @@ RUN apt-get install -y default-jre
 RUN apt-get install -y rsyslog psmisc
 
 # Remove cffi 1.5.2, will install 1.10.0 by pip later
-RUN apt-get remove -y python-cffi python-cffi-backend
+RUN apt-get purge -y python-cffi python-cffi-backend
 # Remove pycparser 2.14, will install >=2.17 by pip later
-RUN apt-get remove -y python-ply python-pycparser
+RUN apt-get purge -y python-ply python-pycparser
 
 RUN easy_install pip
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -307,7 +307,7 @@ sudo LANG=C cp $SCRIPTS_DIR/syncd.sh $FILESYSTEM_ROOT/usr/local/bin/syncd.sh
 sudo cp $BUILD_TEMPLATES/snmp.timer $FILESYSTEM_ROOT/etc/systemd/system/
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable snmp.timer
 
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get remove -y python-dev
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get purge -y python-dev
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get clean -y
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get autoremove -y
 

--- a/rules/python3.mk
+++ b/rules/python3.mk
@@ -26,8 +26,8 @@ $(PY3_MIN)_RDEPENDS += $(LIBPY3_MIN)
 
 PY3 = $(PYTHON_PNAME)_$(PYTHON_VER)_amd64.deb
 $(eval $(call add_derived_package,$(LIBPY3_MIN),$(PY3)))
-$(PY3)_DEPENDS += $(PY3_MIN) $(LIBPY3)
-$(PY3)_RDEPENDS += $(PY3_MIN) $(LIBPY3) $(LIBPY3_MIN)
+$(PY3)_DEPENDS += $(PY3_MIN) $(LIBPY3_STD)
+$(PY3)_RDEPENDS += $(PY3_MIN) $(LIBPY3_STD)
 
 LIBPY3_DEV = lib$(PYTHON_PNAME)-dev_$(PYTHON_VER)_amd64.deb
 $(eval $(call add_derived_package,$(LIBPY3_MIN),$(LIBPY3_DEV)))


### PR DESCRIPTION
To reduce image size.
Unused packages include:
1. python3.4 inside all container: never used
2. libpython3.6 inside snmp container: not used and not required by any python packages

Fixed the build dependencies of python3.6

Use `apt-get purge` instead of `apt-get purge` to clean up even configuration files.