### PR TITLE
[first boot] sync file system after moving/copying files

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -242,6 +242,8 @@ if [ -f $FIRST_BOOT_FILE ]; then
         dpkg -i /host/image-$SONIC_VERSION/platform/$platform/*.deb
     fi
 
+    sync
+
     # If the unit booted into SONiC from another NOS's grub,
     # we now install a grub for SONiC.
     if [ -n "$onie_platform" ] && [ -n "$migration" ]; then

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -33,6 +33,8 @@ function copy_config_files_and_directories()
             logger "Missing SONiC configuration ${file_dir} ..."
         fi
     done
+
+    sync
 }
 
 function check_system_warm_boot()


### PR DESCRIPTION
**- What I did**
This is a tentative fix for an issue noticed in continuous warm reboot upgrade test. Where the files under /etc/sonic/old_config are all in zero size. There are some tentative evidence pointing the
issue at boot up path. Adding a couple sync after moving/copying file to see how it helps.

**- How to verify it**
Still running continuous warm reboot upgrade. It might take long time to see result. Meanwhile, I think this change is harmless.