### PR TITLE
Increase TMOUT for serial console connections to 15 minutes

### DIFF
--- a/files/image_config/bash/bash.bashrc
+++ b/files/image_config/bash/bash.bashrc
@@ -54,5 +54,5 @@ if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-no
     }
 fi
 
-# enable auto-logout for console ttyS* sessions
-tty | grep ttyS >/dev/null && TMOUT=300
+# Automatically log out console ttyS* sessions after 15 minutes of inactivity
+tty | grep ttyS >/dev/null && TMOUT=900


### PR DESCRIPTION
**- What I did**

- Increase `TMOUT` value in order to close inactive serial console connections after 900 seconds (15 minutes) of inactivity

**- How to verify it**

1. Log into device via serial/console port. Wait 15 minutes -- you should be automatically logged out.