### PR TITLE
Revert "Use dot1p to tc mapping for backend switches"

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -29,7 +29,6 @@
 
 
 {%- set pfc_to_pg_map_supported_asics = ['mellanox', 'barefoot', 'marvell'] -%}
-{%- set backend_device_types = ['BackEndToRRouter', 'BackEndLeafRouter'] -%}
 
 
 {
@@ -73,20 +72,6 @@
             "7": "7"
         }
     },
-{% if DEVICE_METADATA['localhost']['type'] in backend_device_types %}
-    "DOT1P_TO_TC_MAP": {
-        "AZURE": {
-            "0": "0",
-            "1": "1",
-            "2": "2",
-            "3": "3",
-            "4": "4",
-            "5": "5",
-            "6": "6",
-            "7": "7"
-        }
-    },
-{% else %}
     "DSCP_TO_TC_MAP": {
         "AZURE": {
             "0" : "1",
@@ -155,7 +140,6 @@
             "63": "1"
         }
     },
-{% endif %}
     "SCHEDULER": {
         "scheduler.0": {
             "type"  : "DWRR",
@@ -176,11 +160,7 @@
 {% endif %}
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-{% if DEVICE_METADATA['localhost']['type'] in backend_device_types %}
-            "dot1p_to_tc_map" : "[DOT1P_TO_TC_MAP|AZURE]",
-{% else %}
             "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-{% endif %}
             "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
             "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
             "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#3412