### PR TITLE
[build] clear dpkg cache and update sources

### DIFF
--- a/sonic-slave-stretch/Dockerfile
+++ b/sonic-slave-stretch/Dockerfile
@@ -256,3 +256,6 @@ RUN add-apt-repository \
 RUN apt-get update
 RUN apt-get install -y docker-ce=17.03.2~ce-0~debian-stretch
 RUN echo "DOCKER_OPTS=\"--experimental\"" >> /etc/default/docker
+
+# Cleanup build environment. Please leave this line at the end and add new changes above
+RUN dpkg --clear-avail; apt-get update

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -309,3 +309,6 @@ RUN add-apt-repository \
 RUN apt-get update
 RUN apt-get install -y docker-ce=17.03.2~ce-0~debian-jessie
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker
+
+# Cleanup build environment. Please leave this line at the end and add new changes above
+RUN dpkg --clear-avail; apt-get update


### PR DESCRIPTION
**- What I did**

This change is intended to fix the issue with dpkg-query during build
process.

The symptom is dpkg-query failed to open package info file, usually
/var/lib/dpkg/updates/000?

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Continuous build test on 201811 branch.