### PR TITLE
[sonic-cfg] [Marvell] read system mac address from eeprom

### DIFF
--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -65,16 +65,21 @@ def get_system_mac():
             if valid_mac_address(mac):
                 return mac
 
-        get_mac_cmd = "sudo decode-syseeprom -m"
+        hw_mac_entry_cmds = [ "sudo decode-syseeprom -m" ]
+    elif (version_info['asic_type'] == 'marvell'):
+        # Try valid mac in eeprom, else fetch it from eth0
+        hw_mac_entry_cmds = [ "sudo decode-syseeprom -m", "ip link show eth0 | grep ether | awk '{print $2}'" ]
     else:
-        get_mac_cmd = "ip link show eth0 | grep ether | awk '{print $2}'"
+        hw_mac_entry_cmds = [ "ip link show eth0 | grep ether | awk '{print $2}'" ]
 
-    proc = subprocess.Popen(get_mac_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    (mac, err) = proc.communicate()
-    if err:
-        return None
-
-    mac = mac.strip()
+    for get_mac_cmd in hw_mac_entry_cmds:
+        proc = subprocess.Popen(get_mac_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (mac, err) = proc.communicate()
+        if err:
+            continue
+        mac = mac.strip()
+        if valid_mac_address(mac):
+            break
 
     if not valid_mac_address(mac):
         return None

--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -68,7 +68,10 @@ def get_system_mac():
         hw_mac_entry_cmds = [ "sudo decode-syseeprom -m" ]
     elif (version_info['asic_type'] == 'marvell'):
         # Try valid mac in eeprom, else fetch it from eth0
-        hw_mac_entry_cmds = [ "sudo decode-syseeprom -m", "ip link show eth0 | grep ether | awk '{print $2}'" ]
+        platform = get_platform_info(get_machine_info())
+        hwsku = get_machine_info()['onie_machine']
+        profile_cmd = 'cat /usr/share/sonic/device/' + platform +'/'+ hwsku +'/profile.ini | cut -f2 -d='
+        hw_mac_entry_cmds = [ profile_cmd, "sudo decode-syseeprom -m", "ip link show eth0 | grep ether | awk '{print $2}'" ]
     else:
         hw_mac_entry_cmds = [ "ip link show eth0 | grep ether | awk '{print $2}'" ]
 


### PR DESCRIPTION
based on platform get_system_mac() to fetch valid mac address from Eeprom else
get mac address from eth0

Signed-off-by: Antony Rheneus <arheneus@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
