### PR TITLE
[sonic-cfggen]: add --key option to show a specific key

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -191,7 +191,7 @@ def main():
     group.add_argument("--print-data", help="print all data", action='store_true')
     group.add_argument("--preset", help="generate sample configuration from a preset template", choices=get_available_config())
     group = parser.add_mutually_exclusive_group()
-    group.add_argument("-f", "--find", help="Find/Search for a specific key")
+    group.add_argument("-K", "--key", help="Lookup for a specific key")
     args = parser.parse_args()
 
     platform = get_platform_info(get_machine_info())

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -124,14 +124,14 @@ TODO(taoyl): Current version of config db only supports BGP admin states.
         return db_data
 
     @staticmethod
-    def to_serialized(data, find_key = ""):
+    def to_serialized(data, lookup_key = None):
         if type(data) is dict:
             data = OrderedDict(natsorted(data.items()))
 
-            if find_key != "":
+            if lookup_key != None:
                 newData = {}
                 for key in data.keys():
-                    if ((type(key) is unicode and find_key == key) or (type(key) is tuple and find_key in key)):
+                    if ((type(key) is unicode and lookup_key == key) or (type(key) is tuple and lookup_key in key)):
                         newData[ConfigDBConnector.serialize_key(key)] = data.pop(key)
                         break
                 return newData

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -124,9 +124,18 @@ TODO(taoyl): Current version of config db only supports BGP admin states.
         return db_data
 
     @staticmethod
-    def to_serialized(data):
+    def to_serialized(data, find_key = ""):
         if type(data) is dict:
             data = OrderedDict(natsorted(data.items()))
+
+            if find_key != "":
+                newData = {}
+                for key in data.keys():
+                    if ((type(key) is unicode and find_key == key) or (type(key) is tuple and find_key in key)):
+                        newData[ConfigDBConnector.serialize_key(key)] = data.pop(key)
+                        break
+                return newData
+
             for key in data.keys():
                 new_key = ConfigDBConnector.serialize_key(key)
                 if new_key != key:
@@ -181,6 +190,8 @@ def main():
     group.add_argument("-w", "--write-to-db", help="write config into configdb", action='store_true')
     group.add_argument("--print-data", help="print all data", action='store_true')
     group.add_argument("--preset", help="generate sample configuration from a preset template", choices=get_available_config())
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-f", "--find", help="Find/Search for a specific key")
     args = parser.parse_args()
 
     platform = get_platform_info(get_machine_info())
@@ -261,7 +272,10 @@ def main():
         print(template.render(data))
 
     if args.var_json != None:
-        print(json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder))
+        if args.find != None:
+            print(json.dumps(FormatConverter.to_serialized(data[args.var_json], args.find), indent=4, cls=minigraph_encoder))
+        else:
+            print(json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder))
 
     if args.write_to_db:
         configdb = ConfigDBConnector(**db_kwargs)

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -272,8 +272,8 @@ def main():
         print(template.render(data))
 
     if args.var_json != None:
-        if args.find != None:
-            print(json.dumps(FormatConverter.to_serialized(data[args.var_json], args.find), indent=4, cls=minigraph_encoder))
+        if args.key != None:
+            print(json.dumps(FormatConverter.to_serialized(data[args.var_json], args.key), indent=4, cls=minigraph_encoder))
         else:
             print(json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder))
 

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -65,6 +65,16 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'value1')
 
+    def test_additional_json_data_level1_key(self):
+        argument = '-a \'{"k1":{"k11":"v11","k12":"v12"}, "k2":{"k22":"v22"}}\' --var-json k1'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), '{\n    "k11": "v11", \n    "k12": "v12"\n}')
+
+    def test_additional_json_data_level2_key(self):
+        argument = '-a \'{"k1":{"k11":"v11","k12":"v12"},"k2":{"k22":"v22"}}\' --var-json k1 -K k11'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), '{\n    "k11": "v11"\n}')
+
     def test_var_json_data(self):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" --var-json VLAN_MEMBER'
         output = self.run_script(argument)


