### PR TITLE
[dockers] Refactor Dockerfiles

### DIFF
--- a/dockers/docker-base-stretch/Dockerfile.j2
+++ b/dockers/docker-base-stretch/Dockerfile.j2
@@ -1,11 +1,12 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM debian:stretch
 
 # Clean documentation in FROM image
 RUN find /usr/share/doc -depth \( -type f -o -type l \) ! -name copyright | xargs rm || true
 
 # Clean doc directories that are empty or only contain empty directories
-RUN while [ -n "$(find /usr/share/doc -depth -type d -empty -print -exec rmdir {} +)" ]; do :; done
-RUN rm -rf               \
+RUN while [ -n "$(find /usr/share/doc -depth -type d -empty -print -exec rmdir {} +)" ]; do :; done && \
+    rm -rf               \
     /usr/share/man/*     \
     /usr/share/groff/*   \
     /usr/share/info/*    \
@@ -21,28 +22,22 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
 COPY ["sources.list", "/etc/apt/sources.list"]
 COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
-RUN apt-get update
 
-# Pre-install fundamental packages
-RUN apt-get -y install \
-    less               \
-    perl               \
-    procps             \
-    python             \
-    rsyslog            \
-    vim-tiny
-
-COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
-COPY ["etc/rsyslog.d/*", "/etc/rsyslog.d/"]
-COPY ["root/.vimrc", "/root/.vimrc"]
-
+# Update apt cache and
+# pre-install fundamental packages
+RUN apt-get update &&        \
+    apt-get -y install       \
+        less                 \
+        perl                 \
+        procps               \
+        python               \
+        rsyslog              \
+        vim-tiny             \
 # Install dependencies of supervisor
-RUN apt-get -y install python-pkg-resources python-meld3
+        python-pkg-resources \
+        python-meld3
 
-RUN mkdir -p /etc/supervisor
-RUN mkdir -p /var/log/supervisor
-
-COPY ["etc/supervisor/supervisord.conf", "/etc/supervisor/"]
+RUN mkdir -p /etc/supervisor /var/log/supervisor
 
 RUN apt-get -y purge   \
     exim4              \
@@ -51,29 +46,29 @@ RUN apt-get -y purge   \
     exim4-daemon-light
 
 {% if docker_base_stretch_debs.strip() -%}
-# Copy built Debian packages
-{%- for deb in docker_base_stretch_debs.split(' ') %}
-COPY debs/{{ deb }} debs/
-{%- endfor %}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_base_stretch_debs.split(' '), "/debs/") }}
 
 # Install built Debian packages and implicitly install their dependencies
-{%- for deb in docker_base_stretch_debs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt debs/{{ deb }}
-{%- endfor %}
+{{ install_debian_packages(docker_base_stretch_debs.split(' ')) }}
 {%- endif %}
 
 {% if docker_base_stretch_dbgs.strip() -%}
 # Install common debug-packages
-{%- for dbg_pkg in docker_base_stretch_dbgs.split(' ') %}
-RUN apt-get -y install {{ dbg_pkg }}
-{%- endfor %}
+RUN apt-get -y install docker_base_stretch_dbgs.split(' ') | join(' ')
 {% else %}
 RUN ln /usr/bin/vim.tiny /usr/bin/vim
 {%- endif %}
 
 # Clean up apt
 # Remove /var/lib/apt/lists/*, could be obsoleted for derived images
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get clean -y                     && \
+    apt-get autoclean -y                 && \
+    apt-get autoremove -y                && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN rm -rf /tmp/*
+COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
+COPY ["etc/rsyslog.d/*", "/etc/rsyslog.d/"]
+COPY ["root/.vimrc", "/root/.vimrc"]
+
+COPY ["etc/supervisor/supervisord.conf", "/etc/supervisor/"]

--- a/dockers/docker-config-engine-stretch/Dockerfile.j2
+++ b/dockers/docker-config-engine-stretch/Dockerfile.j2
@@ -1,47 +1,49 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-base-stretch
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-
-# Dependencies for sonic-cfggen
-RUN apt-get install -y python-lxml python-yaml python-bitarray python-pip python-dev python-natsort python-setuptools
+RUN apt-get update         && \
+    apt-get install -y        \
+        # Dependencies for sonic-cfggen
+        python-lxml           \
+        python-yaml           \
+        python-bitarray       \
+        python-pip            \
+        python-dev            \
+        python-natsort        \
+        python-setuptools
 
 RUN pip install --upgrade pip
 
-RUN pip install netaddr ipaddr jinja2 pyangbind==0.5.10
+RUN pip install             \
+        netaddr             \
+        ipaddr              \
+        jinja2              \
+        pyangbind==0.5.10
 
 {% if docker_config_engine_stretch_debs.strip() %}
-COPY \
-{% for deb in docker_config_engine_stretch_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
-{%- endif -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_config_engine_stretch_debs.split(' '), "/debs/") }}
 
-{% if docker_config_engine_stretch_debs.strip() %}
-RUN dpkg -i \
-{% for deb in docker_config_engine_stretch_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor %}
-{%- endif -%}
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_config_engine_stretch_debs.split(' ')) }}
+{% endif %}
 
 {% if docker_config_engine_stretch_whls.strip() %}
-COPY \
-{% for whl in docker_config_engine_stretch_whls.split(' ') -%}
-python-wheels/{{ whl }}{{' '}}
-{%- endfor -%}
-python-wheels/
-{%- endif -%}
+# Copy locally-built Python wheel dependencies
+{{ copy_files("python-wheels/", docker_config_engine_stretch_whls.split(' '), "/python-wheels/") }}
 
-{% if docker_config_engine_stretch_whls.strip() %}
-RUN pip install \
-{% for whl in docker_config_engine_stretch_whls.split(' ') -%}
-python-wheels/{{ whl }}{{' '}}
-{%- endfor %}
-{%- endif -%}
+# Install locally-built Python wheel dependencies
+{{ install_python_wheels(docker_config_engine_stretch_whls.split(' ')) }}
+{% endif %}
 
 ## Clean up
-RUN apt-get purge -y python-pip python-dev; apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs /python-wheels
+RUN apt-get purge -y               \
+        python-pip                 \
+        python-dev              && \
+    apt-get clean -y            && \
+    apt-get autoclean -y        && \
+    apt-get autoremove -y       && \
+    rm -rf /debs /python-wheels

--- a/dockers/docker-database/Dockerfile.j2
+++ b/dockers/docker-database/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -11,23 +12,18 @@ RUN apt-get update
 
 {% if docker_database_debs.strip() -%}
 # Copy locally-built Debian package dependencies
-{%- for deb in docker_database_debs.split(' ') %}
-COPY debs/{{ deb }} /debs/
-{%- endfor %}
+{{ copy_files("debs/", docker_database_debs.split(' '), "/debs/") }}
 
 # Install locally-built Debian packages and implicitly install their dependencies
-{%- for deb in docker_database_debs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt /debs/{{ deb }}
-{%- endfor %}
+{{ install_debian_packages(docker_database_debs.split(' ')) }}
 {%- endif %}
 
 # Clean up
-RUN apt-get clean -y
-RUN apt-get autoclean -y
-RUN apt-get autoremove -y
-RUN rm -rf /debs ~/.cache
-
-RUN sed -ri 's/^(save .*$)/# \1/g;                       \
+RUN apt-get clean -y                                  && \
+    apt-get autoclean -y                              && \
+    apt-get autoremove -y                             && \
+    rm -rf /debs ~/.cache                             && \
+    sed -ri 's/^(save .*$)/# \1/g;                       \
              s/^daemonize yes$/daemonize no/;            \
              s/^logfile .*$/logfile ""/;                 \
              s/^# syslog-enabled no$/syslog-enabled no/; \

--- a/dockers/docker-dhcp-relay/Dockerfile.j2
+++ b/dockers/docker-dhcp-relay/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -11,19 +12,17 @@ RUN apt-get update
 
 {% if docker_dhcp_relay_debs.strip() -%}
 # Copy built Debian packages
-{%- for deb in docker_dhcp_relay_debs.split(' ') %}
-COPY debs/{{ deb }} debs/
-{%- endfor %}
+{{ copy_files("debs/", docker_dhcp_relay_debs.split(' '), "/debs/") }}
 
 # Install built Debian packages and implicitly install their dependencies
-{%- for deb in docker_dhcp_relay_debs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt debs/{{ deb }}
-{%- endfor %}
+{{ install_debian_packages(docker_dhcp_relay_debs.split(' ')) }}
 {%- endif %}
 
 # Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+RUN apt-get clean -y         && \
+    apt-get autoclean -y     && \
+    apt-get autoremove -y    && \
+    rm -rf /debs
 
 COPY ["docker_init.sh", "start.sh", "/usr/bin/"]
 COPY ["docker-dhcp-relay.supervisord.conf.j2", "wait_for_intf.sh.j2", "/usr/share/sonic/templates/"]

--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -10,33 +11,37 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Update apt's cache of available packages
-RUN apt-get update
-
 # Install required packages
-RUN apt-get install -y libdbus-1-3 libdaemon0 libjansson4 libc-ares2 iproute2 libpython2.7 libjson-c3 logrotate libunwind8
-
-{% if docker_fpm_frr_debs.strip() -%}
-# Copy locally-built Debian package dependencies
-{%- for deb in docker_fpm_frr_debs.split(' ') %}
-COPY debs/{{ deb }} /debs/
-{%- endfor %}
+RUN apt-get update   && \
+    apt-get install -y  \
+        libdbus-1-3     \
+        libdaemon0      \
+        libjansson4     \
+        libc-ares2      \
+        iproute2        \
+        libpython2.7    \
+        libjson-c3      \
+        logrotate       \
+        libunwind8
 
 RUN groupadd -g ${frr_user_gid} frr
 RUN useradd -u ${frr_user_uid} -g ${frr_user_gid} -M -s /bin/false frr
 
+{% if docker_fpm_frr_debs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_fpm_frr_debs.split(' '), "/debs/") }}
+
 # Install locally-built Debian packages and implicitly install their dependencies
-{%- for deb in docker_fpm_frr_debs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt /debs/{{ deb }}
-{%- endfor %}
+{{ install_debian_packages(docker_fpm_frr_debs.split(' ')) }}
 {%- endif %}
 
 RUN chown -R ${frr_user_uid}:${frr_user_gid} /etc/frr/
 
 # Clean up
-RUN apt-get clean -y
-RUN apt-get autoclean -y
-RUN apt-get autoremove -y
-RUN rm -rf /debs ~/.cache
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs ~/.cache
 
 COPY ["bgpcfgd", "start.sh", "/usr/bin/"]
 COPY ["*.j2", "/usr/share/sonic/templates/"]

--- a/dockers/docker-lldp-sv2/Dockerfile.j2
+++ b/dockers/docker-lldp-sv2/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -9,37 +10,30 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Update apt's cache of available packages
 RUN apt-get update
 
-
 {% if docker_lldp_sv2_debs.strip() -%}
 # Copy locally-built Debian package dependencies
-{%- for deb in docker_lldp_sv2_debs.split(' ') %}
-COPY debs/{{ deb }} /debs/
-{%- endfor %}
+{{ copy_files("debs/", docker_lldp_sv2_debs.split(' '), "/debs/") }}
 
 # Install locally-built Debian packages and implicitly install their dependencies
-{%- for deb in docker_lldp_sv2_debs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt /debs/{{ deb }}
-{%- endfor %}
+{{ install_debian_packages(docker_lldp_sv2_debs.split(' ')) }}
 {%- endif %}
 
 {% if docker_lldp_sv2_whls.strip() -%}
 # Copy locally-built Python wheel dependencies
-{%- for whl in docker_lldp_sv2_whls.split(' ') %}
-COPY python-wheels/{{ whl }} /python-wheels/
-{%- endfor %}
+{{ copy_files("python-wheels/", docker_lldp_sv2_whls.split(' '), "/python-wheels/") }}
 
 # Install locally-built Python wheel dependencies
-{%- for whl in docker_lldp_sv2_whls.split(' ') %}
-RUN pip install /python-wheels/{{ whl }}
-{%- endfor %}
+{{ install_python_wheels(docker_lldp_sv2_whls.split(' ')) }}
 {% endif %}
 
 # Clean up
-RUN apt-get purge -y python-pip
-RUN apt-get clean -y
-RUN apt-get autoclean -y
-RUN apt-get autoremove -y
-RUN rm -rf /debs /python-wheels ~/.cache
+RUN apt-get purge -y python-pip && \
+    apt-get clean -y            && \
+    apt-get autoclean -y        && \
+    apt-get autoremove -y       && \
+    rm -rf /debs                   \
+           /python-wheels          \
+           ~/.cache
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -6,36 +7,44 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
+RUN apt-get update &&       \
+    apt-get install -f -y   \
+        ifupdown            \
+        arping              \
+        libdbus-1-3         \
+        libdaemon0          \
+        libjansson4         \
+        libpython2.7        \
+        iproute2            \
+        ndisc6              \
+        tcpdump             \
+        # Install redis-tools dependencies
+        # TODO: implicitly install dependencies
+        libjemalloc1        \
+        libelf1             \
+        libmnl0             \
+        bridge-utils
 
-RUN apt-get install -f -y ifupdown arping libdbus-1-3 libdaemon0 libjansson4 libpython2.7 iproute2
+RUN pip install \
+        scapy==2.4.2 \
+        setuptools \
+        pyroute2==0.5.3 \
+        netifaces==0.10.7 \
+        monotonic==1.5
 
-RUN apt-get install -f -y ndisc6 tcpdump
-RUN pip install scapy==2.4.2
-## Install redis-tools dependencies
-## TODO: implicitly install dependencies
-RUN apt-get -y install libjemalloc1
+{% if docker_orchagent_debs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_orchagent_debs.split(' '), "/debs/") }}
 
-RUN apt-get install -y libelf1 libmnl0 bridge-utils
-
-RUN pip install setuptools
-RUN pip install pyroute2==0.5.3 netifaces==0.10.7
-RUN pip install monotonic==1.5
-
-COPY \
-{% for deb in docker_orchagent_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
-
-RUN dpkg -i \
-{% for deb in docker_orchagent_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor %}
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_orchagent_debs.split(' ')) }}
+{%- endif %}
 
 ## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+RUN apt-get clean -y        && \
+    apt-get autoclean -y    && \
+    apt-get autoremove -y   && \
+    rm -rf /debs
 
 COPY ["files/arp_update", "/usr/bin"]
 COPY ["enable_counters.py", "/usr/bin"]

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -7,50 +8,51 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install required packages
-RUN apt-get update && apt-get install -y python-pip libpython2.7 ipmitool librrd8 librrd-dev rrdtool python-smbus ethtool dmidecode
+RUN apt-get update &&   \
+    apt-get install -y  \
+        python-pip      \
+        libpython2.7    \
+        ipmitool        \
+        librrd8         \
+        librrd-dev      \
+        rrdtool         \
+        python-smbus    \
+        ethtool         \
+        dmidecode
 
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies
-{%- for deb in docker_platform_monitor_debs.split(' ') %}
-COPY debs/{{ deb }} /debs/
-{%- endfor %}
+{{ copy_files("debs/", docker_platform_monitor_debs.split(' '), "/debs/") }}
 
 # Install locally-built Debian packages and implicitly install their dependencies
-{%- for deb in docker_platform_monitor_debs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt /debs/{{ deb }}
-{%- endfor %}
+{{ install_debian_packages(docker_platform_monitor_debs.split(' ')) }}
 {%- endif %}
 
 {% if docker_platform_monitor_pydebs.strip() -%}
 # Copy locally-built Debian package dependencies
-{%- for deb in docker_platform_monitor_pydebs.split(' ') %}
-COPY python-debs/{{ deb }} /debs/
-{%- endfor %}
+{{ copy_files("python-debs/", docker_platform_monitor_pydebs.split(' '), "/debs/") }}
 
 # Install locally-built Debian packages and implicitly install their dependencies
-{%- for deb in docker_platform_monitor_pydebs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt /debs/{{ deb }}
-{%- endfor %}
+{{ install_debian_packages(docker_platform_monitor_pydebs.split(' ')) }}
 {%- endif %}
 
 {% if docker_platform_monitor_whls.strip() -%}
 # Copy locally-built Python wheel dependencies
-{%- for whl in docker_platform_monitor_whls.split(' ') %}
-COPY python-wheels/{{ whl }} /python-wheels/
-{%- endfor %}
+{{ copy_files("python-wheels/", docker_platform_monitor_whls.split(' '), "/python-wheels/") }}
 
 # Install locally-built Python wheel dependencies
-{%- for whl in docker_platform_monitor_whls.split(' ') %}
-RUN pip install /python-wheels/{{ whl }}
-{%- endfor %}
+{{ install_python_wheels(docker_platform_monitor_whls.split(' ')) }}
 {% endif %}
 
 # Clean up
-RUN apt-get purge -y python-pip
-RUN apt-get clean -y
-RUN apt-get autoclean -y
-RUN apt-get autoremove -y
-RUN rm -rf /debs /python-wheels ~/.cache
+RUN apt-get purge -y           \
+        python-pip          && \
+    apt-get clean -y        && \
+    apt-get autoclean -y    && \
+    apt-get autoremove -y   && \
+    rm -rf /debs               \
+           /python-wheels      \
+           ~/.cache
 
 COPY ["docker_init.sh", "lm-sensors.sh", "/usr/bin/"]
 COPY ["docker-pmon.supervisord.conf.j2", "start.sh.j2", "/usr/share/sonic/templates/"]

--- a/dockers/docker-router-advertiser/Dockerfile.j2
+++ b/dockers/docker-router-advertiser/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -11,19 +12,17 @@ RUN apt-get update
 
 {% if docker_router_advertiser_debs.strip() -%}
 # Copy built Debian packages
-{%- for deb in docker_router_advertiser_debs.split(' ') %}
-COPY debs/{{ deb }} debs/
-{%- endfor %}
+{{ copy_files("debs/", docker_router_advertiser_debs.split(' '), "/debs/") }}
 
 # Install built Debian packages and implicitly install their dependencies
-{%- for deb in docker_router_advertiser_debs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt debs/{{ deb }}
-{%- endfor %}
+{{ install_debian_packages(docker_router_advertiser_debs.split(' ')) }}
 {%- endif %}
 
 # Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+RUN apt-get clean -y        && \
+    apt-get autoclean -y    && \
+    apt-get autoremove -y   && \
+    rm -rf /debs
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["docker-router-advertiser.supervisord.conf", "/etc/supervisor/conf.d/"]

--- a/dockers/docker-snmp-sv2/Dockerfile.j2
+++ b/dockers/docker-snmp-sv2/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -10,62 +11,65 @@ ENV PYTHONOPTIMIZE 1
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Update apt's cache of available packages
-RUN apt-get update
-
 # Install curl so we can download and install pip later
 # Also install major root CA certificates for curl to reference
-RUN apt-get install -y curl ca-certificates
-
 # Install gcc which is required for installing hiredis
-RUN apt-get install -y gcc make
-
 # Install libdpkg-perl which is required for python3.6-3.6.0 as one of its specs i.e. no-pie-compile.specs
 # The file referenced (`/usr/share/dpkg/no-pie-compile.specs`) is in the `libdpkg-perl` package on Debian
-RUN apt-get install -y libdpkg-perl
+RUN apt-get update   && \
+    apt-get install -y  \
+        curl            \
+        ca-certificates \
+        gcc             \
+        make            \
+        libdpkg-perl
 
 {% if docker_snmp_sv2_debs.strip() -%}
 # Copy locally-built Debian package dependencies
-{%- for deb in docker_snmp_sv2_debs.split(' ') %}
-COPY debs/{{ deb }} /debs/
-{%- endfor %}
+{{ copy_files("debs/", docker_snmp_sv2_debs.split(' '), "/debs/") }}
 
 # Install locally-built Debian packages and implicitly install their dependencies
-{%- for deb in docker_snmp_sv2_debs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt /debs/{{ deb }}
-{%- endfor %}
+{{ install_debian_packages(docker_snmp_sv2_debs.split(' ')) }}
 {%- endif %}
 
 # Install up-to-date version of pip
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
-RUN python3.6 -m pip install --no-cache-dir hiredis
 
 # Install pyyaml dependency for use by some plugins
-RUN python3.6 -m pip install --no-cache-dir pyyaml
-
 # Install smbus dependency for use by some plugins
-RUN python3.6 -m pip install --no-cache-dir smbus
+RUN python3.6 -m pip install --no-cache-dir \
+        hiredis                             \
+        pyyaml                              \
+        smbus
 
 {% if docker_snmp_sv2_whls.strip() -%}
 # Copy locally-built Python wheel dependencies
-{%- for whl in docker_snmp_sv2_whls.split(' ') %}
-COPY python-wheels/{{ whl }} /python-wheels/
-{%- endfor %}
+{{ copy_files("python-wheels/", docker_snmp_sv2_whls.split(' '), "/python-wheels/") }}
 
 # Install locally-built Python wheel dependencies
-{%- for whl in docker_snmp_sv2_whls.split(' ') %}
-RUN pip install /python-wheels/{{ whl }}
-{%- endfor %}
+{{ install_python_wheels(docker_snmp_sv2_whls.split(' ')) }}
 {% endif %}
 
 RUN python3.6 -m sonic_ax_impl install
 
 # Clean up
-RUN apt-get -y purge libpython3.6-dev libpython3.6 curl gcc make libdpkg-perl
-# Note: these packages should be removed with autoremove but actually not, so explicitly purged
-RUN apt-get -y purge libldap-2.4-2 libsasl2-2 libsasl2-modules libsasl2-modules-db
-RUN apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y --purge
-RUN find / | grep -E "__pycache__" | xargs rm -rf
-RUN rm -rf /debs /python-wheels ~/.cache
+RUN apt-get -y purge     \
+        libpython3.6-dev \
+        libpython3.6     \
+        curl             \
+        gcc              \
+        make             \
+        libdpkg-perl     \
+        # Note: these packages should be removed with autoremove but actually not, so explicitly purged
+        libldap-2.4-2    \
+        libsasl2-2       \
+        libsasl2-modules \
+        libsasl2-modules-db && \
+    apt-get clean -y        && \
+    apt-get autoclean -y    && \
+    apt-get autoremove -y --purge && \
+    find / | grep -E "__pycache__" | xargs rm -rf && \
+    rm -rf /debs /python-wheels ~/.cache
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -6,29 +7,29 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
+RUN apt-get update      && \
+    apt-get install -f -y  \
+        libdbus-1-3        \
+        libdaemon0         \
+        libjansson4        \
+        # Install redis-tools dependencies
+        # TODO: implicitly install dependencies
+        libjemalloc1
 
-RUN apt-get install -f -y libdbus-1-3 libdaemon0 libjansson4
+{% if docker_sonic_telemetry_debs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_sonic_telemetry_debs.split(' '), "/debs/") }}
 
-## Install redis-tools dependencies
-## TODO: implicitly install dependencies
-RUN apt-get -y install libjemalloc1
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_sonic_telemetry_debs.split(' ')) }}
+{%- endif %}
 
-COPY \
-{% for deb in docker_sonic_telemetry_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
-
-RUN dpkg -i \
-{% for deb in docker_sonic_telemetry_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor %}
+RUN apt-get clean -y      && \
+    apt-get autoclean -   && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
 COPY ["start.sh", "telemetry.sh", "dialout.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
-
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -6,29 +7,30 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
+RUN apt-get update      && \
+    apt-get install -f -y  \
+        libdbus-1-3        \
+        libdaemon0         \
+        libjansson4        \
+        libpython2.7       \
+        # Install redis-tools dependencies
+        # TODO: implicitly install dependencies
+        libjemalloc1
 
-RUN apt-get install -f -y libdbus-1-3 libdaemon0 libjansson4 libpython2.7
+{% if docker_teamd_debs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_teamd_debs.split(' '), "/debs/") }}
 
-## Install redis-tools dependencies
-## TODO: implicitly install dependencies
-RUN apt-get -y install libjemalloc1
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_teamd_debs.split(' ')) }}
+{%- endif %}
 
-COPY \
-{% for deb in docker_teamd_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
-
-RUN dpkg -i \
-{% for deb in docker_teamd_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor %}
+RUN apt-get clean -y      && \
+    apt-get autoclean -y  && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
-
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/dockerfile-macros.j2
+++ b/dockers/dockerfile-macros.j2
@@ -1,0 +1,18 @@
+{% macro install_debian_packages(packages) -%}
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; \
+    {%- for deb in packages %}
+        dpkg_apt /debs/{{ deb }} {%- if not loop.last %} && \ {%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{% macro install_python_wheels(packages) -%}
+RUN cd /python-wheels/ && pip install {{ packages | join(' ') }}
+{%- endmacro %}
+
+{% macro copy_files(prefix, files, dest) -%}
+COPY \
+    {%- for file in files %}
+        {{ prefix }}/{{ file }} \
+    {%- endfor %}
+    {{ dest }}
+{%- endmacro %}

--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -1,31 +1,26 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-syncd-mlnx
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-COPY \
-{% for deb in docker_syncd_mlnx_rpc_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
+{% if docker_syncd_mlnx_rpc_debs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_syncd_mlnx_rpc_debs.split(' '), "/debs/") }}
 
-COPY \
-{% for deb in docker_syncd_mlnx_rpc_pydebs.split(' ') -%}
-python-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_mlnx_rpc_debs.split(' ')) }}
+{% endif %}
+
+{% if docker_syncd_mlnx_rpc_pydebs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("python-debs/", docker_syncd_mlnx_rpc_pydebs.split(' '), "/debs/") }}
+
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_mlnx_rpc_pydebs.split(' ')) }}
+{% endif %}
 
 RUN apt-get purge -y syncd
-
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_mlnx_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_mlnx_rpc_pydebs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
 
 ## Pre-install the fundamental packages
 RUN apt-get update \
@@ -58,5 +53,5 @@ RUN apt-get update \
  && rm -rf /root/deps
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
- 
+
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 FROM docker-config-engine-stretch
 
 ARG docker_container_name
@@ -6,37 +7,33 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
+RUN apt-get update && \
+    apt-get install -y \
+        libxml2
 
-COPY \
-{% for deb in docker_syncd_mlnx_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
+{% if docker_syncd_mlnx_debs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("debs/", docker_syncd_mlnx_debs.split(' '), "/debs/") }}
 
-COPY \
-{% for deb in docker_syncd_mlnx_pydebs.split(' ') -%}
-python-debs/{{ deb }}{{' '}}
-{%- endfor -%}
-debs/
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_mlnx_debs.split(' ')) }}
+{% endif %}
 
-RUN apt-get install -y libxml2
+{% if docker_syncd_mlnx_pydebs.strip() -%}
+# Copy locally-built Debian package dependencies
+{{ copy_files("python-debs/", docker_syncd_mlnx_pydebs.split(' '), "/debs/") }}
 
-RUN dpkg -i \
-{% for deb in docker_syncd_mlnx_debs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor %}
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_mlnx_pydebs.split(' ')) }}
+{% endif %}
 
-RUN dpkg -i \
-{% for deb in docker_syncd_mlnx_pydebs.split(' ') -%}
-debs/{{ deb }}{{' '}}
-{%- endfor %}
+## Clean up
+RUN apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /debs
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
-
-## Clean up
-RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
 
 ENTRYPOINT ["/usr/bin/supervisord"]


### PR DESCRIPTION
- create a dockerfile-marcros.j2 file with all common operations
  written as j2 macro
- use single dockerfile instruction for COPY and RUN commands
  when possible to improve build time
- reorganize dockerfile instructions to make more cache friendly
  (in case someday we will remove --no-cache to build docker images)

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Refarctor Dockerfiles
- Remove code duplication in Dockerfiles by creating a j2 file with common macros
- Improved build time by reducing number of steps in Dockerfile
  (e.g. for SNMP docker - 27 minutes to 11 minutes)

**- How I did it**

**- How to verify it**
Build mellanox image, install on DUT, run few tests to verify each docker functionality (lldp, snmp, bgp_fact, fib)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
