### PR TITLE
[build] clear dpkg cache and update sources

### DIFF
--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -388,4 +388,6 @@ RUN apt-get install -y docker-ce=5:18.09.5~3-0~debian-stretch
 RUN apt-get install -y docker-ce=18.06.3~ce~3-0~debian
 {%- endif %}
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker
-RUN dpkg --clear-avail; apt-get -o Acquire::Check-Valid-Until=false update
+
+# Final cleanup. Please add new changes above.
+RUN dpkg --clear-avail; apt-get update

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -388,4 +388,4 @@ RUN apt-get install -y docker-ce=5:18.09.5~3-0~debian-stretch
 RUN apt-get install -y docker-ce=18.06.3~ce~3-0~debian
 {%- endif %}
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker
-RUN apt-get -o Acquire::Check-Valid-Until=false update
+RUN dpkg --clear-avail; apt-get -o Acquire::Check-Valid-Until=false update

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -388,3 +388,4 @@ RUN apt-get install -y docker-ce=5:18.09.5~3-0~debian-stretch
 RUN apt-get install -y docker-ce=18.06.3~ce~3-0~debian
 {%- endif %}
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker
+RUN dpkg --clear-avail; apt-get update

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -388,4 +388,4 @@ RUN apt-get install -y docker-ce=5:18.09.5~3-0~debian-stretch
 RUN apt-get install -y docker-ce=18.06.3~ce~3-0~debian
 {%- endif %}
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker
-RUN dpkg --clear-avail; apt-get update
+RUN apt-get -o Acquire::Check-Valid-Until=false update

--- a/sonic-slave/Dockerfile.j2
+++ b/sonic-slave/Dockerfile.j2
@@ -363,4 +363,6 @@ RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/d
 RUN echo "deb [arch={{ CONFIGURED_ARCH }}] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 RUN apt-get -y -o Acquire::Check-Valid-Until=false install ca-certificates-java=20161107~bpo8+1 openjdk-8-jdk
+
+# Final cleanup. Please add new changes above.
 RUN dpkg --clear-avail; apt-get -o Acquire::Check-Valid-Until=false update

--- a/sonic-slave/Dockerfile.j2
+++ b/sonic-slave/Dockerfile.j2
@@ -363,4 +363,4 @@ RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/d
 RUN echo "deb [arch={{ CONFIGURED_ARCH }}] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 RUN apt-get -y -o Acquire::Check-Valid-Until=false install ca-certificates-java=20161107~bpo8+1 openjdk-8-jdk
-RUN dpkg --clear-avail; apt-get update
+RUN dpkg --clear-avail; apt-get -o Acquire::Check-Valid-Until=false update

--- a/sonic-slave/Dockerfile.j2
+++ b/sonic-slave/Dockerfile.j2
@@ -363,3 +363,4 @@ RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/d
 RUN echo "deb [arch={{ CONFIGURED_ARCH }}] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 RUN apt-get -y -o Acquire::Check-Valid-Until=false install ca-certificates-java=20161107~bpo8+1 openjdk-8-jdk
+RUN dpkg --clear-avail; apt-get update


### PR DESCRIPTION
**- What I did**

Fixes: #119 

This change is intended to fix the issue with dpkg-query during build process.

The symptom is dpkg-query failed to open package info file, usually /var/lib/dpkg/updates/000?

This issue happens rarely. Not sure if this change has fully addressed the issue. So far my continuous build test didn't fail.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How I did it**
https://ubuntuforums.org/showthread.php?t=872210

**- How to verify it**
I made change in 201811 branch initially. Continuous build test was executed there.