### PR TITLE
Add IPv6 Support in TACACS

### DIFF
--- a/src/tacacs/nss/0005-libnss-Modify-parsing-of-IP-addr-and-port-number-str.patch
+++ b/src/tacacs/nss/0005-libnss-Modify-parsing-of-IP-addr-and-port-number-str.patch
@@ -1,0 +1,26 @@
+From aa8af2b2400b7bbcbe7af0cb50047a98e93660ca Mon Sep 17 00:00:00 2001
+From: SuvarnaMeenakshi <sumeenak@microsoft.com>
+Date: Thu, 29 Aug 2019 09:44:24 -0700
+Subject: [PATCH] libnss: Modify parsing of IP addr and port number string to
+ support IPv6
+
+---
+ nss_tacplus.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/nss_tacplus.c b/nss_tacplus.c
+index f2a86e1..3ff3c35 100644
+--- a/nss_tacplus.c
++++ b/nss_tacplus.c
+@@ -98,7 +98,7 @@ static int parse_tac_server(char *srv_buf)
+                 hints.ai_socktype = SOCK_STREAM;
+ 
+                 srv = token + 7;
+-                port = strchr(srv, ':');
++                port = strrchr(srv, ':');
+                 if(port) {
+                     *port = '\0';
+                     port++;
+-- 
+2.17.1
+

--- a/src/tacacs/nss/Makefile
+++ b/src/tacacs/nss/Makefile
@@ -22,6 +22,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git $(GIT_APPLY) ../0002-Enable-modifying-local-user-permission.patch
 	git $(GIT_APPLY) ../0003-management-vrf-support.patch
 	git $(GIT_APPLY) ../0004-Skip-accessing-tacacs-servers-for-local-non-tacacs-u.patch
+	git $(GIT_APPLY) ../0005-libnss-Modify-parsing-of-IP-addr-and-port-number-str.patch
 
 	dpkg-buildpackage -rfakeroot -b -us -uc
 	popd

--- a/src/tacacs/pam/0005-pam-Modify-parsing-of-IP-address-and-port-number-to-.patch
+++ b/src/tacacs/pam/0005-pam-Modify-parsing-of-IP-address-and-port-number-to-.patch
@@ -12,14 +12,6 @@ diff --git a/support.c b/support.c
 index 44efee3..7c00618 100644
 --- a/support.c
 +++ b/support.c
-@@ -36,6 +36,7 @@ int tac_srv_no = 0;
- char tac_service[64];
- char tac_protocol[64];
- char tac_prompt[64];
-+char *__vrfname=NULL;
- 
- void _pam_log(int err, const char *format,...) {
-     char msg[256];
 @@ -225,11 +226,11 @@ int _pam_parse (int argc, const char **argv) {
  
                  if (*server_buf == '[' && (close_bracket = strchr(server_buf, ']')) != NULL) { /* Check for URI syntax */
@@ -34,24 +26,6 @@ index 44efee3..7c00618 100644
                  }
                  if (port != NULL) {
                      *port = '\0';
-@@ -271,6 +272,8 @@ int _pam_parse (int argc, const char **argv) {
-             } else { 
-                 tac_readtimeout_enable = 1;
-             }
-+        } else if(!strncmp(*argv, "vrf=", 4)) {
-+            __vrfname = strdup(*argv + 4);
-         } else {
-             _pam_log (LOG_WARNING, "unrecognized option: %s", *argv);
-         }
-@@ -282,7 +285,7 @@ int _pam_parse (int argc, const char **argv) {
-         _pam_log(LOG_DEBUG, "%d servers defined", tac_srv_no);
- 
-         for(n = 0; n < tac_srv_no; n++) {
--            _pam_log(LOG_DEBUG, "server[%d] { addr=%s, key='%s' }", n, tac_ntop(tac_srv[n].addr->ai_addr), tac_srv[n].key);
-+            _pam_log(LOG_DEBUG, "server[%d] { addr=%s, key='%c*****' }", n, tac_ntop(tac_srv[n].addr->ai_addr), tac_srv[n].key[0]);
-         }
- 
-         _pam_log(LOG_DEBUG, "tac_service='%s'", tac_service);
 -- 
 2.17.1
 

--- a/src/tacacs/pam/0005-pam-Modify-parsing-of-IP-address-and-port-number-to-.patch
+++ b/src/tacacs/pam/0005-pam-Modify-parsing-of-IP-address-and-port-number-to-.patch
@@ -1,0 +1,57 @@
+From 264de96e8a1c411371f9fc20b0b5b00c10e7052d Mon Sep 17 00:00:00 2001
+From: SuvarnaMeenakshi <sumeenak@microsoft.com>
+Date: Thu, 29 Aug 2019 09:51:43 -0700
+Subject: [PATCH] pam: Modify parsing of IP address and port number to support
+ IPv6
+
+---
+ support.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/support.c b/support.c
+index 44efee3..7c00618 100644
+--- a/support.c
++++ b/support.c
+@@ -36,6 +36,7 @@ int tac_srv_no = 0;
+ char tac_service[64];
+ char tac_protocol[64];
+ char tac_prompt[64];
++char *__vrfname=NULL;
+ 
+ void _pam_log(int err, const char *format,...) {
+     char msg[256];
+@@ -225,11 +226,11 @@ int _pam_parse (int argc, const char **argv) {
+ 
+                 if (*server_buf == '[' && (close_bracket = strchr(server_buf, ']')) != NULL) { /* Check for URI syntax */
+                     server_name = server_buf + 1;
+-                    port = strchr(close_bracket, ':');
++                    port = strrchr(close_bracket, ':');
+                     *close_bracket = '\0';
+                 } else { /* Fall back to traditional syntax */
+                     server_name = server_buf;
+-                    port = strchr(server_buf, ':');
++                    port = strrchr(server_buf, ':');
+                 }
+                 if (port != NULL) {
+                     *port = '\0';
+@@ -271,6 +272,8 @@ int _pam_parse (int argc, const char **argv) {
+             } else { 
+                 tac_readtimeout_enable = 1;
+             }
++        } else if(!strncmp(*argv, "vrf=", 4)) {
++            __vrfname = strdup(*argv + 4);
+         } else {
+             _pam_log (LOG_WARNING, "unrecognized option: %s", *argv);
+         }
+@@ -282,7 +285,7 @@ int _pam_parse (int argc, const char **argv) {
+         _pam_log(LOG_DEBUG, "%d servers defined", tac_srv_no);
+ 
+         for(n = 0; n < tac_srv_no; n++) {
+-            _pam_log(LOG_DEBUG, "server[%d] { addr=%s, key='%s' }", n, tac_ntop(tac_srv[n].addr->ai_addr), tac_srv[n].key);
++            _pam_log(LOG_DEBUG, "server[%d] { addr=%s, key='%c*****' }", n, tac_ntop(tac_srv[n].addr->ai_addr), tac_srv[n].key[0]);
+         }
+ 
+         _pam_log(LOG_DEBUG, "tac_service='%s'", tac_service);
+-- 
+2.17.1
+

--- a/src/tacacs/pam/Makefile
+++ b/src/tacacs/pam/Makefile
@@ -18,6 +18,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git apply ../0002-Fix-libtac2-bin-install-directory-error.patch
 	git apply ../0003-Obfuscate-key-before-printing-to-syslog.patch
 	git apply ../0004-management-vrf-support.patch
+	git apply ../0005-pam-Modify-parsing-of-IP-address-and-port-number-to-.patch
 
 	dpkg-buildpackage -rfakeroot -b -us -uc
 	popd


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added support in PAM and NSS library to support IPv6 addresses.

**- How I did it**
It is mainly to change the way the IP address and port number is parsed from the string ip addr: port#.

In current code, they look for the first ‘:’ and anything after that is port number. This does not work for IPv6 as ‘:’ exists in address. SO I changed it to look at the last ‘:’ instead.

**- How to verify it**
Started tac_plus server which has IPv6 address.
Pulled the tac_plus code from:
https://launchpad.net/ubuntu/+source/tacacs+/4.0.4.27a-3 
Started the tac_plus service on server side listening in the default port (49).

Added the configs in DUT.
sudo config tacacs authtype login
sudo config tacacs passkey testing123
sudo config aaa authentication login tacacs+
sudo config tacacs add _IPv6 server address_

$ show tacacs
TACPLUS global auth_type login
TACPLUS global timeout 5 (default)
TACPLUS global passkey testing123

TACPLUS_SERVER address _IPv6 server address_
               priority 1
               tcp_port 49

From an external server, tried logging in to the SONiC device as a test user defined in the tacacs server, was able to login successfully.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog: Add IPv6 support in TACACS
-->


**- A picture of a cute animal (not mandatory but encouraged)**
