### PR TITLE
[Mellanox] enhance the mlnx-sfpd init flow  

### DIFF
--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -129,7 +129,7 @@ class MlnxSfpd:
                     sx_api_host_ifc_open_pass = True
                     retry = 1
                 else:
-                    log_warning("sx_api_host_ifc_open return fail... retrying {}".format(retry))
+                    log_warning("sx_api_host_ifc_open failed with error code {}... retrying {}".format(rc,retry))
                     time.sleep(2 ** retry)
                     retry += 1
                     if retry > self.SX_OPEN_RETRIES:
@@ -148,13 +148,13 @@ class MlnxSfpd:
                     sx_api_host_ifc_trap_id_register_set_pass = True
                     break
                 else:
-                    log_warning("sx_api_host_ifc_trap_id_register_set return fail... retrying {}".format(retry))
+                    log_warning("sx_api_host_ifc_trap_id_register_set failed with error code {}... retrying {}".format(rc,retry))
                     time.sleep(2 ** retry)
                     retry += 1
                     if retry > self.SX_OPEN_RETRIES:
                         sx_api_host_ifc_close(self.handle, self.rx_fd_p)
                         sx_api_close(self.handle)
-                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set exited with error, rc {}".format(rc))
+                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set failed with error after {} retries".format(retry))
                     else:
                         continue
         

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -64,7 +64,7 @@ def log_error(msg, also_print_to_console=False):
 class MlnxSfpd:
     ''' Listen to plugin/plugout cable events '''
 
-    SX_OPEN_RETRIES = 20
+    SX_OPEN_RETRIES = 10
     SELECT_TIMEOUT = 1
 
     def __init__(self):

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 '''
 This code is for a mlnx platform specific daemon, mlnx-sfpd.
 Which listen to the SDK for the SFP change event and post the event to DB.
@@ -75,7 +75,6 @@ class MlnxSfpd:
         # Allocate SDK fd and user channel structures
         self.rx_fd_p = new_sx_fd_t_p()
         self.user_channel_p = new_sx_user_channel_t_p()
-
         self.state_db = SonicV2Connector(host=REDIS_HOSTIP)
 
         # Register our signal handlers
@@ -114,7 +113,7 @@ class MlnxSfpd:
                     sx_api_open_pass = True
                     retry = 1
                 else:    
-                    log_warning("failed to open SDK API handle... retrying {}".format(retry))
+                    log_warning("failed to open SDK API handle with err code {}... retrying {}".format(rc,retry))
                     time.sleep(2 ** retry)
                     retry += 1
                     if retry > self.SX_OPEN_RETRIES:
@@ -155,7 +154,7 @@ class MlnxSfpd:
                     if retry > self.SX_OPEN_RETRIES:
                         sx_api_host_ifc_close(self.handle, self.rx_fd_p)
                         sx_api_close(self.handle)
-                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set exited with error, rc {}".format(c))
+                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set exited with error, rc {}".format(rc))
                     else:
                         continue
         

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#! /usr/bin/python
 '''
 This code is for a mlnx platform specific daemon, mlnx-sfpd.
 Which listen to the SDK for the SFP change event and post the event to DB.
@@ -101,34 +101,65 @@ class MlnxSfpd:
         # open SDK API handle
         # retry at most SX_OPEN_RETRIES times to wait
         # until SDK is started during system startup
+        
         retry = 1
+        sx_api_open_pass = False
+        sx_api_host_ifc_open_pass = False
+        sx_api_host_ifc_trap_id_register_set_pass = False
+        
         while True:
-            rc, self.handle = sx_api_open(None)
-            if rc == SX_STATUS_SUCCESS:
-                break
+            if not sx_api_open_pass:
+                rc, self.handle = sx_api_open(None)
+                if rc == SX_STATUS_SUCCESS:
+                    sx_api_open_pass = True
+                    retry = 1
+                else:    
+                    log_warning("failed to open SDK API handle... retrying {}".format(retry))
+                    time.sleep(2 ** retry)
+                    retry += 1
+                    if retry > self.SX_OPEN_RETRIES:
+                        raise RuntimeError("failed to open SDK API handle after {} retries".format(retry))
+                    else:
+                        continue
+        
+            if not sx_api_host_ifc_open_pass:
+                rc = sx_api_host_ifc_open(self.handle, self.rx_fd_p)
+                if rc == SX_STATUS_SUCCESS:
+                    self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
+                    self.user_channel_p.channel.fd = self.rx_fd_p
+                    sx_api_host_ifc_open_pass = True
+                    retry = 1
+                else:
+                    log_warning("sx_api_host_ifc_open return fail... retrying {}".format(retry))
+                    time.sleep(2 ** retry)
+                    retry += 1
+                    if retry > self.SX_OPEN_RETRIES:
+                        sx_api_close(self.handle)
+                        raise RuntimeError("sx_api_host_ifc_open failed with error after {} retries".format(retry))
+                    else:
+                        continue
 
