### PR TITLE
Fixes the systemd service startup timeout

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -251,6 +251,10 @@ sudo cp $IMAGE_CONFIGS/process-reboot-cause/process-reboot-cause.service  $FILES
 echo "process-reboot-cause.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo cp $IMAGE_CONFIGS/process-reboot-cause/process-reboot-cause $FILESYSTEM_ROOT/usr/bin/
 
+## Increase the systemd service startup timeout
+sudo sed -i "s/.*DefaultTimeoutStartSec.*/DefaultTimeoutStartSec=180s/g" $FILESYSTEM_ROOT/etc/systemd/system.conf
+sudo sed -i "s/.*DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=180s/g" $FILESYSTEM_ROOT/etc/systemd/system.conf
+
 ## Install package without starting service
 ## ref: https://wiki.debian.org/chroot
 sudo tee -a $FILESYSTEM_ROOT/usr/sbin/policy-rc.d > /dev/null <<EOF


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
     On a scaled setup, syncd service takes a long time to start and stop, because of which other services are failed.

**- How I did it**
     The fix is to increase the startup timeout in systemd config.

**- How to verify it**
     Running the config reload command on a scaled setup for multiple times.
**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
