### PR TITLE
removed exec from script which that prevents the further lines to be …

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -228,7 +228,7 @@ if [[ "$1" == "init" ]]; then
 
     # Disable Watchdog Timer
     if [[ -e /usr/local/bin/platform_watchdog_disable.sh ]]; then
-        exec /usr/local/bin/platform_watchdog_disable.sh
+        /usr/local/bin/platform_watchdog_disable.sh
     fi
 
     cpu_board_mux "new_device"


### PR DESCRIPTION
This change fixes the issue "Adding watchdog functionality results in xcvrd not starting"

**- What I did**
The script "platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh" calls the watchdog disable script "/usr/local/bin/platform_watchdog_disable.sh" using "exec", which is incorrect.
When any script is called using "exec" the caller script will not execute any lines after this "exec" lines. Hence, the caller script was not executing the code that starts xcvrd. Hence, the command "sfputil show presence" was always failing.
This "exec" is removed from this line so that the caller script continues to execute the remaining lines.

**- How to verify it**
Executed "sftputil" and confirmed that it works. Sample log is given below.
root@sonic:~# sfputil show presence 
Port        Presence
----------  -----------
Ethernet0   Present
Ethernet1   Present
Ethernet2   Present
Ethernet3   Not present
Ethernet4   Present
Ethernet5   Present
Ethernet6   Not present


root@sonic:~# sfputil show eeprom
Ethernet0: SFP EEPROM detected
                Connector: MPOx12
                Encoding: 64B66B
                Extended Identifier: Power Class 1(1.5W max)
                Extended RateSelect Compliance: QSFP+ Rate Select Version 1
                Identifier: QSFP+ or later
                Length OM3(2m): 50
                Nominal Bit Rate(100Mbs): 103
                Specification compliance:
                                10/40G Ethernet Compliance Code: 40GBASE-SR4
                Vendor Date Code(YYYY-MM-DD Lot): 2013-06-01 
                Vendor Name: AVAGO
                Vendor OUI: 00-17-6a
                Vendor PN: AFBR-79E4Z-D-FT1
                Vendor Rev: 01
                Vendor SN: 7503836100HL

Ethernet1: SFP EEPROM detected
                Connector: MPOx12
                Encoding: 64B66B
                Extended Identifier: Power Class 1(1.5W max)
                Extended RateSelect Compliance: QSFP+ Rate Select Version 1
                Identifier: QSFP+ or later
                Length OM3(2m): 50
                Nominal Bit Rate(100Mbs): 103
                Specification compliance:
                                10/40G Ethernet Compliance Code: 40GBASE-SR4
                Vendor Date Code(YYYY-MM-DD Lot): 2014-03-17 
                Vendor Name: AVAGO
                Vendor OUI: 00-17-6a
                Vendor PN: AFBR-79EQDZ-FT1
                Vendor Rev: 01
                Vendor SN: 4829443H007U

Ethernet2: SFP EEPROM detected
                Connector: No separable connector
                Encoding: Unspecified
                Extended Identifier: Power Class 1(1.5W max)
                Extended RateSelect Compliance: QSFP+ Rate Select Version 1
                Identifier: QSFP+ or later
                Length Cable Assembly(m): 1
                Nominal Bit Rate(100Mbs): 103
                Specification compliance:
                                10/40G Ethernet Compliance Code: 40GBASE-CR4
                Vendor Date Code(YYYY-MM-DD Lot): 2013-02-19 
                Vendor Name: Amphenol
                Vendor OUI: 78-a7-14
                Vendor PN: 599690001
                Vendor Rev: A
                Vendor SN: CN0NWGTV32G4928

Ethernet3: SFP EEPROM not detected


**- Description for the changelog**
Removed the "exec"

