### PR TITLE
[build]: pin down j2cli to 0.3.10 in sonic-slave

### DIFF
--- a/sonic-slave-stretch/Dockerfile
+++ b/sonic-slave-stretch/Dockerfile
@@ -271,7 +271,7 @@ RUN pip install pyangbind==0.6.0
 RUN pip install --force-reinstall --upgrade "jinja2>=2.10"
 
 # For templating
-RUN pip install j2cli
+RUN pip install j2cli==0.3.10
 
 # Remove python-click 6.6
 RUN apt-get purge -y python-click

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -271,7 +271,7 @@ RUN pip install pyangbind==0.6.0
 RUN pip install --force-reinstall --upgrade "jinja2>=2.10"
 
 # For templating (requiring jinja2)
-RUN pip install j2cli
+RUN pip install j2cli==0.3.10
 
 # For sonic utilities testing
 RUN pip install click-default-group click natsort tabulate netifaces==0.10.7 fastentrypoints


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
pin down j2cli to 0.3.10 in sonic-slave

j2cli release a 0.3.11 which break the build, but it was later pull out of pip so it is difficult to repro. 
pin down working version avoid such build break.

https://github.com/kolypto/j2cli/issues/43

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
