### PR TITLE
[lldp]: expose lldpcli command of lldp docker to host

### DIFF
--- a/dockers/docker-lldp-sv2/base_image_files/lldpcli
+++ b/dockers/docker-lldp-sv2/base_image_files/lldpcli
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+DOCKER_EXEC_FLAGS="i"
+
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+    DOCKER_EXEC_FLAGS+="t"
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS lldp lldpcli "$@"

--- a/rules/docker-lldp-sv2.mk
+++ b/rules/docker-lldp-sv2.mk
@@ -29,3 +29,4 @@ $(DOCKER_LLDP_SV2)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_LLDP_SV2)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 $(DOCKER_LLDP_SV2)_BASE_IMAGE_FILES += lldpctl:/usr/bin/lldpctl
+$(DOCKER_LLDP_SV2)_BASE_IMAGE_FILES += lldpcli:/usr/bin/lldpcli


### PR DESCRIPTION
Lldp can not be configured in host environment, so we expose lldpcli command of lldp docker to host for configuring more convenient.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
