### PR TITLE
[baseimage]: install ndisc6 package

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -271,7 +271,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     mtr-tiny                \
     locales                 \
     cgroup-tools            \
-    ipmitool
+    ipmitool                \
+    ndisc6
 
 
 if [[ $CONFIGURED_ARCH == amd64 ]]; then


### PR DESCRIPTION
ndisc6 gathers a few diagnostic tools for IPv6 networks including:

 - ndisc6, which performs ICMPv6 Neighbor Discovery in userland,
 - rdisc6, which performs ICMPv6 Router Discovery in userland,
 - rltraceroute6, a UDP/ICMP IPv6 implementation of traceroute,
 - tcptraceroute6, a TCP/IPv6-based traceroute implementation,
 - tcpspray6, a TCP/IP Discard/Echo bandwidth meter,
 - addrinfo, easy script interface for hostname and address resolution,
 - dnssort, DNS sorting script.

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
