### PR TITLE
[FRR]: Patch for kernel level graceful restart.

### DIFF
--- a/src/sonic-frr/patch/0006-zebra-kernel-level-graceful-restart.patch
+++ b/src/sonic-frr/patch/0006-zebra-kernel-level-graceful-restart.patch
@@ -1,0 +1,228 @@
+ zebra: Add kernel level graceful restart
+
+ <Initial Code from Praveen Chaudhary>
+
+ Add the a `--graceful_restart X` flag to zebra start that
+ now creates a timer that pops in X seconds and will go
+ through and remove all routes that are older than startup.
+
+ If graceful_restart is not specified then we will just pop
+ a timer that cleans everything up immediately.
+
+ Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>
+ Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
+
+diff --git a/doc/user/zebra.rst b/doc/user/zebra.rst
+index 9dfe1ea..23afce9 100644
+--- a/doc/user/zebra.rst
++++ b/doc/user/zebra.rst
+@@ -23,9 +23,12 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
+    Runs in batch mode. *zebra* parses configuration file and terminates
+    immediately.
+ 
+-.. option:: -k, --keep_kernel
++.. option:: -K TIME, --graceful_restart TIME
+ 
+-   When zebra starts up, don't delete old self inserted routes.
++   If this option is specified, the graceful restart time is TIME seconds.
++   Zebra, when started, will read in routes.  Those routes that Zebra
++   identifies that it was the originator of will be swept in TIME seconds.
++   If no time is specified then we will sweep those routes immediately.
+ 
+ .. option:: -r, --retain
+ 
+diff --git a/zebra/main.c b/zebra/main.c
+index b54c36c..15145c2 100644
+--- a/zebra/main.c
++++ b/zebra/main.c
+@@ -80,8 +80,7 @@ int retain_mode = 0;
+ /* Allow non-quagga entities to delete quagga routes */
+ int allow_delete = 0;
+ 
+-/* Don't delete kernel route. */
+-int keep_kernel_mode = 0;
++int graceful_restart;
+ 
+ bool v6_rr_semantics = false;
+ 
+@@ -95,12 +94,12 @@ uint32_t nl_rcvbufsize = 4194304;
+ struct option longopts[] = {
+ 	{"batch", no_argument, NULL, 'b'},
+ 	{"allow_delete", no_argument, NULL, 'a'},
+-	{"keep_kernel", no_argument, NULL, 'k'},
+ 	{"socket", required_argument, NULL, 'z'},
+ 	{"ecmp", required_argument, NULL, 'e'},
+ 	{"label_socket", no_argument, NULL, 'l'},
+ 	{"retain", no_argument, NULL, 'r'},
+ 	{"vrfdefaultname", required_argument, NULL, 'o'},
++	{"graceful_restart", required_argument, NULL, 'K'},
+ #ifdef HAVE_NETLINK
+ 	{"vrfwnetns", no_argument, NULL, 'n'},
+ 	{"nl-bufsize", required_argument, NULL, 's'},
+@@ -271,13 +270,14 @@ int main(int argc, char **argv)
+ 	char *netlink_fuzzing = NULL;
+ #endif /* HANDLE_NETLINK_FUZZING */
+ 
++	graceful_restart = 0;
+ 	vrf_configure_backend(VRF_BACKEND_VRF_LITE);
+ 	logicalrouter_configure_backend(LOGICALROUTER_BACKEND_NETNS);
+ 
+ 	frr_preinit(&zebra_di, argc, argv);
+ 
+ 	frr_opt_add(
+-		"bakz:e:l:o:r"
++		"baz:e:l:o:rK:"
+ #ifdef HAVE_NETLINK
+ 		"s:n"
+ #endif
+@@ -289,24 +289,24 @@ int main(int argc, char **argv)
+ #endif /* HANDLE_NETLINK_FUZZING */
+ 		,
+ 		longopts,
+-		"  -b, --batch           Runs in batch mode\n"
+-		"  -a, --allow_delete    Allow other processes to delete zebra routes\n"
+-		"  -z, --socket          Set path of zebra socket\n"
+-		"  -e, --ecmp            Specify ECMP to use.\n"
+-		"  -l, --label_socket    Socket to external label manager\n"
+-		"  -k, --keep_kernel     Don't delete old routes which were installed by zebra.\n"
+-		"  -r, --retain          When program terminates, retain added route by zebra.\n"
+-		"  -o, --vrfdefaultname  Set default VRF name.\n"
++		"  -b, --batch              Runs in batch mode\n"
++		"  -a, --allow_delete       Allow other processes to delete zebra routes\n"
++		"  -z, --socket             Set path of zebra socket\n"
++		"  -e, --ecmp               Specify ECMP to use.\n"
++		"  -l, --label_socket       Socket to external label manager\n"
++		"  -r, --retain             When program terminates, retain added route by zebra.\n"
++		"  -o, --vrfdefaultname     Set default VRF name.\n"
++		"  -K, --graceful_restart   Graceful restart at the kernel level, timer in seconds for expiration\n"
+ #ifdef HAVE_NETLINK
+-		"  -n, --vrfwnetns       Use NetNS as VRF backend\n"
+-		"  -s, --nl-bufsize      Set netlink receive buffer size\n"
+-		"      --v6-rr-semantics Use v6 RR semantics\n"
++		"  -n, --vrfwnetns          Use NetNS as VRF backend\n"
++		"  -s, --nl-bufsize         Set netlink receive buffer size\n"
++		"      --v6-rr-semantics    Use v6 RR semantics\n"
+ #endif /* HAVE_NETLINK */
+ #if defined(HANDLE_ZAPI_FUZZING)
+-		"  -c <file>             Bypass normal startup and use this file for testing of zapi\n"
++		"  -c <file>                Bypass normal startup and use this file for testing of zapi\n"
+ #endif /* HANDLE_ZAPI_FUZZING */
+ #if defined(HANDLE_NETLINK_FUZZING)
+-		"  -w <file>             Bypass normal startup and use this file for testing of netlink input\n"
++		"  -w <file>                Bypass normal startup and use this file for testing of netlink input\n"
+ #endif /* HANDLE_NETLINK_FUZZING */
+ 	);
+ 
+@@ -325,9 +325,6 @@ int main(int argc, char **argv)
+ 		case 'a':
+ 			allow_delete = 1;
+ 			break;
+-		case 'k':
+-			keep_kernel_mode = 1;
+-			break;
+ 		case 'e':
+ 			multipath_num = atoi(optarg);
+ 			if (multipath_num > MULTIPATH_NUM
+@@ -357,6 +354,9 @@ int main(int argc, char **argv)
+ 		case 'r':
+ 			retain_mode = 1;
+ 			break;
++		case 'K':
++			graceful_restart = atoi(optarg);
++			break;
+ #ifdef HAVE_NETLINK
+ 		case 's':
+ 			nl_rcvbufsize = atoi(optarg);
+@@ -444,9 +444,10 @@ int main(int argc, char **argv)
+ 	*  will be equal to the current getpid(). To know about such routes,
+ 	* we have to have route_read() called before.
+ 	*/
+-	if (!keep_kernel_mode)
+-		rib_sweep_route();
+-
++	struct zebra_ns *zns = zebra_ns_lookup(NS_DEFAULT);
++	zns->startup_time = monotime(NULL);
++	thread_add_timer(zebrad.master, rib_sweep_route,
++			NULL, graceful_restart, NULL);
+ 	/* Needed for BSD routing socket. */
+ 	pid = getpid();
+ 
+diff --git a/zebra/rib.h b/zebra/rib.h
+index ae25a0e..2aad32f 100644
+--- a/zebra/rib.h
++++ b/zebra/rib.h
+@@ -328,7 +328,7 @@ extern struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *p,
+ extern void rib_update(vrf_id_t vrf_id, rib_update_event_t event);
+ extern void rib_update_table(struct route_table *table,
+ 			     rib_update_event_t event);
+-extern void rib_sweep_route(void);
++extern int  rib_sweep_route(struct thread *t);
+ extern void rib_sweep_table(struct route_table *table);
+ extern void rib_close_table(struct route_table *table);
+ extern void rib_init(void);
+diff --git a/zebra/zebra_ns.h b/zebra/zebra_ns.h
+index 01af64c..995412e 100644
+--- a/zebra/zebra_ns.h
++++ b/zebra/zebra_ns.h
+@@ -56,6 +56,10 @@ struct zebra_ns {
+ 
+ 	/* Back pointer */
+ 	struct ns *ns;
++	/*
++	* Time for when we sweep the rib from old routes
++	*/
++	time_t startup_time;
+ };
+ 
+ struct zebra_ns *zebra_ns_lookup(ns_id_t ns_id);
+diff --git a/zebra/zebra_rib.c b/zebra/zebra_rib.c
+index c034d23..7221e3b 100644
+--- a/zebra/zebra_rib.c
++++ b/zebra/zebra_rib.c
+@@ -3061,12 +3061,14 @@ void rib_sweep_table(struct route_table *table)
+ 	struct route_entry *re;
+ 	struct route_entry *next;
+ 	struct nexthop *nexthop;
++	struct zebra_ns *zns = zebra_ns_lookup(NS_DEFAULT);
+ 
+ 	if (!table)
+ 		return;
+ 
+ 	for (rn = route_top(table); rn; rn = srcdest_route_next(rn)) {
+ 		RNODE_FOREACH_RE_SAFE (rn, re, next) {
++
+ 			if (IS_ZEBRA_DEBUG_RIB)
+ 				route_entry_dump(&rn->p, NULL, re);
+ 
+@@ -3077,6 +3079,14 @@ void rib_sweep_table(struct route_table *table)
+ 				continue;
+ 
+ 			/*
++			 * If routes are older than startup_time then
++			 * we know we read them in from the kernel.
++			 * As such we can safely remove them.
++			 */
++			if (zns->startup_time < re->uptime)
++				continue;
++
++			/*
+ 			 * So we are starting up and have received
+ 			 * routes from the kernel that we have installed
+ 			 * from a previous run of zebra but not cleaned
+@@ -3104,7 +3114,7 @@ void rib_sweep_table(struct route_table *table)
+ }
+ 
+ /* Sweep all RIB tables.  */
+-void rib_sweep_route(void)
++int rib_sweep_route(struct thread *t)
+ {
+ 	struct vrf *vrf;
+ 	struct zebra_vrf *zvrf;
+@@ -3118,6 +3128,7 @@ void rib_sweep_route(void)
+ 	}
+ 
+ 	zebra_router_sweep_route();
++	return 0;
+ }
+ 
+ /* Remove specific by protocol routes from 'table'. */

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -3,3 +3,4 @@
 0003-ignore-nexthop-attribute-when-NLRI-is-present.patch
 0004-Allow-BGP-attr-NEXT_HOP-to-be-0.0.0.0-due-to-allevia.patch
 0005-Support-VRF.patch
+0006-zebra-kernel-level-graceful-restart.patch


### PR DESCRIPTION
Original Patch in FRR master:
https://github.com/FRRouting/frr/pull/4301

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added Patch for FRR Master PR 4301.

**- How I did it**
https://github.com/Azure/SONiC/pull/377

**- How to verify it**
Set -K option in daemons.conf file and restart FRR. 
Run fib_warm_restart test case.


Test Results:
------------------------------
Test 0: Set The timer -K 45:

COde diff to test:
        case 'K':
            zlog_err("PC before atoi graceful_restart=%d optarg=%s\n",graceful_restart, optarg);
            graceful_restart = atoi(optarg);
            zlog_err("PC after atoi graceful_restart=%d optarg=%s\n",graceful_restart, optarg);
            break;

Logs:

Exiting from the script
Starting Frr daemons (prio:10):. zebra2019/09/17 19:08:05 unknown: PC before atoi graceful_restart=0 optarg=45

2019/09/17 19:08:05 unknown: PC after atoi graceful_restart=45 optarg=45


Config warm_restart:’
admin@falco-test-dut01:~$ sudo config warm_restart enable bgp
admin@falco-test-dut01:~$ sudo config warm_restart bgp_timer 60


Test 1; APPDB routes recovered after restart [No changes in route]

Routes before restart:
127.0.0.1:6379> keys ROUTE_TABLE:172*
 1) "ROUTE_TABLE:172.16.13.1"
 2) "ROUTE_TABLE:172.16.13.2"
 3) "ROUTE_TABLE:172.16.15.3"
 4) "ROUTE_TABLE:172.16.16.3"
 5) "ROUTE_TABLE:172.16.14.4"
 6) "ROUTE_TABLE:172.16.15.1"
 7) "ROUTE_TABLE:172.16.16.2"
 8) "ROUTE_TABLE:172.16.15.2"
 9) "ROUTE_TABLE:172.16.14.1"
