### PR TITLE
[Accton] Correct port index and offer the default speed.

### DIFF
--- a/device/accton/x86_64-accton_as5712_54x-r0/Accton-AS5712-54X/port_config.ini
+++ b/device/accton/x86_64-accton_as5712_54x-r0/Accton-AS5712-54X/port_config.ini
@@ -1,73 +1,73 @@
-# name         lanes              alias         index
-Ethernet0      13                 tenGigE0      0
-Ethernet1      14                 tenGigE1      1
-Ethernet2      15                 tenGigE2      2
-Ethernet3      16                 tenGigE3      3
-Ethernet4      21                 tenGigE4      4
-Ethernet5      22                 tenGigE5      5
-Ethernet6      23                 tenGigE6      6
-Ethernet7      24                 tenGigE7      7
-Ethernet8      25                 tenGigE8      8
-Ethernet9      26                 tenGigE9      9
-Ethernet10     27                 tenGigE10     10
-Ethernet11     28                 tenGigE11     11
-Ethernet12     29                 tenGigE12     12
-Ethernet13     30                 tenGigE13     13
-Ethernet14     31                 tenGigE14     14
-Ethernet15     32                 tenGigE15     15
-Ethernet16     45                 tenGigE16     16
-Ethernet17     46                 tenGigE17     17
-Ethernet18     47                 tenGigE18     18
-Ethernet19     48                 tenGigE19     19
-Ethernet20     49                 tenGigE20     20
-Ethernet21     50                 tenGigE21     21
-Ethernet22     51                 tenGigE22     22
-Ethernet23     52                 tenGigE23     23
-Ethernet24     53                 tenGigE24     24
-Ethernet25     54                 tenGigE25     25
-Ethernet26     55                 tenGigE26     26
-Ethernet27     56                 tenGigE27     27
-Ethernet28     57                 tenGigE28     28
-Ethernet29     58                 tenGigE29     29
-Ethernet30     59                 tenGigE30     30
-Ethernet31     60                 tenGigE31     31
-Ethernet32     61                 tenGigE32     32
-Ethernet33     62                 tenGigE33     33
-Ethernet34     63                 tenGigE34     34
-Ethernet35     64                 tenGigE35     35
-Ethernet36     65                 tenGigE36     36
-Ethernet37     66                 tenGigE37     37
-Ethernet38     67                 tenGigE38     38
-Ethernet39     68                 tenGigE39     39
-Ethernet40     69                 tenGigE40     40
-Ethernet41     70                 tenGigE41     41
-Ethernet42     71                 tenGigE42     42
-Ethernet43     72                 tenGigE43     43
-Ethernet44     73                 tenGigE44     44
-Ethernet45     74                 tenGigE45     45
-Ethernet46     75                 tenGigE46     46
-Ethernet47     76                 tenGigE47     47
-Ethernet48     97                 tenGigE48     48
-Ethernet49     98                 tenGigE49     49
-Ethernet50     99                 tenGigE50     50
-Ethernet51     100                tenGigE51     51
-Ethernet52     101                tenGigE52     52
-Ethernet53     102                tenGigE53     53
-Ethernet54     103                tenGigE54     54
-Ethernet55     104                tenGigE55     55
-Ethernet56     81                 tenGigE56     56
-Ethernet57     82                 tenGigE57     57
-Ethernet58     83                 tenGigE58     58
-Ethernet59     84                 tenGigE59     59
-Ethernet60     105                tenGigE60     60
-Ethernet61     106                tenGigE61     61
-Ethernet62     107                tenGigE62     62
-Ethernet63     108                tenGigE63     63
-Ethernet64     109                tenGigE64     64
-Ethernet65     110                tenGigE65     65
-Ethernet66     111                tenGigE66     66
-Ethernet67     112                tenGigE67     67
-Ethernet68     77                 tenGigE68     68
-Ethernet69     78                 tenGigE69     69
-Ethernet70     79                 tenGigE70     70
-Ethernet71     80                 tenGigE71     71
+# name         lanes              alias         index  speed
+Ethernet0      13                 tenGigE0      1      10000
+Ethernet1      14                 tenGigE1      2      10000
+Ethernet2      15                 tenGigE2      3      10000
+Ethernet3      16                 tenGigE3      4      10000
+Ethernet4      21                 tenGigE4      5      10000
+Ethernet5      22                 tenGigE5      6      10000
+Ethernet6      23                 tenGigE6      7      10000
+Ethernet7      24                 tenGigE7      8      10000
+Ethernet8      25                 tenGigE8      9      10000
+Ethernet9      26                 tenGigE9      10     10000
+Ethernet10     27                 tenGigE10     11     10000
+Ethernet11     28                 tenGigE11     12     10000
+Ethernet12     29                 tenGigE12     13     10000
+Ethernet13     30                 tenGigE13     14     10000
+Ethernet14     31                 tenGigE14     15     10000
+Ethernet15     32                 tenGigE15     16     10000
+Ethernet16     45                 tenGigE16     17     10000
+Ethernet17     46                 tenGigE17     18     10000
+Ethernet18     47                 tenGigE18     19     10000
+Ethernet19     48                 tenGigE19     20     10000
+Ethernet20     49                 tenGigE20     21     10000
+Ethernet21     50                 tenGigE21     22     10000
+Ethernet22     51                 tenGigE22     23     10000
+Ethernet23     52                 tenGigE23     24     10000
+Ethernet24     53                 tenGigE24     25     10000
+Ethernet25     54                 tenGigE25     26     10000
+Ethernet26     55                 tenGigE26     27     10000
+Ethernet27     56                 tenGigE27     28     10000
+Ethernet28     57                 tenGigE28     29     10000
+Ethernet29     58                 tenGigE29     30     10000
+Ethernet30     59                 tenGigE30     31     10000
+Ethernet31     60                 tenGigE31     32     10000
+Ethernet32     61                 tenGigE32     33     10000
+Ethernet33     62                 tenGigE33     34     10000
+Ethernet34     63                 tenGigE34     35     10000
+Ethernet35     64                 tenGigE35     36     10000
+Ethernet36     65                 tenGigE36     37     10000
+Ethernet37     66                 tenGigE37     38     10000
+Ethernet38     67                 tenGigE38     39     10000
+Ethernet39     68                 tenGigE39     40     10000
+Ethernet40     69                 tenGigE40     41     10000
+Ethernet41     70                 tenGigE41     42     10000
+Ethernet42     71                 tenGigE42     43     10000
+Ethernet43     72                 tenGigE43     44     10000
+Ethernet44     73                 tenGigE44     45     10000
+Ethernet45     74                 tenGigE45     46     10000
+Ethernet46     75                 tenGigE46     47     10000
+Ethernet47     76                 tenGigE47     48     10000
+Ethernet48     97                 tenGigE48     49     10000
+Ethernet49     98                 tenGigE49     49     10000
+Ethernet50     99                 tenGigE50     49     10000
+Ethernet51     100                tenGigE51     49     10000
+Ethernet52     101                tenGigE52     50     10000
+Ethernet53     102                tenGigE53     50     10000
+Ethernet54     103                tenGigE54     50     10000
+Ethernet55     104                tenGigE55     50     10000
+Ethernet56     81                 tenGigE56     51     10000
+Ethernet57     82                 tenGigE57     51     10000
+Ethernet58     83                 tenGigE58     51     10000
+Ethernet59     84                 tenGigE59     51     10000
+Ethernet60     105                tenGigE60     52     10000
+Ethernet61     106                tenGigE61     52     10000
+Ethernet62     107                tenGigE62     52     10000
+Ethernet63     108                tenGigE63     52     10000
+Ethernet64     109                tenGigE64     53     10000
+Ethernet65     110                tenGigE65     53     10000
+Ethernet66     111                tenGigE66     53     10000
+Ethernet67     112                tenGigE67     53     10000
+Ethernet68     77                 tenGigE68     54     10000
+Ethernet69     78                 tenGigE69     54     10000
+Ethernet70     79                 tenGigE70     54     10000
+Ethernet71     80                 tenGigE71     54     10000

--- a/device/accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
@@ -6,20 +6,26 @@ try:
     import time
     import os
     import string
+    import pprint
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
 
+#from xcvrd
+SFP_STATUS_INSERTED = '1'
+SFP_STATUS_REMOVED = '0'
+
+
 class SfpUtil(SfpUtilBase):
     """Platform-specific SfpUtil class"""
 
-    PORT_START = 0
-    PORT_END = 71
-    PORTS_IN_BLOCK = 72
-    QSFP_PORT_START = 48
-    QSFP_PORT_END = 72
+    PORT_START = 1
+    PORT_END = 54
+    PORTS_IN_BLOCK = 54
+    QSFP_PORT_START = 49
+    QSFP_PORT_END = 54
 
     BASE_VAL_PATH = "/sys/class/i2c-adapter/i2c-{0}/{1}-0050/"
     BASE_OOM_PATH = "/sys/bus/i2c/devices/{0}-0050/"
@@ -28,87 +34,67 @@ class SfpUtil(SfpUtilBase):
     I2C_BUS_ORDER = -1
 
     #The sidebands of QSFP is different. 
-    #present is in-order. 
-    #But lp_mode and reset are not. 	
-    qsfp_sb_map = [1, 3, 5, 2, 4, 6]
+    qsfp_sb_map = [0, 2, 4, 1, 3, 5]
 
     _port_to_is_present = {}
     _port_to_lp_mode = {}
 
     _port_to_eeprom_mapping = {}
     _port_to_i2c_mapping = {
-           0: [1, 2],
-           1: [2, 3],
-           2: [3, 4],
-           3: [4, 5],
-           4: [5, 6],
-           5: [6, 7],
-           6: [7, 8],
-           7: [8, 9],
-           8: [9, 10],            
-           9: [10, 11],
-           10: [11, 12],
-           11: [12, 13],
-           12: [13, 14],
-           13: [14, 15],
-           14: [15, 16],
-           15: [16, 17],
-           16: [17, 18],
-           17: [18, 19],
-           18: [19, 20],
-           19: [20, 21],            
-           20: [21, 22],
-           21: [22, 23],
-           22: [23, 24],
-           23: [24, 25],
-           24: [25, 26],
-           25: [26, 27],
-           26: [27, 28],
-           27: [28, 29],
-           28: [29, 30],
-           29: [30, 31],
-           30: [31, 32],
-           31: [32, 33],
-           32: [33, 34],
-           33: [34, 35],
-           34: [35, 36],
-           35: [36, 37],
-           36: [37, 38],
-           37: [38, 39],
-           38: [39, 40],
-           39: [40, 41],
-           40: [41, 42],
-           41: [42, 43],
-           42: [43, 44],
-           43: [44, 45],
-           44: [45, 46],
-           45: [46, 47],
-           46: [47, 48],
-           47: [48, 49],
-           48: [49, 50],#QSFP49
-           49: [49, 50],
-           50: [49, 50],
-           51: [49, 50],            
-           52: [50, 52],#QSFP50
-           53: [50, 52],
-           54: [50, 52],
-           55: [50, 52],
-           56: [51, 54],#QSFP51
-           57: [51, 54],
-           58: [51, 54],
-           59: [51, 54],
-           60: [52, 51],#QSFP52
-           61: [52, 51],
-           62: [52, 51],
-           63: [52, 51], 
-           64: [53, 53], #QSFP53
-           65: [53, 53],
-           66: [53, 53],
-           67: [53, 53],
-           68: [54, 55],#QSFP54          
-           69: [54, 55],          
-           70: [54, 55],          
-           71: [54, 55],          
+           1: [1, 2],
+           2: [2, 3],
+           3: [3, 4],
+           4: [4, 5],
+           5: [5, 6],
+           6: [6, 7],
+           7: [7, 8],
+           8: [8, 9],
+           9: [9, 10],
+           10: [10, 11],
+           11: [11, 12],
+           12: [12, 13],
+           13: [13, 14],
+           14: [14, 15],
+           15: [15, 16],
+           16: [16, 17],
+           17: [17, 18],
+           18: [18, 19],
+           19: [19, 20],
+           20: [20, 21],
+           21: [21, 22],
+           22: [22, 23],
+           23: [23, 24],
+           24: [24, 25],
+           25: [25, 26],
+           26: [26, 27],
+           27: [27, 28],
+           28: [28, 29],
+           29: [29, 30],
+           30: [30, 31],
+           31: [31, 32],
+           32: [32, 33],
+           33: [33, 34],
+           34: [34, 35],
+           35: [35, 36],
+           36: [36, 37],
+           37: [37, 38],
+           38: [38, 39],
+           39: [39, 40],
+           40: [40, 41],
+           41: [41, 42],
+           42: [42, 43],
+           43: [43, 44],
+           44: [44, 45],
+           45: [45, 46],
+           46: [46, 47],
+           47: [47, 48],
+           48: [48, 49],
+           49: [49, 50],#QSFP49
+           50: [51, 52],
+           51: [53, 54],
+           52: [50, 51],
+           53: [52, 53],
+           54: [54, 55],#QSFP54
            }
 
     @property
@@ -135,16 +121,6 @@ class SfpUtil(SfpUtilBase):
     def port_to_eeprom_mapping(self):
         return self._port_to_eeprom_mapping
 
-    def __init__(self):
-        eeprom_path = self.BASE_OOM_PATH + "eeprom"
-
-        for x in range(0, self.port_end+1):
-            self.port_to_eeprom_mapping[x] = eeprom_path.format(
-                self._port_to_i2c_mapping[x][1]
-                )
-
-        SfpUtilBase.__init__(self)
-
     #Two i2c buses might get flipped order, check them both.
     def update_i2c_order(self):
         if self.I2C_BUS_ORDER < 0:
@@ -162,12 +138,11 @@ class SfpUtil(SfpUtilBase):
             return False
 
         order = self.update_i2c_order()
-        if port_num < 24:
-            present_path = self.BASE_CPLD2_PATH.format(order)         
+        if port_num <= 24:
+            present_path = self.BASE_CPLD2_PATH.format(order)
         else:
             present_path = self.BASE_CPLD3_PATH.format(order)
