### PR TITLE
[Pmon docker]Add ethtool to pmon docker

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -7,7 +7,7 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install required packages
-RUN apt-get update && apt-get install -y python-pip libpython2.7 ipmitool librrd8 librrd-dev rrdtool python-smbus
+RUN apt-get update && apt-get install -y python-pip libpython2.7 ipmitool librrd8 librrd-dev rrdtool python-smbus ethtool
 
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Install ethtool to pmon docker.
ethtool can be an alternate way to interpret the SFP eeprom content and dump the raw data with kernel support.
**1. interpret QSFP content:**

        root@mtbc-sonic-03-2700:/# ethtool -m sfp1
        Identifier                                : 0x0d (QSFP+)
        Extended identifier                       : 0x00
        Extended identifier description           : 1.5W max. Power consumption
        Extended identifier description           : No CDR in TX, No CDR in RX
        Extended identifier description           : High Power Class (> 3.5 W) not enabled
        Connector                                 : 0x23 (No separable connector)
        Transceiver codes                         : 0x88 0x00 0x00 0x00 0x00 0x00 0x00 0x00
        Transceiver type                          : 40G Ethernet: 40G Base-CR4
        Transceiver type                          : 100G Ethernet: 100G Base-CR4 or 25G Base-CR CA-L
        Encoding                                  : 0x00 (unspecified)
        BR, Nominal                               : 25500Mbps
        Rate identifier                           : 0x00
        Length (SMF,km)                           : 0km
        Length (OM3 50um)                         : 0m
        Length (OM2 50um)                         : 0m
        Length (OM1 62.5um)                       : 0m
        Length (Copper or Active cable)           : 1m
        Transmitter technology                    : 0xa0 (Copper cable unequalized)
        Attenuation at 2.5GHz                     : 3db
        Attenuation at 5.0GHz                     : 5db
        Attenuation at 7.0GHz                     : 6db
        Attenuation at 12.9GHz                    : 9db
        Vendor name                               : Mellanox
        Vendor OUI                                : 00:02:c9
        Vendor PN                                 : MCP1600-E001
        Vendor rev                                : A3
        Vendor SN                                 : MT1834VS04288
        Revision Compliance                       : SFF-8636 Rev 2.0
        Module temperature                        : 0.00 degrees C / 32.00 degrees F
        Module voltage                            : 0.0000 V

**2. dump SFP eeprom raw data:**

    root@mtbc-sonic-03-2700:/# ethtool -m sfp1 hex on
    Offset          Values
    ------          ------
    0x0000:         0d 06 06 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0010:         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0020:         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0030:         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0040:         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0050:         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0060:         00 00 00 00 00 00 00 00 00 00 00 00 00 01 08 00 
    0x0070:         00 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0080:         0d 00 23 88 00 00 00 00 00 00 00 00 ff 00 00 00 
    0x0090:         00 00 01 a0 4d 65 6c 6c 61 6e 6f 78 20 20 20 20 
    0x00a0:         20 20 20 20 1f 00 02 c9 4d 43 50 31 36 30 30 2d 
    0x00b0:         45 30 30 31 20 20 20 20 41 33 03 05 06 09 46 7d 
    0x00c0:         0b 00 00 00 4d 54 31 38 33 34 56 53 30 34 32 38 
    0x00d0:         38 20 20 20 31 38 30 38 32 34 20 20 00 00 67 69 
    0x00e0:         31 39 32 32 38 32 36 37 39 33 5a 35 00 00 00 00 
    0x00f0:         00 00 00 00 00 00 00 00 00 00 00 00 00 30 00 00 

**3. Read SFP eeprom from certain offset:**
    
    root@mtbc-sonic-03-2700:/# ethtool -m sfp1 hex on offset 0 length 100
    Offset          Values
    ------          ------
    0x0000:         0d 06 06 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0010:         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0020:         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0030:         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0040:         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0050:         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
    0x0060:         00 00 00 00 


**- How I did it**
install ethtool to pmon when complie the pmon docker.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
