### PR TITLE
[Dell][Z9100]Added index for Z9100 C32 SKU

### DIFF
--- a/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/port_config.ini
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes                 alias
-Ethernet0       49,50,51,52           hundredGigE1/1
-Ethernet4       53,54,55,56           hundredGigE1/2
-Ethernet8       57,58,59,60           hundredGigE1/3
-Ethernet12      61,62,63,64           hundredGigE1/4
-Ethernet16      65,66,67,68           hundredGigE1/5
-Ethernet20      69,70,71,72           hundredGigE1/6
-Ethernet24      73,74,75,76           hundredGigE1/7
-Ethernet28      77,78,79,80           hundredGigE1/8
-Ethernet32      37,38,39,40           hundredGigE1/9
-Ethernet36      33,34,35,36           hundredGigE1/10
-Ethernet40      45,46,47,48           hundredGigE1/11
-Ethernet44      41,42,43,44           hundredGigE1/12
-Ethernet48      81,82,83,84           hundredGigE1/13
-Ethernet52      85,86,87,88           hundredGigE1/14
-Ethernet56      89,90,91,92           hundredGigE1/15
-Ethernet60      93,94,95,96           hundredGigE1/16
-Ethernet64      97,98,99,100          hundredGigE1/17
-Ethernet68      101,102,103,104       hundredGigE1/18
-Ethernet72      105,106,107,108       hundredGigE1/19
-Ethernet76      109,110,111,112       hundredGigE1/20
-Ethernet80      21,22,23,24           hundredGigE1/21
-Ethernet84      17,18,19,20           hundredGigE1/22
-Ethernet88      29,30,31,32           hundredGigE1/23
-Ethernet92      25,26,27,28           hundredGigE1/24
-Ethernet96      117,118,119,120       hundredGigE1/25
-Ethernet100     113,114,115,116       hundredGigE1/26
-Ethernet104     125,126,127,128       hundredGigE1/27
-Ethernet108     121,122,123,124       hundredGigE1/28
-Ethernet112     5,6,7,8               hundredGigE1/29
-Ethernet116     1,2,3,4               hundredGigE1/30
-Ethernet120     13,14,15,16           hundredGigE1/31
-Ethernet124     9,10,11,12            hundredGigE1/32
+# name          lanes                 alias              index
+Ethernet0       49,50,51,52           hundredGigE1/1     1
+Ethernet4       53,54,55,56           hundredGigE1/2     2
+Ethernet8       57,58,59,60           hundredGigE1/3     3
+Ethernet12      61,62,63,64           hundredGigE1/4     4
+Ethernet16      65,66,67,68           hundredGigE1/5     5
+Ethernet20      69,70,71,72           hundredGigE1/6     6
+Ethernet24      73,74,75,76           hundredGigE1/7     7
+Ethernet28      77,78,79,80           hundredGigE1/8     8
+Ethernet32      37,38,39,40           hundredGigE1/9     9
+Ethernet36      33,34,35,36           hundredGigE1/10    10
+Ethernet40      45,46,47,48           hundredGigE1/11    11
+Ethernet44      41,42,43,44           hundredGigE1/12    12
+Ethernet48      81,82,83,84           hundredGigE1/13    13
+Ethernet52      85,86,87,88           hundredGigE1/14    14
+Ethernet56      89,90,91,92           hundredGigE1/15    15
+Ethernet60      93,94,95,96           hundredGigE1/16    16
+Ethernet64      97,98,99,100          hundredGigE1/17    17
+Ethernet68      101,102,103,104       hundredGigE1/18    18
+Ethernet72      105,106,107,108       hundredGigE1/19    19
+Ethernet76      109,110,111,112       hundredGigE1/20    20
+Ethernet80      21,22,23,24           hundredGigE1/21    21
+Ethernet84      17,18,19,20           hundredGigE1/22    22
+Ethernet88      29,30,31,32           hundredGigE1/23    23
+Ethernet92      25,26,27,28           hundredGigE1/24    24
+Ethernet96      117,118,119,120       hundredGigE1/25    25
+Ethernet100     113,114,115,116       hundredGigE1/26    26
+Ethernet104     125,126,127,128       hundredGigE1/27    27
+Ethernet108     121,122,123,124       hundredGigE1/28    28
+Ethernet112     5,6,7,8               hundredGigE1/29    29
+Ethernet116     1,2,3,4               hundredGigE1/30    30
+Ethernet120     13,14,15,16           hundredGigE1/31    31
+Ethernet124     9,10,11,12            hundredGigE1/32    32

--- a/device/dell/x86_64-dell_z9100_c2538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/plugins/sfputil.py
@@ -78,7 +78,7 @@ class SfpUtil(SfpUtilBase):
 
     @property
     def qsfp_ports(self):
-        return range(0, self.PORTS_IN_BLOCK + 1)
+        return range(self.PORT_START, self.PORTS_IN_BLOCK + 1)
 
     @property
     def iom1_port_start(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The port_config.ini file missed the index information. Added it and also fixed qsfp_ports API in sfputil

**- How I did it**
Modified port_config.ini to include index column

**- How to verify it**
Plug in transceiver and check if it is detected on correct port

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added index for Z9100 C32 SKU

**- A picture of a cute animal (not mandatory but encouraged)**
