### PR TITLE
[201803][sonic-slave] Install specific version of ctypesgen to fix build

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -240,7 +240,7 @@ RUN python2 -m pip install -U pip==9.0.3
 
 # For p4 build
 RUN pip install \
-        ctypesgen \
+        ctypesgen==0.r125 \
         crc16
 
 # For sonic config engine testing


### PR DESCRIPTION
Port of https://github.com/Azure/sonic-buildimage/pull/3434 to the 201803 branch.

~~Note: Check builds are failing because the kernel fails to build. This is fixed by https://github.com/Azure/sonic-buildimage/pull/3573. These two PRs have a circular dependency on one another.~~

Note: vsimage check build failure is expected on 201803 branch (no make target).