### PR TITLE
DellEmc(Z9264f): Bug fix in show platform psustatus cli

### DIFF
--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/psuutil.py
@@ -30,6 +30,10 @@ class PsuUtil(PsuBase):
 
     def __init__(self):
         PsuBase.__init__(self)
+     
+    def isDockerEnv(self):
+        num_docker = open('/proc/self/cgroup', 'r').read().count(":/docker")
+        return num_docker
 
     # Fetch a BMC register
     def get_pmc_register(self, reg_name):
@@ -38,9 +42,10 @@ class PsuUtil(PsuBase):
         global ipmi_sdr_list
         ipmi_dev_node = "/dev/pmi0"
         ipmi_cmd = IPMI_PSU_DATA
-        
-        if os.path.exists("/.dockerenv"):
+        dockerenv = self.isDockerEnv()
+        if dockerenv > 0:
             ipmi_cmd = IPMI_PSU_DATA_DOCKER
+
         status, ipmi_sdr_list = commands.getstatusoutput(ipmi_cmd)
 
         if status:

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/psuutil.py
@@ -30,10 +30,13 @@ class PsuUtil(PsuBase):
 
     def __init__(self):
         PsuBase.__init__(self)
-     
+
     def isDockerEnv(self):
         num_docker = open('/proc/self/cgroup', 'r').read().count(":/docker")
-        return num_docker
+        if num_docker > 0:
+            return True
+        else:
+            return False
 
     # Fetch a BMC register
     def get_pmc_register(self, reg_name):
@@ -43,7 +46,7 @@ class PsuUtil(PsuBase):
         ipmi_dev_node = "/dev/pmi0"
         ipmi_cmd = IPMI_PSU_DATA
         dockerenv = self.isDockerEnv()
-        if dockerenv > 0:
+        if dockerenv == True:
             ipmi_cmd = IPMI_PSU_DATA_DOCKER
 
         status, ipmi_sdr_list = commands.getstatusoutput(ipmi_cmd)
@@ -57,15 +60,13 @@ class PsuUtil(PsuBase):
                 output = item.strip()
 
         if not output:
-            print('\nFailed to fetch: ' +  reg_name + ' sensor ')
+            print('\nFailed to fetch: ' + reg_name + ' sensor ')
             sys.exit(0)
 
         output = output.split('|')[1]
 
         logging.basicConfig(level=logging.DEBUG)
         return output
-
-
 
     def get_num_psus(self):
         """
@@ -83,11 +84,10 @@ class PsuUtil(PsuBase):
         :return: Boolean, True if PSU is operating properly, False if PSU is\
         faulty
         """
-        #Until psu_status is implemented this is hardcoded temporarily
+    # Until psu_status is implemented this is hardcoded temporarily
 
         status = 1
         return status
-    
 
     def get_psu_presence(self, index):
         """
@@ -98,9 +98,10 @@ class PsuUtil(PsuBase):
         """
         status = 0
         psu_reg_name = PSU_PRESENCE.format(index)
-        psu_status = int(self.get_pmc_register(psu_reg_name),16)
+        psu_status = int(self.get_pmc_register(psu_reg_name), 16)
         if (psu_status != 'ERR'):
             # Check for PSU presence
             if (psu_status):
                     status = 1
         return status
+

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/psuutil.py
@@ -7,10 +7,12 @@
 import os.path
 import logging
 import commands
+import sys
 
 
 Z9264F_MAX_PSUS = 2
-IPMI_SENSOR_DATA = "docker exec -it pmon ipmitool sdr list"
+IPMI_PSU_DATA = "docker exec -it pmon ipmitool sdr list"
+IPMI_PSU_DATA_DOCKER = "ipmitool sdr list"
 PSU_PRESENCE = "PSU{0}_state"
 # Use this for older firmware
 # PSU_PRESENCE="PSU{0}_prsnt"
@@ -35,8 +37,10 @@ class PsuUtil(PsuBase):
         status = 1
         global ipmi_sdr_list
         ipmi_dev_node = "/dev/pmi0"
-
-        ipmi_cmd = IPMI_SENSOR_DATA
+        ipmi_cmd = IPMI_PSU_DATA
+        
+        if os.path.exists("/.dockerenv"):
+            ipmi_cmd = IPMI_PSU_DATA_DOCKER
         status, ipmi_sdr_list = commands.getstatusoutput(ipmi_cmd)
 
         if status:

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/psuutil.py
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/psuutil.py
@@ -84,7 +84,7 @@ class PsuUtil(PsuBase):
         :return: Boolean, True if PSU is operating properly, False if PSU is\
         faulty
         """
-    # Until psu_status is implemented this is hardcoded temporarily
+        # Until psu_status is implemented this is hardcoded temporarily
 
         status = 1
         return status


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
        1. Psud daemon in pmon docker is crashed due to  accessing host command in docker 
            environment. So construct the  ipmi  command string based on
             environments (host or docker).
**- How I did it**
        1. Differentiating host and docker environment based on  dockerenv file in docker. 
**- How to verify it**
        1.show platform psustatus
        2. dump the redis database 
                   Example:-  redis-dump -d 6 -y | grep PSU_ -A5
        3. snmpwalk -v 2c -c public <IP address> 1.3.6.1.4.1.9.9.117.1.1.2.1.2

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
[UT_log.txt](https://github.com/Azure/sonic-buildimage/files/3302944/UT_log.txt)
