### PR TITLE
[aboot]: preserve snmp.yml and acl.json for eos to sonic fast reboot

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -94,7 +94,9 @@ clean_flash() {
            [ $f != "$cmdline_base" ] &&
            [ $f != "aquota.user" ] &&
            [ $f != "old_config" ] &&
-           [ $f != "minigraph.xml" ]
+           [ $f != "minigraph.xml" ] &&
+           [ $f != "snmp.yml" ] &&
+           [ $f != "acl.json" ]
         then
             rm -rf "$target_path/$f"
         fi

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -223,6 +223,8 @@ if [ -f $FIRST_BOOT_FILE ]; then
     elif [ -f /host/minigraph.xml ]; then
         mkdir -p /etc/sonic/old_config
         mv /host/minigraph.xml /etc/sonic/old_config/
+        [ -f /host/acl.json ] && mv /host/acl.json /etc/sonic/old_config/
+        [ -f /host/snmp.yml ] && mv /host/snmp.yml /etc/sonic/old_config/
         touch /tmp/pending_config_migration
     elif [ -n "$migration" ] && [ -f /host/migration/minigraph.xml ];  then
         mkdir -p /etc/sonic/old_config


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
preserve snmp.yml and acl.json for eos to sonic fast reboot

**- How I did it**

**- How to verify it**
manually validated on arista 7050/7260

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
