### PR TITLE
[platform/mellanox] install SDK/SAI dbg symbols in debug image

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx.mk
+++ b/platform/mellanox/docker-syncd-mlnx.mk
@@ -11,5 +11,9 @@ $(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(SYNCD_DBG) \
                                 $(LIBSAIMETADATA_DBG) \
                                 $(LIBSAIREDIS_DBG)
 
+ifeq ($(SDK_FROM_SRC), y)
+$(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(MLNX_SDK_DBG_DEBS) $(MLNX_SAI_DBGSYM)
+endif
+
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/warmboot:/var/warmboot
 

--- a/platform/mellanox/mlnx-sai.mk
+++ b/platform/mellanox/mlnx-sai.mk
@@ -8,4 +8,6 @@ MLNX_SAI = mlnx-sai_1.mlnx.$(MLNX_SAI_VERSION)_amd64.deb
 $(MLNX_SAI)_SRC_PATH = $(PLATFORM_PATH)/mlnx-sai
 $(MLNX_SAI)_DEPENDS += $(MLNX_SDK_DEBS)
 $(MLNX_SAI)_RDEPENDS += $(MLNX_SDK_RDEBS) $(MLNX_SDK_DEBS)
+MLNX_SAI_DBGSYM = mlnx-sai-dbgsym_1.mlnx.$(MLNX_SAI_VERSION)_amd64.deb
+$(eval $(call add_derived_package,$(MLNX_SAI),$(MLNX_SAI_DBGSYM)))
 SONIC_MAKE_DEBS += $(MLNX_SAI)

--- a/platform/mellanox/mlnx-sai/Makefile
+++ b/platform/mellanox/mlnx-sai/Makefile
@@ -3,6 +3,7 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = mlnx-sai_1.mlnx.$(MLNX_SAI_VERSION)_amd64.deb
+DERIVED_TARGETS = mlnx-sai-dbgsym_1.mlnx.$(MLNX_SAI_VERSION)_amd64.deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	pushd SAI-Implementation
@@ -12,5 +13,5 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	debuild -e 'make_extra_flags="DEFS=-DACS_OS"' -us -uc -d -b
 	popd
 
-	mv $* $(DEST)/
+	mv $(DERIVED_TARGETS) $* $(DEST)/
 	popd

--- a/platform/mellanox/sdk-src/applibs/Makefile
+++ b/platform/mellanox/sdk-src/applibs/Makefile
@@ -2,7 +2,7 @@
 SHELL = /bin/bash
 
 MAIN_TARGET = applibs_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
-DERIVED_TARGETS = applibs-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+DERIVED_TARGETS = applibs-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb applibs-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 PACKAGE_NAME = applibs
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :

--- a/platform/mellanox/sdk-src/iproute2/Makefile
+++ b/platform/mellanox/sdk-src/iproute2/Makefile
@@ -2,7 +2,7 @@
 SHELL = /bin/bash
 
 MAIN_TARGET = iproute2_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
-DERIVED_TARGETS = iproute2-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+DERIVED_TARGETS = iproute2-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb iproute2-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 PACKAGE_NAME = iproute2-3.19.0
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :

--- a/platform/mellanox/sdk-src/python-sdk-api/Makefile
+++ b/platform/mellanox/sdk-src/python-sdk-api/Makefile
@@ -2,7 +2,7 @@
 SHELL = /bin/bash
 
 MAIN_TARGET = python-sdk-api_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
-DERIVED_TARGETS =
+DERIVED_TARGETS = python-sdk-api-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 PACKAGE_NAME = python_sdk_api
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :

--- a/platform/mellanox/sdk-src/sx-complib/Makefile
+++ b/platform/mellanox/sdk-src/sx-complib/Makefile
@@ -3,7 +3,8 @@ SHELL = /bin/bash
 
 MAIN_TARGET = sx-complib_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 DERIVED_TARGETS = sx-complib-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb \
-				  sx-complib-dev-static_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+				  sx-complib-dev-static_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb \
+				  sx-complib-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 PACKAGE_NAME = sx_complib
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :

--- a/platform/mellanox/sdk-src/sx-examples/Makefile
+++ b/platform/mellanox/sdk-src/sx-examples/Makefile
@@ -2,7 +2,7 @@
 SHELL = /bin/bash
 
 MAIN_TARGET = sx-examples_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
-DERIVED_TARGETS = sx-examples-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+DERIVED_TARGETS = sx-examples-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb sx-examples-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 PACKAGE_NAME = sx_examples
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :

--- a/platform/mellanox/sdk-src/sx-gen-utils/Makefile
+++ b/platform/mellanox/sdk-src/sx-gen-utils/Makefile
@@ -2,7 +2,7 @@
 SHELL = /bin/bash
 
 MAIN_TARGET = sx-gen-utils_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
-DERIVED_TARGETS = sx-gen-utils-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+DERIVED_TARGETS = sx-gen-utils-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb sx-gen-utils-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 PACKAGE_NAME = sx_gen_utils
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :

--- a/platform/mellanox/sdk-src/sx-scew/Makefile
+++ b/platform/mellanox/sdk-src/sx-scew/Makefile
@@ -3,7 +3,8 @@ SHELL = /bin/bash
 
 MAIN_TARGET = sx-scew_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 DERIVED_TARGETS = sx-scew-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb \
-				  sx-scew-dev-static_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+				  sx-scew-dev-static_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb \
+				  sx-scew-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 PACKAGE_NAME = sx_scew
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :

--- a/platform/mellanox/sdk-src/sxd-libs/Makefile
+++ b/platform/mellanox/sdk-src/sxd-libs/Makefile
@@ -3,7 +3,8 @@ SHELL = /bin/bash
 
 MAIN_TARGET = sxd-libs_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 DERIVED_TARGETS = sxd-libs-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb \
-				  sxd-libs-dev-static_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+				  sxd-libs-dev-static_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb \
+				  sxd-libs-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 PACKAGE_NAME = sxd_libs
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :

--- a/platform/mellanox/sdk-src/wjh-libs/Makefile
+++ b/platform/mellanox/sdk-src/wjh-libs/Makefile
@@ -3,7 +3,8 @@ SHELL = /bin/bash
 
 MAIN_TARGET = wjh-libs_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 DERIVED_TARGETS = wjh-libs-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb \
-				  wjh-libs-dev-static_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+				  wjh-libs-dev-static_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb \
+				  wjh-libs-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 PACKAGE_NAME = wjh_libs
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :

--- a/platform/mellanox/sdk.mk
+++ b/platform/mellanox/sdk.mk
@@ -7,15 +7,25 @@ MLNX_SDK_DEB_VERSION = $(subst _,.,$(MLNX_SDK_VERSION))
 # Place here URL where SDK sources exist
 MLNX_SDK_SOURCE_BASE_URL =
 
+ifneq ($(MLNX_SDK_SOURCE_BASE_URL), )
+SDK_FROM_SRC = y
+else
+SDK_FROM_SRC = n
+endif
+
 export MLNX_SDK_SOURCE_BASE_URL MLNX_SDK_VERSION MLNX_SDK_ISSU_VERSION MLNX_SDK_DEB_VERSION
 
-MLNX_SDK_RDEBS += $(APPLIBS) $(IPROUTE2_MLNX) $(SX_ACL_RM) $(SX_COMPLIB) \
+MLNX_SDK_RDEBS += $(APPLIBS) $(IPROUTE2_MLNX) $(SX_COMPLIB) \
 		  $(SX_EXAMPLES) $(SX_GEN_UTILS) $(SX_SCEW) $(SXD_LIBS) $(WJH_LIBS)
 
-MLNX_SDK_DEBS += $(APPLIBS_DEV) $(IPROUTE2_MLNX_DEV) $(SX_ACL_RM_DEV) \
+MLNX_SDK_DEBS += $(APPLIBS_DEV) $(IPROUTE2_MLNX_DEV) \
 		 $(SX_COMPLIB_DEV) $(SX_COMPLIB_DEV_STATIC) $(SX_EXAMPLES_DEV) \
 		 $(SX_GEN_UTILS_DEV) $(SX_SCEW_DEV) $(SX_SCEW_DEV_STATIC) \
 		 $(SXD_LIBS_DEV) $(SXD_LIBS_DEV_STATIC) $(WJH_LIBS_DEV)
+
+MLNX_SDK_DBG_DEBS += $(APPLIBS_DBGSYM) $(IPROUTE2_MLNX_DBGSYM) $(SX_COMPLIB_DBGSYM) \
+         $(SX_EXAMPLES_DBGSYM) $(SX_GEN_UTILS_DBGSYM) $(SX_SCEW_DBGSYM) \
+         $(SXD_LIBS_DBGSYM) $(WJH_LIBS_DBGSYM)
 
 APPLIBS = applibs_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(APPLIBS)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/applibs
@@ -23,16 +33,28 @@ $(APPLIBS)_DEPENDS += $(SX_COMPLIB_DEV) $(SX_GEN_UTILS_DEV) $(SXD_LIBS_DEV) $(LI
 $(APPLIBS)_RDEPENDS += $(SX_COMPLIB) $(SX_GEN_UTILS) $(SXD_LIBS) $(LIBNL3) $(LIBNL_GENL3)
 APPLIBS_DEV = applibs-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(APPLIBS),$(APPLIBS_DEV)))
+APPLIBS_DBGSYM = applibs-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+ifeq ($(SDK_FROM_SRC),y)
+$(eval $(call add_derived_package,$(APPLIBS),$(APPLIBS_DBGSYM)))
+endif
 
 IPROUTE2_MLNX = iproute2_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(IPROUTE2_MLNX)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/iproute2
 IPROUTE2_MLNX_DEV = iproute2-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(IPROUTE2_MLNX),$(IPROUTE2_MLNX_DEV)))
