### PR TITLE
[Mellanox] Remove platform_wait script from Mellanox simx platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700_simx-r0/platform_wait
+++ b/device/mellanox/x86_64-mlnx_msn2700_simx-r0/platform_wait
@@ -1,1 +1,0 @@
-../x86_64-mlnx_msn2700-r0/platform_wait

--- a/device/mellanox/x86_64-mlnx_msn3700_simx-r0/platform_wait
+++ b/device/mellanox/x86_64-mlnx_msn3700_simx-r0/platform_wait
@@ -1,1 +1,0 @@
-../x86_64-mlnx_msn3700-r0/platform_wait


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix pmon start.sh time out issue on Mellanox simx platform

docker pmon will exit after boot up on Mellanox simx platform
the root cause is because platform_wait scripts will time out since qsfp related sysfs will not be created on simx platform.

```
root@dev-r-vrt-233-010:/home/admin# docker ps -a
CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS                          PORTS               NAMES
d500ae3facf5        docker-syncd-mlnx:latest          "/usr/bin/supervisord"   11 hours ago        Up 6 minutes                                        syncd
25b777b6d8b0        docker-dhcp-relay:latest          "/usr/bin/docker_ini鈥   11 hours ago        Up 6 minutes                                        dhcp_relay
ea900b493ba5        docker-snmp-sv2:latest            "/usr/bin/supervisord"   11 hours ago        Up 6 minutes                                        snmp
10bb199047c5        docker-router-advertiser:latest   "/usr/bin/supervisord"   11 hours ago        Up 6 minutes                                        radv
8e7b983477e9        docker-teamd:latest               "/usr/bin/supervisord"   11 hours ago        Up 6 minutes                                        teamd
ac195d6180bd        docker-orchagent:latest           "/usr/bin/supervisord"   11 hours ago        Up 7 minutes                                        swss
b2ef43c400fb        docker-lldp-sv2:latest            "/usr/bin/supervisord"   11 hours ago        Up 6 minutes                                        lldp
626b3504bee7        docker-platform-monitor:latest    "/usr/bin/docker_ini鈥   11 hours ago        Exited (0) About a minute ago                       pmon
5d320c86ca22        docker-fpm-frr:latest             "/usr/bin/supervisord"   11 hours ago        Up 6 minutes                                        bgp
fe6827797be8        docker-sonic-telemetry:latest     "/usr/bin/supervisord"   11 hours ago        Up 11 hours                                         telemetry
438604b7ad5c        docker-database:latest            "/usr/bin/supervisord"   11 hours ago        Up 11 hours                                         database
root@dev-r-vrt-233-010:/home/admin# 
```

```
Aug 23 08:01:01.266941 dev-r-vrt-233-010 INFO pmon.sh[20307]: Starting existing pmon container with HWSKU ACS-MSN2700
Aug 23 08:01:02.617832 dev-r-vrt-233-010 INFO pmon.sh[20307]: pmon
Aug 23 08:01:07.114219 dev-r-vrt-233-010 INFO pmon#liblogging-stdlog:  [origin software="rsyslogd" swVersion="8.24.0" x-pid="33" x-info="http://www.rsyslog.com"] start
Aug 23 08:01:07.117686 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-22 20:52:04,985 INFO waiting for rsyslogd, start.sh to die
Aug 23 08:01:07.117792 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-22 20:52:04,993 INFO stopped: rsyslogd (exit status 0)
Aug 23 08:01:07.117878 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-22 20:52:04,994 INFO stopped: start.sh (terminated by SIGTERM)
Aug 23 08:01:07.117994 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-23 08:01:05,107 CRIT Set uid to user 0
Aug 23 08:01:07.118076 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-23 08:01:05,107 INFO Included extra file "/etc/supervisor/conf.d/supervisord.conf" during parsing
Aug 23 08:01:07.118157 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-23 08:01:05,128 INFO RPC interface 'supervisor' initialized
Aug 23 08:01:07.118249 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-23 08:01:05,129 INFO supervisord started with pid 1
Aug 23 08:01:07.118333 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-23 08:01:06,133 INFO spawned: 'start.sh' with pid 24
Aug 23 08:01:07.118416 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-23 08:01:07,071 INFO success: start.sh entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
Aug 23 08:01:07.118516 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-23 08:01:07,085 INFO spawned: 'rsyslogd' with pid 33
Aug 23 08:01:07.746488 dev-r-vrt-233-010 INFO pmon.sh[20307]: Set hostname in pmon container
Aug 23 08:01:08.095351 dev-r-vrt-233-010 INFO pmon#supervisord: start.sh rsyslogd: started
Aug 23 08:01:08.142393 dev-r-vrt-233-010 INFO pmon#supervisord: start.sh Wait for QSFP I2C interface is ready
Aug 23 08:01:17.129022 dev-r-vrt-233-010 INFO pmon#supervisord 2019-08-23 08:01:08,088 INFO success: rsyslogd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Aug 23 08:06:15.971426 dev-r-vrt-233-010 INFO pmon#supervisord: start.sh QSFP I2C interface is not ready: timeout
Aug 23 08:06:29.737172 dev-r-vrt-233-010 INFO pmon.sh[22199]: 0
Aug 23 08:06:30.030481 dev-r-vrt-233-010 INFO pmon.sh[24682]: pmon
```

 

**- How I did it**
remove platform_wait script from simx since it not needed.

**- How to verify it**
install image on simx platform and check the pmon status.

**- Description for the changelog**

```
mellanox simx platform don't have QSFP sysfs created, this script will cause timeout issue on simx platform
Signed-off-by: Kebo Liu <kebol@mellanox.com>
```

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
