### PR TITLE
[Mellanox] Stop pmon ahead of syncd

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -156,7 +156,7 @@ stop() {
     if [[ x$sonic_asic_platform == x"mellanox" ]] && [[ x$TYPE == x"cold" ]]; then
         debug "Stopping pmon service ahead of syncd..."
         /bin/systemctl stop pmon
-        debug "Stopped pmon service."
+        debug "Stopped pmon service"
     fi
 
     if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -106,12 +106,11 @@ start() {
                 # The only possibility that pmon is active, is that pmon starts ahead of syncd,
                 # Thus, pmon has been started and stopped for an extra time which is unnecessary
                 # and consume more starting time.
-                # In this sense, should we add explicit dependency of syncd for pmon
-                # and remove the below "stop pmon"?
+                # In this sense, should we add explicit dependency on syncd for pmon
+                # and then remove the below "stop pmon"?
                 /bin/systemctl stop pmon
                 /usr/bin/hw-management.sh chipdown
                 /bin/systemctl restart pmon
-                debug "Assertion failure, pmon is active while syncd starting..."
             else
                 /usr/bin/hw-management.sh chipdown
                 debug "Triger pmon starting"

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -109,15 +109,12 @@ start() {
                 # In this sense, should we add explicit dependency on syncd for pmon
                 # and then remove the below "stop pmon"?
                 /bin/systemctl stop pmon
-                /usr/bin/hw-management.sh chipdown
-                /bin/systemctl restart pmon
-            else
-                /usr/bin/hw-management.sh chipdown
-                debug "Triger pmon starting"
-                debug "Starting pmon service..."
-                /bin/systemctl restart pmon
-                debug "Started pmon service"
+                debug "pmon is active while syncd starting, stop it first"
             fi
+            /usr/bin/hw-management.sh chipdown
+            debug "Starting pmon service..."
+            /bin/systemctl restart pmon
+            debug "Started pmon service"
         fi
 
         if [[ x"$BOOT_TYPE" == x"fast" ]]; then

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -107,10 +107,11 @@ start() {
                 debug "pmon is active while syncd starting, stop it first"
             fi
             /usr/bin/hw-management.sh chipdown
-            debug "Starting pmon service..."
-            /bin/systemctl restart pmon
-            debug "Started pmon service"
         fi
+
+        debug "Starting pmon service..."
+        /bin/systemctl start pmon
+        debug "Started pmon service"
 
         if [[ x"$BOOT_TYPE" == x"fast" ]]; then
             /usr/bin/hw-management.sh chipupdis

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -103,11 +103,6 @@ start() {
 
         if [[ x"$WARM_BOOT" != x"true" ]]; then
             if [[ x"$(/bin/systemctl is-active pmon)" == x"active" ]]; then
-                # The only possibility that pmon is active, is that pmon starts ahead of syncd,
-                # Thus, pmon has been started and stopped for an extra time which is unnecessary
-                # and consume more starting time.
-                # In this sense, should we add explicit dependency on syncd for pmon
-                # and then remove the below "stop pmon"?
                 /bin/systemctl stop pmon
                 debug "pmon is active while syncd starting, stop it first"
             fi

--- a/src/libteam/patch/0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch
+++ b/src/libteam/patch/0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch
@@ -1,0 +1,39 @@
+From 038bed6fe3970dc829dbf9a282f7bea7198e7826 Mon Sep 17 00:00:00 2001
+From: Pavel Shirshov <pavelsh@microsoft.com.com>
+Date: Wed, 28 Aug 2019 16:39:35 -0700
+Subject: [PATCH] When read of timerfd returned 0, don't consider this an error
+
+Just skip this event.
+---
+ teamd/teamd.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/teamd/teamd.c b/teamd/teamd.c
+index 96794e8..a5ce745 100644
+--- a/teamd/teamd.c
++++ b/teamd/teamd.c
+@@ -285,6 +285,10 @@ static int handle_period_fd(int fd)
+ 		teamd_log_err("read() failed.");
+ 		return -errno;
+ 	}
++	if (ret == 0) {
++		teamd_log_warn("read() for timer_fd returned 0.");
++		return 1;
++	}
+ 	if (ret != sizeof(uint64_t)) {
+ 		teamd_log_err("read() returned unexpected number of bytes.");
+ 		return -EINVAL;
+@@ -345,7 +349,9 @@ static int teamd_run_loop_do_callbacks(struct list_item *lcb_list, fd_set *fds,
+ 				continue;
+ 			if (lcb->is_period) {
+ 				err = handle_period_fd(lcb->fd);
+-				if (err)
++				if (err == 1)
++					continue; /* timerfd returned 0. Don't do anything */
++				if (err < 0)
+ 					return err;
+ 			}
+ 			err = lcb->func(ctx, events, lcb->priv);
+-- 
+2.7.4
+

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -7,3 +7,4 @@
 0007-Send-LACP-PDU-immediately-if-our-state-changed.patch
 0008-libteam-Add-warm_reboot-mode.patch
 0009-Fix-ifinfo_link_with_port-race-condition-with-newlink.patch
+0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch


### PR DESCRIPTION
**- What I did**
***Issue Overview***
****shutdown flow****
For any shutdown flow, which means all dockers are stopped in order, pmon docker stops after syncd docker has stopped, causing pmon docker fail to release sx_core resources and leaving sx_core in a bad state. The related logs are like the following:
```
INFO syncd.sh[23597]: modprobe: FATAL: Module sx_core is in use.
INFO syncd.sh[23597]: Unloading sx_core[FAILED]
INFO syncd.sh[23597]: rmmod: ERROR: Module sx_core is in use
```
****config reload & service swss.restart****
In the flows like "config reload" and "service swss restart", the failure cause further consequences:
1. sx_core initialization error with error message like "sx_core: create EMAD sdq 0 failed. err: -16"
2. syncd fails to execute the create switch api with error message "syncd_main: Runtime error: :- processEvent: failed to execute api: create, key: SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000, status: SAI_STATUS_FAILURE"
3. swss fails to call SAI API "SAI_SWITCH_ATTR_INIT_SWITCH", which causes orchagent to restart. This will introduce an extra 1 or 2 minutes for the system to be available, failing related test cases. 

****reboot, warm-reboot & fast-reboot****
In the reboot flows including "reboot", "fast-reboot" and "warm-reboot" this failure doesn't have further negative effects since the system has already rebooted. In addition, "warm-reboot" requires the system to be shutdown as soon as possible to meet the GR time restriction of both BGP and LACP. "fast-reboot" also requires to meet the GR time restriction of BGP which is longer than LACP. In this sense, any unnecessary steps should be avoided. It's better to keep those flows untouched.

****summary****
To summarize, we have to come up with a way to ensure:

1. shutdown pmon docker ahead of syncd for "config reload" or "service swss restart" flow;
2. don't shutdown pmon docker ahead of syncd for "fast-reboot" or "warm-reboot" flow in order to save time.
3. for "reboot" flow, either order is acceptable.

***Solution***
To solve the issue, pmon shoud be stopped ahead of syncd stopped for all flows except for the warm-reboot.

**- How I did it**
1. To stop pmon ahead of syncd stopped. This is done in /usr/local/bin/syncd.sh::stop() and for all shutdown sequence.
2. Now pmon stops ahead of syncd so there must be a way in which pmon can start after syncd started. Another point that should be taken consideration is that pmon starting should be deferred so that services which have the logic of graceful restart in fast-reboot and warm-reboot have sufficient CPU cycles to meet their deadline.
This is done by add "syncd.service" as "After" to pmon.service and startin /usr/local/bin/syncd.sh::wait()
To start pmon automatically after syncd started. 
3. 

**- How to verify it**
Test the following flows and ensure pmon and syncd started and stopped in the correct sequence:
1. config reload
2. service swss restart
3. regular reboot
4. warm-reboot
5. fast-reboot

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
