### PR TITLE
[Mellanox] mlnx-sfpd init flow enhancement

### DIFF
--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -129,7 +129,7 @@ class MlnxSfpd:
                     sx_api_host_ifc_open_pass = True
                     retry = 1
                 else:
-                    log_warning("sx_api_host_ifc_open return fail... retrying {}".format(retry))
+                    log_warning("sx_api_host_ifc_open failed with error code {}... retrying {}".format(rc,retry))
                     time.sleep(2 ** retry)
                     retry += 1
                     if retry > self.SX_OPEN_RETRIES:
@@ -148,13 +148,13 @@ class MlnxSfpd:
                     sx_api_host_ifc_trap_id_register_set_pass = True
                     break
                 else:
-                    log_warning("sx_api_host_ifc_trap_id_register_set return fail... retrying {}".format(retry))
+                    log_warning("sx_api_host_ifc_trap_id_register_set failed with error code {}... retrying {}".format(rc,retry))
                     time.sleep(2 ** retry)
                     retry += 1
                     if retry > self.SX_OPEN_RETRIES:
                         sx_api_host_ifc_close(self.handle, self.rx_fd_p)
                         sx_api_close(self.handle)
-                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set exited with error, rc {}".format(rc))
+                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set failed with error after {} retries".format(retry))
                     else:
                         continue
         

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -28,6 +28,12 @@ STATUS_PLUGIN = '1'
 STATUS_PLUGOUT = '0'
 STATUS_UNKNOWN = '2'
 
+INITIALIZING_PHASE_NONE = 0
+INITIALIZING_PHASE_SX_API_OPENED = 1
+INITIALIZING_PHASE_HOST_IFC_OPENED = 2
+INITIALIZING_PHASE_SWITCH_CREATED = 3
+INITIALIZING_PHASE_HOST_IFC_TRAPID_SET = 4
+
 SFPD_LIVENESS_EXPIRE_SECS = 30
 
 SDK_DAEMON_READY_FILE = '/tmp/sdk_ready'
@@ -66,7 +72,8 @@ def log_error(msg, also_print_to_console=False):
 class MlnxSfpd:
     ''' Listen to plugin/plugout cable events '''
 
-    SX_OPEN_RETRIES = 10
+    SX_OPEN_RETRIES = 30
+    SX_OPEN_TIMEOUT = 5
     SELECT_TIMEOUT = 1
 
     def __init__(self):
@@ -99,68 +106,86 @@ class MlnxSfpd:
     def initialize(self):
         self.state_db.connect("STATE_DB")
 
-        # Wait for SDK daemon to be started with detect the sdk_ready file     
-        retry = 0
-        while not os.path.exists(SDK_DAEMON_READY_FILE):  
-            if retry >= self.SX_OPEN_RETRIES:
-                raise RuntimeError("SDK daemon failed to start after {} retries, exiting...".format(retry))
-            else:
-                log_info("SDK daemon not started yet, retry {} times".format(retry))
-                retry = retry + 1
-                time.sleep(2 ** retry)
-        
-        # After SDK daemon started, sx_api_open and sx_api_host_ifc_open is ready for call
-        rc, self.handle = sx_api_open(None)
-        if rc != SX_STATUS_SUCCESS:
-            raise RuntimeError("failed to call sx_api_open with rc {}, exiting...".format(rc))
+        initializing_phase = INITIALIZING_PHASE_NONE
 
-        rc = sx_api_host_ifc_open(self.handle, self.rx_fd_p)
-        if rc != SX_STATUS_SUCCESS:
-            sx_api_close(self.handle)
-            raise RuntimeError("failed to call sx_api_host_ifc_open with rc {}, exiting...".format(rc))
+        swid_cnt_p = None
 
