### PR TITLE
[docker-vs]: Connect zebra with fpm and add staticd

### DIFF
--- a/platform/vs/docker-sonic-vs/supervisord.conf
+++ b/platform/vs/docker-sonic-vs/supervisord.conf
@@ -100,7 +100,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:zebra]
-command=/usr/lib/frr/zebra -A 127.0.0.1
+command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M fpm
 priority=13
 autostart=false
 autorestart=false
@@ -109,6 +109,14 @@ stderr_logfile=syslog
 
 [program:bgpd]
 command=/usr/lib/frr/bgpd -A 127.0.0.1
+priority=14
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+
+[program:staticd]
+command=/usr/lib/frr/staticd -A 127.0.0.1
 priority=14
 autostart=false
 autorestart=false


### PR DESCRIPTION
Since we move to FRR, we need to connect FRR with fpmsyncd via FPM.
Adding static routes is also required.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>