### PR TITLE
Flashrom utility support for BIOS upgrade

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -247,6 +247,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     tcptraceroute           \
     mtr-tiny                \
     locales                 \
+    flashrom                \
     cgroup-tools
 
 #Adds a locale to a debian system in non-interactive mode


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

 -  Added flashrom utility support for BIOS upgrades.

**- How I did it**
- Includeded flashrom support in build_debian.sh 

**- How to verify it**
```
root@sonic:/home/admin# flashrom
flashrom v0.9.9-r1954 on Linux 4.9.0-8-2-amd64 (x86_64)
flashrom is free software, get the source code at https://flashrom.org

Please select a programmer with the --programmer parameter.
Previously this was not necessary because there was a default set.
To choose the mainboard of this computer use 'internal'. Valid choices are:
internal, dummy, nic3com, nicrealtek, gfxnvidia, drkaiser, satasii, atavia,
it8212, ft2232_spi, serprog, buspirate_spi, dediprog, rayer_spi, pony_spi,
nicintel, nicintel_spi, nicintel_eeprom, ogp_spi, satamv, linux_spi,
usbblaster_spi, pickit2_spi, ch341a_spi
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
