### PR TITLE
[sonic-slave] Update linux-compiler-gcc package version to fix build

### DIFF
--- a/sonic-slave/Dockerfile.j2
+++ b/sonic-slave/Dockerfile.j2
@@ -150,7 +150,7 @@ RUN apt-get update && apt-get install -y \
         zip \
 {%- if CONFIGURED_ARCH == "amd64" %}
 # For broadcom sdk build
-        linux-compiler-gcc-4.8-x86 \
+        linux-compiler-gcc-4.9-x86 \
 {%- endif %}
         linux-kbuild-3.16 \
 # teamd build


### PR DESCRIPTION
**- What I did**

Fix sonic-slave container build. Debian package maintainers have updated the version of the x86 linux-compiler-gcc available for Jessie from linux-compiler-gcc-4.8-x86 to linux-compiler-gcc-4.9-x86. linux-compiler-gcc-4.8-x86 is no longer available, so it caused the build to fail.

**- How to verify it**

`make sonic-slave-build`