### PR TITLE
Add bcmcmd and bcmsh in host when build as rpc image

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-rpc.mk
+++ b/platform/broadcom/docker-syncd-brcm-rpc.mk
@@ -23,3 +23,7 @@ $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+
+$(DOCKER_SYNCD_BRCM_RPC)_BASE_IMAGE_FILES += bcmcmd:/usr/bin/bcmcmd
+$(DOCKER_SYNCD_BRCM_RPC)_BASE_IMAGE_FILES += bcmsh:/usr/bin/bcmsh
+

--- a/platform/broadcom/docker-syncd-brcm-rpc/base_image_files/bcmcmd
+++ b/platform/broadcom/docker-syncd-brcm-rpc/base_image_files/bcmcmd
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -i syncd bcmcmd "$@"

--- a/platform/broadcom/docker-syncd-brcm-rpc/base_image_files/bcmsh
+++ b/platform/broadcom/docker-syncd-brcm-rpc/base_image_files/bcmsh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -it syncd bcmsh "$@"


### PR DESCRIPTION
Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add bcmcmd and bcmsh in host when build as rpc image

**- How I did it**
Add bcmcmd and bcmsh in docker-syncd-brcm-rpc/base_image_files

**- How to verify it**
Build and load on DUT

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
