### PR TITLE
[bcm SAI] upgrade Broadcom SAI to version 3.3.6.1-9

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.3.5.4-1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.3/libsaibcm_3.3.5.4-1_amd64.deb?sv=2015-04-05&sr=b&sig=fjyImKBuCbR8x48tzRhx32tfnDq1kk1VsCJblaXh8U4%3D&se=2032-12-10T01%3A43%3A35Z&sp=r"
+BRCM_SAI = libsaibcm_3.3.6.1-9_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.3/libsaibcm_3.3.6.1-9_amd64.deb?sv=2015-04-05&sr=b&sig=ZsZxC0bmXIX9PCa73BpyMatePq8m2jWvCahFx3OJ%2F8I%3D&se=2033-02-13T21%3A31%3A33Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.3.5.4-1_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.3.6.1-9_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.3/libsaibcm-dev_3.3.5.4-1_amd64.deb?sv=2015-04-05&sr=b&sig=91u8Og2PHD2ig%2BlIyi6UlXQ8rMSxz%2FUeJdyy%2BhecvrE%3D&se=2032-12-10T01%3A43%3A16Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.3/libsaibcm-dev_3.3.6.1-9_amd64.deb?sv=2015-04-05&sr=b&sig=RUAbTNEcmaSvNeAKz%2F8x06hPC%2BS%2BVlGPA2%2FiwHZMF4o%3D&se=2033-02-13T21%3A31%3A02Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
**- What I did**

upgrade Broadcom SAI to version 3.3.6.1-9

- Broadcom SAI GA version 20190513
- Broadcom fix for CS7999193, CS7913246, CS4529162, CS8180755, CS8242625

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
nightly tests
continuous warm reboot.