### PR TITLE
show interface status command fails when port-channel exists.

### DIFF
--- a/device/accton/x86_64-accton_as5712_54x-r0/Accton-AS5712-54X/port_config.ini
+++ b/device/accton/x86_64-accton_as5712_54x-r0/Accton-AS5712-54X/port_config.ini
@@ -1,73 +1,73 @@
-# name         lanes              alias         index
-Ethernet0      13                 tenGigE0      0
-Ethernet1      14                 tenGigE1      1
-Ethernet2      15                 tenGigE2      2
-Ethernet3      16                 tenGigE3      3
-Ethernet4      21                 tenGigE4      4
-Ethernet5      22                 tenGigE5      5
-Ethernet6      23                 tenGigE6      6
-Ethernet7      24                 tenGigE7      7
-Ethernet8      25                 tenGigE8      8
-Ethernet9      26                 tenGigE9      9
-Ethernet10     27                 tenGigE10     10
-Ethernet11     28                 tenGigE11     11
-Ethernet12     29                 tenGigE12     12
-Ethernet13     30                 tenGigE13     13
-Ethernet14     31                 tenGigE14     14
-Ethernet15     32                 tenGigE15     15
-Ethernet16     45                 tenGigE16     16
-Ethernet17     46                 tenGigE17     17
-Ethernet18     47                 tenGigE18     18
-Ethernet19     48                 tenGigE19     19
-Ethernet20     49                 tenGigE20     20
-Ethernet21     50                 tenGigE21     21
-Ethernet22     51                 tenGigE22     22
-Ethernet23     52                 tenGigE23     23
-Ethernet24     53                 tenGigE24     24
-Ethernet25     54                 tenGigE25     25
-Ethernet26     55                 tenGigE26     26
-Ethernet27     56                 tenGigE27     27
-Ethernet28     57                 tenGigE28     28
-Ethernet29     58                 tenGigE29     29
-Ethernet30     59                 tenGigE30     30
-Ethernet31     60                 tenGigE31     31
-Ethernet32     61                 tenGigE32     32
-Ethernet33     62                 tenGigE33     33
-Ethernet34     63                 tenGigE34     34
-Ethernet35     64                 tenGigE35     35
-Ethernet36     65                 tenGigE36     36
-Ethernet37     66                 tenGigE37     37
-Ethernet38     67                 tenGigE38     38
-Ethernet39     68                 tenGigE39     39
-Ethernet40     69                 tenGigE40     40
-Ethernet41     70                 tenGigE41     41
-Ethernet42     71                 tenGigE42     42
-Ethernet43     72                 tenGigE43     43
-Ethernet44     73                 tenGigE44     44
-Ethernet45     74                 tenGigE45     45
-Ethernet46     75                 tenGigE46     46
-Ethernet47     76                 tenGigE47     47
-Ethernet48     97                 tenGigE48     48
-Ethernet49     98                 tenGigE49     49
-Ethernet50     99                 tenGigE50     50
-Ethernet51     100                tenGigE51     51
-Ethernet52     101                tenGigE52     52
-Ethernet53     102                tenGigE53     53
-Ethernet54     103                tenGigE54     54
-Ethernet55     104                tenGigE55     55
-Ethernet56     81                 tenGigE56     56
-Ethernet57     82                 tenGigE57     57
-Ethernet58     83                 tenGigE58     58
-Ethernet59     84                 tenGigE59     59
-Ethernet60     105                tenGigE60     60
-Ethernet61     106                tenGigE61     61
-Ethernet62     107                tenGigE62     62
-Ethernet63     108                tenGigE63     63
-Ethernet64     109                tenGigE64     64
-Ethernet65     110                tenGigE65     65
-Ethernet66     111                tenGigE66     66
-Ethernet67     112                tenGigE67     67
-Ethernet68     77                 tenGigE68     68
-Ethernet69     78                 tenGigE69     69
-Ethernet70     79                 tenGigE70     70
-Ethernet71     80                 tenGigE71     71
+# name         lanes              alias         index       speed
+Ethernet0      13                 tenGigE0      0           10000
+Ethernet1      14                 tenGigE1      1           10000
+Ethernet2      15                 tenGigE2      2           10000
+Ethernet3      16                 tenGigE3      3           10000
+Ethernet4      21                 tenGigE4      4           10000
+Ethernet5      22                 tenGigE5      5           10000
+Ethernet6      23                 tenGigE6      6           10000
+Ethernet7      24                 tenGigE7      7           10000
+Ethernet8      25                 tenGigE8      8           10000
+Ethernet9      26                 tenGigE9      9           10000
+Ethernet10     27                 tenGigE10     10          10000
+Ethernet11     28                 tenGigE11     11          10000
+Ethernet12     29                 tenGigE12     12          10000
+Ethernet13     30                 tenGigE13     13          10000
+Ethernet14     31                 tenGigE14     14          10000
+Ethernet15     32                 tenGigE15     15          10000
+Ethernet16     45                 tenGigE16     16          10000
+Ethernet17     46                 tenGigE17     17          10000
+Ethernet18     47                 tenGigE18     18          10000
+Ethernet19     48                 tenGigE19     19          10000
+Ethernet20     49                 tenGigE20     20          10000
+Ethernet21     50                 tenGigE21     21          10000
+Ethernet22     51                 tenGigE22     22          10000
+Ethernet23     52                 tenGigE23     23          10000
+Ethernet24     53                 tenGigE24     24          10000
+Ethernet25     54                 tenGigE25     25          10000
+Ethernet26     55                 tenGigE26     26          10000
+Ethernet27     56                 tenGigE27     27          10000
+Ethernet28     57                 tenGigE28     28          10000
+Ethernet29     58                 tenGigE29     29          10000
+Ethernet30     59                 tenGigE30     30          10000
+Ethernet31     60                 tenGigE31     31          10000
+Ethernet32     61                 tenGigE32     32          10000
+Ethernet33     62                 tenGigE33     33          10000
+Ethernet34     63                 tenGigE34     34          10000
+Ethernet35     64                 tenGigE35     35          10000
+Ethernet36     65                 tenGigE36     36          10000
+Ethernet37     66                 tenGigE37     37          10000
+Ethernet38     67                 tenGigE38     38          10000
+Ethernet39     68                 tenGigE39     39          10000
+Ethernet40     69                 tenGigE40     40          10000
+Ethernet41     70                 tenGigE41     41          10000
+Ethernet42     71                 tenGigE42     42          10000
+Ethernet43     72                 tenGigE43     43          10000
+Ethernet44     73                 tenGigE44     44          10000
+Ethernet45     74                 tenGigE45     45          10000
+Ethernet46     75                 tenGigE46     46          10000
+Ethernet47     76                 tenGigE47     47          10000
+Ethernet48     97                 tenGigE48     48          10000
+Ethernet49     98                 tenGigE49     49          10000
+Ethernet50     99                 tenGigE50     50          10000
+Ethernet51     100                tenGigE51     51          10000
+Ethernet52     101                tenGigE52     52          10000
+Ethernet53     102                tenGigE53     53          10000
+Ethernet54     103                tenGigE54     54          10000
+Ethernet55     104                tenGigE55     55          10000
+Ethernet56     81                 tenGigE56     56          10000
+Ethernet57     82                 tenGigE57     57          10000
+Ethernet58     83                 tenGigE58     58          10000
+Ethernet59     84                 tenGigE59     59          10000
+Ethernet60     105                tenGigE60     60          10000
+Ethernet61     106                tenGigE61     61          10000
+Ethernet62     107                tenGigE62     62          10000
+Ethernet63     108                tenGigE63     63          10000
+Ethernet64     109                tenGigE64     64          10000
+Ethernet65     110                tenGigE65     65          10000
+Ethernet66     111                tenGigE66     66          10000
+Ethernet67     112                tenGigE67     67          10000
+Ethernet68     77                 tenGigE68     68          10000
+Ethernet69     78                 tenGigE69     69          10000
+Ethernet70     79                 tenGigE70     70          10000
+Ethernet71     80                 tenGigE71     71          10000

