### PR TITLE
[frr] fix pfx_filter in sonic-cfggen

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -6,9 +6,9 @@ minigraph file, config DB, json file(s), yaml files(s), command line input,
 and write the data into DB, print as json, or render a jinja2 config template.
 
 Examples:
-    Render template with minigraph:        
+    Render template with minigraph:
         sonic-cfggen -m -t /usr/share/template/bgpd.conf.j2
-    Dump config DB content into json file: 
+    Dump config DB content into json file:
         sonic-cfggen -d --print-data > db_dump.json
     Load content of json file into config DB:
         sonic-cfggen -j db_dump.json --write-to-db
@@ -93,6 +93,10 @@ def pfx_filter(value):
        For eg - VLAN_INTERFACE|Vlan1000 vs VLAN_INTERFACE|Vlan1000|192.168.0.1/21
     """
     table = OrderedDict()
+
+    if not value:
+        return table
+
     for key,val in value.items():
         if not isinstance(key, tuple):
             continue
@@ -104,7 +108,7 @@ class FormatConverter:
 We will move to DB schema and remove this class when the config templates are modified.
 
 TODO(taoyl): Current version of config db only supports BGP admin states.
-    All other configuration are still loaded from minigraph. Plan to remove 
+    All other configuration are still loaded from minigraph. Plan to remove
     minigraph and move everything into config db in a later commit.
     """
     @staticmethod
@@ -214,7 +218,7 @@ def main():
 
     for yaml_file in args.yaml:
         with open(yaml_file, 'r') as stream:
-            additional_data = yaml.load(stream)      
+            additional_data = yaml.load(stream)
             deep_update(data, FormatConverter.to_deserialized(additional_data))
 
     for json_file in args.json:
@@ -223,7 +227,7 @@ def main():
 
     if args.additional_data != None:
         deep_update(data, json.loads(args.additional_data))
-  
+
     if args.from_db:
         configdb = ConfigDBConnector(**db_kwargs)
         configdb.connect()


### PR DESCRIPTION
Otherwise:

```
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 276, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 253, in main
    print(template.render(sort_data(data)))
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/share/sonic/templates/bgpd.conf.j2", line 49, in top-level template code
    {% block vlan_advertisement %}
  File "/usr/share/sonic/templates/bgpd.conf.j2", line 50, in block "vlan_advertisement"
    {% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
  File "/usr/local/bin/sonic-cfggen", line 96, in pfx_filter
    for key,val in value.items():
jinja2.exceptions.UndefinedError: 'VLAN_INTERFACE' is undefined
```

and

```
root@arc-switch1004:/# vtysh

Hello, this is FRRouting (version 7.0.1-sonic).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

arc-switch1004# show bgp su
% BGP instance not found
arc-switch1004#
root@arc-switch1004:/# cat /etc/frr/bgpd.conf
root@arc-switch1004:/#
```

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
Run on DUT on topology without VLAN

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