-        
-        present_path = present_path + "module_present_" + str(self._port_to_i2c_mapping[port_num][0])            
+        present_path = present_path + "module_present_" + str(port_num)
         self.__port_to_is_present = present_path
 
         try:
@@ -187,8 +162,8 @@ class SfpUtil(SfpUtilBase):
 
     def qsfp_sb_remap(self, port_num):
         qsfp_start = self.qsfp_port_start
-        qsfp_index = self._port_to_i2c_mapping[port_num][0] - qsfp_start
-        qsfp_index = self.qsfp_sb_map[qsfp_index-1]
+        qsfp_index = port_num - qsfp_start
+        qsfp_index = self.qsfp_sb_map[qsfp_index]
         return qsfp_start+qsfp_index
 
     def get_low_power_mode_cpld(self, port_num):
@@ -282,9 +257,8 @@ class SfpUtil(SfpUtilBase):
         mod_rst_path = lp_mode_path + "module_reset_" 
         q = self.qsfp_sb_remap(port_num)
         mod_rst_path = mod_rst_path + str(q)
-        
         try:
-            reg_file = open(mod_rst_path, 'r+')
+            reg_file = open(mod_rst_path, 'r+', buffering=0)
         except IOError as e:
             print "Error: unable to open file: %s" % str(e)          
             return False
@@ -297,12 +271,83 @@ class SfpUtil(SfpUtilBase):
         reg_file.write('1')
         reg_file.close()
         return True
+
+    @property
+    def get_transceiver_status(self):
+	nodes = []
+        order = self.update_i2c_order()
         
-    def get_transceiver_change_event(self):
-        """
-        TODO: This function need to be implemented
-        when decide to support monitoring SFP(Xcvrd)
-        on this platform.
-        """
-        raise NotImplementedError
+        present_path = self.BASE_CPLD2_PATH.format(order)
+        nodes.append(present_path + "module_present_all")
+        present_path = self.BASE_CPLD3_PATH.format(order)
+        nodes.append(present_path + "module_present_all")
+
+	bitmap = ""
+	for node in nodes: 
+            try:
+                reg_file = open(node)
+    
+            except IOError as e:
+                print "Error: unable to open file: %s" % str(e)
+                return False
+            bitmap += reg_file.readline().rstrip() + " "
+            reg_file.close()
+
+        rev = bitmap.split(" ")
+        rev = "".join(rev[::-1])
+        return int(rev,16)
+   
+
+    data = {'valid':0, 'last':0, 'present':0} 
+    def get_transceiver_change_event(self, timeout=2000):
+        now = time.time()
+        port_dict = {}
+        port = 0
+
+        if timeout < 1000:
+            timeout = 1000
+        timeout = (timeout) / float(1000) # Convert to secs
+
+
+        if now < (self.data['last'] + timeout) and self.data['valid']:
+            return True, {}
+
+        reg_value = self.get_transceiver_status
+        changed_ports = self.data['present'] ^ reg_value
+        if changed_ports:
+            for port in range (self.port_start, self.port_end+1):
+                # Mask off the bit corresponding to our port
+                fp_port = self._port_to_i2c_mapping[port][0]
+                mask = (1 << (fp_port - 1))
+                if changed_ports & mask:
+
+                    if (reg_value & mask) == 0:
+                        port_dict[port] = SFP_STATUS_REMOVED
+                    else:
+                        port_dict[port] = SFP_STATUS_INSERTED
+
+            # Update cache 
+            self.data['present'] = reg_value
+            self.data['last'] = now
+            self.data['valid'] = 1
+
+            pprint.pprint(port_dict)
+            return True, port_dict
+        else:
+            return True, {}
+        return False, {}
+
+
+    def __init__(self):
+        eeprom_path = self.BASE_OOM_PATH + "eeprom"
+
+        for x in range(self.port_start, self.port_end+1):
+            self.port_to_eeprom_mapping[x] = eeprom_path.format(
+                self._port_to_i2c_mapping[x][1]
+                )
+
+        SfpUtilBase.__init__(self)
+
+
+
 

--- a/device/accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
@@ -6,7 +6,6 @@ try:
     import time
     import os
     import string
-    import pprint
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:

--- a/device/accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
@@ -273,7 +273,7 @@ class SfpUtil(SfpUtilBase):
         return True
 
     @property
-    def get_transceiver_status(self):
+    def _get_presence_bitmap(self):
 	nodes = []
         order = self.update_i2c_order()
         
@@ -312,7 +312,7 @@ class SfpUtil(SfpUtilBase):
         if now < (self.data['last'] + timeout) and self.data['valid']:
             return True, {}
 
-        reg_value = self.get_transceiver_status
+        reg_value = self._get_presence_bitmap
         changed_ports = self.data['present'] ^ reg_value
         if changed_ports:
             for port in range (self.port_start, self.port_end+1):
@@ -331,7 +331,6 @@ class SfpUtil(SfpUtilBase):
             self.data['last'] = now
             self.data['valid'] = 1
 
-            pprint.pprint(port_dict)
             return True, port_dict
         else:
             return True, {}

--- a/device/accton/x86_64-accton_as5812_54x-r0/Accton-AS5812-54X/port_config.ini
+++ b/device/accton/x86_64-accton_as5812_54x-r0/Accton-AS5812-54X/port_config.ini
@@ -1,73 +1,73 @@
-# name         lanes              alias         index
-Ethernet0      13                 tenGigE0      1
-Ethernet1      14                 tenGigE1      2
-Ethernet2      15                 tenGigE2      3
-Ethernet3      16                 tenGigE3      4
-Ethernet4      21                 tenGigE4      5
-Ethernet5      22                 tenGigE5      6
-Ethernet6      23                 tenGigE6      7
-Ethernet7      24                 tenGigE7      8
-Ethernet8      25                 tenGigE8      9
-Ethernet9      26                 tenGigE9      10
-Ethernet10     27                 tenGigE10     11
-Ethernet11     28                 tenGigE11     12
-Ethernet12     29                 tenGigE12     13
-Ethernet13     30                 tenGigE13     14
-Ethernet14     31                 tenGigE14     15
-Ethernet15     32                 tenGigE15     16
-Ethernet16     45                 tenGigE16     17
-Ethernet17     46                 tenGigE17     18
-Ethernet18     47                 tenGigE18     19
-Ethernet19     48                 tenGigE19     20
-Ethernet20     49                 tenGigE20     21
-Ethernet21     50                 tenGigE21     22
-Ethernet22     51                 tenGigE22     23
-Ethernet23     52                 tenGigE23     24
-Ethernet24     53                 tenGigE24     25
-Ethernet25     54                 tenGigE25     26
-Ethernet26     55                 tenGigE26     27
-Ethernet27     56                 tenGigE27     28
-Ethernet28     57                 tenGigE28     29
-Ethernet29     58                 tenGigE29     30
-Ethernet30     59                 tenGigE30     31
-Ethernet31     60                 tenGigE31     32
-Ethernet32     61                 tenGigE32     33
-Ethernet33     62                 tenGigE33     34
-Ethernet34     63                 tenGigE34     35
-Ethernet35     64                 tenGigE35     36
-Ethernet36     65                 tenGigE36     37
-Ethernet37     66                 tenGigE37     38
-Ethernet38     67                 tenGigE38     39
-Ethernet39     68                 tenGigE39     40
-Ethernet40     69                 tenGigE40     41
-Ethernet41     70                 tenGigE41     42
-Ethernet42     71                 tenGigE42     43
-Ethernet43     72                 tenGigE43     44
-Ethernet44     73                 tenGigE44     45
-Ethernet45     74                 tenGigE45     46
-Ethernet46     75                 tenGigE46     47
-Ethernet47     76                 tenGigE47     48
-Ethernet48     97                 tenGigE48     49
-Ethernet49     98                 tenGigE49     50
-Ethernet50     99                 tenGigE50     51
-Ethernet51     100                tenGigE51     52
-Ethernet52     101                tenGigE52     53
-Ethernet53     102                tenGigE53     54
-Ethernet54     103                tenGigE54     55
-Ethernet55     104                tenGigE55     56
-Ethernet56     81                 tenGigE56     57
-Ethernet57     82                 tenGigE57     58
-Ethernet58     83                 tenGigE58     59
-Ethernet59     84                 tenGigE59     60
-Ethernet60     105                tenGigE60     61
-Ethernet61     106                tenGigE61     62
-Ethernet62     107                tenGigE62     63
-Ethernet63     108                tenGigE63     64
-Ethernet64     109                tenGigE64     65
-Ethernet65     110                tenGigE65     66
-Ethernet66     111                tenGigE66     67
-Ethernet67     112                tenGigE67     68
-Ethernet68     77                 tenGigE68     69
-Ethernet69     78                 tenGigE69     70
-Ethernet70     79                 tenGigE70     71
-EthernEt71     80                 tenGigE71     72
+# name         lanes              alias         index  speed
+Ethernet0      13                 tenGigE0      1      10000
+Ethernet1      14                 tenGigE1      2      10000
+Ethernet2      15                 tenGigE2      3      10000
+Ethernet3      16                 tenGigE3      4      10000
+Ethernet4      21                 tenGigE4      5      10000
+Ethernet5      22                 tenGigE5      6      10000
+Ethernet6      23                 tenGigE6      7      10000
+Ethernet7      24                 tenGigE7      8      10000
+Ethernet8      25                 tenGigE8      9      10000
+Ethernet9      26                 tenGigE9      10     10000
+Ethernet10     27                 tenGigE10     11     10000
+Ethernet11     28                 tenGigE11     12     10000
+Ethernet12     29                 tenGigE12     13     10000
+Ethernet13     30                 tenGigE13     14     10000
+Ethernet14     31                 tenGigE14     15     10000
+Ethernet15     32                 tenGigE15     16     10000
+Ethernet16     45                 tenGigE16     17     10000
+Ethernet17     46                 tenGigE17     18     10000
+Ethernet18     47                 tenGigE18     19     10000
+Ethernet19     48                 tenGigE19     20     10000
+Ethernet20     49                 tenGigE20     21     10000
+Ethernet21     50                 tenGigE21     22     10000
+Ethernet22     51                 tenGigE22     23     10000
+Ethernet23     52                 tenGigE23     24     10000
+Ethernet24     53                 tenGigE24     25     10000
+Ethernet25     54                 tenGigE25     26     10000
+Ethernet26     55                 tenGigE26     27     10000
+Ethernet27     56                 tenGigE27     28     10000
+Ethernet28     57                 tenGigE28     29     10000
+Ethernet29     58                 tenGigE29     30     10000
+Ethernet30     59                 tenGigE30     31     10000
+Ethernet31     60                 tenGigE31     32     10000
+Ethernet32     61                 tenGigE32     33     10000
+Ethernet33     62                 tenGigE33     34     10000
+Ethernet34     63                 tenGigE34     35     10000
+Ethernet35     64                 tenGigE35     36     10000
+Ethernet36     65                 tenGigE36     37     10000
+Ethernet37     66                 tenGigE37     38     10000
+Ethernet38     67                 tenGigE38     39     10000
+Ethernet39     68                 tenGigE39     40     10000
+Ethernet40     69                 tenGigE40     41     10000
+Ethernet41     70                 tenGigE41     42     10000
+Ethernet42     71                 tenGigE42     43     10000
+Ethernet43     72                 tenGigE43     44     10000
+Ethernet44     73                 tenGigE44     45     10000
+Ethernet45     74                 tenGigE45     46     10000
+Ethernet46     75                 tenGigE46     47     10000
+Ethernet47     76                 tenGigE47     48     10000
+Ethernet48     97                 tenGigE48     49     10000
+Ethernet49     98                 tenGigE49     49     10000
+Ethernet50     99                 tenGigE50     49     10000
+Ethernet51     100                tenGigE51     49     10000
+Ethernet52     101                tenGigE52     50     10000
+Ethernet53     102                tenGigE53     50     10000
+Ethernet54     103                tenGigE54     50     10000
+Ethernet55     104                tenGigE55     50     10000
+Ethernet56     81                 tenGigE56     51     10000
+Ethernet57     82                 tenGigE57     51     10000
+Ethernet58     83                 tenGigE58     51     10000
+Ethernet59     84                 tenGigE59     51     10000
+Ethernet60     105                tenGigE60     52     10000
+Ethernet61     106                tenGigE61     52     10000
+Ethernet62     107                tenGigE62     52     10000
+Ethernet63     108                tenGigE63     52     10000
+Ethernet64     109                tenGigE64     53     10000
+Ethernet65     110                tenGigE65     53     10000
+Ethernet66     111                tenGigE66     53     10000
+Ethernet67     112                tenGigE67     53     10000
+Ethernet68     77                 tenGigE68     54     10000
+Ethernet69     78                 tenGigE69     54     10000
+Ethernet70     79                 tenGigE70     54     10000
+Ethernet71     80                 tenGigE71     54     10000

--- a/device/accton/x86_64-accton_as5812_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5812_54x-r0/plugins/sfputil.py
@@ -6,20 +6,25 @@ try:
     import time
     import os
     import pickle
+    import pprint
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
+
+#from xcvrd
+SFP_STATUS_INSERTED = '1'
+SFP_STATUS_REMOVED = '0'
 
 
 class SfpUtil(SfpUtilBase):
     """Platform-specific SfpUtil class"""
 
     PORT_START = 1
-    PORT_END = 72
-    PORTS_IN_BLOCK = 72
-    QSFP_PORT_START = 48
-    QSFP_PORT_END = 72
+    PORT_END = 54
+    PORTS_IN_BLOCK = 54
+    QSFP_PORT_START = 49
+    QSFP_PORT_END = 54
 
     BASE_VAL_PATH = "/sys/class/i2c-adapter/i2c-{0}/{1}-0050/"
     BASE_OOM_PATH = "/sys/bus/i2c/devices/{0}-0050/"
