### PR TITLE
[Mellanox] platform_reboot - sync & umount fs before power cycle

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot
@@ -19,6 +19,14 @@ function ParseArguments() {
     done
 }
 
+function SafePwrCycle() {
+    sync ; sync
+    umount -fa > /dev/null 2&>1
+    echo 1 > $SYSFS_PWR_CYCLE
+    sleep 3
+    echo 0 > $SYSFS_PWR_CYCLE
+}
+
 ParseArguments "$@"
 
 ${FW_UPGRADE_SCRIPT} --upgrade --verbose
@@ -32,7 +40,4 @@ if [[ "${EXIT_CODE}" != "${EXIT_SUCCESS}" ]]; then
     fi
 fi
 
-# perform "hardware" reboot
-echo 1 > $SYSFS_PWR_CYCLE
-sleep 3
-echo 0 > $SYSFS_PWR_CYCLE
+SafePwrCycle


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

We noticed that null characters sometimes appear in our logs after we started using power cycle to reboot.
```
NOTICE admin: User requested rebooting device ...
> ^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@
```

This gets in the way of greping the logs.

**- What I did**
Made sure the filesystem is synced and unmounted before performing the power cycle.
**- How I did it**

**- How to verify it**
Perform multiple reboots, then
cat -A /var/log/syslog* | grep -A 15 rebooting | grep ^@
Check that no null characters are present
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Made sure the filesystem is synced and unmounted before performing the power cycle on Mellanox platforms.

**- A picture of a cute animal (not mandatory but encouraged)**
