### PR TITLE
[Mellanox]Resolve chassis broken due to inconsistent with latest sonic_platform_common

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -63,9 +63,11 @@ class Chassis(ChassisBase):
         self.reboot_cause_initialized = False
         logger.log_info("Chassis loaded successfully")
 
+
     def __del__(self):
         if self.sfp_event_initialized:
             self.sfp_event.deinitialize()
+
 
     def initialize_psu(self):
         from sonic_platform.psu import Psu
@@ -74,6 +76,7 @@ class Chassis(ChassisBase):
         for index in range(MLNX_NUM_PSU):
             psu = Psu(index, self.sku_name)
             self._psu_list.append(psu)
+
 
     def initialize_fan(self):
         from sonic_platform.fan import Fan
@@ -91,6 +94,7 @@ class Chassis(ChassisBase):
             else:
                 fan = Fan(index, index)
             self._fan_list.append(fan)
+
 
     def initialize_sfp(self):
         from sonic_platform.sfp import SFP
@@ -113,15 +117,18 @@ class Chassis(ChassisBase):
 
         self.sfp_module_initialized = True
 
+
     def initialize_thermals(self):
         from sonic_platform.thermal import initialize_thermals
         # Initialize thermals
         initialize_thermals(self.sku_name, self._thermal_list, self._psu_list)
 
+
     def initialize_eeprom(self):
         from eeprom import Eeprom
         # Initialize EEPROM
         self._eeprom = Eeprom()
+
 
     def initialize_components_list(self):
         # Initialize component list
@@ -129,6 +136,7 @@ class Chassis(ChassisBase):
         self._component_list.append(ComponentBIOS())
         self._component_list.append(ComponentCPLD())
         self._component_list.append(ComponentASIC_FW())
+
 
     ##############################################
     # SFP methods
@@ -144,6 +152,7 @@ class Chassis(ChassisBase):
             self.initialize_sfp()
         return len(self._sfp_list)
 
+
     def get_all_sfps(self):
         """
         Retrieves all sfps available on this chassis
@@ -155,6 +164,7 @@ class Chassis(ChassisBase):
         if not self.sfp_module_initialized:
             self.initialize_sfp()
         return self._sfp_list
+
 
     def get_sfp(self, index):
         """
@@ -182,6 +192,7 @@ class Chassis(ChassisBase):
 
         return sfp
 
+
     def _extract_num_of_fans_and_fan_drawers(self):
         num_of_fan = 0
         num_of_drawer = 0
@@ -198,14 +209,17 @@ class Chassis(ChassisBase):
 
         return num_of_fan, num_of_drawer
 
+
     def _get_sku_name(self):
         p = subprocess.Popen(GET_HWSKU_CMD, shell=True, stdout=subprocess.PIPE)
         out, err = p.communicate()
         return out.rstrip('\n')
 
+
     def _get_port_position_tuple_by_sku_name(self):
         position_tuple = port_position_tuple_list[hwsku_dict_port[self.sku_name]]
         return position_tuple
+
 
     def get_watchdog(self):
         """
@@ -231,6 +245,7 @@ class Chassis(ChassisBase):
 
         return self._watchdog
 
+
     def get_base_mac(self):
         """
         Retrieves the base MAC address for the chassis
@@ -241,6 +256,7 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.get_base_mac()
 
+
     def get_serial_number(self):
         """
         Retrieves the hardware serial number for the chassis
@@ -249,6 +265,7 @@ class Chassis(ChassisBase):
             A string containing the hardware serial number for this chassis.
         """
         return self._eeprom.get_serial_number()
+
 
     def get_system_eeprom_info(self):
         """
@@ -260,6 +277,7 @@ class Chassis(ChassisBase):
             values.
         """
         return self._eeprom.get_system_eeprom_info()
