### PR TITLE
Install mcelog package to host OS; log machine check exceptions (MCE) to syslog

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -249,7 +249,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     mtr-tiny                \
     locales                 \
     flashrom                \
-    cgroup-tools
+    cgroup-tools            \
+    mcelog
 
 #Adds a locale to a debian system in non-interactive mode
 sudo sed -i '/^#.* en_US.* /s/^#//' $FILESYSTEM_ROOT/etc/locale.gen && \

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -387,6 +387,9 @@ set /files/etc/sysctl.conf/net.core.rmem_max 2097152
 set /files/etc/sysctl.conf/net.core.wmem_max 2097152
 " -r $FILESYSTEM_ROOT
 
+# Configure mcelog to log machine checks to syslog
+sudo sed -i 's/^#syslog = yes/syslog = yes/' $FILESYSTEM_ROOT/etc/mcelog/mcelog.conf
+
 ## docker-py is needed by Ansible docker module
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT easy_install pip
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'docker-py==1.6.0'


### PR DESCRIPTION
**- What I did**

- Install mcelog package to host Debian OS. This installs a daemon which checks for machine check exceptions (MCE) and logs them to syslog.

**- How to verify it**

Check syslog for messages from the mcelog daemon (example below)

```
Jul 15 19:30:39 sonic mcelog[445]: Starting Machine Check Exceptions decoder: mcelog.
Jul 15 19:30:39 sonic mcelog: failed to prefill DIMM database from DMI data
Jul 15 19:30:39 sonic mcelog: warning: 32 bytes ignored in each record
Jul 15 19:30:39 sonic mcelog: consider an update
Jul 15 19:30:39 sonic mcelog: failed to prefill DIMM database from DMI data
Jul 15 19:30:39 sonic mcelog: warning: 32 bytes ignored in each record
Jul 15 19:30:39 sonic mcelog: consider an update
```

This commit should cherry-pick cleanly into the 201904 branch, but I will need to open a similar PR against the 201811 branch due to conflicts.