### PR TITLE
Re-create containers in case hostname change

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -127,7 +127,7 @@ start() {
             exit $?
         fi
 
-        # docker created with a different HWSKU, remove and recreate
+        # docker created with a different HWSKU and/or hostname, remove and recreate
         echo "Removing obsolete {{docker_container_name}} container with HWSKU $DOCKERMOUNT and HOSTNAME $DOCKERHOSTNAME"
         docker rm -f {{docker_container_name}}
     fi

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -105,7 +105,7 @@ start() {
     # Obtain our HWSKU as we will mount directories with these names in each docker
     HWSKU=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`
     {%- endif %}
-    HOSTNAME=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hostname"]'`
+    HOSTNAME=`sonic-cfggen -m -v 'DEVICE_METADATA["localhost"]["hostname"]'`
 
     DOCKERCHECK=`docker inspect --type container {{docker_container_name}} 2>/dev/null`
     if [ "$?" -eq "0" ]; then

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -5,6 +5,11 @@ function getMountPoint()
     echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.basename(mnts[0]['Source'])" 2>/dev/null
 }
 
+function getHostName()
+{
+    echo $1 | python -c "import sys, json; print json.load(sys.stdin)[0]['Config']['Hostname']" 2>/dev/null
+}
+
 function getBootType()
 {
     local BOOT_TYPE
@@ -100,6 +105,7 @@ start() {
     # Obtain our HWSKU as we will mount directories with these names in each docker
     HWSKU=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`
     {%- endif %}
+    HOSTNAME=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hostname"]'`
 
     DOCKERCHECK=`docker inspect --type container {{docker_container_name}} 2>/dev/null`
     if [ "$?" -eq "0" ]; then
@@ -108,7 +114,8 @@ start() {
         {%- else %}
         DOCKERMOUNT=`getMountPoint "$DOCKERCHECK"`
         {%- endif %}
-        if [ x"$DOCKERMOUNT" == x"$HWSKU" ]; then
+        DOCKERHOSTNAME=`getHostName "$DOCKERCHECK"`
+        if [ x"$DOCKERMOUNT" == x"$HWSKU" ] && [ x"$DOCKERHOSTNAME" == x"$HOSTNAME" ] ; then
             {%- if docker_container_name == "database" %}
             echo "Starting existing {{docker_container_name}} container"
             {%- else %}
@@ -121,7 +128,7 @@ start() {
         fi
 
         # docker created with a different HWSKU, remove and recreate
-        echo "Removing obsolete {{docker_container_name}} container with HWSKU $DOCKERMOUNT"
+        echo "Removing obsolete {{docker_container_name}} container with HWSKU $DOCKERMOUNT and HOSTNAME $DOCKERHOSTNAME"
         docker rm -f {{docker_container_name}}
     fi
 


### PR DESCRIPTION
From my investigation currently there is no way to set `hostname` defined in `config_db.json` to containers in automatic mode. 
`hostname` inside container can be updated in case restarting the container (by `docker rm -f`) however we're runing this only in case `hwsku` change. So, `sudo config reload -y` wil not affect hostname inside containers.
Need to pay an attention that some containers (like dhcp_relay) strongly required to have correct `hostname` as its use it for services runing inside.

**- What I did**
Set `hostname` inside each container from `<docker-name>.service`

**- How I did it**
Compare actual `hostname` from `config_db` and existing obtained by `docker inspect`

**- How to verify it**
- manually change 'hostname' in `config_db.json`
- run `sudo config reload -y`
- check hostname inside any container

**- Description for the changelog**
 Re-create containers in case hostname change

@lguohan @qiluo-msft: please review this