### PR TITLE
[libteam]: Fixing the port add issue

### DIFF
--- a/src/libteam/patch/0008-libteam-Add-warm_reboot-mode.patch
+++ b/src/libteam/patch/0008-libteam-Add-warm_reboot-mode.patch
@@ -1,6 +1,6 @@
-From 113d482704198685fba09cd2597fd93ca9d297c5 Mon Sep 17 00:00:00 2001
+From f58926915201dc8add52934cbb6f510408947f69 Mon Sep 17 00:00:00 2001
 From: Pavel Shirshov <pavelsh@microsoft.com>
-Date: Tue, 1 Oct 2019 09:23:23 -0700
+Date: Thu, 7 Nov 2019 14:55:39 -0800
 Subject: [PATCH 1/1] [libteam]: Reimplement Warm-Reboot procedure
 
 ---
@@ -220,7 +220,7 @@ index f98a90d..a87e809 100644
  		      tdport->ifname, tdport->ifindex);
  	err = team_port_remove(ctx->th, tdport->ifindex);
 diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
-index 4016b15..81be5b7 100644
+index 83c69a5..27918a3 100644
 --- a/teamd/teamd_runner_lacp.c
 +++ b/teamd/teamd_runner_lacp.c
 @@ -31,6 +31,7 @@
@@ -473,7 +473,7 @@ index 4016b15..81be5b7 100644
  static struct lacp_port *lacp_port_get(struct lacp *lacp,
  				       struct teamd_port *tdport)
  {
-@@ -486,20 +697,95 @@ static int lacp_set_carrier(struct lacp *lacp, bool carrier_up)
+@@ -488,20 +699,95 @@ static int lacp_set_carrier(struct lacp *lacp, bool carrier_up)
  	return 0;
  }
  
@@ -572,7 +572,7 @@ index 4016b15..81be5b7 100644
  	}
  
  	return lacp_set_carrier(lacp, false);
-@@ -919,6 +1205,18 @@ static void lacp_port_actor_system_update(struct lacp_port *lacp_port)
+@@ -921,6 +1207,18 @@ static void lacp_port_actor_system_update(struct lacp_port *lacp_port)
  	memcpy(actor->system, lacp_port->ctx->hwaddr, ETH_ALEN);
  }
  
@@ -591,7 +591,7 @@ index 4016b15..81be5b7 100644
  static void lacp_port_actor_init(struct lacp_port *lacp_port)
  {
  	struct lacpdu_info *actor = &lacp_port->actor;
-@@ -926,7 +1224,7 @@ static void lacp_port_actor_init(struct lacp_port *lacp_port)
+@@ -928,7 +1226,7 @@ static void lacp_port_actor_init(struct lacp_port *lacp_port)
  	actor->system_priority = htons(lacp_port->lacp->cfg.sys_prio);
  	actor->key = htons(lacp_port->cfg.lacp_key);
  	actor->port_priority = htons(lacp_port->cfg.lacp_prio);
@@ -600,7 +600,7 @@ index 4016b15..81be5b7 100644
  	lacp_port_actor_system_update(lacp_port);
  }
  
-@@ -1006,6 +1304,13 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
+@@ -1008,6 +1306,13 @@ static int lacp_port_set_state(struct lacp_port *lacp_port,
  		break;
  	}
  
@@ -614,7 +614,7 @@ index 4016b15..81be5b7 100644
  	teamd_log_info("%s: Changed port state: \"%s\" -> \"%s\"",
  		       lacp_port->tdport->ifname,
  		       lacp_port_state_name[lacp_port->state],
-@@ -1095,34 +1400,23 @@ static int lacpdu_send(struct lacp_port *lacp_port)
+@@ -1097,34 +1402,23 @@ static int lacpdu_send(struct lacp_port *lacp_port)
  	return err;
  }
  
@@ -657,7 +657,7 @@ index 4016b15..81be5b7 100644
  		err = lacp_port_partner_update(lacp_port);
  		if (err)
  			return err;
-@@ -1138,21 +1432,56 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
+@@ -1140,21 +1434,56 @@ static int lacpdu_recv(struct lacp_port *lacp_port)
  	lacp_port_actor_update(lacp_port);
  
  	/* Check if the other side has correct info about us */