--- a/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/port_config.ini
+++ b/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/port_config.ini
@@ -1,57 +1,57 @@
-# name          lanes                 alias             index
-Ethernet0       3                     twentyfiveGigE1   0
-Ethernet1       2                     twentyfiveGigE2   1
-Ethernet2       4                     twentyfiveGigE3   2
-Ethernet3       8                     twentyfiveGigE4   3
-Ethernet4       7                     twentyfiveGigE5   4
-Ethernet5       1                     twentyfiveGigE6   5
-Ethernet6       5                     twentyfiveGigE7   6
-Ethernet7       16                    twentyfiveGigE8   7
-Ethernet8       6                     twentyfiveGigE9   8
-Ethernet9       14                    twentyfiveGigE10  9
-Ethernet10      13                    twentyfiveGigE11  10
-Ethernet11      15                    twentyfiveGigE12  11
-Ethernet12      23                    twentyfiveGigE13  12
-Ethernet13      22                    twentyfiveGigE14  13
-Ethernet14      24                    twentyfiveGigE15  14
-Ethernet15      32                    twentyfiveGigE16  15
-Ethernet16      31                    twentyfiveGigE17  16
-Ethernet17      21                    twentyfiveGigE18  17
-Ethernet18      29                    twentyfiveGigE19  18
-Ethernet19      36                    twentyfiveGigE20  19
-Ethernet20      30                    twentyfiveGigE21  20
-Ethernet21      34                    twentyfiveGigE22  21
-Ethernet22      33                    twentyfiveGigE23  22
-Ethernet23      35                    twentyfiveGigE24  23
-Ethernet24      43                    twentyfiveGigE25  24
-Ethernet25      42                    twentyfiveGigE26  25
-Ethernet26      44                    twentyfiveGigE27  26
-Ethernet27      52                    twentyfiveGigE28  27
-Ethernet28      51                    twentyfiveGigE29  28
-Ethernet29      41                    twentyfiveGigE30  29
-Ethernet30      49                    twentyfiveGigE31  30
-Ethernet31      60                    twentyfiveGigE32  31
-Ethernet32      50                    twentyfiveGigE33  32
-Ethernet33      58                    twentyfiveGigE34  33
-Ethernet34      57                    twentyfiveGigE35  34
-Ethernet35      59                    twentyfiveGigE36  35
-Ethernet36      62                    twentyfiveGigE37  36
-Ethernet37      63                    twentyfiveGigE38  37
-Ethernet38      64                    twentyfiveGigE39  38
-Ethernet39      65                    twentyfiveGigE40  39
-Ethernet40      66                    twentyfiveGigE41  40
-Ethernet41      61                    twentyfiveGigE42  41
-Ethernet42      68                    twentyfiveGigE43  42
-Ethernet43      69                    twentyfiveGigE44  43
-Ethernet44      67                    twentyfiveGigE45  44
-Ethernet45      71                    twentyfiveGigE46  45
-Ethernet46      72                    twentyfiveGigE47  46
-Ethernet47      70                    twentyfiveGigE48  47
-Ethernet48      77,78,79,80           hundredGigE49     48
-Ethernet52      85,86,87,88           hundredGigE50     52
-Ethernet56      93,94,95,96           hundredGigE51     56
-Ethernet60      97,98,99,100          hundredGigE52     60
-Ethernet64      105,106,107,108       hundredGigE53     64
-Ethernet68      113,114,115,116       hundredGigE54     68
-Ethernet72      121,122,123,124       hundredGigE55     72
-Ethernet76      125,126,127,128       hundredGigE56     76
+# name          lanes                 alias             index      speed
+Ethernet0       3                     twentyfiveGigE1   0          25000
+Ethernet1       2                     twentyfiveGigE2   1          25000
+Ethernet2       4                     twentyfiveGigE3   2          25000
+Ethernet3       8                     twentyfiveGigE4   3          25000
+Ethernet4       7                     twentyfiveGigE5   4          25000
+Ethernet5       1                     twentyfiveGigE6   5          25000
+Ethernet6       5                     twentyfiveGigE7   6          25000
+Ethernet7       16                    twentyfiveGigE8   7          25000
+Ethernet8       6                     twentyfiveGigE9   8          25000
+Ethernet9       14                    twentyfiveGigE10  9          25000
+Ethernet10      13                    twentyfiveGigE11  10         25000
+Ethernet11      15                    twentyfiveGigE12  11         25000
+Ethernet12      23                    twentyfiveGigE13  12         25000
+Ethernet13      22                    twentyfiveGigE14  13         25000
+Ethernet14      24                    twentyfiveGigE15  14         25000
+Ethernet15      32                    twentyfiveGigE16  15         25000
+Ethernet16      31                    twentyfiveGigE17  16         25000
+Ethernet17      21                    twentyfiveGigE18  17         25000
+Ethernet18      29                    twentyfiveGigE19  18         25000
+Ethernet19      36                    twentyfiveGigE20  19         25000
+Ethernet20      30                    twentyfiveGigE21  20         25000
+Ethernet21      34                    twentyfiveGigE22  21         25000
+Ethernet22      33                    twentyfiveGigE23  22         25000
+Ethernet23      35                    twentyfiveGigE24  23         25000
+Ethernet24      43                    twentyfiveGigE25  24         25000
+Ethernet25      42                    twentyfiveGigE26  25         25000
+Ethernet26      44                    twentyfiveGigE27  26         25000
+Ethernet27      52                    twentyfiveGigE28  27         25000
+Ethernet28      51                    twentyfiveGigE29  28         25000
+Ethernet29      41                    twentyfiveGigE30  29         25000
+Ethernet30      49                    twentyfiveGigE31  30         25000
+Ethernet31      60                    twentyfiveGigE32  31         25000
+Ethernet32      50                    twentyfiveGigE33  32         25000
+Ethernet33      58                    twentyfiveGigE34  33         25000
+Ethernet34      57                    twentyfiveGigE35  34         25000
+Ethernet35      59                    twentyfiveGigE36  35         25000
+Ethernet36      62                    twentyfiveGigE37  36         25000
+Ethernet37      63                    twentyfiveGigE38  37         25000
+Ethernet38      64                    twentyfiveGigE39  38         25000
+Ethernet39      65                    twentyfiveGigE40  39         25000
+Ethernet40      66                    twentyfiveGigE41  40         25000
+Ethernet41      61                    twentyfiveGigE42  41         25000
+Ethernet42      68                    twentyfiveGigE43  42         25000
+Ethernet43      69                    twentyfiveGigE44  43         25000
+Ethernet44      67                    twentyfiveGigE45  44         25000
+Ethernet45      71                    twentyfiveGigE46  45         25000
+Ethernet46      72                    twentyfiveGigE47  46         25000
+Ethernet47      70                    twentyfiveGigE48  47         25000
+Ethernet48      77,78,79,80           hundredGigE49     48         100000
+Ethernet52      85,86,87,88           hundredGigE50     52         100000
+Ethernet56      93,94,95,96           hundredGigE51     56         100000
+Ethernet60      97,98,99,100          hundredGigE52     60         100000
+Ethernet64      105,106,107,108       hundredGigE53     64         100000
+Ethernet68      113,114,115,116       hundredGigE54     68         100000
+Ethernet72      121,122,123,124       hundredGigE55     72         100000
+Ethernet76      125,126,127,128       hundredGigE56     76         100000

