### PR TITLE
Export reboot_reason sysfs attribute for DellEMC S6100/Z9100

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
+++ b/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
@@ -45,6 +45,7 @@
 #define SMF_READ_DATA_REG_OFFSET    2
 #define SMF_REG_ADDR            0x200
 #define SMF_PROBE_ADDR          0x210
+#define SMF_RST_SRC_REG         0x20A
 
 #define SIO_REG_DEVID           0x1
 #define SIO_Z9100_ID            0x1
@@ -499,6 +500,23 @@ static ssize_t show_smf_version(struct device *dev,
     }
 
     return ret;
+}
+
+
+/* SMF Reset Reason */
+static ssize_t show_reset_reason(struct device *dev,
+                struct device_attribute *devattr, char *buf)
+{
+    int              index = to_sensor_dev_attr(devattr)->index;
+    unsigned int     ret = 0, val = 0;
+    struct smf_data *data = dev_get_drvdata(dev);
+
+    ret = inb(SMF_RST_SRC_REG);
+
+    if(ret < 0)
+       return ret;
+
+    return sprintf(buf, "%x\n", ret);
 }
 
 
@@ -1779,10 +1797,14 @@ static SENSOR_DEVICE_ATTR(current_total_power, S_IRUGO, show_psu, NULL, 10);
 static SENSOR_DEVICE_ATTR(smf_version, S_IRUGO, show_smf_version, NULL, 0);
 static SENSOR_DEVICE_ATTR(smf_firmware_ver, S_IRUGO, show_smf_version, NULL, 1);
 
+/* SMF Reset Reason */
+static SENSOR_DEVICE_ATTR(smf_reset_reason, S_IRUGO, show_reset_reason, NULL, 1);
+
 
 static struct attribute *smf_dell_attrs[] = {
         &sensor_dev_attr_smf_version.dev_attr.attr,
         &sensor_dev_attr_smf_firmware_ver.dev_attr.attr,
+        &sensor_dev_attr_smf_reset_reason.dev_attr.attr,
         &sensor_dev_attr_fan_tray_presence.dev_attr.attr,
         &sensor_dev_attr_fan1_airflow.dev_attr.attr,
         &sensor_dev_attr_fan3_airflow.dev_attr.attr,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
-Added sysfs attribute to export reboot-cause register.

**- How I did it**
- smf_reset_reason attribute is exported in hwmon.

**- How to verify it**
- **warm reboot**
root@sonic:/sys/devices/platform/SMF.512/hwmon/hwmon1# cat smf_reset_reason
55
- **watchdog reboot**
root@sonic:/home/admin# cat /sys/devices/platform/SMF.512/hwmon/hwmon0/smf_reset_reason
 33
root@sonic:/home/admin#

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