@@ -30,85 +35,67 @@ class SfpUtil(SfpUtilBase):
     #The sidebands of QSFP is different. 
     #present is in-order. 
     #But lp_mode and reset are not. 	
-    qsfp_sb_map = [1, 3, 5, 2, 4, 6]
+    qsfp_sb_map = [0, 2, 4, 1, 3, 5]
 
     _port_to_is_present = {}
     _port_to_lp_mode = {}
 
     _port_to_eeprom_mapping = {}
     _port_to_i2c_mapping = {
-            1: [1, 2],
-            2: [2, 3],
-            3: [3, 4],
-            4: [4, 5],
-            5: [5, 6],
-            6: [6, 7],
-            7: [7, 8],
-            8: [8, 9],
-            9: [9, 10],
-           10: [10, 11],
-           11: [11, 12],
-           12: [12, 13],
-           13: [13, 14],
-           14: [14, 15],
-           15: [15, 16],
-           16: [16, 17],
-           17: [17, 18],
-           18: [18, 19],
-           19: [19, 20],
-           20: [20, 21],
-           21: [21, 22],
-           22: [22, 23],
-           23: [23, 24],
-           24: [24, 25],
-           25: [25, 26],
-           26: [26, 27],
-           27: [27, 28],
-           28: [28, 29],
-           29: [29, 30],
-           30: [30, 31],
-           31: [31, 32],
-           32: [32, 33],
-           33: [33, 34],
-           34: [34, 35],
-           35: [35, 36],
-           36: [36, 37],
-           37: [37, 38],
-           38: [38, 39],
-           39: [39, 40],
-           40: [40, 41],
-           41: [41, 42],
-           42: [42, 43],
-           43: [43, 44],
-           44: [44, 45],
-           45: [45, 46],
-           46: [46, 47],
-           47: [47, 48],
-           48: [48, 49],
-           49: [49, 50],#QSFP49
-           50: [49, 50],
-           51: [49, 50],
-           52: [49, 50],
-           53: [50, 52],#QSFP50
-           54: [50, 52],
-           55: [50, 52],
-           56: [50, 52],
-           57: [51, 54],#QSFP51
-           58: [51, 54],
-           59: [51, 54],
-           60: [51, 54],
-           61: [52, 51],#QSFP52
-           62: [52, 51],
-           63: [52, 51],
-           64: [52, 51],
-           65: [53, 53],#QSFP53
-           66: [53, 53],
-           67: [53, 53],
-           68: [53, 53],
-           69: [54, 55],#QSFP54
-           70: [54, 55],
-           71: [54, 55],
-           72: [54, 55],
+            1:  [1, 2],
+            2:  [2, 3],
+            3:  [3, 4],
+            4:  [4, 5],
+            5:  [5, 6],
+            6:  [6, 7],
+            7:  [7, 8],
+            8:  [8, 9],
+            9:  [9, 10],
+           10:  [10,11],
+           11:  [11,12],
+           12:  [12,13],
+           13:  [13,14],
+           14:  [14,15],
+           15:  [15,16],
+           16:  [16,17],
+           17:  [17,18],
+           18:  [18,19],
+           19:  [19,20],
+           20:  [20,21],
+           21:  [21,22],
+           22:  [22,23],
+           23:  [23,24],
+           24:  [24,25],
+           25:  [25,26],
+           26:  [26,27],
+           27:  [27,28],
+           28:  [28,29],
+           29:  [29,30],
+           30:  [30,31],
+           31:  [31,32],
+           32:  [32,33],
+           33:  [33,34],
+           34:  [34,35],
+           35:  [35,36],
+           36:  [36,37],
+           37:  [37,38],
+           38:  [38,39],
+           39:  [39,40],
+           40:  [40,41],
+           41:  [41,42],
+           42:  [42,43],
+           43:  [43,44],
+           44:  [44,45],
+           45:  [45,46],
+           46:  [46,47],
+           47:  [47,48],
+           48:  [48,49],
+           49:  [49,50],#QSFP_start
+           50:  [51,52],
+           51:  [53,54],
+           52:  [50,51],
+           53:  [52,53],
+           54:  [54,55],
            }
 
     @property
@@ -142,7 +129,6 @@ class SfpUtil(SfpUtilBase):
             self.port_to_eeprom_mapping[x] = eeprom_path.format(
                 self._port_to_i2c_mapping[x][1]
                 )
-
         SfpUtilBase.__init__(self)
 
     #Two i2c buses might get flipped order, check them both.
@@ -170,7 +156,7 @@ class SfpUtil(SfpUtilBase):
         else:
             present_path = self.BASE_CPLD3_PATH.format(order)
         
-        present_path = present_path + "module_present_" + str(self._port_to_i2c_mapping[port_num][0])            
+        present_path = present_path + "module_present_" + str(port_num)            
         self.__port_to_is_present = present_path
 
         try:
@@ -190,8 +176,8 @@ class SfpUtil(SfpUtilBase):
 
     def qsfp_sb_remap(self, port_num):
         qsfp_start = self.qsfp_port_start
-        qsfp_index = self._port_to_i2c_mapping[port_num][0] - qsfp_start
-        qsfp_index = self.qsfp_sb_map[qsfp_index-1]
+        qsfp_index = port_num - qsfp_start
+        qsfp_index = self.qsfp_sb_map[qsfp_index]
         return qsfp_start+qsfp_index
 
     def get_low_power_mode_cpld(self, port_num):
@@ -287,7 +273,7 @@ class SfpUtil(SfpUtilBase):
         mod_rst_path = mod_rst_path + str(q)
         
         try:
-            reg_file = open(mod_rst_path, 'r+')
+            reg_file = open(mod_rst_path, 'r+', buffering=0)
         except IOError as e:
             print "Error: unable to open file: %s" % str(e)          
             return False
@@ -300,12 +286,68 @@ class SfpUtil(SfpUtilBase):
         reg_file.write('1')
         reg_file.close()
         return True
+
+    @property
+    def _get_presence_bitmap(self):
+	nodes = []
+        order = self.update_i2c_order()
         
-    def get_transceiver_change_event(self):
-        """
-        TODO: This function need to be implemented
-        when decide to support monitoring SFP(Xcvrd)
-        on this platform.
-        """
-        raise NotImplementedError
+        present_path = self.BASE_CPLD2_PATH.format(order)
+        nodes.append(present_path + "module_present_all")
+        present_path = self.BASE_CPLD3_PATH.format(order)
+        nodes.append(present_path + "module_present_all")
+
+	bitmap = ""
+	for node in nodes: 
+            try:
+                reg_file = open(node)
+    
+            except IOError as e:
+                print "Error: unable to open file: %s" % str(e)
+                return False
+            bitmap += reg_file.readline().rstrip() + " "
+            reg_file.close()
+
+        rev = bitmap.split(" ")
+        rev = "".join(rev[::-1])
+        return int(rev,16)
+   
+
+    data = {'valid':0, 'last':0, 'present':0} 
+    def get_transceiver_change_event(self, timeout=2000):
+        now = time.time()
+        port_dict = {}
+        port = 0
+
+        if timeout < 1000:
+            timeout = 1000
+        timeout = (timeout) / float(1000) # Convert to secs
+
+
+        if now < (self.data['last'] + timeout) and self.data['valid']:
+            return True, {}
+
+        reg_value = self._get_presence_bitmap
+        changed_ports = self.data['present'] ^ reg_value
+        if changed_ports:
+            for port in range (self.port_start, self.port_end+1):
+                # Mask off the bit corresponding to our port
+                fp_port = self._port_to_i2c_mapping[port][0]
+                mask = (1 << (fp_port - 1))
+                if changed_ports & mask:
+
+                    if (reg_value & mask) == 0:
+                        port_dict[port] = SFP_STATUS_REMOVED
+                    else:
+                        port_dict[port] = SFP_STATUS_INSERTED
+
+            # Update cache 
+            self.data['present'] = reg_value
+            self.data['last'] = now
+            self.data['valid'] = 1
+
+            return True, port_dict
+        else:
+            return True, {}
+        return False, {}
 

--- a/device/accton/x86_64-accton_as5812_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5812_54x-r0/plugins/sfputil.py
@@ -6,7 +6,6 @@ try:
     import time
     import os
     import pickle
-    import pprint
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:

--- a/device/accton/x86_64-accton_as6712_32x-r0/Accton-AS6712-32X/port_config.ini
+++ b/device/accton/x86_64-accton_as6712_32x-r0/Accton-AS6712-32X/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes                 alias
-Ethernet0       49,50,51,52           fortyGigE1
-Ethernet4       53,54,55,56           fortyGigE2
-Ethernet8       57,58,59,60           fortyGigE3
-Ethernet12      61,62,63,64           fortyGigE4
-Ethernet16      65,66,67,68           fortyGigE5
-Ethernet20      69,70,71,72           fortyGigE6
-Ethernet24      73,74,75,76           fortyGigE7
-Ethernet28      77,78,79,80           fortyGigE8
-Ethernet32      33,34,35,36           fortyGigE9
-Ethernet36      37,38,39,40           fortyGigE10
-Ethernet40      41,42,43,44           fortyGigE11
-Ethernet44      45,46,47,48           fortyGigE12
-Ethernet48      81,82,83,84           fortyGigE13
-Ethernet52      85,86,87,88           fortyGigE14
-Ethernet56      89,90,91,92           fortyGigE15
-Ethernet60      93,94,95,96           fortyGigE16
-Ethernet64      97,98,99,100          fortyGigE17
-Ethernet68      101,102,103,104       fortyGigE18
-Ethernet72      105,106,107,108       fortyGigE19
-Ethernet76      109,110,111,112       fortyGigE20
-Ethernet80      17,18,19,20           fortyGigE21
-Ethernet84      21,22,23,24           fortyGigE22
-Ethernet88      25,26,27,28           fortyGigE23
-Ethernet92      29,30,31,32           fortyGigE24
-Ethernet96      113,114,115,116       fortyGigE25
-Ethernet100     117,118,119,120       fortyGigE26
-Ethernet104     121,122,123,124       fortyGigE27
-Ethernet108     125,126,127,128       fortyGigE28
-Ethernet112     1,2,3,4               fortyGigE29
-Ethernet116     5,6,7,8               fortyGigE30
-Ethernet120     9,10,11,12            fortyGigE31
-Ethernet124     13,14,15,16           fortyGigE32
+# name          lanes                 alias             index  speed
+Ethernet0       49,50,51,52           fortyGigE1        1      40000
+Ethernet4       53,54,55,56           fortyGigE2        2      40000
+Ethernet8       57,58,59,60           fortyGigE3        3      40000
+Ethernet12      61,62,63,64           fortyGigE4        4      40000
+Ethernet16      65,66,67,68           fortyGigE5        5      40000
+Ethernet20      69,70,71,72           fortyGigE6        6      40000
+Ethernet24      73,74,75,76           fortyGigE7        7      40000
+Ethernet28      77,78,79,80           fortyGigE8        8      40000
+Ethernet32      33,34,35,36           fortyGigE9        9      40000
+Ethernet36      37,38,39,40           fortyGigE10       10     40000
+Ethernet40      41,42,43,44           fortyGigE11       11     40000
+Ethernet44      45,46,47,48           fortyGigE12       12     40000
+Ethernet48      81,82,83,84           fortyGigE13       13     40000
+Ethernet52      85,86,87,88           fortyGigE14       14     40000
+Ethernet56      89,90,91,92           fortyGigE15       15     40000
+Ethernet60      93,94,95,96           fortyGigE16       16     40000
+Ethernet64      97,98,99,100          fortyGigE17       17     40000
+Ethernet68      101,102,103,104       fortyGigE18       18     40000
+Ethernet72      105,106,107,108       fortyGigE19       19     40000
+Ethernet76      109,110,111,112       fortyGigE20       20     40000
+Ethernet80      17,18,19,20           fortyGigE21       21     40000
+Ethernet84      21,22,23,24           fortyGigE22       22     40000
+Ethernet88      25,26,27,28           fortyGigE23       23     40000
+Ethernet92      29,30,31,32           fortyGigE24       24     40000
+Ethernet96      113,114,115,116       fortyGigE25       25     40000
+Ethernet100     117,118,119,120       fortyGigE26       26     40000
+Ethernet104     121,122,123,124       fortyGigE27       27     40000
+Ethernet108     125,126,127,128       fortyGigE28       28     40000
+Ethernet112     1,2,3,4               fortyGigE29       29     40000
+Ethernet116     5,6,7,8               fortyGigE30       30     40000
+Ethernet120     9,10,11,12            fortyGigE31       31     40000
+Ethernet124     13,14,15,16           fortyGigE32       32     40000

--- a/device/accton/x86_64-accton_as6712_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as6712_32x-r0/plugins/sfputil.py
@@ -7,19 +7,24 @@ try:
     import time
     import os
     import string
+    import pprint
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
+#from xcvrd
+SFP_STATUS_INSERTED = '1'
+SFP_STATUS_REMOVED = '0'
+
 
 class SfpUtil(SfpUtilBase):
     """Platform-specific SfpUtil class"""
 
-    PORT_START = 0
-    PORT_END = 31
+    PORT_START = 1
+    PORT_END = 32
     PORTS_IN_BLOCK = 32
-    QSFP_PORT_START = 0
+    QSFP_PORT_START = 1
     QSFP_PORT_END = 32
 
     I2C_DEV_PATH = "/sys/bus/i2c/devices/"
