### PR TITLE
[libteam] Send LACP PDU as soon as we need them

### DIFF
--- a/src/libteam/0014-Send-LACP-PDU-immediately-if-our-state-changed.patch
+++ b/src/libteam/0014-Send-LACP-PDU-immediately-if-our-state-changed.patch
@@ -1,0 +1,39 @@
+From 0e0ee4a68b118d540d9ef5836a55483fcfb8771b Mon Sep 17 00:00:00 2001
+From: Pavel Shirshov <pavelsh@microsoft.com>
+Date: Wed, 29 May 2019 19:15:20 +0000
+Subject: [PATCH] Send LACP PDU immediately if our state changed
+
+---
+ teamd/teamd_runner_lacp.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 19592c5..a505284 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -1049,8 +1049,7 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
+ 		return err;
+ 
+ 	lacp_port_actor_update(lacp_port);
+-	if (lacp_port->periodic_on)
+-		return 0;
++
+ 	return lacpdu_send(lacp_port);
+ }
+ 
+@@ -1160,9 +1159,10 @@ static int lacpdu_process(struct lacp_port *lacp_port, struct lacpdu* lacpdu)
+ 	if (err)
+ 		return err;
+ 
++	lacp_port_actor_update(lacp_port);
++
+ 	/* Check if the other side has correct info about us */
+-	if (!lacp_port->periodic_on &&
+-	    memcmp(&lacpdu->partner, &lacp_port->actor,
++	if (memcmp(&lacpdu->partner, &lacp_port->actor,
+ 		   sizeof(struct lacpdu_info))) {
+ 		err = lacpdu_send(lacp_port);
+ 		if (err)
+-- 
+2.7.4
+

--- a/src/libteam/series
+++ b/src/libteam/series
@@ -8,3 +8,4 @@
 0011-libteam-resynchronize-ifinfo-after-lost-RTNLGRP_LINK-.patch
 0012-teamd-do-not-process-lacpdu-before-the-port-ifinfo-i.patch
 0013-teamd-lacp-port-admin-down-recv-not-processing.patch
+0014-Send-LACP-PDU-immediately-if-our-state-changed.patch


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I've fixed a bug in libteam LACP protocol implementation. According to the LACP standard LACP daemon must send LACP PDU packets with updates `when the Actor’s state changes or when it is apparent from the Partner’s LACPDUs that the Partner does not know the Actor’s current state.`
But current libteam implementation sends periodic updates only.

**- How I did it**
I've reverted following libteam patch: https://github.com/jpirko/libteam/commit/b2de61b39696c9158e725a691aee5a6f16a64137 
and added actor state calculation right before the comparison what LACP partner thinks about the actor state.

**- How to verify it**
Build an image with it. Install on you DUT and put one of the remote LACP member interfaces down. Then raise it up and check what LACP packets are send by SONiC side. SONiC must send replies on every partner LACP PDU packets.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[LACP] Send updates of the actor state immediately.

**- A picture of a cute animal (not mandatory but encouraged)**
