### PR TITLE
Add a unit test in sonic-cfggen to test argument "--var-json"

### DIFF
--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -65,6 +65,11 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'value1')
 
+    def test_var_json_data(self):
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" --var-json VLAN_MEMBER'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), '{\n    "Vlan1000|Ethernet8": {\n        "tagging_mode": "untagged"\n    }\n}')
+
     def test_read_yaml(self):
         argument = '-v yml_item -y ' + os.path.join(self.test_dir, 'test.yml')
         output = self.run_script(argument)


### PR DESCRIPTION
**- What I did**
Adding a unit test in sonic-cfggen to test argument `--var-json`

**- How I did it**
Modifying file test_cfggen.py in sonic-cfggen's unit test to test argument `--var-json` of sonic-cfggen

**- How to verify it**
Executing following commands in sequence and there is no error occurs:
```
1. make target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl-clean
2. make target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl
```
