### PR TITLE
[Sonic-config-engine]: View acls and ports or specifc port configs on sonic switch (Json)

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -169,6 +169,14 @@ def sort_data(data):
             data[table] = OrderedDict(natsorted(data[table].items()))
     return data
 
+def get_config(data, keyword):
+    config = {}
+    for key, value in data.iteritems():
+        if key == keyword:
+            config[keyword] = value
+            break
+    return config
+
 
 def main():
     parser=argparse.ArgumentParser(description="Render configuration file from minigraph data and jinja2 template.")
@@ -183,6 +191,7 @@ def main():
     parser.add_argument("-d", "--from-db", help="read config from configdb", action='store_true')
     parser.add_argument("-H", "--platform-info", help="read platform and hardware info", action='store_true')
     parser.add_argument("-s", "--redis-unix-sock-file", help="unix sock file for redis connection")
+    parser.add_argument("-i", "--interface", help="print specific port details")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-t", "--template", help="render the data with the template file")
     group.add_argument("-v", "--var", help="print the value of a variable, support jinja2 expression")
@@ -276,6 +285,10 @@ def main():
             print(json.dumps(FormatConverter.to_serialized(data[args.var_json], args.key), indent=4, cls=minigraph_encoder))
         else:
             print(json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder))
+        config = get_config(data, args.var_json)
+        if args.var_json == "PORT" and args.interface:
+            config = get_config(config[args.var_json], args.interface)
+        print(json.dumps(FormatConverter.to_serialized(config), indent=4, cls=minigraph_encoder))
 
     if args.write_to_db:
         configdb = ConfigDBConnector(**db_kwargs)

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -78,7 +78,12 @@ class TestCfgGen(TestCase):
     def test_var_json_data(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" --var-json VLAN_MEMBER'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), '{\n    "Vlan1000|Ethernet8": {\n        "tagging_mode": "untagged"\n    }\n}')
+        self.assertEqual(output.strip(), '{\n    "VLAN_MEMBER": {\n        "Vlan1000|Ethernet8": {\n            "tagging_mode": "untagged"\n        }\n    }\n}')
+
+    def test_var_json_with_interface(self):
+        argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" --var-json PORT -i Ethernet124'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), '{\n    "Ethernet124": {\n        "alias": "fortyGigE0/124", \n        "description": "fortyGigE0/124", \n        "lanes": "101,102,103,104", \n        "mtu": "9100", \n        "pfc_asym": "off"\n    }\n}')
 
     def test_read_yaml(self):
         argument = '-v yml_item -y ' + os.path.join(self.test_dir, 'test.yml')


### PR DESCRIPTION
Following features are added as the part of this PR, this only involves changes done to **sonic-config-engine**, I will submit a PR for changes done on sonic-utilities.

1) View acl configs
2) View port configs (like speed , lanes index etc)
3) View specific port configs

Signed-off-by: Prem Prakash prprakash@linkedin.com

**- What I did**
To view port configs and acl configs, added the support to sonic-config-engine and implemented the show commands for it
**- How I did it**
Modified sonic-cfggen file to add the support for acl and port running config. Even main.py file is modified under sonic-utilities/show folder.
**- How to verify it**
built sonic-utilities deb package and installed it and also changed the sonic-cfggen file in the switch under /usr/local/bin/sonic-cfggen

Added options **interface** and **accesslist** to the runningconfiguration option

admin@lnos-x1-a-csw02:~$ show runningconfiguration ?
Usage: show runningconfiguration [OPTIONS] COMMAND [ARGS]...

  Show current running configuration information

Options:
  -?, -h, --help  Show this message and exit.

Commands:
  accesslist  Show acl running configuration
  all         Show full running configuration
  bgp         Show BGP running configuration
  interface   Show port running configuration
  interfaces  Show interfaces running configuration
  ntp         Show NTP running configuration
  snmp        Show SNMP information
admin@lnos-x1-a-csw02:~$ 

ACL config- 

admin@lnos-x1-a-csw02:~$ show runningconfiguration accesslist 
{
    "ACL_RULE": {
        "NO-NSW-PACL-V4|DEFAULT_DENY": {
            "PACKET_ACTION": "DROP", 
            "IP_TYPE": "IPv4ANY", 
            "PRIORITY": "0"
        }, 
        "NO-NSW-PACL-V4|Rule_20": {
            "PACKET_ACTION": "FORWARD", 
            "DST_IP": "X.X.X.X/24", 
            "SRC_IP": "X.X.0.0/16", 
            "IP_TYPE": "IPv4ANY", 
            "PRIORITY": "999980"
        }
    }
}
admin@lnos-x1-a-csw02:~$ 

Port configs-


admin@lnos-x1-a-csw02:~$ show runningconfiguration interface
{
    "PORT": {
        "Ethernet0": {
            "index": "1", 
            "lanes": "65,66,67,68", 
            "mtu": "9100", 
            "alias": "Eth1", 
            "admin_status": "up", 
            "speed": "100000"
        }, 
        "Ethernet4": {
            "index": "2", 
            "lanes": "69,70,71,72", 
            "mtu": "9100", 
            "alias": "Eth2", 
            "admin_status": "up", 
            "speed": "100000"
        }, 
        "Ethernet8": {
            "index": "3", 
            "lanes": "73,74,75,76", 
            "mtu": "9100", 
            "alias": "Eth3", 
            "admin_status": "up", 
            "speed": "100000"
        }, 
        "Ethernet12": {
            "index": "4", 
            "lanes": "77,78,79,80", 
            "mtu": "9100", 
            "alias": "Eth4", 
            "admin_status": "up", 
            "speed": "100000"
        }
}

Port config for a specific port-


admin@lnos-x1-a-csw02:~$ show runningconfiguration interface Ethernet0
{
    "Ethernet0": {
        "admin_status": "up", 
        "alias": "Eth1", 
        "index": "1", 
        "lanes": "65,66,67,68", 
        "mtu": "9100", 
        "speed": "100000"
    }
}
admin@lnos-x1-a-csw02:~$ 



