### PR TITLE
[cron.d] Add cron job to periodically clean-up core files

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -463,6 +463,9 @@ build_number: ${BUILD_NUMBER:-0}
 built_by: $USER@$BUILD_HOSTNAME
 EOF
 
+## Copy over clean-up script
+sudo cp ./files/scripts/core_cleanup.py $FILESYSTEM_ROOT/usr/bin/core_cleanup
+
 ## Copy ASIC config checksum
 python files/build_scripts/generate_asic_config_checksum.py
 if [[ ! -f './asic_config_checksum' ]]; then

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -464,7 +464,7 @@ built_by: $USER@$BUILD_HOSTNAME
 EOF
 
 ## Copy over clean-up script
-sudo cp ./files/scripts/core_cleanup.py $FILESYSTEM_ROOT/usr/bin/core_cleanup
+sudo cp ./files/scripts/core_cleanup.py $FILESYSTEM_ROOT/usr/bin/core_cleanup.py
 
 ## Copy ASIC config checksum
 python files/build_scripts/generate_asic_config_checksum.py

--- a/files/image_config/cron.d/core_cleanup
+++ b/files/image_config/cron.d/core_cleanup
@@ -1,3 +1,3 @@
-# Attempts to clean up core files every 15 minutes
-*/15 * * * * root /usr/bin/core_cleanup > /dev/null 2>&1
+# Attempts to clean up core files every 2 hours
+* */2 * * * root /usr/bin/core_cleanup > /dev/null 2>&1
 

--- a/files/image_config/cron.d/core_cleanup
+++ b/files/image_config/cron.d/core_cleanup
@@ -1,0 +1,3 @@
+# Attempts to clean up core files every 15 minutes
+*/15 * * * * root /usr/bin/core_cleanup > /dev/null 2>&1
+

--- a/files/image_config/cron.d/core_cleanup
+++ b/files/image_config/cron.d/core_cleanup
@@ -1,3 +1,3 @@
 # Attempts to clean up core files every 2 hours
-* */2 * * * root /usr/bin/core_cleanup > /dev/null 2>&1
+* */2 * * * root /usr/bin/core_cleanup.py > /dev/null 2>&1
 

--- a/files/scripts/core_cleanup.py
+++ b/files/scripts/core_cleanup.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import syslog
+import os
+
+from collections import defaultdict
+from datetime import datetime
+
+SYSLOG_IDENTIFIER = 'core_cleanup_cronjob'
+CORE_FILE_DIR = os.path.abspath('/var/core')
+MAX_CORE_FILES = 4
+
+def log_info(msg):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_INFO, msg)
+    syslog.closelog()
+
+def log_error(msg):
+    syslog.openlog(SYSLOG_IDENTIFIER)
+    syslog.syslog(syslog.LOG_ERR, msg)
+    syslog.closelog()
+
+def main():
+    if os.getuid() != 0:
+        log_error('Root required to clean up core files')
+        return
+
+    log_info('Cleaning up core files')
+    core_files = [f for f in os.listdir(CORE_FILE_DIR) if os.path.isfile(os.path.join(CORE_FILE_DIR, f))]
+
+    core_files_by_process = defaultdict(list)
+    for f in core_files:
+        process = f.split('.')[0]
+        curr_files = core_files_by_process[process]
+        curr_files.append(f)
+
+        if len(curr_files) > MAX_CORE_FILES:
+            curr_files.sort(reverse = True, key = lambda x: datetime.utcfromtimestamp(int(x.split('.')[1])))
+            oldest_core = curr_files[MAX_CORE_FILES]
+            log_info('Deleting {}'.format(oldest_core))
+            try:
+                os.remove(os.path.join(CORE_FILE_DIR, oldest_core))
+            except:
+                log_error('Unexpected error occured trying to delete {}'.format(oldest_core))
+            core_files_by_process[process] = curr_files[0:MAX_CORE_FILES]
+
+    log_info('Finished cleaning up core files')
+
+if __name__ == '__main__':
+    main()
+

--- a/files/scripts/core_cleanup.py
+++ b/files/scripts/core_cleanup.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from datetime import datetime
 
 SYSLOG_IDENTIFIER = 'core_cleanup.py'
-CORE_FILE_DIR = os.path.abspath('/var/core')
+CORE_FILE_DIR = os.path.basename(__file__)
 MAX_CORE_FILES = 4
 
 def log_info(msg):

--- a/files/scripts/core_cleanup.py
+++ b/files/scripts/core_cleanup.py
@@ -6,7 +6,7 @@ import os
 from collections import defaultdict
 from datetime import datetime
 
-SYSLOG_IDENTIFIER = 'core_cleanup_cronjob'
+SYSLOG_IDENTIFIER = 'core_cleanup.py'
 CORE_FILE_DIR = os.path.abspath('/var/core')
 MAX_CORE_FILES = 4
 


### PR DESCRIPTION
[cron.d] Add cron job to periodically clean-up core files
* Create script to scan /var/core and clean-up older core files
* Create cron job to run clean-up script

Signed-off-by: Danny Allen (daall@microsoft.com)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I added a script to periodically clean-up old core files from the /var/core directory and installed it as a cron job in the image. The script is currently configured to keep the 4 newest core files per process in /var/core.

**- How to verify it**
1. Build image with script and associated cron job
2. Verify that after running the script only the 4 newest core files per process are still present in /var/core.
3. Verify that there are syslog messages indicating the cron job is running on a 15 minute interval.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add cron job to periodically clean-up core files

**- A picture of a cute animal (not mandatory but encouraged)**
![cute animal](https://images.unsplash.com/photo-1449628275652-6a7d8df8951b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=400&q=80)