### PR DESCRIPTION
Signed-off-by: Vasant Patil <vapatil@linkedin.com>

This will help to dispy config DB with more granularity.
For example:
show runningconfiguration interface Ethernet0
show runningconfiguration interfaces Ethernet0                      

Testing done:
-------------
```
[[admin@lnos-x1-a-csw06:~$ show runningconfiguration interfaces
{
    "Ethernet0|10.0.0.0/31": {
        "family": "IPv4", 
        "scope": "global"
    }, 
    "Ethernet4|10.0.0.2/31": {}, 
    "Ethernet8|10.0.0.4/31": {}, 
    "Ethernet12|10.0.0.6/31": {}, 
    "Ethernet16|10.0.0.8/31": {}, 
    "Ethernet20|10.0.0.10/31": {}, 
    "Ethernet24|10.0.0.12/31": {}, 
    "Ethernet28|10.0.0.14/31": {}, 
    "Ethernet32|10.0.0.16/31": {}, 
    "Ethernet36|10.0.0.18/31": {}, 
    "Ethernet40|10.0.0.20/31": {}, 
    "Ethernet44|10.0.0.22/31": {}, 
    "Ethernet48|10.0.0.24/31": {}, 
    "Ethernet52|10.0.0.26/31": {}, 
    "Ethernet56|10.0.0.28/31": {}, 
    "Ethernet60|10.0.0.30/31": {}, 
    "Ethernet64|10.0.0.32/31": {}, 
    "Ethernet68|10.0.0.34/31": {}, 
    "Ethernet72|10.0.0.36/31": {}, 
    "Ethernet76|10.0.0.38/31": {}, 
    "Ethernet80|10.0.0.40/31": {}, 
    "Ethernet84|10.0.0.42/31": {}, 
    "Ethernet88|10.0.0.44/31": {}, 
    "Ethernet92|10.0.0.46/31": {}, 
    "Ethernet96|10.0.0.48/31": {}, 
    "Ethernet100|10.0.0.50/31": {}, 
    "Ethernet104|10.0.0.52/31": {}, 
    "Ethernet108|10.0.0.54/31": {}, 
    "Ethernet112|10.0.0.56/31": {}, 
    "Ethernet116|10.0.0.58/31": {}, 
    "Ethernet120|10.0.0.60/31": {}, 
    "Ethernet124|10.0.0.62/31": {}
}
admin@lnos-x1-a-csw06:~$ show runningconfiguration interface
{
    "Ethernet0": {
        "admin_status": "up", 
        "alias": "Eth1", 
        "index": "1", 
        "lanes": "65,66,67,68", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet4": {
        "admin_status": "up", 
        "alias": "Eth2", 
        "index": "2", 
        "lanes": "69,70,71,72", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet8": {
        "admin_status": "up", 
        "alias": "Eth3", 
        "index": "3", 
        "lanes": "73,74,75,76", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet12": {
        "admin_status": "up", 
        "alias": "Eth4", 
        "index": "4", 
        "lanes": "77,78,79,80", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet16": {
        "admin_status": "up", 
        "alias": "Eth5", 
        "index": "5", 
        "lanes": "33,34,35,36", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet20": {
        "admin_status": "up", 
        "alias": "Eth6", 
        "index": "6", 
        "lanes": "37,38,39,40", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet24": {
        "admin_status": "up", 
        "alias": "Eth7", 
        "index": "7", 
        "lanes": "41,42,43,44", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet28": {
        "admin_status": "up", 
        "alias": "Eth8", 
        "index": "8", 
        "lanes": "45,46,47,48", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet32": {
        "admin_status": "up", 
        "alias": "Eth9", 
        "index": "9", 
        "lanes": "49,50,51,52", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet36": {
        "admin_status": "up", 
        "alias": "Eth10", 
        "index": "10", 
        "lanes": "53,54,55,56", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet40": {
        "admin_status": "up", 
        "alias": "Eth11", 
        "index": "11", 
        "lanes": "57,58,59,60", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet44": {
        "admin_status": "up", 
        "alias": "Eth12", 
        "index": "12", 
        "lanes": "61,62,63,64", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet48": {
        "admin_status": "up", 
        "alias": "Eth13", 
        "index": "13", 
        "lanes": "81,82,83,84", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet52": {
        "admin_status": "up", 
        "alias": "Eth14", 
        "index": "14", 
        "lanes": "85,86,87,88", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet56": {
        "admin_status": "up", 
        "alias": "Eth15", 
        "index": "15", 
        "lanes": "89,90,91,92", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet60": {
        "admin_status": "up", 
        "alias": "Eth16", 
        "index": "16", 
        "lanes": "93,94,95,96", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet64": {
        "admin_status": "up", 
        "alias": "Eth17", 
        "index": "17", 
        "lanes": "97,98,99,100", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet68": {
        "admin_status": "up", 
        "alias": "Eth18", 
        "index": "18", 
        "lanes": "101,102,103,104", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet72": {
        "admin_status": "up", 
        "alias": "Eth19", 
        "index": "19", 
        "lanes": "105,106,107,108", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet76": {
        "admin_status": "up", 
        "alias": "Eth20", 
        "index": "20", 
        "lanes": "109,110,111,112", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet80": {
        "admin_status": "up", 
        "alias": "Eth21", 
        "index": "21", 
        "lanes": "1,2,3,4", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet84": {
        "admin_status": "up", 
        "alias": "Eth22", 
        "index": "22", 
        "lanes": "5,6,7,8", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet88": {
        "admin_status": "up", 
        "alias": "Eth23", 
        "index": "23", 
        "lanes": "9,10,11,12", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet92": {
        "admin_status": "up", 
        "alias": "Eth24", 
        "index": "24", 
        "lanes": "13,14,15,16", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet96": {
        "admin_status": "up", 
        "alias": "Eth25", 
        "index": "25", 
        "lanes": "17,18,19,20", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet100": {
        "admin_status": "up", 
        "alias": "Eth26", 
        "index": "26", 
        "lanes": "21,22,23,24", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet104": {
        "admin_status": "up", 
        "alias": "Eth27", 
        "index": "27", 
        "lanes": "25,26,27,28", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet108": {
        "admin_status": "up", 
        "alias": "Eth28", 
        "index": "28", 
        "lanes": "29,30,31,32", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet112": {
        "admin_status": "up", 
        "alias": "Eth29", 
        "index": "29", 
        "lanes": "113,114,115,116", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet116": {
        "admin_status": "up", 
        "alias": "Eth30", 
        "index": "30", 
        "lanes": "117,118,119,120", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet120": {
        "admin_status": "up", 
        "alias": "Eth31", 
        "index": "31", 
        "lanes": "121,122,123,124", 
        "mtu": "9100", 
        "speed": "100000"
    }, 
    "Ethernet124": {
        "admin_status": "up", 
        "alias": "Eth32", 
        "index": "32", 
        "lanes": "125,126,127,128", 
        "mtu": "9100", 
        "speed": "100000"
    }
}
admin@lnos-x1-a-csw06:~$ show runningconfiguration interface Ethernet4
{
    "Ethernet4": {
        "index": "2", 
        "lanes": "69,70,71,72", 
        "mtu": "9100", 
        "alias": "Eth2", 
        "admin_status": "up", 
        "speed": "100000"
    }
}
admin@lnos-x1-a-csw06:~$ show runningconfiguration interface Ethernet40
{
    "Ethernet40": {
        "index": "11", 
        "lanes": "57,58,59,60", 
        "mtu": "9100", 
        "alias": "Eth11", 
        "admin_status": "up", 
        "speed": "100000"
    }
}
admin@lnos-x1-a-csw06:~$ show runningconfiguration interfaces Ethernet4
{
    "Ethernet4|10.0.0.2/31": {}
}
admin@lnos-x1-a-csw06:~$ show runningconfiguration interfaces Ethernet40
{
    "Ethernet40|10.0.0.20/31": {}
}
admin@lnos-x1-a-csw06:~$](url)
```
](url)
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
