### PR TITLE
Restart snmpd when it crashes

### DIFF
--- a/dockers/docker-snmp-sv2/supervisord.conf
+++ b/dockers/docker-snmp-sv2/supervisord.conf
@@ -23,7 +23,7 @@ stderr_logfile=syslog
 command=/usr/sbin/snmpd -f -LS4d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw -p /run/snmpd.pid
 priority=3
 autostart=false
-autorestart=false
+autorestart=true
 stdout_logfile=syslog
 stderr_logfile=syslog
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enabled restarting snmpd when it crashes.
snmpd crashes because of agentx cache invalid state which is not fixed yet. It's rare case but we see it sometimes. If restart snmpd after the crash, everything will work as expected.

**- How I did it**
Enabled autorestart in supervisord

**- How to verify it**
Go to snmp docker container, stop snmpd process and check that supervisord enable it back

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