+IPROUTE2_MLNX_DBGSYM = iproute2-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+ifeq ($(SDK_FROM_SRC),y)
+$(eval $(call add_derived_package,$(IPROUTE2_MLNX),$(IPROUTE2_MLNX_DBGSYM)))
+endif
 
 SX_COMPLIB = sx-complib_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(SX_COMPLIB)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/sx-complib
 SX_COMPLIB_DEV = sx-complib-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(SX_COMPLIB),$(SX_COMPLIB_DEV)))
+SX_COMPLIB_DBGSYM = sx-complib-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+ifeq ($(SDK_FROM_SRC),y)
+$(eval $(call add_derived_package,$(SX_COMPLIB),$(SX_COMPLIB_DBGSYM)))
+endif
 
 SX_EXAMPLES = sx-examples_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(SX_EXAMPLES)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/sx-examples
@@ -40,6 +62,10 @@ $(SX_EXAMPLES)_DEPENDS += $(APPLIBS_DEV) $(SX_SCEW_DEV) $(SXD_LIBS_DEV)
 $(SX_EXAMPLES)_RDEPENDS += $(APPLIBS) $(SX_SCEW) $(SXD_LIBS)
 SX_EXAMPLES_DEV = sx-examples-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(SX_EXAMPLES),$(SX_EXAMPLES_DEV)))
