### PR TITLE
[docker-frr]: change default routing mode to separated and fix a bug …

### DIFF
--- a/dockers/docker-fpm-frr/start.sh
+++ b/dockers/docker-fpm-frr/start.sh
@@ -35,7 +35,7 @@ supervisorctl start zebra
 supervisorctl start staticd
 supervisorctl start bgpd
 
-if [ "$CONFIG_TYPE" == "unified" ]; then
+if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "separated" ]; then
     supervisorctl start vtysh_b
 fi
 

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -432,7 +432,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
     neighbors = None
     devices = None
     hostname = None
-    docker_routing_config_mode = "unified"
+    docker_routing_config_mode = "separated"
     port_speeds_default = {}
     port_speed_png = {}
     port_descriptions = {}


### PR DESCRIPTION
…in separated mode

In separated mode, frr requires to run vtysh_b to load individual configuration

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
tested on virtual switch.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
