### PR TITLE
[Mellanox] Enable ISSU on MSN2410

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/sai_2410.xml
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/sai_2410.xml
@@ -5,6 +5,9 @@
 		<!-- Device MAC address  -->
 		<device-mac-address>00:02:03:04:05:00</device-mac-address>
 
+		<!-- ISSU enabled -->
+		<issu-enabled>1</issu-enabled>
+
 		<!-- Number of ports in the following port list -->
 		<number-of-physical-ports>56</number-of-physical-ports>
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enable ISSU on Mellanox MSN2410 device

**- How I did it**
Add ISSU enable config in sai_2410.xml

**- How to verify it**
run warm reboot test with MSN2410 device

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
