### PR TITLE
Fix for management port speed issue

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -403,6 +403,15 @@ def parse_deviceinfo(meta, hwsku):
                 if desc != None:
                     port_descriptions[port_alias_map.get(alias, alias)] = desc.text
                 port_speeds[port_alias_map.get(alias, alias)] = speed
+            interfaces = device_info.find(str(QName(ns, "ManagementInterfaces")))
+            if interfaces:
+                for interface in interfaces.findall(str(QName(ns1, "ManagementInterface"))):
+                    alias = interface.find(str(QName(ns, "InterfaceName"))).text
+                    speed = interface.find(str(QName(ns, "Speed"))).text
+                    desc  = interface.find(str(QName(ns, "Description")))
+                    if desc != None:
+                        port_descriptions[port_alias_map.get(alias, alias)] = desc.text
+                    port_speeds[port_alias_map.get(alias, alias)] = speed
     return port_speeds, port_descriptions
 
 def parse_xml(filename, platform=None, port_config_file=None):
@@ -484,6 +493,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
     results['MGMT_PORT'] = {}
     results['MGMT_INTERFACE'] = {}
     mgmt_intf_count = 0
+    mgmt_speed = 0
     mgmt_alias_reverse_mapping = {}
     for key in mgmt_intf:
         alias = key[0]
@@ -493,7 +503,11 @@ def parse_xml(filename, platform=None, port_config_file=None):
             name = 'eth' + str(mgmt_intf_count)
             mgmt_intf_count += 1
             mgmt_alias_reverse_mapping[alias] = name
-        results['MGMT_PORT'][name] = {'alias': alias, 'admin_status': 'up'}
+        if port_speeds_default.has_key(alias):
+            port_speed = port_speeds_default[alias]
+            results['MGMT_PORT'][name] = {'alias': alias, 'admin_status': 'up', 'speed': port_speed}
+        else:
+            results['MGMT_PORT'][name] = {'alias': alias, 'admin_status': 'up'}
         results['MGMT_INTERFACE'][(name, key[1])] = mgmt_intf[key]
     results['LOOPBACK_INTERFACE'] = lo_intfs
 

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -325,6 +325,19 @@
       <FlowControl>true</FlowControl>
       <Height>0</Height>
       <HwSku>Force10-S6000</HwSku>
+      <ManagementInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+	<a:ManagementInterface>
+	  <ElementType>DeviceInterface</ElementType>
+	  <AlternateSpeeds i:nil="true"/>
+	  <EnableAutoNegotiation>true</EnableAutoNegotiation>
+	  <EnableFlowControl>true</EnableFlowControl>
+	  <Index>1</Index>
+	  <InterfaceName>eth0</InterfaceName>
+	  <MultiPortsInterface>false</MultiPortsInterface>
+	  <PortName>eth0</PortName>
+	  <Speed>1000</Speed>
+	</a:ManagementInterface>
+      </ManagementInterfaces>
     </DeviceInfo>
   </DeviceInfos>
   <Hostname>switch-T0</Hostname>

--- a/src/sonic-config-engine/tests/simple-sample-graph-metadata.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-metadata.xml
@@ -310,6 +310,19 @@
       <FlowControl>true</FlowControl>
       <Height>0</Height>
       <HwSku>Force10-S6000</HwSku>
+      <ManagementInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+	<a:ManagementInterface>
+	  <ElementType>DeviceInterface</ElementType>
+	  <AlternateSpeeds i:nil="true"/>
+	  <EnableAutoNegotiation>true</EnableAutoNegotiation>
+	  <EnableFlowControl>true</EnableFlowControl>
+	  <Index>1</Index>
+	  <InterfaceName>Management1</InterfaceName>
+	  <MultiPortsInterface>false</MultiPortsInterface>
+	  <PortName>mgmt1</PortName>
+	  <Speed>1000</Speed>
+  	</a:ManagementInterface>
+      </ManagementInterfaces>
     </DeviceInfo>
   </DeviceInfos>
   <Hostname>switch-t0</Hostname>

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -342,6 +342,18 @@
       <FlowControl>true</FlowControl>
       <Height>0</Height>
       <HwSku>Force10-S6000</HwSku>
+      <ManagementInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+	<a:ManagementInterface>
+	  <ElementType>DeviceInterface</ElementType>
+	  <AlternateSpeeds i:nil="true"/>
+	  <EnableAutoNegotiation>true</EnableAutoNegotiation>
+	  <Index>1</Index>
+	  <InterfaceName>Management1</InterfaceName>
+	  <MultiPortsInterface>false</MultiPortsInterface>
+	  <PortName>mgmt1</PortName>
+	  <Speed>1000</Speed>
+  	</a:ManagementInterface>
+      </ManagementInterfaces>
     </DeviceInfo>
   </DeviceInfos>
   <Hostname>switch-t0</Hostname>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -114,8 +114,12 @@ class TestCfgGenCaseInsensitive(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'10.0.10.7': {'priority': '1', 'tcp_port': '49'}, '10.0.10.8': {'priority': '1', 'tcp_port': '49'}}")
 
+    def test_minigraph_mgmt_port(self):
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "MGMT_PORT"'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), "{'eth0': {'alias': 'eth0', 'admin_status': 'up', 'speed': '1000'}}")
+
     def test_metadata_ntp(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "NTP_SERVER"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'10.0.10.1': {}, '10.0.10.2': {}}")
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed the SNMP port speed missing issue.
**- How I did it**
Port speed was not being updated in the Config DB. Made changes to the minigraph parser to obtain the management port speed information from the minigraph. Now that the parser will return this information to the config-engine, which will be updated in the Config DB.

**- How to verify it**
Check the config DB for the changes in the MGMT_PORT key. It should then contain speed value as well.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
I added the logic to lookup for the ManagementInterface section in the minigraph xml file and add this to the dictionary object returned by parse_xml method in the minigraph.py module

**- A picture of a cute animal (not mandatory but encouraged)**
