### PR TITLE
[docker-fpm-frr/bgpcfgd]: Update interface of bgpcfgd from swsssdk to swsscommon

### DIFF
--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -36,12 +36,9 @@ class BGPConfigManager(object):
         run_command("supervisorctl restart start.sh")
         run_command("service frr restart")
         self.bgp_asn = data["bgp_asn"]
-    
-    def __bgp_handler(self, key, op, data):
-        self.bgp_message.put((key, op, data))
-        # If ASN was set
-        if self.bgp_asn == None:
-            return
+        self.__update_bgp()
+
+    def __update_bgp(self):
         while not self.bgp_message.empty():
             key, op, data = self.bgp_message.get()
             syslog.syslog(syslog.LOG_INFO, 'value for {} changed to {}'.format(key, data))
@@ -59,6 +56,13 @@ class BGPConfigManager(object):
                 # Neighbor is deleted
                 command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'no neighbor {}'".format(self.bgp_asn, key)
                 run_command(command)
+
+    def __bgp_handler(self, key, op, data):
+        self.bgp_message.put((key, op, data))
+        # If ASN doesn't be set, we just cache this message until the ASN is set.
+        if self.bgp_asn == None:
+            return
+        self.__update_bgp()
 
 
 class Daemon(object):

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -32,7 +32,6 @@ class BGPConfigManager(object):
             or "bgp_asn" not in data \
                 or self.bgp_asn == data["bgp_asn"]:
             return
-        syslog.syslog(syslog.LOG_INFO, 'ASN changed to {} from {}, restart BGP...'.format(data['bgp_asn'], self.bgp_asn))
 
         # TODO add ASN update commands 
 

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -33,8 +33,9 @@ class BGPConfigManager(object):
                 or self.bgp_asn == data["bgp_asn"]:
             return
         syslog.syslog(syslog.LOG_INFO, 'ASN changed to {} from {}, restart BGP...'.format(data['bgp_asn'], self.bgp_asn))
-        run_command("supervisorctl restart start.sh")
-        run_command("service frr restart")
+
+        # TODO add ASN update commands 
+
         self.bgp_asn = data["bgp_asn"]
         self.__update_bgp()
 

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -11,12 +11,12 @@ from swsscommon import swsscommon
 
 
 def run_command(command):
-    syslog.syslog(syslog.LOG_DEBUG, "[bgp cfgd] execute command {}.".format(command))
+    syslog.syslog(syslog.LOG_DEBUG, "execute command {}.".format(command))
     p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
     stdout = p.communicate()[0]
     p.wait()
     if p.returncode != 0:
-        syslog.syslog(syslog.LOG_ERR, '[bgp cfgd] command execution returned {}. Command: "{}", stdout: "{}"'.format(p.returncode, command, stdout))
+        syslog.syslog(syslog.LOG_ERR, 'command execution returned {}. Command: "{}", stdout: "{}"'.format(p.returncode, command, stdout))
 
 
 class BGPConfigManager(object):
@@ -32,19 +32,19 @@ class BGPConfigManager(object):
             or "bgp_asn" not in data \
                 or self.bgp_asn == data["bgp_asn"]:
             return
-        syslog.syslog(syslog.LOG_INFO, '[bgp cfgd] ASN changed to {} from {}, restart BGP...'.format(data['bgp_asn'], self.bgp_asn))
+        syslog.syslog(syslog.LOG_INFO, 'ASN changed to {} from {}, restart BGP...'.format(data['bgp_asn'], self.bgp_asn))
         run_command("supervisorctl restart start.sh")
         run_command("service frr restart")
         self.bgp_asn = data["bgp_asn"]
     
     def __bgp_handler(self, key, op, data):
         self.bgp_message.put((key, op, data))
-        # If ASN was setted
+        # If ASN was set
         if self.bgp_asn == None:
             return
         while not self.bgp_message.empty():
             key, op, data = self.bgp_message.get()
-            syslog.syslog(syslog.LOG_INFO, '[bgp cfgd] value for {} changed to {}'.format(key, data))
+            syslog.syslog(syslog.LOG_INFO, 'value for {} changed to {}'.format(key, data))
             if op == swsscommon.SET_COMMAND:
                 command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'neighbor {} remote-as {}'".format(self.bgp_asn, key, data['asn'])
                 run_command(command)
@@ -110,9 +110,11 @@ class Daemon(object):
 
 
 def main():
