### PR TITLE
[platform]: Added exceptions handling for BFN syseeprom and psuutil

### DIFF
--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/plugins/psuutil.py
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/plugins/psuutil.py
@@ -63,9 +63,13 @@ class PsuUtil(PsuBase):
             return False
 
         global pltfm_mgr
-        self.thrift_setup()
-        psu_info = pltfm_mgr.pltfm_mgr_pwr_supply_info_get(index)
-        self.thrift_teardown()
+
+        try:
+           self.thrift_setup()
+           psu_info = pltfm_mgr.pltfm_mgr_pwr_supply_info_get(index)
+           self.thrift_teardown()
+        except:
+            return False
 
         return (psu_info.ffault == False)
 
@@ -80,9 +84,13 @@ class PsuUtil(PsuBase):
             return False
 
         global pltfm_mgr
-        self.thrift_setup()
-        status = pltfm_mgr.pltfm_mgr_pwr_supply_present_get(index)
-        self.thrift_teardown()
+
+        try:
+	    self.thrift_setup()
+	    status = pltfm_mgr.pltfm_mgr_pwr_supply_present_get(index)
+	    self.thrift_teardown()
+        except:
+            return False
 
         return status
 


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

**- What I did**
Added exceptions handling for BFN psuutil.py and eeprom.py which are raised when syseepromd and psud try to connect to the BFN thrift server which is not up yet.  Now the exceptions backtrace is not logged to the syslog. Also psud doesn't exit on system bootup due to uncaught exception.

**- How to verify it**
sudo psuutil numpsus
sudo psuutil status
redis-dump -d 6 | python -mjson.tool | grep PSU
show version
sudo decode-syseeprom
redis-dump -d 6 | python -mjson.tool | grep EEPROM
