### PR TITLE
[docker_image_ctl.j2] skip hostname update if is up to date

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -119,7 +119,7 @@ function postStartAction()
     v3SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestIp`
     v3SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestPort`
     v3MgmtVrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" vrf`
-    
+
     if [ "${v1SnmpTrapIp}" != "" ]
     then
 	sed -i "s/v1_trap_dest:.*/v1_trap_dest: ${v1SnmpTrapIp}:${v1SnmpTrapPort}%${v1MgmtVrf}/" "/etc/sonic/snmp.yml"
@@ -185,7 +185,10 @@ start() {
             {%- endif %}
             preStartAction
             docker start {{docker_container_name}}
-            updateHostName "$HOSTNAME"
+            CURRENT_HOSTNAME="$(docker exec {{docker_container_name}} hostname)"
+            if [ x"$HOSTNAME" != x"$CURRENT_HOSTNAME" ]; then
+                updateHostName "$HOSTNAME"
+            fi
             postStartAction
             exit $?
         fi


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Skip container hostname update in case container hostname is up to date.
This improves LAG restoration time during warm reboot by 10 seconds.

**- How I did it**
Implement a condition

**- How to verify it**
```
admin@r-boxer-sw01:~$ docker exec -it lldp hostname
r-boxer-sw01
admin@r-boxer-sw01:~$ redis-cli -n 4 hset 'DEVICE_METADATA|localhost' hostname sonic
admin@r-boxer-sw01:~$ sudo lldp.sh stop
admin@r-boxer-sw01:~$ sudo lldp.sh start
admin@r-boxer-sw01:~$ docker exec -it lldp hostname
sonic
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
