### PR TITLE
add led_fw_path to permitted_list

### DIFF
--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -159,4 +159,4 @@ ccmdma_intr_enable
 phy_enable
 init_all_modules
 port_fec
-led_fw_dir
+led_fw_path

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -159,3 +159,4 @@ ccmdma_intr_enable
 phy_enable
 init_all_modules
 port_fec
+led_fw_dir


### PR DESCRIPTION
**- What I did**
Fix the issue 
https://github.com/Azure/sonic-buildimage/issues/3497
**- How I did it**
add led_fw_path to src/sonic-device-data/tests/permitted_list
**- How to verify it**
after adding the string led_fw_path to config.bcm file and build should be successful.
**- Description for the changelog**
add  the string led_fw_path to permitted_list, it is required to load the LED binaries
for newer BRCM platforms like TD3 & TH3.


**- A picture of a cute animal (not mandatory but encouraged)**
