### PR TITLE
[Mellanox] Fix SN2010 issue: "show platform psustatus" returns "NOT PRESENT" for power off PSU on 201811

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/plugins/psuutil.py
@@ -20,6 +20,7 @@ class PsuUtil(PsuBase):
 
     def __init__(self):
         PsuBase.__init__(self)
+
         self.psu_path = ""
         for index in range(0, 100):
             hwmon_path = "/sys/devices/platform/mlxplat/mlxreg-hotplug/hwmon/hwmon{}/".format(index)
@@ -65,14 +66,4 @@ class PsuUtil(PsuBase):
         :param index: An integer, 1-based index of the PSU of which to query status
         :return: Boolean, True if PSU is plugged, False if not
         """
-        if index is None:
-            return False
-
-        status = 0
-        try:
-            with open(self.psu_path + self.psu_presence.format(index), 'r') as presence_status:
-                status = int(presence_status.read())
-        except IOError:
-            return False
-
-        return status == 1
+        return isinstance(index, int) and index > 0 and index <= self.get_num_psus()

--- a/device/mellanox/x86_64-mlnx_msn2010-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/plugins/psuutil.py
@@ -66,4 +66,7 @@ class PsuUtil(PsuBase):
         :param index: An integer, 1-based index of the PSU of which to query status
         :return: Boolean, True if PSU is plugged, False if not
         """
-        return isinstance(index, int) and index > 0 and index <= self.get_num_psus()
+        if not isinstance(index, int):
+            return False
+
+        return index > 0 and index <= self.get_num_psus()

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/plugins/psuutil.py
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/plugins/psuutil.py
@@ -66,4 +66,7 @@ class PsuUtil(PsuBase):
         :param index: An integer, 1-based index of the PSU of which to query status
         :return: Boolean, True if PSU is plugged, False if not
         """
-        return isinstance(index, int) and index > 0 and index <= self.get_num_psus()
+        if not isinstance(index, int):
+            return False
+
+        return index > 0 and index <= self.get_num_psus()


### PR DESCRIPTION
**- What I did**
Fix SN2010 issue: "show platform psustatus" returns "NOT PRESENT" when PSU is power off.

**- How I did it**
SN2010's PSUs aren't pluggable so that "show platform psustatus" should returns "NOT OK" when PSU is power off. 

**- How to verify it**
verify "show platform psustatus" with one PSU powered off.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
