### PR TITLE
[DELL] S6100 Support PowerCycle in Last Reboot Reason

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -233,6 +233,9 @@ if [ -f $FIRST_BOOT_FILE ]; then
         touch /tmp/pending_config_initialization
     fi
 
+    # Notify firstboot to Platform, to use it for reboot-cause
+    touch /tmp/notify_firstboot_to_platform
+
     if [ -d /host/image-$SONIC_VERSION/platform/$platform ]; then
         dpkg -i /host/image-$SONIC_VERSION/platform/$platform/*.deb
     fi

--- a/files/image_config/process-reboot-cause/process-reboot-cause
+++ b/files/image_config/process-reboot-cause/process-reboot-cause
@@ -21,6 +21,7 @@ SYSLOG_IDENTIFIER = "process-reboot-cause"
 REBOOT_CAUSE_DIR = "/host/reboot-cause/"
 REBOOT_CAUSE_FILE = REBOOT_CAUSE_DIR + "reboot-cause.txt"
 PREVIOUS_REBOOT_CAUSE_FILE = REBOOT_CAUSE_DIR + "previous-reboot-cause.txt"
+FIRST_BOOT_PLATFORM_FILE = "/tmp/notify_firstboot_to_platform"
 
 UNKNOWN_REBOOT_CAUSE = "Unknown"
 
@@ -86,6 +87,13 @@ def main():
                 cause_file = open(REBOOT_CAUSE_FILE, "r")
                 previous_reboot_cause = cause_file.readline().rstrip('\n')
                 cause_file.close()
+            # If it is FirstTime Boot and previous_reboot_cause is unknown
+            # and hardware_reboot cause is non_hardware then
+            # Update the reboot cause as required
+            if os.path.isfile(FIRST_BOOT_PLATFORM_FILE):
+                if (previous_reboot_cause == UNKNOWN_REBOOT_CAUSE):
+                     previous_reboot_cause = UNKNOWN_REBOOT_CAUSE
+                os.remove(FIRST_BOOT_PLATFORM_FILE)
         elif hardware_reboot_cause == chassis.REBOOT_CAUSE_HARDWARE_OTHER:
             previous_reboot_cause = "{} ({})".format(hardware_reboot_cause, optional_details)
         else:
@@ -100,6 +108,12 @@ def main():
             previous_reboot_cause = cause_file.readline().rstrip('\n')
             cause_file.close()
 
+        # If it is FirstTime Boot and previous_reboot_cause is unknown
+        # Update the reboot cause as required
+        if os.path.isfile(FIRST_BOOT_PLATFORM_FILE):
+            if (previous_reboot_cause == UNKNOWN_REBOOT_CAUSE):
+                 previous_reboot_cause = UNKNOWN_REBOOT_CAUSE
+            os.remove(FIRST_BOOT_PLATFORM_FILE)
     # Write the previous reboot cause to PREVIOUS_REBOOT_CAUSE_FILE
     prev_cause_file = open(PREVIOUS_REBOOT_CAUSE_FILE, "w")
     prev_cause_file.write(previous_reboot_cause)

--- a/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
+++ b/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
@@ -43,6 +43,7 @@
 #define IOREGION_LENGTH           0x4
 #define SMF_ADDR_REG_OFFSET         0
 #define SMF_READ_DATA_REG_OFFSET    2
+#define SMF_WRITE_DATA_REG_OFFSET   3
 #define SMF_REG_ADDR            0x200
 #define SMF_POR_SRC_REG         0x209
 #define SMF_RST_SRC_REG         0x20A
@@ -156,6 +157,9 @@
 #define CPU_6_MONITOR_STATUS    0x02E7
 #define CPU_7_MONITOR_STATUS    0x02E8
 #define CPU_8_MONITOR_STATUS    0x02E9
+
+/* Mailbox PowerOn Reason */
+#define TRACK_POWERON_REASON    0x05FF
 
 /* EEPROM PPID */
 /* FAN and PSU EEPROM PPID format is:
@@ -461,6 +465,18 @@ struct smf_sio_data {
         enum kinds kind;
 };
 
+static int smf_write_reg(struct smf_data *data, u16 reg, u16 dev_data)
+{
+        int res = 0;
+
+        mutex_lock(&data->lock);
+        outb_p(reg>> 8, data->addr + SMF_ADDR_REG_OFFSET);
+        outb_p(reg & 0xff, data->addr + SMF_ADDR_REG_OFFSET + 1);
+        outb_p(dev_data & 0xff, data->addr + SMF_WRITE_DATA_REG_OFFSET);
+        mutex_unlock(&data->lock);
+
+        return res;
+}
 
 static int smf_read_reg(struct smf_data *data, u16 reg) 
 { 
@@ -550,6 +566,40 @@ static ssize_t show_power_on_reason(struct device *dev,
        return ret;
 
     return sprintf(buf, "%x\n", ret);
+}
+
+/* SMF Mailbox Power ON Reason */
+static ssize_t set_mb_poweron_reason(struct device *dev,
+              struct device_attribute *devattr, const char *buf, size_t count)
+{
+    int              err = 0;
+    unsigned int     dev_data = 0;
+    struct smf_data *data = dev_get_drvdata(dev);
+
+    err = kstrtouint(buf, 16, &dev_data);
+    if (err)
+        return err;
+
+    err = smf_write_reg(data, TRACK_POWERON_REASON, dev_data);
+
+    if(err < 0)
+       return err;
+
+    return count;
+}
+
+static ssize_t show_mb_poweron_reason(struct device *dev,
+                struct device_attribute *devattr, char *buf)
+{
+    unsigned int     ret = 0;
+    struct smf_data *data = dev_get_drvdata(dev);
+
+    ret = smf_read_reg(data, TRACK_POWERON_REASON);
+
+    if(ret < 0)
+       return ret;
+
+    return sprintf(buf, "0x%x\n", ret);
 }
 
 /* FANIN ATTR */
