### PR TITLE
[mellanox]: Fixed config reload race

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -101,8 +101,13 @@ start() {
         fi
 
         if [[ x"$WARM_BOOT" != x"true" ]]; then
-            /bin/systemctl stop pmon
-            /usr/bin/hw-management.sh chipdown
+            if [[ x"$(/bin/systemctl is-active pmon)" == x"active" ]]; then
+                /bin/systemctl stop pmon
+                /usr/bin/hw-management.sh chipdown
+                /bin/systemctl restart pmon
+            else
+                /usr/bin/hw-management.sh chipdown
+            fi
         fi
 
         if [[ x"$BOOT_TYPE" == x"fast" ]]; then
@@ -112,10 +117,6 @@ start() {
         /usr/bin/mst start
         /usr/bin/mlnx-fw-upgrade.sh
         /etc/init.d/sxdkernel start
-
-        if [[ x"$WARM_BOOT" != x"true" ]]; then
-            /bin/systemctl start pmon
-        fi
     fi
 
     if [[ x"$WARM_BOOT" != x"true" ]]; then
@@ -127,10 +128,6 @@ start() {
     # start service docker
     /usr/bin/${SERVICE}.sh start
     debug "Started ${SERVICE} service..."
-
-    if [[ x"$sonic_asic_platform" == x"mellanox" && x"$BOOT_TYPE" == x"fast" ]]; then
-        /usr/bin/hw-management.sh chipupen
-    fi
 
     unlock_service_state_change
 }


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

**This PR propagates fix for config reload race:**
```bash
root@sonic:/etc/sonic# config load_minigraph -y
Running command: systemctl stop dhcp_relay
Running command: systemctl stop swss
Running command: systemctl stop snmp
Warning: Stopping snmp.service, but it can still be activated by:
snmp.timer
Running command: systemctl stop lldp
Running command: systemctl stop pmon
Running command: systemctl stop bgp
Running command: systemctl stop teamd
Running command: systemctl stop hostcfgd
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Running command: pfcwd start_default
Running command: config qos reload
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers.json.j2 >/tmp/buffers.json
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json.j2 -y /etc/sonic/sonic_version.yml >/tmp/qos.json
Running command: /usr/local/bin/sonic-cfggen -j /tmp/buffers.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -j /tmp/qos.json --write-to-db

Running command: systemctl restart hostname-config
Running command: systemctl restart interfaces-config
Running command: systemctl restart ntp-config
Running command: systemctl restart rsyslog-config
Running command: systemctl restart swss
Running command: systemctl restart bgp
Running command: systemctl restart teamd
Running command: systemctl restart pmon
Job for pmon.service canceled.
```

**The issue was introduced by these PRs:**
1. https://github.com/Azure/sonic-buildimage/pull/2639/files
2. https://github.com/Azure/sonic-buildimage/pull/2634/files

**- What I did**
* Fixed pmon restart race
* Removed redundant chipupen logic

**- How I did it**
* Added check to do pmon restart only if service is active

**- How to verify it**
1. config reload -y
2. systemctl restart swss

**- Description for the changelog**
* N/A