### PR TITLE
fix bug in file sonic-cfggen

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -109,13 +109,13 @@ TODO(taoyl): Current version of config db only supports BGP admin states.
 
     @staticmethod
     def to_serialized(data):
-        for table in data:
-            if type(data[table]) is dict:
-                data[table] = OrderedDict(natsorted(data[table].items()))
-                for key in data[table].keys():
-                    new_key = ConfigDBConnector.serialize_key(key)
-                    if new_key != key:
-                        data[table][new_key] = data[table].pop(key)
+        if type(data) is dict:
+            data = OrderedDict(natsorted(data.items()))
+            for key in data.keys():
+                new_key = ConfigDBConnector.serialize_key(key)
+                if new_key != key:
+                    data[new_key] = data.pop(key)
+                data[new_key] = FormatConverter.to_serialized(data[new_key])
         return data
 
     @staticmethod


### PR DESCRIPTION
**- What I did**
Fixing bug of file sonic-cfggen. Error occurs if argument ***--var-json*** is set when running **sonic-cfggen**，for example：
```
Command: sonic-cfggen -d --var-json VLAN_MEMBER
Configuration in config_db.json: 
            "VLAN_MEMBER": {
            ......
                "Vlan11|Ethernet32": {
                 "tagging_mode": "untagged"
             },
             ......
```
Error occurs because `FormatConverter.to_serialized(data)` in file sonic-cfggen doesn't serialize
keys correctly

**- How I did it**
Fixing `FormatConverter.to_serialized(data)` in file sonic-cfggen

**- How to verify it**
Running command `sonic-cfggen -d --print-data`
Running command `sonic-cfggen -d --var-json VLAN_MEMBER `using configuration below

**- Description for the changelog**
Fixing `FormatConverter.to_serialized(data)` in sonic-cfggen

**- Screen shot of this error**

![sonic-cfggen error!](https://github.com/jihaix/files/blob/master/sonic-cfggen%20error.png?raw=true "sonic-cfggen error!")

**- Screen shot of running fixed file**
![sonic-cfggen fixed!](https://github.com/jihaix/files/blob/master/sonic-cfggen%20fixed.png?raw=true "sonic-cfggen fixed!")
