### PR TITLE
[radv service] radv service should be a cold boot only dependent of swss

### DIFF
--- a/files/build_templates/radv.service.j2
+++ b/files/build_templates/radv.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=Router advertiser container
-Requires=updategraph.service swss.service
+Requires=updategraph.service
 After=updategraph.service swss.service
 Before=ntp-config.service
 
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/{{ docker_container_name }}.sh wait
 ExecStop=/usr/bin/{{ docker_container_name }}.sh stop
 
 [Install]
-WantedBy=multi-user.target swss.service
+WantedBy=multi-user.target

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -2,7 +2,7 @@
 
 SERVICE="swss"
 PEER="syncd"
-DEPENDENT="teamd"
+DEPENDENT="teamd radv"
 DEBUGLOG="/tmp/swss-syncd-debug.log"
 LOCKFILE="/tmp/swss-syncd-lock"
 


### PR DESCRIPTION
**- What I did**

radv should be left alone during warm restart of swss. Otherwise it will
announce departure and cause hosts to lose default gateway.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
warm reboot with IPv6 IO going through.