### PR TITLE
Fix for LLDP portname issue

### DIFF
--- a/dockers/docker-lldp-sv2/lldpmgrd
+++ b/dockers/docker-lldp-sv2/lldpmgrd
@@ -78,16 +78,10 @@ def is_port_exist(port_name):
     if os.path.exists(filename):
         with open(filename) as fp:
             state = fp.read()
-            if "up" in state:
-                return True
-            else:
-                return False
+            return "up" in state
     else:
         filename = "/sys/class/net/%s/ifindex" % port_name
-        if os.path.exists(filename):
-            return True
-        else:
-            return False
+        return os.path.exists(filename)
 
 # ============================== Classes ==============================
 

--- a/dockers/docker-lldp-sv2/lldpmgrd
+++ b/dockers/docker-lldp-sv2/lldpmgrd
@@ -74,11 +74,20 @@ def signal_handler(sig, frame):
 # ========================== Helpers ==================================
 
 def is_port_exist(port_name):
-    filename = "/sys/class/net/%s/ifindex" % port_name
-    if not os.path.exists(filename):
-        return False
-
-    return True
+    filename = "/sys/class/net/%s/operstate" % port_name
+    if os.path.exists(filename):
+        with open(filename) as fp:
+            state = fp.read()
+            if "up" in state:
+                return True
+            else:
+                return False
+    else:
+        filename = "/sys/class/net/%s/ifindex" % port_name
+        if os.path.exists(filename):
+            return True
+        else:
+            return False
 
 # ============================== Classes ==============================
 


### PR DESCRIPTION
First check for operstate and if its not present then check for ifindex

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed the issue in LLDP where portname was advertised as a MAC address instead
**- How I did it**
To decide whether a port exists, first we check for operstate file. If this file is present, then we check if the state is "up" or not. If the file itself is not present, then we know that it is a v-switch, so we can now look for ifindex file and make a decision whether the port exists or not.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
To decide the existence of a port, check for status in the operstate file. If this file is not present check ifindex file.  

**- A picture of a cute animal (not mandatory but encouraged)**
