### PR TITLE
changes to handle snmp configuration as per the modified CLI

### DIFF
--- a/dockers/docker-snmp-sv2/snmpd.conf.j2
+++ b/dockers/docker-snmp-sv2/snmpd.conf.j2
@@ -106,19 +106,19 @@ load   12 10 5
 #
 #   send SNMPv1  traps
 {%if v1_trap_dest and v1_trap_dest != 'NotConfigured' %}
-trapsink {{ v1_trap_dest }} public
+trapsink {{ v1_trap_dest }}
 {% else %}
 #trapsink     localhost public
 {% endif %}
 #   send SNMPv2c traps
 {%if v2_trap_dest and v2_trap_dest != 'NotConfigured' %}
-trap2sink {{ v2_trap_dest }} public
+trap2sink {{ v2_trap_dest }}
 {% else %}
 #trap2sink    localhost public
 {% endif %}
 #   send SNMPv2c INFORMs
 {%if v3_trap_dest and v3_trap_dest != 'NotConfigured' %}
-informsink {{ v3_trap_dest }} public
+informsink {{ v3_trap_dest }}
 {% else %}
 #informsink   localhost public
 {% endif %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -62,6 +62,75 @@ function preStartAction()
         echo -n > /tmp/dump.rdb
         docker cp /tmp/dump.rdb database:/var/lib/redis/
     fi
+{%- elif docker_container_name == "snmp" %}
+    docker exec -i database redis-cli -n 6 HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
+    vrfenabled=`/usr/bin/redis-cli -n 4 hget "MGMT_VRF_CONFIG|vrf_global" mgmtVrfEnabled`
+    v1SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestIp`
+    v1SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestPort`
+    v1Vrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" vrf`
+    v1Comm=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" Community`
+    v2SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" DestIp`
+    v2SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" DestPort`
+    v2Vrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" vrf`
+    v2Comm=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" Community`
+    v3SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestIp`
+    v3SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestPort`
+    v3Vrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" vrf`
+    v3Comm=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" Community`
+
+    if [ "${v1SnmpTrapIp}" != "" ]
+    then
+        if [ "${v1Vrf}" != "None" ]
+        then
+            sed -i "s/v1_trap_dest:.*/v1_trap_dest: ${v1SnmpTrapIp}:${v1SnmpTrapPort}%${v1Vrf} ${v1Comm}/" "/etc/sonic/snmp.yml"
+        else
+            sed -i "s/v1_trap_dest:.*/v1_trap_dest: ${v1SnmpTrapIp}:${v1SnmpTrapPort} ${v1Comm}/" "/etc/sonic/snmp.yml"
+        fi
+    else
+        sed -i "s/v1_trap_dest:.*/v1_trap_dest: NotConfigured/" "/etc/sonic/snmp.yml"
+    fi
+    if [ "${v2SnmpTrapIp}" != "" ]
+    then
+        if [ "${v2Vrf}" != "None" ]
+        then
+            sed -i "s/v2_trap_dest:.*/v2_trap_dest: ${v2SnmpTrapIp}:${v2SnmpTrapPort}%${v2Vrf} ${v2Comm}/" "/etc/sonic/snmp.yml"
+        else
+            sed -i "s/v2_trap_dest:.*/v2_trap_dest: ${v2SnmpTrapIp}:${v2SnmpTrapPort} ${v2Comm}/" "/etc/sonic/snmp.yml"
+        fi
+    else
+        sed -i "s/v2_trap_dest:.*/v2_trap_dest: NotConfigured/" "/etc/sonic/snmp.yml"
+    fi
+    if [ "${v3SnmpTrapIp}" != "" ]
+    then
+        if [ "${v3Vrf}" != "None" ]
+        then
+            sed -i "s/v3_trap_dest:.*/v3_trap_dest: ${v3SnmpTrapIp}:${v3SnmpTrapPort}%${v3Vrf} ${v3Comm}/" "/etc/sonic/snmp.yml"
+        else
+            sed -i "s/v3_trap_dest:.*/v3_trap_dest: ${v3SnmpTrapIp}:${v3SnmpTrapPort} ${v3Comm}/" "/etc/sonic/snmp.yml"
+        fi
+    else
+        sed -i "s/v3_trap_dest:.*/v3_trap_dest: NotConfigured/" "/etc/sonic/snmp.yml"
+    fi
+
+    echo -n "" > /tmp/snmpagentaddr.yml
+    keys=`/usr/bin/redis-cli -n 4 keys "SNMP_AGENT_ADDRESS_CONFIG|*"`
+    count=1
+    for key in $keys;do
+        ip=`echo $key|cut -d "|" -f2`
+        echo -n "snmp_agent_address_$count: $ip" >> /tmp/snmpagentaddr.yml
+        port=`echo $key|cut -d "|" -f3`
+        if [ -n "$port" ]; then
+            echo -n ":$port" >> /tmp/snmpagentaddr.yml
+        fi
+        vrf=`echo $key|cut -d "|" -f4`
+        if [ -n "$vrf" ]; then
+            echo -n "%$vrf" >> /tmp/snmpagentaddr.yml
+        fi
+        echo "" >> /tmp/snmpagentaddr.yml
+        count=$((count+1))
+    done
+    sed -i '/snmp_agent_address_*/d' /etc/sonic/snmp.yml
+    cat /tmp/snmpagentaddr.yml >> /etc/sonic/snmp.yml
 {%- else %}
     : # nothing
 {%- endif %}
@@ -106,45 +175,6 @@ function postStartAction()
         if [ -z "$exist" ]; then
             docker cp $PSENSOR pmon:/usr/bin/
         fi
-    fi
-{%- elif docker_container_name == "snmp" %}
-    docker exec -i database redis-cli -n 6 HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
-    vrfenabled=`/usr/bin/redis-cli -n 4 hget "MGMT_VRF_CONFIG|vrf_global" mgmtVrfEnabled`
-    v1SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestIp`
-    v1SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestPort`
-    v1MgmtVrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" vrf`
-    v2SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" DestIp`
-    v2SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" DestPort`
-    v2MgmtVrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" vrf`
-    v3SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestIp`
-    v3SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestPort`
-    v3MgmtVrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" vrf`
-
-    if [ "${v1SnmpTrapIp}" != "" ]
-    then
-	sed -i "s/v1_trap_dest:.*/v1_trap_dest: ${v1SnmpTrapIp}:${v1SnmpTrapPort}%${v1MgmtVrf}/" "/etc/sonic/snmp.yml"
-    fi
-    if [ "${v2SnmpTrapIp}" != "" ]
-    then
-	sed -i "s/v2_trap_dest:.*/v2_trap_dest: ${v2SnmpTrapIp}:${v2SnmpTrapPort}%${v2MgmtVrf}/" "/etc/sonic/snmp.yml"
-    fi
-    if [ "${v3SnmpTrapIp}" != "" ]
-    then
-	sed -i "s/v3_trap_dest:.*/v3_trap_dest: ${v3SnmpTrapIp}:${v3SnmpTrapPort}%${v3MgmtVrf}/" "/etc/sonic/snmp.yml"
-    fi
-
-    if [ "${vrfenabled}" == "true" ]
-    then
-        keys=`/usr/bin/redis-cli -n 4 keys "SNMP_AGENT_ADDRESS_CONFIG|*"`
-	    count=1
-	    for key in $keys;do
-	        ip=`echo $key|cut -d "|" -f2`
-	        vrf=`echo $key|cut -d "|" -f3`
-	        echo "snmp_agent_address_$count: $ip%$vrf" >> /tmp/snmpagentaddr.yml
-	        count=$((count+1))
-        done
-        sed -i '/snmp_agent_address_*/d' /etc/sonic/snmp.yml
-        cat /tmp/snmpagentaddr.yml >> /etc/sonic/snmp.yml
     fi
 {%- else %}
     : # nothing


### PR DESCRIPTION
While doing CLI changes for SNMP configuration, few changes are made in backend to handle the modified CLI. 

** Changes**   
1) "community" for "snmp trap" is also made as "configurable". snmpd_conf.j2 is modified to handle the same.
2) Changed the snmp.yml file generation from postStartAction to preStartAction in docker_image_ctl.j2 specific to SNMP docker, to ensure that the snmp.yml is generated before sonic-cfggen generates the snmpd.conf.
3) Changed to make the code common for management vrf and default vrf. Users can configure snmp trap and snmp listening IP for both management vrf and default vrf.

**Testing Done**   
Tested by configuring the SNMP listening IP as well as the trap server IP.

admin@sonic:~$ sudo config vrf add mgmt
admin@sonic:~$ sudo config snmpagentaddress add 100.104.45.9 -v mgmt
admin@sonic:~$ sudo config snmptrap modify 3 100.94.212.7 -v mgmt
admin@sonic:~$ sudo cat /etc/sonic/snmp.yml
snmp_rocommunity: public
snmp_location: public
v1_trap_dest: NotConfigured
v2_trap_dest: NotConfigured
v3_trap_dest: 100.94.212.7:162%mgmt public
snmp_agent_address_1: 100.104.45.9%mgmt

root@sonic:~# docker exec -it snmp bash
The file  /etc/snmp/snmpd.conf  inside snmp docker shows the following configuration which will be used by snmpd daemon.
Following %mgmt will be used by snmpd to listen to the IP 100.104.45.9 in "mgmt" vrf.
agentAddress 100.104.45.9%mgmt

Following %mgmt will be used by snmpd to send traps to the server 100.94.212.7 in "mgmt" vrf.
informsink 100.94.212.7:162%mgmt public