10) "ROUTE_TABLE:172.16.15.4"
11) "ROUTE_TABLE:172.16.13.4"
12) "ROUTE_TABLE:172.16.16.1"
13) "ROUTE_TABLE:172.16.13.0"
14) "ROUTE_TABLE:172.16.16.4"
15) "ROUTE_TABLE:172.16.14.3"
16) "ROUTE_TABLE:172.16.14.0"
17) "ROUTE_TABLE:172.16.13.3"
18) "ROUTE_TABLE:172.25.11.0/24"
19) "ROUTE_TABLE:172.16.16.0"
20) "ROUTE_TABLE:172.16.14.2"
21) "ROUTE_TABLE:172.16.15.0"


Sep 17 19:26:49.172904 falco-test-dut01 NOTICE bgp#fpmsyncd: :- getWarmStartTimer: Getting warmStartTimer for docker: bgp, app: bgp, value: 60
Sep 17 19:26:49.173688 falco-test-dut01 NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Initiating AppDB restoration process for bgp application.
Sep 17 19:26:49.180990 falco-test-dut01 NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Received 63 records from AppDB for bgp application.
Sep 17 19:26:49.181157 falco-test-dut01 NOTICE bgp#fpmsyncd: :- setWarmStartState: bgp warm start state changed to restored
Sep 17 19:26:49.181240 falco-test-dut01 NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Completed AppDB restoration process for bgp application.
Sep 17 19:26:49.567164 falco-test-dut01 NOTICE ZTP: Retrying to get the Bootstrap script URL...
Sep 17 19:27:19.570402 falco-test-dut01 NOTICE ZTP: Retrying to get the Bootstrap script URL...
Sep 17 19:27:49.181435 falco-test-dut01 NOTICE bgp#fpmsyncd: :- main: Warm-Restart timer expired.
Sep 17 19:27:49.181892 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart: Initiating reconciliation process for bgp application.
Sep 17 19:27:49.183877 falco-test-dut01 NOTICE bgp#fpmsyncd: :- setWarmStartState: bgp warm start state changed to reconciled
Sep 17 19:27:49.183877 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart: Concluded reconciliation process for bgp application.

