### PR TITLE
[Makefile/slave-docker] Makefile fixes and multiarch change

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -53,7 +53,7 @@ endif
 docker_min := 17.06.1
 docker_min_ver := $(shell echo "$(docker_min)" | awk -F. '{printf("%d%03d%03d\n",$$1,$$2,$$3);}' 2>/dev/null)
 docker_ver := $(shell docker info 2>/dev/null | grep -i "server version" | rev | cut -d' ' -f1 | rev | awk -F. '{printf("%d%03d%03d\n",$$1,$$2,$$3);}' 2>/dev/null)
-docker_is_valid := $(shell if [ $(docker_ver) -lt $(docker_min_ver) ] ; then echo "0"; else echo "1"; fi)
+docker_is_valid := $(shell if [[ "$(docker_ver)" -lt $(docker_min_ver) ]] ; then echo "0"; else echo "1"; fi)
 ifeq (0,$(docker_is_valid))
 $(error SONiC requires Docker version $(docker_min) or later)
 endif

--- a/slave.mk
+++ b/slave.mk
@@ -81,6 +81,8 @@ list :
 ## Include other rules
 ###############################################################################
 
+include $(RULES_PATH)/config
+
 ifeq ($(SONIC_ENABLE_PFCWD_ON_START),y)
 ENABLE_PFCWD_ON_START = y
 endif
@@ -97,7 +99,6 @@ ifeq ($(SONIC_INSTALL_DEBUG_TOOLS),y)
 INSTALL_DEBUG_TOOLS = y
 endif
 
-include $(RULES_PATH)/config
 include $(RULES_PATH)/functions
 include $(RULES_PATH)/*.mk
 ifneq ($(CONFIGURED_PLATFORM), undefined)

--- a/sonic-slave/Dockerfile.j2
+++ b/sonic-slave/Dockerfile.j2
@@ -360,6 +360,6 @@ RUN apt-get install -y docker-ce=18.06.3~ce~3-0~debian
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker
 
 # For jenkins slave
-RUN echo "deb [arch=amd64] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
+RUN echo "deb [arch={{ CONFIGURED_ARCH }}] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 RUN apt-get -y -o Acquire::Check-Valid-Until=false install ca-certificates-java=20161107~bpo8+1 openjdk-8-jdk


### PR DESCRIPTION
        Fix for rules/config as it is overridden by Make infra
        Fix for docker service not running case, makefile return shell script error.
        Error: 
               /bin/bash: line 0: [: -lt: unary operator expected
        After Fix:
             Makefile.work:58: *** SONiC requires Docker version 17.06.1 or later.  Stop.
 

Signed-off-by: Antony Rheneus <arheneus@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
