### PR TITLE
Add python linuxfd to image and pmon

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -18,7 +18,9 @@ RUN apt-get update &&   \
         rrdtool         \
         python-smbus    \
         ethtool         \
-        dmidecode
+        dmidecode       \
+        gcc             \
+        libpython-dev
 
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies
@@ -44,14 +46,21 @@ RUN apt-get update &&   \
 {{ install_python_wheels(docker_platform_monitor_whls.split(' ')) }}
 {% endif %}
 
+# Install python dependencies for use by some plugins
+RUN pip install --no-cache-dir \
+        linuxfd==1.4.4
+
 # Clean up
 RUN apt-get purge -y           \
-        python-pip          && \
+        python-pip             \
+        gcc                    \
+        libpython-dev       && \
     apt-get clean -y        && \
     apt-get autoclean -y    && \
     apt-get autoremove -y   && \
     rm -rf /debs               \
            /python-wheels      \
+           /var/lib/apt/lists  \
            ~/.cache
 
 COPY ["docker_init.sh", "lm-sensors.sh", "/usr/bin/"]

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -95,6 +95,9 @@ sudo rm -rf $FILESYSTEM_ROOT/$CONFIG_ENGINE_WHEEL_NAME
 # Install Python client for Redis
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install "redis==2.10.6"
 
+# Install Python linuxfd
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install "linuxfd==1.4.4"
+
 # Install redis-dump-load Python 2 package
 REDIS_DUMP_LOAD_PY2_WHEEL_NAME=$(basename {{redis_dump_load_py2_wheel_path}})
 sudo cp {{redis_dump_load_py2_wheel_path}} $FILESYSTEM_ROOT/$REDIS_DUMP_LOAD_PY2_WHEEL_NAME


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add python linuxfd support in base image and pmon container.

To support a mix of blocking fd and polling event change detection in platform API, a timerfd is best suited to this task. Currently it would only be needed in base image but added for pmon as well since platform API functionality will most likely be used by pmon services in the future.

**- How I did it**

**- How to verify it**
linuxfd is able to be imported on device, and is able to be imported by python2 and python3 in pmon container.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
