### PR TITLE
[docker-sonic-vs]: Install libunwind8 and libjson-c3 as frr dependencies

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -51,7 +51,9 @@ RUN apt-get install -y net-tools \
                        apt-utils \
                        psmisc \
                        tcpdump \
-                       python-scapy
+                       python-scapy \
+                       libjson-c3 \
+                       libunwind8
 
 RUN pip install setuptools
 RUN pip install py2_ipaddress


### PR DESCRIPTION
frr depends on libjson-c3 (>= 0.11); however:
  Package libjson-c3 is not installed.
 frr depends on libunwind8; however:
  Package libunwind8 is not installed.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>