### PR TITLE
[slave.mk]: remove updategraph.service generation in slave.mk

### DIFF
--- a/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/port_config.ini
+++ b/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/port_config.ini
@@ -1,55 +1,55 @@
-# name          lanes                 alias             index
-Ethernet0       1                     twentyfiveGigE1   1
-Ethernet1       2                     twentyfiveGigE2   2
-Ethernet2       3                     twentyfiveGigE3   3
-Ethernet3       4                     twentyfiveGigE4   4
-Ethernet4       5                     twentyfiveGigE5   5
-Ethernet5       6                     twentyfiveGigE6   6
-Ethernet6       7                     twentyfiveGigE7   7
-Ethernet7       8                     twentyfiveGigE8   8
-Ethernet8       9                     twentyfiveGigE9   9
-Ethernet9       10                    twentyfiveGigE10  10
-Ethernet10      11                    twentyfiveGigE11  11
-Ethernet11      12                    twentyfiveGigE12  12
-Ethernet12      13                    twentyfiveGigE13  13
-Ethernet13      14                    twentyfiveGigE14  14
-Ethernet14      15                    twentyfiveGigE15  15
-Ethernet15      16                    twentyfiveGigE16  16
-Ethernet16      17                    twentyfiveGigE17  17
-Ethernet17      18                    twentyfiveGigE18  18
-Ethernet18      19                    twentyfiveGigE19  19
-Ethernet19      20                    twentyfiveGigE20  20
-Ethernet20      21                    twentyfiveGigE21  21
-Ethernet21      22                    twentyfiveGigE22  22
-Ethernet22      23                    twentyfiveGigE23  23
-Ethernet23      24                    twentyfiveGigE24  24
-Ethernet24      53                    twentyfiveGigE25  25
-Ethernet25      54                    twentyfiveGigE26  26
-Ethernet26      55                    twentyfiveGigE27  27
-Ethernet27      56                    twentyfiveGigE28  28
-Ethernet28      57                    twentyfiveGigE29  29
-Ethernet29      58                    twentyfiveGigE30  30
-Ethernet30      59                    twentyfiveGigE31  31
-Ethernet31      60                    twentyfiveGigE32  32
-Ethernet32      61                    twentyfiveGigE33  33
-Ethernet33      62                    twentyfiveGigE34  34
-Ethernet34      63                    twentyfiveGigE35  35
-Ethernet35      64                    twentyfiveGigE36  36
-Ethernet36      65                    twentyfiveGigE37  37
-Ethernet37      66                    twentyfiveGigE38  38
-Ethernet38      67                    twentyfiveGigE39  39
-Ethernet39      68                    twentyfiveGigE40  40
-Ethernet40      69                    twentyfiveGigE41  41
-Ethernet41      70                    twentyfiveGigE42  42
-Ethernet42      71                    twentyfiveGigE43  43
-Ethernet43      72                    twentyfiveGigE44  44
-Ethernet44      73                    twentyfiveGigE45  45
-Ethernet45      74                    twentyfiveGigE46  46
-Ethernet46      75                    twentyfiveGigE47  47
-Ethernet47      76                    twentyfiveGigE48  48
-Ethernet48      29,30,31,32           hundredGigE49     49
-Ethernet52      33,34,35,36           hundredGigE50     53
-Ethernet56      37,38,39,40           hundredGigE51     57
-Ethernet60      41,42,43,44           hundredGigE52     61
-Ethernet64      45,46,47,48           hundredGigE53     65
-Ethernet68      49,50,51,52           hundredGigE54     69
+# name          lanes                 alias             index	speed
+Ethernet0       1                     tenGigE1   	1	10000
+Ethernet1       2                     tenGigE2   	2	10000
+Ethernet2       3                     tenGigE3   	3	10000
+Ethernet3       4                     tenGigE4   	4	10000
+Ethernet4       5                     tenGigE5   	5	10000
+Ethernet5       6                     tenGigE6   	6	10000
+Ethernet6       7                     tenGigE7   	7	10000
+Ethernet7       8                     tenGigE8   	8	10000
+Ethernet8       9                     tenGigE9   	9	10000
+Ethernet9       10                    tenGigE10  	10	10000
+Ethernet10      11                    tenGigE11  	11	10000
+Ethernet11      12                    tenGigE12  	12	10000
+Ethernet12      13                    tenGigE13  	13	10000
+Ethernet13      14                    tenGigE14  	14	10000
+Ethernet14      15                    tenGigE15  	15	10000
+Ethernet15      16                    tenGigE16  	16	10000
+Ethernet16      17                    tenGigE17  	17	10000
+Ethernet17      18                    tenGigE18  	18	10000
+Ethernet18      19                    tenGigE19  	19	10000
+Ethernet19      20                    tenGigE20  	20	10000
+Ethernet20      21                    tenGigE21  	21	10000
+Ethernet21      22                    tenGigE22  	22	10000
+Ethernet22      23                    tenGigE23  	23	10000
+Ethernet23      24                    tenGigE24  	24	10000
+Ethernet24      53                    tenGigE25  	25	10000
+Ethernet25      54                    tenGigE26  	26	10000
+Ethernet26      55                    tenGigE27  	27	10000
+Ethernet27      56                    tenGigE28  	28	10000
+Ethernet28      57                    tenGigE29  	29	10000
+Ethernet29      58                    tenGigE30  	30	10000
+Ethernet30      59                    tenGigE31  	31	10000
+Ethernet31      60                    tenGigE32  	32	10000
+Ethernet32      61                    tenGigE33  	33	10000
+Ethernet33      62                    tenGigE34  	34	10000
+Ethernet34      63                    tenGigE35  	35	10000
+Ethernet35      64                    tenGigE36  	36	10000
+Ethernet36      65                    tenGigE37  	37	10000
+Ethernet37      66                    tenGigE38  	38	10000
+Ethernet38      67                    tenGigE39  	39	10000
+Ethernet39      68                    tenGigE40  	40	10000
+Ethernet40      69                    tenGigE41  	41	10000
+Ethernet41      70                    tenGigE42  	42	10000
+Ethernet42      71                    tenGigE43  	43	10000
+Ethernet43      72                    tenGigE44  	44	10000
+Ethernet44      73                    tenGigE45  	45	10000
+Ethernet45      74                    tenGigE46  	46	10000
+Ethernet46      75                    tenGigE47  	47	10000
+Ethernet47      76                    tenGigE48  	48	10000
+Ethernet48      29,30,31,32           hundredGigE49     49	100000
+Ethernet52      33,34,35,36           hundredGigE50     53	100000
+Ethernet56      37,38,39,40           hundredGigE51     57	100000
+Ethernet60      41,42,43,44           hundredGigE52     61	100000
+Ethernet64      45,46,47,48           hundredGigE53     65	100000
+Ethernet68      49,50,51,52           hundredGigE54     69	100000

