### PR TITLE
add kernel coredump and analysis on sonic kernel

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -161,6 +161,7 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            PLATFORM_ARCH=$(PLATFORM_ARCH) \
                            BUILD_NUMBER=$(BUILD_NUMBER) \
                            BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
+                           SONIC_ENABLE_KDUMP=$(SONIC_ENABLE_KDUMP) \
                            ENABLE_DHCP_GRAPH_SERVICE=$(ENABLE_DHCP_GRAPH_SERVICE) \
                            SHUTDOWN_BGP_ON_START=$(SHUTDOWN_BGP_ON_START) \
                            SONIC_ENABLE_PFCWD_ON_START=$(ENABLE_PFCWD_ON_START) \

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -368,13 +368,12 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get clean
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get autoremove -y
 
 # install kernel dump utility
-{% set coredump = [ "crash", "makedumpfile" ] -%}
-{% for pkg in coredump -%}
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y {{ pkg }}
-{% endfor -%}
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y kdump-tools || true
 sudo sed -i 's/\/MODULES=dep\//\/MODULES=most\//' $FILESYSTEM_ROOT/etc/kernel/postinst.d/kdump-tools
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y kdump-tools
+{% if sonic_kdump_enable == "y" %}
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y crash
+{% endif -%}
 
 {% for file in installer_extra_files.split(' ') -%}
 {% if file.strip() -%}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -367,6 +367,15 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get purge
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get clean -y
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get autoremove -y
 
+# install kernel dump utility
+{% set coredump = [ "crash", "makedumpfile" ] -%}
+{% for pkg in coredump -%}
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y {{ pkg }}
+{% endfor -%}
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y kdump-tools || true
+sudo sed -i 's/\/MODULES=dep\//\/MODULES=most\//' $FILESYSTEM_ROOT/etc/kernel/postinst.d/kdump-tools
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y kdump-tools
+
 {% for file in installer_extra_files.split(' ') -%}
 {% if file.strip() -%}
 {% set src = file.split(':')[0] -%}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -368,6 +368,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get clean
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get autoremove -y
 
 # install kernel dump utility
+{%- if sonic_kdump_enable == "y" %}
 {% set coredump = [ "crash", "makedumpfile" ] -%}
 {% for pkg in coredump -%}
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y {{ pkg }}
@@ -375,6 +376,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get insta
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y kdump-tools || true
 sudo sed -i 's/\/MODULES=dep\//\/MODULES=most\//' $FILESYSTEM_ROOT/etc/kernel/postinst.d/kdump-tools
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y kdump-tools
+{% endif -%}
 
 {% for file in installer_extra_files.split(' ') -%}
 {% if file.strip() -%}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -368,7 +368,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get clean
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get autoremove -y
 
 # install kernel dump utility
-{%- if sonic_kdump_enable == "y" %}
 {% set coredump = [ "crash", "makedumpfile" ] -%}
 {% for pkg in coredump -%}
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y {{ pkg }}
@@ -376,7 +375,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get insta
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y kdump-tools || true
 sudo sed -i 's/\/MODULES=dep\//\/MODULES=most\//' $FILESYSTEM_ROOT/etc/kernel/postinst.d/kdump-tools
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y kdump-tools
-{% endif -%}
 
 {% for file in installer_extra_files.split(' ') -%}
 {% if file.strip() -%}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -370,6 +370,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get autor
 # install kernel dump utility
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y kdump-tools || true
 sudo sed -i 's/\/MODULES=dep\//\/MODULES=most\//' $FILESYSTEM_ROOT/etc/kernel/postinst.d/kdump-tools
+# TODO : this is a work around due to current kdump-tools package bug, should be removed when bug fixed
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y kdump-tools
 {% if sonic_kdump_enable == "y" %}
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get install -y crash

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -325,11 +325,15 @@ if [ -f $FIRST_BOOT_FILE ]; then
         # Initialize the SONiC's grub config
         mv /host/grub.cfg /host/grub/grub.cfg
     fi
-    sed -i 's/[^M] quiet/ crashkernel=256M quiet/' /host/grub/grub.cfg
 
-    kdump-config unload
-    kdump-config symlinks `uname -r`
-    kdump-config load
+    if `dpkg -l kdump-tools > /dev/null 2>&1`;
+    then
+	sed -i 's/[^M] quiet/ crashkernel=256M quiet/' /host/grub/grub.cfg
+
+	kdump-config unload
+	kdump-config symlinks `uname -r`
+	kdump-config load
+    fi
 
     firsttime_exit
 fi

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -325,6 +325,11 @@ if [ -f $FIRST_BOOT_FILE ]; then
         # Initialize the SONiC's grub config
         mv /host/grub.cfg /host/grub/grub.cfg
     fi
+    sed -i 's/[^M] quiet/ crashkernel=768M quiet/' /host/grub/grub.cfg
+
+    kdump-config unload
+    kdump-config symlinks `uname -r`
+    kdump-config load
 
     firsttime_exit
 fi

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -326,8 +326,7 @@ if [ -f $FIRST_BOOT_FILE ]; then
         mv /host/grub.cfg /host/grub/grub.cfg
     fi
 