@@ -717,7 +717,7 @@ index 4016b15..81be5b7 100644
  static int lacp_callback_timeout(struct teamd_context *ctx, int events,
  				 void *priv)
  {
-@@ -1258,6 +1587,8 @@ static int lacp_port_added(struct teamd_context *ctx,
+@@ -1260,6 +1589,8 @@ static int lacp_port_added(struct teamd_context *ctx,
  	struct lacp *lacp = creator_priv;
  	int err;
  
@@ -726,8 +726,8 @@ index 4016b15..81be5b7 100644
  	lacp_port->ctx = ctx;
  	lacp_port->tdport = tdport;
  	lacp_port->lacp = lacp;
-@@ -1304,6 +1635,13 @@ static int lacp_port_added(struct teamd_context *ctx,
- 		goto periodic_callback_del;
+@@ -1314,6 +1645,13 @@ static int lacp_port_added(struct teamd_context *ctx,
+ 			goto timeout_callback_del;
  	}
  
 +	/* refresh ports from the kernel */
@@ -737,10 +737,10 @@ index 4016b15..81be5b7 100644
 +		goto timeout_callback_del;
 +	}
 +
- 	/* Newly added ports are disabled */
- 	err = team_set_port_enabled(ctx->th, tdport->ifindex, false);
- 	if (err) {
-@@ -1341,7 +1679,13 @@ static void lacp_port_removed(struct teamd_context *ctx,
+ 	err = lacp_port_set_mac(ctx, tdport);
+ 	if (err)
+ 		goto timeout_callback_del;
+@@ -1343,7 +1681,13 @@ static void lacp_port_removed(struct teamd_context *ctx,
  {
  	struct lacp_port *lacp_port = priv;
  
@@ -755,7 +755,7 @@ index 4016b15..81be5b7 100644
  	teamd_loop_callback_del(ctx, LACP_TIMEOUT_CB_NAME, lacp_port);
  	teamd_loop_callback_del(ctx, LACP_PERIODIC_CB_NAME, lacp_port);
  	teamd_loop_callback_del(ctx, LACP_SOCKET_CB_NAME, lacp_port);
-@@ -1449,16 +1793,51 @@ static int lacp_event_watch_port_changed(struct teamd_context *ctx,
+@@ -1451,16 +1795,51 @@ static int lacp_event_watch_port_changed(struct teamd_context *ctx,
  	return lacp_port_link_update(lacp_port);
  }
  
@@ -810,7 +810,7 @@ index 4016b15..81be5b7 100644
  static const struct teamd_event_watch_ops lacp_event_watch_ops = {
  	.hwaddr_changed = lacp_event_watch_hwaddr_changed,
  	.port_hwaddr_changed = lacp_event_watch_port_hwaddr_changed,
-@@ -1467,21 +1846,35 @@ static const struct teamd_event_watch_ops lacp_event_watch_ops = {
+@@ -1469,21 +1848,35 @@ static const struct teamd_event_watch_ops lacp_event_watch_ops = {
  	.port_changed = lacp_event_watch_port_changed,
  	.admin_state_changed = lacp_event_watch_admin_state_changed,
  	.refresh = lacp_event_watch_refresh,
@@ -851,7 +851,7 @@ index 4016b15..81be5b7 100644
  	return 0;
  }
  
-@@ -1949,6 +2342,12 @@ static int lacp_init(struct teamd_context *ctx, void *priv)
+@@ -1951,6 +2344,12 @@ static int lacp_init(struct teamd_context *ctx, void *priv)
  	}
  
  	lacp->ctx = ctx;
@@ -864,7 +864,7 @@ index 4016b15..81be5b7 100644
  	err = teamd_hash_func_set(ctx);
  	if (err)
  		return err;
-@@ -1990,10 +2389,13 @@ static void lacp_fini(struct teamd_context *ctx, void *priv)
+@@ -1992,10 +2391,13 @@ static void lacp_fini(struct teamd_context *ctx, void *priv)
  {
  	struct lacp *lacp = priv;
  


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed a bug. Which caused following log output. The bug was observed, because team_refresh() expect to see the port enabled, but the port is being enabled later by team_set_port_enabled().
```
Ethernet50: Failed to find "enabled" option.
get_ifinfo_list: check_call_change_handers failed
Failed to get interface information list.
Failed to refresh interface information list.
Ethernet50: Team refresh failed.
```
```
    /* refresh ports from the kernel */
    err = team_refresh(ctx->th);
    if (err) {
        teamd_log_err("%s: Team refresh failed.", tdport->ifname);
        goto timeout_callback_del;
    }

    /* Newly added ports are disabled */
    err = team_set_port_enabled(ctx->th, tdport->ifindex, false);
    if (err) {
        teamd_log_err("%s: Failed to disable port.", tdport->ifname);
        if (!TEAMD_ENOENT(err))
            goto timeout_callback_del;
    }
```
**- How I did it**
I run team_set_port_enabled() function before the team_refresh() function

**- How to verify it**
Build libteam and run on the switch

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