+
 
     def _read_generic_file(self, filename, len):
         """
@@ -275,6 +293,7 @@ class Chassis(ChassisBase):
             logger.log_info("Fail to read file {} due to {}".format(filename, repr(e)))
             return '0'
 
+
     def _verify_reboot_cause(self, filename):
         '''
         Open and read the reboot cause file in 
@@ -282,6 +301,7 @@ class Chassis(ChassisBase):
         If a reboot cause file doesn't exists, returns '0'.
         '''
         return bool(int(self._read_generic_file(join(REBOOT_CAUSE_ROOT, filename), REBOOT_CAUSE_FILE_LENGTH).rstrip('\n')))
+
 
     def initialize_reboot_cause(self):
         self.reboot_major_cause_dict = {
@@ -308,6 +328,7 @@ class Chassis(ChassisBase):
         }
         self.reboot_cause_initialized = True
 
+
     def get_reboot_cause(self):
         """
         Retrieves the cause of the previous reboot
@@ -333,6 +354,7 @@ class Chassis(ChassisBase):
 
         return self.REBOOT_CAUSE_NON_HARDWARE, ''
 
+
     def _show_capabilities(self):
         """
         This function is for debug purpose
@@ -353,6 +375,7 @@ class Chassis(ChassisBase):
                     )
             except:
                 print "fail to retrieve capabilities for module index {}".format(s.index)
+
 
     def get_change_event(self, timeout=0):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -132,10 +132,9 @@ class Chassis(ChassisBase):
 
     def initialize_components(self):
         # Initialize component list
-        from sonic_platform.component import ComponentBIOS, ComponentCPLD, ComponentASIC_FW
+        from sonic_platform.component import ComponentBIOS, ComponentCPLD
         self._component_list.append(ComponentBIOS())
         self._component_list.append(ComponentCPLD())
-        self._component_list.append(ComponentASIC_FW())
 
 
     ##############################################

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -130,7 +130,7 @@ class Chassis(ChassisBase):
         self._eeprom = Eeprom()
 
 
-    def initialize_components_list(self):
+    def initialize_components(self):
         # Initialize component list
         from sonic_platform.component import ComponentBIOS, ComponentCPLD, ComponentASIC_FW
         self._component_list.append(ComponentBIOS())

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -40,9 +40,8 @@ class Component(ComponentBase):
         """
         result = ''
         try:
-            fileobj = io.open(filename)
-            result = fileobj.read(len)
-            fileobj.close()
+            with io.open(filename, 'r') as fileobj:
+                result = fileobj.read(len)
             return result
         except Exception as e:
             logger.log_info("Fail to read file {} due to {}".format(filename, repr(e)))
@@ -132,7 +131,7 @@ class ComponentCPLD(Component):
         """
         cpld_version_file_list = glob(CPLD_VERSION_FILE_PATTERN)
         cpld_version = ''
-        if cpld_version_file_list is not None and not cpld_version_file_list == []:
+        if cpld_version_file_list is not None and cpld_version_file_list:
             cpld_version_file_list.sort()
             for version_file in cpld_version_file_list:
                 version = self._read_generic_file(version_file, CPLD_VERSION_MAX_LENGTH)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -35,6 +35,7 @@ class Component(ComponentBase):
         """
         return self.name
 
+
     def _read_generic_file(self, filename, len):
         """
         Read a generic file, returns the contents of the file
@@ -49,6 +50,7 @@ class Component(ComponentBase):
             logger.log_info("Fail to read file {} due to {}".format(filename, repr(e)))
             return '0'
 
+
     def _get_command_result(self, cmdline):
         try:
             proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE, shell=True, stderr=subprocess.STDOUT)
@@ -61,9 +63,11 @@ class Component(ComponentBase):
 
         return result
 
+
 class ComponentBIOS(Component):
     def __init__(self):
         self.name = COMPONENT_BIOS
+
 
     def get_description(self):
         """
@@ -73,6 +77,7 @@ class ComponentBIOS(Component):
             A string containing the description of the component
         """
         raise NotImplementedError
+
 
     def get_firmware_version(self):
         """