admin@falco-test-dut01:~$ date
Tue Sep 17 19:32:18 UTC 2019
admin@falco-test-dut01:~$ sudo redis-cli keys ROUTE_TABLE:172*
 1) "ROUTE_TABLE:172.16.13.1"
 2) "ROUTE_TABLE:172.16.13.2"
 3) "ROUTE_TABLE:172.16.15.3"
 4) "ROUTE_TABLE:172.16.16.3"
 5) "ROUTE_TABLE:172.16.14.4"
 6) "ROUTE_TABLE:172.16.15.1"
 7) "ROUTE_TABLE:172.16.16.2"
 8) "ROUTE_TABLE:172.16.15.2"
 9) "ROUTE_TABLE:172.16.14.1"
10) "ROUTE_TABLE:172.16.15.4"
11) "ROUTE_TABLE:172.16.13.4"
12) "ROUTE_TABLE:172.16.16.1"
13) "ROUTE_TABLE:172.16.13.0"
14) "ROUTE_TABLE:172.16.16.4"
15) "ROUTE_TABLE:172.16.14.3"
16) "ROUTE_TABLE:172.16.14.0"
17) "ROUTE_TABLE:172.16.13.3"
18) "ROUTE_TABLE:172.25.11.0/24"
19) "ROUTE_TABLE:172.16.16.0"
20) "ROUTE_TABLE:172.16.14.2"
21) "ROUTE_TABLE:172.16.15.0"


