### PR TITLE
Remove macro generate_pg_profils for 7170 buffer

### DIFF
--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t0.j2
@@ -59,14 +59,6 @@
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names) %}
-    "BUFFER_PG": {
-        "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }
-    },
-{%- endmacro %}
-
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t1.j2
@@ -59,14 +59,6 @@
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names) %}
-    "BUFFER_PG": {
-        "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }
-    },
-{%- endmacro %}
-
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers_defaults_t0.j2
@@ -71,14 +71,6 @@
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names) %}
-    "BUFFER_PG": {
-        "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }
-    },
-{%- endmacro %}
-
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers_defaults_t1.j2
@@ -71,14 +71,6 @@
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names) %}
-    "BUFFER_PG": {
-        "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }
-    },
-{%- endmacro %}
-
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

From Barefoot:
"In 7170 Sonic buffer config files, we found one issue where autogenerated ingress losslesss buffer profiles are not attached to the ingress priority groups. To solve this, 
'macro generate_pg_profiles' lines from t0 and t1 script needs to be removed."

**- What I did**
Remove the macros from 7170 buffer defaults files.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
