### PR TITLE
[baseimage] Avoid race condition in sonic-platform-common

### DIFF
--- a/rules/sonic-platform-common.mk
+++ b/rules/sonic-platform-common.mk
@@ -6,8 +6,9 @@ $(SONIC_PLATFORM_COMMON_PY2)_PYTHON_VERSION = 2
 SONIC_PYTHON_WHEELS += $(SONIC_PLATFORM_COMMON_PY2)
 
 # Als build sonic-platform-common into python3 wheel, so we can use PSU code in SNMP docker
-# Note: _DEPENDS macro is not defined
 SONIC_PLATFORM_COMMON_PY3 = sonic_platform_common-1.0-py3-none-any.whl
 $(SONIC_PLATFORM_COMMON_PY3)_SRC_PATH = $(SRC_PATH)/sonic-platform-common
 $(SONIC_PLATFORM_COMMON_PY3)_PYTHON_VERSION = 3
+# Synthetic dependency just to avoid race condition
+$(SONIC_PLATFORM_COMMON_PY3)_DEPENDS = $(SONIC_PLATFORM_COMMON_PY2)
 SONIC_PYTHON_WHEELS += $(SONIC_PLATFORM_COMMON_PY3)


### PR DESCRIPTION
* rules/sonic-platform-common.mk

Both python2 and python3 wheels being built out of the same
source directory can interfere with each other when
SONIC_BUILD_JOBS > 1.

Signed-off-by: Greg Paussa <greg.paussa@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Resolved a build-time race condition between the python2 and python3 targets for the src/sonic-platform-common package. This issue can randomly occur when SONIC_BUILD_JOBS is greater than 1 (I'm using 8), and manifests itself as an error in either of the target/python-wheels/sonic_platform_common-1.0-py2-none-any.whl or target/python-wheels/sonic_platform_common-1.0-py3-none-any.whl targets.

The exact error reported in the corresponding .log file varies, but here is one example:
```
creating build/bdist.linux-x86_64/wheel/sonic_platform_common-1.0.dist-info/WHEEL
error: [Errno 39] Directory not empty: 'build/bdist.linux-x86_64/wheel'
[  FAIL LOG END  ] [ target/python-wheels/sonic_platform_common-1.0-py3-none-any.whl ]
make: *** [target/python-wheels/sonic_platform_common-1.0-py3-none-any.whl] Error 1
```

**- How I did it**
Added the following _DEPENDS statement to rules/sonic-platform-common.mk, ensuring python3 is built after python2 is complete:
```
# Synthetic dependency just to avoid race condition
$(SONIC_PLATFORM_COMMON_PY3)_DEPENDS = $(SONIC_PLATFORM_COMMON_PY2)
```
This change is patterned after a similar statement in rules/swsssdk-py3.mk that addressed a previous race condition in that package.

**- How to verify it**
1) Build SONiC successfully.
2) rm target/python-wheels/sonic_platform_common-1.0-py*.whl
3) rm target/sonic-vs.img.gz
4) make SONIC_BUILD_JOBS=8 target/sonic-vs.img.gz

Note: In steps 3 and 4, substitute whatever target image file name corresponds to the configured .platform.

Without the fix, either py2 or py3 fails to build. With the fix, py2 always builds before py3.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Avoid race condition in src/sonic-platform-common when building multiple sub-targets in parallel.

**- A picture of a cute animal (not mandatory but encouraged)**
