### PR TITLE
[logrotate] Enhance robustness

### DIFF
--- a/files/image_config/cron.d/logrotate
+++ b/files/image_config/cron.d/logrotate
@@ -1,2 +1,3 @@
-# Attempt to rotate system logs once per minute
-* * * * * root /usr/sbin/logrotate /etc/logrotate.conf > /dev/null 2>&1
+# Attempt to rotate system logs once every 10 minutes.
+# First kill any logrotate process(es) if they are still running, as they're most likely hung
+*/10 * * * * root /usr/bin/pkill -9 logrotate > /dev/null 2>&1; /usr/sbin/logrotate /etc/logrotate.conf > /dev/null 2>&1

--- a/files/image_config/logrotate/logrotate.d/rsyslog
+++ b/files/image_config/logrotate/logrotate.d/rsyslog
@@ -19,11 +19,7 @@
     delaycompress
     sharedscripts
     postrotate
-        # calling kill directly instead of 'service rsyslog rotate >/dev/null' due
-        # to bug in init-system-helpers. bug has apparently been fixed in v1.47.
-        # however, debian jessie is still using v1.22.
-        # see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=672218
-        kill -hup $(cat /var/run/rsyslogd.pid)
+        /bin/kill -HUP $(cat /var/run/rsyslogd.pid)
     endscript
 }
 
@@ -44,7 +40,7 @@
     compress
     delaycompress
     nosharedscripts
-    prerotate
+    firstaction
         # Adjust NUM_LOGS_TO_ROTATE to reflect number of log files that trigger this block specified above
         NUM_LOGS_TO_ROTATE=8
 
@@ -64,6 +60,10 @@
         # Most likely, some logs will have non-zero size when this is called, so this errs on the side
         # of caution, giving us a bit of a cushion if a log grows quickly and passes its rotation size
         THRESHOLD_KB=$((USABLE_SPACE_KB - (NUM_LOGS_TO_ROTATE * LOG_FILE_ROTATE_SIZE_KB * 2)))
+
+        # First, delete any *.1.gz files that might be left around from a prior incomplete
+        # logrotate execution, otherwise logrotate will fail to do its job
+        find /var/log/ -name '*.1.gz' -type f -exec rm -f {} +
 
         while true; do
             USED_KB=$(du -s /var/log | awk '{ print $1; }')
@@ -87,11 +87,7 @@
         if [ $(echo $1 | grep -c "/var/log/swss/") -gt 0 ]; then
             pgrep -x orchagent | xargs /bin/kill -HUP 2>/dev/null || true
         else
-            # Calling kill directly instead of 'service rsyslog rotate >/dev/null' due
-            # to bug in init-system-helpers. Bug has apparently been fixed in v1.47.
-            # However, Debian Jessie is still using v1.22.
-            # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=672218
-            kill -HUP $(cat /var/run/rsyslogd.pid)
+            /bin/kill -HUP $(cat /var/run/rsyslogd.pid)
         fi
     endscript
 }


### PR DESCRIPTION
**- What I did**

- Enhance the robustness of logrotate

**- How I did it**

- Prevent multiple hung logrotate processes from accumulating and consuming CPU/memory
    - Decrease frequency of cron job which runs logrotate from every 1 minute to every 10 minutes
    - In cron job, before running logrotate, kill any lingering logrotate processes, as they are most likely hung
- Add step to `prerotate` script to delete all `*.1.gz` files which, if they are present, means they were left over from a prior, incomplete run of logrotate. If any of these files exist, logrotate will fail to do its job for that log.
- Rename `prerotate` script to `firstaction`, as `prerotate` is run after logrotate renames existing scripts, which is too late to delete all `*.1.gz` files, as the renaming will fail and `prerotate` will never be run. `firstaction` runs before everything, so this is the appropriate script for all of this cleanup.
- Remove note about working around a bug in init-system-helpers < 1.47. Debian Stretch now has init-system-helpers version 1.48 installed, and while calling `service rsyslog rotate` no longer reports an error, it doesn't seem to cause rsyslogd to properly close the old file. Therefore, we will continue sending SIGHUP directly to the rsyslogd process and no longer consider it a workaround.

**- How to verify it**

1.) Simulate a left-behind *.1.gz file: `touch /var/log/syslog.1.gz`
2.) Fill syslog past the 1MB size threshold specified in the block
3.) Wait for 10 minutes (you can also tail /var/log/cron.log to watch for the next execution of logrotate), then check to ensure /var/log/syslog.1.gz is no longer present and that syslog has been rotated.
4.) Repeat with the other log files specified in this section