### PR TITLE
Check for broadcom platform sdk init ready during syncd start.

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/start.sh
+++ b/platform/broadcom/docker-syncd-brcm/start.sh
@@ -15,7 +15,20 @@ wait_syncd() {
     done
 
     # wait until bcm sdk is ready to get a request
-    sleep 3
+    counter=0
+    while true; do
+        /usr/bin/bcmcmd -t 1 "show unit" | grep BCM >/dev/null 2>&1
+        rv=$?
+        if [ $rv -eq 0 ]; then
+            break
+        fi
+        counter=$((counter+1))
+        if [ $counter -ge 60 ]; then
+            echo "syncd is not ready to take commands after $counter re-tries; Exiting!"
+            break
+        fi
+        sleep 1
+    done
 }
 
 


### PR DESCRIPTION
**- What I did**
During boot/reload time, wait in a loop to check for bcm initialization.
Break the loop, once sdk is ready to process the 'bcmcmd' request (or) loop count reached the maximum value. 

**- How I did it**
In the existing implementation during syncd start process will sleep for a fixed time (3 secs)
for sdk initialization to happen. But the time taken for sdk initialization is varying for different platforms.
To fix this issue, the syncd start process wait in a loop and check whether sdk is ready to process 'bcmcmd' command.

**- How to verify it**
Check for syncd process status and interface status.
Check for syslogs and no failures related to syncd should be present.
 
Without fix:
This issue is not seen on all platforms. 
When this issue is observed, the syncd initialization and ledinit are failed. The system is not in a ready state.
The show commands ('show interface status', 'show arp' etc) will not display any output.

The syslogs contains the below failure information.
2016-12-08 16:22:36,675 INFO success: ledinit entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2016-12-08 16:22:36,770 INFO exited: start.sh (exit status 0; expected)
2016-12-08 16:23:36,717 INFO exited: ledinit (exit status 62; not expected)
