### PR TITLE
[FRR]: Aligned configs for unified/separated modes.

### DIFF
--- a/dockers/docker-fpm-frr/bgpd.conf.j2
+++ b/dockers/docker-fpm-frr/bgpd.conf.j2
@@ -40,7 +40,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   network {{ prefix | ip }}/32
 {% elif prefix | ipv6 and name == 'Loopback0' %}
   address-family ipv6
-    network {{ prefix | ip }}/128
+    network {{ prefix | ip }}/64
   exit-address-family
 {% endif %}
 {% endfor %}

--- a/dockers/docker-fpm-frr/bgpd.conf.j2
+++ b/dockers/docker-fpm-frr/bgpd.conf.j2
@@ -40,7 +40,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   network {{ prefix | ip }}/32
 {% elif prefix | ipv6 and name == 'Loopback0' %}
   address-family ipv6
-    network {{ prefix | ip }}/64
+    network {{ prefix | ip }}/128
   exit-address-family
 {% endif %}
 {% endfor %}
@@ -77,6 +77,12 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
     neighbor {{ neighbor_addr }} activate
     neighbor {{ neighbor_addr }} soft-reconfiguration inbound
+{% if bgp_session['rrclient'] | int != 0 %}
+    neighbor {{ neighbor_addr }} route-reflector-client
+{% endif %}
+{% if bgp_session['nhopself'] | int != 0 %}
+    neighbor {{ neighbor_addr }} next-hop-self
+{% endif %}
     maximum-paths 64
   exit-address-family
 {% endif %}
@@ -87,6 +93,15 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
     neighbor {{ neighbor_addr }} activate
     neighbor {{ neighbor_addr }} soft-reconfiguration inbound
+{% if bgp_session['rrclient'] | int != 0 %}
+    neighbor {{ neighbor_addr }} route-reflector-client
+{% endif %}
+{% if bgp_session['nhopself'] | int != 0 %}
+    neighbor {{ neighbor_addr }} next-hop-self
+{% endif %}
+{% if bgp_session['asn'] != DEVICE_METADATA['localhost']['bgp_asn'] %}
+    neighbor {{ neighbor_addr }} route-map set-next-hop-global-v6 in
+{% endif %}
     maximum-paths 64
   exit-address-family
 {% endif %}
@@ -137,4 +152,7 @@ maximum-paths 64
 route-map ISOLATE permit 10
 set as-path prepend {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
+!
+route-map set-next-hop-global-v6 permit 10
+set ipv6 next-hop prefer-global
 !

--- a/dockers/docker-fpm-frr/start.sh
+++ b/dockers/docker-fpm-frr/start.sh
@@ -7,12 +7,12 @@ CONFIG_TYPE=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["docker_routing_co
 if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "separated" ]; then
     sonic-cfggen -d -y /etc/sonic/deployment_id_asn_map.yml -t /usr/share/sonic/templates/bgpd.conf.j2 > /etc/frr/bgpd.conf
     sonic-cfggen -d -t /usr/share/sonic/templates/zebra.conf.j2 > /etc/frr/zebra.conf
-    touch /etc/frr/vtysh.conf
+    echo "no service integrated-vtysh-config" > /etc/frr/vtysh.conf
     rm -f /etc/frr/frr.conf
 elif [ "$CONFIG_TYPE" == "unified" ]; then
     sonic-cfggen -d -y /etc/sonic/deployment_id_asn_map.yml -t /usr/share/sonic/templates/frr.conf.j2 >/etc/frr/frr.conf
     echo "service integrated-vtysh-config" > /etc/frr/vtysh.conf
-    rm -f /etc/frr/bgpd.conf /etc/frr/vtysh.conf
+    rm -f /etc/frr/bgpd.conf /etc/frr/zebra.conf
 fi
 
 sonic-cfggen -d -t /usr/share/sonic/templates/isolate.j2 > /usr/sbin/bgp-isolate


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

**- What I did**
* Aligned FRR configs for unified/separated modes
* Fixed IPv6 neighbors issue: #2986 

**- How I did it**
* Fixed bgpd.conf.j2

**- How to verify it**
```
root@sonic:/home/admin# ndisc6 fc00::76 PortChannel0002
Soliciting fc00::76 (fc00::76) on PortChannel0002...
Target link-layer address: 52:54:00:F6:F6:4A
 from fc00::76

root@sonic:/home/admin# ndisc6 fe80::34f1:92ff:feb9:129c PortChannel0002
Soliciting fe80::34f1:92ff:feb9:129c (fe80::34f1:92ff:feb9:129c) on PortChannel0002...
Target link-layer address: 36:F1:92:B9:12:9C
 from fe80::34f1:92ff:feb9:129c
```

**- Description for the changelog**
* N/A