@@ -32,78 +37,38 @@ class SfpUtil(SfpUtilBase):
 
     _port_to_eeprom_mapping = {}
     _port_to_i2c_mapping = {
-           0: [1, 2],
-           1: [2, 3],
-           2: [3, 4],
-           3: [4, 5],
-           4: [5, 6],
-           5: [6, 7],
-           6: [7, 8],
-           7: [8, 9],
-           8: [9, 10],            
-           9: [10, 11],
-           10: [11, 12],
-           11: [12, 13],
-           12: [13, 14],
-           13: [14, 15],
-           14: [15, 16],
-           15: [16, 17],
-           16: [17, 18],
-           17: [18, 19],
-           18: [19, 20],
-           19: [20, 21],            
-           20: [21, 22],
-           21: [22, 23],
-           22: [23, 24],
-           23: [24, 25],
-           24: [25, 26],
-           25: [26, 27],
-           26: [27, 28],
-           27: [28, 29],
-           28: [29, 30],
-           29: [30, 31],
-           30: [31, 32],
-           31: [32, 33],
-           32: [33, 34],
-           33: [34, 35],
-           34: [35, 36],
-           35: [36, 37],
-           36: [37, 38],
-           37: [38, 39],
-           38: [39, 40],
-           39: [40, 41],
-           40: [41, 42],
-           41: [42, 43],
-           42: [43, 44],
-           43: [44, 45],
-           44: [45, 46],
-           45: [46, 47],
-           46: [47, 48],
-           47: [48, 49],
-           48: [49, 50],#QSFP49
-           49: [49, 50],
-           50: [49, 50],
-           51: [49, 50],            
-           52: [50, 52],#QSFP50
-           53: [50, 52],
-           54: [50, 52],
-           55: [50, 52],
-           56: [51, 54],#QSFP51
-           57: [51, 54],
-           58: [51, 54],
-           59: [51, 54],
-           60: [52, 51],#QSFP52
-           61: [52, 51],
-           62: [52, 51],
-           63: [52, 51], 
-           64: [53, 53], #QSFP53
-           65: [53, 53],
-           66: [53, 53],
-           67: [53, 53],
-           68: [54, 55],#QSFP54          
-           69: [54, 55],          
-           70: [54, 55],          
-           71: [54, 55],          
+           1: [1, 2],
+           2: [2, 3],
+           3: [3, 4],
+           4: [4, 5],
+           5: [5, 6],
+           6: [6, 7],
+           7: [7, 8],
+           8: [8, 9],
+           9: [9, 10],
+           10: [10, 11],
+           11: [11, 12],
+           12: [12, 13],
+           13: [13, 14],
+           14: [14, 15],
+           15: [15, 16],
+           16: [16, 17],
+           17: [17, 18],
+           18: [18, 19],
+           19: [19, 20],
+           20: [20, 21],
+           21: [21, 22],
+           22: [22, 23],
+           23: [23, 24],
+           24: [24, 25],
+           25: [25, 26],
+           26: [26, 27],
+           27: [27, 28],
+           28: [28, 29],
+           29: [29, 30],
+           30: [30, 31],
+           31: [31, 32],
+           32: [32, 33],
            }
 
     @property
@@ -133,15 +98,14 @@ class SfpUtil(SfpUtilBase):
     def __init__(self):
         eeprom_path = self.BASE_OOM_PATH + "eeprom"
 
-        for x in range(0, self.port_end+1):
+        for x in range(self.port_start, self.port_end+1):
             self.port_to_eeprom_mapping[x] = eeprom_path.format(
                 self._port_to_i2c_mapping[x][1]
                 )
-
         SfpUtilBase.__init__(self)
 
     def get_cpld_dev_path(self, port_num):
-        if port_num < 16:
+        if port_num <= 16:
             cpld_num = 0
         else:
             cpld_num = 1
@@ -156,6 +120,7 @@ class SfpUtil(SfpUtilBase):
         # Check for invalid port_num
         if port_num < self.port_start or port_num > self.port_end:
             return False
+
 
         cpld_path = self.get_cpld_dev_path(port_num)
         present_path = cpld_path + "/module_present_" 
@@ -281,11 +246,68 @@ class SfpUtil(SfpUtilBase):
         
         return True
 
-    def get_transceiver_change_event(self):
-        """
-        TODO: This function need to be implemented
-        when decide to support monitoring SFP(Xcvrd)
-        on this platform.
-        """
-        raise NotImplementedError
+    @property
+    def get_transceiver_status(self):
+        nodes = []
+
+        cpld_path = self.get_cpld_dev_path(self.port_start)
+        nodes.append(cpld_path + "/module_present_all")
+        cpld_path = self.get_cpld_dev_path(self.port_end)
+        nodes.append(cpld_path + "/module_present_all")
+
+        bitmap = ""
+        for node in nodes:
+            try:
+                reg_file = open(node)
+
+            except IOError as e:
+                print "Error: unable to open file: %s" % str(e)
+                return False
+            bitmap += reg_file.readline().rstrip() + " "
+            reg_file.close()
+
+        rev = bitmap.split(" ")
+        rev = "".join(rev[::-1])
+        return int(rev,16)
+
+
+    data = {'valid':0, 'last':0, 'present':0}
+    def get_transceiver_change_event(self, timeout=2000):
+        now = time.time()
+        port_dict = {}
+        port = 0
+
+        if timeout < 1000:
+            timeout = 1000
+        timeout = (timeout) / float(1000) # Convert to secs
+
+
+        if now < (self.data['last'] + timeout) and self.data['valid']:
+            return True, {}
+
+        reg_value = self.get_transceiver_status
+        changed_ports = self.data['present'] ^ reg_value
+        if changed_ports:
+            for port in range (self.port_start, self.port_end+1):
+                # Mask off the bit corresponding to our port
+                fp_port = self._port_to_i2c_mapping[port][0]
+                mask = (1 << (fp_port - 1))
+                if changed_ports & mask:
+
+                    if (reg_value & mask) == 0:
+                        port_dict[port] = SFP_STATUS_REMOVED
+                    else:
+                        port_dict[port] = SFP_STATUS_INSERTED
+
+            # Update cache
+            self.data['present'] = reg_value
+            self.data['last'] = now
+            self.data['valid'] = 1
+
+            pprint.pprint(port_dict)
+            return True, port_dict
+        else:
+            return True, {}
+        return False, {}
+
 

--- a/device/accton/x86_64-accton_as6712_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as6712_32x-r0/plugins/sfputil.py
@@ -7,7 +7,6 @@ try:
     import time
     import os
     import string
-    import pprint
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
@@ -304,7 +303,6 @@ class SfpUtil(SfpUtilBase):
             self.data['last'] = now
             self.data['valid'] = 1
 
-            pprint.pprint(port_dict)
             return True, port_dict
         else:
             return True, {}

--- a/device/accton/x86_64-accton_as7312_54x-r0/Accton-AS7312-54X/port_config.ini
+++ b/device/accton/x86_64-accton_as7312_54x-r0/Accton-AS7312-54X/port_config.ini
@@ -1,55 +1,55 @@
-# name          lanes                 alias             index
-Ethernet0       41                    twentyfiveGigE1   0    
-Ethernet1       42                    twentyfiveGigE2   1
-Ethernet2       43                    twentyfiveGigE3   2
-Ethernet3       44                    twentyfiveGigE4   3
-Ethernet4       49                    twentyfiveGigE5   4
-Ethernet5       50                    twentyfiveGigE6   5
-Ethernet6       51                    twentyfiveGigE7   6
-Ethernet7       52                    twentyfiveGigE8   7
-Ethernet8       53                    twentyfiveGigE9   8
-Ethernet9       54                    twentyfiveGigE10  9
-Ethernet10      55                    twentyfiveGigE11  10
-Ethernet11      56                    twentyfiveGigE12  11
-Ethernet12      65                    twentyfiveGigE13  12
-Ethernet13      66                    twentyfiveGigE14  13
-Ethernet14      67                    twentyfiveGigE15  14
-Ethernet15      68                    twentyfiveGigE16  15
-Ethernet16      33                    twentyfiveGigE17  16
-Ethernet17      34                    twentyfiveGigE18  17
-Ethernet18      35                    twentyfiveGigE19  18
-Ethernet19      36                    twentyfiveGigE20  19
-Ethernet20      37                    twentyfiveGigE21  20
-Ethernet21      38                    twentyfiveGigE22  21
-Ethernet22      39                    twentyfiveGigE23  22
-Ethernet23      40                    twentyfiveGigE24  23
-Ethernet24      69                    twentyfiveGigE25  24
-Ethernet25      70                    twentyfiveGigE26  25
-Ethernet26      71                    twentyfiveGigE27  26
-Ethernet27      72                    twentyfiveGigE28  27
-Ethernet28      81                    twentyfiveGigE29  28
-Ethernet29      82                    twentyfiveGigE30  29
-Ethernet30      83                    twentyfiveGigE31  30
-Ethernet31      84                    twentyfiveGigE32  31
-Ethernet32      85                    twentyfiveGigE33  32
-Ethernet33      86                    twentyfiveGigE34  33
-Ethernet34      87                    twentyfiveGigE35  34
-Ethernet35      88                    twentyfiveGigE36  35
-Ethernet36      97                    twentyfiveGigE37  36
-Ethernet37      98                    twentyfiveGigE38  37
-Ethernet38      99                    twentyfiveGigE39  38
-Ethernet39      100                   twentyfiveGigE40  39
-Ethernet40      101                   twentyfiveGigE41  40
-Ethernet41      102                   twentyfiveGigE42  41
-Ethernet42      103                   twentyfiveGigE43  42
-Ethernet43      104                   twentyfiveGigE44  43
-Ethernet44      105                   twentyfiveGigE45  44
-Ethernet45      106                   twentyfiveGigE46  45
-Ethernet46      107                   twentyfiveGigE47  46
-Ethernet47      108                   twentyfiveGigE48  47
-Ethernet48      5,6,7,8               hundredGigE49     48
-Ethernet52      1,2,3,4               hundredGigE50     52
-Ethernet56      109,110,111,112       hundredGigE51     56
-Ethernet60      21,22,23,24           hundredGigE52     60 
-Ethernet64      9,10,11,12            hundredGigE53     64
-Ethernet68      117,118,119,120       hundredGigE54     68 
+# name          lanes                 alias             index  speed
+Ethernet0       41                    twentyfiveGigE1   1       25000
+Ethernet1       42                    twentyfiveGigE2   2       25000
+Ethernet2       43                    twentyfiveGigE3   3       25000
+Ethernet3       44                    twentyfiveGigE4   4       25000
+Ethernet4       49                    twentyfiveGigE5   5       25000
+Ethernet5       50                    twentyfiveGigE6   6       25000
+Ethernet6       51                    twentyfiveGigE7   7       25000
+Ethernet7       52                    twentyfiveGigE8   8       25000
+Ethernet8       53                    twentyfiveGigE9   9       25000
+Ethernet9       54                    twentyfiveGigE10  10      25000
+Ethernet10      55                    twentyfiveGigE11  11      25000
+Ethernet11      56                    twentyfiveGigE12  12      25000
+Ethernet12      65                    twentyfiveGigE13  13      25000
+Ethernet13      66                    twentyfiveGigE14  14      25000
+Ethernet14      67                    twentyfiveGigE15  15      25000
+Ethernet15      68                    twentyfiveGigE16  16      25000
+Ethernet16      33                    twentyfiveGigE17  17      25000
+Ethernet17      34                    twentyfiveGigE18  18      25000
+Ethernet18      35                    twentyfiveGigE19  19      25000
+Ethernet19      36                    twentyfiveGigE20  20      25000
+Ethernet20      37                    twentyfiveGigE21  21      25000
+Ethernet21      38                    twentyfiveGigE22  22      25000
+Ethernet22      39                    twentyfiveGigE23  23      25000
+Ethernet23      40                    twentyfiveGigE24  24      25000
+Ethernet24      69                    twentyfiveGigE25  25      25000
+Ethernet25      70                    twentyfiveGigE26  26      25000
+Ethernet26      71                    twentyfiveGigE27  27      25000
+Ethernet27      72                    twentyfiveGigE28  28      25000
+Ethernet28      81                    twentyfiveGigE29  29      25000
+Ethernet29      82                    twentyfiveGigE30  30      25000
+Ethernet30      83                    twentyfiveGigE31  31      25000
+Ethernet31      84                    twentyfiveGigE32  32      25000
+Ethernet32      85                    twentyfiveGigE33  33      25000
+Ethernet33      86                    twentyfiveGigE34  34      25000
+Ethernet34      87                    twentyfiveGigE35  35      25000
+Ethernet35      88                    twentyfiveGigE36  36      25000
+Ethernet36      97                    twentyfiveGigE37  37      25000
+Ethernet37      98                    twentyfiveGigE38  38      25000
+Ethernet38      99                    twentyfiveGigE39  39      25000
+Ethernet39      100                   twentyfiveGigE40  40      25000
+Ethernet40      101                   twentyfiveGigE41  41      25000
+Ethernet41      102                   twentyfiveGigE42  42      25000
+Ethernet42      103                   twentyfiveGigE43  43      25000
+Ethernet43      104                   twentyfiveGigE44  44      25000
+Ethernet44      105                   twentyfiveGigE45  45      25000
+Ethernet45      106                   twentyfiveGigE46  46      25000
+Ethernet46      107                   twentyfiveGigE47  47      25000
+Ethernet47      108                   twentyfiveGigE48  48      25000
+Ethernet48      5,6,7,8               hundredGigE49     49     100000
+Ethernet52      1,2,3,4               hundredGigE50     50     100000
+Ethernet56      109,110,111,112       hundredGigE51     51     100000
+Ethernet60      21,22,23,24           hundredGigE52     52     100000
+Ethernet64      9,10,11,12            hundredGigE53     53     100000
+Ethernet68      117,118,119,120       hundredGigE54     54     100000

--- a/device/accton/x86_64-accton_as7312_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/plugins/sfputil.py
@@ -15,11 +15,11 @@ except ImportError as e:
 class SfpUtil(SfpUtilBase):
     """Platform-specific SfpUtil class"""
 
-    PORT_START = 0
-    PORT_END = 71
-    PORTS_IN_BLOCK = 72
-    QSFP_PORT_START = 48
-    QSFP_PORT_END = 72
+    PORT_START = 1
+    PORT_END = 54
+    PORTS_IN_BLOCK = 54
+    QSFP_PORT_START = 49
+    QSFP_PORT_END = 54
 
     BASE_VAL_PATH = "/sys/class/i2c-adapter/i2c-{0}/{1}-0050/"
 
