### PR TITLE
[Mellanox] fix the issue that failing to test whether dom supported prior to reading dom data

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -10,8 +10,10 @@ try:
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
-#sfp supports dom
+# sfp supports dom
 XCVR_DOM_CAPABILITY_DOM_SUPPORT_BIT = 0x40
+# I2C page size for sfp
+SFP_I2C_PAGE_SIZE = 256
 
 # parameters for DB connection 
 REDIS_HOSTNAME = "localhost"
@@ -517,9 +519,9 @@ class SfpUtil(SfpUtilBase):
             transceiver_dom_info_dict['tx4bias'] = dom_channel_monitor_data['data']['TX4Bias']['value']
 
         else:
-            offset = 256
+            offset = SFP_I2C_PAGE_SIZE
 
-            eeprom_raw = ['0'] * 256
+            eeprom_raw = ['0'] * SFP_I2C_PAGE_SIZE
             eeprom_raw[XCVR_DOM_CAPABILITY_OFFSET : XCVR_DOM_CAPABILITY_OFFSET + XCVR_DOM_CAPABILITY_WIDTH] = \
                 self._read_eeprom_specific_bytes_via_ethtool(port_num, XCVR_DOM_CAPABILITY_OFFSET, XCVR_DOM_CAPABILITY_WIDTH)
             sfp_obj = sff8472InterfaceId()
@@ -529,7 +531,7 @@ class SfpUtil(SfpUtilBase):
             if not dom_supported:
                 return transceiver_dom_info_dict
 
-            eeprom_domraw = self._read_eeprom_specific_bytes_via_ethtool(port_num, offset, 256)
+            eeprom_domraw = self._read_eeprom_specific_bytes_via_ethtool(port_num, offset, SFP_I2C_PAGE_SIZE)
             if eeprom_domraw is None:
                 return transceiver_dom_info_dict
 

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -10,6 +10,9 @@ try:
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
+#sfp supports dom
+XCVR_DOM_CAPABILITY_DOM_SUPPORT_BIT = 0x40
+
 # parameters for DB connection 
 REDIS_HOSTNAME = "localhost"
 REDIS_PORT = 6379
@@ -517,11 +520,12 @@ class SfpUtil(SfpUtilBase):
             offset = 256
 
             eeprom_raw = ['0'] * 256
-            eeprom_raw[92:92+16] = self._read_eeprom_specific_bytes_via_ethtool(port_num, 92, 16)
+            eeprom_raw[XCVR_DOM_CAPABILITY_OFFSET : XCVR_DOM_CAPABILITY_OFFSET + XCVR_DOM_CAPABILITY_WIDTH] = \
+                self._read_eeprom_specific_bytes_via_ethtool(port_num, XCVR_DOM_CAPABILITY_OFFSET, XCVR_DOM_CAPABILITY_WIDTH)
             sfp_obj = sff8472InterfaceId()
             calibration_type = sfp_obj._get_calibration_type(eeprom_raw)
 
-            dom_supported = (int(eeprom_raw[92], 16) & 0x40 != 0)
+            dom_supported = (int(eeprom_raw[XCVR_DOM_CAPABILITY_OFFSET], 16) & XCVR_DOM_CAPABILITY_DOM_SUPPORT_BIT != 0)
             if not dom_supported:
                 return transceiver_dom_info_dict
 

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -521,6 +521,10 @@ class SfpUtil(SfpUtilBase):
             sfp_obj = sff8472InterfaceId()
             calibration_type = sfp_obj._get_calibration_type(eeprom_raw)
 
+            dom_supported = (int(eeprom_raw[92], 16) & 0x40 != 0)
+            if not dom_supported:
+                return transceiver_dom_info_dict
+
             eeprom_domraw = self._read_eeprom_specific_bytes_via_ethtool(port_num, offset, 256)
             if eeprom_domraw is None:
                 return transceiver_dom_info_dict


### PR DESCRIPTION
**- What I did**
 fix the issue that failing to test whether dom supported prior to reading dom data.
it depends on pr [https://github.com/Azure/sonic-buildimage/pull/3118)](https://github.com/Azure/sonic-buildimage/pull/3118)

**- How I did it**
test dom support prior to reading dom data for SFP.

**- How to verify it**
check whether log "Cannot get Module EEPROM data: Invalid argument" can be found in syslog in a testbed that has some SFP modules without DOM supporting.

**- Description for the changelog**
 fix the issue that failing to test whether dom supported prior to reading dom data

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