+SX_EXAMPLES_DBGSYM = sx-examples-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+ifeq ($(SDK_FROM_SRC),y)
+$(eval $(call add_derived_package,$(SX_EXAMPLES),$(SX_EXAMPLES_DBGSYM)))
+endif
 
 SX_GEN_UTILS = sx-gen-utils_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(SX_GEN_UTILS)_SRC_PATH += $(PLATFORM_PATH)/sdk-src/sx-gen-utils
@@ -47,29 +73,39 @@ $(SX_GEN_UTILS)_DEPENDS += $(SX_COMPLIB_DEV) $(SXD_LIBS_DEV)
 $(SX_GEN_UTILS)_RDEPENDS += $(SX_COMPLIB)
 SX_GEN_UTILS_DEV = sx-gen-utils-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(SX_GEN_UTILS),$(SX_GEN_UTILS_DEV)))
+SX_GEN_UTILS_DBGSYM = sx-gen-utils-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+ifeq ($(SDK_FROM_SRC),y)
+$(eval $(call add_derived_package,$(SX_GEN_UTILS),$(SX_GEN_UTILS_DBGSYM)))
+endif
 
 SX_SCEW = sx-scew_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(SX_SCEW)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/sx-scew
 SX_SCEW_DEV = sx-scew-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(SX_SCEW),$(SX_SCEW_DEV)))
