### PR TITLE
Resubmit: use dot1p to tc mapping for backend switches

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -73,6 +73,20 @@
             "7": "7"
         }
     },
+{% if DEVICE_METADATA['localhost']['type'] in backend_device_types %}
+    "DOT1P_TO_TC_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7"
+        }
+    },
+{% else %}
     "DSCP_TO_TC_MAP": {
         "AZURE": {
             "0" : "1",
@@ -141,18 +155,7 @@
             "63": "1"
         }
     },
-    "DOT1P_TO_TC_MAP": {
-        "AZURE": {
-            "0": "0",
-            "1": "1",
-            "2": "2",
-            "3": "3",
-            "4": "4",
-            "5": "5",
-            "6": "6",
-            "7": "7"
-        }
-    },
+{% endif %}
     "SCHEDULER": {
         "scheduler.0": {
             "type"  : "DWRR",

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -73,7 +73,7 @@
             "7": "7"
         }
     },
-{% if DEVICE_METADATA['localhost']['type'] in backend_device_types %}
+{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] in backend_device_types %}
     "DOT1P_TO_TC_MAP": {
         "AZURE": {
             "0": "0",
@@ -176,7 +176,7 @@
 {% endif %}
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-{% if DEVICE_METADATA['localhost']['type'] in backend_device_types %}
+{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] in backend_device_types %}
             "dot1p_to_tc_map" : "[DOT1P_TO_TC_MAP|AZURE]",
 {% else %}
             "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -29,6 +29,7 @@
 
 
 {%- set pfc_to_pg_map_supported_asics = ['mellanox', 'barefoot', 'marvell'] -%}
+{%- set backend_device_types = ['BackEndToRRouter', 'BackEndLeafRouter'] -%}
 
 
 {
@@ -140,6 +141,18 @@
             "63": "1"
         }
     },
+    "DOT1P_TO_TC_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7"
+        }
+    },
     "SCHEDULER": {
         "scheduler.0": {
             "type"  : "DWRR",
@@ -160,7 +173,11 @@
 {% endif %}
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
+{% if DEVICE_METADATA['localhost']['type'] in backend_device_types %}
+            "dot1p_to_tc_map" : "[DOT1P_TO_TC_MAP|AZURE]",
+{% else %}
             "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+{% endif %}
             "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
             "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
             "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -18,7 +18,7 @@ if [ -f /etc/sonic/config_db.json ]; then
 else
     # generate and merge buffers configuration into config file
     sonic-cfggen -t /usr/share/sonic/hwsku/buffers.json.j2 > /tmp/buffers.json
-    sonic-cfggen -t /usr/share/sonic/hwsku/qos.json.j2 > /tmp/qos.json
+    sonic-cfggen -j /etc/sonic/init_cfg.json -t /usr/share/sonic/hwsku/qos.json.j2 > /tmp/qos.json
     sonic-cfggen -p /usr/share/sonic/hwsku/port_config.ini -k $HWSKU --print-data > /tmp/ports.json
     sonic-cfggen -j /etc/sonic/init_cfg.json -j /tmp/buffers.json -j /tmp/qos.json -j /tmp/ports.json --print-data > /etc/sonic/config_db.json
 fi


### PR DESCRIPTION
Also deal with the situation when key 'type' is not defined in CONFIG_DB DEVICE_METADATA['localhost'], such as in the vs case

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