--- a/device/accton/x86_64-accton_as7712_32x-r0/Accton-AS7712-32X/port_config.ini
+++ b/device/accton/x86_64-accton_as7712_32x-r0/Accton-AS7712-32X/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes                 alias
-Ethernet0       49,50,51,52           hundredGigE1
-Ethernet4       53,54,55,56           hundredGigE2
-Ethernet8       57,58,59,60           hundredGigE3
-Ethernet12      61,62,63,64           hundredGigE4
-Ethernet16      65,66,67,68           hundredGigE5
-Ethernet20      69,70,71,72           hundredGigE6
-Ethernet24      73,74,75,76           hundredGigE7
-Ethernet28      77,78,79,80           hundredGigE8
-Ethernet32      33,34,35,36           hundredGigE9
-Ethernet36      37,38,39,40           hundredGigE10
-Ethernet40      41,42,43,44           hundredGigE11
-Ethernet44      45,46,47,48           hundredGigE12
-Ethernet48      81,82,83,84           hundredGigE13
-Ethernet52      85,86,87,88           hundredGigE14
-Ethernet56      89,90,91,92           hundredGigE15
-Ethernet60      93,94,95,96           hundredGigE16
-Ethernet64      97,98,99,100          hundredGigE17
-Ethernet68      101,102,103,104       hundredGigE18
-Ethernet72      105,106,107,108       hundredGigE19
-Ethernet76      109,110,111,112       hundredGigE20
-Ethernet80      17,18,19,20           hundredGigE21
-Ethernet84      21,22,23,24           hundredGigE22
-Ethernet88      25,26,27,28           hundredGigE23
-Ethernet92      29,30,31,32           hundredGigE24
-Ethernet96      113,114,115,116       hundredGigE25
-Ethernet100     117,118,119,120       hundredGigE26
-Ethernet104     121,122,123,124       hundredGigE27
-Ethernet108     125,126,127,128       hundredGigE28
-Ethernet112     1,2,3,4               hundredGigE29
-Ethernet116     5,6,7,8               hundredGigE30
-Ethernet120     9,10,11,12            hundredGigE31
-Ethernet124     13,14,15,16           hundredGigE32
+# name          lanes                 alias              speed
+Ethernet0       49,50,51,52           hundredGigE1       100000
+Ethernet4       53,54,55,56           hundredGigE2       100000
+Ethernet8       57,58,59,60           hundredGigE3       100000
+Ethernet12      61,62,63,64           hundredGigE4       100000
+Ethernet16      65,66,67,68           hundredGigE5       100000
+Ethernet20      69,70,71,72           hundredGigE6       100000
+Ethernet24      73,74,75,76           hundredGigE7       100000
+Ethernet28      77,78,79,80           hundredGigE8       100000
+Ethernet32      33,34,35,36           hundredGigE9       100000
+Ethernet36      37,38,39,40           hundredGigE10      100000
+Ethernet40      41,42,43,44           hundredGigE11      100000
+Ethernet44      45,46,47,48           hundredGigE12      100000
+Ethernet48      81,82,83,84           hundredGigE13      100000
+Ethernet52      85,86,87,88           hundredGigE14      100000
+Ethernet56      89,90,91,92           hundredGigE15      100000
+Ethernet60      93,94,95,96           hundredGigE16      100000
+Ethernet64      97,98,99,100          hundredGigE17      100000
+Ethernet68      101,102,103,104       hundredGigE18      100000
+Ethernet72      105,106,107,108       hundredGigE19      100000
+Ethernet76      109,110,111,112       hundredGigE20      100000
+Ethernet80      17,18,19,20           hundredGigE21      100000
+Ethernet84      21,22,23,24           hundredGigE22      100000
+Ethernet88      25,26,27,28           hundredGigE23      100000
+Ethernet92      29,30,31,32           hundredGigE24      100000
+Ethernet96      113,114,115,116       hundredGigE25      100000
+Ethernet100     117,118,119,120       hundredGigE26      100000
+Ethernet104     121,122,123,124       hundredGigE27      100000
+Ethernet108     125,126,127,128       hundredGigE28      100000
+Ethernet112     1,2,3,4               hundredGigE29      100000
+Ethernet116     5,6,7,8               hundredGigE30      100000
+Ethernet120     9,10,11,12            hundredGigE31      100000
+Ethernet124     13,14,15,16           hundredGigE32      100000

