### PR TITLE
[kvm]: add eeprom.py for kvm image

### DIFF
--- a/device/virtual/x86_64-kvm_x86_64-r0/plugins/eeprom.py
+++ b/device/virtual/x86_64-kvm_x86_64-r0/plugins/eeprom.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+#############################################################################
+# SONiC Virtual switch platform
+#
+#############################################################################
+
+class board():
+
+    def __init__(self, name, path, cpld_root, ro):
+        return
+
+    def check_status(self):
+        return "ok"
+
+    def is_checksum_valid(self, e):
+        return (True, 0)
+
+    def read_eeprom(self):
+        return \
+"""
+TLV Name             Code Len Value
+-------------------- ---- --- -----
+Product Name         0x21   5 SONiC
+Part Number          0x22   6 000000
+Serial Number        0x23  20 0000000000000000000
+Base MAC Address     0x24   6 00:00:00:00:00:01
+Manufacture Date     0x25  19 10/19/2019 00:00:03
+Device Version       0x26   1 1
+Label Revision       0x27   3 A01
+Platform Name        0x28  20 x86_64-kvm_x86_64-r0
+ONIE Version         0x29  19 master-201811170418
+MAC Addresses        0x2A   2 16
+Vendor Name          0x2D   5 SONiC
+"""
+
+    def decode_eeprom(self, e):
+        print e
+
+    def serial_number_str(self, e):
+        """Return service tag instead of serial number"""
+        return "000000"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
build image

```
admin@sonic:/usr/share/sonic/device/x86_64-kvm_x86_64-r0$ show version

SONiC Software Version: SONiC.HEAD.91-3c0b56a7
Distribution: Debian 9.11
Kernel: 4.9.0-9-2-amd64
Build commit: 3c0b56a7
Build date: Wed Sep 18 10:44:08 UTC 2019
Built by: johnar@jenkins-worker-8

Platform: x86_64-kvm_x86_64-r0
HwSKU: Force10-S6000
ASIC: vs
sSerial Number: 000000
Uptime: 07:31:36 up 30 days,  9:42,  1 user,  load average: 1.19, 0.84, 0.82

Docker images:
REPOSITORY                 TAG                 IMAGE ID            SIZE
docker-syncd-vs            HEAD.91-3c0b56a7    858a70c9d14f        286MB
docker-syncd-vs            latest              858a70c9d14f        286MB
docker-fpm-frr             HEAD.91-3c0b56a7    fbffeecb1dd8        319MB
docker-fpm-frr             latest              fbffeecb1dd8        319MB
docker-sflow               HEAD.91-3c0b56a7    00c6f431b984        303MB
docker-sflow               latest              00c6f431b984        303MB
docker-lldp-sv2            HEAD.91-3c0b56a7    433790d30403        298MB
docker-lldp-sv2            latest              433790d30403        298MB
docker-dhcp-relay          HEAD.91-3c0b56a7    4c1c995d355d        289MB
docker-dhcp-relay          latest              4c1c995d355d        289MB
docker-database            HEAD.91-3c0b56a7    0a229dfbbf8c        281MB
docker-database            latest              0a229dfbbf8c        281MB
docker-teamd               HEAD.91-3c0b56a7    198a43d7c4a7        302MB
docker-teamd               latest              198a43d7c4a7        302MB
docker-snmp-sv2            HEAD.91-3c0b56a7    3a6981fbfd71        334MB
docker-snmp-sv2            latest              3a6981fbfd71        334MB
docker-orchagent           HEAD.91-3c0b56a7    02a6ff692060        321MB
docker-orchagent           latest              02a6ff692060        321MB
docker-sonic-telemetry     HEAD.91-3c0b56a7    43d4cbd455a6        304MB
docker-sonic-telemetry     latest              43d4cbd455a6        304MB
docker-router-advertiser   HEAD.91-3c0b56a7    6b735f14a62d        281MB
docker-router-advertiser   latest              6b735f14a62d        281MB
docker-platform-monitor    HEAD.91-3c0b56a7    3263644e8212        326MB
docker-platform-monitor    latest              3263644e8212        326MB

admin@sonic:/usr/share/sonic/device/x86_64-kvm_x86_64-r0$ sudo decode-syseeprom

TLV Name             Code Len Value
-------------------- ---- --- -----
Product Name         0x21   5 SONiC
Part Number          0x22   6 000000
Serial Number        0x23  20 0000000000000000000
Base MAC Address     0x24   6 00:00:00:00:00:01
Manufacture Date     0x25  19 10/19/2019 00:00:03
Device Version       0x26   1 1
Label Revision       0x27   3 A01
Platform Name        0x28  20 x86_64-kvm_x86_64-r0
ONIE Version         0x29  19 master-201811170418
MAC Addresses        0x2A   2 16
Vendor Name          0x2D   5 SONiC

(checksum valid)
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
