### PR TITLE
Update docker engine to 18.09.8

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -29,7 +29,7 @@
 set -x -e
 
 ## docker engine version (with platform)
-DOCKER_VERSION=5:18.09.2~3-0~debian-stretch
+DOCKER_VERSION=5:18.09.8~3-0~debian-stretch
 LINUX_KERNEL_VERSION=4.9.0-9-2
 
 ## Working directory to prepare the file system


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>
After warm reboot with sad path lag member down case, following errors were seen and DUT could only be recovered with a cold reboot

Jul 17 10:57:55.506614 str-7260cx3-acs-2 INFO dockerd[758]: time="2019-07-17T10:57:55.506412474Z" level=error msg="Handler for POST /v1.39/containers/database/start returned error: id already in use"
Jul 17 10:57:55.507527 str-7260cx3-acs-2 INFO database.sh[991]: Error response from daemon: id already in use
Jul 17 10:57:55.508096 str-7260cx3-acs-2 INFO database.sh[991]: Error: failed to start containers: database
Jul 17 10:57:55.559361 str-7260cx3-acs-2 INFO dockerd[758]: time="2019-07-17T10:57:55.559217827Z" level=error msg="Error setting up exec command in container database: Container 57ad146532fb34992fcbf5b37674a55f84428038b61613efbb5c775be5b015b6 is not running"
Jul 17 10:57:55.559995 str-7260cx3-acs-2 INFO database.sh[991]: Error response from daemon: Container 57ad146532fb34992fcbf5b37674a55f84428038b61613efbb5c775be5b015b6 is not running

Issue fixed in https://github.com/docker/engine/pull/154

Verified by upgrading the docker version to 18.09.8 and running warm-reboot sad path lag member case multiple times. No longer seeing the issue

root@str-7260cx3-acs-7:~# docker info
Containers: 10
 Running: 10
 Paused: 0
 Stopped: 0
Images: 10
Server Version: 18.09.8
Storage Driver: overlay2
 Backing Filesystem: extfs
 Supports d_type: true
 Native Overlay Diff: true
Logging Driver: json-file
Cgroup Driver: cgroupfs
Plugins:
 Volume: local
 Network: bridge host macvlan null overlay
 Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
Swarm: inactive
Runtimes: runc
Default Runtime: runc
Init Binary: docker-init
containerd version: 894b81a4b802e4eb2a91d1ce216b8817763c29fb
runc version: 425e105d5a03fabd737a126ad93d62a9eeede87f
init version: fec3683
Security Options:
 apparmor
 seccomp
  Profile: default
Kernel Version: 4.9.0-9-amd64
Operating System: Debian GNU/Linux 9 (stretch)
OSType: linux
Architecture: x86_64
CPUs: 4
Total Memory: 7.848GiB
Name: str-7260cx3-acs-7
ID: Z3BM:OSND:I77N:FNVD:QICE:HNTF:UCRJ:WZRH:ZBYV:LTQD:THJH:CT6K
Docker Root Dir: /var/lib/docker
Debug Mode (client): false
Debug Mode (server): false
Registry: https://index.docker.io/v1/
Labels:
Experimental: false
Insecure Registries:
 127.0.0.0/8
Live Restore Enabled: false
Product License: Community Engine

WARNING: No swap limit support
WARNING: bridge-nf-call-iptables is disabled
WARNING: bridge-nf-call-ip6tables is disabled