### PR TITLE
[201811][sonic-slave] Update linux-compiler-gcc package version to fix build

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -127,7 +127,7 @@ RUN apt-get update && apt-get install -y \
         squashfs-tools \
         zip \
 # For broadcom sdk build
-        linux-compiler-gcc-4.8-x86 \
+        linux-compiler-gcc-4.9-x86 \
         linux-kbuild-3.16 \
 # teamd build
         libdaemon-dev \


### PR DESCRIPTION
**- What I did**

[Port of #3514 to the 201811 branch]

Fix sonic-slave container build. Debian package maintainers have updated the version of the x86 linux-compiler-gcc package available for Jessie from linux-compiler-gcc-4.8-x86 to linux-compiler-gcc-4.9-x86. linux-compiler-gcc-4.8-x86 is no longer available, so it caused the build to fail.

Reference: https://packages.debian.org/search?suite=jessie&searchon=names&keywords=linux-compiler-gcc

**- How to verify it**

`make sonic-slave-build`