### PR TITLE
[build]: fail the build when there is error in build_image.sh

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 ## This script is to generate an ONIE installer image based on a file system overload
 
+## Enable debug output for script
+set -x -e
+
 ## Read ONIE image related config file
 
 CONFIGURED_ARCH=$([ -f .arch ] && cat .arch || echo amd64)


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
add -e and -x to the build_image.sh script

Here, the build failed due to disk space, but the build is not marked as failed accordingly.

https://sonic-jenkins.westus2.cloudapp.azure.com/job/broadcom/job/buildimage-brcm-all-pr/461/artifact/target/sonic-broadcom.raw.log/*view*/

**- How I did it**

**- How to verify it**
todo

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
