### PR TITLE
Return evpn configuration into bgp templates

### DIFF
--- a/dockers/docker-fpm-frr/bgpd.peer.conf.j2
+++ b/dockers/docker-fpm-frr/bgpd.peer.conf.j2
@@ -25,6 +25,14 @@
 {% if bgp_session['nhopself'] | int != 0 %}
     neighbor {{ neighbor_addr }} next-hop-self
 {% endif %}
+{% if  bgp_session["asn"] == DEVICE_METADATA['localhost']['bgp_asn']
+   and DEVICE_METADATA['localhost']['type'] == "SpineChassisFrontendRouter"
+   and (not bgp_session.has_key("local_addr") or bgp_session["local_addr"] not in interfaces_in_vnets) %}
+  address-family l2vpn evpn
+    neighbor {{ neighbor_addr }} activate
+    advertise-all-vni
+  exit-address-family
+{% endif %}
     neighbor {{ neighbor_addr }} activate
   exit-address-family
 {% endblock bgp_peer %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Restore bgp configuration for SpineChassisFrontendRouter scenario

**- How I did it**
By changing frr templates

**- How to verify it**
Build an image run on your dut
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