Test 2: Deletion in Routes by bringing one interface down during FRR restart:

Before restart:
admin@falco-test-dut01:~$ sudo redis-cli keys ROUTE_TABLE:172*
 1) "ROUTE_TABLE:172.16.13.1"
 2) "ROUTE_TABLE:172.16.13.2"
 3) "ROUTE_TABLE:172.16.15.3"
 4) "ROUTE_TABLE:172.16.16.3"
 5) "ROUTE_TABLE:172.16.14.4"
 6) "ROUTE_TABLE:172.16.15.1"
 7) "ROUTE_TABLE:172.16.16.2"
 8) "ROUTE_TABLE:172.16.15.2"
 9) "ROUTE_TABLE:172.16.14.1"
10) "ROUTE_TABLE:172.16.15.4"
11) "ROUTE_TABLE:172.16.13.4"
12) "ROUTE_TABLE:172.16.16.1"
13) "ROUTE_TABLE:172.16.13.0"
14) "ROUTE_TABLE:172.16.16.4"
15) "ROUTE_TABLE:172.16.14.3"
16) "ROUTE_TABLE:172.16.14.0"
17) "ROUTE_TABLE:172.16.13.3"
18) "ROUTE_TABLE:172.25.11.0/24"
19) "ROUTE_TABLE:172.16.16.0"
20) "ROUTE_TABLE:172.16.14.2"
21) "ROUTE_TABLE:172.16.15.0"
admin@falco-test-dut01:~$

Routes from Ethernet124
B> 172.16.16.0/32 [20/0] via 10.0.0.63, Ethernet124, 00:07:48 B> 172.16.16.1/32 [20/0] via 10.0.0.63, Ethernet124, 00:07:48
B> 172.16.16.2/32 [20/0] via 10.0.0.63, Ethernet124, 00:07:48 B> 172.16.16.3/32 [20/0] via 10.0.0.63, Ethernet124, 00:07:48
B>* 172.16.16.4/32 [20/0] via 10.0.0.63, Ethernet124, 00:07:48


admin@falco-test-dut01:~$ date
Tue Sep 17 19:35:06 UTC 2019
admin@falco-test-dut01:~$ sudo service bgp stop



admin@falco-test-dut01:~$ date
Tue Sep 17 19:35:22 UTC 2019

admin@falco-test-dut01:~$ sudo config interface shutdown Ethernet124
admin@falco-test-dut01:~$


admin@falco-test-dut01:~$ sudo service bgp start
admin@falco-test-dut01:~$ date
Tue Sep 17 19:36:05 UTC 2019


Sep 17 19:36:09.314139 falco-test-dut01 NOTICE bgp#fpmsyncd: :- checkWarmStart: bgp doing warm start, restore count 2
Sep 17 19:36:09.314325 falco-test-dut01 NOTICE bgp#fpmsyncd: :- checkAndStart: Initializing Warm-Restart cycle for bgp application.
Sep 17 19:36:09.314409 falco-test-dut01 NOTICE bgp#fpmsyncd: :- setWarmStartState: bgp warm start state changed to initialized
Sep 17 19:36:09.314690 falco-test-dut01 NOTICE bgp#fpmsyncd: :- getWarmStartTimer: Getting warmStartTimer for docker: bgp, app: bgp, value: 60
Sep 17 19:36:09.314957 falco-test-dut01 NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Initiating AppDB restoration process for bgp application.
Sep 17 19:36:09.321162 falco-test-dut01 NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Received 63 records from AppDB for bgp application.
Sep 17 19:36:09.321496 falco-test-dut01 NOTICE bgp#fpmsyncd: :- setWarmStartState: bgp warm start state changed to restored
Sep 17 19:36:09.321622 falco-test-dut01 NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Completed AppDB restoration process for bgp application.
Sep 17 19:36:19.633191 falco-test-dut01 NOTICE ZTP: Retrying to get the Bootstrap script URL...

