### PR TITLE
sonic-device-data: update SAI config checker for Broadcom TD3 and TH3

### DIFF
--- a/src/sonic-device-data/tests/config_checker
+++ b/src/sonic-device-data/tests/config_checker
@@ -34,6 +34,7 @@ def check_file(file_name):
                 p = re.sub(r"\.[0-9]+$", '', p)
                 # Remove trailing port name
                 p = re.sub(r"_[cxg]e(\d+)?$", '', p)
+                p = re.sub(r"\{.*\}", '', p)
                 # Remove trailing port name example
                 p = re.sub(r"_<port>$", '', p)
                 # Remove trailing port number

--- a/src/sonic-device-data/tests/config_checker
+++ b/src/sonic-device-data/tests/config_checker
@@ -34,6 +34,7 @@ def check_file(file_name):
                 p = re.sub(r"\.[0-9]+$", '', p)
                 # Remove trailing port name
                 p = re.sub(r"_[cxg]e(\d+)?$", '', p)
+                # Remove trailing port id "{id/number}"
                 p = re.sub(r"\{.*\}", '', p)
                 # Remove trailing port name example
                 p = re.sub(r"_<port>$", '', p)

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -13,6 +13,7 @@ bcm56340_config
 cdma_timeout_usec
 core_clock_frequency
 ctr_evict_enable
+device_clock_frequency
 dma_desc_timeout_usec
 dport_map_direct
 dport_map_enable
@@ -25,6 +26,7 @@ ext_tcam_freq
 force_core_pll
 fpem_mem_entries
 higig2_hdr_mode
+ifp_inports_support_enable
 ipmc_do_vlan
 ipv6_lpm_128b_enable
 knet_filter_persist
@@ -34,6 +36,7 @@ l2mod_dma_intr_enable
 l2xmsg_hostbuf_size
 l2xmsg_mode
 l3_alpm_enable
+l3_alpm_ipv6_128b_bkt_rsvd
 l3_intf_vlan_split_egress
 l3_max_ecmp_mode
 l3_mem_entries
@@ -54,6 +57,7 @@ miim_intr_enable
 miim_timeout_usec
 mmu_init_config
 mmu_lossless
+mmu_port_num_mc_queue
 module_64ports
 multicast_l2_r
 multicast_l2_range
@@ -96,6 +100,8 @@ phy_tx_polarity_flip
 phy_xaui_rx_polarity_flip
 phy_xaui_tx_polarity_flip
 physical_ports
+pll_bypass
+port_flex_enable
 port_init_autoneg
 port_init_cl72
 port_init_speed
@@ -116,6 +122,8 @@ schan_intr_enable
 schan_timeout_usec
 serdes_automed
 serdes_automedium
+serdes_core_rx_polarity_flip_physical
+serdes_core_tx_polarity_flip_physical
 serdes_driver_current
 serdes_fiber_pref
 serdes_firmware_mode


### PR DESCRIPTION
The following properties have been approved by the Broadcom chip arch team:

l3_alpm_ipv6_128b_bkt_rsvd
ifp_inports_support_enable
pll_bypass
dpr_clock_frequency
device_clock_frequency
port_flex_enable
mmu_port_num_mc_queue
serdes_core_rx_polarity_flip_physical{<PORT>}
serdes_core_tx_polarity_flip_physical{<PORT>}

Signed-off-by: Dante (Kuo-Jung) Su <dante.su@broadcom.com>
Change-Id: I1c6239cddfb0582a9298e671d792a32f79e4f006

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add missing soc properties for Broadcom TD3 and TH3

**- How I did it**
Update the SAI config checker to prevent build failures

**- How to verify it**
Rebuild the 'sonic-device-data'

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update the SAI config checker to include soc properties for TD3 and TH3

**- A picture of a cute animal (not mandatory but encouraged)**
