### PR TITLE
Revert "[database] save configuration after DB migration"

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -89,11 +89,6 @@ function postStartAction()
     if [[ -x /usr/bin/db_migrator.py ]]; then
         # Migrate the DB to the latest schema version if needed
         /usr/bin/db_migrator.py -o migrate
-
-        # Save in memory config_db to config_db.json for 2 reasons:
-        # 1. Persist the DB migration result.
-        # 2. Save in memory DB after warm reboot.
-        /usr/bin/config save -y
     fi
 {%- elif docker_container_name == "swss" %}
     docker exec swss rm -f /ready   # remove cruft


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#3143

This change caused a regression in sonic to sonic upgrade:

The updategraph service depends on database service. upgradegraph will convert minigraph if config_db.json is missing upon the first boot. If we save db in database service, then the config_db.json will exist even it is an empty database, and subsequently causing updategraph service to skip loading minigraph.

To guarantee saving database after warm reboot, we need to add save to warm boot finalize service.