@@ -104,9 +109,11 @@ class ComponentBIOS(Component):
 
         return result
 
+
 class ComponentCPLD(Component):
     def __init__(self):
         self.name = COMPONENT_CPLD
+
 
     def get_description(self):
         """
@@ -116,6 +123,7 @@ class ComponentCPLD(Component):
             A string containing the description of the component
         """
         raise NotImplementedError
+
 
     def get_firmware_version(self):
         """
@@ -136,9 +144,11 @@ class ComponentCPLD(Component):
 
         return cpld_version
 
+
 class ComponentASIC_FW(Component):
     def __init__(self):
         self.name = COMPONENT_FIRMWARE
+
 
     def get_description(self):
         """
@@ -148,6 +158,7 @@ class ComponentASIC_FW(Component):
             A string containing the description of the component
         """
         raise NotImplementedError
+
 
     def get_firmware_version(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -74,7 +74,7 @@ class ComponentBIOS(Component):
         Returns:
             A string containing the description of the component
         """
-        raise NotImplementedError
+        return "BIOS - Basic Input/Output System"
 
 
     def get_firmware_version(self):
@@ -120,7 +120,7 @@ class ComponentCPLD(Component):
         Returns:
             A string containing the description of the component
         """
-        raise NotImplementedError
+        return "CPLD - includes all CPLDs in the switch"
 
 
     def get_firmware_version(self):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+
+#############################################################################
+# Mellanox
+#
+# implementation of new platform api
+#############################################################################
+
+try:
+    from sonic_platform_base.component_base import ComponentBase
+    from glob import glob
+    import subprocess
+    import io
+    import re
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+#components definitions
+COMPONENT_BIOS = "BIOS"
+COMPONENT_FIRMWARE = "ASIC-FIRMWARE"
+COMPONENT_CPLD = "CPLD"
+
+FW_QUERY_VERSION_COMMAND = 'mlxfwmanager --query'
+BIOS_QUERY_VERSION_COMMAND = 'dmidecode -t 11'
+CPLD_VERSION_FILE_PATTERN = '/var/run/hw-management/system/cpld?_version'
+CPLD_VERSION_MAX_LENGTH = 4
+
+class Component(ComponentBase):
+    def get_name(self):
+        """
+        Retrieves the name of the component
+
+        Returns:
+            A string containing the name of the component
+        """
+        return self.name
+
+    def _read_generic_file(self, filename, len):
+        """
+        Read a generic file, returns the contents of the file
+        """
+        result = ''
+        try:
+            fileobj = io.open(filename)
+            result = fileobj.read(len)
+            fileobj.close()
+            return result
+        except Exception as e:
+            logger.log_info("Fail to read file {} due to {}".format(filename, repr(e)))
+            return '0'
+
+    def _get_command_result(self, cmdline):
+        try:
+            proc = subprocess.Popen(cmdline, stdout=subprocess.PIPE, shell=True, stderr=subprocess.STDOUT)
+            stdout = proc.communicate()[0]
+            proc.wait()
+            result = stdout.rstrip('\n')
+
+        except OSError, e:
+            result = ''
+
+        return result
+
+class ComponentBIOS(Component):
+    def __init__(self):
+        self.name = COMPONENT_BIOS
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+
+        Returns:
+            A string containing the description of the component
+        """
+        raise NotImplementedError
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of the component
+
+        Returns:
+            A string containing the firmware version of the component
+
+        BIOS version is retrieved via command 'dmidecode -t 11'
+        which should return result in the following convention
+            # dmidecode 3.0
+            Getting SMBIOS data from sysfs.
+            SMBIOS 2.7 present.
+
+            Handle 0x0022, DMI type 11, 5 bytes
+            OEM Strings
+                    String 1:*0ABZS017_02.02.002*
+                    String 2: To Be Filled By O.E.M.
+
+        By using regular expression 'OEM[\s]*Strings\n[\s]*String[\s]*1:[\s]*([0-9a-zA-Z_\.]*)'
+        we can extrace the version string which is marked with * in the above context
+        """
+        bios_ver_str = self._get_command_result(BIOS_QUERY_VERSION_COMMAND)
+        try:
+            m = re.search('OEM[\s]*Strings\n[\s]*String[\s]*1:[\s]*([0-9a-zA-Z_\.]*)', bios_ver_str)
+            result = m.group(1)
+        except:
+            result = ''
+
+        return result
+
+class ComponentCPLD(Component):
+    def __init__(self):
+        self.name = COMPONENT_CPLD
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+
+        Returns:
+            A string containing the description of the component
+        """
+        raise NotImplementedError
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of the component
+
+        Returns:
+            A string containing the firmware version of the component
+        """
+        cpld_version_file_list = glob(CPLD_VERSION_FILE_PATTERN)
+        cpld_version = ''
+        if cpld_version_file_list is not None and not cpld_version_file_list == []:
+            cpld_version_file_list.sort()
+            for version_file in cpld_version_file_list:
+                version = self._read_generic_file(version_file, CPLD_VERSION_MAX_LENGTH)
+                if not cpld_version == '':
+                    cpld_version += '.'
+                cpld_version += version.rstrip('\n')
+
+        return cpld_version
+
+class ComponentASIC_FW(Component):
+    def __init__(self):
+        self.name = COMPONENT_FIRMWARE
+
+    def get_description(self):
+        """
+        Retrieves the description of the component
+
+        Returns:
+            A string containing the description of the component
+        """
+        raise NotImplementedError
+
+    def get_firmware_version(self):
+        """
+        Retrieves the firmware version of the component
+
+        Returns:
+            A string containing the firmware version of the component
+
+        firmware version is retrieved via command 'mlxfwmanager --query'
+        which should return result in the following convention
+            admin@mtbc-sonic-01-2410:~$ sudo mlxfwmanager --query
+            Querying Mellanox devices firmware ...
+
+            Device #1:
+            ----------
+
+            Device Type:      Spectrum
+            Part Number:      MSN2410-CxxxO_Ax_Bx
+            Description:      Spectrum based 25GbE/100GbE 1U Open Ethernet switch with ONIE; 48 SFP28 ports; 8 QSFP28 ports; x86 dual core; RoHS6
+            PSID:             MT_2860111033
+            PCI Device Name:  /dev/mst/mt52100_pci_cr0
+            Base MAC:         98039bf3f500
+            Versions:         Current        Available     
+                FW         ***13.2000.1140***N/A           
+
+            Status:           No matching image found
+
+        By using regular expression '(Versions:.*\n[\s]+FW[\s]+)([\S]+)',
+        we can extrace the version which is marked with *** in the above context
+        """
+        fw_ver_str = self._get_command_result(FW_QUERY_VERSION_COMMAND)
+        try: 
+            m = re.search('(Versions:.*\n[\s]+FW[\s]+)([\S]+)', fw_ver_str)
+            result = m.group(2)
+        except :
+            result = ''
+
+        return result

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -139,6 +139,8 @@ class ComponentCPLD(Component):
                 if not cpld_version == '':
                     cpld_version += '.'
                 cpld_version += version.rstrip('\n')
+        else:
+            raise RuntimeError("Failed to get CPLD version files by matching {}".format(CPLD_VERSION_FILE_PATTERN))
 
         return cpld_version
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -17,10 +17,8 @@ except ImportError as e:
 
 #components definitions
 COMPONENT_BIOS = "BIOS"
-COMPONENT_FIRMWARE = "ASIC-FIRMWARE"
 COMPONENT_CPLD = "CPLD"
 
-FW_QUERY_VERSION_COMMAND = 'mlxfwmanager --query'
 BIOS_QUERY_VERSION_COMMAND = 'dmidecode -t 11'
 CPLD_VERSION_FILE_PATTERN = '/var/run/hw-management/system/cpld[0-9]_version'
 CPLD_VERSION_MAX_LENGTH = 4
@@ -144,56 +142,3 @@ class ComponentCPLD(Component):
 
         return cpld_version
 
-
-class ComponentASIC_FW(Component):
-    def __init__(self):
-        self.name = COMPONENT_FIRMWARE
-
-
-    def get_description(self):
-        """
-        Retrieves the description of the component
-
-        Returns:
-            A string containing the description of the component
-        """
-        raise NotImplementedError
-
-
-    def get_firmware_version(self):
-        """
-        Retrieves the firmware version of the component
-
-        Returns:
-            A string containing the firmware version of the component
-
-        firmware version is retrieved via command 'mlxfwmanager --query'
-        which should return result in the following convention
-            admin@mtbc-sonic-01-2410:~$ sudo mlxfwmanager --query
-            Querying Mellanox devices firmware ...
-
-            Device #1:
-            ----------
-
-            Device Type:      Spectrum
-            Part Number:      MSN2410-CxxxO_Ax_Bx
-            Description:      Spectrum based 25GbE/100GbE 1U Open Ethernet switch with ONIE; 48 SFP28 ports; 8 QSFP28 ports; x86 dual core; RoHS6
-            PSID:             MT_2860111033
-            PCI Device Name:  /dev/mst/mt52100_pci_cr0
-            Base MAC:         98039bf3f500
-            Versions:         Current        Available     
-                FW         ***13.2000.1140***N/A           
-
-            Status:           No matching image found
-
-        By using regular expression '(Versions:.*\n[\s]+FW[\s]+)([\S]+)',
-        we can extrace the version which is marked with *** in the above context
-        """
-        fw_ver_str = self._get_command_result(FW_QUERY_VERSION_COMMAND)
-        try: 
-            m = re.search('(Versions:.*\n[\s]+FW[\s]+)([\S]+)', fw_ver_str)
-            result = m.group(2)
-        except :
-            result = ''
-
-        return result

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -22,7 +22,7 @@ COMPONENT_CPLD = "CPLD"
 
 FW_QUERY_VERSION_COMMAND = 'mlxfwmanager --query'
 BIOS_QUERY_VERSION_COMMAND = 'dmidecode -t 11'
-CPLD_VERSION_FILE_PATTERN = '/var/run/hw-management/system/cpld?_version'
+CPLD_VERSION_FILE_PATTERN = '/var/run/hw-management/system/cpld[0-9]_version'
 CPLD_VERSION_MAX_LENGTH = 4
 
 class Component(ComponentBase):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -18,7 +18,7 @@ class Platform(PlatformBase):
         PlatformBase.__init__(self)
         if self._is_host():
             self._chassis = Chassis()
-            self._chassis.initialize_components_list()
+            self._chassis.initialize_components()
         else:
             self._chassis = Chassis()
             self._chassis.initialize_psu()

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -18,12 +18,12 @@ class Platform(PlatformBase):
         PlatformBase.__init__(self)
         if self._is_host():
             self._chassis = Chassis()
+            self._chassis.initialize_components_list()
         else:
             self._chassis = Chassis()
             self._chassis.initialize_psu()
             self._chassis.initialize_fan()
             self._chassis.initialize_eeprom()
-            self._chassis.initialize_components_list()
 
     def _is_host(self):
         """


### PR DESCRIPTION
**- What I did**
Resolve chassis broken by supporting the latest component API (get_firmware_version) 
Currently get_firmware_version implemented by using chassis.get_firmware_version and chassis._component_name_list which are not supported in the latest sonic_platform_common, causing chassis broken.
Update this part so that it aligns to the latest sonic_platform_common

**- How I did it**
Originally get_firmware_version is a member function of chassis but recently it is moved to component.py. In this case, mlnx-platform-api should be updated accordingly otherwise chassis is broken.

**- How to verify it**
test
- whether firmware versions can be fetch
- whether chassis can be loaded successfully

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
