### PR TITLE
Add hash seed for SpineRouter type.

### DIFF
--- a/dockers/docker-orchagent/switch.json.j2
+++ b/dockers/docker-orchagent/switch.json.j2
@@ -6,6 +6,8 @@
 {% set hash_seed = 0 %}
 {% elif DEVICE_METADATA.localhost.type == "LeafRouter" %}
 {% set hash_seed = 10 %}
+{% elif DEVICE_METADATA.localhost.type == "SpineRouter" %}
+{% set hash_seed = 15 %}
 {% endif %}
 {% endif %}
 [


### PR DESCRIPTION
Add hash seed for SpineRouter type.

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add hash seed for SpineRouter type.

**- How I did it**
change the switch.json.j2 file to check SpineRouter type and provide a different hash seed.

**- How to verify it**
Change config_db.json for the type:
    "DEVICE_METADATA": {
        "localhost": {
            ...
            "type": "SpineRouter"
        }
    },

We can see the the file /etc/swss/config.d/switch.json in swss docker has below config:

[
    {
        "SWITCH_TABLE:switch": {
            "ecmp_hash_seed": "15",
            "lag_hash_seed": "15",
            "fdb_aging_time": "600"
        },
        "OP": "SET"
    }
]

```
$ redis-cli hgetall SWITCH_TABLE:switch
1) "ecmp_hash_seed"
2) "15"
3) "fdb_aging_time"
4) "600"
5) "lag_hash_seed"
6) "15"
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
