### PR TITLE
[201811][process-reboot-cause] Revert back to 'import sonic_platform'

### DIFF
--- a/files/image_config/process-reboot-cause/process-reboot-cause
+++ b/files/image_config/process-reboot-cause/process-reboot-cause
@@ -70,7 +70,7 @@ def main():
     # if there is no sonic_platform package installed, we only provide
     # software-related reboot causes.
     try:
-        import sonic_platform.platform
+        import sonic_platform
 
         # Check if the previous reboot was caused by hardware
         platform = sonic_platform.platform.Platform()


### PR DESCRIPTION
**- What I did**

- Undo a change made in https://github.com/Azure/sonic-buildimage/pull/3198. This change should not be necessary, and in fact, it broke process-reboot-cause compatibility with other vendors' platform API packages.