### PR TITLE
Configure buffer profile to all ports

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -131,7 +131,7 @@ def
 {{ defs.generate_pg_profils(port_names_active) }}
 {% else %}
     "BUFFER_PG": {
-{% for port in PORT_ACTIVE %}
+{% for port in PORT_ALL %}
         "{{ port }}|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         }{% if not loop.last %},{% endif %}
@@ -144,17 +144,17 @@ def
 {{ defs.generate_queue_buffers(port_names_active) }}
 {% else %}
     "BUFFER_QUEUE": {
-{% for port in PORT_ACTIVE %}
+{% for port in PORT_ALL %}
         "{{ port }}|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
 {% endfor %}
-{% for port in PORT_ACTIVE %}
+{% for port in PORT_ALL %}
         "{{ port }}|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
 {% endfor %}
-{% for port in PORT_ACTIVE %}
+{% for port in PORT_ALL %}
         "{{ port }}|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         }{% if not loop.last %},{% endif %}

--- a/src/sonic-config-engine/tests/sample_output/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/buffers-dell6100.json
@@ -111,6 +111,12 @@
         "Ethernet1|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
+        "Ethernet2|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet3|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
         "Ethernet4|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
@@ -153,6 +159,12 @@
         "Ethernet17|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
+        "Ethernet18|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet19|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
         "Ethernet20|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
@@ -192,6 +204,15 @@
         "Ethernet32|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
+        "Ethernet33|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet34|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet35|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
         "Ethernet36|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
@@ -213,7 +234,31 @@
         "Ethernet42|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
+        "Ethernet43|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet44|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet45|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet46|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet47|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
         "Ethernet48|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet49|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet50|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet51|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet52|0": {
@@ -236,6 +281,21 @@
         },
         "Ethernet58|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet59|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet60|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet61|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet62|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet63|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         }
     },
 
@@ -244,6 +304,12 @@
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet1|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet2|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet3|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet4|3-4": {
@@ -288,6 +354,12 @@
         "Ethernet17|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
+        "Ethernet18|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet19|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
         "Ethernet20|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
@@ -327,6 +399,15 @@
         "Ethernet32|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
+        "Ethernet33|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet34|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet35|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
         "Ethernet36|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
@@ -348,7 +429,31 @@
         "Ethernet42|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
+        "Ethernet43|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet44|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet45|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet46|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet47|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
         "Ethernet48|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet49|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet50|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet51|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet52|3-4": {
@@ -372,10 +477,31 @@
         "Ethernet58|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
+        "Ethernet59|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet60|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet61|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet62|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet63|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
         "Ethernet0|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet1|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet2|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet3|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet4|0-2": {
@@ -420,6 +546,12 @@
         "Ethernet17|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
+        "Ethernet18|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet19|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
         "Ethernet20|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
@@ -459,6 +591,15 @@
         "Ethernet32|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
+        "Ethernet33|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet34|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet35|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
         "Ethernet36|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
@@ -480,7 +621,31 @@
         "Ethernet42|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
+        "Ethernet43|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet44|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet45|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet46|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet47|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
         "Ethernet48|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet49|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet50|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet51|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet52|0-2": {
@@ -504,10 +669,31 @@
         "Ethernet58|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
+        "Ethernet59|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet60|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet61|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet62|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet63|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
         "Ethernet0|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet1|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet2|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet3|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet4|5-6": {
@@ -552,6 +738,12 @@
         "Ethernet17|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
+        "Ethernet18|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet19|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
         "Ethernet20|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
@@ -591,6 +783,15 @@
         "Ethernet32|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
+        "Ethernet33|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet34|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet35|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
         "Ethernet36|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
@@ -612,7 +813,31 @@
         "Ethernet42|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
+        "Ethernet43|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet44|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet45|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet46|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet47|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
         "Ethernet48|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet49|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet50|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet51|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet52|5-6": {
@@ -634,6 +859,21 @@
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet58|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet59|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet60|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet61|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet62|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet63|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         }
     }


### PR DESCRIPTION
This overwrites the current approach to configure only active ports, which have neighbors in the minigraph.

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
