### PR TITLE
201811: Debug Image only fix: Source path for archive 

### DIFF
--- a/dbg_files.sh
+++ b/dbg_files.sh
@@ -1,26 +1,8 @@
 #!/bin/bash
 
-# Provie file paths to archive for debug image as relative to src subdir
+# Provide file paths to archive for debug image as relative to src subdir
 #
-SRC_DIR_LIST="\
-    libteam \
-    lldpd \
-    libnl3 \
-    radvd \
-    redis \
-    snmpd \
-    sonic-dbsyncd \
-    sonic-frr \
-    sonic-platform-common \
-    sonic-platform-daemons \
-    sonic-py-swsssdk \
-    sonic-sairedis \
-    sonic-snmpagent \
-    sonic-swss \
-    sonic-swss-common \
-    tacacs"
-
-for i in $SRC_DIR_LIST
+for i in $debug_src_archive
 do
     find $i/ -name "*.c" -o -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -type f
 done

--- a/rules/frr.mk
+++ b/rules/frr.mk
@@ -11,3 +11,8 @@ SONIC_MAKE_DEBS += $(FRR)
 FRR_DBG = frr-dbgsym_$(FRR_VERSION)-sonic-$(FRR_SUBVERSION)_amd64.deb
 $(eval $(call add_derived_package,$(FRR),$(FRR_DBG)))
 
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += sonic-frr
+

--- a/rules/libnl3.mk
+++ b/rules/libnl3.mk
@@ -46,3 +46,8 @@ $(eval $(call add_derived_package,$(LIBNL3),$(LIBNL_CLI)))
 LIBNL_CLI_DEV = libnl-cli-3-dev_$(LIBNL3_VERSION)_amd64.deb
 $(LIBNL_CLI_DEV)_DEPENDS += $(LIBNL_CLI) $(LIBNL_GENL3_DEV) $(LIBNL_NF3_DEV) $(LIBNL_ROUTE3_DEV)
 $(eval $(call add_derived_package,$(LIBNL3),$(LIBNL_CLI_DEV)))
+
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += libnl3

--- a/rules/libteam.mk
+++ b/rules/libteam.mk
@@ -19,3 +19,9 @@ $(eval $(call add_derived_package,$(LIBTEAM),$(LIBTEAMDCT)))
 LIBTEAM_UTILS = libteam-utils_$(LIBTEAM_VERSION)_amd64.deb
 $(LIBTEAM_UTILS)_DEPENDS += $(LIBTEAMDCT)
 $(eval $(call add_derived_package,$(LIBTEAM),$(LIBTEAM_UTILS)))
+
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += libteam
+

--- a/rules/lldpd.mk
+++ b/rules/lldpd.mk
@@ -15,3 +15,9 @@ $(eval $(call add_derived_package,$(LLDPD),$(LIBLLDPCTL)))
 export LLDPD_VERSION
 export LLDPD
 export LIBLLDPCTL
+
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += lldpd
+

--- a/rules/radvd.mk
+++ b/rules/radvd.mk
@@ -7,3 +7,10 @@ export RADVD_VERSION
 RADVD = radvd_$(RADVD_VERSION)_amd64.deb
 $(RADVD)_SRC_PATH = $(SRC_PATH)/radvd
 SONIC_MAKE_DEBS += $(RADVD)
+
+
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += radvd
+

--- a/rules/redis.mk
+++ b/rules/redis.mk
@@ -13,3 +13,9 @@ REDIS_SENTINEL = redis-sentinel_$(REDIS_VERSION)_amd64.deb
 $(REDIS_SENTINEL)_DEPENDS += $(REDIS_SERVER)
 $(REDIS_SENTINEL)_RDEPENDS += $(REDIS_SERVER)
 $(eval $(call add_derived_package,$(REDIS_TOOLS),$(REDIS_SENTINEL)))
+
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += redis
+

--- a/rules/sairedis.mk
+++ b/rules/sairedis.mk
@@ -59,3 +59,10 @@ LIBSAIMETADATA_DBG = libsaimetadata-dbg_1.0.0_amd64.deb
 $(LIBSAIMETADATA_DBG)_DEPENDS += $(LIBSAIMETADATA)
 $(LIBSAIMETADATA_DBG)_RDEPENDS += $(LIBSAIMETADATA)
 $(eval $(call add_derived_package,$(LIBSAIREDIS),$(LIBSAIMETADATA_DBG)))
+
+
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += sonic-sairedis
+

--- a/rules/snmpd.mk
+++ b/rules/snmpd.mk
@@ -53,3 +53,9 @@ TKMIB = tkmib_$(SNMPD_VERSION_FULL)_all.deb
 $(TKMIB)_DEPENDS += $(LIBSNMP_PERL)
 $(TKMIB)_RDEPENDS += $(LIBSNMP_PERL)
 $(eval $(call add_derived_package,$(LIBSNMP_BASE),$(TKMIB)))
+
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += snmpd
+

--- a/rules/swss-common.mk
+++ b/rules/swss-common.mk
@@ -19,3 +19,9 @@ LIBSWSSCOMMON_DBG = libswsscommon-dbg_1.0.0_amd64.deb
 $(LIBSWSSCOMMON_DBG)_DEPENDS += $(LIBSWSSCOMMON)
 $(LIBSWSSCOMMON_DBG)_RDEPENDS += $(LIBSWSSCOMMON)
 $(eval $(call add_derived_package,$(LIBSWSSCOMMON),$(LIBSWSSCOMMON_DBG)))
+
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += sonic-swss-common
+

--- a/rules/swss.mk
+++ b/rules/swss.mk
@@ -11,3 +11,9 @@ SWSS_DBG = swss-dbg_1.0.0_amd64.deb
 $(SWSS_DBG)_DEPENDS += $(SWSS)
 $(SWSS_DBG)_RDEPENDS += $(SWSS)
 $(eval $(call add_derived_package,$(SWSS),$(SWSS_DBG)))
+
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += sonic-swss
+

--- a/rules/tacacs.mk
+++ b/rules/tacacs.mk
@@ -30,3 +30,10 @@ $(LIBNSS_TACPLUS)_SRC_PATH = $(SRC_PATH)/tacacs/nss
 SONIC_MAKE_DEBS += $(LIBNSS_TACPLUS)
 
 SONIC_STRETCH_DEBS += $(LIBPAM_TACPLUS) $(LIBNSS_TACPLUS)
+
+
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += tacacs
+

--- a/slave.mk
+++ b/slave.mk
@@ -607,6 +607,8 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		chmod +x sonic_debian_extension.sh,
 	)
 
+	export debug_src_archive="$(DBG_SRC_ARCHIVE)"
+
 	DEBUG_IMG="$(INSTALL_DEBUG_TOOLS)" \
 	USERNAME="$(USERNAME)" \
 	PASSWORD="$(PASSWORD)" \


### PR DESCRIPTION
Let individual make files dictate the source path

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
