### PR TITLE
[updategraph] enhance update graph handling

### DIFF
--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -60,13 +60,20 @@ if [ -f /tmp/pending_config_migration ]; then
     copy_config_files_and_directories $copy_list
     if [ x"${WARM_BOOT}" == x"true" ]; then
         echo "Warm reboot detected..."
-    elif [ "$enabled" = "true" ]; then
+    elif [ -r /etc/sonic/config_db.json ]; then
+        echo "Use config_db.json from old system..."
+        sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
+
+        if [[ -x /usr/bin/db_migrator.py ]]; then
+            # Migrate the DB to the latest schema version if needed
+            /usr/bin/db_migrator.py -o migrate
+        fi
+    elif [ -r /etc/sonic/minigraph.xml ]; then
         echo "Use minigraph.xml from old system..."
         reload_minigraph
         sonic-cfggen -d --print-data > /etc/sonic/config_db.json
     else
-        echo "Use config_db.json from old system..."
-        sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
+        echo "Didn't found neither config_db.json nor minigraph.xml ..."
     fi
     rm -f /tmp/pending_config_migration
     sed -i "/enabled=/d" /etc/sonic/updategraph.conf


### PR DESCRIPTION
**- What I did**

- after reloading minigraph, write latest version string in the DB.
- if old config_db.json file exists, use it and migrate to latest version.
- only reload minigraph when config_db.json doesn't exist and minigraph
  exists.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
sonic upgrade