-        self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
-        self.user_channel_p.channel.fd = self.rx_fd_p
-
-        # Wait for switch to be created and inited inside SDK
-        retry = 0
-        swid_cnt_p = new_uint32_t_p()
-        uint32_t_p_assign(swid_cnt_p, 0)
-        swid_cnt = 0
-        while True:
-            if retry > self.SX_OPEN_RETRIES:
-                delete_uint32_t_p(swid_cnt_p)
-                sx_api_host_ifc_close(self.handle, self.rx_fd_p)
-                sx_api_close(self.handle)
-                raise RuntimeError("switch not created after {} retries, exiting...".format(retry))
-            else:
-                rc = sx_api_port_swid_list_get(self.handle, None, swid_cnt_p)
-                if rc == SX_STATUS_SUCCESS:
-                    swid_cnt = uint32_t_p_value(swid_cnt_p)
-                    if swid_cnt > 0:
-                        delete_uint32_t_p(swid_cnt_p)
-                        break
-                    else:
-                        log_info("switch not created yet, swid_cnt {}, retry {} times".format(swid_cnt, retry))
+        try:
+            # Wait for SDK daemon to be started with detect the sdk_ready file
+            retry = 0
+            while not os.path.exists(SDK_DAEMON_READY_FILE):  
+                if retry >= self.SX_OPEN_RETRIES:
+                    raise RuntimeError("SDK daemon failed to start after {} retries and {} seconds waiting, exiting..."
+                        .format(retry, self.SX_OPEN_TIMEOUT * self.SX_OPEN_RETRIES))
                 else:
-                    log_info("sx_api_port_swid_list_get fail with rc {}, retry {} times".format(rc, retry))
+                    log_info("SDK daemon not started yet, retry {} times".format(retry))
+                    retry = retry + 1
+                    time.sleep(self.SX_OPEN_TIMEOUT)
 
-                retry = retry + 1
-                time.sleep(2 ** retry)
+            # After SDK daemon started, sx_api_open and sx_api_host_ifc_open is ready for call
+            rc, self.handle = sx_api_open(None)
+            if rc != SX_STATUS_SUCCESS:
+                raise RuntimeError("failed to call sx_api_open with rc {}, exiting...".format(rc))
 
-        # After switch was created inside SDK, sx_api_host_ifc_trap_id_register_set is ready to call
-        rc = sx_api_host_ifc_trap_id_register_set(self.handle,
-                                                  SX_ACCESS_CMD_REGISTER,
-                                                  self.swid,
-                                                  SX_TRAP_ID_PMPE,
-                                                  self.user_channel_p)
+            initializing_phase = INITIALIZING_PHASE_SX_API_OPENED
 
-        if rc != SX_STATUS_SUCCESS:
-            sx_api_host_ifc_close(self.handle, self.rx_fd_p)
-            sx_api_close(self.handle)
-            raise RuntimeError("sx_api_host_ifc_trap_id_register_set failed with rc {}, exiting...".format(rc))
-            
-        self.running = True
+            rc = sx_api_host_ifc_open(self.handle, self.rx_fd_p)
+            if rc != SX_STATUS_SUCCESS:
+                raise RuntimeError("failed to call sx_api_host_ifc_open with rc {}, exiting...".format(rc))
+
+            self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
+            self.user_channel_p.channel.fd = self.rx_fd_p
+
+            initializing_phase = INITIALIZING_PHASE_HOST_IFC_OPENED
+
+            # Wait for switch to be created and initialized inside SDK
+            retry = 0
+            swid_cnt_p = new_uint32_t_p()
+            uint32_t_p_assign(swid_cnt_p, 0)
+            swid_cnt = 0
+            while True:
+                if retry > self.SX_OPEN_RETRIES:
+                    raise RuntimeError("switch not created after {} retries and {} seconds waiting, exiting..."
+                        .format(retry, self.SX_OPEN_RETRIES * self.SX_OPEN_TIMEOUT))
+                else:
+                    rc = sx_api_port_swid_list_get(self.handle, None, swid_cnt_p)
+                    if rc == SX_STATUS_SUCCESS:
+                        swid_cnt = uint32_t_p_value(swid_cnt_p)
+                        if swid_cnt > 0:
+                            delete_uint32_t_p(swid_cnt_p)
+                            break
+                        else:
+                            log_info("switch not created yet, swid_cnt {}, retry {} times and wait for {} seconds"
+                                .format(swid_cnt, retry, self.SX_OPEN_TIMEOUT * retry))
+                    else:
+                        raise RuntimeError("sx_api_port_swid_list_get fail with rc {}, retry {} times and wait for {} seconds".
+                            format(rc, retry, self.SX_OPEN_TIMEOUT * retry))
+
+                    retry = retry + 1
+                    time.sleep(self.SX_OPEN_TIMEOUT)
+
+            initializing_phase = INITIALIZING_PHASE_SWITCH_CREATED
+
+            # After switch was created inside SDK, sx_api_host_ifc_trap_id_register_set is ready to call
+            rc = sx_api_host_ifc_trap_id_register_set(self.handle,
+                                                    SX_ACCESS_CMD_REGISTER,
+                                                    self.swid,
+                                                    SX_TRAP_ID_PMPE,
+                                                    self.user_channel_p)
+
+            if rc != SX_STATUS_SUCCESS:
+                raise RuntimeError("sx_api_host_ifc_trap_id_register_set failed with rc {}, exiting...".format(rc))
+
+            self.running = True
+        except Exception as e:
+            log_error("mlnx-sfpd initialization failed due to {}".format(repr(e)))
+            if initializing_phase >= INITIALIZING_PHASE_SX_API_OPENED:
+                if initializing_phase >= INITIALIZING_PHASE_HOST_IFC_OPENED:
+                    if initializing_phase >= INITIALIZING_PHASE_SWITCH_CREATED:
+                        if swid_cnt_p is not None:
+                            delete_uint32_t_p(swid_cnt_p)
+                    sx_api_host_ifc_close(self.handle, self.rx_fd_p)
+                sx_api_close(self.handle)
 
     def deinitialize(self):
         # remove mlnx-sfpd liveness key in DB if not expired yet

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -64,7 +64,7 @@ def log_error(msg, also_print_to_console=False):
 class MlnxSfpd:
     ''' Listen to plugin/plugout cable events '''
 