@@ -33,78 +33,60 @@ class SfpUtil(SfpUtilBase):
        2:  "6-0064",
            }
     _port_to_i2c_mapping = {
-           0:  18, 
-           1:  19, 
-           2:  20, 
-           3:  21, 
-           4:  22, 
-           5:  23, 
-           6:  24, 
-           7:  25, 
-           8:  26,
-           9:  27,
-           10: 28,
-           11: 29,
-           12: 30,
-           13: 31,
-           14: 32,
-           15: 33,
-           16: 34,
-           17: 35,
-           18: 36,
-           19: 37,
-           20: 38,
-           21: 39,
-           22: 40,
-           23: 41,
-           24: 42,
-           25: 43,
-           26: 44,
-           27: 45,
-           28: 46,
-           29: 47,
-           30: 48,
-           31: 49,
-           32: 50,
-           33: 51,
-           34: 52,
-           35: 53,
-           36: 54,
-           37: 55,
-           38: 56,
-           39: 57,
-           40: 58,
-           41: 59,
-           42: 60,
-           43: 61,
-           44: 62,
-           45: 63,
-           46: 64,
-           47: 65,
-           48: 66, #QSFP49
-           49: 66,
-           50: 66,
-           51: 66,
-           52: 67, #QSFP50
-           53: 67,
-           54: 67,
-           55: 67,
-           56: 68, #QSFP51
-           57: 68,
-           58: 68,
-           59: 68,
-           60: 69, #QSFP52
-           61: 69,
-           62: 69,
-           63: 69,
-           64: 70, #QSFP53
-           65: 70,
-           66: 70,
-           67: 70,
-           68: 71, #QSFP54
-           69: 71,
-           70: 71,
-           71: 71,
+           1:  18, 
+           2:  19, 
+           3:  20, 
+           4:  21, 
+           5:  22, 
+           6:  23, 
+           7:  24, 
+           8:  25, 
+           9:  26,
+           10: 27,
+           11: 28,
+           12: 29,
+           13: 30,
+           14: 31,
+           15: 32,
+           16: 33,
+           17: 34,
+           18: 35,
+           19: 36,
+           20: 37,
+           21: 38,
+           22: 39,
+           23: 40,
+           24: 41,
+           25: 42,
+           26: 43,
+           27: 44,
+           28: 45,
+           29: 46,
+           30: 47,
+           31: 48,
+           32: 49,
+           33: 50,
+           34: 51,
+           35: 52,
+           36: 53,
+           37: 54,
+           38: 55,
+           39: 56,
+           40: 57,
+           41: 58,
+           42: 59,
+           43: 60,
+           44: 61,
+           45: 62,
+           46: 63,
+           47: 64,
+           48: 65,
+           49: 66, #QSFP49
+           50: 67,
+           51: 68,
+           52: 69,
+           53: 70,
+           54: 71, #QSFP54
            }
 
     @property
@@ -133,30 +115,18 @@ class SfpUtil(SfpUtilBase):
 
     def __init__(self):
         eeprom_path = '/sys/bus/i2c/devices/{0}-0050/eeprom'
-        for x in range(0, self.port_end+1):
+        for x in range(self.port_start, self.port_end+1):
             self.port_to_eeprom_mapping[x] = eeprom_path.format(
                 self._port_to_i2c_mapping[x])
 
         SfpUtilBase.__init__(self)
 
-
-    # For port 48~51 are QSFP, here presumed they're all split to 4 lanes.
-    def get_cage_num(self, port_num):             
-        cage_num = port_num
-        if (port_num >= self.QSFP_PORT_START):
-            cage_num = (port_num - self.QSFP_PORT_START)/4
-            cage_num = cage_num + self.QSFP_PORT_START
-
-        return cage_num
-
-    # For cage 0~23 and 48~51 are at cpld2, others are at cpld3.
     def get_cpld_num(self, port_num):             
         cpld_i = 1
-        cage_num = self.get_cage_num(port_num)
-        if (port_num > 23 and port_num < self.QSFP_PORT_START):
+        if (port_num > 24 and port_num < self.qsfp_port_start):
             cpld_i = 2
 
-        if (cage_num >= 52): 
+        if (port_num > 52): 
             cpld_i = 2
 
         return cpld_i
@@ -166,12 +136,11 @@ class SfpUtil(SfpUtilBase):
         if port_num < self.port_start or port_num > self.port_end:
             return False
         
-        cage_num = self.get_cage_num(port_num)
         cpld_i = self.get_cpld_num(port_num)
 
         cpld_ps = self._cpld_mapping[cpld_i]
         path = "/sys/bus/i2c/devices/{0}/module_present_{1}"
-        port_ps = path.format(cpld_ps, cage_num+1)
+        port_ps = path.format(cpld_ps, port_num)
 
         try:
             val_file = open(port_ps)
@@ -250,11 +219,10 @@ class SfpUtil(SfpUtilBase):
         if port_num < self.qsfp_port_start or port_num > self.qsfp_port_end:
             return False
          
-        cage_num = self.get_cage_num(port_num)
         cpld_i = self.get_cpld_num(port_num)
         cpld_ps = self._cpld_mapping[cpld_i]
         path = "/sys/bus/i2c/devices/{0}/module_reset_{1}"
-        port_ps = path.format(cpld_ps, cage_num+1)
+        port_ps = path.format(cpld_ps, port_num)
         try:
             reg_file = open(port_ps, 'w')
         except IOError as e:

--- a/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/port_config.ini
+++ b/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/port_config.ini
@@ -1,57 +1,57 @@
-# name          lanes                 alias             index
-Ethernet0       3                     twentyfiveGigE1   0
-Ethernet1       2                     twentyfiveGigE2   1
-Ethernet2       4                     twentyfiveGigE3   2
-Ethernet3       8                     twentyfiveGigE4   3
-Ethernet4       7                     twentyfiveGigE5   4
-Ethernet5       1                     twentyfiveGigE6   5
-Ethernet6       5                     twentyfiveGigE7   6
-Ethernet7       16                    twentyfiveGigE8   7
-Ethernet8       6                     twentyfiveGigE9   8
-Ethernet9       14                    twentyfiveGigE10  9
-Ethernet10      13                    twentyfiveGigE11  10
-Ethernet11      15                    twentyfiveGigE12  11
-Ethernet12      23                    twentyfiveGigE13  12
-Ethernet13      22                    twentyfiveGigE14  13
-Ethernet14      24                    twentyfiveGigE15  14
-Ethernet15      32                    twentyfiveGigE16  15
-Ethernet16      31                    twentyfiveGigE17  16
-Ethernet17      21                    twentyfiveGigE18  17
-Ethernet18      29                    twentyfiveGigE19  18
-Ethernet19      36                    twentyfiveGigE20  19
-Ethernet20      30                    twentyfiveGigE21  20
-Ethernet21      34                    twentyfiveGigE22  21
-Ethernet22      33                    twentyfiveGigE23  22
-Ethernet23      35                    twentyfiveGigE24  23
-Ethernet24      43                    twentyfiveGigE25  24
-Ethernet25      42                    twentyfiveGigE26  25
-Ethernet26      44                    twentyfiveGigE27  26
-Ethernet27      52                    twentyfiveGigE28  27
-Ethernet28      51                    twentyfiveGigE29  28
-Ethernet29      41                    twentyfiveGigE30  29
-Ethernet30      49                    twentyfiveGigE31  30
-Ethernet31      60                    twentyfiveGigE32  31
-Ethernet32      50                    twentyfiveGigE33  32
-Ethernet33      58                    twentyfiveGigE34  33
-Ethernet34      57                    twentyfiveGigE35  34
-Ethernet35      59                    twentyfiveGigE36  35
-Ethernet36      62                    twentyfiveGigE37  36
-Ethernet37      63                    twentyfiveGigE38  37
-Ethernet38      64                    twentyfiveGigE39  38
-Ethernet39      65                    twentyfiveGigE40  39
-Ethernet40      66                    twentyfiveGigE41  40
-Ethernet41      61                    twentyfiveGigE42  41
-Ethernet42      68                    twentyfiveGigE43  42
-Ethernet43      69                    twentyfiveGigE44  43
-Ethernet44      67                    twentyfiveGigE45  44
-Ethernet45      71                    twentyfiveGigE46  45
-Ethernet46      72                    twentyfiveGigE47  46
-Ethernet47      70                    twentyfiveGigE48  47
-Ethernet48      77,78,79,80           hundredGigE49     48
-Ethernet52      85,86,87,88           hundredGigE50     52
-Ethernet56      93,94,95,96           hundredGigE51     56
-Ethernet60      97,98,99,100          hundredGigE52     60
-Ethernet64      105,106,107,108       hundredGigE53     64
-Ethernet68      113,114,115,116       hundredGigE54     68
-Ethernet72      121,122,123,124       hundredGigE55     72
-Ethernet76      125,126,127,128       hundredGigE56     76
+# name          lanes                 alias             index    speed
+Ethernet0       3                     twentyfiveGigE1   1        25000
+Ethernet1       2                     twentyfiveGigE2   2        25000
+Ethernet2       4                     twentyfiveGigE3   3        25000
+Ethernet3       8                     twentyfiveGigE4   4        25000
+Ethernet4       7                     twentyfiveGigE5   5        25000
+Ethernet5       1                     twentyfiveGigE6   6        25000
+Ethernet6       5                     twentyfiveGigE7   7        25000
+Ethernet7       16                    twentyfiveGigE8   8        25000
+Ethernet8       6                     twentyfiveGigE9   9        25000
+Ethernet9       14                    twentyfiveGigE10  10       25000
+Ethernet10      13                    twentyfiveGigE11  11       25000
+Ethernet11      15                    twentyfiveGigE12  12       25000
+Ethernet12      23                    twentyfiveGigE13  13       25000
+Ethernet13      22                    twentyfiveGigE14  14       25000
+Ethernet14      24                    twentyfiveGigE15  15       25000
+Ethernet15      32                    twentyfiveGigE16  16       25000
+Ethernet16      31                    twentyfiveGigE17  17       25000
+Ethernet17      21                    twentyfiveGigE18  18       25000
+Ethernet18      29                    twentyfiveGigE19  19       25000
+Ethernet19      36                    twentyfiveGigE20  20       25000
+Ethernet20      30                    twentyfiveGigE21  21       25000
+Ethernet21      34                    twentyfiveGigE22  22       25000
+Ethernet22      33                    twentyfiveGigE23  23       25000
+Ethernet23      35                    twentyfiveGigE24  24       25000
+Ethernet24      43                    twentyfiveGigE25  25       25000
+Ethernet25      42                    twentyfiveGigE26  26       25000
+Ethernet26      44                    twentyfiveGigE27  27       25000
+Ethernet27      52                    twentyfiveGigE28  28       25000
+Ethernet28      51                    twentyfiveGigE29  29       25000
+Ethernet29      41                    twentyfiveGigE30  30       25000
+Ethernet30      49                    twentyfiveGigE31  31       25000
+Ethernet31      60                    twentyfiveGigE32  32       25000
+Ethernet32      50                    twentyfiveGigE33  33       25000
+Ethernet33      58                    twentyfiveGigE34  34       25000
+Ethernet34      57                    twentyfiveGigE35  35       25000
+Ethernet35      59                    twentyfiveGigE36  36       25000
+Ethernet36      62                    twentyfiveGigE37  37       25000
+Ethernet37      63                    twentyfiveGigE38  38       25000
+Ethernet38      64                    twentyfiveGigE39  39       25000
+Ethernet39      65                    twentyfiveGigE40  40       25000
+Ethernet40      66                    twentyfiveGigE41  41       25000
+Ethernet41      61                    twentyfiveGigE42  42       25000
+Ethernet42      68                    twentyfiveGigE43  43       25000
+Ethernet43      69                    twentyfiveGigE44  44       25000
+Ethernet44      67                    twentyfiveGigE45  45       25000
+Ethernet45      71                    twentyfiveGigE46  46       25000
+Ethernet46      72                    twentyfiveGigE47  47       25000
+Ethernet47      70                    twentyfiveGigE48  48       25000
+Ethernet48      77,78,79,80           hundredGigE49     49       100000
+Ethernet52      85,86,87,88           hundredGigE50     50       100000
+Ethernet56      93,94,95,96           hundredGigE51     51       100000
+Ethernet60      97,98,99,100          hundredGigE52     52       100000
+Ethernet64      105,106,107,108       hundredGigE53     53       100000
+Ethernet68      113,114,115,116       hundredGigE54     54       100000
+Ethernet72      121,122,123,124       hundredGigE55     55       100000
+Ethernet76      125,126,127,128       hundredGigE56     56       100000

