### PR TITLE
[warm reboot] save configuration after warm reboot

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -80,7 +80,7 @@ fi
 
 # No need to wait for the reconciliation process. Database has been loaded
 # and migrated. This is good enough to save a copy.
-debug "Save in memory database after warm reboot ..."
+debug "Save in-memory database after warm reboot ..."
 config save -y
 
 list=${COMP_LIST}

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -78,6 +78,11 @@ if [[ x"${WARM_BOOT}" != x"true" ]]; then
     exit 0
 fi
 
+# No need to wait for the reconciliation process. Database has been loaded
+# and migrated. This is good enough to save a copy.
+debug "Save in memory database after warm reboot ..."
+config save -y
+
 list=${COMP_LIST}
 
 # Wait up to 5 minutes


### PR DESCRIPTION
**- What I did**

After warm reboot, save a copy of in memory database to config_db.json,
upgrade procedure might have removed config_db.json to force new image
to reload minigraph. However, reload minigraph is skipped during warm
reboot. Missing config_db.json would cause device to fault in next
non-upgrading cold/fast reboot.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
