### PR TITLE
[ptf] Fixed root ssh authentication issue

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -97,10 +97,10 @@ RUN rm -rf /debs \
 
 ## Adjust sshd settings
 RUN mkdir /var/run/sshd \
- && echo 'root:root' | chpasswd \
- && sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
- && sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config \
- && sed -i '$aUseDNS no' /etc/ssh/sshd_config
+    && echo 'root:root' | chpasswd \
+    && sed -ri '/^#?PermitRootLogin/c\PermitRootLogin yes' /etc/ssh/sshd_config \
+    && sed -ri '/^#?UsePAM/c\UsePAM no' /etc/ssh/sshd_config \
+    && sed -ri '/^#?UseDNS/c\UseDNS no' /etc/ssh/sshd_config
 
 COPY ["supervisord.conf", "/etc/supervisor/"]
 COPY ["conf.d/supervisord.conf", "conf.d/sshd.conf", "conf.d/ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

SSH authentication via root is a common issue:
without this fix all PTF tests fails with the latest PFT docker.

**- What I did**
* Fixed root ssh authentication issue

**- How I did it**
* Made sed rules more robust

**- How to verify it**
1. make configure PLATFORM=mellanox
2. make target/docker-ptf-mlnx.gz

**- Description for the changelog**
* N/A

**- A picture of a cute animal (not mandatory but encouraged)**
```
       .---.        .-----------
      /     \  __  /    ------
     / /     \(  )/    -----
    //////   ' \/ `   ---
   //// / // :    : ---
  // /   /  /`    '--
 //          //..\\
        ====UU====UU====
            '//||\\`
              ''``
```
