### PR TITLE
[Mellanox] Expose SDK share buffer and unix socket from syncd

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -148,6 +148,8 @@ start() {
         -v /var/log/mellanox/sniffer:/var/log/mellanox/sniffer:rw \
         -v sx_api:/tmp \
         -v /dev/shm:/dev/shm:rw \
+{%- else %}
+        --tmpfs /tmp \
 {%- endif %}
 {%- if docker_container_name == "pmon" %}
         -v /var/run/hw-management:/var/run/hw-management:rw \
@@ -160,9 +162,6 @@ start() {
 {%- endif %}
 {%- if sonic_asic_platform != "mellanox" %}
         --tmpfs /tmp \
-{%- elif docker_container_name != "syncd" %}
-        --tmpfs /tmp \
-{%- else %}
 {%- endif %}
         --tmpfs /var/tmp \
         --name={{docker_container_name}} {{docker_image_name}}:latest || {

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -135,6 +135,9 @@ start() {
 {%- else %}
     echo "Creating new {{docker_container_name}} container with HWSKU $HWSKU"
 {%- endif %}
+{%- if sonic_asic_platform == "mellanox" %}
+    # TODO: Mellanox will remove the --tmpfs exception after SDK socket path changed in new SDK version 
+{%- endif %}
     docker create {{docker_image_run_opt}} \
 {%- if '--log-driver=json-file' in docker_image_run_opt or '--log-driver' not in docker_image_run_opt %}
         --log-opt max-size=2M --log-opt max-file=5 \
@@ -146,7 +149,7 @@ start() {
         -e PRM_SNIFFER \
         -e PRM_SNIFFER_FILE_PATH \
         -v /var/log/mellanox/sniffer:/var/log/mellanox/sniffer:rw \
-        -v sx_api:/tmp \
+        -v mlnx_sdk_socket:/tmp \
         -v /dev/shm:/dev/shm:rw \
 {%- else %}
         --tmpfs /tmp \

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -146,6 +146,8 @@ start() {
         -e PRM_SNIFFER \
         -e PRM_SNIFFER_FILE_PATH \
         -v /var/log/mellanox/sniffer:/var/log/mellanox/sniffer:rw \
+        -v sx_api:/tmp \
+        -v /dev/shm:/dev/shm:rw \
 {%- endif %}
 {%- if docker_container_name == "pmon" %}
         -v /var/run/hw-management:/var/run/hw-management:rw \
@@ -156,7 +158,12 @@ start() {
 {%- if docker_container_name != "database" %}
         -v /usr/share/sonic/device/$PLATFORM/$HWSKU:/usr/share/sonic/hwsku:ro \
 {%- endif %}
+{%- if sonic_asic_platform != "mellanox" %}
         --tmpfs /tmp \
+{%- elif docker_container_name != "syncd" %}
+        --tmpfs /tmp \
+{%- else %}
+{%- endif %}
         --tmpfs /var/tmp \
         --name={{docker_container_name}} {{docker_image_name}}:latest || {
             echo "Failed to docker run" >&1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Expose SDK share buffer and unix socket from syncd, so other containers can call SDK API with accessing these stuff.

**- How I did it**
Remove line --tmpfs /tmp \ in Mellanox syncd docker create command
Add line -v sx_api:/tmp \ in docker create command to share /tmp/sx_api unix socket
Add line -v /dev/shm:/dev/shm:rw \ to expose share buffer


**- How to verify it**
run regression on Mellanox platform

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
