### PR TITLE
Fixes the psud crash when database connection gets reset

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -388,6 +388,9 @@ set /files/etc/sysctl.conf/net.ipv4.udp_l3mdev_accept 1
 
 set /files/etc/sysctl.conf/net.core.rmem_max 2097152
 set /files/etc/sysctl.conf/net.core.wmem_max 2097152
+
+set /files/etc/sysctl.conf/net.core.somaxconn 512
+
 " -r $FILESYSTEM_ROOT
 
 if [[ $CONFIGURED_ARCH == amd64 ]]; then

--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=Platform monitor container
-Requires=updategraph.service
-After=updategraph.service
+Requires=database.service updategraph.service
+After=database.service updategraph.service
 {% if sonic_asic_platform == 'mellanox' %}
 After=syncd.service
 {% endif %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When database service is down, psud daemon throws an error because of DB connection reset, this because pmon service has no dependency with database service.

**- How I did it**

  Added database service dependency to the pmon service.
  Increased the net.core.somaxconn value to 512 to solve the connection failure on the scaled setup.

**- How to verify it**
     Verified that pmon service gets stopped when database service is stopped.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
