### PR TITLE
[libteam]: Keep member ports parts of a team when teamd quits in FR a…

### DIFF
--- a/src/libteam/patch/0008-libteam-Add-warm_reboot-mode.patch
+++ b/src/libteam/patch/0008-libteam-Add-warm_reboot-mode.patch
@@ -1,18 +1,19 @@
-From 5d418847bf6fa86f049e18c1b57028c71e40a9c4 Mon Sep 17 00:00:00 2001
+From 113d482704198685fba09cd2597fd93ca9d297c5 Mon Sep 17 00:00:00 2001
 From: Pavel Shirshov <pavelsh@microsoft.com>
-Date: Thu, 19 Sep 2019 14:49:17 -0700
+Date: Tue, 1 Oct 2019 09:23:23 -0700
 Subject: [PATCH 1/1] [libteam]: Reimplement Warm-Reboot procedure
 
 ---
  libteam/ifinfo.c          |   6 +-
- teamd/teamd.c             |  57 ++++-
+ teamd/teamd.c             |  51 +++-
  teamd/teamd.h             |   6 +
  teamd/teamd_events.c      |  13 ++
+ teamd/teamd_per_port.c    |   6 +
  teamd/teamd_runner_lacp.c | 474 +++++++++++++++++++++++++++++++++++---
- 5 files changed, 509 insertions(+), 47 deletions(-)
+ 6 files changed, 512 insertions(+), 44 deletions(-)
 
 diff --git a/libteam/ifinfo.c b/libteam/ifinfo.c
-index a15788b..e48193e 100644
+index 46d56a2..b86d34c 100644
 --- a/libteam/ifinfo.c
 +++ b/libteam/ifinfo.c
 @@ -109,15 +109,13 @@ static void update_hwaddr(struct team_ifinfo *ifinfo, struct rtnl_link *link)
@@ -34,7 +35,7 @@ index a15788b..e48193e 100644
  	}
  }
 diff --git a/teamd/teamd.c b/teamd/teamd.c
-index 9dc85b5..679da49 100644
+index 9dc85b5..17221a9 100644
 --- a/teamd/teamd.c
 +++ b/teamd/teamd.c
 @@ -117,7 +117,9 @@ static void print_help(const struct teamd_context *ctx) {
@@ -90,7 +91,7 @@ index 9dc85b5..679da49 100644
  	if (optind < argc) {
  		fprintf(stderr, "Too many arguments\n");
  		return -1;
-@@ -390,12 +410,21 @@ static int teamd_run_loop_run(struct teamd_context *ctx)
+@@ -390,9 +410,18 @@ static int teamd_run_loop_run(struct teamd_context *ctx)
  			if (err != -1) {
  				switch(ctrl_byte) {
  				case 'q':
@@ -99,9 +100,6 @@ index 9dc85b5..679da49 100644
  					if (quit_in_progress)
  						return -EBUSY;
 -					teamd_refresh_ports(ctx);
--					err = teamd_flush_ports(ctx);
--					if (err)
--						return err;
 +					if (ctrl_byte == 'w' || ctrl_byte == 'f') {
 +						ctx->keep_ports = true;
 +						ctx->no_quit_destroy = true;
@@ -110,12 +108,9 @@ index 9dc85b5..679da49 100644
 +							teamd_ports_flush_data(ctx);
 +					}
 +
-+					err = teamd_flush_ports(ctx);
-+					if (err)
-+						return err;
- 					quit_in_progress = true;
- 					continue;
- 				case 'r':
+ 					err = teamd_flush_ports(ctx);
+ 					if (err)
+ 						return err;
 @@ -434,6 +463,12 @@ void teamd_run_loop_quit(struct teamd_context *ctx, int err)
  	teamd_run_loop_sent_ctrl_byte(ctx, 'q');
  }
@@ -207,6 +202,23 @@ index 221803e..bd4dcc1 100644
  int teamd_event_port_added(struct teamd_context *ctx,
  			   struct teamd_port *tdport)
  {
+diff --git a/teamd/teamd_per_port.c b/teamd/teamd_per_port.c
+index f98a90d..a87e809 100644
+--- a/teamd/teamd_per_port.c
++++ b/teamd/teamd_per_port.c
+@@ -350,6 +350,12 @@ static int teamd_port_remove(struct teamd_context *ctx,
+ {
+ 	int err;
+ 
++	if (ctx->keep_ports) {
++		teamd_log_dbg("%s: Keeping port (found ifindex \"%d\").",
++		      tdport->ifname, tdport->ifindex);
++		return 0;
++	}
++
+ 	teamd_log_dbg("%s: Removing port (found ifindex \"%d\").",
+ 		      tdport->ifname, tdport->ifindex);
+ 	err = team_port_remove(ctx->th, tdport->ifindex);
 diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
 index 4016b15..81be5b7 100644
 --- a/teamd/teamd_runner_lacp.c


### PR DESCRIPTION
…nd WR

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a feature to don't remove member ports from LAG, when teamd quits in FR/WR mode.

**- How I did it**
Added an if in port remove procedure.

**- How to verify it**
Build teamd, install on your dut.
then
1. tail -F syslog
2. tail -F teamd.log
3. docker exec -ti teamd pkill -USR2 teamd
4. Check that all teamd processes were quit and you don't see events of removing ports in syslog output.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
