### PR TITLE
[fast-reboot] fix fast reboot compatibility (#3083) and advance sai-redis/201811 point

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -7,15 +7,15 @@ function getMountPoint()
 
 function getBootType()
 {
-    local BOOT_TYPE
-    case "$(cat /proc/cmdline | grep -o 'SONIC_BOOT_TYPE=\S*' | cut -d'=' -f2)" in
-    warm*)
+    # same code snippet in files/scripts/syncd.sh
+    case "$(cat /proc/cmdline)" in
+    *SONIC_BOOT_TYPE=warm*)
         TYPE='warm'
         ;;
-    fastfast)
+    *SONIC_BOOT_TYPE=fastfast*)
         TYPE='fastfast'
         ;;
-    fast*)
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         TYPE='fast'
         ;;
     *)

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -55,14 +55,15 @@ function wait_for_database_service()
 
 function getBootType()
 {
-    case "$(cat /proc/cmdline | grep -o 'SONIC_BOOT_TYPE=\S*' | cut -d'=' -f2)" in
-    warm*)
+    # same code snippet in files/build_templates/docker_image_ctl.j2
+    case "$(cat /proc/cmdline)" in
+    *SONIC_BOOT_TYPE=warm*)
         TYPE='warm'
         ;;
-    fastfast)
+    *SONIC_BOOT_TYPE=fastfast*)
         TYPE='fastfast'
         ;;
-    fast*)
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         TYPE='fast'
         ;;
     *)


### PR DESCRIPTION
I cannot do a clean cherry-pick so create standalone PR against 201811.