### PR TITLE
[bgpcfgd]: Avoid crashing bgpcfgd when render of bgpd.peer.conf.j2 has issues

### DIFF
--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -116,9 +116,14 @@ class BGPConfigManager(object):
         for key, op, data in self.bgp_messages:
             if op == swsscommon.SET_COMMAND:
                 if key not in self.peers:
-                    cmds.append(self.bgp_peer_add_template.render(DEVICE_METADATA=self.meta, neighbor_addr=key, bgp_session=data))
-                    syslog.syslog(syslog.LOG_INFO, 'Peer {} added with attributes {}'.format(key, data))
-                    self.peers.add(key)
+                    try:
+                        txt = self.bgp_peer_add_template.render(DEVICE_METADATA=self.meta, neighbor_addr=key, bgp_session=data)
+                        cmds.append(txt)
+                    except:
+                        syslog.syslog(syslog.LOG_ERR, 'Peer {}. Error in rendering the template for "SET" command {}'.format(key, data))
+                    else:
+                        syslog.syslog(syslog.LOG_INFO, 'Peer {} added with attributes {}'.format(key, data))
+                        self.peers.add(key)
                 else:
                     # when the peer is already configured we support "shutdown/no shutdown"
                     # commands for the peers only


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a possibility to crash bgpcfgd by incorrect j2 template
**- How I did it**
Add try catch block
**- How to verify it**
1. Delete existing bgp peer: DEL BGP_PEER|10.0.0.1
2. Change properties for the deleted peer: hset BGP_PEER|10.0.0.1 admin up

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
