### PR TITLE
yaml.load() is deprecated in latest versions of PyYAML module

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -229,7 +229,10 @@ def main():
 
     for yaml_file in args.yaml:
         with open(yaml_file, 'r') as stream:
-            additional_data = yaml.load(stream)
+            if yaml.__version__ >= "5.1":
+                additional_data = yaml.full_load(stream)
+            else:
+                additional_data = yaml.load(stream)
             deep_update(data, FormatConverter.to_deserialized(additional_data))
 
     for json_file in args.json:

--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -42,7 +42,10 @@ def get_sonic_version_info():
         return None
     data = {}
     with open('/etc/sonic/sonic_version.yml') as stream:
-        data = yaml.load(stream)
+        if yaml.__version__ >= "5.1":
+            data = yaml.full_load(stream)
+        else:
+            data = yaml.load(stream)
     return data
 
 def valid_mac_address(mac):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
From 5.1 version of PyYAML python module, yaml.load() API is deprecated. Code should be compatible to support both the versions, else error/warning messages are seen like below,

2019-07-02 08:25:35,284 – INFO: [D1] /usr/local/lib/python2.7/dist-packages/sonic_device_util.py:44: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

**- How I did it**
Made the code compatible with both the syntax based on the module version

**- How to verify it**
Build and boot should not throw any warnings/errors such as the one mentioned above.

**- Description for the changelog**
yaml.load() is deprecated in latest versions of PyYAML module

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
