### PR TITLE
[database] save configuration after DB migration

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -89,6 +89,11 @@ function postStartAction()
     if [[ -x /usr/bin/db_migrator.py ]]; then
         # Migrate the DB to the latest schema version if needed
         /usr/bin/db_migrator.py -o migrate
+
+        # Save in memory config_db to config_db.json for 2 reasons:
+        # 1. Persist the DB migration result.
+        # 2. Save in memory DB after warm reboot.
+        /usr/bin/config save -y
     fi
 {%- elif docker_container_name == "swss" %}
     docker exec swss rm -f /ready   # remove cruft


### PR DESCRIPTION
**- What I did**

- Make sure that migrated DB contents persisted for next boot
- Make sure that db saved after warm reboot.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Warm reboot into an image with the fix. Check that /etc/sonic/config_db.json exists after warm reboot. Then cold reboot the device to make sure that the device come up properly.