-    if `grep crashkernel=256M /proc/cmdline > /dev/null 2>&1`;
-    then
+    if `grep crashkernel=256M /proc/cmdline > /dev/null 2>&1`; then
 	kdump-config unload
 	kdump-config symlinks `uname -r`
 	kdump-config load

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -325,7 +325,7 @@ if [ -f $FIRST_BOOT_FILE ]; then
         # Initialize the SONiC's grub config
         mv /host/grub.cfg /host/grub/grub.cfg
     fi
-    sed -i 's/[^M] quiet/ crashkernel=768M quiet/' /host/grub/grub.cfg
+    sed -i 's/[^M] quiet/ crashkernel=256M quiet/' /host/grub/grub.cfg
 
     kdump-config unload
     kdump-config symlinks `uname -r`

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -326,10 +326,11 @@ if [ -f $FIRST_BOOT_FILE ]; then
         mv /host/grub.cfg /host/grub/grub.cfg
     fi
 
-    if `grep crashkernel=256M /proc/cmdline > /dev/null 2>&1`; then
-	kdump-config unload
-	kdump-config symlinks `uname -r`
-	kdump-config load
+    if `grep crashkernel=256M /proc/cmdline > /dev/null 2>&1`;
+    then
+        kdump-config unload
+        kdump-config symlinks `uname -r`
+        kdump-config load
     fi
 
     firsttime_exit

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -326,10 +326,8 @@ if [ -f $FIRST_BOOT_FILE ]; then
         mv /host/grub.cfg /host/grub/grub.cfg
     fi
 
-    if `dpkg -l kdump-tools > /dev/null 2>&1`;
+    if `grep crashkernel=256M /proc/cmdline > /dev/null 2>&1`;
     then
-	sed -i 's/[^M] quiet/ crashkernel=256M quiet/' /host/grub/grub.cfg
-
 	kdump-config unload
 	kdump-config symlinks `uname -r`
 	kdump-config load

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -125,6 +125,9 @@ if [ "$install_env" = "onie" ]; then
     onie_initrd_tmp=/
 fi
 
+enable_kdump="%%ENABLE_KDUMP%%"
+KDUMP_PARAM="crashkernel=256M"
+
 # The build system prepares this script by replacing %%DEMO-TYPE%%
 # with "OS" or "DIAG".
 demo_type="%%DEMO_TYPE%%"
@@ -536,7 +539,11 @@ trap_push "rm $grub_cfg || true"
 [ -r ./platform.conf ] && . ./platform.conf
 
 DEFAULT_GRUB_SERIAL_COMMAND="serial --port=${CONSOLE_PORT} --speed=${CONSOLE_SPEED} --word=8 --parity=no --stop=1"
-DEFAULT_GRUB_CMDLINE_LINUX="console=tty0 console=ttyS${CONSOLE_DEV},${CONSOLE_SPEED}n8 quiet"
+if [ $enable_kdump = "y" ];then
+    DEFAULT_GRUB_CMDLINE_LINUX="console=tty0 console=ttyS${CONSOLE_DEV},${CONSOLE_SPEED}n8 ${KDUMP_PARAM} quiet"
+else
+    DEFAULT_GRUB_CMDLINE_LINUX="console=tty0 console=ttyS${CONSOLE_DEV},${CONSOLE_SPEED}n8 quiet"
+fi
 GRUB_SERIAL_COMMAND=${GRUB_SERIAL_COMMAND:-"$DEFAULT_GRUB_SERIAL_COMMAND"}
 GRUB_CMDLINE_LINUX=${GRUB_CMDLINE_LINUX:-"$DEFAULT_GRUB_CMDLINE_LINUX"}
 export GRUB_SERIAL_COMMAND

--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -89,10 +89,8 @@ output_raw_image=$(cat onie-image.conf | grep OUTPUT_RAW_IMAGE | cut -f2 -d"=")
 output_raw_image=$(eval echo $output_raw_image)
 
 # Tailor the demo installer for OS mode or DIAG mode
-if [ $sonic_kdump_enable = "y" ]; then
-    sed -i "s/[^M] quiet/ crashkernel=256M quiet/" $tmp_installdir/install.sh
-fi
-sed -i -e "s/%%DEMO_TYPE%%/$demo_type/g" \
+sed -i -e "s/%%ENABLE_KDUMP%%/$sonic_kdump_enable/g" \
+       -e "s/%%DEMO_TYPE%%/$demo_type/g" \
        -e "s/%%IMAGE_VERSION%%/$image_version/g" \
        -e "s/%%ONIE_IMAGE_PART_SIZE%%/$onie_image_part_size/" \
        -e "s/%%EXTRA_CMDLINE_LINUX%%/$EXTRA_CMDLINE_LINUX/" \

