### PR TITLE
[service dependent] describe non-warm-reboot dependency outside systemd

### DIFF
--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=TEAMD container
-Requires=updategraph.service swss.service
+Requires=updategraph.service
 After=updategraph.service swss.service
 Before=ntp-config.service
 

--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
 [Install]
-WantedBy=multi-user.target swss.service
+WantedBy=multi-user.target

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -79,7 +79,7 @@ function clean_up_tables()
     end" 0
 }
 
-startPeerAndDependentService() {
+start_peer_and_dependent_services() {
     check_warm_boot
 
     if [[ x"$WARM_BOOT" != x"true" ]]; then
@@ -90,7 +90,7 @@ startPeerAndDependentService() {
     fi
 }
 
-stopPeerAndDependentService() {
+stop_peer_and_dependent_services() {
     # if warm start enabled or peer lock exists, don't stop peer service docker
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         /bin/systemctl stop ${PEER}
@@ -130,7 +130,7 @@ start() {
 }
 
 wait() {
-    startPeerAndDependentService
+    start_peer_and_dependent_services
     /usr/bin/${SERVICE}.sh wait
 }
 
@@ -149,7 +149,7 @@ stop() {
     # Unlock has to happen before reaching out to peer service
     unlock_service_state_change
 
-    stopPeerAndDependentService
+    stop_peer_and_dependent_services
 }
 
 case "$1" in

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -2,6 +2,7 @@
 
 SERVICE="swss"
 PEER="syncd"
+DEPENDENT="teamd"
 DEBUGLOG="/tmp/swss-syncd-debug.log"
 LOCKFILE="/tmp/swss-syncd-lock"
 
@@ -83,6 +84,9 @@ startPeerService() {
 
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         /bin/systemctl start ${PEER}
+        for dep in ${DEPENDENT}; do
+            /bin/systemctl start ${dep}
+        done
     fi
 }
 
@@ -138,6 +142,9 @@ stop() {
     # if warm start enabled or peer lock exists, don't stop peer service docker
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         /bin/systemctl stop ${PEER}
+        for dep in ${DEPENDENT}; do
+            /bin/systemctl stop ${dep}
+        done
     fi
 }
 


### PR DESCRIPTION
**- What I did**

When dependency was described with systemctl, it will kick in all the time,
including under warm reboot/restart scenarios. This is not what we always
want. For components that are capable of warm reboot/start, they need to
describe dependency in service files.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Without this change, when warm reboot test is executed, randomly the LAGs would flap. When running continuous warm reboot test, the LAG up time on the peers will eventually show this problem.

With the change in place, the LAG reset is not seen.