### PR TITLE
enabling telemetry feature by default

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -730,6 +730,11 @@ def parse_xml(filename, platform=None, port_config_file=None):
     results['TACPLUS_SERVER'] = dict((item, {'priority': '1', 'tcp_port': '49'}) for item in tacacs_servers)
 
     results['ACL_TABLE'] = acls
+    results['FEATURES'] = {
+        'telemetry': {
+            'status': 'on'
+        }
+    }
 
     # Do not configure the minigraph's mirror session, which is currently unused
     # mirror_sessions = {}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enabling telemetry feature by default
**- How I did it**
on minigraph load adding new table in config db as 'features|telemetry' {'status':'on'}
**- How to verify it**
config load_minigraph
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
