### PR TITLE
Fix the issue 'branch already exist' in rebuilds

### DIFF
--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -4,8 +4,9 @@ SHELL = /bin/bash
 
 MAIN_TARGET = $(FRR)
 DERIVED_TARGET = $(FRR_PYTHONTOOLS) $(FRR_DBG) $(FRR_SNMP) $(FRR_SNMP_DBG)
+SUFFIX = $(shell date +%Y%m%d\.%H%M%S)
 FRR_BRANCH = frr/$(FRR_VERSION)
-STG_BRANCH = stg_temp
+STG_BRANCH = stg_temp.$(SUFFIX)
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Build the package
@@ -15,11 +16,12 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	stg import -s ../patch/series
 	tools/tarsource.sh -V -e '-sonic'
 	dpkg-buildpackage -rfakeroot -b -us -uc -Ppkg.frr.nortrlib -j$(SONIC_CONFIG_MAKE_JOBS)
-	stg undo
+	stg undo || true
 	git clean -xfdf
 	git checkout $(FRR_BRANCH)
 	stg branch --delete $(STG_BRANCH)
 	git rev-parse --short HEAD | xargs git checkout
+	git checkout master
 	git branch -D $(FRR_BRANCH)
 	popd
 	mv $(DERIVED_TARGET) $* $(DEST)/


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed Makefile of FRR. Before we had issues after https://github.com/Azure/sonic-buildimage/pull/3589:
1. When you want to rebuild frr with new changes you get error "branch frr/7.1 is already exist".
2. When your patch list is empty stg undo gives an error

**- How I did it**
1. checkout to master branch after build.
2. Using temporary stg branch with timestamp
3. ignoring result code of stg undo

**- How to verify it**
`make target/debs/stretch/frr_7.1-sonic-0_amd64.deb` must work for you first
then
`make target/debs/stretch/frr_7.1-sonic-0_amd64.deb-clean` and
`make target/debs/stretch/frr_7.1-sonic-0_amd64.deb` must work for you again

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