Sep 17 19:36:49.636558 falco-test-dut01 NOTICE ZTP: Retrying to get the Bootstrap script URL...
Sep 17 19:37:09.321642 falco-test-dut01 NOTICE bgp#fpmsyncd: :- main: Warm-Restart timer expired.
Sep 17 19:37:09.321642 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart: Initiating reconciliation process for bgp application.
Sep 17 19:37:09.321822 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry fc00::7c/126 { nexthop:  | ifname: Ethernet124 }
Sep 17 19:37:09.322070 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 172.16.16.3 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:37:09.322189 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 20ac:1010:0:4::/64 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:37:09.322272 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 172.16.16.2 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:37:09.322436 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 10.0.0.62/31 { nexthop:  | ifname: Ethernet124 }
Sep 17 19:37:09.322517 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 172.16.16.1 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:37:09.323004 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 172.16.16.4 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:37:09.323399 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 20ac:1010:0:2::/64 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:37:09.323837 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 20ac:1010::/64 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:37:09.324195 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 20ac:1010:0:3::/64 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:37:09.324472 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 100.1.0.32 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:37:09.324565 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 20ac:1010:0:1::/64 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:37:09.324724 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 172.16.16.0 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:37:09.324807 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: deleting stale entry 2064💯:20 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:37:09.325474 falco-test-dut01 NOTICE bgp#fpmsyncd: :- setWarmStartState: bgp warm start state changed to reconciled
Sep 17 19:37:09.325474 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart: Concluded reconciliation process for bgp application.
Sep 17 19:37:09.333668 falco-test-dut01 NOTICE swss#orchagent: :- removeNeighbor: Removed next hop 10.0.0.63 on Ethernet124
Sep 17 19:37:09.334205 falco-test-dut01 NOTICE swss#orchagent: :- removeNeighbor: Removed neighbor 52:54:00:c7:69:59 on Ethernet124
Sep 17 19:37:09.334617 falco-test-dut01 NOTICE swss#orchagent: :- removeNeighbor: Removed next hop fc00::7e on Ethernet124
Sep 17 19:37:09.336408 falco-test-dut01 NOTICE swss#orchagent: :- removeNeighbor: Removed neighbor 52:54:00:c7:69:59 on Ethernet124

admin@falco-test-dut01:~$ date
Tue Sep 17 19:39:17 UTC 2019
admin@falco-test-dut01:~$ sudo redis-cli keys ROUTE_TABLE:172*
 1) "ROUTE_TABLE:172.16.13.1"
 2) "ROUTE_TABLE:172.16.13.2"
 3) "ROUTE_TABLE:172.16.15.3"
 4) "ROUTE_TABLE:172.16.14.4"
 5) "ROUTE_TABLE:172.16.15.1"
 6) "ROUTE_TABLE:172.16.15.2"
 7) "ROUTE_TABLE:172.16.14.1"
 8) "ROUTE_TABLE:172.16.15.4"
 9) "ROUTE_TABLE:172.16.13.4"
10) "ROUTE_TABLE:172.16.13.0"
11) "ROUTE_TABLE:172.16.14.3"
12) "ROUTE_TABLE:172.16.14.0"
13) "ROUTE_TABLE:172.16.13.3"
14) "ROUTE_TABLE:172.25.11.0/24"
15) "ROUTE_TABLE:172.16.14.2"
16) "ROUTE_TABLE:172.16.15.0"


Kernel routes after reconciliation:
admin@falco-test-dut01:~$ show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, P - PIM, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       > - selected route, * - FIB route

S   0.0.0.0/0 [200/0] via 172.25.11.1 inactive, 00:04:18
S> 0.0.0.0/0 [1/20] via 172.25.11.1, eth0, 00:04:19 C> 10.0.0.56/31 is directly connected, Ethernet112, 00:04:19
C> 10.0.0.58/31 is directly connected, Ethernet116, 00:04:19 C> 10.0.0.60/31 is directly connected, Ethernet120, 00:04:19
C> 10.1.0.1/32 is directly connected, lo, 00:04:19 C> 10.1.0.32/32 is directly connected, lo, 00:04:19
B> 100.1.0.29/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16 B> 100.1.0.30/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16
B> 100.1.0.31/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16 B> 172.16.13.0/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16
B> 172.16.13.1/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16 B> 172.16.13.2/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16
B> 172.16.13.3/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16 B> 172.16.13.4/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16
B> 172.16.14.0/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16 B> 172.16.14.1/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16
B> 172.16.14.2/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16 B> 172.16.14.3/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16
B> 172.16.14.4/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16 B> 172.16.15.0/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16
B> 172.16.15.1/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16 B> 172.16.15.2/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16
B> 172.16.15.3/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16 B> 172.16.15.4/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16
C>* 172.25.11.0/24 is directly connected, eth0, 00:04:19



Test 3: Addition in Routes by bringing one interface up during FRR restart:

Routes before reconciliation:

