### PR TITLE
[sonic-cfggen] Fix a wrong attribute of VXLAN_TUNNEL

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -448,7 +448,7 @@ def parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_m
             break        
 
     results['VXLAN_TUNNEL'] = {chassis_vxlan_tunnel: {
-        'source_ip': lo_addr
+        'src_ip': lo_addr
     }}
 
     # Vnet information

--- a/src/sonic-config-engine/tests/test_cfggen_t2_chassis_fe.py
+++ b/src/sonic-config-engine/tests/test_cfggen_t2_chassis_fe.py
@@ -69,4 +69,4 @@ class TestCfgGenT2ChassisFe(TestCase):
     def test_minigraph_t2_chassis_fe_vxlan(self):
         argument = '-m "' + self.sample_graph_t2_chassis_fe + '" -p "' + self.t2_chassis_fe_port_config + '" -v "VXLAN_TUNNEL"'
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'TunnelInt': {'source_ip': '4.0.0.0'}}")
+        self.assertEqual(output.strip(), "{'TunnelInt': {'src_ip': '4.0.0.0'}}")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Change VXLAN_TUNNEL attribute "source_ip" to "src_ip" for T2 chassis frontend configuration
 
**- How I did it**
Modify minigraph.py 

**- How to verify it**
Check config DB in Redis. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix #3100 

Signed-off-by: Wei Bai baiwei0427@gmail.com