+    syslog.openlog("bgpcfgd")
     daemon = Daemon()
     bgp_manager = BGPConfigManager(daemon)
     daemon.start()
+    syslog.closelog()
 
 if __name__ == "__main__":
     main()

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -1,64 +1,117 @@
 #!/usr/bin/env python
 
 import sys
+import copy
+import Queue
 import redis
 import subprocess
 import syslog
-from swsssdk import ConfigDBConnector
+import os
+from swsscommon import swsscommon
 
-class BGPConfigDaemon:
+
+def run_command(command):
+    syslog.syslog(syslog.LOG_DEBUG, "[bgp cfgd] execute command {}.".format(command))
+    p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+    stdout = p.communicate()[0]
+    p.wait()
+    if p.returncode != 0:
+        syslog.syslog(syslog.LOG_ERR, '[bgp cfgd] command execution returned {}. Command: "{}", stdout: "{}"'.format(p.returncode, command, stdout))
+
+
+class BGPConfigManager(object):
+    def __init__(self, daemon):
+        self.daemon = daemon
+        self.bgp_asn = None
+        self.bgp_message = Queue.Queue(0)
+        daemon.add_manager(swsscommon.CONFIG_DB, swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, self.__metadata_handler)
+        daemon.add_manager(swsscommon.CONFIG_DB, swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME, self.__bgp_handler)
+
+    def __metadata_handler(self, key, op, data):
+        if key != "localhost" \
+            or "bgp_asn" not in data \
+                or self.bgp_asn == data["bgp_asn"]:
+            return
+        syslog.syslog(syslog.LOG_INFO, '[bgp cfgd] ASN changed to {} from {}, restart BGP...'.format(data['bgp_asn'], self.bgp_asn))
+        run_command("supervisorctl restart start.sh")
+        run_command("service frr restart")
+        self.bgp_asn = data["bgp_asn"]
+    
+    def __bgp_handler(self, key, op, data):
+        self.bgp_message.put((key, op, data))
+        # If ASN was setted
+        if self.bgp_asn == None:
+            return
+        while not self.bgp_message.empty():
+            key, op, data = self.bgp_message.get()
+            syslog.syslog(syslog.LOG_INFO, '[bgp cfgd] value for {} changed to {}'.format(key, data))
+            if op == swsscommon.SET_COMMAND:
+                command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'neighbor {} remote-as {}'".format(self.bgp_asn, key, data['asn'])
+                run_command(command)
+                if "name" in data:
+                    command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'neighbor {} description {}'".format(self.bgp_asn, key, data['name'])
+                    run_command(command)
+                if "admin_status" in data:
+                    command_mod = "no " if data["admin_status"] == "up" else ""
+                    command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c '{}neighbor {} shutdown'".format(self.bgp_asn, command_mod, key)
+                    run_command(command)                
+            elif op == swsscommon.DEL_COMMAND:
+                # Neighbor is deleted
+                command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'no neighbor {}'".format(self.bgp_asn, key)
+                run_command(command)
+
+
+class Daemon(object):
+   
+    SELECT_TIMEOUT = 1000
+    SUPPORT_DATABASE_LIST = (swsscommon.APPL_DB, swsscommon.CONFIG_DB)
 
     def __init__(self):
-        self.config_db = ConfigDBConnector()
-        self.config_db.connect()
-        self.bgp_asn = self.config_db.get_entry('DEVICE_METADATA', 'localhost')['bgp_asn']
-        self.bgp_neighbor = self.config_db.get_table('BGP_NEIGHBOR')
+        self.appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, swsscommon.DBConnector.DEFAULT_UNIXSOCKET, 0)
+        self.conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, swsscommon.DBConnector.DEFAULT_UNIXSOCKET, 0)
+        self.selector = swsscommon.Select()
+        self.db_connectors = {}
+        self.callbacks = {}
+        self.subscribers = set()
 
-    def __run_command(self, command):
-#        print command
-        p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
-        stdout = p.communicate()[0]
-        p.wait()
-        if p.returncode != 0:
-            syslog.syslog(syslog.LOG_ERR, '[bgp cfgd] command execution returned {}. Command: "{}", stdout: "{}"'.format(p.returncode, command, stdout))
+    def get_db_connector(self, db):
+        if db not in Daemon.SUPPORT_DATABASE_LIST:
+            raise ValueError("database {} not Daemon support list {}.".format(db, SUPPORT_DATABASE_LIST))
+        # if this database connector has been initialized
+        if db not in self.db_connectors:
+            self.db_connectors[db] = swsscommon.DBConnector(db, swsscommon.DBConnector.DEFAULT_UNIXSOCKET, 0)
+        return self.db_connectors[db]
 
