### PR TITLE
[bfn] Add missing port 65 for Mavericks board

### DIFF
--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/port_config.ini
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/port_config.ini
@@ -62,4 +62,5 @@ Ethernet236    236,237,238,239   Ethernet236    60    100000   0         rs
 Ethernet240    240,241,242,243   Ethernet240    61    100000   0         rs
 Ethernet244    244,245,246,247   Ethernet244    62    100000   0         rs
 Ethernet248    248,249,250,251   Ethernet248    63    100000   0         rs
-Ethernet252    252,253,254,255   Etherner252    64    100000   0         rs
+Ethernet252    252,253,254,255   Ethernet252    64    100000   0         rs
+Ethernet256    256,257,258,259   Ethernet256    65    100000   0         none


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <akokhan@barefootnetworks.com>

**- What I did**
For Mavericks board, added missing port 65 into port_config.ini

**- How to verify it**
100G, FEC none