### PR TITLE
[device/Accton] bugfix: potential i2c fault from IC IR3570a.

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_util.py
@@ -252,7 +252,7 @@ def driver_inserted():
 kos = [
 'depmod -ae',
 'modprobe i2c_dev',
-'modprobe i2c_mux_pca954x',
+'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
 'modprobe optoe',
 'modprobe i2c-mux-accton_as5712_54x_cpld',
 'modprobe cpr_4011_4mxx',
@@ -273,7 +273,15 @@ def driver_install():
 def driver_uninstall():
     global FORCE
     for i in range(0,len(kos)):
-        rm = kos[-(i+1)].replace("modprobe", "modprobe -rq")
+        #remove parameter if any
+        rm = kos[-(i+1)]
+        lst = rm.split(" ")
+        if len(lst) > 2:
+            del(lst[2:])
+        rm = " ".join(lst)
+
+        #Change to removing commands
+        rm = rm.replace("modprobe", "modprobe -rq")
         rm = rm.replace("insmod", "rmmod")
         status, output = log_os_system(rm, 1)
         if status:

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/utils/accton_as5812_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/utils/accton_as5812_util.py
@@ -252,7 +252,7 @@ def driver_inserted():
 kos = [
 'depmod -ae',
 'modprobe i2c_dev',
-'modprobe i2c_mux_pca954x',
+'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
 'modprobe optoe',
 'modprobe i2c-mux-accton_as5812_54x_cpld',
 'modprobe cpr_4011_4mxx',
@@ -273,7 +273,15 @@ def driver_install():
 def driver_uninstall():
     global FORCE
     for i in range(0,len(kos)):
-        rm = kos[-(i+1)].replace("modprobe", "modprobe -rq")
+        #remove parameter if any
+        rm = kos[-(i+1)]
+        lst = rm.split(" ")
+        if len(lst) > 2:
+            del(lst[2:])
+        rm = " ".join(lst)
+
+        #Change to removing commands
+        rm = rm.replace("modprobe", "modprobe -rq")
         rm = rm.replace("insmod", "rmmod")
         status, output = log_os_system(rm, 1)
         if status:

--- a/platform/broadcom/sonic-platform-modules-accton/as6712-32x/utils/accton_as6712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as6712-32x/utils/accton_as6712_util.py
@@ -260,7 +260,7 @@ def driver_inserted():
 kos = [
 'depmod -ae',
 'modprobe i2c_dev',
-'modprobe i2c_mux_pca954x',
+'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
 'modprobe optoe',
 'modprobe accton_as6712_32x_cpld',
 'modprobe cpr_4011_4mxx',
@@ -281,7 +281,15 @@ def driver_install():
 def driver_uninstall():
     global FORCE
     for i in range(0,len(kos)):
-        rm = kos[-(i+1)].replace("modprobe", "modprobe -rq")
+        #remove parameter if any
+        rm = kos[-(i+1)]
+        lst = rm.split(" ")
+        if len(lst) > 2:
+            del(lst[2:])
+        rm = " ".join(lst)
+
+        #Change to removing commands
+        rm = rm.replace("modprobe", "modprobe -rq")
         rm = rm.replace("insmod", "rmmod")
         status, output = log_os_system(rm, 1)
         if status:

--- a/platform/broadcom/sonic-platform-modules-accton/minipack/utils/accton_minipack_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/minipack/utils/accton_minipack_util.py
@@ -193,7 +193,6 @@ kos = [
 'depmod -ae',
 'modprobe i2c_dev',
 'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
-#'modprobe i2c_mux_pca954x',
 'modprobe optoe',
 'modprobe minipack_psensor']
 
@@ -207,7 +206,15 @@ def driver_install():
 
 def driver_uninstall():
     for i in range(0,len(kos)):
-        rm = kos[-(i+1)].replace("modprobe", "modprobe -rq")
+        #remove parameter if any
+        rm = kos[-(i+1)]
+        lst = rm.split(" ")
+        if len(lst) > 2:
+            del(lst[2:])
+        rm = " ".join(lst)
+
+        #Change to removing commands
+        rm = rm.replace("modprobe", "modprobe -rq")
         rm = rm.replace("insmod", "rmmod")
         status, output = log_os_system(rm, 1)
         if status:


### PR DESCRIPTION
Error are reported from customers for
1. Error on reading eeprom on some units.
2. Presence of transceivers are mismatched.
This symptom occurs on model asXX26 and asXX16.

Signed-off-by: roy_lee <roy_lee@accton.com>

**- What I did**
1. Disabling i2c function of ir3570a which may failed i2c tranfer to others.
2. Close channel of mux after data transfered.

**- How I did it**
1. Identify version of ir3570, if it's ir3570a, disable its alias i2c address.
2. Enable parameter of driver i2c_mux_pca954x to close channel on after every access.

**- How to verify it**
1. Write 08 to offset 0xcf of systom eeprom and execute i2c block read.
    It will return error. 
2. plug-in several transceivers and run "show interfaces transceiver presence" and "sfputil show presence".  You may see the different result. (But doing this requires updated xcvrd).

**- Description for the changelog**
As the code diff.