### PR TITLE
Configure dhcp_relay container hostname from config DB

### DIFF
--- a/dockers/docker-dhcp-relay/start.sh
+++ b/dockers/docker-dhcp-relay/start.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+CURRENT_HOSTNAME=`hostname`
+HOSTNAME=`sonic-cfggen -d -v DEVICE_METADATA[\'localhost\'][\'hostname\']`
+
+if [ "$?" == "0" ] && [ "$HOSTNAME" != "" ]; then
+    echo $HOSTNAME > /etc/hostname
+    hostname -F /etc/hostname
+
+    tempfile=`mktemp -q -t hosts.XXXX`
+    sed "/\s$CURRENT_HOSTNAME$/d" /etc/hosts > $tempfile
+    echo "127.0.0.1 $HOSTNAME" >> $tempfile
+    cat $tempfile > /etc/hosts && rm $tempfile
+fi
+
 # Remove stale rsyslog PID file if it exists
 rm -f /var/run/rsyslogd.pid
 

--- a/dockers/docker-dhcp-relay/start.sh
+++ b/dockers/docker-dhcp-relay/start.sh
@@ -10,7 +10,7 @@ if [ "$?" == "0" ] && [ "$HOSTNAME" != "" ]; then
     tempfile=`mktemp -q -t hosts.XXXX`
     sed "/\s$CURRENT_HOSTNAME$/d" /etc/hosts > $tempfile
     echo "127.0.0.1 $HOSTNAME" >> $tempfile
-    cat $tempfile > /etc/hosts && rm $tempfile
+    cat $tempfile > /etc/hosts ; rm $tempfile
 fi
 
 # Remove stale rsyslog PID file if it exists

--- a/dockers/docker-snmp-sv2/start.sh
+++ b/dockers/docker-snmp-sv2/start.sh
@@ -16,8 +16,10 @@ if [ "$?" == "0" ] && [ "$HOSTNAME" != "" ]; then
     echo $HOSTNAME > /etc/hostname
     hostname -F /etc/hostname
 
-    sed -i "/\s$CURRENT_HOSTNAME$/d" /etc/hosts
-    echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
+    tempfile=`mktemp -q -t hosts.XXXX`
+    sed "/\s$CURRENT_HOSTNAME$/d" /etc/hosts > $tempfile
+    echo "127.0.0.1 $HOSTNAME" >> $tempfile
+    cat $tempfile > /etc/hosts && rm $tempfile
 fi
 
 rm -f /var/run/rsyslogd.pid

--- a/dockers/docker-snmp-sv2/start.sh
+++ b/dockers/docker-snmp-sv2/start.sh
@@ -19,7 +19,7 @@ if [ "$?" == "0" ] && [ "$HOSTNAME" != "" ]; then
     tempfile=`mktemp -q -t hosts.XXXX`
     sed "/\s$CURRENT_HOSTNAME$/d" /etc/hosts > $tempfile
     echo "127.0.0.1 $HOSTNAME" >> $tempfile
-    cat $tempfile > /etc/hosts && rm $tempfile
+    cat $tempfile > /etc/hosts ; rm $tempfile
 fi
 
 rm -f /var/run/rsyslogd.pid


### PR DESCRIPTION
**- What I did**
Implemented as a result of discussion in [#2806](https://github.com/Azure/sonic-buildimage/pull/2806).

- Configure dhcp_relay docker hostname with the value received from the config DB in order to fix dhcp_relay CT which failed because the "sonic" hostname was always received.
- fixed `sed` introduced in [#2773](https://github.com/Azure/sonic-buildimage/pull/2773) as inline operation can't be applied to `/etc/hosts` inside docker container

```
admin@bfn-switch-l1:~$ docker exec -it dhcp_relay bash
root@sonic-switch-l1:/# cat /etc/hosts
127.0.0.1       localhost
127.0.0.1 sonic-switch-l1
root@sonic-switch-l1:/# sed -i '/\ssonic-switch-l1$/d' /etc/hosts
sed: cannot rename /etc/sedJugNFO: Device or resource busy
```

**- How I did it**
Configure `dhcp_relay` docker hostname in the same way as this is done in `hostname-config.sh`

**- How to verify it**
    1) Run `dhcp_relay` CT and verify it will pass
    2)
      2.1)  manually change 'hostname' in `config_db.json`
      2.2)  run `sudo config reload -y`
      2.3)  check hostname inside `dhcp_relay` container

**- Description for the changelog**
Set proper hostname for dhcp_relay container on startup

@qiluo-msft please review and merge this.