### PR TITLE
[dhcp_relay] Only call 'wait_until_iface_ready' once for each interface

### DIFF
--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -29,12 +29,19 @@ function wait_until_iface_ready
 
 
 # Wait for all interfaces to be up and ready
-{% for (name, prefix) in INTERFACE|pfx_filter %}
+{% for name in PORT %}
+{% if name in INTERFACE %}
 wait_until_iface_ready ${PORT_TABLE_PREFIX} {{ name }}
+{% endif %}
 {% endfor %}
-{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
+{% for name in VLAN %}
+{% if name in VLAN_INTERFACE %}
 wait_until_iface_ready ${VLAN_TABLE_PREFIX} {{ name }}
+{% endif %}
 {% endfor %}
-{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
+{% for name in PORTCHANNEL %}
+{% if name in PORTCHANNEL_INTERFACE %}
 wait_until_iface_ready ${LAG_TABLE_PREFIX} {{ name }}
+{% endif %}
 {% endfor %}
+


### PR DESCRIPTION
[dhcp_relay]'wait_for_init.sh.j2' translate duplicate if the interface has both ipv4 and ipv6 address #3316

Signed-off-by: wangshengjun wangshengjun@asterfusion.com

**- What I did**
When the interface has configured  both ipv4 and ipv6 address, the 'wait_until_iface_ready' function called twice .So the j2 template of 'wait_for_init.sh.j2' was changed to fix the problem.
**- How I did it**

**- How to verify it**
1.configure the interface with both ipv4 and ipv6 addresses.
part of config file
....
 "PORTCHANNEL_INTERFACE": {
        "PortChannel0001": {}, 
        "PortChannel0002": {}, 
        "PortChannel0001|10.0.0.56/31": {}, 
        "PortChannel0001|FC00::71/126": {}, 
        "PortChannel0002|10.0.0.58/31": {}, 
        "PortChannel0002|FC00::75/126": {}
    }, 
...
2.check the 'wait_for_init.sh' translated by  'wait_for_init.sh.j2'  according to the configuration.
function wait_until_iface_ready
{
   .....
}
Wait for all interfaces to be up and ready
wait_until_iface_ready ${LAG_TABLE_PREFIX} PortChannel0001
wait_until_iface_ready ${LAG_TABLE_PREFIX} PortChannel0002

The 'wait_until_iface_ready' function should call once for each interface.