### PR TITLE
Regular quit needs to clean the ports too

### DIFF
--- a/src/libteam/patch/0008-libteam-Add-warm_reboot-mode.patch
+++ b/src/libteam/patch/0008-libteam-Add-warm_reboot-mode.patch
@@ -108,11 +108,11 @@ index 9dc85b5..679da49 100644
 +						teamd_refresh_ports(ctx);
 +						if (ctrl_byte == 'w')
 +							teamd_ports_flush_data(ctx);
-+						/* Flush ports to destroy port object */
-+						err = teamd_flush_ports(ctx);
-+						if (err)
-+							return err;
 +					}
++
++					err = teamd_flush_ports(ctx);
++					if (err)
++						return err;
  					quit_in_progress = true;
  					continue;
  				case 'r':


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Reduced scope of if for WR and FR clean-up mode.

**- How I did it**

**- How to verify it**
Build teamd, install on your dut, send INT signal to teamd process. teamd must exit immediately.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
