### PR TITLE
[Services] Restart Teamd service upon unexpected critical process exit.

### DIFF
--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -36,5 +36,7 @@ RUN apt-get clean -y      && \
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
+COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
+COPY ["critical_proceses", "/etc/supervisor"]
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -37,6 +37,6 @@ RUN apt-get clean -y      && \
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
-COPY ["critical_proceses", "/etc/supervisor"]
+COPY ["critical_processes", "/etc/supervisor"]
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-teamd/critical_processes
+++ b/dockers/docker-teamd/critical_processes
@@ -1,0 +1,2 @@
+teammgrd
+teamsyncd

--- a/dockers/docker-teamd/supervisord.conf
+++ b/dockers/docker-teamd/supervisord.conf
@@ -3,6 +3,12 @@ logfile_maxbytes=1MB
 logfile_backups=2
 nodaemon=true
 
+[eventlistener:supervisor-proc-exit-listener]
+command=/usr/bin/supervisor-proc-exit-listener
+events=PROCESS_STATE_EXITED
+autostart=true
+autorestart=unexpected
+
 [program:start.sh]
 command=/usr/bin/start.sh
 priority=1
@@ -15,7 +21,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
-autorestart=false
+autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -3,12 +3,16 @@ Description=TEAMD container
 Requires=updategraph.service
 After=updategraph.service swss.service
 Before=ntp-config.service
+StartLimitIntervalSec=1200
+StartLimitBurst=3
 
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/rules/docker-teamd.mk
+++ b/rules/docker-teamd.mk
@@ -29,3 +29,4 @@ $(DOCKER_TEAMD)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_TEAMD)_RUN_OPT += -v /host/warmboot:/var/warmboot
 
 $(DOCKER_TEAMD)_BASE_IMAGE_FILES += teamdctl:/usr/bin/teamdctl
+$(DOCKER_TEAMD)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
- What I did
Restart Teamd service if one of critical processes running in Teamd container exited or crashed abnormally.

- How I did it
Generally I follow the framework created by Joe to implement this feature in Teamd container.
**First**, add supervisor-proc-exit-listener event listener option in Supervisord configuration file in Teamd docker container. Supervisord will read a list of critical processes for which to monitor the unexpected crashed and exited.
**Second**, configure teamd.service to always auto-restart the service if it stops, with a delay of 30 seconds. Also set a rate limit of 3 restarts within 20 minutes (1200 seconds).

- How to verify it
On your switch device, please use _docker ps_ command to list all running docker containers.
Then use _docker exec -it container_id bash_ to login target container. Typing _top_ command
on the shell will display all the processes dynamically and you will spot the process id of one
of the critical processes. Finally type the command _kill -9 process_id_ to terminate one process.
After exiting the container, you can use _watch -n 1 docker ps_ to dynamically see the restart
of Teamd container.