### PR TITLE
[services] BGP service depends on SwSS service

### DIFF
--- a/files/build_templates/bgp.service.j2
+++ b/files/build_templates/bgp.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=BGP container
-Requires=updategraph.service
-After=updategraph.service
+Requires=updategraph.service swss.service
+After=updategraph.service swss.service
 Before=ntp-config.service
 
 [Service]
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target swss.service


### PR DESCRIPTION
**- What I did/How I did it**

Make BGP service dependent upon SwSS service. BGP service should never run unless SwSS is running and healthy, otherwise the switch could blackhole traffic. By adding SwSS to the `Requires=` and `After=` options, the BGP service will now start only after SwSS successfully starts. 

Also, with the addition of https://github.com/Azure/sonic-buildimage/pull/2845, I also added SwSS to the `WantedBy=` option, which will ensure the BGP service gets stopped if SwSS ever stops, and it will also get restarted if SwSS gets restarted.

**- How to verify it**

- At boot, ensure bgp.service starts after swss.service
- Kill a critical process in the SwSS container (e.g., `pkill -11 orchagent`). This will cause the SwSS service to stop and restart. Ensure that the BGP service stops shortly after the SwSS service stops. Wait until SwSS automatically restarts, then ensure the BGP service also gets restarted afterward.