### PR TITLE
[Teamd] Adding port member failed 

### DIFF
--- a/src/libteam/patch/0011-teamd-init-port-priv-failure-retry.patch
+++ b/src/libteam/patch/0011-teamd-init-port-priv-failure-retry.patch
@@ -1,0 +1,42 @@
+From 038bed6fe3970dc829dbf9a282f7bea7198e7826 Wed Oct 30 00:00:00 2001
+From: Antony Rheneus <arheneus@marvell.com>
+Date: Wed, 30 Oct 2019 16:39:35 -0700
+Subject: [PATCH] Init failure retry
+
+ Failed to find "enabled" option.
+---
+ teamd/teamd_per_port.c | 20 +++++++++++---------
+ 1 file changed, 11 insertions(+), 9 deletion(-)
+
+diff --git a/teamd/teamd_per_port.c b/teamd/teamd_per_port.c
+index b5b8c04..ae16904 100644
+--- a/teamd/teamd_per_port.c
++++ b/teamd/teamd_per_port.c
+@@ -106,16 +106,18 @@ static int port_priv_init_all(struct teamd_context *ctx, struct port_obj *port_o
+ 			continue;
+                 while(--retry)
+                 {
+-		err = ppitem->pp->init(ctx, _port(port_obj), &ppitem->priv,
+-				       ppitem->creator_priv);
+-		if (err) {
+-			teamd_log_err("Failed to init port priv. err %d retries %d", err, (RETRY_BEFORE_ROLLING_BACK - retry));
++                    err = ppitem->pp->init(ctx, _port(port_obj), &ppitem->priv,
++                            ppitem->creator_priv);
++                    if (err) {
++                        teamd_log_err("Failed to init port priv. err %d retries %d", err, (RETRY_BEFORE_ROLLING_BACK - retry));
+                         if (retry <= 0)
+-			goto rollback;
+-		}
+-                else {
+-                    break;
+-                }
++                            goto rollback;
++                        else
++                            sleep(1);
++                    }
++                    else {
++                        break;
++                    }
+                 }
+ 	}
+ 	return 0;

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -8,3 +8,4 @@
 0008-libteam-Add-warm_reboot-mode.patch
 0009-Fix-ifinfo_link_with_port-race-condition-with-newlink.patch
 0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch
+0011-teamd-init-port-priv-failure-retry.patch


### PR DESCRIPTION
during port init in "team_option *team_get_option()"

which got err as -ENOENT (-2).
If port init failed, it does rollback and remove the LAG member and never adds back until reboot
TO avoid this, retry the port init 30 times.
Failure LOG from teamd.log:
 Ethernet50: Failed to find "enabled" option.
 get_ifinfo_list: check_call_change_handers failed
 Failed to get interface information list.
 Failed to refresh interface information list.
 Ethernet50: Team refresh failed.

Signed-off-by: Antony Rheneus <arheneus@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
