### PR TITLE
DellEMC S6100 Enabling Polling Mode for Miim Operation

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t0.config.bcm
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t0.config.bcm
@@ -10,6 +10,7 @@ lpm_ipv6_128b_reserved=0
 ipv6_lpm_128b_enable=1
 l2xmsg_mode=1
 oversubscribe_mode=1
+miim_intr_enable=0
 
 phy_gearbox_enable=1
 phy_84752=1

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t1.config.bcm
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t1.config.bcm
@@ -10,6 +10,7 @@ lpm_ipv6_128b_reserved=0
 ipv6_lpm_128b_enable=1
 l2xmsg_mode=1
 oversubscribe_mode=1
+miim_intr_enable=0
 
 phy_gearbox_enable=1
 phy_84752=1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enabled Polling to verify Miim Operation Completion in S6100
BCM is running in User Mode in Sonic Image. Verifying the Miim Operation completion via interrupt will exhibit performance degradation during high CPU utilization times. We might take more time in handling interrupts. This might lead BCM to declare MIIM timeout. 
Moving to MIIM Poller approach will help in mitigating these conditions.

**- How I did it**
miim_intr_enable = 0
**- How to verify it**
drivshell>config show miim_intr_enable
config show miim_intr_enable
    miim_intr_enable=0

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[DellEMC] [S6100] Enabling Polling Mode for Miim Operation

**- A picture of a cute animal (not mandatory but encouraged)**
