### PR TITLE
DellEMC S6100 : Platform2.0 API implementation for PSU

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -11,8 +11,13 @@
 try:
     import os
     from sonic_platform_base.chassis_base import ChassisBase
+    from sonic_platform.psu import Psu
+    from sonic_platform.fan import Fan
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
+
+MAX_S6100_FAN = 4
+MAX_S6100_PSU = 2
 
 
 class Chassis(ChassisBase):
@@ -39,19 +44,28 @@ class Chassis(ChassisBase):
     def __init__(self):
         ChassisBase.__init__(self)
 
+        for i in range(MAX_S6100_FAN):
+            fan = Fan(i)
+            self._fan_list.append(fan)
+
+        for i in range(MAX_S6100_PSU):
+            psu = Psu(i)
+            self._psu_list.append(psu)
+
     def get_pmc_register(self, reg_name):
+        # On successful read, returns the value read from given
+        # reg_name and on failure returns 'ERR'
         rv = 'ERR'
-        mb_reg_file = self.MAILBOX_DIR+'/'+reg_name
+        mb_reg_file = self.MAILBOX_DIR + '/' + reg_name
 
         if (not os.path.isfile(mb_reg_file)):
-            print mb_reg_file,  'not found !'
             return rv
 
         try:
             with open(mb_reg_file, 'r') as fd:
                 rv = fd.read()
         except Exception as error:
