### PR TITLE
[minigraph]: Ignore mirror session portion in minigraph

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -716,19 +716,21 @@ def parse_xml(filename, platform=None, port_config_file=None):
     results['TACPLUS_SERVER'] = dict((item, {'priority': '1', 'tcp_port': '49'}) for item in tacacs_servers)
 
     results['ACL_TABLE'] = acls
-    mirror_sessions = {}
-    if erspan_dst:
-        lo_addr = '0.0.0.0'
-        for lo in lo_intfs:
-            lo_network = ipaddress.IPNetwork(lo[1])
-            if lo_network.version == 4:
-                lo_addr = str(lo_network.ip)
-                break
-        count = 0
-        for dst in erspan_dst:
-            mirror_sessions['everflow{}'.format(count)] = {"dst_ip": dst, "src_ip": lo_addr}
-            count += 1
-        results['MIRROR_SESSION'] = mirror_sessions
+
+    # Do not configure the minigraph's mirror session, which is currently unused
+    # mirror_sessions = {}
+    # if erspan_dst:
+    #     lo_addr = '0.0.0.0'
+    #     for lo in lo_intfs:
+    #         lo_network = ipaddress.IPNetwork(lo[1])
+    #         if lo_network.version == 4:
+    #             lo_addr = str(lo_network.ip)
+    #             break
+    #     count = 0
+    #     for dst in erspan_dst:
+    #         mirror_sessions['everflow{}'.format(count)] = {"dst_ip": dst, "src_ip": lo_addr}
+    #         count += 1
+    #     results['MIRROR_SESSION'] = mirror_sessions
 
     # Special parsing for spine chassis frontend routers
     if current_device['type'] == spine_chassis_frontend_role:

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -104,10 +104,11 @@ class TestCfgGen(TestCase):
                                          "'SSH_ACL': {'services': ['SSH'], 'type': 'CTRLPLANE', 'policy_desc': 'SSH_ACL'}, "
                                          "'EVERFLOWV6': {'type': 'MIRRORV6', 'policy_desc': 'EVERFLOWV6', 'ports': ['PortChannel01', 'PortChannel02', 'PortChannel03', 'PortChannel04', 'Ethernet24', 'Ethernet40', 'Ethernet20', 'Ethernet44', 'Ethernet48', 'Ethernet28', 'Ethernet96', 'Ethernet92', 'Ethernet76', 'Ethernet72', 'Ethernet52', 'Ethernet80', 'Ethernet56', 'Ethernet32', 'Ethernet16', 'Ethernet36', 'Ethernet12', 'Ethernet60', 'Ethernet8', 'Ethernet4', 'Ethernet0', 'Ethernet64', 'Ethernet68', 'Ethernet84', 'Ethernet88', 'Ethernet108', 'Ethernet104', 'Ethernet100']}}")
 
-    def test_minigraph_everflow(self):
-        argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v MIRROR_SESSION'
-        output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '2.2.2.2'}}")
+#     everflow portion is not used
+#     def test_minigraph_everflow(self):
+#         argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v MIRROR_SESSION'
+#         output = self.run_script(argument)
+#         self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '2.2.2.2'}}")
 
     def test_minigraph_mgmt_ports(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v MGMT_PORT'
@@ -234,10 +235,11 @@ class TestCfgGen(TestCase):
             "'Ethernet20': {'alias': 'fortyGigE0/20', 'pfc_asym': 'off', 'lanes': '45,46,47,48', 'description': 'fortyGigE0/20', 'mtu': '9100'}, "
             "'Ethernet24': {'alias': 'fortyGigE0/24', 'pfc_asym': 'off', 'lanes': '5,6,7,8', 'description': 'fortyGigE0/24', 'mtu': '9100'}}")
 
-    def test_metadata_everflow(self):
-        argument = '-m "' + self.sample_graph_metadata + '" -p "' + self.port_config + '" -v "MIRROR_SESSION"'
-        output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '10.0.100.1'}}")
+#     everflow portion is not used
+#     def test_metadata_everflow(self):
+#         argument = '-m "' + self.sample_graph_metadata + '" -p "' + self.port_config + '" -v "MIRROR_SESSION"'
+#         output = self.run_script(argument)
+#         self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '10.0.100.1'}}")
 
     def test_metadata_tacacs(self):
         argument = '-m "' + self.sample_graph_metadata + '" -p "' + self.port_config + '" -v "TACPLUS_SERVER"'

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -59,10 +59,11 @@ class TestCfgGenCaseInsensitive(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'value1\nvalue2')
 
-    def test_minigraph_everflow(self):
-        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v MIRROR_SESSION'
-        output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '10.0.100.1'}}")
+#     everflow portion is not used
+#     def test_minigraph_everflow(self):
+#         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v MIRROR_SESSION'
+#         output = self.run_script(argument)
+#         self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '10.0.100.1'}}")
 
     def test_minigraph_interfaces(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v \'INTERFACE.keys()\''
@@ -104,10 +105,11 @@ class TestCfgGenCaseInsensitive(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'switch-01t1': {'lo_addr': '10.1.0.186/32', 'mgmt_addr': '10.7.0.196/26', 'hwsku': 'Force10-S6000', 'type': 'LeafRouter', 'deployment_id': '2'}}")
 
-    def test_metadata_everflow(self):
-        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "MIRROR_SESSION"'
-        output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '10.0.100.1'}}")
+#     everflow portion is not used
+#     def test_metadata_everflow(self):
+#         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "MIRROR_SESSION"'
+#         output = self.run_script(argument)
+#         self.assertEqual(output.strip(), "{'everflow0': {'src_ip': '10.1.0.32', 'dst_ip': '10.0.100.1'}}")
 
     def test_metadata_tacacs(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "TACPLUS_SERVER"'


### PR DESCRIPTION
This piece of information is currently not used. Revert this
pull request in the future to add back the default mirror
session information into the configuration database.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>