### PR TITLE
[Mellanox] enhance the reboot cause handling on 201811 

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/__init__.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["platform", "chassis"]
+from sonic_platform import *


### PR DESCRIPTION
**- What I did**
1. Enable platform-api to be loaded as a whole so that other modules can import it simply by "import sonic_platform". Currently, only process-reboot-cause imports this module. Originally it uses "import sonic_platform.platform", which can fail when "platform" is not supported.
2. Support currently hw-management currently running on 201811.

**- How I did it**
1. add specific initialization to __init__.py for the module.
2. adaptively find reboot cause file by searching for a series of possible dirs.

**- How to verify it**
test whether the reboot cause can be successfully parsed.

**- Description for the changelog**
[Mellanox] enable new platform api to be loaded as a whole.

**- A picture of a cute animal (not mandatory but encouraged)**
