### PR TITLE
[sonic_daemon_base]Fix the issue "'NoneType' object has no attribute 'closelog'"

### DIFF
--- a/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
+++ b/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
@@ -49,37 +49,38 @@ def db_connect(db):
 
 class Logger(object):
     def __init__(self, syslog_identifier):
-        syslog.openlog(ident=syslog_identifier, logoption=syslog.LOG_NDELAY, facility=syslog.LOG_DAEMON)
+        self.syslog = syslog
+        self.syslog.openlog(ident=syslog_identifier, logoption=self.syslog.LOG_NDELAY, facility=self.syslog.LOG_DAEMON)
 
     def __del__(self):
-        syslog.closelog()
+        self.syslog.closelog()
 
     def log_error(self, msg, also_print_to_console=False):
-        syslog.syslog(syslog.LOG_ERR, msg)
+        self.syslog.syslog(self.syslog.LOG_ERR, msg)
 
         if also_print_to_console:
             print msg
 
     def log_warning(self, msg, also_print_to_console=False):
-        syslog.syslog(syslog.LOG_WARNING, msg)
+        self.syslog.syslog(self.syslog.LOG_WARNING, msg)
 
         if also_print_to_console:
             print msg
 
     def log_notice(self, msg, also_print_to_console=False):
-        syslog.syslog(syslog.LOG_NOTICE, msg)
+        self.syslog.syslog(self.syslog.LOG_NOTICE, msg)
 
         if also_print_to_console:
             print msg
 
     def log_info(self, msg, also_print_to_console=False):
-        syslog.syslog(syslog.LOG_INFO, msg)
+        self.syslog.syslog(self.syslog.LOG_INFO, msg)
 
         if also_print_to_console:
             print msg
 
     def log_debug(self, msg, also_print_to_console=False):
-        syslog.syslog(syslog.LOG_DEBUG, msg)
+        self.syslog.syslog(self.syslog.LOG_DEBUG, msg)
 
         if also_print_to_console:
             print msg
@@ -98,15 +99,15 @@ class DaemonBase(object):
     # Signal handler
     def signal_handler(self, sig, frame):
         if sig == signal.SIGHUP:
-            syslog.syslog(syslog.LOG_INFO, "Caught SIGHUP - ignoring...")
+            self.syslog.syslog(self.syslog.LOG_INFO, "Caught SIGHUP - ignoring...")
         elif sig == signal.SIGINT:
-            syslog.syslog(syslog.LOG_INFO, "Caught SIGINT - exiting...")
+            self.syslog.syslog(self.syslog.LOG_INFO, "Caught SIGINT - exiting...")
             sys.exit(128 + sig)
         elif sig == signal.SIGTERM:
-            syslog.syslog(syslog.LOG_INFO, "Caught SIGTERM - exiting...")
+            self.syslog.syslog(self.syslog.LOG_INFO, "Caught SIGTERM - exiting...")
             sys.exit(128 + sig)
         else:
-            syslog.syslog(syslog.LOG_WARNING, "Caught unhandled signal '" + sig + "'")
+            self.syslog.syslog(self.syslog.LOG_WARNING, "Caught unhandled signal '" + sig + "'")
 
     # Returns platform and hwsku
     def get_platform_and_hwsku(self):


### PR DESCRIPTION
**- What I did**
Fix the issue "'NoneType' object has no attribute 'closelog'" which results from referencing an already destroyed global variable "syslog" when destructuring daemon_base.Logger. The root cause is that python doesn't have a definite sequence in which objects being destroyed when a program exits.
This issue is only observed when sonic_platform/chassis.py is loaded via python shell.

**- How I did it**
Introduce a class member to represent the "syslog" so that it is accessible during the class destructing.

**- How to verify it**
verify whether the information can be logged and confirm no error message when the process exits

**- Description for the changelog**
[sonic_daemon_base]fix the issue "'NoneType' object has no attribute 'closelog'"

**- A picture of a cute animal (not mandatory but encouraged)**