+SX_SCEW_DBGSYM = sx-scew-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+ifeq ($(SDK_FROM_SRC),y)
+$(eval $(call add_derived_package,$(SX_SCEW),$(SX_SCEW_DBGSYM)))
+endif
 
 SXD_LIBS = sxd-libs_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(SXD_LIBS)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/sxd-libs
 $(SXD_LIBS)_DEPENDS += $(SX_COMPLIB_DEV)
 SXD_LIBS_DEV = sxd-libs-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(SXD_LIBS),$(SXD_LIBS_DEV)))
+SXD_LIBS_DBGSYM = sxd-libs-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+ifeq ($(SDK_FROM_SRC),y)
+$(eval $(call add_derived_package,$(SXD_LIBS),$(SXD_LIBS_DBGSYM)))
+endif
 
 #packages that are required for runtime only
 PYTHON_SDK_API = python-sdk-api_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(PYTHON_SDK_API)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/python-sdk-api
 $(PYTHON_SDK_API)_DEPENDS += $(APPLIBS_DEV) $(SXD_LIBS_DEV) $(SWIG)
 $(PYTHON_SDK_API)_RDEPENDS += $(APPLIBS) $(SXD_LIBS)
-
-SX_KERNEL = sx-kernel_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
-$(SX_KERNEL)_DEPENDS += $(LINUX_HEADERS) $(LINUX_HEADERS_COMMON)
-$(SX_KERNEL)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/sx-kernel
-SX_KERNEL_DEV = sx-kernel-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
-$(eval $(call add_derived_package,$(SX_KERNEL),$(SX_KERNEL_DEV)))
+PYTHON_SDK_API_DBGSYM = python-sdk-api-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+ifeq ($(SDK_FROM_SRC),y)
+$(eval $(call add_derived_package,$(PYTHON_SDK_API),$(PYTHON_SDK_API_DBGSYM)))
+endif
 
 WJH_LIBS = wjh-libs_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(WJH_LIBS)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/wjh-libs
@@ -77,6 +113,16 @@ $(WJH_LIBS)_DEPENDS += $(SX_COMPLIB_DEV) $(SXD_LIBS_DEV) $(APPLIBS_DEV)
 $(WJH_LIBS)_RDEPENDS += $(SX_COMPLIB) $(PYTHON_SDK_API)
 WJH_LIBS_DEV = wjh-libs-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(WJH_LIBS),$(WJH_LIBS_DEV)))
+WJH_LIBS_DBGSYM = wjh-libs-dbgsym_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+ifeq ($(SDK_FROM_SRC),y)
+$(eval $(call add_derived_package,$(WJH_LIBS),$(WJH_LIBS_DBGSYM)))
+endif
+
+SX_KERNEL = sx-kernel_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+$(SX_KERNEL)_DEPENDS += $(LINUX_HEADERS) $(LINUX_HEADERS_COMMON)
+$(SX_KERNEL)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/sx-kernel
+SX_KERNEL_DEV = sx-kernel-dev_1.mlnx.$(MLNX_SDK_DEB_VERSION)_amd64.deb
+$(eval $(call add_derived_package,$(SX_KERNEL),$(SX_KERNEL_DEV)))
 
 define make_url
 	$(1)_URL = $(MLNX_SDK_BASE_URL)/$(1)
@@ -87,7 +133,7 @@ $(eval $(foreach deb,$(MLNX_SDK_DEBS),$(call make_url,$(deb))))
 $(eval $(foreach deb,$(MLNX_SDK_RDEBS),$(call make_url,$(deb))))
 $(eval $(foreach deb,$(PYTHON_SDK_API) $(SX_KERNEL) $(SX_KERNEL_DEV),$(call make_url,$(deb))))
 
-ifneq ($(MLNX_SDK_SOURCE_BASE_URL), )
+ifeq ($(SDK_FROM_SRC), y)
 SONIC_MAKE_DEBS += $(MLNX_SDK_RDEBS) $(PYTHON_SDK_API) $(SX_KERNEL)
 else
 SONIC_ONLINE_DEBS += $(MLNX_SDK_RDEBS) $(PYTHON_SDK_API) $(SX_KERNEL)


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When SDK is built from sources and debug build was requested install debug symbols in image.
Also install SAI debug symbols.

**- How I did it**

**- How to verify it**

Tested on mellanox image (gdb -p `pidof sx_sdk` ; info functions)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
