### PR TITLE
[makefile] build Jessie slave unless NOJESSIE is specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 clean reset init configure showtag sonic-slave-build sonic-slave-bash :
 	@echo "+++ Making $@ +++"
-ifneq ($(NOJESSIE), 0)
+ifeq ($(NOJESSIE), 0)
 	make -f Makefile.work $@
 endif
 	BLDENV=stretch make -f Makefile.work $@

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,7 @@ endif
 
 clean reset init configure showtag sonic-slave-build sonic-slave-bash :
 	@echo "+++ Making $@ +++"
+ifneq ($(NOJESSIE), 0)
+	make -f Makefile.work $@
+endif
 	BLDENV=stretch make -f Makefile.work $@


### PR DESCRIPTION
Provide a method in master branch to build Jessie slave docker. This option is currently on by default unless NOJESSIE=1 is specified. The default for NOJESSIE should probably becomes 1 at some point when we fully understand what needs Jessie slave docker where from the master branch.