### PR TITLE
[Mellanox] Update egress lossless pool size for 37xx platforms

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t0.j2
@@ -1,7 +1,7 @@
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '8224768' %}
 {% set ingress_lossy_pool_size =  '8224768' %}
-{% set egress_lossless_pool_size =  '38797200' %}
+{% set egress_lossless_pool_size =  '35966016' %}
 {% set egress_lossy_pool_size =  '8224768' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t1.j2
@@ -1,7 +1,7 @@
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '12042240' %}
 {% set ingress_lossy_pool_size =  '12042240' %}
-{% set egress_lossless_pool_size =  '38797200' %}
+{% set egress_lossless_pool_size =  '35966016' %}
 {% set egress_lossy_pool_size =  '12042240' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}


### PR DESCRIPTION
new FW/SDK limits pool size to 34M

Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
