### PR TITLE
Feed device info to orchagent process

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -3,6 +3,7 @@
 # Export platform information. Required to be able to write
 # vendor specific code.
 export platform=`sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type`
+export device=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
 
 MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
 


### PR DESCRIPTION
Some platform is not capable of buffer pool watermark clear; use device info to fall back such platforms to read-only polling mode

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
