### PR TITLE
[Mellanox] Fix typo "xSFP_VLOT_OFFSET"

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -464,7 +464,7 @@ class SfpUtil(SfpUtilBase):
             else:
                 return transceiver_dom_info_dict
 
-            dom_voltage_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + QSFP_VLOT_OFFSET), QSFP_VOLT_WIDTH)
+            dom_voltage_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + QSFP_VOLT_OFFSET), QSFP_VOLT_WIDTH)
             if dom_voltage_raw is not None:
                 dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
             else:
@@ -533,7 +533,7 @@ class SfpUtil(SfpUtilBase):
             dom_temperature_raw = eeprom_domraw[SFP_TEMPE_OFFSET:SFP_TEMPE_OFFSET+SFP_TEMPE_WIDTH]
             dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
 
-            dom_voltage_raw = eeprom_domraw[SFP_VLOT_OFFSET:SFP_VLOT_OFFSET+SFP_VOLT_WIDTH]
+            dom_voltage_raw = eeprom_domraw[SFP_VOLT_OFFSET:SFP_VOLT_OFFSET+SFP_VOLT_WIDTH]
             dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
 
             dom_channel_monitor_raw = eeprom_domraw[SFP_CHANNL_MON_OFFSET:SFP_CHANNL_MON_OFFSET+SFP_CHANNL_MON_WIDTH]

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -76,7 +76,7 @@ QSFP_DOM_REV_OFFSET = 1
 QSFP_DOM_REV_WIDTH = 1
 QSFP_TEMPE_OFFSET = 22
 QSFP_TEMPE_WIDTH = 2
-QSFP_VLOT_OFFSET = 26
+QSFP_VOLT_OFFSET = 26
 QSFP_VOLT_WIDTH = 2
 QSFP_VERSION_COMPLIANCE_OFFSET = 1
 QSFP_VERSION_COMPLIANCE_WIDTH = 1
@@ -102,7 +102,7 @@ QSFP_OPTION_VALUE_WIDTH = 4
 
 SFP_TEMPE_OFFSET = 96
 SFP_TEMPE_WIDTH = 2
-SFP_VLOT_OFFSET = 98
+SFP_VOLT_OFFSET = 98
 SFP_VOLT_WIDTH = 2
 SFP_CHANNL_MON_OFFSET = 100
 SFP_CHANNL_MON_WIDTH = 6
@@ -617,7 +617,7 @@ class SFP(SfpBase):
                 transceiver_dom_info_dict['temperature'] = 'N/A'
 
             if self.dom_volt_supported:
-                dom_voltage_raw = self._read_eeprom_specific_bytes((offset + QSFP_VLOT_OFFSET), QSFP_VOLT_WIDTH)
+                dom_voltage_raw = self._read_eeprom_specific_bytes((offset + QSFP_VOLT_OFFSET), QSFP_VOLT_WIDTH)
                 if dom_voltage_raw is not None:
                     dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
                     volt = self._convert_string_to_num(dom_voltage_data['data']['Vcc']['value'])
@@ -677,7 +677,7 @@ class SFP(SfpBase):
             else:
                 return None
 
-            dom_voltage_raw = self._read_eeprom_specific_bytes((offset + SFP_VLOT_OFFSET), SFP_VOLT_WIDTH)
+            dom_voltage_raw = self._read_eeprom_specific_bytes((offset + SFP_VOLT_OFFSET), SFP_VOLT_WIDTH)
             if dom_voltage_raw is not None:
                 dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
             else:
@@ -979,7 +979,7 @@ class SFP(SfpBase):
                 return None
 
             if self.dom_volt_supported:
-                dom_voltage_raw = self._read_eeprom_specific_bytes((offset + QSFP_VLOT_OFFSET), QSFP_VOLT_WIDTH)
+                dom_voltage_raw = self._read_eeprom_specific_bytes((offset + QSFP_VOLT_OFFSET), QSFP_VOLT_WIDTH)
                 if dom_voltage_raw is not None:
                     dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
                     voltage = self._convert_string_to_num(dom_voltage_data['data']['Vcc']['value'])
@@ -996,7 +996,7 @@ class SFP(SfpBase):
 
             sfpd_obj._calibration_type = self.calibration
 
-            dom_voltage_raw = self._read_eeprom_specific_bytes((offset + SFP_VLOT_OFFSET), SFP_VOLT_WIDTH)
+            dom_voltage_raw = self._read_eeprom_specific_bytes((offset + SFP_VOLT_OFFSET), SFP_VOLT_WIDTH)
             if dom_voltage_raw is not None:
                 dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
                 voltage = self._convert_string_to_num(dom_voltage_data['data']['Vcc']['value'])


### PR DESCRIPTION
**- What I did**
Fix typo "xSFP_VLOT_OFFSET"
Variables SFP_VLOT_OFFSET and QSFP_VLOT_OFFSET containing the typo are originally defined in repo sonic-platform-common. The typo has been fixed in [PR #33](https://github.com/Azure/sonic-platform-common/pull/33). However,  some Mellanox-specific code hasn't updated correspondingly, which results in xcvrd fail to start.
This PR updates the variable name in Mellanox-specific code correspondingly to fix that.

**- How I did it**
fix the typo

**- How to verify it**
check whether xcvrd can start normally

**- Description for the changelog**
[Mellanox] [Mellanox] Fix typo "xSFP_VLOT_OFFSET"

**- A picture of a cute animal (not mandatory but encouraged)**
