### PR TITLE
[supervisord] Remove "-p port_config.ini" option from the portsyncd

### DIFF
--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -34,7 +34,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:portsyncd]
-command=/usr/bin/portsyncd -p /usr/share/sonic/hwsku/port_config.ini
+command=/usr/bin/portsyncd
 priority=4
 autostart=false
 autorestart=false

--- a/platform/p4/docker-sonic-p4/supervisord.conf
+++ b/platform/p4/docker-sonic-p4/supervisord.conf
@@ -61,7 +61,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:portsyncd]
-command=/usr/bin/portsyncd -p /port_config.ini
+command=/usr/bin/portsyncd
 priority=6
 autostart=false
 autorestart=false

--- a/platform/vs/docker-sonic-vs/supervisord.conf
+++ b/platform/vs/docker-sonic-vs/supervisord.conf
@@ -44,7 +44,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:portsyncd]
-command=/usr/bin/portsyncd -p /usr/share/sonic/hwsku/port_config.ini
+command=/usr/bin/portsyncd
 priority=6
 autostart=false
 autorestart=false


### PR DESCRIPTION
[portsyncd] Remove "-p port_config.ini" option from the portsyncd

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

This PR is depending on https://github.com/Azure/sonic-swss/pull/1107


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove "-p port_config.ini" option from the portsyncd

**- How I did it**
Remove "-p port_config.ini" option from the portsyncd

**- How to verify it**
vs tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
