### PR TITLE
[Services] Restart LLDP service upon unexpected critical process exit.

### DIFF
--- a/dockers/docker-lldp-sv2/Dockerfile.j2
+++ b/dockers/docker-lldp-sv2/Dockerfile.j2
@@ -40,5 +40,7 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["lldpd.conf.j2", "/usr/share/sonic/templates/"]
 COPY ["lldpd", "/etc/default/"]
 COPY ["lldpmgrd", "/usr/bin/"]
+COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
+COPY ["critical_processes", "/etc/supervisor"]
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-lldp-sv2/critical_processes
+++ b/dockers/docker-lldp-sv2/critical_processes
@@ -1,0 +1,3 @@
+lldpd
+lldp-syncd
+lldpmgrd

--- a/dockers/docker-lldp-sv2/supervisord.conf
+++ b/dockers/docker-lldp-sv2/supervisord.conf
@@ -3,6 +3,12 @@ logfile_maxbytes=1MB
 logfile_backups=2
 nodaemon=true
 
+[eventlistener:supervisor-proc-exit-listener]
+command=/usr/bin/supervisor-proc-exit-listener
+events=PROCESS_STATE_EXITED
+autostart=true
+autorestart=unexpected
+
 [program:start.sh]
 command=/usr/bin/start.sh
 priority=1

--- a/files/build_templates/lldp.service.j2
+++ b/files/build_templates/lldp.service.j2
@@ -3,12 +3,16 @@ Description=LLDP container
 Requires=updategraph.service
 After=updategraph.service
 Before=ntp-config.service
+StartLimitIntervalSec=1200
+StartLimitBurst=3
 
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/rules/docker-lldp-sv2.mk
+++ b/rules/docker-lldp-sv2.mk
@@ -30,3 +30,4 @@ $(DOCKER_LLDP_SV2)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 $(DOCKER_LLDP_SV2)_BASE_IMAGE_FILES += lldpctl:/usr/bin/lldpctl
 $(DOCKER_LLDP_SV2)_BASE_IMAGE_FILES += lldpcli:/usr/bin/lldpcli
+$(DOCKER_LLDP_SV2)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
- What I did
Restart LLDP service if one of critical processes running in LLDP container exited or crashed abnormally.

- How I did it
Generally I follow the framework created by Joe to implement this feature in LLDP container.
**First**, add supervisor-proc-exit-listener event listener option in Supervisord configuration file in LLDP docker container. Supervisord will read a list of critical processes for which to monitor the unexpected crashed and exited.
**Second**, configure LLDP.service to always auto-restart the service if it stops, with a delay of 30 seconds. Also set a rate limit of 3 restarts within 20 minutes (1200 seconds).

- How to verify it
On your switch device, please use _docker ps_ command to list all running docker containers.
Then use _docker exec -it container_id bash_ to login target container. Typing _top_ command
on the shell will display all the processes dynamically and you will spot the process id of one
of the critical processes. Finally type the command _kill -9 process_id_ to terminate one process.
After exiting the container, you can use _watch -n 1 docker ps_ to dynamically see the restart
of LLDP container.