admin@falco-test-dut01:~$ date
Tue Sep 17 19:39:17 UTC 2019
admin@falco-test-dut01:~$ sudo redis-cli keys ROUTE_TABLE:172*
 1) "ROUTE_TABLE:172.16.13.1"
 2) "ROUTE_TABLE:172.16.13.2"
 3) "ROUTE_TABLE:172.16.15.3"
 4) "ROUTE_TABLE:172.16.14.4"
 5) "ROUTE_TABLE:172.16.15.1"
 6) "ROUTE_TABLE:172.16.15.2"
 7) "ROUTE_TABLE:172.16.14.1"
 8) "ROUTE_TABLE:172.16.15.4"
 9) "ROUTE_TABLE:172.16.13.4"
10) "ROUTE_TABLE:172.16.13.0"
11) "ROUTE_TABLE:172.16.14.3"
12) "ROUTE_TABLE:172.16.14.0"
13) "ROUTE_TABLE:172.16.13.3"
14) "ROUTE_TABLE:172.25.11.0/24"
15) "ROUTE_TABLE:172.16.14.2"
16) "ROUTE_TABLE:172.16.15.0"



admin@falco-test-dut01:~$ show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, P - PIM, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       > - selected route, * - FIB route

S   0.0.0.0/0 [200/0] via 172.25.11.1 inactive, 00:04:18
S> 0.0.0.0/0 [1/20] via 172.25.11.1, eth0, 00:04:19 C> 10.0.0.56/31 is directly connected, Ethernet112, 00:04:19
C> 10.0.0.58/31 is directly connected, Ethernet116, 00:04:19 C> 10.0.0.60/31 is directly connected, Ethernet120, 00:04:19
C> 10.1.0.1/32 is directly connected, lo, 00:04:19 C> 10.1.0.32/32 is directly connected, lo, 00:04:19
B> 100.1.0.29/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16 B> 100.1.0.30/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16
B> 100.1.0.31/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16 B> 172.16.13.0/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16
B> 172.16.13.1/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16 B> 172.16.13.2/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16
B> 172.16.13.3/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16 B> 172.16.13.4/32 [20/0] via 10.0.0.57, Ethernet112, 00:04:16
B> 172.16.14.0/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16 B> 172.16.14.1/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16
B> 172.16.14.2/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16 B> 172.16.14.3/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16
B> 172.16.14.4/32 [20/0] via 10.0.0.59, Ethernet116, 00:04:16 B> 172.16.15.0/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16
B> 172.16.15.1/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16 B> 172.16.15.2/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16
B> 172.16.15.3/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16 B> 172.16.15.4/32 [20/0] via 10.0.0.61, Ethernet120, 00:04:16
C>* 172.25.11.0/24 is directly connected, eth0, 00:04:19


admin@falco-test-dut01:~$ date
Tue Sep 17 19:52:28 UTC 2019
admin@falco-test-dut01:~$ sudo service bgp stop
admin@falco-test-dut01:~$ date
Tue Sep 17 19:52:54 UTC 2019
admin@falco-test-dut01:~$ sudo config interface startup Ethernet124
admin@falco-test-dut01:~$ date
Tue Sep 17 19:53:08 UTC 2019
admin@falco-test-dut01:~$ sudo service bgp start
admin@falco-test-dut01:~$


Sep 17 19:53:27.084254 falco-test-dut01 NOTICE bgp#fpmsyncd: :- checkWarmStart: bgp doing warm start, restore count 3
Sep 17 19:53:27.084254 falco-test-dut01 NOTICE bgp#fpmsyncd: :- checkAndStart: Initializing Warm-Restart cycle for bgp application.
Sep 17 19:53:27.084819 falco-test-dut01 NOTICE bgp#fpmsyncd: :- setWarmStartState: bgp warm start state changed to initialized
Sep 17 19:53:27.085478 falco-test-dut01 NOTICE bgp#fpmsyncd: :- getWarmStartTimer: Getting warmStartTimer for docker: bgp, app: bgp, value: 60
Sep 17 19:53:27.085478 falco-test-dut01 NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Initiating AppDB restoration process for bgp application.
Sep 17 19:53:27.090624 falco-test-dut01 NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Received 49 records from AppDB for bgp application.
Sep 17 19:53:27.090867 falco-test-dut01 NOTICE bgp#fpmsyncd: :- setWarmStartState: bgp warm start state changed to restored
Sep 17 19:53:27.090952 falco-test-dut01 NOTICE bgp#fpmsyncd: :- runRestoration: Warm-Restart: Completed AppDB restoration process for bgp application.
Sep 17 19:53:27.751516 falco-test-dut01 NOTICE swss#orchagent: :- addNeighbor: Created neighbor 52:54:00:c7:69:59 on Ethernet124
Sep 17 19:53:27.752052 falco-test-dut01 NOTICE swss#orchagent: :- addNextHop: Created next hop 10.0.0.63 on Ethernet124
Sep 17 19:53:28.168820 falco-test-dut01 INFO bgp#bgpd[83]: %ADJCHANGE: neighbor 10.0.0.63(Unknown) in vrf Default Up
Sep 17 19:53:45.875026 falco-test-dut01 NOTICE swss#orchagent: :- addNeighbor: Created neighbor 52:54:00:c7:69:59 on Ethernet124
Sep 17 19:53:45.875559 falco-test-dut01 NOTICE swss#orchagent: :- addNextHop: Created next hop fc00::7e on Ethernet124
Sep 17 19:53:45.927533 falco-test-dut01 INFO bgp#bgpd[83]: %ADJCHANGE: neighbor fc00::7e(Unknown) in vrf Default Up
Sep 17 19:53:49.758334 falco-test-dut01 NOTICE ZTP: Retrying to get the Bootstrap script URL...
Sep 17 19:54:19.761482 falco-test-dut01 NOTICE ZTP: Retrying to get the Bootstrap script URL...
Sep 17 19:54:27.091868 falco-test-dut01 NOTICE bgp#fpmsyncd: :- main: Warm-Restart timer expired.
Sep 17 19:54:27.091868 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart: Initiating reconciliation process for bgp application.
Sep 17 19:54:27.093201 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 20ac:1010:0:4::/64 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:54:27.093622 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 20ac:1010:0:2::/64 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:54:27.094153 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 20ac:1010:0:1::/64 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:54:27.094512 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 2064💯:20 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:54:27.094825 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 172.16.16.4 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:54:27.095129 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry fc00::7c/126 { nexthop:  | ifname: Ethernet124 }
Sep 17 19:54:27.095460 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 20ac:1010::/64 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:54:27.095758 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 172.16.16.1 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:54:27.096359 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 20ac:1010:0:3::/64 { nexthop: fc00::7e | ifname: Ethernet124 }
Sep 17 19:54:27.096747 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 172.16.16.2 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:54:27.097059 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 10.0.0.62/31 { nexthop:  | ifname: Ethernet124 }
Sep 17 19:54:27.097344 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 100.1.0.32 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:54:27.097639 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 172.16.16.3 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:54:27.097930 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart reconciliation: introducing new entry 172.16.16.0 { nexthop: 10.0.0.63 | ifname: Ethernet124 }
Sep 17 19:54:27.098216 falco-test-dut01 NOTICE bgp#fpmsyncd: :- setWarmStartState: bgp warm start state changed to reconciled
Sep 17 19:54:27.098505 falco-test-dut01 NOTICE bgp#fpmsyncd: :- reconcile: Warm-Restart: Concluded reconciliation process for bgp application.



