### PR TITLE
[lldpd]: LLDP changing the tx-interval parameter is not reflected on the peer device immediately

### DIFF
--- a/src/lldpd/patch/0003-update-tx-interval-immediately.patch
+++ b/src/lldpd/patch/0003-update-tx-interval-immediately.patch
@@ -1,0 +1,20 @@
+diff --git a/src/daemon/client.c b/src/daemon/client.c
+index 8382d02..38cf3f3 100644
+--- a/src/daemon/client.c
++++ b/src/daemon/client.c
+@@ -71,7 +71,6 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type,
+ 	if (CHANGED(c_tx_interval) && config->c_tx_interval != 0) {
+ 		if (config->c_tx_interval < 0) {
+ 			log_debug("rpc", "client asked for immediate retransmission");
+-			levent_send_now(cfg);
+ 		} else {
+ 			log_debug("rpc", "client change transmit interval to %d",
+ 			    config->c_tx_interval);
+@@ -79,6 +78,7 @@ client_handle_set_configuration(struct lldpd *cfg, enum hmsg_type *type,
+ 			LOCAL_CHASSIS(cfg)->c_ttl = cfg->g_config.c_tx_interval *
+ 			    cfg->g_config.c_tx_hold;
+ 		}
++		levent_send_now(cfg);
+ 	}
+ 	if (CHANGED(c_tx_hold) && config->c_tx_hold > 0) {
+ 		log_debug("rpc", "client change transmit hold to %d",

--- a/src/lldpd/patch/series
+++ b/src/lldpd/patch/series
@@ -1,3 +1,4 @@
 # This series applies on GIT commit 396961a038a38675d46f96eaa7b430b2a1f8701b
 0001-return-error-when-port-does-not-exist.patch
 0002-Let-linux-kernel-to-find-appropriate-nl_pid-automa.patch
+0003-update-tx-interval-immediately.patch


### PR DESCRIPTION


**- What I did**
When LLDP parameter tx-interval value is modified, there was no immediate PDU sent to peer to update the peer with the latest values. Due to this the update on peer happened only after the next PDU is sent which can cause a delay of upto 30 secs (default value).
**- How I did it**
The fix is to ensure the LLDP PDU is sent immediately when the tx-interval configuration is modified.
**- How to verify it**
Modify LLDP tx-interval on one side and check the "show lldp neighbor" output on the peer device to see if its updated immediately
**- Description for the changelog**
<!--
Send LLDP PDU immediately after tx-interval configuration change, to update the peer quickly
-->

