### PR TITLE
[Mellanox] Fix the memory leak in mlnx-sfpd (201807)

### DIFF
--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -79,38 +79,42 @@ def sx_recv(fd_p, handle):
     pkt = new_uint8_t_arr(pkt_size)
     recv_info_p = new_sx_receive_info_t_p()
     pmpe_t = sx_event_pmpe_t()
-    logical_port_list = new_sx_port_log_id_t_arr(4)
     port_attributes_list = new_sx_port_attributes_t_arr(64)
     port_cnt_p = new_uint32_t_p()
     uint32_t_p_assign(port_cnt_p,64)
     label_port_list = []
-    status = True
     module_state = 0
 
     rc = sx_lib_host_ifc_recv(fd_p, pkt, pkt_size_p, recv_info_p)
     if rc != 0:
         log_error("event receive exit with error, rc %d" % rc)
         status = False
-        return status, label_port_list, module_state
+    else:
+        status = True
+        pmpe_t = recv_info_p.event_info.pmpe
+        port_list_size = pmpe_t.list_size
+        logical_port_list = pmpe_t.log_port_list
+        module_state = pmpe_t.module_state
 
-    pmpe_t = recv_info_p.event_info.pmpe
-    port_list_size = pmpe_t.list_size
-    logical_port_list = pmpe_t.log_port_list
-    module_state = pmpe_t.module_state
+        for i in range(0, port_list_size):
+            logical_port = sx_port_log_id_t_arr_getitem(logical_port_list, i)
+            rc = sx_api_port_device_get(handle, 1 , 0, port_attributes_list,  port_cnt_p)
+            port_cnt = uint32_t_p_value(port_cnt_p)
 
-    for i in range(0, port_list_size):
-        logical_port = sx_port_log_id_t_arr_getitem(logical_port_list, i)
-        rc = sx_api_port_device_get(handle, 1 , 0, port_attributes_list,  port_cnt_p)
-        port_cnt = uint32_t_p_value(port_cnt_p)
+            for i in range(0, port_cnt):
+                port_attributes = sx_port_attributes_t_arr_getitem(port_attributes_list,i)
+                if port_attributes.log_port == logical_port:
+                    lable_port = port_attributes.port_mapping.module_port
+                    break
+            label_port_list.append(lable_port)
 
-        for i in range(0, port_cnt):
-            port_attributes = sx_port_attributes_t_arr_getitem(port_attributes_list,i)
-            if port_attributes.log_port == logical_port:
-                lable_port = port_attributes.port_mapping.module_port
-                break
-        label_port_list.append(lable_port)
+    delete_uint32_t_p(pkt_size_p)
+    delete_uint8_t_arr(pkt)
+    delete_sx_receive_info_t_p(recv_info_p)
+    delete_sx_port_attributes_t_arr(port_attributes_list)
+    delete_uint32_t_p(port_cnt_p)
 
-    return status, label_port_list, module_state, 
+    return status, label_port_list, module_state
 
 def send_sfp_notification(db, interface, state):
     sfp_notify = [interface, state]


### PR DESCRIPTION
**- What I did**
Fix the memory leak in mlnx-sfpd.

**- How I did it**
Fix the memory leak in mlnx-sfpd::sx_recv.

**- How to verify it**
reset an SFP module, and then:
  1. observe /proc/<pid of mlnx-sfpd>/maps and check whether [heap] increases.
  2. observe syslog and check whether SFP module plugin/out event has been recorded.

**- Description for the changelog**
[Mellanox] Fix the memory leak in mlnx-sfpd

**- A picture of a cute animal (not mandatory but encouraged)**
