### PR TITLE
[monit] Restart rsyslog service if rsyslogd consumes > 800 MB memory

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -310,6 +310,10 @@ check system $HOST
   if memory usage > 50% for 5 times within 10 cycles then alert
   if cpu usage (user) > 90% for 5 times within 10 cycles then alert
   if cpu usage (system) > 90% for 5 times within 10 cycles then alert
+check process rsyslog with pidfile /var/run/rsyslogd.pid
+  start program = "/bin/systemctl start rsyslog.service"
+  stop program = "/bin/systemctl stop rsyslog.service"
+  if totalmem > 800 MB for 5 times within 10 cycles then restart
 EOF
 
 ## Config sysctl


### PR DESCRIPTION
Configure monit to monitor the resident memory consumption of rsyslogd. If memory usage is > 800 MB for 5 out of 10 checks (2-minute cycle interval, so 10 out of 20 minutes), restart the rsyslog service, because rsyslogd is most likely leaking memory. This is the same change that was committed to the 201803 branch here: https://github.com/Azure/sonic-buildimage/pull/2963.

I tested an alternative solution using systemd (which in turn uses memory cgroups, which are now supported and enabled by default in Stretch). However, now that we have configured panic_on_oom = 2 ([link](https://github.com/Azure/sonic-buildimage/pull/2988)), this will cause ALL OOM situations (even within memory cgroups) to trigger kernel panic. This defeats the purpose, as this solution is meant to prevent OOM situations, so I have decided to utilize monit for this purpose in the master branch (Stretch) as well as the 201803 (Jessie) branch.