--- a/device/accton/x86_64-accton_as7816_64x-r0/Accton-AS7816-64X/port_config.ini
+++ b/device/accton/x86_64-accton_as7816_64x-r0/Accton-AS7816-64X/port_config.ini
@@ -1,65 +1,65 @@
-# name          lanes                 alias
-Ethernet0       73,74,75,76           hundredGigE1
-Ethernet4       65,66,67,68           hundredGigE2
-Ethernet8       81,82,83,84           hundredGigE3
-Ethernet12      89,90,91,92           hundredGigE4
-Ethernet16      105,106,107,108       hundredGigE5
-Ethernet20      97,98,99,100          hundredGigE6
-Ethernet24      113,114,115,116       hundredGigE7
-Ethernet28      121,122,123,124       hundredGigE8
-Ethernet32      41,42,43,44           hundredGigE9
-Ethernet36      33,34,35,36           hundredGigE10
-Ethernet40      49,50,51,52           hundredGigE11
-Ethernet44      57,58,59,60           hundredGigE12
-Ethernet48      137,138,139,140       hundredGigE13
-Ethernet52      129,130,131,132       hundredGigE14
-Ethernet56      145,146,147,148       hundredGigE15
-Ethernet60      153,154,155,156       hundredGigE16
-Ethernet64      173,174,175,176       hundredGigE17
-Ethernet68      165,166,167,168       hundredGigE18
-Ethernet72      181,182,183,184       hundredGigE19
-Ethernet76      189,190,191,192       hundredGigE20
-Ethernet80      13,14,15,16           hundredGigE21
-Ethernet84      5,6,7,8               hundredGigE22
-Ethernet88      29,30,31,32           hundredGigE23
-Ethernet92      21,22,23,24           hundredGigE24
-Ethernet96      205,206,207,208       hundredGigE25
-Ethernet100     197,198,199,200       hundredGigE26
-Ethernet104     213,214,215,216       hundredGigE27
-Ethernet108     221,222,223,224       hundredGigE28
-Ethernet112     229,230,231,232       hundredGigE29
-Ethernet116     237,238,239,240       hundredGigE30
-Ethernet120     245,246,247,248       hundredGigE31
-Ethernet124     253,254,255,256       hundredGigE32
-Ethernet128     69,70,71,72           hundredGigE33
-Ethernet132     77,78,79,80           hundredGigE34
-Ethernet136     93,94,95,96           hundredGigE35
-Ethernet140     85,86,87,88           hundredGigE36
-Ethernet144     101,102,103,104       hundredGigE37
-Ethernet148     109,110,111,112       hundredGigE38
-Ethernet152     125,126,127,128       hundredGigE39
-Ethernet156     117,118,119,120       hundredGigE40
-Ethernet160     37,38,39,40           hundredGigE41
-Ethernet164     45,46,47,48           hundredGigE42
-Ethernet168     61,62,63,64           hundredGigE43
-Ethernet172     53,54,55,56           hundredGigE44
-Ethernet176     133,134,135,136       hundredGigE45
-Ethernet180     141,142,143,144       hundredGigE46
-Ethernet184     157,158,159,160       hundredGigE47
-Ethernet188     149,150,151,152       hundredGigE48
-Ethernet192     161,162,163,164       hundredGigE49
-Ethernet196     169,170,171,172       hundredGigE50
-Ethernet200     185,186,187,188       hundredGigE51
-Ethernet204     177,178,179,180       hundredGigE52
-Ethernet208     1,2,3,4               hundredGigE53
-Ethernet212     9,10,11,12            hundredGigE54
-Ethernet216     25,26,27,28           hundredGigE55
-Ethernet220     17,18,19,20           hundredGigE56
-Ethernet224     193,194,195,196       hundredGigE57
-Ethernet228     201,202,203,204       hundredGigE58
-Ethernet232     217,218,219,220       hundredGigE59
-Ethernet236     209,210,211,212       hundredGigE60
-Ethernet240     225,226,227,228       hundredGigE61
-Ethernet244     233,234,235,236       hundredGigE62
-Ethernet248     249,250,251,252       hundredGigE63
-Ethernet252     241,242,243,244       hundredGigE64
+# name          lanes                 alias              speed
+Ethernet0       73,74,75,76           hundredGigE1       100000
+Ethernet4       65,66,67,68           hundredGigE2       100000
+Ethernet8       81,82,83,84           hundredGigE3       100000
+Ethernet12      89,90,91,92           hundredGigE4       100000
+Ethernet16      105,106,107,108       hundredGigE5       100000
+Ethernet20      97,98,99,100          hundredGigE6       100000
+Ethernet24      113,114,115,116       hundredGigE7       100000
+Ethernet28      121,122,123,124       hundredGigE8       100000
+Ethernet32      41,42,43,44           hundredGigE9       100000
+Ethernet36      33,34,35,36           hundredGigE10      100000
+Ethernet40      49,50,51,52           hundredGigE11      100000
+Ethernet44      57,58,59,60           hundredGigE12      100000
+Ethernet48      137,138,139,140       hundredGigE13      100000
+Ethernet52      129,130,131,132       hundredGigE14      100000
+Ethernet56      145,146,147,148       hundredGigE15      100000
+Ethernet60      153,154,155,156       hundredGigE16      100000
+Ethernet64      173,174,175,176       hundredGigE17      100000
+Ethernet68      165,166,167,168       hundredGigE18      100000
+Ethernet72      181,182,183,184       hundredGigE19      100000
+Ethernet76      189,190,191,192       hundredGigE20      100000
+Ethernet80      13,14,15,16           hundredGigE21      100000
+Ethernet84      5,6,7,8               hundredGigE22      100000
+Ethernet88      29,30,31,32           hundredGigE23      100000
+Ethernet92      21,22,23,24           hundredGigE24      100000
+Ethernet96      205,206,207,208       hundredGigE25      100000
+Ethernet100     197,198,199,200       hundredGigE26      100000
+Ethernet104     213,214,215,216       hundredGigE27      100000
+Ethernet108     221,222,223,224       hundredGigE28      100000
+Ethernet112     229,230,231,232       hundredGigE29      100000
+Ethernet116     237,238,239,240       hundredGigE30      100000
+Ethernet120     245,246,247,248       hundredGigE31      100000
+Ethernet124     253,254,255,256       hundredGigE32      100000
+Ethernet128     69,70,71,72           hundredGigE33      100000
+Ethernet132     77,78,79,80           hundredGigE34      100000
+Ethernet136     93,94,95,96           hundredGigE35      100000
+Ethernet140     85,86,87,88           hundredGigE36      100000
+Ethernet144     101,102,103,104       hundredGigE37      100000
+Ethernet148     109,110,111,112       hundredGigE38      100000
+Ethernet152     125,126,127,128       hundredGigE39      100000
+Ethernet156     117,118,119,120       hundredGigE40      100000
+Ethernet160     37,38,39,40           hundredGigE41      100000
+Ethernet164     45,46,47,48           hundredGigE42      100000
+Ethernet168     61,62,63,64           hundredGigE43      100000
+Ethernet172     53,54,55,56           hundredGigE44      100000
+Ethernet176     133,134,135,136       hundredGigE45      100000
+Ethernet180     141,142,143,144       hundredGigE46      100000
+Ethernet184     157,158,159,160       hundredGigE47      100000
+Ethernet188     149,150,151,152       hundredGigE48      100000
+Ethernet192     161,162,163,164       hundredGigE49      100000
+Ethernet196     169,170,171,172       hundredGigE50      100000
+Ethernet200     185,186,187,188       hundredGigE51      100000
+Ethernet204     177,178,179,180       hundredGigE52      100000
+Ethernet208     1,2,3,4               hundredGigE53      100000
+Ethernet212     9,10,11,12            hundredGigE54      100000
+Ethernet216     25,26,27,28           hundredGigE55      100000
+Ethernet220     17,18,19,20           hundredGigE56      100000
+Ethernet224     193,194,195,196       hundredGigE57      100000
+Ethernet228     201,202,203,204       hundredGigE58      100000
+Ethernet232     217,218,219,220       hundredGigE59      100000
+Ethernet236     209,210,211,212       hundredGigE60      100000
+Ethernet240     225,226,227,228       hundredGigE61      100000
+Ethernet244     233,234,235,236       hundredGigE62      100000
+Ethernet248     249,250,251,252       hundredGigE63      100000
+Ethernet252     241,242,243,244       hundredGigE64      100000

