### PR TITLE
[hostcfgd] hostcfgd will exit when set hostname in DEVICE_METADATA

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -24,9 +24,7 @@ TACPLUS_SERVER_AUTH_TYPE_DEFAULT = "pap"
 
 
 def is_valid_hostname(hostname):
-    if hostname[-1] == ".":
-        return False
-    if len(hostname) > 253:
+    if hostname[-1] == "." or len(hostname) > 253:
         return False
     allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
     return all(allowed.match(x) for x in hostname.split("."))

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -23,9 +23,9 @@ TACPLUS_SERVER_TIMEOUT_DEFAULT = "5"
 TACPLUS_SERVER_AUTH_TYPE_DEFAULT = "pap"
 
 
-def is_valid_hostname(name):
+def is_valid_hostname(hostname):
     if hostname[-1] == ".":
-        hostname = hostname[:-1] # strip exactly one dot from the right, if present
+        return False
     if len(hostname) > 253:
         return False
     allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
@@ -187,6 +187,7 @@ class HostConfigDaemon:
             syslog.syslog(syslog.LOG_WARNING, "hostname key is missing")
             return
         if not is_valid_hostname(hostname):
+            syslog.syslog(syslog.LOG_WARNING, "hostname {} is invalid".format(hostname))
             return
         if hostname == self.hostname_cache:
             return


### PR DESCRIPTION
Signed-off-by: ouxiaolong <ouxiaolong@asterfusion.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1.when execute ‘redis-cli -n 4 HSET "DEVICE_METADATA|localhost" hostname 48S-wz.’ in SONiC bash ，hostcfgdwill exit，and there is a Traceback information in /var/log/syslog like this:

Aug 28 17:35:14.551892 48S-wz INFO hostcfgd[21512]: Traceback (most recent call last):
Aug 28 17:35:14.552642 48S-wz INFO hostcfgd[21512]:   File "/usr/bin/hostcfgd", line 232, in <module>
Aug 28 17:35:14.553171 48S-wz INFO hostcfgd[21512]:     main()
Aug 28 17:35:14.553701 48S-wz INFO hostcfgd[21512]:   File "/usr/bin/hostcfgd", line 228, in main
Aug 28 17:35:14.554190 48S-wz INFO hostcfgd[21512]:     daemon.start()
Aug 28 17:35:14.554735 48S-wz INFO hostcfgd[21512]:   File "/usr/bin/hostcfgd", line 223, in start
Aug 28 17:35:14.555217 48S-wz INFO hostcfgd[21512]:     self.config_db.listen()
Aug 28 17:35:14.555704 48S-wz INFO hostcfgd[21512]:   File "/usr/local/lib/python2.7/dist-packages/swsssdk/configdb.py", line 102, in listen
Aug 28 17:35:14.556188 48S-wz INFO hostcfgd[21512]:     self.__fire(table, row, data)
Aug 28 17:35:14.556750 48S-wz INFO hostcfgd[21512]:   File "/usr/local/lib/python2.7/dist-packages/swsssdk/configdb.py", line 87, in __fire
Aug 28 17:35:14.557263 48S-wz INFO hostcfgd[21512]:     handler(table, key, data)
Aug 28 17:35:14.557764 48S-wz INFO hostcfgd[21512]:   File "/usr/bin/hostcfgd", line 222, in <lambda>
Aug 28 17:35:14.558266 48S-wz INFO hostcfgd[21512]:     self.config_db.subscribe('DEVICE_METADATA', lambda table, key, data: self.hostname_handler(key, data))
Aug 28 17:35:14.558821 48S-wz INFO hostcfgd[21512]:   File "/usr/bin/hostcfgd", line 189, in hostname_handler
Aug 28 17:35:14.559325 48S-wz INFO hostcfgd[21512]:     if not is_valid_hostname(hostname):
Aug 28 17:35:14.559830 48S-wz INFO hostcfgd[21512]:   File "/usr/bin/hostcfgd", line 27, in is_valid_hostname
Aug 28 17:35:14.560476 48S-wz INFO hostcfgd[21512]:     if hostname[-1] == ".":
Aug 28 17:35:14.560993 48S-wz INFO hostcfgd[21512]: UnboundLocalError: local variable 'hostname' referenced before assignment

2.after I fixed it, there are some other err log in /var/log/syslog like this

Aug 29 10:13:33.583491 48S-wz INFO hostcfgd[27773]: Set hostname in bgp container
Aug 29 10:13:33.880805 48S-wz INFO hostcfgd[27773]: hostname: the specified hostname is invalid
Aug 29 10:13:36.008242 48S-wz INFO hostcfgd[27773]: Set hostname in swss container
Aug 29 10:13:36.276700 48S-wz INFO hostcfgd[27773]: hostname: the specified hostname is invalid
Aug 29 10:13:38.560297 48S-wz INFO hostcfgd[27773]: Set hostname in syncd container
Aug 29 10:13:38.853333 48S-wz INFO hostcfgd[27773]: hostname: the specified hostname is invalid
Aug 29 10:13:41.084499 48S-wz INFO hostcfgd[27773]: Set hostname in dhcp_relay container
Aug 29 10:13:41.357581 48S-wz INFO hostcfgd[27773]: hostname: the specified hostname is invalid
Aug 29 10:13:43.669783 48S-wz INFO hostcfgd[27773]: Set hostname in radv container
Aug 29 10:13:43.934936 48S-wz INFO hostcfgd[27773]: hostname: the specified hostname is invalid
Aug 29 10:13:46.110223 48S-wz INFO hostcfgd[27773]: Set hostname in snmp container
Aug 29 10:13:46.361012 48S-wz INFO hostcfgd[27773]: hostname: the specified hostname is invalid
Aug 29 10:13:48.693676 48S-wz INFO hostcfgd[27773]: Set hostname in teamd container
Aug 29 10:13:48.965765 48S-wz INFO hostcfgd[27773]: hostname: the specified hostname is invalid
Aug 29 10:13:51.149399 48S-wz INFO hostcfgd[27773]: Set hostname in lldp container
Aug 29 10:13:51.433085 48S-wz INFO hostcfgd[27773]: hostname: the specified hostname is invalid
Aug 29 10:13:53.758775 48S-wz INFO hostcfgd[27773]: Set hostname in pmon container
Aug 29 10:13:54.029597 48S-wz INFO hostcfgd[27773]: hostname: the specified hostname is invalid
Aug 29 10:13:56.273657 48S-wz INFO hostcfgd[27773]: Set hostname in database container
Aug 29 10:13:56.549141 48S-wz INFO hostcfgd[27773]: hostname: the specified hostname is invalid



**- How I did it**
1.fix is_valid_hostname in hostcfgd
2. log warning when hostname is invalid

**- How to verify it**
execute ‘redis-cli -n 4 HSET "DEVICE_METADATA|localhost" hostname 48S-wz.’ in SONiC bash, then check log in /var/log/syslog 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