--- a/device/accton/x86_64-accton_as7712_32x-r0/Accton-AS7712-32X/port_config.ini
+++ b/device/accton/x86_64-accton_as7712_32x-r0/Accton-AS7712-32X/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes                 alias
-Ethernet0       49,50,51,52           hundredGigE1
-Ethernet4       53,54,55,56           hundredGigE2
-Ethernet8       57,58,59,60           hundredGigE3
-Ethernet12      61,62,63,64           hundredGigE4
-Ethernet16      65,66,67,68           hundredGigE5
-Ethernet20      69,70,71,72           hundredGigE6
-Ethernet24      73,74,75,76           hundredGigE7
-Ethernet28      77,78,79,80           hundredGigE8
-Ethernet32      33,34,35,36           hundredGigE9
-Ethernet36      37,38,39,40           hundredGigE10
-Ethernet40      41,42,43,44           hundredGigE11
-Ethernet44      45,46,47,48           hundredGigE12
-Ethernet48      81,82,83,84           hundredGigE13
-Ethernet52      85,86,87,88           hundredGigE14
-Ethernet56      89,90,91,92           hundredGigE15
-Ethernet60      93,94,95,96           hundredGigE16
-Ethernet64      97,98,99,100          hundredGigE17
-Ethernet68      101,102,103,104       hundredGigE18
-Ethernet72      105,106,107,108       hundredGigE19
-Ethernet76      109,110,111,112       hundredGigE20
-Ethernet80      17,18,19,20           hundredGigE21
-Ethernet84      21,22,23,24           hundredGigE22
-Ethernet88      25,26,27,28           hundredGigE23
-Ethernet92      29,30,31,32           hundredGigE24
-Ethernet96      113,114,115,116       hundredGigE25
-Ethernet100     117,118,119,120       hundredGigE26
-Ethernet104     121,122,123,124       hundredGigE27
-Ethernet108     125,126,127,128       hundredGigE28
-Ethernet112     1,2,3,4               hundredGigE29
-Ethernet116     5,6,7,8               hundredGigE30
-Ethernet120     9,10,11,12            hundredGigE31
-Ethernet124     13,14,15,16           hundredGigE32
+# name          lanes                 alias             index  speed
+Ethernet0       49,50,51,52           hundredGigE1      1      100000
+Ethernet4       53,54,55,56           hundredGigE2      2      100000
+Ethernet8       57,58,59,60           hundredGigE3      3      100000
+Ethernet12      61,62,63,64           hundredGigE4      4      100000
+Ethernet16      65,66,67,68           hundredGigE5      5      100000
+Ethernet20      69,70,71,72           hundredGigE6      6      100000
+Ethernet24      73,74,75,76           hundredGigE7      7      100000
+Ethernet28      77,78,79,80           hundredGigE8      8      100000
+Ethernet32      33,34,35,36           hundredGigE9      9      100000
+Ethernet36      37,38,39,40           hundredGigE10     10     100000
+Ethernet40      41,42,43,44           hundredGigE11     11     100000
+Ethernet44      45,46,47,48           hundredGigE12     12     100000
+Ethernet48      81,82,83,84           hundredGigE13     13     100000
+Ethernet52      85,86,87,88           hundredGigE14     14     100000
+Ethernet56      89,90,91,92           hundredGigE15     15     100000
+Ethernet60      93,94,95,96           hundredGigE16     16     100000
+Ethernet64      97,98,99,100          hundredGigE17     17     100000
+Ethernet68      101,102,103,104       hundredGigE18     18     100000
+Ethernet72      105,106,107,108       hundredGigE19     19     100000
+Ethernet76      109,110,111,112       hundredGigE20     20     100000
+Ethernet80      17,18,19,20           hundredGigE21     21     100000
+Ethernet84      21,22,23,24           hundredGigE22     22     100000
+Ethernet88      25,26,27,28           hundredGigE23     23     100000
+Ethernet92      29,30,31,32           hundredGigE24     24     100000
+Ethernet96      113,114,115,116       hundredGigE25     25     100000
+Ethernet100     117,118,119,120       hundredGigE26     26     100000
+Ethernet104     121,122,123,124       hundredGigE27     27     100000
+Ethernet108     125,126,127,128       hundredGigE28     28     100000
+Ethernet112     1,2,3,4               hundredGigE29     29     100000
+Ethernet116     5,6,7,8               hundredGigE30     30     100000
+Ethernet120     9,10,11,12            hundredGigE31     31     100000
+Ethernet124     13,14,15,16           hundredGigE32     32     100000

--- a/device/accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
@@ -3,7 +3,6 @@
 try:
     import time
     import string
-    import pprint
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase 
 except ImportError, e:
@@ -64,7 +63,6 @@ class SfpUtil(SfpUtilBase):
         for x in range(self.port_start, self.port_end + 1):
             port_eeprom_path = eeprom_path.format(self.port_to_i2c_mapping[x])
             self._port_to_eeprom_mapping[x] = port_eeprom_path
-        self.get_transceiver_change_event()
         SfpUtilBase.__init__(self)
 
     def reset(self, port_num):
@@ -235,7 +233,6 @@ class SfpUtil(SfpUtilBase):
             self.data['present'] = reg_value
             self.data['last'] = now
             self.data['valid'] = 1
-            pprint.pprint(port_dict)
             return True, port_dict
         else:
             return True, {}

--- a/device/accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
@@ -3,17 +3,22 @@
 try:
     import time
     import string
+    import pprint
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase 
 except ImportError, e:
     raise ImportError (str(e) + "- required module not found")
 
+#from xcvrd
+SFP_STATUS_INSERTED = '1'
+SFP_STATUS_REMOVED = '0'
+
 
 class SfpUtil(SfpUtilBase):
     """Platform specific SfpUtill class"""
 
-    _port_start = 0
-    _port_end = 31
+    _port_start = 1
+    _port_end = 32
     ports_in_block = 32
 
     _port_to_eeprom_mapping = {}
@@ -56,9 +61,10 @@ class SfpUtil(SfpUtilBase):
 
     def __init__(self):
         eeprom_path = '/sys/bus/i2c/devices/{0}-0050/eeprom'
-        for x in range(0, self._port_end + 1):
-            port_eeprom_path = eeprom_path.format(self.port_to_i2c_mapping[x+1])
+        for x in range(self.port_start, self.port_end + 1):
+            port_eeprom_path = eeprom_path.format(self.port_to_i2c_mapping[x])
             self._port_to_eeprom_mapping[x] = port_eeprom_path
+        self.get_transceiver_change_event()
         SfpUtilBase.__init__(self)
 
     def reset(self, port_num):
@@ -67,10 +73,10 @@ class SfpUtil(SfpUtilBase):
             return False
 
         path = "/sys/bus/i2c/devices/4-0060/module_reset_{0}"
-        port_ps = path.format(port_num+1)
+        port_ps = path.format(port_num)
         
         try:
-            reg_file = open(port_ps, 'w')
+            reg_file = open(port_ps, 'w', buffering=0)
         except IOError as e:
             print "Error: unable to open file: %s" % str(e)
             return False
@@ -90,9 +96,8 @@ class SfpUtil(SfpUtilBase):
             return False
 
         path = "/sys/bus/i2c/devices/4-0060/module_present_{0}"
-        port_ps = path.format(port_num+1)
+        port_ps = path.format(port_num)
 
-          
         try:
             reg_file = open(port_ps)
         except IOError as e:
@@ -115,19 +120,11 @@ class SfpUtil(SfpUtilBase):
 	
     @property
     def qsfp_ports(self):
-        return range(0, self.ports_in_block + 1)
+        return range(self.port_start, self.ports_in_block + 1)
 
     @property 
     def port_to_eeprom_mapping(self):
          return self._port_to_eeprom_mapping
-
-    def get_transceiver_change_event(self):
-        """
-        TODO: This function need to be implemented
-        when decide to support monitoring SFP(Xcvrd)
-        on this platform.
-        """
-        raise NotImplementedError
 
     def get_low_power_mode(self, port_num):
         # Check for invalid port_num
@@ -186,3 +183,61 @@ class SfpUtil(SfpUtilBase):
             if eeprom is not None:
                 eeprom.close()
                 time.sleep(0.01)
+
+    @property
+    def _get_all_presence(self):
+        nodes = []
+
+        cpld_path = "/sys/bus/i2c/devices/4-0060/"
+        nodes.append(cpld_path + "module_present_all")
+
+        bitmap = ""
+        for node in nodes:
+            try:
+                reg_file = open(node)
+
+            except IOError as e:
+                print "Error: unable to open file: %s" % str(e)
+                return False
+            bitmap += reg_file.readline().rstrip() + " "
+            reg_file.close()
+
+        rev = bitmap.split(" ")
+        rev = "".join(rev[::-1])
+        return int(rev,16)
+
+    data = {'valid':0, 'last':0, 'present':0}
+    def get_transceiver_change_event(self, timeout=2000):
+        now = time.time()
+        port_dict = {}
+        port = 0
+
+        if timeout < 1000:
+            timeout = 1000
+        timeout = (timeout) / float(1000) # Convert to secs
+
+        if now < (self.data['last'] + timeout) and self.data['valid']:
+            return True, {}
+
+        reg_value = self._get_all_presence
+        changed_ports = self.data['present'] ^ reg_value
+        if changed_ports:
+            for port in range (self.port_start, self.port_end+1):
+                # Mask off the bit corresponding to our port
+                mask = (1 << (port - 1))
+                if changed_ports & mask:
+                    if (reg_value & mask) == 0:
+                        port_dict[port] = SFP_STATUS_INSERTED
+                    else:
+                        port_dict[port] = SFP_STATUS_REMOVED
+
+            # Update cache
+            self.data['present'] = reg_value
+            self.data['last'] = now
+            self.data['valid'] = 1
+            pprint.pprint(port_dict)
+            return True, port_dict
+        else:
+            return True, {}
+        return False, {}
+ 

--- a/device/accton/x86_64-accton_as7716_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7716_32x-r0/plugins/sfputil.py
@@ -7,7 +7,6 @@ try:
     import time
     import string
     from ctypes import create_string_buffer
-    import pprint
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))

--- a/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/port_config.ini
+++ b/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes                 alias
-Ethernet0       1,2,3,4               hundredGigE1
-Ethernet4       5,6,7,8               hundredGigE2
-Ethernet8       9,10,11,12            hundredGigE3
-Ethernet12      13,14,15,16           hundredGigE4
-Ethernet16      17,18,19,20           hundredGigE5
-Ethernet20      21,22,23,24           hundredGigE6
-Ethernet24      25,26,27,28           hundredGigE7
-Ethernet28      29,30,31,32           hundredGigE8
-Ethernet32      33,34,35,36           hundredGigE9
-Ethernet36      37,38,39,40           hundredGigE10
-Ethernet40      41,42,43,44           hundredGigE11
-Ethernet44      45,46,47,48           hundredGigE12
-Ethernet48      49,50,51,52           hundredGigE13
-Ethernet52      53,54,55,56           hundredGigE14
-Ethernet56      57,58,59,60           hundredGigE15
-Ethernet60      61,62,63,64           hundredGigE16
-Ethernet64      65,66,67,68           hundredGigE17
-Ethernet68      69,70,71,72           hundredGigE18
-Ethernet72      73,74,75,76           hundredGigE19
-Ethernet76      77,78,79,80           hundredGigE20
-Ethernet80      81,82,83,84           hundredGigE21
-Ethernet84      85,86,87,88           hundredGigE22
-Ethernet88      89,90,91,92           hundredGigE23
-Ethernet92      93,94,95,96           hundredGigE24
-Ethernet96      97,98,99,100          hundredGigE25
-Ethernet100     101,102,103,104       hundredGigE26
-Ethernet104     105,106,107,108       hundredGigE27
-Ethernet108     109,110,111,112       hundredGigE28
-Ethernet112     113,114,115,116       hundredGigE29
-Ethernet116     117,118,119,120       hundredGigE30
-Ethernet120     121,122,123,124       hundredGigE31
-Ethernet124     125,126,127,128       hundredGigE32
+# name          lanes                 alias             index  speed
+Ethernet0       1,2,3,4               hundredGigE1      1      100000
+Ethernet4       5,6,7,8               hundredGigE2      2      100000
+Ethernet8       9,10,11,12            hundredGigE3      3      100000
+Ethernet12      13,14,15,16           hundredGigE4      4      100000
+Ethernet16      17,18,19,20           hundredGigE5      5      100000
+Ethernet20      21,22,23,24           hundredGigE6      6      100000
+Ethernet24      25,26,27,28           hundredGigE7      7      100000
+Ethernet28      29,30,31,32           hundredGigE8      8      100000
+Ethernet32      33,34,35,36           hundredGigE9      9      100000
+Ethernet36      37,38,39,40           hundredGigE10     10     100000
+Ethernet40      41,42,43,44           hundredGigE11     11     100000
+Ethernet44      45,46,47,48           hundredGigE12     12     100000
+Ethernet48      49,50,51,52           hundredGigE13     13     100000
+Ethernet52      53,54,55,56           hundredGigE14     14     100000
+Ethernet56      57,58,59,60           hundredGigE15     15     100000
+Ethernet60      61,62,63,64           hundredGigE16     16     100000
+Ethernet64      65,66,67,68           hundredGigE17     17     100000
+Ethernet68      69,70,71,72           hundredGigE18     18     100000
+Ethernet72      73,74,75,76           hundredGigE19     19     100000
+Ethernet76      77,78,79,80           hundredGigE20     20     100000
+Ethernet80      81,82,83,84           hundredGigE21     21     100000
+Ethernet84      85,86,87,88           hundredGigE22     22     100000
+Ethernet88      89,90,91,92           hundredGigE23     23     100000
+Ethernet92      93,94,95,96           hundredGigE24     24     100000
+Ethernet96      97,98,99,100          hundredGigE25     25     100000
+Ethernet100     101,102,103,104       hundredGigE26     26     100000
+Ethernet104     105,106,107,108       hundredGigE27     27     100000
+Ethernet108     109,110,111,112       hundredGigE28     28     100000
+Ethernet112     113,114,115,116       hundredGigE29     29     100000
+Ethernet116     117,118,119,120       hundredGigE30     30     100000
+Ethernet120     121,122,123,124       hundredGigE31     31     100000
+Ethernet124     125,126,127,128       hundredGigE32     32     100000

--- a/device/accton/x86_64-accton_as7726_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/plugins/sfputil.py
@@ -6,7 +6,6 @@
 try:
     import time
     import string
-    import pprint
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:

--- a/device/accton/x86_64-accton_as7726_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/plugins/sfputil.py
@@ -6,18 +6,23 @@
 try:
     import time
     import string
+    import pprint
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
+#from xcvrd
+SFP_STATUS_INSERTED = '1'
+SFP_STATUS_REMOVED = '0'
+
 
 class SfpUtil(SfpUtilBase):
     """Platform-specific SfpUtil class"""
     
-    PORT_START = 0
-    PORT_END = 33
-    PORTS_IN_BLOCK = 34
+    PORT_START = 1
+    PORT_END = 32  #34 cages actually, but last 2 are not at port_config.ini.
+    PORTS_IN_BLOCK = 32
     
     BASE_OOM_PATH = "/sys/bus/i2c/devices/{0}-0050/"
     BASE_CPLD_PATH = "/sys/bus/i2c/devices/11-0060/"
