### PR TITLE
Flush port in both WR and FR mode on exit. Otherwise teamd will stuck

### DIFF
--- a/src/libteam/patch/0008-libteam-Add-warm_reboot-mode.patch
+++ b/src/libteam/patch/0008-libteam-Add-warm_reboot-mode.patch
@@ -108,7 +108,7 @@ index 9dc85b5..679da49 100644
 +						teamd_refresh_ports(ctx);
 +						if (ctrl_byte == 'w')
 +							teamd_ports_flush_data(ctx);
-+					} else {
++						/* Flush ports to destroy port object */
 +						err = teamd_flush_ports(ctx);
 +						if (err)
 +							return err;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a bug which prevented teamd to exit gracefully.

**- How I did it**
by remove 'else' keyword

**- How to verify it**
Build teamd, install on your DUT, then in teamd container `killall -USR2 teamd` you should see no teamd processes after that.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
