### PR TITLE
[barefoot][pmon] Fixed pmon Docker failure

### DIFF
--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/pmon_daemon_control.json
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/pmon_daemon_control.json
@@ -1,0 +1,6 @@
+{
+    "skip_ledd": true,
+    "skip_xcvrd": false,
+    "skip_psud": false,
+    "skip_syseepromd": false 
+}

--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/pmon_daemon_control.json
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/pmon_daemon_control.json
@@ -1,0 +1,6 @@
+{
+    "skip_ledd": true,
+    "skip_xcvrd": false,
+    "skip_psud": false,
+    "skip_syseepromd": false 
+}


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <akokhan@barefootnetworks.com>

**- What I did**
Disable ledd for Montara/Maveriks Barefoot platforms.

**- How I did it**
Added pmon_daemon_control.json for Montara/Maveriks with `"skip_ledd": true`.

**- How to verify it**
Check that pmon Docker is running after SONiC boot-up.