### PR TITLE
[dhcp_relay]:filter out the ipv6 address of dhcp server for dhcp rela…

### DIFF
--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -43,8 +43,16 @@ isc-dhcp-relay-{{ vlan_name }}
 
 
 {# Create a program entry for each DHCP relay agent instance #}
+{% set relay_for_ipv4 = { 'flag': False } %}
 {% for vlan_name in VLAN %}
 {% if VLAN[vlan_name]['dhcp_servers'] %}
+{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
+{% if  dhcp_server | ipv4 %}
+{% set _dummy = relay_for_ipv4.update({'flag': True}) %}
+{% endif %}
+{% endfor %}
+{% if relay_for_ipv4.flag %}
+{% set _dummy = relay_for_ipv4.update({'flag': False}) %}
 [program:isc-dhcp-relay-{{ vlan_name }}]
 {# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
 command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}
@@ -58,7 +66,9 @@ command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /t
 {% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
 {% endfor %}
-{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %} {{ dhcp_server }}{% endfor %}
+{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
+{%- if dhcp_server | ipv4 %} {{ dhcp_server }}{% endif -%}
+{% endfor %}
 
 priority=3
 autostart=false
@@ -66,6 +76,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -47,7 +47,7 @@ isc-dhcp-relay-{{ vlan_name }}
 {% for vlan_name in VLAN %}
 {% if VLAN[vlan_name]['dhcp_servers'] %}
 {% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-{% if  dhcp_server | ipv4 %}
+{% if dhcp_server | ipv4 %}
 {% set _dummy = relay_for_ipv4.update({'flag': True}) %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
…y(v4) config file.

Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
For dhcp relay docker,   the startup command (command=/usr/sbin/dhcrelay -d) of dhcp relay only for ipv4. But the command 'dhcrelay' option for dhcp server address doesn't filter out  ipv6 address.

**- How I did it**
Add the filter of dhcp server address to select the ipv4 address.

**- How to verify it**
1. add the ipv6 address of dhcp servers for vlan interface
        "Vlan1000": {
            "dhcp_servers": [
                "192.0.0.1", 
        	"3302::1238"
            ], 
            "vlanid": "1000"
        }
2. load the config 

3. generate the config file 'docker-dhcp-relay.supervisord.conf' 
sonic-cfggen -d -t /usr/share/sonic/templates/docker-dhcp-relay.supervisord.conf.j2

4. check the dhcp relay section


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
