### PR TITLE
NTP support for management VRF 

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -449,6 +449,9 @@ sudo cp files/dhcp/graphserviceurl $FILESYSTEM_ROOT/etc/dhcp/dhclient-exit-hooks
 sudo cp files/dhcp/snmpcommunity $FILESYSTEM_ROOT/etc/dhcp/dhclient-exit-hooks.d/
 sudo cp files/dhcp/vrf $FILESYSTEM_ROOT/etc/dhcp/dhclient-exit-hooks.d/
 sudo cp files/dhcp/dhclient.conf $FILESYSTEM_ROOT/etc/dhcp/
+if [ -f files/image_config/ntp/mgmtvrf_add_cgexec_to_ntp.sh ]; then
+    ./files/image_config/ntp/mgmtvrf_add_cgexec_to_ntp.sh $FILESYSTEM_ROOT/etc/init.d/ntp
+fi
 
 ## Version file
 sudo mkdir -p $FILESYSTEM_ROOT/etc/sonic

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -21,6 +21,13 @@ iface lo {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
 #
 {% endfor %}
+# The loopback network interface for mgmt VRF that is required for applications like NTP
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
+    up ip link add lo-m type dummy
+    up ip addr add 127.0.0.1/8 dev lo-m
+    up ip link set lo-m up
+    up ip link set dev lo-m master mgmt
+{% endif %}
 {% endblock loopback %}
 {% block mgmt_interface %}
 

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -27,6 +27,7 @@ iface lo {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     up ip addr add 127.0.0.1/8 dev lo-m
     up ip link set lo-m up
     up ip link set dev lo-m master mgmt
+	down ip link delete dev lo-m
 {% endif %}
 {% endblock loopback %}
 {% block mgmt_interface %}

--- a/files/image_config/ntp/mgmtvrf_add_cgexec_to_ntp.sh
+++ b/files/image_config/ntp/mgmtvrf_add_cgexec_to_ntp.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo sed -i '/start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON -- -p $PIDFILE $NTPD_OPTS/d' $1
+sudo sed -i '/flock -w 180 9/a \\t\t\tvrfEnabled=$(/usr/local/bin/sonic-cfggen -d -v '"'MGMT_VRF_CONFIG[\"vrf_global\"][\"mgmtVrfEnabled\"]'"')\n\t\t\tif [ "$vrfEnabled" = "true" ]\n\t\t\tthen\n\t\t\t\tlog_daemon_msg "Starting NTP server in mgmt-vrf" "ntpd"\n\t\t\t\tcgexec -g l3mdev:mgmt start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON -- -p $PIDFILE $NTPD_OPTS\n\t\t\telse\n\t\t\t\tlog_daemon_msg "Starting NTP server in default-vrf" "ntpd"\n\t\t\t\tstart-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON -- -p $PIDFILE $NTPD_OPTS\n\t\t\tfi' $1


### PR DESCRIPTION
Support for NTP to run in management VRF is added.
As part of l3mdev based management VRF implementation, in order to execute the NTP daemon in the context of management vrf using cgexec, the NTP script /etc/init.d/ntp is updated to check for mvrf enabled status and call "start-stop-daemon" using cgexec.  Since this /etc/init.d/ntp script is installed as part of NTP application (apt-get), a new script is used to update the installed /etc/init.d/ntp.
In addition, the linux NTP commands (programs) like “ntpq” and “ntpstat” require a loopback interface to connect to the ntpd and hence a dummy loopback interface lo-m is created in interfaces.j2 as part of management vrf. 

TESTING:
Verified NTP using “ntpq -p” and “ntpstat” before enabling management VRF.
Enabled management vrf using “config vrf add mgmt” command that is explained in PR https://github.com/Azure/sonic-utilities/pull/463
Verified NTP in management VRF using “cgexec” as follows.
root@sonic:/home/admin# date
Fri Aug 30 15:31:53 UTC 2019
root@sonic:/home/admin# cgexec -g l3mdev:mgmt ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
================================================================
23.92.29.245    .STEP.          16 u    -   64    0    0.000    0.000   0.000
*204.2.134.164   44.24.199.34     3 u    9   64    1  200.601   -0.199   2.589

root@sonic:/home/admin# cgexec -g l3mdev:mgmt ntpstat
synchronised to NTP server (204.2.134.164) at stratum 4 
   time correct to within 1085 ms
   polling server every 64 s
root@sonic:/home/admin# ps -ax | grep ntp
9761 ?        Ssl    0:00 /usr/sbin/ntpd -p /var/run/ntpd.pid -g -u 106:110
9799 ttyS1    S+     0:00 grep ntp
root@sonic:/home/admin#