-    SX_OPEN_RETRIES = 20
+    SX_OPEN_RETRIES = 10
     SELECT_TIMEOUT = 1
 
     def __init__(self):

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/env python
 '''
 This code is for a mlnx platform specific daemon, mlnx-sfpd.
 Which listen to the SDK for the SFP change event and post the event to DB.
@@ -75,7 +75,6 @@ class MlnxSfpd:
         # Allocate SDK fd and user channel structures
         self.rx_fd_p = new_sx_fd_t_p()
         self.user_channel_p = new_sx_user_channel_t_p()
-
         self.state_db = SonicV2Connector(host=REDIS_HOSTIP)
 
         # Register our signal handlers
@@ -114,7 +113,7 @@ class MlnxSfpd:
                     sx_api_open_pass = True
                     retry = 1
                 else:    
-                    log_warning("failed to open SDK API handle... retrying {}".format(retry))
+                    log_warning("failed to open SDK API handle with err code {}... retrying {}".format(rc,retry))
                     time.sleep(2 ** retry)
                     retry += 1
                     if retry > self.SX_OPEN_RETRIES:
@@ -155,7 +154,7 @@ class MlnxSfpd:
                     if retry > self.SX_OPEN_RETRIES:
                         sx_api_host_ifc_close(self.handle, self.rx_fd_p)
                         sx_api_close(self.handle)
-                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set exited with error, rc {}".format(c))
+                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set exited with error, rc {}".format(rc))
                     else:
                         continue
         

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#! /usr/bin/python
 '''
 This code is for a mlnx platform specific daemon, mlnx-sfpd.
 Which listen to the SDK for the SFP change event and post the event to DB.
@@ -101,34 +101,65 @@ class MlnxSfpd:
         # open SDK API handle
         # retry at most SX_OPEN_RETRIES times to wait
         # until SDK is started during system startup
+        
         retry = 1
+        sx_api_open_pass = False
+        sx_api_host_ifc_open_pass = False
+        sx_api_host_ifc_trap_id_register_set_pass = False
+        
         while True:
-            rc, self.handle = sx_api_open(None)
-            if rc == SX_STATUS_SUCCESS:
-                break
+            if not sx_api_open_pass:
+                rc, self.handle = sx_api_open(None)
+                if rc == SX_STATUS_SUCCESS:
+                    sx_api_open_pass = True
+                    retry = 1
+                else:    
+                    log_warning("failed to open SDK API handle... retrying {}".format(retry))
+                    time.sleep(2 ** retry)
+                    retry += 1
+                    if retry > self.SX_OPEN_RETRIES:
+                        raise RuntimeError("failed to open SDK API handle after {} retries".format(retry))
+                    else:
+                        continue
+        
+            if not sx_api_host_ifc_open_pass:
+                rc = sx_api_host_ifc_open(self.handle, self.rx_fd_p)
+                if rc == SX_STATUS_SUCCESS:
+                    self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
+                    self.user_channel_p.channel.fd = self.rx_fd_p
+                    sx_api_host_ifc_open_pass = True
+                    retry = 1
+                else:
+                    log_warning("sx_api_host_ifc_open return fail... retrying {}".format(retry))
+                    time.sleep(2 ** retry)
+                    retry += 1
+                    if retry > self.SX_OPEN_RETRIES:
+                        sx_api_close(self.handle)
+                        raise RuntimeError("sx_api_host_ifc_open failed with error after {} retries".format(retry))
+                    else:
+                        continue
 
-            log_warning("failed to open SDK API handle... retrying {}".format(retry))
-
-            time.sleep(2 ** retry)
-            retry += 1
-
-            if retry > self.SX_OPEN_RETRIES:
-                raise RuntimeError("failed to open SDK API handle after {} retries".format(retry))
-
-        rc = sx_api_host_ifc_open(self.handle, self.rx_fd_p)
-        if rc != SX_STATUS_SUCCESS:
-            raise RuntimeError("sx_api_host_ifc_open exited with error, rc {}".format(rc))
-
-        self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
-        self.user_channel_p.channel.fd = self.rx_fd_p
-
-        rc = sx_api_host_ifc_trap_id_register_set(self.handle,
-                                                  SX_ACCESS_CMD_REGISTER,
-                                                  self.swid,
-                                                  SX_TRAP_ID_PMPE,
-                                                  self.user_channel_p)
-        if rc != SX_STATUS_SUCCESS:
-            raise RuntimeError("sx_api_host_ifc_trap_id_register_set exited with error, rc {}".format(c))
+            if not sx_api_host_ifc_trap_id_register_set_pass:
+                rc = sx_api_host_ifc_trap_id_register_set(self.handle,
+                                                          SX_ACCESS_CMD_REGISTER,
+                                                          self.swid,
+                                                          SX_TRAP_ID_PMPE,
+                                                          self.user_channel_p)
+                if rc == SX_STATUS_SUCCESS:
+                    sx_api_host_ifc_trap_id_register_set_pass = True
+                    break
+                else:
+                    log_warning("sx_api_host_ifc_trap_id_register_set return fail... retrying {}".format(retry))
+                    time.sleep(2 ** retry)
+                    retry += 1
+                    if retry > self.SX_OPEN_RETRIES:
+                        sx_api_host_ifc_close(self.handle, self.rx_fd_p)
+                        sx_api_close(self.handle)
+                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set exited with error, rc {}".format(c))
+                    else:
+                        continue
+        
+        self.running = True
 
     def deinitialize(self):
         # remove mlnx-sfpd liveness key in DB if not expired yet
@@ -156,7 +187,6 @@ class MlnxSfpd:
             log_error("sx_api_close exited with error, rc {}".format(rc))
 
     def run(self):
-        self.running = True
 
         while self.running:
             try:

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -28,12 +28,6 @@ STATUS_PLUGIN = '1'
 STATUS_PLUGOUT = '0'
 STATUS_UNKNOWN = '2'
 
-INITIALIZING_PHASE_NONE = 0
-INITIALIZING_PHASE_SX_API_OPENED = 1
-INITIALIZING_PHASE_HOST_IFC_OPENED = 2
-INITIALIZING_PHASE_SWITCH_CREATED = 3
-INITIALIZING_PHASE_HOST_IFC_TRAPID_SET = 4
-
 SFPD_LIVENESS_EXPIRE_SECS = 30
 
 SDK_DAEMON_READY_FILE = '/tmp/sdk_ready'
@@ -106,8 +100,6 @@ class MlnxSfpd:
     def initialize(self):
         self.state_db.connect("STATE_DB")
 
-        initializing_phase = INITIALIZING_PHASE_NONE
-
         swid_cnt_p = None
 
         try:
@@ -130,8 +122,6 @@ class MlnxSfpd:
             if rc != SX_STATUS_SUCCESS:
                 raise RuntimeError("failed to call sx_api_open with rc {}, exiting...".format(rc))
 