-    def metadata_handler(self, key, data):
-        if key == 'localhost' and data.has_key('bgp_asn'):
-            if data['bgp_asn'] != self.bgp_asn:
-                syslog.syslog(syslog.LOG_INFO, '[bgp cfgd] ASN changed to {} from {}, restart BGP...'.format(data['bgp_asn'], self.bgp_asn))
-                self.__run_command("supervisorctl restart start.sh")
-                self.__run_command("service quagga restart")
-                self.bgp_asn = data['bgp_asn']
-
-    def bgp_handler(self, key, data):
-        syslog.syslog(syslog.LOG_INFO, '[bgp cfgd] value for {} changed to {}'.format(key, data))
-        if not data:
-            # Neighbor is deleted
-            command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'no neighbor {}'".format(self.bgp_asn, key)
-            self.__run_command(command)
-            self.bgp_neighbor.pop(key)
-        else:
-            command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'neighbor {} remote-as {}'".format(self.bgp_asn, key, data['asn'])
-            self.__run_command(command)
-            if data.has_key('name'):
-                command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c 'neighbor {} description {}'".format(self.bgp_asn, key, data['name'])
-                self.__run_command(command)
-            if data.has_key('admin_status'):
-                command_mod = 'no ' if data['admin_status'] == 'up' else ''
-                command = "vtysh -c 'configure terminal' -c 'router bgp {}' -c '{}neighbor {} shutdown'".format(self.bgp_asn, command_mod, key)
-                self.__run_command(command)
-            self.bgp_neighbor[key] = data
+    def add_manager(self, db, table_name, callback):
+        if db not in self.callbacks:
+            self.callbacks[db] = {}
+        if table_name not in self.callbacks[db]:
+            self.callbacks[db][table_name] = []
+            conn = self.get_db_connector(db)
+            subscriber = swsscommon.SubscriberStateTable(conn, table_name)
+            self.subscribers.add(subscriber)
+            self.selector.addSelectable(subscriber)
+        self.callbacks[db][table_name].append(callback)
 
     def start(self):
-        self.config_db.subscribe('BGP_NEIGHBOR', 
-                lambda table, key, data: self.bgp_handler(key, data))
-        self.config_db.subscribe('DEVICE_METADATA',
-                lambda table, key, data: self.metadata_handler(key, data))
-        self.config_db.listen()
+        while True:
+            state, selectable = self.selector.select(Daemon.SELECT_TIMEOUT)
+            if not selectable:
+                continue
+            for subscriber in self.subscribers:
+                key, op, fvs = subscriber.pop()
+                # if no new message
+                if not key:
+                    continue
+                data = dict(fvs)
+                syslog.syslog(syslog.LOG_DEBUG, "Receive message : {}".format((key, op, fvs)))
+                for callback in self.callbacks[subscriber.getDbConnector().getDbId()][subscriber.getTableName()]:
+                    callback(key, op, data)
 
 
 def main():
-    daemon = BGPConfigDaemon()
+    daemon = Daemon()
+    bgp_manager = BGPConfigManager(daemon)
     daemon.start()
 
 if __name__ == "__main__":

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -60,7 +60,7 @@ class BGPConfigManager(object):
 
     def __bgp_handler(self, key, op, data):
         self.bgp_message.put((key, op, data))
-        # If ASN doesn't be set, we just cache this message until the ASN is set.
+        # If ASN is not set, we just cache this message until the ASN is set.
         if self.bgp_asn == None:
             return
         self.__update_bgp()


### PR DESCRIPTION
Update interfaces of bgpcfd from swsssdk to swsscommon to unify a suit of interface with other component. Meanwhile, we can listen multiple tables at one thread under swsscommon interface.
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Move the interface of bgpcfgd from swsssdk to swsscommon. Because bgpcfgd need to listen more events in the future and we want to maintain one kind of APIs, swsscommon is more suitable than swsssdk. 

**- How I did it**
Refactor the BGPConfigDaemon to two components, `Daemon` and `BGPConfigManager`. We can register new managers to the Daemon object if we want to listen more events.

**- How to verify it**
If it can pass all existing test cases, which means this update is success.

**- Description for the changelog**
Update interface of bgpcfgd from swsssdk to swsscommon

**- A picture of a cute animal (not mandatory but encouraged)**
