### PR TITLE
[counters] interface and pfc counters are shown negative after config…

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -62,6 +62,17 @@ function preStartAction()
         echo -n > /tmp/dump.rdb
         docker cp /tmp/dump.rdb database:/var/lib/redis/
     fi
+{%- elif docker_container_name == "syncd" %}
+    # Clear the portstat counters
+    for file in `ls /tmp/portstat*/*`
+    do
+      sed -i "s|S'[0-9]*'|S'0'|g" $file
+    done
+    # Clear the pfcstat counters
+    for file in `ls /tmp/pfcstat*/*`
+    do
+      sed -i "s|S'[0-9]*'|S'0'|g" $file
+    done
 {%- else %}
     : # nothing
 {%- endif %}


### PR DESCRIPTION
… reload

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
During syncd docker init, initialize the interface and pfc counters to 0.
**- How I did it**
By clearing the counters values in /tmp/portstat*/* amd /tmp/pfcstat*/* files. 
**- How to verify it**
For Interface counters-
     Send traffic for a couple of minutes on few ports
     Check the counters values using show interface counters, 
     Clear the counters "sow interface counters -c"
     Perform config reload
     Check the counters values using show interface counters, values are negative.  

For PFC counters-
     Create congestion on a port by sending traffic from 2 ports to 1 port on no-drop priorities
     Check the counters values using show pfc counters
     Clear the counters using "show pfc counters -c"
     Perform config reload
     Check the counters values using show pfc counters, values are negative.
     
**- Description for the changelog**
Initializes ps and pfcstat counters during docker initialization.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