-            initializing_phase = INITIALIZING_PHASE_SX_API_OPENED
-
             rc = sx_api_host_ifc_open(self.handle, self.rx_fd_p)
             if rc != SX_STATUS_SUCCESS:
                 raise RuntimeError("failed to call sx_api_host_ifc_open with rc {}, exiting...".format(rc))
@@ -139,15 +129,13 @@ class MlnxSfpd:
             self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
             self.user_channel_p.channel.fd = self.rx_fd_p
 
-            initializing_phase = INITIALIZING_PHASE_HOST_IFC_OPENED
-
             # Wait for switch to be created and initialized inside SDK
             retry = 0
             swid_cnt_p = new_uint32_t_p()
             uint32_t_p_assign(swid_cnt_p, 0)
             swid_cnt = 0
             while True:
-                if retry > self.SX_OPEN_RETRIES:
+                if retry >= self.SX_OPEN_RETRIES:
                     raise RuntimeError("switch not created after {} retries and {} seconds waiting, exiting..."
                         .format(retry, self.SX_OPEN_RETRIES * self.SX_OPEN_TIMEOUT))
                 else:
@@ -156,6 +144,7 @@ class MlnxSfpd:
                         swid_cnt = uint32_t_p_value(swid_cnt_p)
                         if swid_cnt > 0:
                             delete_uint32_t_p(swid_cnt_p)
