### PR TITLE
[Arista] Add QoS needed files for Arista 7170

### DIFF
--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers.json.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers.json.j2
@@ -1,0 +1,3 @@
+{%- set default_topo = 't0' %}
+{%- include 'buffers_config.j2' %}
+

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t0.j2
@@ -1,0 +1,46 @@
+{%- set default_cable = '5m' %}
+
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(0,64) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx * 4)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "33329088",
+            "type": "ingress",
+            "mode": "dynamic",
+            "xoff": "7827456"
+        },
+        "egress_lossy_pool": {
+            "size": "26663272",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "42349632",
+            "type": "egress",
+            "mode": "static"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "static_th":"11075584"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "static_th":"10587408"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"1664",
+            "dynamic_th":"-1"
+        }
+    },
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/qos.json.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/qos.json.j2
@@ -1,0 +1,1 @@
+{%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/switch-sai.conf
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/switch-sai.conf
@@ -26,7 +26,8 @@
             "tofino-bin": "share/tofinopd/switch/tofino.bin",
             "switchapi": "lib/libswitchapi.so",
             "switchsai": "lib/libswitchsai.so",
-            "switchapi_port_add": false
+            "switchapi_port_add": false,
+            "non_default_port_ppgs": 5
         }
     ]
 }

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers.json.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers.json.j2
@@ -1,0 +1,3 @@
+{%- set default_topo = 't0' %}
+{%- include 'buffers_config.j2' %}
+

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers_defaults_t0.j2
@@ -1,0 +1,58 @@
+{%- set default_cable = '5m' %}
+
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(0,20) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx * 4)) %}{%- endif %}
+    {%- endfor %}
+    {%- for port_idx in range(80,88) %}
+        {%- if PORT_ALL.append("Ethernet%d" % port_idx) %}{%- endif %}
+    {%- endfor %}
+    {%- for port_idx in range(22,32) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx * 4)) %}{%- endif %}
+    {%- endfor %}
+    {%- for port_idx in range(128,140) %}
+        {%- if PORT_ALL.append("Ethernet%d" % port_idx) %}{%- endif %}
+    {%- endfor %}
+    {%- for port_idx in range(35,64) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx * 4)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "33329088",
+            "type": "ingress",
+            "mode": "dynamic",
+            "xoff": "7827456"
+        },
+        "egress_lossy_pool": {
+            "size": "26663272",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "42349632",
+            "type": "egress",
+            "mode": "static"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "static_th":"11075584"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "static_th":"10587408"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"1664",
+            "dynamic_th":"-1"
+        }
+    },
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/qos.json.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/qos.json.j2
@@ -1,0 +1,1 @@
+{%- include 'qos_config.j2' %}

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/switch-sai.conf
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/switch-sai.conf
@@ -26,7 +26,8 @@
             "tofino-bin": "share/tofinopd/switch/tofino.bin",
             "switchapi": "lib/libswitchapi.so",
             "switchsai": "lib/libswitchsai.so",
-            "switchapi_port_add": false
+            "switchapi_port_add": false,
+            "non_default_port_ppgs": 5
         }
     ]
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix QoS reload as the template files do not exist.

~$ sudo config qos reload 
Buffer definition template not found at /usr/share/sonic/device/x86_64-arista_7170_64c/Arista-7170-64C/buffers.json.j2

Add required non_default_port_ppgs to configurations which was causes errors when SONiC tries to create non default PPG.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
