### PR TITLE
Remove old ping permission fix because of aufs->overlay filesystem

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -274,12 +274,6 @@ sudo sed -i 's/LOAD_KEXEC=true/LOAD_KEXEC=false/' $FILESYSTEM_ROOT/etc/default/k
 ## jump when time difference is greater than 1000 seconds (remove -g).
 sudo sed -i "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/" $FILESYSTEM_ROOT/etc/default/ntp
 
-## Fix ping tools permission so non root user can directly use them
-## Note: this is a workaround since aufs doesn't support extended attributes
-## Ref: https://github.com/moby/moby/issues/5650#issuecomment-303499489
-## TODO: remove workaround when the overlay filesystem support extended attributes
-sudo chmod u+s $FILESYSTEM_ROOT/bin/ping{,6}
-
 ## Remove sshd host keys, and will regenerate on first sshd start
 sudo rm -f $FILESYSTEM_ROOT/etc/ssh/ssh_host_*_key*
 sudo cp files/sshd/host-ssh-keygen.sh $FILESYSTEM_ROOT/usr/local/bin/


### PR DESCRIPTION
Tested on DUT:
```
admin@sonic:~$ ping 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.078 ms
64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.058 ms
```
