### PR TITLE
[db migrator] migrate the DB to latest schema when needed

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -59,6 +59,11 @@ function postStartAction()
 
         redis-cli -n 4 SET "CONFIG_DB_INITIALIZED" "1"
     fi
+
+    if [[ -x /usr/bin/db_migrator.py ]]; then
+        # Migrate the DB to the latest schema version if needed
+        /usr/bin/db_migrator.py -o migrate
+    fi
 {%- elif docker_container_name == "swss" %}
     docker exec swss rm -f /ready   # remove cruft
     if [[ "$BOOT_TYPE" == "fast" ]] && [[ -d /host/fast-reboot ]]; then


### PR DESCRIPTION
**- What I did**
Migrate the DB to latest schema after database service is up. This is:
- cold reboot: after loading config_db.json
- warm reboot: after restore backed up database.

**- Dependencies**
- This change is not effective unless https://github.com/Azure/sonic-utilities/pull/519 is merged [Done]
- Advance sonic-utilities sub-module: https://github.com/Azure/sonic-buildimage/pull/2842