### PR TITLE
[Mellanox] align platform_reboot to use "hardware reboot"

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
@@ -4,7 +4,7 @@ declare -r EXIT_SUCCESS="0"
 declare -r EXIT_ERROR="1"
 
 declare -r FW_UPGRADE_SCRIPT="/usr/bin/mlnx-fw-upgrade.sh"
-declare -r SYSFS_PWR_CYCLE="/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon1/pwr_cycle"
+declare -r SYSFS_PWR_CYCLE="/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/pwr_cycle"
 
 FORCE_REBOOT="no"
 

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
@@ -4,6 +4,7 @@ declare -r EXIT_SUCCESS="0"
 declare -r EXIT_ERROR="1"
 
 declare -r FW_UPGRADE_SCRIPT="/usr/bin/mlnx-fw-upgrade.sh"
+declare -r SYSFS_PWR_CYCLE="/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon1/pwr_cycle"
 
 FORCE_REBOOT="no"
 
@@ -31,6 +32,6 @@ if [[ "${EXIT_CODE}" != "${EXIT_SUCCESS}" ]]; then
     fi
 fi
 
-echo 1 > /bsp/system/pwr_cycle
+echo 1 > $SYSFS_PWR_CYCLE
 sleep 3
-echo 0 > /bsp/system/pwr_cycle
+echo 0 > $SYSFS_PWR_CYCLE

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
@@ -20,7 +20,7 @@ function ParseArguments() {
 
 ParseArguments "$@"
 
-${FW_UPGRADE_SCRIPT} --upgrade
+${FW_UPGRADE_SCRIPT} --upgrade --verbose
 EXIT_CODE="$?"
 if [[ "${EXIT_CODE}" != "${EXIT_SUCCESS}" ]]; then
     echo "Failed to burn MLNX FW: errno=${EXIT_CODE}"
@@ -31,4 +31,6 @@ if [[ "${EXIT_CODE}" != "${EXIT_SUCCESS}" ]]; then
     fi
 fi
 
-exec /sbin/reboot $@
+echo 1 > /bsp/system/pwr_cycle
+sleep 3
+echo 0 > /bsp/system/pwr_cycle


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Aligned  Mellanox specific platform_reboot script to perform a power cycle instead of calling /sbin/reboot. Also added verbosity to the fw upgrade script call.

Motivation: switches were reported "stuck" after a reboot call, most vendors use "hardware reboot" in their platform_reboot scripts. We now go with the same approach of a more harsh reboot.


**- How I did it**

**- How to verify it**
 - manual reboot
- continuous reboot test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Mellanox platform_reboot to use power cycle

**- A picture of a cute animal (not mandatory but encouraged)**