--- a/device/delta/x86_64-delta_ag9032v1-r0/Delta-ag9032v1/port_config.ini
+++ b/device/delta/x86_64-delta_ag9032v1-r0/Delta-ag9032v1/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes                 alias
-Ethernet0       41,42,43,44           hundredGigE1/1
-Ethernet4       45,46,47,48           hundredGigE1/2
-Ethernet8       49,50,51,52           hundredGigE1/3
-Ethernet12      37,38,39,40           hundredGigE1/4
-Ethernet16      33,34,35,36           hundredGigE1/5
-Ethernet20      53,54,55,56           hundredGigE1/6
-Ethernet24      57,58,59,60           hundredGigE1/7
-Ethernet28      61,62,63,64           hundredGigE1/8
-Ethernet32      65,66,67,68           hundredGigE1/9
-Ethernet36      69,70,71,72           hundredGigE1/10
-Ethernet40      73,74,75,76           hundredGigE1/11
-Ethernet44      77,78,79,80           hundredGigE1/12
-Ethernet48      81,82,83,84           hundredGigE1/13
-Ethernet52      85,86,87,88           hundredGigE1/14
-Ethernet56      89,90,91,92           hundredGigE1/15
-Ethernet60      93,94,95,96           hundredGigE1/16
-Ethernet64      97,98,99,100          hundredGigE1/17
-Ethernet68      101,102,103,104       hundredGigE1/18
-Ethernet72      105,106,107,108       hundredGigE1/19
-Ethernet76      109,110,111,112       hundredGigE1/20
-Ethernet80      121,122,123,124       hundredGigE1/21
-Ethernet84      113,114,115,116       hundredGigE1/22
-Ethernet88      1,2,3,4               hundredGigE1/23
-Ethernet92      117,118,119,120       hundredGigE1/24
-Ethernet96      5,6,7,8               hundredGigE1/25
-Ethernet100     125,126,127,128       hundredGigE1/26
-Ethernet104     29,30,31,32           hundredGigE1/27
-Ethernet108     9,10,11,12            hundredGigE1/28
-Ethernet112     13,14,15,16           hundredGigE1/29
-Ethernet116     25,26,27,28           hundredGigE1/30
-Ethernet120     17,18,19,20           hundredGigE1/31
-Ethernet124     21,22,23,24           hundredGigE1/32
+# name          lanes                 alias                speed
+Ethernet0       41,42,43,44           hundredGigE1/1       100000
+Ethernet4       45,46,47,48           hundredGigE1/2       100000
+Ethernet8       49,50,51,52           hundredGigE1/3       100000
+Ethernet12      37,38,39,40           hundredGigE1/4       100000
+Ethernet16      33,34,35,36           hundredGigE1/5       100000
+Ethernet20      53,54,55,56           hundredGigE1/6       100000
+Ethernet24      57,58,59,60           hundredGigE1/7       100000
+Ethernet28      61,62,63,64           hundredGigE1/8       100000
+Ethernet32      65,66,67,68           hundredGigE1/9       100000
+Ethernet36      69,70,71,72           hundredGigE1/10      100000
+Ethernet40      73,74,75,76           hundredGigE1/11      100000
+Ethernet44      77,78,79,80           hundredGigE1/12      100000
+Ethernet48      81,82,83,84           hundredGigE1/13      100000
+Ethernet52      85,86,87,88           hundredGigE1/14      100000
+Ethernet56      89,90,91,92           hundredGigE1/15      100000
+Ethernet60      93,94,95,96           hundredGigE1/16      100000
+Ethernet64      97,98,99,100          hundredGigE1/17      100000
+Ethernet68      101,102,103,104       hundredGigE1/18      100000
+Ethernet72      105,106,107,108       hundredGigE1/19      100000
+Ethernet76      109,110,111,112       hundredGigE1/20      100000
+Ethernet80      121,122,123,124       hundredGigE1/21      100000
+Ethernet84      113,114,115,116       hundredGigE1/22      100000
+Ethernet88      1,2,3,4               hundredGigE1/23      100000
+Ethernet92      117,118,119,120       hundredGigE1/24      100000
+Ethernet96      5,6,7,8               hundredGigE1/25      100000
+Ethernet100     125,126,127,128       hundredGigE1/26      100000
+Ethernet104     29,30,31,32           hundredGigE1/27      100000
+Ethernet108     9,10,11,12            hundredGigE1/28      100000
+Ethernet112     13,14,15,16           hundredGigE1/29      100000
+Ethernet116     25,26,27,28           hundredGigE1/30      100000
+Ethernet120     17,18,19,20           hundredGigE1/31      100000
+Ethernet124     21,22,23,24           hundredGigE1/32      100000

