### PR TITLE
[Platform] Marvell hwsku ET6448M i2c slave access fixes

### DIFF
--- a/device/marvell/armhf-marvell_et6448m_52x-r0/plugins/psuutil.py
+++ b/device/marvell/armhf-marvell_et6448m_52x-r0/plugins/psuutil.py
@@ -1,7 +1,18 @@
 #!/usr/bin/env python
 
+import sys
 import os.path
-import subprocess
+if sys.version_info[0] < 3:
+    import commands as cmd
+else:
+    import subprocess as cmd
+
+smbus_present = 1
+try:
+   import smbus
+except ImportError as e:
+   smbus_present = 0 
+
 try:
     from sonic_psu.psu_base import PsuBase
 except ImportError as e:
@@ -21,34 +32,45 @@ class PsuUtil(PsuBase):
     def get_psu_status(self, index):
         if index is None:
            return False
-
-        cmdstatus, psustatus = subprocess.getstatusoutput('i2cget -y 0 0x41 0xa') #need to verify the cpld register logic
-        psustatus = int(psustatus, 16)
-        if cmdstatus == 0:
-            if index == 1:
-                psustatus = psustatus&4
-                if psustatus == 4 :
-                    return True
-            if index == 2:
-                psustatus = psustatus&8
-                if psustatus == 8 :
-                    return True
+        if smbus_present == 0: 
+             cmdstatus, psustatus = cmd.getstatusoutput('i2cget -y 0 0x41 0xa') #need to verify the cpld register logic
+             psustatus = int(psustatus, 16)
+        else :
+             bus = smbus.SMBus(0)
+             DEVICE_ADDRESS = 0x41
+             DEVICE_REG = 0xa
+             psustatus = bus.read_byte_data(DEVICE_ADDRESS, DEVICE_REG)
+        if index == 1:
+            psustatus = psustatus&4
+            if psustatus == 4 :
+               return True
+        if index == 2:
+            psustatus = psustatus&8
+            if psustatus == 8 :
+               return True
+                    
         return False
 
     def get_psu_presence(self, index):
         if index is None:
             return False
 
-        cmdstatus , psustatus = subprocess.getstatusoutput('i2cget -y 0 0x41 0xa') #need to verify the cpld register logic
-        psustatus = int(psustatus, 16)
-        if cmdstatus == 0:
-            if index == 1:
-                 psustatus = psustatus&1
-                 if psustatus == 1 :
-                     return True
-            if index == 2:
-                psustatus = psustatus&2
-                if psustatus == 2 :
-                    return True
+        if smbus_present == 0: 
+             cmdstatus, psustatus = cmd.getstatusoutput('i2cget -y 0 0x41 0xa') #need to verify the cpld register logic
+             psustatus = int(psustatus, 16)
+        else :
+             bus = smbus.SMBus(0)
+             DEVICE_ADDRESS = 0x41
+             DEVICE_REG = 0xa
+             psustatus = bus.read_byte_data(DEVICE_ADDRESS, DEVICE_REG)
+
+        if index == 1:
+             psustatus = psustatus&1
+             if psustatus == 1 :
+                 return True
+        if index == 2:
+            psustatus = psustatus&2
+            if psustatus == 2 :
+                return True
         return False
 


### PR DESCRIPTION
Fixed i2c access for PSU and SFP utils
Signed-off-by: Antony Rheneus <arheneus@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
