### PR TITLE
[Mellanox] Fix wrong type of parameter in mlnx-sfpd notification

### DIFF
--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -181,7 +181,7 @@ class MlnxSfpd:
 
                     for port in port_list:
                         log_info("SFP on port {} state {}".format(port, sfp_state))
-                        self.send_sfp_notification(port, sfp_state)
+                        self.send_sfp_notification(str(port), sfp_state)
 
             self.update_sfpd_liveness_key(SFPD_LIVENESS_EXPIRE_SECS)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fix an mlnx-sfpd bug that sends out notifications with the wrong type of parameters:

```
May 28 06:39:23.777382 arc-mtbc-1001 INFO syncd#mlnx-sfpd: SFP on port 48 state 0
May 28 06:39:23.779545 arc-mtbc-1001 INFO pmon#supervisord: xcvrd terminate called after throwing an instance of 'std::domain_error'
May 28 06:39:23.779856 arc-mtbc-1001 INFO pmon#supervisord: xcvrd   what():  type must be string, but is number
May 28 06:39:23.827453 arc-mtbc-1001 ERR syncd#mlnx-sfpd: unknown module state 0 on port 48
May 28 06:39:26.849262 arc-mtbc-1001 INFO syncd#mlnx-sfpd: SFP on port 48 state 
```

**- How I did it**
change the type of the parameter to string. 

**- How to verify it**
trigger cable plug in/plug out event on Mellanox platform and see the result of xcvrd.
with this fix, events sends to xcvrd with expected parameter type and can be handled correctly. 

```
May 28 06:31:32.561216 arc-mtbc-1001 INFO syncd#mlnx-sfpd: SFP on port 48 state 0
May 28 06:31:32.561921 arc-mtbc-1001 INFO pmon#xcvrd: Got SFP removed event
May 28 06:31:32.563551 arc-mtbc-1001 ERR syncd#mlnx-sfpd: unknown module state 0 on port 48
May 28 06:31:35.635751 arc-mtbc-1001 INFO syncd#mlnx-sfpd: SFP on port 48 state 1
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
