### PR TITLE
Added debug dockers & image info

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,65 +124,7 @@ Every target has a clean target, so in order to clean swss, execute:
 It is recommended to use clean targets to clean all packages that are built together, like dev packages for instance. In order to be more familiar with build process and make some changes to it, it is recommended to read this short [Documentation](README.buildsystem.md).
 
 ## Build debug dockers and debug SONiC installer image:
-_Note: For now enabled for Broadcom platform only. Soon it will be extended to all._
-
-`make INSTALL_DEBUG_TOOLS=y make target/sonic-broadcom.bin`
-
-* Builds debug docker images.
-* Debug images carry a suffix of "-dbg"
-    * e.g. target/docker-orchagent-dbg.gz
-* target/sonic-broadcom.bin is built using debug docker images
-    * Selective sources are archived and available under /src
-    * An empty /debug dir is created for use during debug session.
-    * All debug dockers are mounted with /src:ro and /debug:rw
-    * Login banner will briefly describe these features.
-  
-
-_Note: target/sonic-broadcom.bin name is the same irrespective of built using debug or non-debug dockers._
-
-_Recommend: Rename image built using INSTALL_DEBUG_TOOLS=y to mark it explicit. May be `mv target/sonic-broadcom.bin target/sonic-broadcom-dbg.bin`_
-
-### Debug dockers
-* Built with all available debug symbols.
-* Installed with many basic packages that would be required for debugging
-    * gdb
-    * gdbserver
-    * vim
-    * strace
-    * openssh-client
-    * sshpass
-* Loadable into any environment that supports docker
-* Outside SONiC image, you may run the docker with `--entrypoint=/bin/bash` 
-* Use -v to map any of your host directories
-* To debug a core file in non-SONiC environment that supports docker
-    * `docker load -i docker-<name>-dbg.gz`
-    * copy your unzipped core file into ~/debug
-    * `docker run -it -entrypoint=/bin/bash -v ~/debug:/debug <image id>`
-    * `gdb /usr/bin/<your binary> -c /debug/<your core>`
-    
-### Debug SONiC image
-_NOTE: For now available for broadcom only; soon to be extended._
-
-* Install this image into your broadcom switch that supports SONiC.
-* Open the archive in /src, if you would need source code for debugging
-* Every debug enabled docker is mounted with /src as read-only
-* The host has /debug dir and it is mapped into every debuggable docker as /debug with read-write permission.
-* To debug a core
-    * Copy core into /debug of host and unzip it
-        * Feel free to create & use sub-dirs as needed.
-        * Entire /debug is mounted inside docker
-    * Get into the docker (`docker -it exec <name> bash`)
-    * `gdb /usr/bin/<binary> -c /debug/<core file path>`
-    * Use set-directory in gdb to map appropriate source dir from under /src
-    * You may set gdb logs to go into /debug
-* For live debugging
-    * Use this as a regular switch
-    * Get into docker, and you may
-        * start process under dbg
-        * attach gdb to running process
-    * Set required source dir from under /src as needed
-    * May use /debug to reecord all geb logs or any spew from debug session.
-    
+SONiC build system supports building dockers and ONE-image with debug tools and debug symbols, to help with live & core debugging. For details refer to [(SONiC Buildimage Guide)](https://github.com/Azure/sonic-buildimage/blob/master/README.buildsystem.md).
 
 ## Notes:
 - If you are running make for the first time, a sonic-slave-${USER} docker image will be built automatically.


### PR DESCRIPTION
Added details on how to build debug docker images and how they can be exploited for debugging.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
