### PR TITLE
Fix typos and comment alignment in supervisor.conf files

### DIFF
--- a/dockers/docker-base-stretch/etc/supervisor/supervisord.conf
+++ b/dockers/docker-base-stretch/etc/supervisor/supervisord.conf
@@ -1,15 +1,15 @@
 ; supervisor config file
 
 [unix_http_server]
-file=/var/run/supervisor.sock   ; (the path to the socket file)
-chmod=0700                       ; sockef file mode (default 0700)
+file=/var/run/supervisor.sock  ; (the path to the socket file)
+chmod=0700                     ; socket file mode (default 0700)
 username=dummy
 password=dummy
 
 [supervisord]
-logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
-pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+logfile=/var/log/supervisor/supervisord.log  ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid             ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor              ; ('AUTO' child log dir, default $TEMP)
 user=root
 
 ; the below section must remain in the config file for RPC
@@ -19,7 +19,7 @@ user=root
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///var/run/supervisor.sock  ; use a unix:// URL  for a unix socket
 username=dummy
 password=dummy
 

--- a/dockers/docker-base/etc/supervisor/supervisord.conf
+++ b/dockers/docker-base/etc/supervisor/supervisord.conf
@@ -1,15 +1,15 @@
 ; supervisor config file
 
 [unix_http_server]
-file=/var/run/supervisor.sock   ; (the path to the socket file)
-chmod=0700                       ; sockef file mode (default 0700)
+file=/var/run/supervisor.sock  ; (the path to the socket file)
+chmod=0700                     ; socket file mode (default 0700)
 username=dummy
 password=dummy
 
 [supervisord]
-logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
-pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+logfile=/var/log/supervisor/supervisord.log  ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid             ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor              ; ('AUTO' child log dir, default $TEMP)
 user=root
 
 ; the below section must remain in the config file for RPC
@@ -19,7 +19,7 @@ user=root
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///var/run/supervisor.sock  ; use a unix:// URL  for a unix socket
 username=dummy
 password=dummy
 

--- a/dockers/docker-ptf/supervisord.conf
+++ b/dockers/docker-ptf/supervisord.conf
@@ -1,13 +1,13 @@
 ; supervisor config file
 
 [unix_http_server]
-file=/var/run/supervisor.sock    ; (the path to the socket file)
-chmod=0700                       ; sockef file mode (default 0700)
+file=/var/run/supervisor.sock  ; (the path to the socket file)
+chmod=0700                     ; socket file mode (default 0700)
 
 [supervisord]
-logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
-pidfile=/var/run/supervisord.pid            ; (supervisord pidfile;default supervisord.pid)
-childlogdir=/var/log/supervisor             ; ('AUTO' child log dir, default $TEMP)
+logfile=/var/log/supervisor/supervisord.log  ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid             ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor              ; ('AUTO' child log dir, default $TEMP)
 
 ; the below section must remain in the config file for RPC
 ; (supervisorctl/web interface) to work, additional interfaces may be
@@ -16,7 +16,7 @@ childlogdir=/var/log/supervisor             ; ('AUTO' child log dir, default $TE
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///var/run/supervisor.sock  ; use a unix:// URL  for a unix socket
 
 ; The [include] section can just contain the "files" setting.  This
 ; setting can list multiple files (separated by whitespace or


### PR DESCRIPTION
Self-explanatory