-            log_warning("failed to open SDK API handle... retrying {}".format(retry))
-
-            time.sleep(2 ** retry)
-            retry += 1
-
-            if retry > self.SX_OPEN_RETRIES:
-                raise RuntimeError("failed to open SDK API handle after {} retries".format(retry))
-
-        rc = sx_api_host_ifc_open(self.handle, self.rx_fd_p)
-        if rc != SX_STATUS_SUCCESS:
-            raise RuntimeError("sx_api_host_ifc_open exited with error, rc {}".format(rc))
-
-        self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
-        self.user_channel_p.channel.fd = self.rx_fd_p
-
-        rc = sx_api_host_ifc_trap_id_register_set(self.handle,
-                                                  SX_ACCESS_CMD_REGISTER,
-                                                  self.swid,
-                                                  SX_TRAP_ID_PMPE,
-                                                  self.user_channel_p)
-        if rc != SX_STATUS_SUCCESS:
-            raise RuntimeError("sx_api_host_ifc_trap_id_register_set exited with error, rc {}".format(c))
+            if not sx_api_host_ifc_trap_id_register_set_pass:
+                rc = sx_api_host_ifc_trap_id_register_set(self.handle,
+                                                          SX_ACCESS_CMD_REGISTER,
+                                                          self.swid,
+                                                          SX_TRAP_ID_PMPE,
+                                                          self.user_channel_p)
+                if rc == SX_STATUS_SUCCESS:
+                    sx_api_host_ifc_trap_id_register_set_pass = True
+                    break
+                else:
+                    log_warning("sx_api_host_ifc_trap_id_register_set return fail... retrying {}".format(retry))
+                    time.sleep(2 ** retry)
+                    retry += 1
+                    if retry > self.SX_OPEN_RETRIES:
+                        sx_api_host_ifc_close(self.handle, self.rx_fd_p)
+                        sx_api_close(self.handle)
+                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set exited with error, rc {}".format(c))
+                    else:
+                        continue
+        
+        self.running = True
 
     def deinitialize(self):
         # remove mlnx-sfpd liveness key in DB if not expired yet
@@ -156,7 +187,6 @@ class MlnxSfpd:
             log_error("sx_api_close exited with error, rc {}".format(rc))
 
     def run(self):
-        self.running = True
 
         while self.running:
             try:

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -101,7 +101,7 @@ class MlnxSfpd:
         # retry at most SX_OPEN_RETRIES times to wait
         # until SDK is started during system startup
         
-        retry = 1
+        retry = 0
         sx_api_open_pass = False
         sx_api_host_ifc_open_pass = False
         sx_api_host_ifc_trap_id_register_set_pass = False
@@ -111,11 +111,11 @@ class MlnxSfpd:
                 rc, self.handle = sx_api_open(None)
                 if rc == SX_STATUS_SUCCESS:
                     sx_api_open_pass = True
-                    retry = 1
+                    retry = 0
                 else:    
                     log_warning("failed to open SDK API handle with err code {}... retrying {}".format(rc,retry))
-                    time.sleep(2 ** retry)
                     retry += 1
+                    time.sleep(2 ** retry)
                     if retry > self.SX_OPEN_RETRIES:
                         raise RuntimeError("failed to open SDK API handle after {} retries".format(retry))
                     else:
@@ -127,11 +127,11 @@ class MlnxSfpd:
                     self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
                     self.user_channel_p.channel.fd = self.rx_fd_p
                     sx_api_host_ifc_open_pass = True
-                    retry = 1
+                    retry = 0
                 else:
                     log_warning("sx_api_host_ifc_open failed with error code {}... retrying {}".format(rc,retry))
-                    time.sleep(2 ** retry)
                     retry += 1
+                    time.sleep(2 ** retry)
                     if retry > self.SX_OPEN_RETRIES:
                         sx_api_close(self.handle)
                         raise RuntimeError("sx_api_host_ifc_open failed with error after {} retries".format(retry))
@@ -149,8 +149,8 @@ class MlnxSfpd:
                     break
                 else:
                     log_warning("sx_api_host_ifc_trap_id_register_set failed with error code {}... retrying {}".format(rc,retry))
-                    time.sleep(2 ** retry)
                     retry += 1
+                    time.sleep(2 ** retry)
                     if retry > self.SX_OPEN_RETRIES:
                         sx_api_host_ifc_close(self.handle, self.rx_fd_p)
                         sx_api_close(self.handle)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enhance the mlnx-sfpd flow, 3 sdk API are called during mlnx-sfpd init, in some cases these sdk API may not ready and return false, need retry.

**- How I did it**
Add code to retry all the SDK API calls, if failed, wait for some time and call again until exceed the max retry time. 

**- How to verify it**
reboot, config reload and check the init log of mlnx-sfpd

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