@@ -27,40 +32,40 @@ class SfpUtil(SfpUtilBase):
 
     _port_to_eeprom_mapping = {}
     _port_to_i2c_mapping = {
-           0: [1, 21],
-           1: [2, 22],
-           2: [3, 23],
-           3: [4, 24],
-           4: [5, 26],
-           5: [6, 25],
-           6: [7, 28],
-           7: [8, 27],
-           8: [9, 17],
-           9: [10, 18],
-           10: [11, 19],
-           11: [12, 20],
-           12: [13, 29],
-           13: [14, 30],
-           14: [15, 31],
-           15: [16, 32],
-           16: [17, 33],
-           17: [18, 34],
-           18: [19, 35],
-           19: [20, 36],
-           20: [21, 45],
-           21: [22, 46],
-           22: [23, 47],
-           23: [24, 48],
-           24: [25, 37],
-           25: [26, 38],
-           26: [27, 39],
-           27: [28, 40],
-           28: [29, 41],
-           29: [30, 42],
-           30: [31, 43],
-           31: [32, 44],              
-           32: [33, 15], 
-           33: [34, 16], 
+           1:  21,
+           2:  22,
+           3:  23,
+           4:  24,
+           5:  26,
+           6:  25,
+           7:  28,
+           8:  27,
+           9:  17,
+           10: 18,
+           11: 19,
+           12: 20,
+           13: 29,
+           14: 30,
+           15: 31,
+           16: 32,
+           17: 33,
+           18: 34,
+           19: 35,
+           20: 36,
+           21: 45,
+           22: 46,
+           23: 47,
+           24: 48,
+           25: 37,
+           26: 38,
+           27: 39,
+           28: 40,
+           29: 41,
+           30: 42,
+           31: 43,
+           32: 44,              
+           33: 15, 
+           34: 16, 
            }
 
     @property
@@ -82,19 +87,18 @@ class SfpUtil(SfpUtilBase):
     def __init__(self):
         eeprom_path = self.BASE_OOM_PATH + "eeprom"
         
-        for x in range(0, self.port_end+1):
+        for x in range(self.port_start, self.port_end+1):
             self.port_to_eeprom_mapping[x] = eeprom_path.format(
-                self._port_to_i2c_mapping[x][1]
+                self._port_to_i2c_mapping[x]
                 )
-
         SfpUtilBase.__init__(self)
 
     def get_presence(self, port_num):
         # Check for invalid port_num
-        if port_num < self.port_start or port_num > self.port_end:
+        if not port_num in range(self.port_start, self.port_end+1):
             return False
-       
-        present_path = self.BASE_CPLD_PATH + "module_present_" + str(port_num+1)
+
+        present_path = self.BASE_CPLD_PATH + "module_present_" + str(port_num)
         self.__port_to_is_present = present_path
 
         try:
@@ -174,26 +178,81 @@ class SfpUtil(SfpUtilBase):
         if port_num < self.port_start or port_num > self.port_end:
             return False
             
-        mod_rst_path = self.BASE_CPLD_PATH + "module_reset_" + str(port_num+1)
+        mod_rst_path = self.BASE_CPLD_PATH + "module_reset_" + str(port_num)
         
         self.__port_to_mod_rst = mod_rst_path
         try:
-            reg_file = open(self.__port_to_mod_rst, 'r+')
+            reg_file = open(self.__port_to_mod_rst, 'r+', buffering=0)
         except IOError as e:
             print "Error: unable to open file: %s" % str(e)          
             return False
 
-        reg_value = '1'
-
-        reg_file.write(reg_value)
+        #toggle reset
+        reg_file.seek(0)
+        reg_file.write('1')
+        time.sleep(1)
+        reg_file.seek(0)
+        reg_file.write('0')
         reg_file.close()
         
         return True
 
-    def get_transceiver_change_event(self):
-        """
-        TODO: This function need to be implemented
-        when decide to support monitoring SFP(Xcvrd)
-        on this platform.
-        """
-        raise NotImplementedError
+    @property
+    def get_transceiver_status(self):
+        nodes = []
+
+        cpld_path = self.BASE_CPLD_PATH
+        nodes.append(cpld_path + "module_present_all")
+
+        bitmap = ""
+        for node in nodes:
+            try:
+                reg_file = open(node)
+
+            except IOError as e:
+                print "Error: unable to open file: %s" % str(e)
+                return False
+            bitmap += reg_file.readline().rstrip() + " "
+            reg_file.close()
+
+        rev = bitmap.split(" ")
+        rev = "".join(rev[::-1])
+        return int(rev,16)
+
+    data = {'valid':0, 'last':0, 'present':0}
+    def get_transceiver_change_event(self, timeout=2000):
+        now = time.time()
+        port_dict = {}
+        port = 0
+
+        if timeout < 1000:
+            timeout = 1000
+        timeout = (timeout) / float(1000) # Convert to secs
+
+
+        if now < (self.data['last'] + timeout) and self.data['valid']:
+            return True, {}
+
+        reg_value = self.get_transceiver_status
+        changed_ports = self.data['present'] ^ reg_value
+        if changed_ports:
+            for port in range (self.port_start, self.port_end+1):
+                # Mask off the bit corresponding to our port
+                fp_port = port
+                mask = (1 << (fp_port - 1))
+                if changed_ports & mask:
+                    if (reg_value & mask) == 0:
+                        port_dict[port] = SFP_STATUS_REMOVED
+                    else:
+                        port_dict[port] = SFP_STATUS_INSERTED
+
+            # Update cache
+            self.data['present'] = reg_value
+            self.data['last'] = now
+            self.data['valid'] = 1
+
+            return True, port_dict
+        else:
+            return True, {}
+        return False, {}
+

--- a/device/accton/x86_64-accton_as7816_64x-r0/Accton-AS7816-64X/port_config.ini
+++ b/device/accton/x86_64-accton_as7816_64x-r0/Accton-AS7816-64X/port_config.ini
@@ -1,65 +1,65 @@
-# name          lanes                 alias
-Ethernet0       73,74,75,76           hundredGigE1
-Ethernet4       65,66,67,68           hundredGigE2
-Ethernet8       81,82,83,84           hundredGigE3
-Ethernet12      89,90,91,92           hundredGigE4
-Ethernet16      105,106,107,108       hundredGigE5
-Ethernet20      97,98,99,100          hundredGigE6
-Ethernet24      113,114,115,116       hundredGigE7
-Ethernet28      121,122,123,124       hundredGigE8
-Ethernet32      41,42,43,44           hundredGigE9
-Ethernet36      33,34,35,36           hundredGigE10
-Ethernet40      49,50,51,52           hundredGigE11
-Ethernet44      57,58,59,60           hundredGigE12
-Ethernet48      137,138,139,140       hundredGigE13
-Ethernet52      129,130,131,132       hundredGigE14
-Ethernet56      145,146,147,148       hundredGigE15
-Ethernet60      153,154,155,156       hundredGigE16
-Ethernet64      173,174,175,176       hundredGigE17
-Ethernet68      165,166,167,168       hundredGigE18
-Ethernet72      181,182,183,184       hundredGigE19
-Ethernet76      189,190,191,192       hundredGigE20
-Ethernet80      13,14,15,16           hundredGigE21
-Ethernet84      5,6,7,8               hundredGigE22
-Ethernet88      29,30,31,32           hundredGigE23
-Ethernet92      21,22,23,24           hundredGigE24
-Ethernet96      205,206,207,208       hundredGigE25
-Ethernet100     197,198,199,200       hundredGigE26
-Ethernet104     213,214,215,216       hundredGigE27
-Ethernet108     221,222,223,224       hundredGigE28
-Ethernet112     229,230,231,232       hundredGigE29
-Ethernet116     237,238,239,240       hundredGigE30
-Ethernet120     245,246,247,248       hundredGigE31
-Ethernet124     253,254,255,256       hundredGigE32
-Ethernet128     69,70,71,72           hundredGigE33
-Ethernet132     77,78,79,80           hundredGigE34
-Ethernet136     93,94,95,96           hundredGigE35
-Ethernet140     85,86,87,88           hundredGigE36
-Ethernet144     101,102,103,104       hundredGigE37
-Ethernet148     109,110,111,112       hundredGigE38
-Ethernet152     125,126,127,128       hundredGigE39
-Ethernet156     117,118,119,120       hundredGigE40
-Ethernet160     37,38,39,40           hundredGigE41
-Ethernet164     45,46,47,48           hundredGigE42
-Ethernet168     61,62,63,64           hundredGigE43
-Ethernet172     53,54,55,56           hundredGigE44
-Ethernet176     133,134,135,136       hundredGigE45
-Ethernet180     141,142,143,144       hundredGigE46
-Ethernet184     157,158,159,160       hundredGigE47
-Ethernet188     149,150,151,152       hundredGigE48
-Ethernet192     161,162,163,164       hundredGigE49
-Ethernet196     169,170,171,172       hundredGigE50
-Ethernet200     185,186,187,188       hundredGigE51
-Ethernet204     177,178,179,180       hundredGigE52
-Ethernet208     1,2,3,4               hundredGigE53
-Ethernet212     9,10,11,12            hundredGigE54
-Ethernet216     25,26,27,28           hundredGigE55
-Ethernet220     17,18,19,20           hundredGigE56
-Ethernet224     193,194,195,196       hundredGigE57
-Ethernet228     201,202,203,204       hundredGigE58
-Ethernet232     217,218,219,220       hundredGigE59
-Ethernet236     209,210,211,212       hundredGigE60
-Ethernet240     225,226,227,228       hundredGigE61
-Ethernet244     233,234,235,236       hundredGigE62
-Ethernet248     249,250,251,252       hundredGigE63
-Ethernet252     241,242,243,244       hundredGigE64
+# name          lanes                 alias             index  speed
+Ethernet0       73,74,75,76           hundredGigE1      1      100000
+Ethernet4       65,66,67,68           hundredGigE2      2      100000
+Ethernet8       81,82,83,84           hundredGigE3      3      100000
+Ethernet12      89,90,91,92           hundredGigE4      4      100000
+Ethernet16      105,106,107,108       hundredGigE5      5      100000
+Ethernet20      97,98,99,100          hundredGigE6      6      100000
+Ethernet24      113,114,115,116       hundredGigE7      7      100000
+Ethernet28      121,122,123,124       hundredGigE8      8      100000
+Ethernet32      41,42,43,44           hundredGigE9      9      100000
+Ethernet36      33,34,35,36           hundredGigE10     10     100000
+Ethernet40      49,50,51,52           hundredGigE11     11     100000
+Ethernet44      57,58,59,60           hundredGigE12     12     100000
+Ethernet48      137,138,139,140       hundredGigE13     13     100000
+Ethernet52      129,130,131,132       hundredGigE14     14     100000
+Ethernet56      145,146,147,148       hundredGigE15     15     100000
+Ethernet60      153,154,155,156       hundredGigE16     16     100000
+Ethernet64      173,174,175,176       hundredGigE17     17     100000
+Ethernet68      165,166,167,168       hundredGigE18     18     100000
+Ethernet72      181,182,183,184       hundredGigE19     19     100000
+Ethernet76      189,190,191,192       hundredGigE20     20     100000
+Ethernet80      13,14,15,16           hundredGigE21     21     100000
+Ethernet84      5,6,7,8               hundredGigE22     22     100000
+Ethernet88      29,30,31,32           hundredGigE23     23     100000
+Ethernet92      21,22,23,24           hundredGigE24     24     100000
+Ethernet96      205,206,207,208       hundredGigE25     25     100000
+Ethernet100     197,198,199,200       hundredGigE26     26     100000
+Ethernet104     213,214,215,216       hundredGigE27     27     100000
+Ethernet108     221,222,223,224       hundredGigE28     28     100000
+Ethernet112     229,230,231,232       hundredGigE29     29     100000
+Ethernet116     237,238,239,240       hundredGigE30     30     100000
+Ethernet120     245,246,247,248       hundredGigE31     31     100000
+Ethernet124     253,254,255,256       hundredGigE32     32     100000
+Ethernet128     69,70,71,72           hundredGigE33     33     100000
+Ethernet132     77,78,79,80           hundredGigE34     34     100000
+Ethernet136     93,94,95,96           hundredGigE35     35     100000
+Ethernet140     85,86,87,88           hundredGigE36     36     100000
+Ethernet144     101,102,103,104       hundredGigE37     37     100000
+Ethernet148     109,110,111,112       hundredGigE38     38     100000
+Ethernet152     125,126,127,128       hundredGigE39     39     100000
+Ethernet156     117,118,119,120       hundredGigE40     40     100000
+Ethernet160     37,38,39,40           hundredGigE41     41     100000
+Ethernet164     45,46,47,48           hundredGigE42     42     100000
+Ethernet168     61,62,63,64           hundredGigE43     43     100000
+Ethernet172     53,54,55,56           hundredGigE44     44     100000
+Ethernet176     133,134,135,136       hundredGigE45     45     100000
+Ethernet180     141,142,143,144       hundredGigE46     46     100000
+Ethernet184     157,158,159,160       hundredGigE47     47     100000
+Ethernet188     149,150,151,152       hundredGigE48     48     100000
+Ethernet192     161,162,163,164       hundredGigE49     49     100000
+Ethernet196     169,170,171,172       hundredGigE50     50     100000
+Ethernet200     185,186,187,188       hundredGigE51     51     100000
+Ethernet204     177,178,179,180       hundredGigE52     52     100000
+Ethernet208     1,2,3,4               hundredGigE53     53     100000
+Ethernet212     9,10,11,12            hundredGigE54     54     100000
+Ethernet216     25,26,27,28           hundredGigE55     55     100000
+Ethernet220     17,18,19,20           hundredGigE56     56     100000
+Ethernet224     193,194,195,196       hundredGigE57     57     100000
+Ethernet228     201,202,203,204       hundredGigE58     58     100000
+Ethernet232     217,218,219,220       hundredGigE59     59     100000
+Ethernet236     209,210,211,212       hundredGigE60     60     100000
+Ethernet240     225,226,227,228       hundredGigE61     61     100000
+Ethernet244     233,234,235,236       hundredGigE62     62     100000
+Ethernet248     249,250,251,252       hundredGigE63     63     100000
+Ethernet252     241,242,243,244       hundredGigE64     64     100000

