### PR TITLE
fix fast reboot compatibility

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -33,15 +33,14 @@ function updateHostName()
 
 function getBootType()
 {
-    local BOOT_TYPE
     case "$(cat /proc/cmdline)" in
-    *warm*)
+    *SONIC_BOOT_TYPE=warm*)
         TYPE='warm'
         ;;
-    *fastfast*)
+    *SONIC_BOOT_TYPE=fastfast*)
         TYPE='fastfast'
         ;;
-    *fast*)
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         TYPE='fast'
         ;;
     *)

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -34,14 +34,14 @@ function updateHostName()
 function getBootType()
 {
     local BOOT_TYPE
-    case "$(cat /proc/cmdline | grep -o 'SONIC_BOOT_TYPE=\S*' | cut -d'=' -f2)" in
-    warm*)
+    case "$(cat /proc/cmdline)" in
+    *warm*)
         TYPE='warm'
         ;;
-    fastfast)
+    *fastfast*)
         TYPE='fastfast'
         ;;
-    fast*)
+    *fast*)
         TYPE='fast'
         ;;
     *)
@@ -167,7 +167,7 @@ start() {
     echo "Creating new {{docker_container_name}} container with HWSKU $HWSKU"
 {%- endif %}
 {%- if sonic_asic_platform == "mellanox" %}
-    # TODO: Mellanox will remove the --tmpfs exception after SDK socket path changed in new SDK version 
+    # TODO: Mellanox will remove the --tmpfs exception after SDK socket path changed in new SDK version
 {%- endif %}
     docker create {{docker_image_run_opt}} \
 {%- if '--log-driver=json-file' in docker_image_run_opt or '--log-driver' not in docker_image_run_opt %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -33,6 +33,7 @@ function updateHostName()
 
 function getBootType()
 {
+    # same code snippet in files/scripts/syncd.sh
     case "$(cat /proc/cmdline)" in
     *SONIC_BOOT_TYPE=warm*)
         TYPE='warm'

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -56,13 +56,13 @@ function wait_for_database_service()
 function getBootType()
 {
     case "$(cat /proc/cmdline)" in
-    *warm*)
+    *SONIC_BOOT_TYPE=warm*)
         TYPE='warm'
         ;;
-    *fastfast*)
+    *SONIC_BOOT_TYPE=fastfast*)
         TYPE='fastfast'
         ;;
-    *fast*)
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         TYPE='fast'
         ;;
     *)

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -55,14 +55,14 @@ function wait_for_database_service()
 
 function getBootType()
 {
-    case "$(cat /proc/cmdline | grep -o 'SONIC_BOOT_TYPE=\S*' | cut -d'=' -f2)" in
-    warm*)
+    case "$(cat /proc/cmdline)" in
+    *warm*)
         TYPE='warm'
         ;;
-    fastfast)
+    *fastfast*)
         TYPE='fastfast'
         ;;
-    fast*)
+    *fast*)
         TYPE='fast'
         ;;
     *)

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -55,6 +55,7 @@ function wait_for_database_service()
 
 function getBootType()
 {
+    # same code snippet in files/build_templates/docker_image_ctl.j2
     case "$(cat /proc/cmdline)" in
     *SONIC_BOOT_TYPE=warm*)
         TYPE='warm'


### PR DESCRIPTION
We should handle both cases for backward-compatible with 201803:
 - fast-reboot
 - SONIC_BOOT_TYPE=fast-reboot

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

**NOTE** : DEPENDS on https://github.com/Azure/sonic-sairedis/pull/480

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

Run 201803 (157th public jenkins image + https://github.com/Azure/sonic-buildimage/pull/3077) -> 201811 (73th public jenkins image + this PR)
* verified 201811 image started in fast mode
Run 201811 (73th public jenkins image + this PR) fast reboot test
Run 201811 (73th public jenkins image + this PR) warm reboot test


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
