### PR TITLE
DellEmc Z9264f: Adding port speed entry in port_config.ini

### DIFF
--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C64/port_config.ini
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C64/port_config.ini
@@ -1,65 +1,65 @@
-# name          lanes                 alias              index
-Ethernet0       49,50,51,52           hundredGigE1/1     1
-Ethernet4       53,54,55,56           hundredGigE1/2     2
-Ethernet8       65,66,67,68           hundredGigE1/3     3
-Ethernet12      69,70,71,72           hundredGigE1/4     4
-Ethernet16      81,82,83,84           hundredGigE1/5     5
-Ethernet20      85,86,87,88           hundredGigE1/6     6
-Ethernet24      97,98,99,100          hundredGigE1/7     7
-Ethernet28      101,102,103,104       hundredGigE1/8     8
-Ethernet32      1,2,3,4               hundredGigE1/9     9
-Ethernet36      5,6,7,8               hundredGigE1/10    10
-Ethernet40      17,18,19,20           hundredGigE1/11    11
-Ethernet44      21,22,23,24           hundredGigE1/12    12
-Ethernet48      33,34,35,36           hundredGigE1/13    13
-Ethernet52      37,38,39,40           hundredGigE1/14    14
-Ethernet56      113,114,115,116       hundredGigE1/15    15
-Ethernet60      117,118,119,120       hundredGigE1/16    16
-Ethernet64      133,134,135,136       hundredGigE1/17    17
-Ethernet68      129,130,131,132       hundredGigE1/18    18
-Ethernet72      213,214,215,216       hundredGigE1/19    19
-Ethernet76      209,210,211,212       hundredGigE1/20    20
-Ethernet80      229,230,231,232       hundredGigE1/21    21
-Ethernet84      225,226,227,228       hundredGigE1/22    22
-Ethernet88      245,246,247,248       hundredGigE1/23    23
-Ethernet92      241,242,243,244       hundredGigE1/24    24
-Ethernet96      149,150,151,152       hundredGigE1/25    25
-Ethernet100     145,146,147,148       hundredGigE1/26    26
-Ethernet104     165,166,167,168       hundredGigE1/27    27
-Ethernet108     161,162,163,164       hundredGigE1/28    28
-Ethernet112     181,182,183,184       hundredGigE1/29    29
-Ethernet116     177,178,179,180       hundredGigE1/30    30
-Ethernet120     197,198,199,200       hundredGigE1/31    31
-Ethernet124     193,194,195,196       hundredGigE1/32    32
-Ethernet128     61,62,63,64           hundredGigE1/33    33
-Ethernet132     57,58,59,60           hundredGigE1/34    34
-Ethernet136     77,78,79,80           hundredGigE1/35    35
-Ethernet140     73,74,75,76           hundredGigE1/36    36
-Ethernet144     93,94,95,96           hundredGigE1/37    37
-Ethernet148     89,90,91,92           hundredGigE1/38    38
-Ethernet152     109,110,111,112       hundredGigE1/39    39
-Ethernet156     105,106,107,108       hundredGigE1/40    40
-Ethernet160     13,14,15,16           hundredGigE1/41    41
-Ethernet164     9,10,11,12            hundredGigE1/42    42
-Ethernet168     29,30,31,32           hundredGigE1/43    43
-Ethernet172     25,26,27,28           hundredGigE1/44    44
-Ethernet176     45,46,47,48           hundredGigE1/45    45
-Ethernet180     41,42,43,44           hundredGigE1/46    46
-Ethernet184     125,126,127,128       hundredGigE1/47    47
-Ethernet188     121,122,123,124       hundredGigE1/48    48
-Ethernet192     137,138,139,140       hundredGigE1/49    49
-Ethernet196     141,142,143,144       hundredGigE1/50    50
-Ethernet200     217,218,219,220       hundredGigE1/51    51
-Ethernet204     221,222,223,224       hundredGigE1/52    52
-Ethernet208     233,234,235,236       hundredGigE1/53    53
-Ethernet212     237,238,239,240       hundredGigE1/54    54
-Ethernet216     249,250,251,252       hundredGigE1/55    55
-Ethernet220     253,254,255,256       hundredGigE1/56    56
-Ethernet224     153,154,155,156       hundredGigE1/57    57
-Ethernet228     157,158,159,160       hundredGigE1/58    58
-Ethernet232     169,170,171,172       hundredGigE1/59    59
-Ethernet236     173,174,175,176       hundredGigE1/60    60
-Ethernet240     185,186,187,188       hundredGigE1/61    61
-Ethernet244     189,190,191,192       hundredGigE1/62    62
-Ethernet248     201,202,203,204       hundredGigE1/63    63
-Ethernet252     205,206,207,208       hundredGigE1/64    64
+# name          lanes                 alias              index      speed
+Ethernet0       49,50,51,52           hundredGigE1/1     1          100000
+Ethernet4       53,54,55,56           hundredGigE1/2     2          100000 
+Ethernet8       65,66,67,68           hundredGigE1/3     3          100000 
+Ethernet12      69,70,71,72           hundredGigE1/4     4          100000 
+Ethernet16      81,82,83,84           hundredGigE1/5     5          100000 
+Ethernet20      85,86,87,88           hundredGigE1/6     6          100000 
+Ethernet24      97,98,99,100          hundredGigE1/7     7          100000 
+Ethernet28      101,102,103,104       hundredGigE1/8     8          100000 
+Ethernet32      1,2,3,4               hundredGigE1/9     9          100000 
+Ethernet36      5,6,7,8               hundredGigE1/10    10         100000 
+Ethernet40      17,18,19,20           hundredGigE1/11    11         100000 
+Ethernet44      21,22,23,24           hundredGigE1/12    12         100000 
+Ethernet48      33,34,35,36           hundredGigE1/13    13         100000 
+Ethernet52      37,38,39,40           hundredGigE1/14    14         100000 
+Ethernet56      113,114,115,116       hundredGigE1/15    15         100000 
+Ethernet60      117,118,119,120       hundredGigE1/16    16         100000 
+Ethernet64      133,134,135,136       hundredGigE1/17    17         100000 
+Ethernet68      129,130,131,132       hundredGigE1/18    18         100000 
+Ethernet72      213,214,215,216       hundredGigE1/19    19         100000 
+Ethernet76      209,210,211,212       hundredGigE1/20    20         100000 
+Ethernet80      229,230,231,232       hundredGigE1/21    21         100000 
+Ethernet84      225,226,227,228       hundredGigE1/22    22         100000 
+Ethernet88      245,246,247,248       hundredGigE1/23    23         100000 
+Ethernet92      241,242,243,244       hundredGigE1/24    24         100000 
+Ethernet96      149,150,151,152       hundredGigE1/25    25         100000 
+Ethernet100     145,146,147,148       hundredGigE1/26    26         100000 
+Ethernet104     165,166,167,168       hundredGigE1/27    27         100000 
+Ethernet108     161,162,163,164       hundredGigE1/28    28         100000 
+Ethernet112     181,182,183,184       hundredGigE1/29    29         100000 
+Ethernet116     177,178,179,180       hundredGigE1/30    30         100000 
+Ethernet120     197,198,199,200       hundredGigE1/31    31         100000 
+Ethernet124     193,194,195,196       hundredGigE1/32    32         100000 
+Ethernet128     61,62,63,64           hundredGigE1/33    33         100000 
+Ethernet132     57,58,59,60           hundredGigE1/34    34         100000 
+Ethernet136     77,78,79,80           hundredGigE1/35    35         100000 
+Ethernet140     73,74,75,76           hundredGigE1/36    36         100000 
+Ethernet144     93,94,95,96           hundredGigE1/37    37         100000 
+Ethernet148     89,90,91,92           hundredGigE1/38    38         100000 
+Ethernet152     109,110,111,112       hundredGigE1/39    39         100000 
+Ethernet156     105,106,107,108       hundredGigE1/40    40         100000 
+Ethernet160     13,14,15,16           hundredGigE1/41    41         100000 
+Ethernet164     9,10,11,12            hundredGigE1/42    42         100000 
+Ethernet168     29,30,31,32           hundredGigE1/43    43         100000 
+Ethernet172     25,26,27,28           hundredGigE1/44    44         100000 
+Ethernet176     45,46,47,48           hundredGigE1/45    45         100000 
+Ethernet180     41,42,43,44           hundredGigE1/46    46         100000 
+Ethernet184     125,126,127,128       hundredGigE1/47    47         100000 
+Ethernet188     121,122,123,124       hundredGigE1/48    48         100000 
+Ethernet192     137,138,139,140       hundredGigE1/49    49         100000 
+Ethernet196     141,142,143,144       hundredGigE1/50    50         100000 
+Ethernet200     217,218,219,220       hundredGigE1/51    51         100000 
+Ethernet204     221,222,223,224       hundredGigE1/52    52         100000 
+Ethernet208     233,234,235,236       hundredGigE1/53    53         100000 
+Ethernet212     237,238,239,240       hundredGigE1/54    54         100000 
+Ethernet216     249,250,251,252       hundredGigE1/55    55         100000 
+Ethernet220     253,254,255,256       hundredGigE1/56    56         100000 
+Ethernet224     153,154,155,156       hundredGigE1/57    57         100000 
+Ethernet228     157,158,159,160       hundredGigE1/58    58         100000 
+Ethernet232     169,170,171,172       hundredGigE1/59    59         100000 
+Ethernet236     173,174,175,176       hundredGigE1/60    60         100000 
+Ethernet240     185,186,187,188       hundredGigE1/61    61         100000 
+Ethernet244     189,190,191,192       hundredGigE1/62    62         100000 
+Ethernet248     201,202,203,204       hundredGigE1/63    63         100000 
+Ethernet252     205,206,207,208       hundredGigE1/64    64         100000 

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/port_config.ini
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/port_config.ini
@@ -1,65 +1,65 @@
-# name          lanes                 alias            index
-Ethernet0       49,50,51,52           fortyGigE1/1     1
-Ethernet4       53,54,55,56           fortyGigE1/2     2
-Ethernet8       65,66,67,68           fortyGigE1/3     3
-Ethernet12      69,70,71,72           fortyGigE1/4     4
-Ethernet16      81,82,83,84           fortyGigE1/5     5
-Ethernet20      85,86,87,88           fortyGigE1/6     6
-Ethernet24      97,98,99,100          fortyGigE1/7     7
-Ethernet28      101,102,103,104       fortyGigE1/8     8
-Ethernet32      1,2,3,4               fortyGigE1/9     9
-Ethernet36      5,6,7,8               fortyGigE1/10    10
-Ethernet40      17,18,19,20           fortyGigE1/11    11
-Ethernet44      21,22,23,24           fortyGigE1/12    12
-Ethernet48      33,34,35,36           fortyGigE1/13    13
-Ethernet52      37,38,39,40           fortyGigE1/14    14
-Ethernet56      113,114,115,116       fortyGigE1/15    15
-Ethernet60      117,118,119,120       fortyGigE1/16    16
-Ethernet64      133,134,135,136       fortyGigE1/17    17
-Ethernet68      129,130,131,132       fortyGigE1/18    18
-Ethernet72      213,214,215,216       fortyGigE1/19    19
-Ethernet76      209,210,211,212       fortyGigE1/20    20
-Ethernet80      229,230,231,232       fortyGigE1/21    21
-Ethernet84      225,226,227,228       fortyGigE1/22    22
-Ethernet88      245,246,247,248       fortyGigE1/23    23
-Ethernet92      241,242,243,244       fortyGigE1/24    24
-Ethernet96      149,150,151,152       fortyGigE1/25    25
-Ethernet100     145,146,147,148       fortyGigE1/26    26
-Ethernet104     165,166,167,168       fortyGigE1/27    27
-Ethernet108     161,162,163,164       fortyGigE1/28    28
-Ethernet112     181,182,183,184       fortyGigE1/29    29
-Ethernet116     177,178,179,180       fortyGigE1/30    30
-Ethernet120     197,198,199,200       fortyGigE1/31    31
-Ethernet124     193,194,195,196       fortyGigE1/32    32
-Ethernet128     61,62,63,64           fortyGigE1/33    33
-Ethernet132     57,58,59,60           fortyGigE1/34    34
-Ethernet136     77,78,79,80           fortyGigE1/35    35
-Ethernet140     73,74,75,76           fortyGigE1/36    36
-Ethernet144     93,94,95,96           fortyGigE1/37    37
-Ethernet148     89,90,91,92           fortyGigE1/38    38
-Ethernet152     109,110,111,112       fortyGigE1/39    39
-Ethernet156     105,106,107,108       fortyGigE1/40    40
-Ethernet160     13,14,15,16           fortyGigE1/41    41
-Ethernet164     9,10,11,12            fortyGigE1/42    42
-Ethernet168     29,30,31,32           fortyGigE1/43    43
-Ethernet172     25,26,27,28           fortyGigE1/44    44
-Ethernet176     45,46,47,48           fortyGigE1/45    45
-Ethernet180     41,42,43,44           fortyGigE1/46    46
-Ethernet184     125,126,127,128       fortyGigE1/47    47
-Ethernet188     121,122,123,124       fortyGigE1/48    48
-Ethernet192     137,138,139,140       fortyGigE1/49    49
-Ethernet196     141,142,143,144       fortyGigE1/50    50
-Ethernet200     217,218,219,220       fortyGigE1/51    51
-Ethernet204     221,222,223,224       fortyGigE1/52    52
-Ethernet208     233,234,235,236       fortyGigE1/53    53
-Ethernet212     237,238,239,240       fortyGigE1/54    54
-Ethernet216     249,250,251,252       fortyGigE1/55    55
-Ethernet220     253,254,255,256       fortyGigE1/56    56
-Ethernet224     153,154,155,156       fortyGigE1/57    57
-Ethernet228     157,158,159,160       fortyGigE1/58    58
-Ethernet232     169,170,171,172       fortyGigE1/59    59
-Ethernet236     173,174,175,176       fortyGigE1/60    60
-Ethernet240     185,186,187,188       fortyGigE1/61    61
-Ethernet244     189,190,191,192       fortyGigE1/62    62
-Ethernet248     201,202,203,204       fortyGigE1/63    63
-Ethernet252     205,206,207,208       fortyGigE1/64    64
+# name          lanes                 alias            index        speed
+Ethernet0       49,50,51,52           fortyGigE1/1     1            40000
+Ethernet4       53,54,55,56           fortyGigE1/2     2            40000
+Ethernet8       65,66,67,68           fortyGigE1/3     3            40000
+Ethernet12      69,70,71,72           fortyGigE1/4     4            40000
+Ethernet16      81,82,83,84           fortyGigE1/5     5            40000
+Ethernet20      85,86,87,88           fortyGigE1/6     6            40000
+Ethernet24      97,98,99,100          fortyGigE1/7     7            40000
+Ethernet28      101,102,103,104       fortyGigE1/8     8            40000
+Ethernet32      1,2,3,4               fortyGigE1/9     9            40000
+Ethernet36      5,6,7,8               fortyGigE1/10    10           40000
+Ethernet40      17,18,19,20           fortyGigE1/11    11           40000
+Ethernet44      21,22,23,24           fortyGigE1/12    12           40000
+Ethernet48      33,34,35,36           fortyGigE1/13    13           40000
+Ethernet52      37,38,39,40           fortyGigE1/14    14           40000
+Ethernet56      113,114,115,116       fortyGigE1/15    15           40000
+Ethernet60      117,118,119,120       fortyGigE1/16    16           40000
+Ethernet64      133,134,135,136       fortyGigE1/17    17           40000
+Ethernet68      129,130,131,132       fortyGigE1/18    18           40000
+Ethernet72      213,214,215,216       fortyGigE1/19    19           40000
+Ethernet76      209,210,211,212       fortyGigE1/20    20           40000
+Ethernet80      229,230,231,232       fortyGigE1/21    21           40000
+Ethernet84      225,226,227,228       fortyGigE1/22    22           40000
+Ethernet88      245,246,247,248       fortyGigE1/23    23           40000
+Ethernet92      241,242,243,244       fortyGigE1/24    24           40000
+Ethernet96      149,150,151,152       fortyGigE1/25    25           40000
+Ethernet100     145,146,147,148       fortyGigE1/26    26           40000
+Ethernet104     165,166,167,168       fortyGigE1/27    27           40000
+Ethernet108     161,162,163,164       fortyGigE1/28    28           40000
+Ethernet112     181,182,183,184       fortyGigE1/29    29           40000
+Ethernet116     177,178,179,180       fortyGigE1/30    30           40000
+Ethernet120     197,198,199,200       fortyGigE1/31    31           40000
+Ethernet124     193,194,195,196       fortyGigE1/32    32           40000
+Ethernet128     61,62,63,64           fortyGigE1/33    33           40000
+Ethernet132     57,58,59,60           fortyGigE1/34    34           40000
+Ethernet136     77,78,79,80           fortyGigE1/35    35           40000
+Ethernet140     73,74,75,76           fortyGigE1/36    36           40000
+Ethernet144     93,94,95,96           fortyGigE1/37    37           40000
+Ethernet148     89,90,91,92           fortyGigE1/38    38           40000
+Ethernet152     109,110,111,112       fortyGigE1/39    39           40000
+Ethernet156     105,106,107,108       fortyGigE1/40    40           40000
+Ethernet160     13,14,15,16           fortyGigE1/41    41           40000
+Ethernet164     9,10,11,12            fortyGigE1/42    42           40000
+Ethernet168     29,30,31,32           fortyGigE1/43    43           40000
+Ethernet172     25,26,27,28           fortyGigE1/44    44           40000
+Ethernet176     45,46,47,48           fortyGigE1/45    45           40000
+Ethernet180     41,42,43,44           fortyGigE1/46    46           40000
+Ethernet184     125,126,127,128       fortyGigE1/47    47           40000
+Ethernet188     121,122,123,124       fortyGigE1/48    48           40000
+Ethernet192     137,138,139,140       fortyGigE1/49    49           40000
+Ethernet196     141,142,143,144       fortyGigE1/50    50           40000
+Ethernet200     217,218,219,220       fortyGigE1/51    51           40000
+Ethernet204     221,222,223,224       fortyGigE1/52    52           40000
+Ethernet208     233,234,235,236       fortyGigE1/53    53           40000
+Ethernet212     237,238,239,240       fortyGigE1/54    54           40000
+Ethernet216     249,250,251,252       fortyGigE1/55    55           40000
+Ethernet220     253,254,255,256       fortyGigE1/56    56           40000
+Ethernet224     153,154,155,156       fortyGigE1/57    57           40000
+Ethernet228     157,158,159,160       fortyGigE1/58    58           40000
+Ethernet232     169,170,171,172       fortyGigE1/59    59           40000
+Ethernet236     173,174,175,176       fortyGigE1/60    60           40000
+Ethernet240     185,186,187,188       fortyGigE1/61    61           40000
+Ethernet244     189,190,191,192       fortyGigE1/62    62           40000
+Ethernet248     201,202,203,204       fortyGigE1/63    63           40000
+Ethernet252     205,206,207,208       fortyGigE1/64    64           40000


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
      Default port speed is been populated in config_db during first initialization for DellEMC Z9264f platform.
**- How I did it**
      Added Speed entry column in DellEmc Z9264f port_config.ini 
**- How to verify it**
      Bring-up the system with an image having these changes. 
     show interfaces status - show default port speed for all the interfaces

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
