### PR TITLE
[Makefile] Multiarch docker service cleanup at make reset

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -242,3 +242,7 @@ reset :
 	    else \
 	        echo "Reset aborted"; \
 	    fi
+ifneq (,$(filter $(CONFIGURED_ARCH), armhf arm64))
+	@sudo kill -9 `sudo cat /var/run/march/docker.pid` || true
+	@sudo sudo rm -f /var/run/march/docker.pid || true
+endif


### PR DESCRIPTION
Signed-off-by: Antony Rheneus <arheneus@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
