### PR TITLE
Fix process-reboot-cause possibly throwing OSError

### DIFF
--- a/files/image_config/process-reboot-cause/process-reboot-cause
+++ b/files/image_config/process-reboot-cause/process-reboot-cause
@@ -109,7 +109,8 @@ def main():
     log_info("Previous reboot cause: {}".format(previous_reboot_cause))
 
     # Remove the old REBOOT_CAUSE_FILE
-    os.remove(REBOOT_CAUSE_FILE)
+    if os.path.exists(REBOOT_CAUSE_FILE):
+        os.remove(REBOOT_CAUSE_FILE)
 
     # Write a new default reboot cause file for the next reboot
     cause_file = open(REBOOT_CAUSE_FILE, "w")


### PR DESCRIPTION
In case of going from previous iteration of SONiC, and the last reboot
was hardware, REBOOT_CAUSE_FILE may not be present and the service may
throw an error.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add check for file before removing it.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
