### PR TITLE
Added python-libpcap for the updated arp responder

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -53,6 +53,7 @@ RUN sed --in-place 's/httpredir.debian.org/debian-archive.trafficmanager.net/' /
         tcpdump             \
         python              \
         python-dev          \
+        python-libpcap      \
         python-scapy        \
         python-six
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added python-libpcap to be used by arp_responder.py utility. This is needed to set conf.use_pcap which will make sure that L2pcapListenSocket uses libpcap instead of Linux PF_PACKET sockets. By using libpcap the vlan field will not be removed when the application receives the packet.

**- How I did it**
Added python-libpcap in docker-ptf Dockerfile.j2

**- How to verify it**
After setting conf.use_pcap = True
print the value of conf.L2listen
and the value is
 <L2pcapListenSocket: read packets at layer 2 using libpcap>

Without the configuration the value printed would be
<L2ListenSocket: read packets at layer 2 using Linux PF_PACKET sockets>


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
