### PR TITLE
Fix install debug tools variable in rules/config

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -52,9 +52,9 @@ DEFAULT_PASSWORD = YourPaSsWoRd
 # by default for TOR switch
 # ENABLE_PFCWD_ON_START = y
 
-# SONIC_INSTALL_DEBUG_TOOLS - installs debugging tools in baseline docker
+# INSTALL_DEBUG_TOOLS - installs debugging tools in baseline docker
 # Uncomment next line to enable:
-# SONIC_INSTALL_DEBUG_TOOLS = y
+# INSTALL_DEBUG_TOOLS = y
 
 # SONIC_ROUTING_STACK - specify the routing-stack being elected to drive SONiC's control-plane.
 # Supported routing stacks on SONiC are:


### PR DESCRIPTION
Makefile.work expects input using INSTALL_DEBUG_TOOLS=y
Instead rules/config is using SONIC_iNSTALL_DEBUG_TOOLS

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Corrected the input variable in rules/config for installing debug tools. Makefile.work expects it to be
INSTALL_DEBUG_TOOLS.

**- How I did it**
Replaced SONIC_INSTALL_DEBUG_TOOLS with INSTALL_DEBUG_TOOLS in rules/config

**- How to verify it**
- Change rules/config to have INSTALL_DEBUG_TOOLS = y
- make platform=broadcom config

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use INSTALL_DEBUG_TOOLS as the variable in rules/config to configure SONiC image to have debug tools installed at build time.

**- A picture of a cute animal (not mandatory but encouraged)**
