### PR TITLE
[Accton AS7326]: Add lpmode in sfputil.py

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/plugins/sfputil.py
@@ -5,6 +5,8 @@
 
 try:
     import time
+    import string
+    from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
@@ -193,11 +195,63 @@ class SfpUtil(SfpUtilBase):
 
         return False
 
-    def get_low_power_mode(self, port_num):             
-        raise NotImplementedError
+    def get_low_power_mode(self, port_num):
+        # Check for invalid port_num
+        if port_num < self.qsfp_port_start or port_num > self.qsfp_port_end:
+            return False
 
-    def set_low_power_mode(self, port_num, lpmode):                
-        raise NotImplementedError
+        try:
+            eeprom = None
+
+            if not self.get_presence(port_num):
+                return False
+
+            eeprom = open(self.port_to_eeprom_mapping[port_num], "rb")
+            eeprom.seek(93)
+            lpmode = ord(eeprom.read(1))
+
+            if ((lpmode & 0x3) == 0x1):
+                return False # High Power Mode if "Power override" bit is 1 and "Power set" bit is 0
+            else:
+                return True # Low Power Mode if one of the following conditions is matched:
+                            # 1. Power override" bit is 0
+                            # 2. Power override" bit is 1 and "Power set" bit is 1
+        except IOError as e:
+            print "Error: unable to open file: %s" % str(e)
+            return False
+        finally:
+            if eeprom is not None:
+                eeprom.close()
+                time.sleep(0.01)
+
+    def set_low_power_mode(self, port_num, lpmode): 
+        # Check for invalid port_num
+        if port_num < self.qsfp_port_start or port_num > self.qsfp_port_end:
+            return False
+
+        try:
+            eeprom = None
+
+            if not self.get_presence(port_num):
+                return False # Port is not present, unable to set the eeprom
+
+            # Fill in write buffer
+            regval = 0x3 if lpmode else 0x1 # 0x3:Low Power Mode, 0x1:High Power Mode
+            buffer = create_string_buffer(1)
+            buffer[0] = chr(regval)
+
+            # Write to eeprom
+            eeprom = open(self.port_to_eeprom_mapping[port_num], "r+b")
+            eeprom.seek(93)
+            eeprom.write(buffer[0])
+            return True
+        except IOError as e:
+            print "Error: unable to open file: %s" % str(e)
+            return False
+        finally:
+            if eeprom is not None:
+                eeprom.close()
+                time.sleep(0.01)
 
     def reset(self, port_num):
         raise NotImplementedError


### PR DESCRIPTION
CPU: Intel Broadwell-DE XeonD-1518 1.6G 4 Core
MAC: Broadcom Trident3 BCM56873
BMC: None	

- What I did
Add lpmode in sfputil.py for as7326-56x.

- How I did it
Implement get_low_power_mode/set_low_power_mode in sfputil.py

- How to verify it
sfputil show lpmode
sfputil lpmode off
sfputil lpmode on

- Description for the changelog
Access eeprom from transceiver to get/set lpmode status
If "Power override" bit is not set, return the H/W pin status depended on H/W design.
For as7326-56x, this pin is pulled high which is Low Power Mode.
If "Power override" bit is set, retrun the S/W lpmode status read from eeprom.

Below is the Power Mode Truth Table defined in sff-8436

LPMode_Pin    Power_overide_Bit    Power_set_Bit    Module_Power_Allowed
    1               0                    X              Low Power
    0               0                    X              High Power
    X               1                    1              Low Power
    X               1                    0              High Power 