### PR TITLE
[Mellanox]update thermal sensor names in new platform api

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -49,8 +49,8 @@ thermal_api_handler_cpu_pack = {
     THERMAL_API_GET_HIGH_THRESHOLD:"cpu_pack_max"
 }
 thermal_api_handler_module = {
-    THERMAL_API_GET_TEMPERATURE:"temp_input_module{}",
-    THERMAL_API_GET_HIGH_THRESHOLD:"temp_crit_module{}"
+    THERMAL_API_GET_TEMPERATURE:"module{}_temp_input",
+    THERMAL_API_GET_HIGH_THRESHOLD:"module{}_temp_crit"
 }
 thermal_api_handler_psu = {
     THERMAL_API_GET_TEMPERATURE:"psu{}_temp",


### PR DESCRIPTION
**- What I did**
update thermal sensor names in new platform api in order to align with hw-management v2.0.0.191

**- How I did it**
platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
temp_xxxx_module{} => module{}_temp_xxxx

**- How to verify it**
check whether thermal information can be correctly retrieved.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