-            logging.error("Unable to open ", mb_reg_file, "file !")
+            rv = 'ERR'
 
         rv = rv.rstrip('\r\n')
         rv = rv.lstrip(" ")

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+########################################################################
+# DellEMC
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the Fans' information which are available in the platform
+#
+########################################################################
+
+
+try:
+    import os
+    from sonic_platform_base.fan_base import FanBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+MAX_S6100_PSU_FAN_SPEED = 18000
+MAX_S6100_FAN_SPEED = 16000
+
+
+class Fan(FanBase):
+    """DellEMC Platform-specific FAN class"""
+
+    HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
+    HWMON_NODE = os.listdir(HWMON_DIR)[0]
+    MAILBOX_DIR = HWMON_DIR + HWMON_NODE
+
+    def __init__(self, fan_index, psu_fan=False):
+        self.is_psu_fan = psu_fan
+        if not self.is_psu_fan:
+            # Fan is 1-based in DellEMC platforms
+            self.index = fan_index + 1
+            self.get_fan_speed_reg = "fan{}_input".format(2*self.index - 1)
+            self.max_fan_speed = MAX_S6100_FAN_SPEED
+        else:
+            # PSU Fan index starts from 11
+            self.index = fan_index + 10
+            self.get_fan_speed_reg = "fan{}_input".format(self.index)
+            self.max_fan_speed = MAX_S6100_PSU_FAN_SPEED
+

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/psu.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+
+########################################################################
+# DellEMC
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the PSUs' information which are available in the platform
+#
+########################################################################
+
+
+try:
+    import os
+    from sonic_platform_base.psu_base import PsuBase
+    from sonic_platform.fan import Fan
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Psu(PsuBase):
+    """DellEMC Platform-specific PSU class"""
+
+    HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
+    HWMON_NODE = os.listdir(HWMON_DIR)[0]
+    MAILBOX_DIR = HWMON_DIR + HWMON_NODE
+
+    def __init__(self, psu_index):
+        # PSU is 1-based in DellEMC platforms
+        self.index = psu_index + 1
+        self.psu_presence_reg = "psu{}_presence".format(self.index)
+        self.psu_serialno_reg = "psu{}_serialno".format(self.index)
+        if self.index == 1:
+            self.psu_voltage_reg = "in30_input"
+            self.psu_current_reg = "curr602_input"
+            self.psu_power_reg = "power2_input"
+        elif self.index == 2:
+            self.psu_voltage_reg = "in32_input"
+            self.psu_current_reg = "curr702_input"
+            self.psu_power_reg = "power4_input"
+
+        # Overriding _fan_list class variable defined in PsuBase, to
+        # make it unique per Psu object
+        self._fan_list = []
+
+        # Passing True to specify it is a PSU fan
+        psu_fan = Fan(self.index, True)
+        self._fan_list.append(psu_fan)
+
+    def get_pmc_register(self, reg_name):
+        # On successful read, returns the value read from given
+        # reg_name and on failure returns 'ERR'
+        rv = 'ERR'
+        mb_reg_file = self.MAILBOX_DIR + '/' + reg_name
+
+        if (not os.path.isfile(mb_reg_file)):
+            return rv
+
+        try:
+            with open(mb_reg_file, 'r') as fd:
+                rv = fd.read()
+        except Exception as error:
+            rv = 'ERR'
+
+        rv = rv.rstrip('\r\n')
+        rv = rv.lstrip(" ")
+        return rv
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+
+        Returns:
+            string: The name of the device
+        """
+        return "PSU{}".format(self.index)
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the Power Supply Unit (PSU)
+
+        Returns:
+            bool: True if PSU is present, False if not
+        """
+        status = False
+        psu_presence = self.get_pmc_register(self.psu_presence_reg)
+        if (psu_presence != 'ERR'):
+            psu_presence = int(psu_presence, 16)
+            # Checking whether bit 0 is not set
+            if (~psu_presence & 0b1):
+                status = True
+
+        return status
+
+    def get_model(self):
+        """
+        Retrieves the part number of the PSU
+
+        Returns:
+            string: Part number of PSU
+        """
+        # For Serial number "US-01234D-54321-25A-0123-A00", the part
+        # number is "01234D"
+        psu_serialno = self.get_pmc_register(self.psu_serialno_reg)
+        if (psu_serialno != 'ERR') and self.get_presence():
+            if (len(psu_serialno.split('-')) > 1):
+                psu_partno = psu_serialno.split('-')[1]
+            else:
+                psu_partno = 'NA'
+        else:
+            psu_partno = 'NA'
+
+        return psu_partno
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the PSU
+
+        Returns:
+            string: Serial number of PSU
+        """
+        # Sample Serial number format "US-01234D-54321-25A-0123-A00"
+        psu_serialno = self.get_pmc_register(self.psu_serialno_reg)
+        if (psu_serialno == 'ERR') or not self.get_presence():
+            psu_serialno = 'NA'
+
+        return psu_serialno
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the PSU
+
+        Returns:
+            bool: True if PSU is operating properly, False if not
+        """
+        status = False
+        psu_status = self.get_pmc_register(self.psu_presence_reg)
+        if (psu_status != 'ERR'):
+            psu_status = int(psu_status, 16)
+            # Checking whether both bit 3 and bit 2 are not set
+            if (~psu_status & 0b1000) and (~psu_status & 0b0100):
+                status = True
+
+        return status
+
+    def get_voltage(self):
+        """
+        Retrieves current PSU voltage output
+
+        Returns:
+            A float number, the output voltage in volts,
+            e.g. 12.1
+        """
+        psu_voltage = self.get_pmc_register(self.psu_voltage_reg)
+        if (psu_voltage != 'ERR') and self.get_presence():
+            # Converting the value returned by driver which is in
+            # millivolts to volts
+            psu_voltage = float(psu_voltage) / 1000
+        else:
+            psu_voltage = 0.0
+
+        return psu_voltage
+
+    def get_current(self):
+        """
+        Retrieves present electric current supplied by PSU
+
+        Returns:
+            A float number, electric current in amperes,
+            e.g. 15.4
+        """
+        psu_current = self.get_pmc_register(self.psu_current_reg)
+        if (psu_current != 'ERR') and self.get_presence():
+            # Converting the value returned by driver which is in
+            # milliamperes to amperes
+            psu_current = float(psu_current) / 1000
+        else:
+            psu_current = 0.0
+
+        return psu_current
+
+    def get_power(self):
+        """
+        Retrieves current energy supplied by PSU
+
+        Returns:
+            A float number, the power in watts,
+            e.g. 302.6
+        """
+        psu_power = self.get_pmc_register(self.psu_power_reg)
+        if (psu_power != 'ERR') and self.get_presence():
+            # Converting the value returned by driver which is in
+            # microwatts to watts
+            psu_power = float(psu_power) / 1000000
+        else:
+            psu_power = 0.0
+
+        return psu_power
+
+    def set_status_led(self):
+        """
+        Sets the state of the PSU status LED
+        Args:
+            color: A string representing the color with which to set the
+                   PSU status LED
+        Returns:
+            bool: True if status LED state is set successfully, False if
+                  not
+        """
+        # In S6100, SmartFusion FPGA controls the PSU LED and the PSU
+        # LED state cannot be changed from CPU.
+        return False

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/__init__.py
@@ -1,1 +1,2 @@
-../../s6100/sonic_platform/__init__.py
+
+

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
@@ -1,1 +1,83 @@
-../../s6100/sonic_platform/chassis.py
+#!/usr/bin/env python
+
+#############################################################################
+# DELLEMC
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the platform information
+#
+#############################################################################
+
+try:
+    import os
+    from sonic_platform_base.chassis_base import ChassisBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Chassis(ChassisBase):
+    """
+    DELLEMC Platform-specific Chassis class
+    """
+
+    HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
+    HWMON_NODE = os.listdir(HWMON_DIR)[0]
+    MAILBOX_DIR = HWMON_DIR + HWMON_NODE
+
+    reset_reason_dict = {}
+    reset_reason_dict[11] = ChassisBase.REBOOT_CAUSE_POWER_LOSS
+    reset_reason_dict[33] = ChassisBase.REBOOT_CAUSE_WATCHDOG
+    reset_reason_dict[44] = ChassisBase.REBOOT_CAUSE_NON_HARDWARE
+    reset_reason_dict[55] = ChassisBase.REBOOT_CAUSE_NON_HARDWARE
+
+    power_reason_dict = {}
+    power_reason_dict[11] = ChassisBase.REBOOT_CAUSE_POWER_LOSS
+    power_reason_dict[22] = ChassisBase.REBOOT_CAUSE_THERMAL_OVERLOAD_CPU
+    power_reason_dict[33] = ChassisBase.REBOOT_CAUSE_THERMAL_OVERLOAD_ASIC
+    power_reason_dict[44] = ChassisBase.REBOOT_CAUSE_INSUFFICIENT_FAN_SPEED
+
+    def __init__(self):
+        ChassisBase.__init__(self)
+
+    def get_pmc_register(self, reg_name):
+        # On successful read, returns the value read from given
+        # reg_name and on failure returns 'ERR'
+        rv = 'ERR'
+        mb_reg_file = self.MAILBOX_DIR + '/' + reg_name
+
+        if (not os.path.isfile(mb_reg_file)):
+            return rv
+
+        try:
+            with open(mb_reg_file, 'r') as fd:
+                rv = fd.read()
+        except Exception as error:
+            rv = 'ERR'
+
+        rv = rv.rstrip('\r\n')
+        rv = rv.lstrip(" ")
+        return rv
+
+    def get_reboot_cause(self):
+        """
+        Retrieves the cause of the previous reboot
+        """
+        reset_reason = int(self.get_pmc_register('smf_reset_reason'))
+        power_reason = int(self.get_pmc_register('smf_poweron_reason'))
+
+        # Reset_Reason = 11 ==> PowerLoss
+        # So return the reboot reason from Last Power_Reason Dictionary
+        # If Reset_Reason is not 11 return from Reset_Reason dictionary
+        # Also check if power_reason, reset_reason are valid values by
+        # checking key presence in dictionary else return
+        # REBOOT_CAUSE_HARDWARE_OTHER as the Power_Reason and Reset_Reason
+        # registers returned invalid data
+        if (reset_reason == 11):
+            if (power_reason in self.power_reason_dict):
+                return (self.power_reason_dict[power_reason], None)
+        else:
+            if (reset_reason in self.reset_reason_dict):
+                return (self.reset_reason_dict[reset_reason], None)
+
+        return (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "Invalid Reason")
+


### PR DESCRIPTION
**- What I did**

1.  Implement PSU platform2.0 API for DellEMC S6100 platform
2.  Init fan list in PSU Class
3.  Init PSU list and fan list in Chassis Class
4.  Created seperate chassis.py and __init__.py files for DellEMC Z9100 platform

**- How I did it**

1.  Added new file psu.py and fan.py for PSU platform2.0 API implementation 
2.  Made necessary changes in S6100 platform module file to retrive serial number of PSUs

**- How to verify it**

Wrote a python script to load Chassis class and then call PSU APIs accordingly 
UT logs attached with more details.

**- Description for the changelog**

DellEMC S6100 : Platform2.0 API implementation for PSU

**- A picture of a cute animal (not mandatory but encouraged)**