### PR TITLE
[dhcp_relay] Properly wait for routed interfaces to be ready before starting relay agent

### DIFF
--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -2,21 +2,17 @@
 
 STATE_DB_IDX="6"
 
-PORT_TABLE_PREFIX="PORT_TABLE"
-VLAN_TABLE_PREFIX="VLAN_TABLE"
-LAG_TABLE_PREFIX="LAG_TABLE"
-
 function wait_until_iface_ready
 {
-    TABLE_PREFIX=$1
-    IFACE=$2
+    IFACE_NAME=$1
+    IFACE_CIDR=$2
 
-    echo "Waiting until interface $IFACE is ready..."
+    echo "Waiting until interface ${IFACE_NAME} is ready..."
 
     # Wait for the interface to come up
     # (i.e., interface is present in STATE_DB and state is "ok")
     while true; do
-        RESULT=$(redis-cli -n ${STATE_DB_IDX} HGET "${TABLE_PREFIX}|${IFACE}" "state" 2> /dev/null)
+        RESULT=$(redis-cli -n ${STATE_DB_IDX} HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
         if [ x"$RESULT" == x"ok" ]; then
             break
         fi
@@ -24,24 +20,23 @@ function wait_until_iface_ready
         sleep 1
     done
 
-    echo "Interface ${IFACE} is ready!"
+    echo "Interface ${IFACE_NAME} is ready!"
 }
 
 
-# Wait for all interfaces to be up and ready
-{% for name in PORT %}
-{% if name in INTERFACE %}
-wait_until_iface_ready ${PORT_TABLE_PREFIX} {{ name }}
+# Wait for all interfaces with IPv4 addresses to be up and ready
+{% for (name, prefix) in INTERFACE %}
+{% if prefix | ipv4 %}
+wait_until_iface_ready {{ name }} {{ prefix }}
 {% endif %}
 {% endfor %}
-{% for name in VLAN %}
-{% if name in VLAN_INTERFACE %}
-wait_until_iface_ready ${VLAN_TABLE_PREFIX} {{ name }}
+{% for (name, prefix) in VLAN_INTERFACE %}
+{% if prefix | ipv4 %}
+wait_until_iface_ready {{ name }} {{ prefix }}
 {% endif %}
 {% endfor %}
-{% for name in PORTCHANNEL %}
-{% if name in PORTCHANNEL_INTERFACE %}
-wait_until_iface_ready ${LAG_TABLE_PREFIX} {{ name }}
+{% for (name, prefix) in PORTCHANNEL_INTERFACE %}
+{% if prefix | ipv4 %}
+wait_until_iface_ready {{ name }} {{ prefix }}
 {% endif %}
 {% endfor %}
-


### PR DESCRIPTION
**- What I did**

Previous solution wouldn't necessarily wait until interfaces were completely up and configured with an IP address. This solution checks the INTERFACE_TABLE in STATE_DB, which should only report "ok" if the interface is completely up and ready.

Also enhanced the code to only wait for interfaces with an IPv4 address configured, as the DHCP relay agent currently only support IPv4.