+                            swid_cnt_p = None
                             break
                         else:
                             log_info("switch not created yet, swid_cnt {}, retry {} times and wait for {} seconds"
@@ -166,8 +155,6 @@ class MlnxSfpd:
 
                     retry = retry + 1
                     time.sleep(self.SX_OPEN_TIMEOUT)
-
-            initializing_phase = INITIALIZING_PHASE_SWITCH_CREATED
 
             # After switch was created inside SDK, sx_api_host_ifc_trap_id_register_set is ready to call
             rc = sx_api_host_ifc_trap_id_register_set(self.handle,
@@ -181,14 +168,10 @@ class MlnxSfpd:
 
             self.running = True
         except Exception as e:
-            log_error("mlnx-sfpd initialization failed due to {}".format(repr(e)))
-            if initializing_phase >= INITIALIZING_PHASE_SX_API_OPENED:
-                if initializing_phase >= INITIALIZING_PHASE_HOST_IFC_OPENED:
-                    if initializing_phase >= INITIALIZING_PHASE_SWITCH_CREATED:
-                        if swid_cnt_p is not None:
-                            delete_uint32_t_p(swid_cnt_p)
-                    sx_api_host_ifc_close(self.handle, self.rx_fd_p)
-                sx_api_close(self.handle)
+            log_error("mlnx-sfpd initialization failed due to {}, exiting...".format(repr(e)))
+            if swid_cnt_p is not None:
+                delete_uint32_t_p(swid_cnt_p)
+            self.deinitialize()
 
     def deinitialize(self):
         # remove mlnx-sfpd liveness key in DB if not expired yet

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -101,7 +101,7 @@ class MlnxSfpd:
         # retry at most SX_OPEN_RETRIES times to wait
         # until SDK is started during system startup
         
-        retry = 1
+        retry = 0
         sx_api_open_pass = False
         sx_api_host_ifc_open_pass = False
         sx_api_host_ifc_trap_id_register_set_pass = False
@@ -111,11 +111,11 @@ class MlnxSfpd:
                 rc, self.handle = sx_api_open(None)
                 if rc == SX_STATUS_SUCCESS:
                     sx_api_open_pass = True
-                    retry = 1
+                    retry = 0
                 else:    
                     log_warning("failed to open SDK API handle with err code {}... retrying {}".format(rc,retry))
-                    time.sleep(2 ** retry)
                     retry += 1
+                    time.sleep(2 ** retry)
                     if retry > self.SX_OPEN_RETRIES:
                         raise RuntimeError("failed to open SDK API handle after {} retries".format(retry))
                     else:
@@ -127,11 +127,11 @@ class MlnxSfpd:
                     self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
                     self.user_channel_p.channel.fd = self.rx_fd_p
                     sx_api_host_ifc_open_pass = True
-                    retry = 1
+                    retry = 0
                 else:
                     log_warning("sx_api_host_ifc_open failed with error code {}... retrying {}".format(rc,retry))
-                    time.sleep(2 ** retry)
                     retry += 1
+                    time.sleep(2 ** retry)
                     if retry > self.SX_OPEN_RETRIES:
                         sx_api_close(self.handle)
                         raise RuntimeError("sx_api_host_ifc_open failed with error after {} retries".format(retry))
@@ -149,8 +149,8 @@ class MlnxSfpd:
                     break
                 else:
                     log_warning("sx_api_host_ifc_trap_id_register_set failed with error code {}... retrying {}".format(rc,retry))
-                    time.sleep(2 ** retry)
                     retry += 1
+                    time.sleep(2 ** retry)
                     if retry > self.SX_OPEN_RETRIES:
                         sx_api_host_ifc_close(self.handle, self.rx_fd_p)
                         sx_api_close(self.handle)

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -30,6 +30,8 @@ STATUS_UNKNOWN = '2'
 
 SFPD_LIVENESS_EXPIRE_SECS = 30
 
+SDK_DAEMON_READY_FILE = '/tmp/sdk_ready'
+
 sfp_value_status_dict = {
         SDK_SFP_STATE_IN:  STATUS_PLUGIN,
         SDK_SFP_STATE_OUT: STATUS_PLUGOUT,
@@ -97,67 +99,67 @@ class MlnxSfpd:
     def initialize(self):
         self.state_db.connect("STATE_DB")
 
-        # open SDK API handle
-        # retry at most SX_OPEN_RETRIES times to wait
-        # until SDK is started during system startup
-        
+        # Wait for SDK daemon to be started with detect the sdk_ready file     
         retry = 0
-        sx_api_open_pass = False
-        sx_api_host_ifc_open_pass = False
-        sx_api_host_ifc_trap_id_register_set_pass = False
+        while not os.path.exists(SDK_DAEMON_READY_FILE):  
+            if retry >= self.SX_OPEN_RETRIES:
+                raise RuntimeError("SDK daemon failed to start after {} retries, exiting...".format(retry))
+            else:
+                log_info("SDK daemon not started yet, retry {} times".format(retry))
+                retry = retry + 1
+                time.sleep(2 ** retry)
         
-        while True:
-            if not sx_api_open_pass:
-                rc, self.handle = sx_api_open(None)
-                if rc == SX_STATUS_SUCCESS:
-                    sx_api_open_pass = True
-                    retry = 0
-                else:    
-                    log_warning("failed to open SDK API handle with err code {}... retrying {}".format(rc,retry))
-                    retry += 1
-                    time.sleep(2 ** retry)
-                    if retry > self.SX_OPEN_RETRIES:
-                        raise RuntimeError("failed to open SDK API handle after {} retries".format(retry))
-                    else:
-                        continue
-        
-            if not sx_api_host_ifc_open_pass:
-                rc = sx_api_host_ifc_open(self.handle, self.rx_fd_p)
-                if rc == SX_STATUS_SUCCESS:
-                    self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
-                    self.user_channel_p.channel.fd = self.rx_fd_p
-                    sx_api_host_ifc_open_pass = True
-                    retry = 0
-                else:
-                    log_warning("sx_api_host_ifc_open failed with error code {}... retrying {}".format(rc,retry))
-                    retry += 1
-                    time.sleep(2 ** retry)
-                    if retry > self.SX_OPEN_RETRIES:
-                        sx_api_close(self.handle)
-                        raise RuntimeError("sx_api_host_ifc_open failed with error after {} retries".format(retry))
-                    else:
-                        continue
+        # After SDK daemon started, sx_api_open and sx_api_host_ifc_open is ready for call
+        rc, self.handle = sx_api_open(None)
+        if rc != SX_STATUS_SUCCESS:
+            raise RuntimeError("failed to call sx_api_open with rc {}, exiting...".format(rc))
 
-            if not sx_api_host_ifc_trap_id_register_set_pass:
-                rc = sx_api_host_ifc_trap_id_register_set(self.handle,
-                                                          SX_ACCESS_CMD_REGISTER,
-                                                          self.swid,
-                                                          SX_TRAP_ID_PMPE,
-                                                          self.user_channel_p)
+        rc = sx_api_host_ifc_open(self.handle, self.rx_fd_p)
+        if rc != SX_STATUS_SUCCESS:
+            sx_api_close(self.handle)
+            raise RuntimeError("failed to call sx_api_host_ifc_open with rc {}, exiting...".format(rc))
+
+        self.user_channel_p.type = SX_USER_CHANNEL_TYPE_FD
+        self.user_channel_p.channel.fd = self.rx_fd_p
+
+        # Wait for switch to be created and inited inside SDK
+        retry = 0
+        swid_cnt_p = new_uint32_t_p()
+        uint32_t_p_assign(swid_cnt_p, 0)
+        swid_cnt = 0
+        while True:
+            if retry > self.SX_OPEN_RETRIES:
+                delete_uint32_t_p(swid_cnt_p)
+                sx_api_host_ifc_close(self.handle, self.rx_fd_p)
+                sx_api_close(self.handle)
+                raise RuntimeError("switch not created after {} retries, exiting...".format(retry))
+            else:
+                rc = sx_api_port_swid_list_get(self.handle, None, swid_cnt_p)
                 if rc == SX_STATUS_SUCCESS:
-                    sx_api_host_ifc_trap_id_register_set_pass = True
-                    break
-                else:
-                    log_warning("sx_api_host_ifc_trap_id_register_set failed with error code {}... retrying {}".format(rc,retry))
-                    retry += 1
-                    time.sleep(2 ** retry)
-                    if retry > self.SX_OPEN_RETRIES:
-                        sx_api_host_ifc_close(self.handle, self.rx_fd_p)
-                        sx_api_close(self.handle)
-                        raise RuntimeError("sx_api_host_ifc_trap_id_register_set failed with error after {} retries".format(retry))
+                    swid_cnt = uint32_t_p_value(swid_cnt_p)
+                    if swid_cnt > 0:
+                        delete_uint32_t_p(swid_cnt_p)
+                        break
                     else:
-                        continue
-        
+                        log_info("switch not created yet, swid_cnt {}, retry {} times".format(swid_cnt, retry))
+                else:
+                    log_info("sx_api_port_swid_list_get fail with rc {}, retry {} times".format(rc, retry))
+
+                retry = retry + 1
+                time.sleep(2 ** retry)
+
+        # After switch was created inside SDK, sx_api_host_ifc_trap_id_register_set is ready to call
+        rc = sx_api_host_ifc_trap_id_register_set(self.handle,
+                                                  SX_ACCESS_CMD_REGISTER,
+                                                  self.swid,
+                                                  SX_TRAP_ID_PMPE,
+                                                  self.user_channel_p)
+
+        if rc != SX_STATUS_SUCCESS:
+            sx_api_host_ifc_close(self.handle, self.rx_fd_p)
+            sx_api_close(self.handle)
+            raise RuntimeError("sx_api_host_ifc_trap_id_register_set failed with rc {}, exiting...".format(rc))
+            
         self.running = True
 
     def deinitialize(self):

--- a/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
+++ b/platform/mellanox/mlnx-sfpd/scripts/mlnx-sfpd
@@ -122,6 +122,9 @@ class MlnxSfpd:
                     retry = retry + 1
                     time.sleep(self.SX_OPEN_TIMEOUT)
 
+            # to make sure SDK daemon has started
+            time.sleep(self.SX_OPEN_TIMEOUT)
+
             # After SDK daemon started, sx_api_open and sx_api_host_ifc_open is ready for call
             rc, self.handle = sx_api_open(None)
             if rc != SX_STATUS_SUCCESS:


### PR DESCRIPTION
**- What I did**
change the mlnx-sfpd start flow to make it more robust

**- How I did it**
1. Before start calling the SDK APIs, make sure SDK daemon was started, this was done by detecting "sdk_reay" existence.
2. Before calling sx_api_host_ifc_trap_id_register_set, make sure switch has already been created inside SDK, this is done by detecting the existence of switch id.

**- How to verify it**
test whether mlnx-sfpd can successfully start in procedures like config reload, warm reboot.

**- Description for the changelog**
[Mellanox] mlnx-sfpd init flow enhancement

**- A picture of a cute animal (not mandatory but encouraged)**
