### PR TITLE
[sudoers] Add /usr/bin/teamshow to READ_ONLY_CMDS

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -32,6 +32,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /sbin/brctl show, \
                                  /usr/bin/psuutil *, \
                                  /usr/bin/sensors, \
                                  /usr/bin/sfputil show *, \
+                                 /usr/bin/teamshow, \
                                  /usr/bin/vtysh -c show *, \
                                  /bin/cat /var/log/syslog*, \
                                  /usr/bin/tail -F /var/log/syslog


### PR DESCRIPTION
Add /usr/bin/teamshow to READ_ONLY_CMDS in sudoers file. This will fix `show interfaces portchannel` along with the commit @https://github.com/Azure/sonic-utilities/pull/524 (Submodule update here: https://github.com/Azure/sonic-buildimage/pull/2847)