--- a/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/Quanta-IX1B-32X/port_config.ini
+++ b/device/quanta/x86_64-quanta_ix1b_rglbmc-r0/Quanta-IX1B-32X/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes                 alias
-Ethernet0       65,66,67,68           hundredGigE1
-Ethernet4       69,70,71,72           hundredGigE2
-Ethernet8       73,74,75,76           hundredGigE3
-Ethernet12      77,78,79,80           hundredGigE4
-Ethernet16      45,46,47,48           hundredGigE5
-Ethernet20      41,42,43,44           hundredGigE6
-Ethernet24      53,54,55,56           hundredGigE7
-Ethernet28      49,50,51,52           hundredGigE8
-Ethernet32      61,62,63,64           hundredGigE9
-Ethernet36      57,58,59,60           hundredGigE10
-Ethernet40      37,38,39,40           hundredGigE11
-Ethernet44      33,34,35,36           hundredGigE12
-Ethernet48      81,82,83,84           hundredGigE13
-Ethernet52      85,86,87,88           hundredGigE14
-Ethernet56      89,90,91,92           hundredGigE15
-Ethernet60      93,94,95,96           hundredGigE16
-Ethernet64      97,98,99,100          hundredGigE17
-Ethernet68      101,102,103,104       hundredGigE18
-Ethernet72      105,106,107,108       hundredGigE19
-Ethernet76      109,110,111,112       hundredGigE20
-Ethernet80      29,30,31,32           hundredGigE21
-Ethernet84      25,26,27,28           hundredGigE22
-Ethernet88      5,6,7,8               hundredGigE23
-Ethernet92      1,2,3,4               hundredGigE24
-Ethernet96      13,14,15,16           hundredGigE25
-Ethernet100     9,10,11,12            hundredGigE26
-Ethernet104     21,22,23,24           hundredGigE27
-Ethernet108     17,18,19,20           hundredGigE28
-Ethernet112     113,114,115,116       hundredGigE29
-Ethernet116     117,118,119,120       hundredGigE30
-Ethernet120     121,122,123,124       hundredGigE31
-Ethernet124     125,126,127,128       hundredGigE32
+# name          lanes                 alias                 speed
+Ethernet0       65,66,67,68           hundredGigE1          100000
+Ethernet4       69,70,71,72           hundredGigE2          100000
+Ethernet8       73,74,75,76           hundredGigE3          100000
+Ethernet12      77,78,79,80           hundredGigE4          100000
+Ethernet16      45,46,47,48           hundredGigE5          100000
+Ethernet20      41,42,43,44           hundredGigE6          100000
+Ethernet24      53,54,55,56           hundredGigE7          100000
+Ethernet28      49,50,51,52           hundredGigE8          100000
+Ethernet32      61,62,63,64           hundredGigE9          100000
+Ethernet36      57,58,59,60           hundredGigE10         100000
+Ethernet40      37,38,39,40           hundredGigE11         100000
+Ethernet44      33,34,35,36           hundredGigE12         100000
+Ethernet48      81,82,83,84           hundredGigE13         100000
+Ethernet52      85,86,87,88           hundredGigE14         100000
+Ethernet56      89,90,91,92           hundredGigE15         100000
+Ethernet60      93,94,95,96           hundredGigE16         100000
+Ethernet64      97,98,99,100          hundredGigE17         100000
+Ethernet68      101,102,103,104       hundredGigE18         100000
+Ethernet72      105,106,107,108       hundredGigE19         100000
+Ethernet76      109,110,111,112       hundredGigE20         100000
+Ethernet80      29,30,31,32           hundredGigE21         100000
+Ethernet84      25,26,27,28           hundredGigE22         100000
+Ethernet88      5,6,7,8               hundredGigE23         100000
+Ethernet92      1,2,3,4               hundredGigE24         100000
+Ethernet96      13,14,15,16           hundredGigE25         100000
+Ethernet100     9,10,11,12            hundredGigE26         100000
+Ethernet104     21,22,23,24           hundredGigE27         100000
+Ethernet108     17,18,19,20           hundredGigE28         100000
+Ethernet112     113,114,115,116       hundredGigE29         100000
+Ethernet116     117,118,119,120       hundredGigE30         100000
+Ethernet120     121,122,123,124       hundredGigE31         100000
+Ethernet124     125,126,127,128       hundredGigE32         100000


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Made sure that the default port speed is been populated in config_db during first initialization for the hardware platforms, AS5712, AS7712, AS7816, AS7326, AG9032 and Quanta IX4.
**- How I did it**
Speed is been added in port_config.ini of the platforms - AS5712, AS7712, AS7816, AS7326, AG9032 and Quanta IX4
**- How to verify it**
1. Bring-up the system with an image having these changes.
2. show interface status - This should show default port speed for all the interfaces.
3. Create a port-channel
4. show interface status - this should show aggregate  speed of member ports as port-channel speed.

**- Description for the changelog**
Speed is been added in port_config.ini of the platforms - AS5712, AS7712, AS7816, AS7326, AG9032 and Quanta IX4

**- A picture of a cute animal (not mandatory but encouraged)**