--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -89,6 +89,10 @@ output_raw_image=$(cat onie-image.conf | grep OUTPUT_RAW_IMAGE | cut -f2 -d"=")
 output_raw_image=$(eval echo $output_raw_image)
 
 # Tailor the demo installer for OS mode or DIAG mode
+if [ $sonic_kdump_enable == "y" ];
+then
+    sed -i "s/[^M] quiet/ crashkernel=256M quiet/"
+fi
 sed -i -e "s/%%DEMO_TYPE%%/$demo_type/g" \
        -e "s/%%IMAGE_VERSION%%/$image_version/g" \
        -e "s/%%ONIE_IMAGE_PART_SIZE%%/$onie_image_part_size/" \

--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -89,8 +89,7 @@ output_raw_image=$(cat onie-image.conf | grep OUTPUT_RAW_IMAGE | cut -f2 -d"=")
 output_raw_image=$(eval echo $output_raw_image)
 
 # Tailor the demo installer for OS mode or DIAG mode
-if [ $sonic_kdump_enable = "y" ];
-then
+if [ $sonic_kdump_enable = "y" ]; then
     sed -i "s/[^M] quiet/ crashkernel=256M quiet/" $tmp_installdir/install.sh
 fi
 sed -i -e "s/%%DEMO_TYPE%%/$demo_type/g" \

--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -89,9 +89,9 @@ output_raw_image=$(cat onie-image.conf | grep OUTPUT_RAW_IMAGE | cut -f2 -d"=")
 output_raw_image=$(eval echo $output_raw_image)
 
 # Tailor the demo installer for OS mode or DIAG mode
-if [ $sonic_kdump_enable == "y" ];
+if [ $sonic_kdump_enable = "y" ];
 then
-    sed -i "s/[^M] quiet/ crashkernel=256M quiet/"
+    sed -i "s/[^M] quiet/ crashkernel=256M quiet/" $tmp_installdir/install.sh
 fi
 sed -i -e "s/%%DEMO_TYPE%%/$demo_type/g" \
        -e "s/%%IMAGE_VERSION%%/$image_version/g" \

--- a/slave.mk
+++ b/slave.mk
@@ -185,6 +185,7 @@ ifeq ($(SONIC_ROUTING_STACK),frr)
 $(info "FRR_USER_UID"                    : "$(FRR_USER_UID)")
 $(info "FRR_USER_GID"                    : "$(FRR_USER_GID)")
 endif
+$(info "ENABLE_KDUMP"                    : "$(SONIC_ENABLE_KDUMP)")
 $(info "ENABLE_SYNCD_RPC"                : "$(ENABLE_SYNCD_RPC)")
 $(info "ENABLE_ORGANIZATION_EXTENSIONS"  : "$(ENABLE_ORGANIZATION_EXTENSIONS)")
 $(info "HTTP_PROXY"                      : "$(HTTP_PROXY)")
@@ -648,6 +649,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	export platform_common_py2_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_PLATFORM_COMMON_PY2))"
 	export redis_dump_load_py2_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(REDIS_DUMP_LOAD_PY2))"
 	export install_debug_image="$(INSTALL_DEBUG_TOOLS)"
+	export sonic_kdump_enable="$(SONIC_KDUMP_ENABLE)"
 
 	$(foreach docker, $($*_DOCKERS),\
 		export docker_image="$(docker)"

--- a/slave.mk
+++ b/slave.mk
@@ -649,7 +649,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	export platform_common_py2_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_PLATFORM_COMMON_PY2))"
 	export redis_dump_load_py2_wheel_path="$(addprefix $(PYTHON_WHEELS_PATH)/,$(REDIS_DUMP_LOAD_PY2))"
 	export install_debug_image="$(INSTALL_DEBUG_TOOLS)"
-	export sonic_kdump_enable="$(SONIC_KDUMP_ENABLE)"
+	export sonic_kdump_enable="$(SONIC_ENABLE_KDUMP)"
 
 	$(foreach docker, $($*_DOCKERS),\
 		export docker_image="$(docker)"


### PR DESCRIPTION
Summary: add kdump package to j2 template and config after

this is the to add kdump to capture the kernel crash core and for further analysis by crash tool

in this PR, contain two part

1,  install kdump tool chain to host environment
2,  configure kdump tool in both boot up via grub.cfg and system level

test done:

test build process, build sonic-broadcom.bin and sonic-aboot-broadcom.swi

-rwxr-xr-x  1 sun sun 562086493 Jul 28 21:28 sonic-aboot-broadcom.swi
-rw-r--r--  1 sun sun    215882 Jul 28 21:28 sonic-aboot-broadcom.swi.log
-rwxr-xr-x  1 sun sun 569867542 Jul 28 00:52 sonic-broadcom.bin
-rw-r--r--  1 sun sun    285585 Jul 28 00:52 sonic-broadcom.bin.log

test image, load sonic-broadcom.bin to switch

 Signed-off-by: siyuan sun siyuan.sun@alibaba-inc.com