### PR TITLE
[FRR]: enable bgp graceful-restart preserve-fw-state for FRR warm reb…

### DIFF
--- a/dockers/docker-fpm-frr/bgpd.conf.j2
+++ b/dockers/docker-fpm-frr/bgpd.conf.j2
@@ -29,6 +29,9 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   no bgp default ipv4-unicast
   bgp graceful-restart restart-time 240
   bgp graceful-restart
+{% if DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+  bgp graceful-restart preserve-fw-state
+{% endif %}
 {% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 and name == 'Loopback0' %}
   bgp router-id {{ prefix | ip }}


### PR DESCRIPTION
…oot support on T0

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**- What I did**
bgp graceful-restart preserve-fw-state for FRR warm reboot support on T0

In quagga versions of sonic, the setting was hardcoded.

**- How I did it**

**- How to verify it**
Before the change:

One peer node:  "Forwarding State is not preserved".

```
ARISTA01T1#show ipv6 bgp neighbors
BGP neighbor is fc00::71, remote AS 65100, external link
  Description: 65100
  BGP version 4, remote router ID 10.1.0.32, VRF default
  Negotiated BGP version 4
  Member of update group 3
  Last read 00:00:02, last write 00:00:02
  Hold time is 10, keepalive interval is 3 seconds
  Configured hold time is 180, keepalive interval is 60 seconds
  Connect timer is inactive
  Idle-restart timer is inactive
  BGP state is Established, up for 00:06:01
  Number of transitions to established: 2
  Last state was OpenConfirm
  Last event was RecvKeepAlive
  Last rcvd notification:Cease/connection collision resolution, Last time 00:06:03
  Last sent socket-error:local address fc00::72 unavailable, Last time 00:06:21, First time 00:38:52, Repeats 4
  Neighbor Capabilities:
    Multiprotocol IPv6 Unicast: advertised and received and negotiated
    Four Octet ASN: advertised and received and negotiated
    Route Refresh: advertised and received and negotiated
    Send End-of-RIB messages: advertised and received and negotiated
    Additional-paths recv capability:
      IPv6 Unicast: advertised
    Additional-paths send capability:
      IPv6 Unicast: received
    Graceful Restart received:
       Restart-time is 240
       Restarting: yes
       IPv6 Unicast is enabled, Forwarding State is not preserved
  Restart timer is inactive
  End of rib timer is inactive
  Message Statistics:
    InQ depth is 0
    OutQ depth is 0
                         Sent      Rcvd
    Opens:                  3         3
    Notifications:          0         1
    Updates:             5772      3768
    Keepalives:           118       122
    Route-Refresh:          0         0
    Total messages:      5893      3894
  Prefix Statistics:
                         Sent      Rcvd
    IPv4 Unicast:           0         0
    IPv6 Unicast:        6400         1
    IPv4 SR-TE:             0         0
    IPv6 SR-TE:             0         0
  Inbound updates dropped by reason:
    AS path loop detection: 3662
    Enforced First AS: 0
    Originator ID matches local router ID: 0
    Nexthop matches local IP address: 0
    Unexpected IPv6 nexthop for IPv4 routes: 0
    Nexthop invalid for single hop eBGP: 0
  Inbound updates with attribute errors:
    Resulting in removal of all paths in update (treat-as-withdraw): 0
    Resulting in AFI/SAFI disable: 0
    Resulting in attribute ignore: 0
  Inbound paths dropped by reason:
    IPv4 labeled-unicast NLRIs dropped due to excessive labels: 0
    IPv6 labeled-unicast NLRIs dropped due to excessive labels: 0
  Outbound paths dropped by reason:
    IPv4 local address not available: 0
    IPv6 local address not available: 0
Local AS is 64600, local router ID 100.1.0.29
TTL is 1
Local TCP address is fc00::72, local port is 179
Remote TCP address is fc00::71, remote port is 60994
Auto-Local-Addr is disabled
TCP Socket Information:
  TCP state is ESTABLISHED
  Recv-Q: 0/32768
  Send-Q: 0/32768
  Outgoing Maximum Segment Size (MSS): 1428
  Total Number of TCP retransmissions: 5
  Options:
    Timestamps enabled: yes
    Selective Acknowledgments enabled: yes
    Window Scale enabled: yes
    Explicit Congestion Notification (ECN) enabled: no
  Socket Statistics:
    Window Scale (wscale): 7,7
    Retransmission Timeout (rto): 212.0ms
    Round-trip Time (rtt/rtvar): 10.7ms/3.5ms
    Delayed Ack Timeout (ato): 40.0ms
    Congestion Window (cwnd): 10
    Slow-start Threshold (ssthresh): 23
    TCP Throughput: 10.71 Mbps
    Recv Round-trip Time (rcv_rtt): 491.5ms
    Advertised Recv Window (rcv_space): 28560
 ```

After the change:  Forwarding State is  preserved.    

```
ARISTA01T1#show ip bgp neighbors 
BGP neighbor is 10.0.0.56, remote AS 65100, external link
  Description: 65100
  BGP version 4, remote router ID 10.1.0.32, VRF default
  Negotiated BGP version 4
  Member of update group 2
  Last read 00:00:01, last write 00:00:01
  Hold time is 10, keepalive interval is 3 seconds
  Configured hold time is 180, keepalive interval is 60 seconds
  Connect timer is inactive
  Idle-restart timer is inactive
  BGP state is Established, up for 00:00:31
  Number of transitions to established: 6
  Last state was OpenConfirm
  Last event was RecvKeepAlive
  Last sent notification:Cease/connection collision resolution, Last time 22:24:00
  Last sent socket-error:Network is unreachable, Last time 23:12:52
  Last rcvd socket-error:received unexpected EOF, Last time 00:00:41, First time 22:22:19, Repeats 2
  Neighbor Capabilities:
    Multiprotocol IPv4 Unicast: advertised and received and negotiated
    Four Octet ASN: advertised and received and negotiated
    Route Refresh: advertised and received and negotiated
    Send End-of-RIB messages: advertised and received and negotiated
    Additional-paths recv capability:
      IPv4 Unicast: advertised
    Additional-paths send capability:
      IPv4 Unicast: received
    Graceful Restart received:
       Restart-time is 240
       Restarting: yes
       IPv4 Unicast is enabled, Forwarding State is  preserved
  Restart timer is inactive
  End of rib timer is inactive
  Message Statistics:
    InQ depth is 0
    OutQ depth is 0
                         Sent      Rcvd
    Opens:                  6         8
    Notifications:          4         0
    Updates:            18019     21393
    Keepalives:         27057     27099
    Route-Refresh:          0         0
    Total messages:     45086     48500
  Prefix Statistics:
                         Sent      Rcvd
    IPv4 Unicast:        6400         2
    IPv6 Unicast:           0         0
    IPv4 SR-TE:             0         0
    IPv6 SR-TE:             0         0
  Inbound updates dropped by reason:
    AS path loop detection: 3984
    Enforced First AS: 0
    Originator ID matches local router ID: 0
    Nexthop matches local IP address: 83
    Unexpected IPv6 nexthop for IPv4 routes: 0
    Nexthop invalid for single hop eBGP: 0
  Inbound updates with attribute errors:
    Resulting in removal of all paths in update (treat-as-withdraw): 0
    Resulting in AFI/SAFI disable: 0
    Resulting in attribute ignore: 0
  Inbound paths dropped by reason:
    IPv4 labeled-unicast NLRIs dropped due to excessive labels: 0
    IPv6 labeled-unicast NLRIs dropped due to excessive labels: 0
  Outbound paths dropped by reason:
    IPv4 local address not available: 0
    IPv6 local address not available: 0
Local AS is 64600, local router ID 100.1.0.29
TTL is 1
Local TCP address is 10.0.0.57, local port is 47057
Remote TCP address is 10.0.0.56, remote port is 179
Auto-Local-Addr is disabled
TCP Socket Information:
  TCP state is ESTABLISHED
  Recv-Q: 0/32768
  Send-Q: 19/32768
  Outgoing Maximum Segment Size (MSS): 1448
  Total Number of TCP retransmissions: 2
  Options:
    Timestamps enabled: yes
    Selective Acknowledgments enabled: yes
    Window Scale enabled: yes
    Explicit Congestion Notification (ECN) enabled: no
  Socket Statistics:
    Window Scale (wscale): 7,7
    Retransmission Timeout (rto): 1588.0ms
    Round-trip Time (rtt/rtvar): 1028.6ms/136.9ms
    Delayed Ack Timeout (ato): 40.0ms
    Congestion Window (cwnd): 10
    Slow-start Threshold (ssthresh): 9
    TCP Throughput: 0.11 Mbps
    Recv Round-trip Time (rcv_rtt): 1031.5ms
    Advertised Recv Window (rcv_space): 29200
 

ARISTA01T1#show ipv6  bgp neighbors
BGP neighbor is fc00::71, remote AS 65100, external link
  Description: 65100
  BGP version 4, remote router ID 10.1.0.32, VRF default
  Negotiated BGP version 4
  Member of update group 3
  Last read 00:00:02, last write 00:00:02
  Hold time is 10, keepalive interval is 3 seconds
  Configured hold time is 180, keepalive interval is 60 seconds
  Connect timer is inactive
  Idle-restart timer is inactive
  BGP state is Established, up for 00:00:41
  Number of transitions to established: 6
  Last state was OpenConfirm
  Last event was RecvKeepAlive
  Last sent notification:Cease/other configuration change, Last time 22:36:26
  Last rcvd notification:Cease/connection collision resolution, Last time 22:46:49
  Last sent socket-error:local address fc00::72 unavailable, Last time 22:24:11, First time 23:19:38, Repeats 7
  Last rcvd socket-error:received unexpected EOF, Last time 00:00:51, First time 22:22:29, Repeats 2
  Neighbor Capabilities:
    Multiprotocol IPv6 Unicast: advertised and received and negotiated
    Four Octet ASN: advertised and received and negotiated
    Route Refresh: advertised and received and negotiated
    Send End-of-RIB messages: advertised and received and negotiated
    Additional-paths recv capability:
      IPv6 Unicast: advertised
    Additional-paths send capability:
      IPv6 Unicast: received
    Graceful Restart received:
       Restart-time is 240
       Restarting: yes
       IPv6 Unicast is enabled, Forwarding State is  preserved
  Restart timer is inactive
  End of rib timer is inactive
  Message Statistics:
    InQ depth is 0
    OutQ depth is 0
                         Sent      Rcvd
    Opens:                  7         7
    Notifications:          1         1
    Updates:            18584     25068
    Keepalives:         27050     27100
    Route-Refresh:          0         0
    Total messages:     45642     52176
  Prefix Statistics:
                         Sent      Rcvd
    IPv4 Unicast:           0         0
    IPv6 Unicast:        6400         1
    IPv4 SR-TE:             0         0
    IPv6 SR-TE:             0         0
  Inbound updates dropped by reason:
    AS path loop detection: 5446
    Enforced First AS: 0
    Originator ID matches local router ID: 0
ARISTA01T1#
```

```
vlab-01# show running-config 
Building configuration...

Current configuration:
!
frr version 7.0.1-sonic
frr defaults traditional
hostname vlab-01
log syslog informational
log facility local4
!
password zebra
!
router bgp 65100
 bgp router-id 10.1.0.32
 bgp log-neighbor-changes
 no bgp default ipv4-unicast
 bgp graceful-restart restart-time 240
 bgp graceful-restart
 bgp graceful-restart preserve-fw-state
 bgp bestpath as-path multipath-relax
 neighbor BGPSLBPassive peer-group
...
```
