### PR TITLE
[teamd] fix lacp fallback mode breakage in teamd v1.28

### DIFF
--- a/src/libteam/patch/0003-libteam-Add-fallback-support-for-single-member-port-.patch
+++ b/src/libteam/patch/0003-libteam-Add-fallback-support-for-single-member-port-.patch
@@ -1,17 +1,16 @@
-From 9b40af58575a89d06be51cfbb5a2265a59826110 Mon Sep 17 00:00:00 2001
-From: yorke <yorke.yuan@asterfusion.com>
-Date: Mon, 3 Jun 2019 12:02:36 +0800
-Subject: [PATCH 3/8] [libteam] Add fallback support for single-member-port LAG
-     From: Haiyang Zheng <haiyang.z@alibaba-inc.com>     Date: Fri, 15 Dec
- 2017 21:07:53 -0800
+commit f475746f56602a40861b8d94eac5f0979c4703f3
+Author: yorke <yorke.yuan@asterfusion.com>
+Date:   Mon Jun 3 12:02:36 2019 +0800
 
-Signed-off-by: yorke <yorke.yuan@asterfusion.com>
----
- teamd/teamd_runner_lacp.c | 42 ++++++++++++++++++++++++++++++++++++++++--
- 1 file changed, 40 insertions(+), 2 deletions(-)
+    From 9b40af58575a89d06be51cfbb5a2265a59826110 Mon Sep 17 00:00:00 2001
+    Subject: [PATCH 3/8] [libteam] Add fallback support for single-member-port LAG
+         From: Haiyang Zheng <haiyang.z@alibaba-inc.com>     Date: Fri, 15 Dec
+     2017 21:07:53 -0800
+    
+    Signed-off-by: yorke <yorke.yuan@asterfusion.com>
 
 diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
-index 4dbd015..9836824 100644
+index 4dbd015..f8a9e16 100644
 --- a/teamd/teamd_runner_lacp.c
 +++ b/teamd/teamd_runner_lacp.c
 @@ -138,6 +138,8 @@ struct lacp {
@@ -71,7 +70,27 @@ index 4dbd015..9836824 100644
  		return false;
  	return true;
  }
-@@ -1502,6 +1525,16 @@ static int lacp_state_fast_rate_get(struct teamd_context *ctx,
+@@ -334,7 +357,8 @@ static int lacp_port_should_be_enabled(struct lacp_port *lacp_port)
+ 
+ 	if (lacp_port_selected(lacp_port) &&
+ 	    lacp_port->agg_lead == lacp->selected_agg_lead &&
+-	    lacp_port->partner.state & INFO_STATE_SYNCHRONIZATION)
++	    (lacp_port->partner.state & INFO_STATE_SYNCHRONIZATION ||
++	    is_lacp_fallback_eligible(lacp_port)))
+ 		return true;
+ 	return false;
+ }
+@@ -345,7 +369,8 @@ static int lacp_port_should_be_disabled(struct lacp_port *lacp_port)
+ 
+ 	if (!lacp_port_selected(lacp_port) ||
+ 	    lacp_port->agg_lead != lacp->selected_agg_lead ||
+-	    !(lacp_port->partner.state & INFO_STATE_SYNCHRONIZATION))
++	    (!(lacp_port->partner.state & INFO_STATE_SYNCHRONIZATION) &&
++	    !is_lacp_fallback_eligible(lacp_port)))
+ 		return true;
+ 	return false;
+ }
+@@ -1502,6 +1527,16 @@ static int lacp_state_fast_rate_get(struct teamd_context *ctx,
  	return 0;
  }
  
@@ -88,7 +107,7 @@ index 4dbd015..9836824 100644
  static int lacp_state_select_policy_get(struct teamd_context *ctx,
  					struct team_state_gsc *gsc,
  					void *priv)
-@@ -1529,6 +1562,11 @@ static const struct teamd_state_val lacp_state_vals[] = {
+@@ -1529,6 +1564,11 @@ static const struct teamd_state_val lacp_state_vals[] = {
  		.getter = lacp_state_fast_rate_get,
  	},
  	{
@@ -100,6 +119,3 @@ index 4dbd015..9836824 100644
  		.subpath = "select_policy",
  		.type = TEAMD_STATE_ITEM_TYPE_STRING,
  		.getter = lacp_state_select_policy_get,
--- 
-2.7.4
-


### PR DESCRIPTION
fixes #951

In teamd v1.28, the port can only be enabled if sync bit is set
in recveived LACPDU from partner by the following commit
"teamd: lacp: update port state according to partner's sync bit"
(https://github.com/jpirko/libteam/commit/54f137c10579bf97800c61ebb13e732aa1d843e6)

However, lacp fallback feature needs to enable port even if partner
LACPDU is not received within a given period and fallback cfg is enabled.
To fix the lacp fallback breakage, we have to bypass the sync bit
check in lacp fallback mode.

Signed-off-by: Haiyang Zheng <haiyang.z@alibaba-inc.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix lacp fallback mode breakage in teamd v 1.28

**- How I did it**

bypass the sync bit check in lacp fallback mode, which is introduced in teamd v1.28 and later

**- How to verify it**

verify that the port can enter and exit lacp fallback mode with the change as expected.

And the change passed the following test case
https://github.com/Azure/sonic-mgmt/pull/379/files

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[teamd] fix lacp fallback mode breakage in teamd v1.28

**- A picture of a cute animal (not mandatory but encouraged)**
