### PR TITLE
[docker-fpm-frr] Filter out 'Dockerfile.j2' from the 'docker-fpm-frr' image

### DIFF
--- a/dockers/docker-fpm-frr/.dockerignore
+++ b/dockers/docker-fpm-frr/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile.j2


### PR DESCRIPTION
[docker-fpm-frr]:filter out the file of 'Dockerfile.j2' from the 'docker-fpm-frr' image.

Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
filter out the file of 'Dockerfile.j2' from the docker image.
**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
