### PR TITLE
Administratively shutdown port channel has member ports in deselected state and traffic is not forwarded. #1771

### DIFF
--- a/src/libteam/0013-teamd-lacp-port-admin-down-recv-not-processing.patch
+++ b/src/libteam/0013-teamd-lacp-port-admin-down-recv-not-processing.patch
@@ -14,11 +14,8 @@ index 5fa026a..5f4ba75 100644
  		return err;
  
 +        admin_state = team_get_ifinfo_admin_state(lacp_port->ctx->ifinfo);
-+        if (!admin_state) {
-+                teamd_log_dbg("%s received PDU in admin down state.",
-+                       lacp_port->tdport->ifname);
++        if (!admin_state)
 +                return 0;
-+        }
 +
  	return lacpdu_process(lacp_port, &lacpdu);
  }

--- a/src/libteam/0013-teamd-lacp-port-admin-down-recv-not-processing.patch
+++ b/src/libteam/0013-teamd-lacp-port-admin-down-recv-not-processing.patch
@@ -15,7 +15,7 @@ index 5fa026a..5f4ba75 100644
  
 +        admin_state = team_get_ifinfo_admin_state(lacp_port->ctx->ifinfo);
 +        if (!admin_state) {
-+                teamd_log_info("%s received PDU in admin down state.",
++                teamd_log_dbg("%s received PDU in admin down state.",
 +                       lacp_port->tdport->ifname);
 +                return 0;
 +        }

--- a/src/libteam/0013-teamd-lacp-port-admin-down-recv-not-processing.patch
+++ b/src/libteam/0013-teamd-lacp-port-admin-down-recv-not-processing.patch
@@ -1,0 +1,25 @@
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 5fa026a..5f4ba75 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -1179,12 +1179,20 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
+ 	struct lacpdu lacpdu;
+ 	struct sockaddr_ll ll_from;
+ 	int err;
++	bool admin_state;
+ 
+ 	err = teamd_recvfrom(lacp_port->sock, &lacpdu, sizeof(lacpdu), 0,
+ 			     (struct sockaddr *) &ll_from, sizeof(ll_from));
+ 	if (err <= 0)
+ 		return err;
+ 
++        admin_state = team_get_ifinfo_admin_state(lacp_port->ctx->ifinfo);
++        if (!admin_state) {
++                teamd_log_info("%s received PDU in admin down state.",
++                       lacp_port->tdport->ifname);
++                return 0;
++        }
++
+ 	return lacpdu_process(lacp_port, &lacpdu);
+ }
+ 

--- a/src/libteam/0013-teamd-lacp-port-admin-down-recv-not-processing.patch
+++ b/src/libteam/0013-teamd-lacp-port-admin-down-recv-not-processing.patch
@@ -1,21 +1,21 @@
 diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
-index 5fa026a..5f4ba75 100644
+index 4a3fe6b..19592c5 100644
 --- a/teamd/teamd_runner_lacp.c
 +++ b/teamd/teamd_runner_lacp.c
-@@ -1179,12 +1179,20 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
+@@ -1182,12 +1182,17 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
  	struct lacpdu lacpdu;
  	struct sockaddr_ll ll_from;
  	int err;
-+	bool admin_state;
++        bool admin_state;
  
  	err = teamd_recvfrom(lacp_port->sock, &lacpdu, sizeof(lacpdu), 0,
  			     (struct sockaddr *) &ll_from, sizeof(ll_from));
  	if (err <= 0)
  		return err;
  
-+        admin_state = team_get_ifinfo_admin_state(lacp_port->ctx->ifinfo);
-+        if (!admin_state)
-+                return 0;
++	admin_state = team_get_ifinfo_admin_state(lacp_port->ctx->ifinfo);
++	if (!admin_state)
++		return 0;
 +
  	return lacpdu_process(lacp_port, &lacpdu);
  }

--- a/src/libteam/series
+++ b/src/libteam/series
@@ -7,3 +7,4 @@
 0010-teamd-lacp-update-port-state-according-to-partners-sy.patch
 0011-libteam-resynchronize-ifinfo-after-lost-RTNLGRP_LINK-.patch
 0012-teamd-do-not-process-lacpdu-before-the-port-ifinfo-i.patch
+0013-teamd-lacp-port-admin-down-recv-not-processing.patch


### PR DESCRIPTION
**- What I did**
Added code in teamd for the issue reported in https://github.com/Azure/sonic-buildimage/issues/1771.

**- How I did it**
Added a conditional check in teamd runner (lacp) code to ensure LACP frames received on an administratively shutdown port channel, are not processed. This results in the member ports of the port channel staying in 'deselected' state. Hardware does not have these ports part of the port channel and thereby traffic is not forwarded.

**- How to verify it**
1. Configure a port channel with two physical ports connected back-to-back between two devices.
2. Execute 'teamshow' or 'show interfaces portchannel' to ensure the member ports are in selected (S) state after LACP exchange.
3. Shutdown the port channel.
4. Execute 'teamshow' or 'show interfaces portchannel'. Notice that the member ports remain in deselected (D) state. Send bi-directional traffic to confirm the flow across devices has stopped.
5. Bring up the port channel. Member ports need to be placed in selected (S) state. And traffic flow across the devices needs to resume.

Without the fix:
root@sonic:/home/admin# show int port
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev      Protocol     Ports
-----  ------------  -----------  -------------------------
    1  PortChannel1  LACP(A)(Up)  Ethernet2(S) Ethernet4(S)

root@sonic:/home/admin# config interface shutdown PortChannel1
root@sonic:/home/admin# show int port
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev      Protocol     Ports
-----  ------------  -----------  -------------------------
    1  PortChannel1  LACP(A)(Dw)  Ethernet2(D) Ethernet4(D)
root@sonic:/home/admin# show int port
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev      Protocol     Ports
-----  ------------  -----------  -------------------------
    1  PortChannel1  LACP(A)(Dw)  Ethernet2(S) Ethernet4(S)

With the fix:
root@sonic:/home/admin# show int port
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev      Protocol     Ports
-----  ------------  -----------  -------------------------
    1  PortChannel1  LACP(A)(Up)  Ethernet2(S) Ethernet4(S)
root@sonic:/home/admin# config interface shutdown PortChannel1
root@sonic:/home/admin# show int port
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev      Protocol     Ports
-----  ------------  -----------  -------------------------
    1  PortChannel1  LACP(A)(Dw)  Ethernet2(D) Ethernet4(D)
root@sonic:/home/admin# config interface startup PortChannel1
root@sonic:/home/admin# show int port
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev      Protocol     Ports
-----  ------------  -----------  -------------------------
    1  PortChannel1  LACP(A)(Up)  Ethernet2(S) Ethernet4(S)

**- Description for the changelog**
Administratively shutdown port channel has member ports in deselected state and traffic is not forwarded.

**- A picture of a cute animal (not mandatory but encouraged)**
