### PR TITLE
Fix to ensure that tacacs servers are ordered in pam's conf

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -114,7 +114,7 @@ class AaaCfg(object):
                 server['ip'] = addr
                 server.update(self.tacplus_servers[addr])
                 servers_conf.append(server)
-            sorted(servers_conf, key=lambda t: t['priority'], reverse=True)
+            servers_conf = sorted(servers_conf, key=lambda t: int(t['priority']), reverse=True)
 
         template_file = os.path.abspath(PAM_AUTH_CONF_TEMPLATE)
         env = jinja2.Environment(loader=jinja2.FileSystemLoader('/'), trim_blocks=True)


### PR DESCRIPTION
Present: Servers are listed in the same order as in redis-db
Fix: Save the sorted o/p, so it use sorted list to write into pam.d's conf.
     As well convert priority to integer for use by sort.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
