### PR TITLE
[libteam] Send LACP PDU as soon as we need them. 201803 version

### DIFF
--- a/src/libteam/0007-Send-LACP-PDU-immediately-if-the-actor-state-changed.patch
+++ b/src/libteam/0007-Send-LACP-PDU-immediately-if-the-actor-state-changed.patch
@@ -1,0 +1,39 @@
+From b05c1302de1245ab3ffda905fd222adc3d0e98d6 Mon Sep 17 00:00:00 2001
+From: Pavel Shirshov <pavelsh@microsoft.com>
+Date: Wed, 29 May 2019 20:44:25 +0000
+Subject: [PATCH] Send LACP PDU immediately if the actor state changed
+
+---
+ teamd/teamd_runner_lacp.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 813b604..395d105 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -1012,8 +1012,7 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
+ 		return err;
+ 
+ 	lacp_port_actor_update(lacp_port);
+-	if (lacp_port->periodic_on)
+-		return 0;
++
+ 	return lacpdu_send(lacp_port);
+ }
+ 
+@@ -1123,9 +1122,10 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
+ 	if (err)
+ 		return err;
+ 
++	lacp_port_actor_update(lacp_port);
++
+ 	/* Check if the other side has correct info about us */
+-	if (!lacp_port->periodic_on &&
+-	    memcmp(&lacpdu.partner, &lacp_port->actor,
++	if (memcmp(&lacpdu.partner, &lacp_port->actor,
+ 		   sizeof(struct lacpdu_info))) {
+ 		err = lacpdu_send(lacp_port);
+ 		if (err)
+-- 
+2.7.4
+

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -21,6 +21,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git apply ../0004-libteam-Add-lacp-fallback-support-for-single-member-.patch
 	git apply ../0005-update-hwaddr-orig-unconditionally.patch
 	git apply ../0006-teamd-lacp-update-port-state-according-to-partners-sy.patch
+	git apply ../0007-Send-LACP-PDU-immediately-if-the-actor-state-changed.patch
 	popd
 
 	# Obtain debian packaging


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I've fixed a bug in libteam LACP protocol implementation. According to the LACP standard LACP daemon must send LACP PDU packets with updates `when the Actor’s state changes or when it is apparent from the Partner’s LACPDUs that the Partner does not know the Actor’s current state.`
But current libteam implementation sends periodic updates only.

**- How I did it**
I've reverted following libteam patch: https://github.com/jpirko/libteam/commit/b2de61b39696c9158e725a691aee5a6f16a64137 
and added actor state calculation right before the comparison what LACP partner thinks about the actor state.

**- How to verify it**
Build an image with it. Install on you DUT and put one of the remote LACP member interfaces down. Then raise it up and check what LACP packets are send by SONiC side. SONiC must send replies on every partner LACP PDU packets.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[LACP] Send updates of the actor state immediately.

**- A picture of a cute animal (not mandatory but encouraged)**
