### PR TITLE
[201811] Log message containing SONiC version to syslog at boot

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -121,6 +121,8 @@ program_console_speed()
 
 #### Begin Main Body ####
 
+logger "SONiC version ${SONIC_VERSION} starting up..."
+
 # If the machine.conf is absent, it indicates that the unit booted
 # into SONiC from another NOS. Extract the machine.conf from ONIE.
 if [ ! -e /host/machine.conf ]; then


### PR DESCRIPTION
Self-explanatory. Same change as https://github.com/Azure/sonic-buildimage/pull/3416, ported to the 201811 branch, as the other PR won't cherry-pick cleanly.