### PR TITLE
[docker-pmon] install dmidecode in pmon docker

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -7,7 +7,7 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install required packages
-RUN apt-get update && apt-get install -y python-pip libpython2.7 ipmitool librrd8 librrd-dev rrdtool python-smbus ethtool
+RUN apt-get update && apt-get install -y python-pip libpython2.7 ipmitool librrd8 librrd-dev rrdtool python-smbus ethtool dmidecode
 
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies


### PR DESCRIPTION
**- What I did**
Install dmidecode in pmon docker.
It is a widely used tool designed to dump EEPROM contents.

**- How I did it**
Append the "dmidecode" at the end of "# Install required packages" part of dockers/docker-platform-monitor/Dockerfile.j2

**- How to verify it**
Rebuild, install and start docker-pmon, check whether "dmidecode" works.

**- Description for the changelog**
Install dmidecode in pmon docker.

**- A picture of a cute animal (not mandatory but encouraged)**
