### PR TITLE
[dhcp_relay] fix the compile error introduced by the fixed issue  of '#3316', change the sample_output file of 'wait_for_intf.sh'

### DIFF
--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -29,12 +29,19 @@ function wait_until_iface_ready
 
 
 # Wait for all interfaces to be up and ready
-{% for (name, prefix) in INTERFACE|pfx_filter %}
+{% for name in PORT %}
+{% if name in INTERFACE %}
 wait_until_iface_ready ${PORT_TABLE_PREFIX} {{ name }}
+{% endif %}
 {% endfor %}
-{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
+{% for name in VLAN %}
+{% if name in VLAN_INTERFACE %}
 wait_until_iface_ready ${VLAN_TABLE_PREFIX} {{ name }}
+{% endif %}
 {% endfor %}
-{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
+{% for name in PORTCHANNEL %}
+{% if name in PORTCHANNEL_INTERFACE %}
 wait_until_iface_ready ${LAG_TABLE_PREFIX} {{ name }}
+{% endif %}
 {% endfor %}
+

--- a/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
@@ -31,11 +31,7 @@ function wait_until_iface_ready
 # Wait for all interfaces to be up and ready
 wait_until_iface_ready ${VLAN_TABLE_PREFIX} Vlan1000
 wait_until_iface_ready ${LAG_TABLE_PREFIX} PortChannel01
-wait_until_iface_ready ${LAG_TABLE_PREFIX} PortChannel01
-wait_until_iface_ready ${LAG_TABLE_PREFIX} PortChannel02
 wait_until_iface_ready ${LAG_TABLE_PREFIX} PortChannel02
 wait_until_iface_ready ${LAG_TABLE_PREFIX} PortChannel03
-wait_until_iface_ready ${LAG_TABLE_PREFIX} PortChannel03
-wait_until_iface_ready ${LAG_TABLE_PREFIX} PortChannel04
 wait_until_iface_ready ${LAG_TABLE_PREFIX} PortChannel04
 


### PR DESCRIPTION
Signed-off-by: wangshengjun wangshengjun@asterfusion.com

**- What I did**
change the sample_output file of 'wait_for_intf.sh' to fix the compile error. 
'wait_for_intf.sh.j2' was changed by the commit id '7b0389d8a3a44a8351cb8195d1f308e48a2b087b'

**- How I did it**
change the  sample_output file of 'wait_for_intf.sh' .
**- How to verify it**
Recompile ok after the change.


