### PR TITLE
[libteam]: Fix libteam race condition when interface is created and enslaved

### DIFF
--- a/src/libteam/patch/0009-Fix-ifinfo_link_with_port-race-condition-with-newlink.patch
+++ b/src/libteam/patch/0009-Fix-ifinfo_link_with_port-race-condition-with-newlink.patch
@@ -1,0 +1,45 @@
+From 9a27e9b85afbbf6235e61c2426481e49a2139219 Mon Sep 17 00:00:00 2001
+From: Shu0T1an ChenG <shuche@microsoft.com>
+Date: Tue, 15 Jan 2019 12:23:02 -0800
+Subject: [PATCH] Fix ifinfo_link_with_port race condition with newlink
+
+The race condition could happen like this:
+When an interface is enslaved into the port channel immediately after
+it is created, the order of creating the ifinfo and linking the ifinfo to
+the port is not guaranteed.
+
+The team handler will listen to both netlink message to track new links
+get created to allocate the ifinfo and add the ifinfo into its linked list,
+and the team port change message to link the new port with ifinfo found
+in its linkedin list. However, when the ifinfo is not yet created, the error
+message "Failed to link port with ifinfo" is thrown with member port failed
+to be added into the team handler's port list.
+
+This fix adds a condition to check if ifinfo_link_with_port is linking ifinfo
+to a port or to the team interface itself. If it is a port, ifinfo_find_create
+function is used to fix the race condition.
+
+Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
+---
+ libteam/ifinfo.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/libteam/ifinfo.c b/libteam/ifinfo.c
+index 44de4ca..444e0cd 100644
+--- a/libteam/ifinfo.c
++++ b/libteam/ifinfo.c
+@@ -429,7 +429,10 @@ int ifinfo_link_with_port(struct team_handle *th, uint32_t ifindex,
+ {
+ 	struct team_ifinfo *ifinfo;
+ 
+-	ifinfo = ifinfo_find(th, ifindex);
++	if (port)
++		ifinfo = ifinfo_find_create(th, ifindex);
++	else
++		ifinfo = ifinfo_find(th, ifindex);
+ 	if (!ifinfo)
+ 		return -ENOENT;
+ 	if (ifinfo->linked)
+-- 
+2.1.4
+

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -6,3 +6,4 @@
 0006-teamd-Administratively-shutdown-port-channel-has-mem.patch
 0007-Send-LACP-PDU-immediately-if-our-state-changed.patch
 0008-libteam-Add-warm_reboot-mode.patch
+0009-Fix-ifinfo_link_with_port-race-condition-with-newlink.patch


### PR DESCRIPTION
The race condition could happen like this:
When an interface is enslaved into the port channel immediately after
it is created, the order of creating the ifinfo and linking the ifinfo to
the port is not guaranteed.

Please check the patch commit message to get full details.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>