### PR TITLE
Do not start pfcwd on M0

### DIFF
--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -15,7 +15,10 @@ reload_minigraph()
         acl-loader update full /etc/sonic/acl.json
     fi
     config qos reload
-    pfcwd start_default
+    DEVICE_TYPE=`sonic-cfggen -m -v DEVICE_METADATA.localhost.type`
+    if [ "${DEVICE_TYPE}" != "MgmtToRRouter" ]; then
+        pfcwd start_default
+    fi
 
     if [[ -x /usr/bin/db_migrator.py ]]; then
         # Set latest version number


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

**- What I did**
Disable pfcwd on M0 in the upgraded version

**- How I did it**
Use device type for comparison

**- How to verify it**
1. On M0, set enabled to reload_only in /etc/sonic/updategraph and rebooted the system. 
2. issued 'pfcwd show config' and ensured it was empty
3. On non M0, set enabled to reload_only in /etc/sonic/updategraph and rebooted the system. 
4. issued 'pfcwd show config' and ensured it had port info with the action, detection and restoration time populated