### PR TITLE
Fix syncd terminated in rpc image

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-rpc.mk
+++ b/platform/broadcom/docker-syncd-brcm-rpc.mk
@@ -19,5 +19,6 @@ endif
 $(DOCKER_SYNCD_BRCM_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro


### PR DESCRIPTION
Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add mount "/host/warmboot" for syncd container

**- How I did it**
Modify docker-syncd-brcm-rpc.mk

**- How to verify it**
Use "make target/sonic-broadcom.bin ENABLE_SYNCD_RPC=y" to make image.
And then load the image on DUT.
Check if the syncd work well.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