--- a/slave.mk
+++ b/slave.mk
@@ -644,8 +644,6 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	j2 -f env files/initramfs-tools/union-mount.j2 onie-image.conf > files/initramfs-tools/union-mount
 	j2 -f env files/initramfs-tools/arista-convertfs.j2 onie-image.conf > files/initramfs-tools/arista-convertfs
 
-	j2 files/build_templates/updategraph.service.j2 > updategraph.service
-
 	$(if $($*_DOCKERS),
 		j2 files/build_templates/sonic_debian_extension.j2 > sonic_debian_extension.sh
 		chmod +x sonic_debian_extension.sh,
@@ -668,7 +666,6 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		rm -f $($(docker:-dbg.gz=.gz)_CONTAINER_NAME).sh
 		rm -f $($(docker:-dbg.gz=.gz)_CONTAINER_NAME).service
 	)
-    rm -f updategraph.service
 
 	$(if $($*_DOCKERS),
 		rm sonic_debian_extension.sh,

--- a/slave.mk
+++ b/slave.mk
@@ -668,6 +668,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		rm -f $($(docker:-dbg.gz=.gz)_CONTAINER_NAME).sh
 		rm -f $($(docker:-dbg.gz=.gz)_CONTAINER_NAME).service
 	)
+    rm -f updategraph.service
 
 	$(if $($*_DOCKERS),
 		rm sonic_debian_extension.sh,


### PR DESCRIPTION

Signed-off-by: Lawrence Lee <t-lale@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Currently, updategraph.service is created from the template in files/build_templates at build time and placed in the main directory, but this file is unused and not cleaned up after the build finishes. This is redundant since sonic_debian_extension.sh generates and places a copy inside the built image.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Stop updategraph.service from being redundantly generated inside slave.mk

**- A picture of a cute animal (not mandatory but encouraged)**
