### PR TITLE
[slave] upgrade docker to 18.09 in stretch slave

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -117,6 +117,7 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            PASSWORD=$(PASSWORD) \
                            USERNAME=$(USERNAME) \
                            SONIC_BUILD_JOBS=$(SONIC_BUILD_JOBS) \
+                           SONIC_USE_DOCKER_BUILDKIT=$(SONIC_USE_DOCKER_BUILDKIT) \
                            VS_PREPARE_MEM=$(VS_PREPARE_MEM) \
                            KERNEL_PROCURE_METHOD=$(KERNEL_PROCURE_METHOD) \
                            HTTP_PROXY=$(http_proxy) \

--- a/rules/config
+++ b/rules/config
@@ -16,6 +16,14 @@ SONIC_CONFIG_BUILD_JOBS = 1
 # Corresponding -j argument will be passed to make/dpkg commands that build separate packages
 SONIC_CONFIG_MAKE_JOBS = $(shell nproc)
 
+# SONIC_USE_DOCKER_BUILDKIT - use docker buildkit for build.
+# If set to y SONiC build system will set environment variable DOCKER_BUILDKIT=1
+# to enable docker buildkit.
+# This options will speed up docker image build time.
+# NOTE: SONIC_USE_DOCKER_BUILDKIT will produce larger installable SONiC image
+# because of a docker bug (more details: https://github.com/moby/moby/issues/38903)
+# SONIC_USE_DOCKER_BUILDKIT = y
+
 # SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD - use native dockerd for build.
 # If set to y SONiC build container will use native dockerd instead of dind for faster build
 # SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD = y

--- a/slave.mk
+++ b/slave.mk
@@ -151,6 +151,7 @@ $(info "CONFIGURED_PLATFORM"             : "$(if $(PLATFORM),$(PLATFORM),$(CONFI
 $(info "SONIC_CONFIG_PRINT_DEPENDENCIES" : "$(SONIC_CONFIG_PRINT_DEPENDENCIES)")
 $(info "SONIC_BUILD_JOBS"                : "$(SONIC_BUILD_JOBS)")
 $(info "SONIC_CONFIG_MAKE_JOBS"          : "$(SONIC_CONFIG_MAKE_JOBS)")
+$(info "SONIC_USE_DOCKER_BUILDKIT"       : "$(SONIC_USE_DOCKER_BUILDKIT)")
 $(info "USERNAME"                        : "$(USERNAME)")
 $(info "PASSWORD"                        : "$(PASSWORD)")
 $(info "ENABLE_DHCP_GRAPH_SERVICE"       : "$(ENABLE_DHCP_GRAPH_SERVICE)")
@@ -174,6 +175,12 @@ $(info "BUILD_TIMESTAMP"                 : "$(BUILD_TIMESTAMP)")
 $(info "BLDENV"                          : "$(BLDENV)")
 $(info "VS_PREPARE_MEM"                  : "$(VS_PREPARE_MEM)")
 $(info )
+
+ifeq ($(SONIC_USE_DOCKER_BUILDKIT),y)
+$(warning "Using SONIC_USE_DOCKER_BUILDKIT will produce larger installable SONiC image because of a docker bug (more details: https://github.com/moby/moby/issues/38903)")
+export DOCKER_BUILDKIT=1
+endif
+
 
 ###############################################################################
 ## Generic rules section

--- a/sonic-slave-stretch/Dockerfile
+++ b/sonic-slave-stretch/Dockerfile
@@ -326,5 +326,5 @@ RUN add-apt-repository \
            $(lsb_release -cs) \
            stable"
 RUN apt-get update
-RUN apt-get install -y docker-ce=17.03.2~ce-0~debian-stretch
+RUN apt-get install -y docker-ce=5:18.09.5~3-0~debian-stretch
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker


### PR DESCRIPTION
Also add an option to use docker buildkit for image build

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Upgrade docker in sonic-slave container
Add option to use DOCKER BUILD KIT to build docker images
This option can improve the docker image build time (2.5x improvements on our build server per docker image)

**- How I did it**
Change docker version

**- How to verify it**
Build an image, verify ports are up, bgp is up

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
