### PR TITLE
[ntp]: Use loopback address when we don't have MGMT interface

### DIFF
--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -27,11 +27,18 @@ filegen clockstats file clockstats type day enable
 server {{ ntp_server }} iburst
 {% endfor %}
 
-#only listen on localhost and eth0 ips (default is to listen on all ip addresses)
+#only listen on MGMT_INTERFACE, LOOPBACK_INTERFACE ip when MGMT_INTERFACE is not defined, or eth0 
+# if we don't have both of them (default is to listen on all ip addresses)
 interface ignore wildcard
 {% if MGMT_INTERFACE %}
 {% for (mgmt_intf, mgmt_prefix) in MGMT_INTERFACE|pfx_filter %}
 interface listen {{ mgmt_prefix | ip }}
+{% endfor %}
+{% elif LOOPBACK_INTERFACE %}
+{% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
+{% if prefix | ipv4 and name == 'Loopback0' %}
+interface listen {{ prefix | ip }}
+{% endif %}
 {% endfor %}
 {% else %}
 interface listen eth0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added configuration to use Loopback ip if a switch doesn't have MGMT_PORT.

**- How I did it**
Add extra "if" in ntp.conf template.

**- How to verify it**
Build an image and run on your DUT.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
