### PR TITLE
[mellanox]: Fixed SDK build: added missing SWIG dependency

### DIFF
--- a/platform/mellanox/sdk.mk
+++ b/platform/mellanox/sdk.mk
@@ -62,7 +62,7 @@ $(eval $(call add_derived_package,$(SXD_LIBS),$(SXD_LIBS_DEV)))
 #packages that are required for runtime only
 PYTHON_SDK_API = python-sdk-api_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(PYTHON_SDK_API)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/python-sdk-api
-$(PYTHON_SDK_API)_DEPENDS += $(APPLIBS_DEV) $(SXD_LIBS_DEV)
+$(PYTHON_SDK_API)_DEPENDS += $(APPLIBS_DEV) $(SXD_LIBS_DEV) $(SWIG)
 $(PYTHON_SDK_API)_RDEPENDS += $(APPLIBS) $(SXD_LIBS)
 
 SX_KERNEL = sx-kernel_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

**- What I did**
* Fixed Mellanox SDK build

**- How I did it**
* Added missing SWIG dependency

**- How to verify it**
1. make configure PLATFORM=mellanox
2. make mlnx-sdk-packages

**- Description for the changelog**
* N/A