### PR TITLE
[frr.conf] Advertise /64 prefix for ipv6 lo addresses in case 'unified' config mode

### DIFF
--- a/dockers/docker-fpm-frr/frr.conf.j2
+++ b/dockers/docker-fpm-frr/frr.conf.j2
@@ -99,7 +99,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   network {{ prefix | ip }}/32
 {% elif prefix | ipv6 and name == 'Loopback0' %}
   address-family ipv6
-    network {{ prefix | ip }}/128
+    network {{ prefix | ip }}/64
   exit-address-family
 {% endif %}
 {% endfor %}

--- a/src/sonic-config-engine/tests/sample_output/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/frr.conf
@@ -55,7 +55,7 @@ router bgp 65100
   bgp router-id 10.1.0.32
   network 10.1.0.32/32
   address-family ipv6
-    network fc00:1::32/128
+    network fc00:1::32/64
   exit-address-family
   network 192.168.0.1/27
   neighbor 10.0.0.57 remote-as 64600


### PR DESCRIPTION
**- What I did**

Advertise /64 prefix for ipv6 lo addresses. The same as [#1050](https://github.com/Azure/sonic-buildimage/pull/1050) but for docker frr, in case 'unified' config type. Also it will keep in sync this parameter with 'docker-fpm-frr/bgpd.conf.j2'

**- How to verify it**

Run `fast-reboot` community test, verify it pass.

**- Description for the changelog**

[frr.conf] Advertise /64 prefix for ipv6 lo addresses in case using 'unified' config mode


@lguohan please review and merge this
