### PR TITLE
Revert "[services] make snmp.timer work again and delay telemetry.service"

### DIFF
--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -14,3 +14,5 @@ ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 Restart=always
 RestartSec=30
 
+[Install]
+WantedBy=multi-user.target swss.service

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -317,7 +317,7 @@ EOF
 ## Bind docker path
 if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
     sudo mkdir -p $FILESYSTEM_ROOT/dockerfs
-    sudo mount --bind dockerfs $FILESYSTEM_ROOT/dockerfs
+    sudo mount --bind dockerfs $FILESYSTEM_ROOT/dockerfs 
 fi
 
 {% if installer_images.strip() -%}
@@ -334,7 +334,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT docker $SONIC_NATIVE_DOCKERD_FOR_DOCKERFS ta
 {% endif %}
 {% endfor %}
 if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
-    sudo umount $FILESYSTEM_ROOT/dockerfs
+    sudo umount $FILESYSTEM_ROOT/dockerfs 
     sudo rm -fr $FILESYSTEM_ROOT/dockerfs
     sudo kill -9 `sudo $SONIC_NATIVE_DOCKERD_FOR_DOCKERFS_PID` || true
 else
@@ -362,8 +362,6 @@ sudo LANG=C cp $SCRIPTS_DIR/syncd.sh $FILESYSTEM_ROOT/usr/local/bin/syncd.sh
 # It implements delayed start of services
 sudo cp $BUILD_TEMPLATES/snmp.timer $FILESYSTEM_ROOT/etc/systemd/system/
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable snmp.timer
-sudo cp $BUILD_TEMPLATES/telemetry.timer $FILESYSTEM_ROOT/etc/systemd/system/
-sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable telemetry.timer
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get purge -y python-dev
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get clean -y

--- a/files/build_templates/telemetry.service.j2
+++ b/files/build_templates/telemetry.service.j2
@@ -10,3 +10,5 @@ ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 
+[Install]
+WantedBy=multi-user.target

--- a/files/build_templates/telemetry.timer
+++ b/files/build_templates/telemetry.timer
@@ -1,9 +1,0 @@
-[Unit]
-Description=Delays telemetry container until SONiC has started
-
-[Timer]
-OnBootSec=3min 30 sec
-Unit=telemetry.service
-
-[Install]
-WantedBy=timers.target


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#3657 per request from submitter.