### PR TITLE
celestica: reallocate the empty LIST at the constructor of subclasses

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/chassis.py
@@ -42,6 +42,7 @@ class Chassis(ChassisBase):
     """Platform-specific Chassis class"""
 
     def __init__(self):
+        ChassisBase.__init__(self)
         self.config_data = {}
         for fant_index in range(0, NUM_FAN_TRAY):
             for fan_index in range(0, NUM_FAN):
@@ -59,7 +60,6 @@ class Chassis(ChassisBase):
         for index in range(0, NUM_COMPONENT):
             component = Component(index)
             self._component_list.append(component)
-        ChassisBase.__init__(self)
         self._reboot_cause_path = HOST_REBOOT_CAUSE_PATH if self.__is_host(
         ) else PMON_REBOOT_CAUSE_PATH
 

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/chassis.py
@@ -44,6 +44,7 @@ class Chassis(ChassisBase):
     """Platform-specific Chassis class"""
 
     def __init__(self):
+        ChassisBase.__init__(self)
         self.config_data = {}
         for fant_index in range(0, NUM_FAN_TRAY):
             for fan_index in range(0, NUM_FAN):
@@ -61,7 +62,6 @@ class Chassis(ChassisBase):
         for index in range(0, NUM_COMPONENT):
             component = Component(index)
             self._component_list.append(component)
-        ChassisBase.__init__(self)
 
         self._watchdog = Watchdog()
         self._eeprom = Tlv()

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/psu.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/psu.py
@@ -39,6 +39,7 @@ class Psu(PsuBase):
     """Platform-specific Psu class"""
 
     def __init__(self, psu_index):
+        PsuBase.__init__(self)
         self.index = psu_index
         self.green_led_path = GREEN_LED_PATH.format(self.index+1)
         self.dx010_psu_gpio = [
@@ -52,7 +53,6 @@ class Psu(PsuBase):
         for fan_index in range(0, PSU_NUM_FAN[self.index]):
             fan = Fan(fan_index, 0, is_psu_fan=True, psu_index=self.index)
             self._fan_list.append(fan)
-        PsuBase.__init__(self)
 
     def __read_txt_file(self, file_path):
         try:


### PR DESCRIPTION
While this is part of the following PR, it will do no harm even if the
PR is rejected

https://github.com/Azure/sonic-platform-common/pull/65

Signed-off-by: Dante Su <dante.su@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Calling `superclass.__init__()` at the beginning the constructor

**- How I did it**
Move the `superclass.__init__()` to the beginning of the constructor

**- How to verify it**
It does not make any difference if PR#65 to sonic-platform-common is not in place,
and it could be verified with the following scripts when the PR#65 is merged

```
# source /host/machine.conf
# export PYTHONPATH=/usr/share/sonic/device/$onie_platform
# vi test.py
--------------------------------------------------------------------------------------
#!/usr/bin/env python

import sonic_platform.platform

chassis = sonic_platform.platform.Platform().get_chassis()
if chassis is None:
    print("Error getting chassis!")
    sys.exit(1)

print("FAN number: {}".format(chassis.get_num_fans()))

chassis = sonic_platform.platform.Platform().get_chassis()
if chassis is None:
    print("Error getting chassis!")
    sys.exit(1)

print("FAN number: {}".format(chassis.get_num_fans()))
--------------------------------------------------------------------------------------

# chmod +x test.py
# ./test.py
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