Ip monitor:
100.1.0.32 via 10.0.0.63 dev Ethernet124 proto 186 src 10.1.0.32 metric 20
172.16.16.0 via 10.0.0.63 dev Ethernet124 proto 186 src 10.1.0.32 metric 20
172.16.16.1 via 10.0.0.63 dev Ethernet124 proto 186 src 10.1.0.32 metric 20
172.16.16.2 via 10.0.0.63 dev Ethernet124 proto 186 src 10.1.0.32 metric 20
172.16.16.3 via 10.0.0.63 dev Ethernet124 proto 186 src 10.1.0.32 metric 20
172.16.16.4 via 10.0.0.63 dev Ethernet124 proto 186 src 10.1.0.32 metric 20



admin@falco-test-dut01:~$ date
Tue Sep 17 19:57:29 UTC 2019

Routes after restart:
admin@falco-test-dut01:~$ show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, P - PIM, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       > - selected route, * - FIB route

S   0.0.0.0/0 [200/0] via 172.25.11.1 inactive, 00:03:33
S> 0.0.0.0/0 [1/20] via 172.25.11.1, eth0, 00:03:34 C> 10.0.0.56/31 is directly connected, Ethernet112, 00:03:34
C> 10.0.0.58/31 is directly connected, Ethernet116, 00:03:34 C> 10.0.0.60/31 is directly connected, Ethernet120, 00:03:34
C> 10.0.0.62/31 is directly connected, Ethernet124, 00:03:34 C> 10.1.0.1/32 is directly connected, lo, 00:03:34
C> 10.1.0.32/32 is directly connected, lo, 00:03:34 B> 100.1.0.29/32 [20/0] via 10.0.0.57, Ethernet112, 00:03:32
B> 100.1.0.30/32 [20/0] via 10.0.0.59, Ethernet116, 00:03:32 B> 100.1.0.31/32 [20/0] via 10.0.0.61, Ethernet120, 00:03:32
B> 100.1.0.32/32 [20/0] via 10.0.0.63, Ethernet124, 00:03:28 B> 172.16.13.0/32 [20/0] via 10.0.0.57, Ethernet112, 00:03:32
B> 172.16.13.1/32 [20/0] via 10.0.0.57, Ethernet112, 00:03:32 B> 172.16.13.2/32 [20/0] via 10.0.0.57, Ethernet112, 00:03:32
B> 172.16.13.3/32 [20/0] via 10.0.0.57, Ethernet112, 00:03:32 B> 172.16.13.4/32 [20/0] via 10.0.0.57, Ethernet112, 00:03:32
B> 172.16.14.0/32 [20/0] via 10.0.0.59, Ethernet116, 00:03:32 B> 172.16.14.1/32 [20/0] via 10.0.0.59, Ethernet116, 00:03:32
B> 172.16.14.2/32 [20/0] via 10.0.0.59, Ethernet116, 00:03:32 B> 172.16.14.3/32 [20/0] via 10.0.0.59, Ethernet116, 00:03:32
B> 172.16.14.4/32 [20/0] via 10.0.0.59, Ethernet116, 00:03:32 B> 172.16.15.0/32 [20/0] via 10.0.0.61, Ethernet120, 00:03:32
B> 172.16.15.1/32 [20/0] via 10.0.0.61, Ethernet120, 00:03:32 B> 172.16.15.2/32 [20/0] via 10.0.0.61, Ethernet120, 00:03:32
B> 172.16.15.3/32 [20/0] via 10.0.0.61, Ethernet120, 00:03:32 B> 172.16.15.4/32 [20/0] via 10.0.0.61, Ethernet120, 00:03:32
B> 172.16.16.0/32 [20/0] via 10.0.0.63, Ethernet124, 00:03:28 B> 172.16.16.1/32 [20/0] via 10.0.0.63, Ethernet124, 00:03:28
B> 172.16.16.2/32 [20/0] via 10.0.0.63, Ethernet124, 00:03:28 B> 172.16.16.3/32 [20/0] via 10.0.0.63, Ethernet124, 00:03:28
B> 172.16.16.4/32 [20/0] via 10.0.0.63, Ethernet124, 00:03:28 C> 172.25.11.0/24 is directly connected, eth0, 00:03:34


