### PR TITLE
[telemetry]: change the service dependency from swss to database

### DIFF
--- a/files/build_templates/telemetry.service.j2
+++ b/files/build_templates/telemetry.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=Telemetry container
-Requires=swss.service
-After=swss.service
+Requires=database.service
+After=database.service
 Before=ntp-config.service
 
 [Service]


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**- What I did**
Change Telemetry container dependency from swss to database.

Telemetry container doesn't have dependency on swss service.

**- How I did it**

**- How to verify it**
Stop swss service, telemetry container remains up
```
root@vlab-01:/etc/systemd/system# systemctl stop swss
root@vlab-01:/etc/systemd/system# docker ps
CONTAINER ID        IMAGE                           COMMAND                  CREATED             STATUS              PORTS               NAMES
dc801e18e9ed        docker-sonic-telemetry:latest   "/usr/bin/supervisord"   36 hours ago        Up About a minute                       telemetry
334d8a1ce0ef        docker-fpm-frr:latest           "/usr/bin/supervisord"   36 hours ago        Up 5 hours                              bgp
899e7f34b639        docker-lldp-sv2:latest          "/usr/bin/supervisord"   36 hours ago        Up 5 hours                              lldp
d8d419e050e6        docker-database:latest          "/usr/bin/supervisord"   36 hours ago        Up 5 hours                              database
root@vlab-01:/etc/systemd/system# systemctl status telemetry
● telemetry.service - Telemetry container
   Loaded: loaded (/etc/systemd/system/telemetry.service; enabled; vendor preset: enabled)
   Active: active (running) since Mon 2019-06-24 08:45:03 UTC; 1min 23s ago
  Process: 27588 ExecStartPre=/usr/bin/telemetry.sh start (code=exited, status=0/SUCCESS)
 Main PID: 28180 (telemetry.sh)
    Tasks: 9 (limit: 4915)
   Memory: 20.5M
      CPU: 2.563s
   CGroup: /system.slice/telemetry.service
           ├─28180 /bin/bash /usr/bin/telemetry.sh wait
           └─28183 docker wait telemetry

Jun 24 08:44:51 vlab-01 systemd[1]: Starting Telemetry container...
Jun 24 08:44:55 vlab-01 telemetry.sh[27588]: Starting existing telemetry container with HWSKU Force10-S6000
Jun 24 08:44:56 vlab-01 telemetry.sh[27588]: telemetry
Jun 24 08:44:59 vlab-01 telemetry.sh[27588]: Set hostname in telemetry container
Jun 24 08:45:03 vlab-01 systemd[1]: Started Telemetry container.
```

Restart swss service, telemetry service stays as before:
```
root@vlab-01:/etc/systemd/system# systemctl  restart swss
root@vlab-01:/etc/systemd/system# docker ps
CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS              PORTS               NAMES
5f38ac6776e2        docker-syncd-vs:latest            "/usr/bin/supervisord"   36 hours ago        Up 3 minutes                            syncd
25e96b649ee1        docker-dhcp-relay:latest          "/usr/bin/docker_ini…"   36 hours ago        Up 2 minutes                            dhcp_relay
15fe114b6e9c        docker-snmp-sv2:latest            "/usr/bin/supervisord"   36 hours ago        Up 3 minutes                            snmp
21caf4cb0468        docker-router-advertiser:latest   "/usr/bin/supervisord"   36 hours ago        Up 3 minutes                            radv
1c52ab2a93f3        docker-teamd:latest               "/usr/bin/supervisord"   36 hours ago        Up 3 minutes                            teamd
dc801e18e9ed        docker-sonic-telemetry:latest     "/usr/bin/supervisord"   36 hours ago        Up 5 minutes                            telemetry
7322f76f110d        docker-orchagent:latest           "/usr/bin/supervisord"   36 hours ago        Up 3 minutes                            swss
334d8a1ce0ef        docker-fpm-frr:latest             "/usr/bin/supervisord"   36 hours ago        Up 5 hours                              bgp
899e7f34b639        docker-lldp-sv2:latest            "/usr/bin/supervisord"   36 hours ago        Up 5 hours                              lldp
d8d419e050e6        docker-database:latest            "/usr/bin/supervisord"   36 hours ago        Up 5 hours                              database
root@vlab-01:/etc/systemd/system# systemctl status telemetry
● telemetry.service - Telemetry container
   Loaded: loaded (/etc/systemd/system/telemetry.service; enabled; vendor preset: enabled)
   Active: active (running) since Mon 2019-06-24 08:45:03 UTC; 6min ago
  Process: 27588 ExecStartPre=/usr/bin/telemetry.sh start (code=exited, status=0/SUCCESS)
 Main PID: 28180 (telemetry.sh)
    Tasks: 9 (limit: 4915)
   Memory: 20.7M
      CPU: 2.586s
   CGroup: /system.slice/telemetry.service
           ├─28180 /bin/bash /usr/bin/telemetry.sh wait
           └─28183 docker wait telemetry

Jun 24 08:44:51 vlab-01 systemd[1]: Starting Telemetry container...
Jun 24 08:44:55 vlab-01 telemetry.sh[27588]: Starting existing telemetry container with HWSKU Force10-S6000
Jun 24 08:44:56 vlab-01 telemetry.sh[27588]: telemetry
Jun 24 08:44:59 vlab-01 telemetry.sh[27588]: Set hostname in telemetry container
Jun 24 08:45:03 vlab-01 systemd[1]: Started Telemetry container.
root@vlab-01:/etc/systemd/system# 
```
