### PR TITLE
DellEMC Z9264f LED profile changes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9264f.init
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9264f.init
@@ -22,7 +22,7 @@ start)
     ;;
 
 stop)
-    /usr/local/bin/z9100_platform.sh deinit
+    /usr/local/bin/z9264f_platform.sh deinit
     echo "done."
 
     ;;

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/scripts/z9264f_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/scripts/z9264f_platform.sh
@@ -85,6 +85,22 @@ switch_board_modsel() {
 		python /usr/bin/pcisysfs.py --set --offset $hex --val 0x10 --res $resource  > /dev/null 2>&1
 	done
 }
+
+# Copy led_proc_init.soc file according to the HWSKU
+init_switch_port_led() {
+    device="/usr/share/sonic/device"
+    platform=$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+    hwsku=$(cat /etc/sonic/config_db.json | grep "hwsku" | cut -d ":" -f2 | sed 's/"//g' | sed 's/,//g'| xargs )
+
+    led_proc_init="$device/$platform/$hwsku/led_proc_init.soc"
+    # Remove old HWSKU LED file..
+    rm -rf $device/$platform/led_proc_init.soc
+
+    if [ -e $led_proc_init ] && [ ! -e $device/$platform/led_proc_init.soc ]; then
+      cp $led_proc_init $device/$platform/
+    fi
+}
+
 init_devnum
 
 if [ "$1" == "init" ]; then
@@ -98,6 +114,7 @@ if [ "$1" == "init" ]; then
     switch_board_qsfp_mux "new_device"
     switch_board_qsfp "new_device"
     switch_board_modsel
+    init_switch_port_led
     python /usr/bin/qsfp_irq_enable.py
 
 elif [ "$1" == "deinit" ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 In Z9264f,when 100G HWSKU is changed to 40G,LED profile is not getting updated after reboot.
**- How I did it**
 Updated z9264_platform.sh to change appropriate LED when HWSKU is changed. 
**- How to verify it**
Tested by switching 100G to 40G and vice versa,the LED profile(led_proc_init.soc) is updated according the HWSKU that's been selected.
Attached UT logs for verification.
[Unit test logs.txt](https://github.com/Azure/sonic-buildimage/files/3530186/Unit.test.logs.txt)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