@@ -1981,11 +2031,16 @@ static SENSOR_DEVICE_ATTR(smf_reset_reason, S_IRUGO, show_reset_reason, NULL, 1)
 static SENSOR_DEVICE_ATTR(smf_poweron_reason, S_IRUGO,
                                             show_power_on_reason, NULL, 1);
 
+/* Mailbox Power tracking Reason */
+static SENSOR_DEVICE_ATTR(mb_poweron_reason, S_IRUGO|S_IWUSR,
+                            show_mb_poweron_reason, set_mb_poweron_reason, 0);
+
 static struct attribute *smf_dell_attrs[] = {
         &sensor_dev_attr_smf_version.dev_attr.attr,
         &sensor_dev_attr_smf_firmware_ver.dev_attr.attr,
         &sensor_dev_attr_smf_reset_reason.dev_attr.attr,
         &sensor_dev_attr_smf_poweron_reason.dev_attr.attr,
+        &sensor_dev_attr_mb_poweron_reason.dev_attr.attr,
         &sensor_dev_attr_fan_tray_presence.dev_attr.attr,
         &sensor_dev_attr_fan1_airflow.dev_attr.attr,
         &sensor_dev_attr_fan3_airflow.dev_attr.attr,

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
@@ -70,9 +70,11 @@ class Chassis(ChassisBase):
 
         # In S6000, We track the reboot reason by writing the reason in
         # NVRAM. Only Warmboot and Coldboot reason are supported here.
+        # Since it does not support any hardware reason, we return
+        # non_hardware as default
 
         if (reset_reason in self.reset_reason_dict):
             return (self.reset_reason_dict[reset_reason], None)
 
-        return (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "Invalid Reason")
+        return (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, None)
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -217,6 +217,25 @@ reset_muxes() {
     io_rd_wr.py --set --val 0xff --offset 0x20b
 }
 
+
+track_reboot_reason() {
+    if [[ -d /sys/devices/platform/SMF.512/hwmon/ ]]; then
+        rv=$(cd /sys/devices/platform/SMF.512/hwmon/*; cat mb_poweron_reason)
+        reason=$(echo $rv | cut -d 'x' -f2)
+        if [ $reason == "ff" ]; then
+            cd /sys/devices/platform/SMF.512/hwmon/*
+            if [[ -e /tmp/notify_firstboot_to_platform ]]; then
+                echo 0x01 > mb_poweron_reason
+            else
+                echo 0xbb > mb_poweron_reason
+            fi
+        elif [ $reason == "bb" ] || [ $reason == "01"]; then
+            cd /sys/devices/platform/SMF.512/hwmon/*
+            echo 0xaa > mb_poweron_reason
+        fi
+    fi
+}
+
 install_python_api_package() {
     device="/usr/share/sonic/device"
     platform=$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
@@ -239,6 +258,7 @@ if [[ "$1" == "init" ]]; then
     modprobe dell_ich
     modprobe dell_s6100_iom_cpld
     modprobe dell_s6100_lpc
+    track_reboot_reason
 
     # Disable Watchdog Timer
     if [[ -e /usr/local/bin/platform_watchdog_disable.sh ]]; then

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -150,6 +150,13 @@ class Chassis(ChassisBase):
         rv = rv.lstrip(" ")
         return rv
 
+    def _get_reboot_reason_smf_register(self):
+        # Returns 0xAA on software reload
+        # Returns 0xFF on power-cycle
+        # Returns 0x01 on first-boot
+        smf_mb_reg_reason = self._get_pmc_register('mb_poweron_reason')
+        return int(smf_mb_reg_reason, 16)
+
     # Run bash command and print output to stdout
     def run_command(self, command):
         click.echo(click.style("Command: ", fg='cyan') +
@@ -236,6 +243,10 @@ class Chassis(ChassisBase):
 
         reset_reason = int(self._get_pmc_register('smf_reset_reason'))
         power_reason = int(self._get_pmc_register('smf_poweron_reason'))
+        smf_mb_reg_reason = self._get_reboot_reason_smf_register()
+
+        if ((smf_mb_reg_reason == 0x01) and (power_reason == 0x11)):
+            return (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, None)
 
         # Reset_Reason = 11 ==> PowerLoss
         # So return the reboot reason from Last Power_Reason Dictionary
@@ -244,10 +255,16 @@ class Chassis(ChassisBase):
         # checking key presence in dictionary else return
         # REBOOT_CAUSE_HARDWARE_OTHER as the Power_Reason and Reset_Reason
         # registers returned invalid data
+
+        # In S6100, if Reset_Reason is not 11 and smf_mb_reg_reason
+        # is ff or bb, then it is PowerLoss
         if (reset_reason == 11):
             if (power_reason in self.power_reason_dict):
                 return (self.power_reason_dict[power_reason], None)
         else:
+            if ((smf_mb_reg_reason == 0xbb) or (smf_mb_reg_reason == 0xff)):
+                return (ChassisBase.REBOOT_CAUSE_POWER_LOSS, None)
+
             if (reset_reason in self.reset_reason_dict):
                 return (self.reset_reason_dict[reset_reason], None)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added support to fix power-cycle last reboot cause in S6100
Known Caveat :- If we upgrade old_image (old_image without this fix) to the new_image(with this fix)
                If we do a power-cycle instead of fast/warm/cold reset, show reboot-cause will return "Unknown" instead of "power-cycle"
				
**- How I did it**
Changes Done
        modified:   files/image_config/process-reboot-cause/process-reboot-cause
        modified:   files/image_config/platform/rc.local
        modified:   platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
        modified:   platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
        modified:   platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
        modified:   platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py

rc.local will inform the platform about first boot. Platform Init Script will use the info and update the
logical to return non-hardware in case of first time onie boot/image upgrade.

process-reboot-cause will use the first_boot notification and use it to return Valid last-reset-reason
Currently it will show unkwown which is not correct.

**- How to verify it**
Unit Test Results attached
---------------------------
a) power-cycle the box and issue show reboot-cause
b) Onie install the box and check return value of get_reboot_cause api
c) Upgrade the image and check return value of get_reboot_Cause api

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[DELL] S6100 Support PowerCycle in Last Reboot Reason

**- A picture of a cute animal (not mandatory but encouraged)**
