### PR TITLE
Enable zebra IPv6 route semantics for route updates

### DIFF
--- a/dockers/docker-fpm-frr/supervisord.conf
+++ b/dockers/docker-fpm-frr/supervisord.conf
@@ -31,7 +31,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:zebra]
-command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M fpm -M snmp
+command=/usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M fpm -M snmp --v6-rr-semantics
 priority=4
 autostart=false
 autorestart=false


### PR DESCRIPTION
Starting zebra with --v6_rr_semantics to enable ipv6 route semantics:
This enables IPv6 routes are updated in kernel with NLM_F_REPLACE flag
whenever there is route update instead of treating route update as
delete and add.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enable IPv6 Route semantics in zebra by starting zebra with command line option --v6-rr-semantics
This enables IPv6 routes are updated in kernel with NLM_F_REPLACE flag
whenever there is route update from zebra instead of treating route update as
delete and add.

**- How I did it**

Adding --v6-rr-semantics option to frr docker supervisor.conf

**- How to verify it**
Create ECMP IPv6 static routes with multiple nhops.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- Steps to recreate**

In FRR:

ipv6 route 2222::2/128 100::2
ipv6 route 2222::2/128 100::3
ipv6 route 2222::2/128 100::4
ipv6 route 2222::2/128 100::5
ipv6 route 2222::2/128 100::6
ipv6 route 2222::2/128 100::7
ipv6 route 2222::2/128 100::8
ipv6 route 2222::2/128 100::9
ipv6 route 2222::2/128 100::10
ipv6 route 2222::2/128 100::11
ipv6 route 2222::2/128 100::12
ipv6 route 2222::2/128 100::13
ipv6 route 2222::2/128 100::14
ipv6 route 2222::2/128 100::15
ipv6 route 2222::2/128 100::16
ipv6 route 2222::2/128 100::17
ipv6 route 2222::2/128 100::18
ipv6 route 2222::2/128 100::19
ipv6 route 2222::2/128 100::20
!
line vty
!
end
VS1#
root@VS1:~# ip -6 route show 2222::2/128
2222::2 via 100::9 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::10 dev Vlan100 proto 196 metric 20 pref medium

root@VS1:# ps -aef | grep -i zebra
300 4208 2937 0 Sep17 pts/0 00:02:04 /usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M fpm -M snmp
root 28292 28226 0 09:48 pts/0 00:00:00 grep -i zebra
root@VS1:#

**After fix:**

root@VS1:# ps -aef | grep -i zebra
300 3456 3379 0 09:34 pts/0 00:00:00 /usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M fpm -M snmp **--v6-rr-semantics**
root 3964 31001 0 09:36 pts/0 00:00:00 grep -i zebra
root@VS1:#

sonic(config)# ipv6 route 2222::2/128 100::2
ipv6 route 2222::2/128 100::4
sonic(config)# ipv6 route 2222::2/128 100::3
sonic(config)# ipv6 route 2222::2/128 100::4
sonic(config)# ipv6 route 2222::2/128 100::5
sonic(config)# ipv6 route 2222::2/128 100::6
sonic(config)# ipv6 route 2222::2/128 100::7
sonic(config)# ipv6 route 2222::2/128 100::8
sonic(config)# ipv6 route 2222::2/128 100::9
sonic(config)# ipv6 route 2222::2/128 100::10
sonic(config)# ipv6 route 2222::2/128 100::11
sonic(config)# ipv6 route 2222::2/128 100::12
sonic(config)# ipv6 route 2222::2/128 100::13
sonic(config)# ipv6 route 2222::2/128 100::14
sonic(config)# ipv6 route 2222::2/128 100::15
sonic(config)# ipv6 route 2222::2/128 100::16
sonic(config)# ipv6 route 2222::2/128 100::17
sonic(config)# ipv6 route 2222::2/128 100::18
sonic(config)# ipv6 route 2222::2/128 100::19
sonic(config)# ipv6 route 2222::2/128 100::20
sonic(config)# end
sonic#
root@VS1:~# ip -6 route show 2222::2/128
2222::2 via 100::2 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::3 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::4 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::5 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::6 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::7 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::8 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::9 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::10 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::11 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::12 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::13 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::14 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::15 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::16 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::17 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::18 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::19 dev Vlan100 proto 196 metric 20 pref medium
2222::2 via 100::20 dev Vlan100 proto 196 metric 20 pref medium
