### PR TITLE
use docker without sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ To build SONiC installer image and docker images, run the following commands:
     # (Optional) Checkout a specific branch. By default, it uses master branch
     git checkout [branch_name]
 
+    # Use docker command without sudo
+      1. Add current user to the docker group
+	 sudo gpasswd -a ${USER} docker
+      2. Log out and log back in ?so that your group membership is re-evaluated .	
+
     # Execute make init once after cloning the repo, or after fetching remote repo with submodule updates
     make init
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
      
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
     Users can install docker with sudo, and it requires sudo to issue docker command. This will cause few errors in Makefile.work which need use docker without sudo.

**- A picture of a cute animal (not mandatory but encouraged)**
