### PR TITLE
[mellanox]: fix orchagent start args for mellanox

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -29,6 +29,8 @@ elif [ "$platform" == "barefoot" ]; then
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
 elif [ "$platform" == "vs" ]; then
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
+elif [ "$platform" == "mellanox" ]; then
+    ORCHAGENT_ARGS+=""
 else
     MAC_ADDRESS=`sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'`
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"


### PR DESCRIPTION
Bug is introduced in #2980. Mellanox does not support setting
MAC on switch create.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