--- a/device/accton/x86_64-accton_as7816_64x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/plugins/sfputil.py
@@ -2,18 +2,22 @@
 
 try:
     import time
+    import pprint
     import string
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase 
 except ImportError, e:
     raise ImportError (str(e) + "- required module not found")
 
+#from xcvrd
+SFP_STATUS_INSERTED = '1'
+SFP_STATUS_REMOVED = '0'
 
 class SfpUtil(SfpUtilBase):
     """Platform specific SfpUtill class"""
 
-    _port_start = 0
-    _port_end = 63
+    _port_start = 1
+    _port_end = 64
     ports_in_block = 64
 
     _port_to_eeprom_mapping = {}
@@ -86,18 +90,18 @@ class SfpUtil(SfpUtilBase):
     _qsfp_ports = range(0, ports_in_block + 1)
 
     def __init__(self):
-        eeprom_path = '/sys/bus/i2c/devices/{0}-0050/sfp_eeprom'
-        for x in range(0, self._port_end + 1):
-            port_eeprom_path = eeprom_path.format(self.port_to_i2c_mapping[x+1])
+        eeprom_path = '/sys/bus/i2c/devices/{0}-0050/eeprom'
+        for x in range(self.port_start, self.port_end + 1):
+            port_eeprom_path = eeprom_path.format(self.port_to_i2c_mapping[x])
             self._port_to_eeprom_mapping[x] = port_eeprom_path
         SfpUtilBase.__init__(self)
 
     def reset(self, port_num):
         # Check for invalid port_num
-        if port_num < self._port_start or port_num > self._port_end:
+        if port_num < self.port_start or port_num > self.port_end:
             return False
 	path = "/sys/bus/i2c/devices/19-0060/module_reset_{0}"
-        port_ps = path.format(port_num+1)
+        port_ps = path.format(port_num)
           
         try:
             reg_file = open(port_ps, 'w')
@@ -113,12 +117,11 @@ class SfpUtil(SfpUtilBase):
         
     def get_presence(self, port_num):
         # Check for invalid port_num
-        if port_num < self._port_start or port_num > self._port_end:
+        if port_num < self.port_start or port_num > self.port_end:
             return False
 
-        path = "/sys/bus/i2c/devices/{0}-0050/sfp_is_present"
-        port_ps = path.format(self.port_to_i2c_mapping[port_num+1])
-
+        path = "/sys/bus/i2c/devices/19-0060/module_present_{0}"
+        port_ps = path.format(port_num)
           
         try:
             reg_file = open(port_ps)
@@ -147,14 +150,6 @@ class SfpUtil(SfpUtilBase):
     @property 
     def port_to_eeprom_mapping(self):
          return self._port_to_eeprom_mapping
-
-    def get_transceiver_change_event(self):
-        """
-        TODO: This function need to be implemented
-        when decide to support monitoring SFP(Xcvrd)
-        on this platform.
-        """
-        raise NotImplementedError
 
     def get_low_power_mode(self, port_num):
         # Check for invalid port_num
@@ -213,3 +208,62 @@ class SfpUtil(SfpUtilBase):
             if eeprom is not None:
                 eeprom.close()
                 time.sleep(0.01)
+
+    @property
+    def _get_present_bitmap(self):
+        nodes = []
+
+        cpld_path = "/sys/bus/i2c/devices/19-0060/"
+        nodes.append(cpld_path + "module_present_all")
+
+        bitmap = ""
+        for node in nodes:
+            try:
+                reg_file = open(node)
+
+            except IOError as e:
+                print "Error: unable to open file: %s" % str(e)
+                return False
+            bitmap += reg_file.readline().rstrip() + " "
+            reg_file.close()
+
+        rev = bitmap.split(" ")
+        rev = "".join(rev[::-1])
+        return int(rev,16)
+
+
+    data = {'valid':0, 'last':0, 'present':0}
+    def get_transceiver_change_event(self, timeout=2000):
+        now = time.time()
+        port_dict = {}
+        port = 0
+
+        if timeout < 1000:
+            timeout = 1000
+        timeout = (timeout) / float(1000) # Convert to secs
+
+        if now < (self.data['last'] + timeout) and self.data['valid']:
+            return True, {}
+
+        reg_value = self._get_present_bitmap
+        reg_value = ~reg_value
+        changed_ports = self.data['present'] ^ reg_value
+        if changed_ports:
+            for port in range (self.port_start, self.port_end+1):
+                # Mask off the bit corresponding to our port
+                mask = (1 << (port - 1))
+                if changed_ports & mask:
+                    if (reg_value & mask) == 0:
+                        port_dict[port] = SFP_STATUS_REMOVED
+                    else:
+                        port_dict[port] = SFP_STATUS_INSERTED
+
+            # Update cache
+            self.data['present'] = reg_value
+            self.data['last'] = now
+            self.data['valid'] = 1
+            return True, port_dict
+        else:
+            return True, {}
+        return False, {}
+

--- a/device/accton/x86_64-accton_as7816_64x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/plugins/sfputil.py
@@ -2,7 +2,6 @@
 
 try:
     import time
-    import pprint
     import string
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase 

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/classes/fanutil.py
@@ -96,58 +96,71 @@ class FanUtil(object):
            (FAN_NUM_5_IDX, FANR_NODE_SPEED_IDX_OF_MAP): 'fanr5_speed_rpm',
            }
 
+    logger = logging.getLogger(__name__)
+    def __init__(self, log_level=logging.DEBUG):
+        ch = logging.StreamHandler()
+        ch.setLevel(log_level)
+        self.logger.addHandler(ch)
+
+        fan_path = self.BASE_VAL_PATH
+        for fan_num in range(self.FAN_NUM_1_IDX, self.FAN_NUM_ON_MAIN_BROAD+1):
+            for node_num in range(self.FAN_NODE_FAULT_IDX_OF_MAP, self.FAN_NODE_NUM_OF_MAP+1):
+                self._fan_to_device_path_mapping[(fan_num, node_num)] = fan_path.format(
+                    self._fan_to_device_node_mapping[(fan_num, node_num)])
+
+
     def _get_fan_to_device_node(self, fan_num, node_num):
         return self._fan_to_device_node_mapping[(fan_num, node_num)]
 
     def _get_fan_node_val(self, fan_num, node_num):
         if fan_num < self.FAN_NUM_1_IDX or fan_num > self.FAN_NUM_ON_MAIN_BROAD:
-            logging.debug('GET. Parameter error. fan_num:%d', fan_num)
+            self.logger.debug('GET. Parameter error. fan_num:%d', fan_num)
             return None
 
         if node_num < self.FAN_NODE_FAULT_IDX_OF_MAP or node_num > self.FAN_NODE_NUM_OF_MAP:
-            logging.debug('GET. Parameter error. node_num:%d', node_num)
+            self.logger.debug('GET. Parameter error. node_num:%d', node_num)
             return None
 
         device_path = self.get_fan_to_device_path(fan_num, node_num)
         try:
             val_file = open(device_path, 'r')
         except IOError as e:
-            logging.error('GET. unable to open file: %s', str(e))
+            self.logger.error('GET. unable to open file: %s', str(e))
             return None
 
         content = val_file.readline().rstrip()
 
         if content == '':
-            logging.debug('GET. content is NULL. device_path:%s', device_path)
+            self.logger.debug('GET. content is NULL. device_path:%s', device_path)
             return None
 
         try:
 		    val_file.close()
         except:
-            logging.debug('GET. unable to close file. device_path:%s', device_path)
+            self.logger.debug('GET. unable to close file. device_path:%s', device_path)
             return None
 
         return int(content)
 
     def _set_fan_node_val(self, fan_num, node_num, val):
         if fan_num < self.FAN_NUM_1_IDX or fan_num > self.FAN_NUM_ON_MAIN_BROAD:
-            logging.debug('GET. Parameter error. fan_num:%d', fan_num)
+            self.logger.debug('GET. Parameter error. fan_num:%d', fan_num)
             return None
 
         if node_num < self.FAN_NODE_FAULT_IDX_OF_MAP or node_num > self.FAN_NODE_NUM_OF_MAP:
-            logging.debug('GET. Parameter error. node_num:%d', node_num)
+            self.logger.debug('GET. Parameter error. node_num:%d', node_num)
             return None
 
         content = str(val)
         if content == '':
-            logging.debug('GET. content is NULL. device_path:%s', device_path)
+            self.logger.debug('GET. content is NULL. device_path:%s', device_path)
             return None
 
         device_path = self.get_fan_to_device_path(fan_num, node_num)
         try:
             val_file = open(device_path, 'w')
         except IOError as e:
-            logging.error('GET. unable to open file: %s', str(e))
+            self.logger.error('GET. unable to open file: %s', str(e))
             return None
 
         val_file.write(content)
@@ -155,18 +168,10 @@ class FanUtil(object):
         try:
 		    val_file.close()
         except:
-            logging.debug('GET. unable to close file. device_path:%s', device_path)
+            self.logger.debug('GET. unable to close file. device_path:%s', device_path)
             return None
 
         return True
-
-    def __init__(self):
-        fan_path = self.BASE_VAL_PATH
-
-        for fan_num in range(self.FAN_NUM_1_IDX, self.FAN_NUM_ON_MAIN_BROAD+1):
-            for node_num in range(self.FAN_NODE_FAULT_IDX_OF_MAP, self.FAN_NODE_NUM_OF_MAP+1):
-                self._fan_to_device_path_mapping[(fan_num, node_num)] = fan_path.format(
-                    self._fan_to_device_node_mapping[(fan_num, node_num)])
 
     def get_num_fans(self):
         return self.FAN_NUM_ON_MAIN_BROAD
@@ -212,15 +217,15 @@ class FanUtil(object):
 
     def get_fan_status(self, fan_num):
         if fan_num < self.FAN_NUM_1_IDX or fan_num > self.FAN_NUM_ON_MAIN_BROAD:
-            logging.debug('GET. Parameter error. fan_num, %d', fan_num)
+            self.logger.debug('GET. Parameter error. fan_num, %d', fan_num)
             return None
 
         if self.get_fan_fault(fan_num) is not None and self.get_fan_fault(fan_num) > 0:
-            logging.debug('GET. FAN fault. fan_num, %d', fan_num)
+            self.logger.debug('GET. FAN fault. fan_num, %d', fan_num)
             return False
 
         if self.get_fanr_fault(fan_num) is not None and self.get_fanr_fault(fan_num) > 0:
-            logging.debug('GET. FANR fault. fan_num, %d', fan_num)
+            self.logger.debug('GET. FANR fault. fan_num, %d', fan_num)
             return False
 
         return True

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/classes/thermalutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/classes/thermalutil.py
@@ -52,7 +52,11 @@ class ThermalUtil(object):
             THERMAL_NUM_3_IDX: ['63', '4a'],
            }
 
-    def __init__(self):
+    logger = logging.getLogger(__name__)
+    def __init__(self, log_level=logging.DEBUG):
+        ch = logging.StreamHandler()
+        ch.setLevel(log_level)
+        self.logger.addHandler(ch)
         thermal_path = self.BASE_VAL_PATH
 
         for x in range(self.THERMAL_NUM_1_IDX, self.THERMAL_NUM_ON_MAIN_BROAD+1):
@@ -62,7 +66,7 @@ class ThermalUtil(object):
 
     def _get_thermal_node_val(self, thermal_num):
         if thermal_num < self.THERMAL_NUM_1_IDX or thermal_num > self.THERMAL_NUM_ON_MAIN_BROAD:
-            logging.debug('GET. Parameter error. thermal_num, %d', thermal_num)
+            self.logger.debug('GET. Parameter error. thermal_num, %d', thermal_num)
             return None
 
         device_path = self.get_thermal_to_device_path(thermal_num)
@@ -70,19 +74,19 @@ class ThermalUtil(object):
             try:
                 val_file = open(filename, 'r')
             except IOError as e:
-                logging.error('GET. unable to open file: %s', str(e))
+                self.logger.error('GET. unable to open file: %s', str(e))
                 return None
 
         content = val_file.readline().rstrip()
 
         if content == '':
-            logging.debug('GET. content is NULL. device_path:%s', device_path)
+            self.logger.debug('GET. content is NULL. device_path:%s', device_path)
             return None
 
         try:
 		    val_file.close()
         except:
-            logging.debug('GET. unable to close file. device_path:%s', device_path)
+            self.logger.debug('GET. unable to close file. device_path:%s', device_path)
             return None
 
         return int(content)

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/service/as5812-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/service/as5812-platform-monitor.service
@@ -5,10 +5,10 @@ After=sysinit.target
 DefaultDependencies=no
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStartPre=/usr/local/bin/accton_as5812_util.py install
 ExecStart=/usr/local/bin/accton_as5812_monitor.py
-RemainAfterExit=yes
+#RemainAfterExit=yes
 
 # Resource Limitations
 LimitCORE=infinity


### PR DESCRIPTION
Update port config for index from 1 and give default port speed.

But following model are not updated:
as7116_54x:  with nephos MAC.
as7212_54x:  with marvell MAC.
as4630_54pe: no avaiable DUT.
as7716_32xb: No production.
minipack:    Due to hot-swappable port modules.

Note, this may conflict to https://github.com/Azure/sonic-buildimage/pull/2923.

**- What I did**
1. Update port config for index from 1
2. Give default port speed.
3. Implement get_transceiver_change_event() of sfputil.

**- How I did it**
Update port_config and sfputil with the index changed. 
Generate new config_db with new port_config, and reload that new config.

**- How to verify it**
sfputil show presence
sfputil show eeprom
show interfaces transciever (but not for all platform)

**- Description for the changelog**
With port index changed, it has to update sfputil.py for new mapping.