### PR TITLE
[teamd service] start teamd service after swss

### DIFF
--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=TEAMD container
 Requires=updategraph.service
-After=updategraph.service
+After=updategraph.service swss.service
 Before=ntp-config.service
 
 [Service]


### PR DESCRIPTION
**- What I did**

SWSS clears DB tables, if teamd is not started after swss, there is a
race condition that swss might clear vital teamd information.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
continuous warm reboot, reboot.