### PR TITLE
add sonic-db-cli wrapper for replacing redis-cli later

### DIFF
--- a/dockers/docker-database/base_image_files/sonic-db-cli
+++ b/dockers/docker-database/base_image_files/sonic-db-cli
@@ -16,18 +16,18 @@ if os.isatty(1):
     DOCKER_EXEC_FLAGS += "t"
 
 if len(sys.argv) < 3:
-    msg = "More than three arguments are required. 'usage: sonic-db-cli 'dbname' 'redis commands''"
+    msg = "More than three arguments are required. 'usage: sonic-db-cli dbname rediscommands'"
     print >> sys.stderr, msg
     logger.error(msg)
 else:
     try:
         dbid = swsssdk.SonicDBConfig.get_dbid(sys.argv[1])
         dbport = swsssdk.SonicDBConfig.get_port(sys.argv[1])
-        cmd = "docker exec -{} database redis-cli -n {} -p {} {}".format(DOCKER_EXEC_FLAGS, dbid, dbport, "
-".join(sys.argv[2:]))
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True, stderr=subprocess.STDOUT)
-        print proc.stdout.read()
     except RuntimeError:
         msg = "Invalid database name input : '{}'".format(sys.argv[1])
         print >> sys.stderr, msg
         logger.error(msg)
+    else:
+        cmd = "docker exec -{} database redis-cli -n {} -p {} {}".format(DOCKER_EXEC_FLAGS, dbid, dbport, " ".join(sys.argv[2:]))
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True, stderr=subprocess.STDOUT)
+        print proc.stdout.read()

--- a/dockers/docker-database/base_image_files/sonic-db-cli
+++ b/dockers/docker-database/base_image_files/sonic-db-cli
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+DOCKER_EXEC_FLAGS="i"
+
+# Determine whether stdout is on a terminal
+if [ -t 1 ] ; then
+    DOCKER_EXEC_FLAGS+="t"
+fi
+
+dbid=`python -c "import swsssdk ; print swsssdk.SonicDBConfig.get_dbid(\"$1\")"`
+if [ $? -gt 0 ]; then
+    echo "Cannot get DB id for $1"
+    exit 1
+fi
+
+dbport=`python -c "import swsssdk ; print swsssdk.SonicDBConfig.get_port(\"$1\")"`
+if [ $? -gt 0 ]; then
+    echo "Cannot get DB port for $1"
+    exit 1
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS database redis-cli -n $dbid -p $dbport "${@:2}"

--- a/dockers/docker-database/base_image_files/sonic-db-cli
+++ b/dockers/docker-database/base_image_files/sonic-db-cli
@@ -1,22 +1,33 @@
-#!/bin/bash
+#!/usr/bin/python
+import os
+import sys
+import swsssdk
+import logging
+import subprocess
 
-DOCKER_EXEC_FLAGS="i"
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.NullHandler())
+
+DOCKER_EXEC_FLAGS = "i"
 
 # Determine whether stdout is on a terminal
-if [ -t 1 ] ; then
-    DOCKER_EXEC_FLAGS+="t"
-fi
+if os.isatty(1):
+    DOCKER_EXEC_FLAGS += "t"
 
-dbid=`python -c "import swsssdk ; print swsssdk.SonicDBConfig.get_dbid(\"$1\")"`
-if [ $? -gt 0 ]; then
-    echo "Cannot get DB id for $1"
-    exit 1
-fi
-
-dbport=`python -c "import swsssdk ; print swsssdk.SonicDBConfig.get_port(\"$1\")"`
-if [ $? -gt 0 ]; then
-    echo "Cannot get DB port for $1"
-    exit 1
-fi
-
-docker exec -$DOCKER_EXEC_FLAGS database redis-cli -n $dbid -p $dbport "${@:2}"
+if len(sys.argv) < 3:
+    msg = "More than three arguments are required. 'usage: sonic-db-cli 'dbname' 'redis commands''"
+    print >> sys.stderr, msg
+    logger.error(msg)
+else:
+    try:
+        dbid = swsssdk.SonicDBConfig.get_dbid(sys.argv[1])
+        dbport = swsssdk.SonicDBConfig.get_port(sys.argv[1])
+        cmd = "docker exec -{} database redis-cli -n {} -p {} {}".format(DOCKER_EXEC_FLAGS, dbid, dbport, "
+".join(sys.argv[2:]))
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True, stderr=subprocess.STDOUT)
+        print proc.stdout.read()
+    except RuntimeError:
+        msg = "Invalid database name input : '{}'".format(sys.argv[1])
+        print >> sys.stderr, msg
+        logger.error(msg)

--- a/rules/docker-database.mk
+++ b/rules/docker-database.mk
@@ -27,3 +27,4 @@ $(DOCKER_DATABASE)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_DATABASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 $(DOCKER_DATABASE)_BASE_IMAGE_FILES += redis-cli:/usr/bin/redis-cli
+$(DOCKER_DATABASE)_BASE_IMAGE_FILES += sonic-db-cli:/usr/bin/sonic-db-cli


### PR DESCRIPTION
* add sonic-db-cli wrapper to replace redis-cli later when applying multiDB
  - sonic-db-cli CONFIG_DB keys *   =   redis-cli -p 6379 -n 4 keys * 

admin@ASW-7005:~$ sonic-db-cli LOGLEVEL_Dx
More than three arguments are required. 'usage: sonic-db-cli 'dbname' 'redis commands''

admin@ASW-7005:~$ sonic-db-cli LOGLEVEL_DB x
(error) ERR unknown command `x`, with args beginning with: 

admin@ASW-7005:~$ sonic-db-cli LOGLEVEL_DB1 keys *
Invalid database name input : 'LOGLEVEL_DB1'

admin@ASW-7005:~$ sonic-db-cli LOGLEVEL_DB keys *
 1) "SAI_API_IPMC_GROUP:SAI_API_IPMC_GROUP"
 2) "SAI_API_VLAN:SAI_API_VLAN"
 3) "SAI_API_LAG:SAI_API_LAG"
 4) "vxlanmgrd:vxlanmgrd"
 5) "teamsyncd:teamsyncd"
 6) "vlanmgrd:vlanmgrd"



Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com