### PR TITLE
[DELL]Optics related fixes in Dell Z9100/Z9264f platforms

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/z9100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/z9100_platform.sh
@@ -221,6 +221,10 @@ if [[ "$1" == "init" ]]; then
     #Copy led_proc_init.soc
     init_switch_port_led
 
+    value=0x0
+    echo $value > /sys/class/i2c-adapter/i2c-14/14-003e/qsfp_lpmode
+    echo $value > /sys/class/i2c-adapter/i2c-15/15-003e/qsfp_lpmode
+    echo $value > /sys/class/i2c-adapter/i2c-16/16-003e/qsfp_lpmode
 
 elif [[ "$1" == "deinit" ]]; then
     xcvr_presence_interrupts "disable"

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/scripts/z9264f_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/scripts/z9264f_platform.sh
@@ -82,7 +82,7 @@ switch_board_modsel() {
 	do
 		port_addr=$(( 16384 + ((i - 1) * 16)))
 		hex=$( printf "0x%x" $port_addr )
-		python /usr/bin/pcisysfs.py --set --offset $hex --val 0x41 --res $resource  > /dev/null 2>&1
+		python /usr/bin/pcisysfs.py --set --offset $hex --val 0x10 --res $resource  > /dev/null 2>&1
 	done
 }
 init_devnum


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixing optics issues in Z9100 and Z9264f Dell platforms
**- How I did it**
Z9100- The platform init is missing disabling low power mode during init. This was done in march branch. Ported the change and the links came up
Z9264f  - Disabled LP mode, moved ports out of reset and optical module transmitter output is turned on for SFP(which was disabled).

**- How to verify it**
Attaching the log outputs for z9100 and z9264f
[z9100-log.txt](https://github.com/Azure/sonic-buildimage/files/3210233/z9100-log.txt)
[z9264f-log.txt](https://github.com/Azure/sonic-buildimage/files/3210234/z9264f-log.txt)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Optics related fixes in Dell Z9100/Z9264f platforms

**- A picture of a cute animal (not mandatory but encouraged)**
