### PR TITLE
[Services] Restart SNMP service upon unexpected critical process exit. 

### DIFF
--- a/dockers/docker-snmp-sv2/Dockerfile.j2
+++ b/dockers/docker-snmp-sv2/Dockerfile.j2
@@ -84,6 +84,8 @@ RUN apt-get -y purge     \
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["*.j2", "/usr/share/sonic/templates/"]
+COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
+COPY ["critical_processes", "/etc/supervisor"]
 
 # Although exposing ports is not needed for host net mode, keep it for possible bridge mode
 EXPOSE 161/udp 162/udp

--- a/dockers/docker-snmp-sv2/critical_processes
+++ b/dockers/docker-snmp-sv2/critical_processes
@@ -1,0 +1,2 @@
+snmpd
+snmp-subagent

--- a/dockers/docker-snmp-sv2/supervisord.conf
+++ b/dockers/docker-snmp-sv2/supervisord.conf
@@ -3,6 +3,12 @@ logfile_maxbytes=1MB
 logfile_backups=2
 nodaemon=true
 
+[eventlistener:supervisor-proc-exit-listener]
+command=/usr/bin/supervisor-proc-exit-listener
+events=PROCESS_STATE_EXITED
+autostart=true
+autorestart=unexpected
+
 [program:start.sh]
 command=/usr/bin/start.sh
 priority=1
@@ -15,7 +21,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
-autorestart=false
+autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -4,11 +4,15 @@ Requires=updategraph.service
 Requisite=swss.service
 After=updategraph.service swss.service
 Before=ntp-config.service
+StartLimitIntervalSec=1200
+StartLimitBurst=3
 
 [Service]
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target swss.service

--- a/rules/docker-snmp-sv2.mk
+++ b/rules/docker-snmp-sv2.mk
@@ -30,3 +30,4 @@ $(DOCKER_SNMP_SV2)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_SNMP_SV2)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 # mount Arista platform python libraries to support corresponding platforms SNMP power status query
 $(DOCKER_SNMP_SV2)_RUN_OPT += -v /usr/lib/python3/dist-packages/arista:/usr/lib/python3/dist-packages/arista:ro
+$(DOCKER_SNMP_SV2)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
- What I did
Restart **SNMP** service if one of critical processes running in SNMP container exited or crashed abnormally.

- How I did it
Generally I follow the framework created by Joe to implement this feature in SNMP container.
**First**, add supervisor-proc-exit-listener event listener option in Supervisord configuration file in SNMP docker container. Supervisord will read a list of critical processes for which to monitor the unexpected crashed and exited.
**Second**, configure snmp.service to always auto-restart the service if it stops, with a delay of 30 seconds. Also set a rate limit of 3 restarts within 20 minutes (1200 seconds).

- How to verify it
On your switch device, please use _docker ps_ command to list all running docker containers.
Then use _docker exec -it container_id /bin/bash_ to login target container. Typing _top_ command
on the shell will display all the processes dynamically and you will spot the process id of one
of the critical processes. Finally type the command _kill -9 process_id_ to terminate one process.
After exiting the container, you can use _watch -n 1 docker ps_ to dynamically see the restart
of SNMP container.