admin@falco-test-dut01:~$ date
Tue Sep 17 19:57:46 UTC 2019
admin@falco-test-dut01:~$ sudo redis-cli keys ROUTE_TABLE:172*
 1) "ROUTE_TABLE:172.16.13.1"
 2) "ROUTE_TABLE:172.16.13.2"
 3) "ROUTE_TABLE:172.16.15.3"
 4) "ROUTE_TABLE:172.16.16.3"
 5) "ROUTE_TABLE:172.16.14.4"
 6) "ROUTE_TABLE:172.16.15.1"
 7) "ROUTE_TABLE:172.16.16.2"
 8) "ROUTE_TABLE:172.16.15.2"
 9) "ROUTE_TABLE:172.16.14.1"
10) "ROUTE_TABLE:172.16.15.4"
11) "ROUTE_TABLE:172.16.13.4"
12) "ROUTE_TABLE:172.16.16.1"
13) "ROUTE_TABLE:172.16.13.0"
14) "ROUTE_TABLE:172.16.16.4"
15) "ROUTE_TABLE:172.16.14.3"
16) "ROUTE_TABLE:172.16.14.0"
17) "ROUTE_TABLE:172.16.13.3"
18) "ROUTE_TABLE:172.25.11.0/24"
19) "ROUTE_TABLE:172.16.16.0"
20) "ROUTE_TABLE:172.16.14.2"
21) "ROUTE_TABLE:172.16.15.0"




IPV6 routes behavior is slightly different

Note: For IPV6 routes, If old route exist in kernel, always Delete and add will be done instead of change. So there may be few micro seconds when a IPV6 route is not available in kernel.

void kernel_route_rib(struct route_node rn, struct prefix p,
              struct prefix src_p, struct route_entry old,
              struct route_entry *new)
{
    int ret = 0;

assert(old || new);

if (new) {
    if (p->family == AF_INET)
        ret = netlink_route_multipath(RTM_NEWROUTE, p, src_p,
                          new, (old) ? 1 : 0);
    else {
        /*
         * So v6 route replace semantics are not in
         * the kernel at this point as I understand it.
         * So let's do a delete than an add.
         * In the future once v6 route replace semantics
         * are in we can figure out what to do here to
         * allow working with old and new kernels.
         *
         * I'm also intentionally ignoring the failure case
         * of the route delete.  If that happens yeah we're
         * screwed.
         */
        if (old)
            netlink_route_multipath(RTM_DELROUTE, p,
                        src_p, old, 0);
        ret = netlink_route_multipath(RTM_NEWROUTE, p,
                          src_p, new, 0);
    }



admin@falco-test-dut01:~$ show ip route 172.16.16.4
Routing entry for 172.16.16.4/32
  Known via "bgp", distance 20, metric 0, best
  Last update 2d03h08m ago
  * 10.0.0.63, via Ethernet124



fast ping from DUT

With -K option:
admin@falco-test-dut01:~$ date
Thu Sep 19 23:27:08 UTC 2019
admin@falco-test-dut01:~$ sudo service bgp stop
admin@falco-test-dut01:~$ date
Thu Sep 19 23:27:24 UTC 2019
admin@falco-test-dut01:~$ sudo service bgp start
admin@falco-test-dut01:~$ date
Thu Sep 19 23:27:32 UTC 2019


Fast Ping; (Outgoing packets went fine )
admin@falco-test-dut01:~$ date
Thu Sep 19 23:27:05 UTC 2019
admin@falco-test-dut01:~$ sudo ping 172.16.16.4 -f
PING 172.16.16.4 (172.16.16.4) 56(84) bytes of data.
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................^C
--- 172.16.16.4 ping statistics ---
6441 packets transmitted, 0 received, 100% packet loss, time 103968ms

admin@falco-test-dut01:~$ date
Thu Sep 19 23:28:45 UTC 2019

Watch for ip monitor:
admin@falco-test-dut01:~$ ip monitor | grep 172.16.16.4
No update
----------------------------

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
