### PR TITLE
[201811][ntp] remove invocation of undefined filter

### DIFF
--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -35,7 +35,7 @@ interface ignore wildcard
 interface listen {{ mgmt_prefix | ip }}
 {% endfor %}
 {% elif LOOPBACK_INTERFACE %}
-{% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
+{% for (name, prefix) in LOOPBACK_INTERFACE %}
 {% if prefix | ipv4 and name == 'Loopback0' %}
 interface listen {{ prefix | ip }}
 {% endif %}


### PR DESCRIPTION
**- What I did**

don't use pfx_filter, it is not defined in 201811 branch.

**- How to verify it**
ntp test.