### PR TITLE
After installing the SONiC image under ONIE on AS7326-56X/AS7726-56X, all ports cannot link up at the first boot of SONiC

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-platform-handle_mac.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-platform-handle_mac.service
@@ -1,16 +1,15 @@
 [Unit]
-Description=Accton AS7326-56X Platform MAC hnadle service
-Before=pmon.service
-After=sysinit.target
-DefaultDependencies=no
+Description=Accton AS7326-56X Platform MAC handle service
+Before=opennsl-modules.service
+After=local-fs.target
 
 [Service]
-ExecStart=/usr/local/bin/accton_handle_idt.sh
-KillSignal=SIGKILL
-SuccessExitStatus=SIGKILL
+Type=oneshot
+ExecStart=/usr/local/bin/idt_init.sh
+RemainAfterExit=yes
 
 # Resource Limitations
 LimitCORE=infinity
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=opennsl-modules.service

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/service/as7726-32x-platform-handle_mac.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/service/as7726-32x-platform-handle_mac.service
@@ -1,16 +1,15 @@
 [Unit]
-Description=Accton AS7726-32X Platform MAC hnadle  service
-Before=pmon.service
-After=sysinit.target
-DefaultDependencies=no
+Description=Accton AS7726-32X Platform MAC handle service
+Before=opennsl-modules.service
+After=local-fs.target
 
 [Service]
-ExecStart=/usr/local/bin/accton_handle_idt.sh
-KillSignal=SIGKILL
-SuccessExitStatus=SIGKILL
+Type=oneshot
+ExecStart=/usr/local/bin/idt_init.sh
+RemainAfterExit=yes
 
 # Resource Limitations
 LimitCORE=infinity
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=opennsl-modules.service


### PR DESCRIPTION
After installing the SONiC image under ONIE on AS7326-56X/AS7726-56X, all ports cannot link up at the first boot of SONiC

AS7326-56X and AS7726-56X use the same design so both devices have the same problem.
The detailed description below takes AS7326-56X as the example to explain.

Original implementation:
- In platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-platform-handle_mac.service,
  it executes the script file "accton_handle_idt.sh".
- In "accton_handle_idt.sh", it modifies the content of the script file "/etc/init.d/opennsl-modules"
  to insert the lines to execute "idt_init.sh" before the command to load broadcom linux kernel module
  "linux-kernel-bde.ko".
- The script "idt_init.sh" cannot be executed at the first boot of SONiC after
  installing SONiC under ONIE. This is the reason why all of the ports does not work.

New implementation:
- Let "as7326-platform-handle_mac.service" execute "idt_init.sh".
- Change the content of "as7326-platform-handle_mac.service" to define the service type as "oneshot".
  Add the settings to ensure "as7326-platform-handle_mac.service" is executed before "opennsl-modules.service".
  By setting the service type as "oneshot", it is guaranteed that "opennsl-modules.services" is started only when
  the forked process to execute the script file "idt_init.sh" is terminated

Signed-off-by: charlie_chen <charlie_chen@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Change the service defintion file "as7326-platform-handle_mac.service" and "as7726-32x-platform-handle_mac.service"
to execute "idt_init.sh" directly. The service type and the service dependency is also modified to ensure that
"opennsl-modules.services" is started after the execution of "idt_init.sh" is terminated.

**- How I did it**

**- How to verify it**
Install the modified SONiC image on AS7326-56X and AS7726-56X under ONIE.
Verify all of the ports can link up successfully at the first boot of SONiC after the ONIE installation procedure.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Change the service defintion file "as7326-platform-handle_mac.service" and "as7726-32x-platform-handle_mac.service" to execute "idt_init.sh" directly.

**- A picture of a cute animal (not mandatory but encouraged)**
