### PR TITLE
DellEMC : Platform2.0 API - xcvrd support for Platform2.0 in DellEMC S6100 and other API changes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
@@ -65,7 +65,7 @@ class Chassis(ChassisBase):
         # Get Transceiver status
         self.modprs_register = self._get_transceiver_status()
 
-        self.sys_eeprom = Eeprom()
+        self._eeprom = Eeprom()
         for i in range(MAX_S6000_FAN):
             fan = Fan(i)
             self._fan_list.append(fan)
@@ -105,7 +105,7 @@ class Chassis(ChassisBase):
         Returns:
             string: The name of the chassis
         """
-        return self.sys_eeprom.modelstr()
+        return self._eeprom.modelstr()
 
     def get_presence(self):
         """
@@ -121,7 +121,7 @@ class Chassis(ChassisBase):
         Returns:
             string: Model/part number of chassis
         """
-        return self.sys_eeprom.part_number_str()
+        return self._eeprom.part_number_str()
 
     def get_serial(self):
         """
@@ -129,7 +129,7 @@ class Chassis(ChassisBase):
         Returns:
             string: Serial number of chassis
         """
-        return self.sys_eeprom.serial_str()
+        return self._eeprom.serial_str()
 
     def get_status(self):
         """
@@ -148,7 +148,7 @@ class Chassis(ChassisBase):
             A string containing the MAC address in the format
             'XX:XX:XX:XX:XX:XX'
         """
-        return self.sys_eeprom.base_mac_addr()
+        return self._eeprom.base_mac_addr()
 
     def get_serial_number(self):
         """
@@ -158,7 +158,7 @@ class Chassis(ChassisBase):
             A string containing the hardware serial number for this
             chassis.
         """
-        return self.sys_eeprom.serial_number_str()
+        return self._eeprom.serial_number_str()
 
     def get_system_eeprom_info(self):
         """
@@ -170,7 +170,7 @@ class Chassis(ChassisBase):
             OCP ONIE TlvInfo EEPROM format and values are their
             corresponding values.
         """
-        return self.sys_eeprom.system_eeprom_info()
+        return self._eeprom.system_eeprom_info()
 
     def get_reboot_cause(self):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/psu.py
@@ -13,6 +13,7 @@ try:
     import os
     from sonic_platform_base.psu_base import PsuBase
     from sonic_platform.eeprom import Eeprom
+    from sonic_platform.fan import Fan
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -45,6 +46,8 @@ class Psu(PsuBase):
         # Overriding _fan_list class variable defined in PsuBase, to
         # make it unique per Psu object
         self._fan_list = []
+
+        self._fan_list.append(Fan(self.index, psu_fan=True, dependency=self))
 
     def _get_cpld_register(self, reg_name):
         # On successful read, returns the value read from given

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_sensors.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_sensors.py
@@ -255,8 +255,8 @@ def print_psu(psu):
         psu_fan_present = int(get_pmc_register('fan11_fault'))
         input_voltage = float(get_pmc_register('in29_input')) / 1000
         output_voltage = float(get_pmc_register('in30_input')) / 1000
-        input_current = float(get_pmc_register('curr601_input')) / 100
-        output_current = float(get_pmc_register('curr602_input')) / 100
+        input_current = float(get_pmc_register('curr601_input')) / 1000
+        output_current = float(get_pmc_register('curr602_input')) / 1000
         input_power = float(get_pmc_register('power1_input')) / 1000000
         output_power = float(get_pmc_register('power2_input')) / 1000000
         if (input_power != 0):
@@ -268,8 +268,8 @@ def print_psu(psu):
         psu_fan_present = int(get_pmc_register('fan12_fault'))
         input_voltage = float(get_pmc_register('in31_input')) / 1000
         output_voltage = float(get_pmc_register('in32_input')) / 1000
-        input_current = float(get_pmc_register('curr701_input')) / 100
-        output_current = float(get_pmc_register('curr702_input')) / 100
+        input_current = float(get_pmc_register('curr701_input')) / 1000
+        output_current = float(get_pmc_register('curr702_input')) / 1000
         input_power = float(get_pmc_register('power3_input')) / 1000000
         output_power = float(get_pmc_register('power4_input')) / 1000000
         if (input_power != 0):

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -54,6 +54,26 @@ sys_eeprom() {
     esac
 }
 
+#Attach/Detach eeprom on each IOM
+switch_board_eeprom() {
+    case $1 in
+        "new_device")
+                      for ((i=14;i<=17;i++));
+                      do
+                          i2c_config "echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
+                      done
+                      ;;
+        "delete_device")
+                      for ((i=14;i<=17;i++));
+                      do
+                          i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
+                      done
+                      ;;
+        *)            echo "s6100_platform: switch_board_eeprom : invalid command !"
+                      ;;
+    esac
+}
+
 #Attach/Detach CPLD devices to drivers for each IOM
 switch_board_cpld() {
     case $1 in
@@ -245,7 +265,7 @@ install_python_api_package() {
 remove_python_api_package() {
     rv=$(pip show sonic-platform > /dev/null 2>/dev/null)
     if [ $? -eq 0 ]; then
-        rv = $(pip uninstall -y sonic-platform > /dev/null 2>/dev/null)
+        rv=$(pip uninstall -y sonic-platform > /dev/null 2>/dev/null)
     fi
 }
 
@@ -267,6 +287,7 @@ if [[ "$1" == "init" ]]; then
     cpu_board_mux "new_device"
     switch_board_mux "new_device"
     sys_eeprom "new_device"
+    switch_board_eeprom "new_device"
     switch_board_cpld "new_device"
     switch_board_qsfp_mux "new_device"
     switch_board_sfp "new_device"
@@ -280,6 +301,7 @@ elif [[ "$1" == "deinit" ]]; then
     xcvr_presence_interrupts "disable"
     switch_board_sfp "delete_device"
     switch_board_cpld "delete_device"
+    switch_board_eeprom "delete_device"
     switch_board_mux "delete_device"
     sys_eeprom "delete_device"
     switch_board_qsfp "delete_device"

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -54,10 +54,11 @@ class Chassis(ChassisBase):
 
         ChassisBase.__init__(self)
         # Initialize EEPROM
-        self.sys_eeprom = Eeprom()
+        self._eeprom = Eeprom()
         for i in range(MAX_S6100_MODULE):
             module = Module(i)
             self._module_list.append(module)
+            self._sfp_list.extend(module._sfp_list)
 
         for i in range(MAX_S6100_FAN):
             fan = Fan(i)
@@ -107,7 +108,7 @@ class Chassis(ChassisBase):
         Returns:
             string: The name of the chassis
         """
-        return self.sys_eeprom.modelstr()
+        return self._eeprom.modelstr()
 
     def get_presence(self):
         """
@@ -123,7 +124,7 @@ class Chassis(ChassisBase):
         Returns:
             string: Model/part number of chassis
         """
-        return self.sys_eeprom.part_number_str()
+        return self._eeprom.part_number_str()
 
     def get_serial(self):
         """
@@ -131,7 +132,7 @@ class Chassis(ChassisBase):
         Returns:
             string: Serial number of chassis
         """
-        return self.sys_eeprom.serial_str()
+        return self._eeprom.serial_str()
 
     def get_status(self):
         """
@@ -150,7 +151,7 @@ class Chassis(ChassisBase):
             A string containing the MAC address in the format
             'XX:XX:XX:XX:XX:XX'
         """
-        return self.sys_eeprom.base_mac_addr()
+        return self._eeprom.base_mac_addr()
 
     def get_serial_number(self):
         """
@@ -160,7 +161,7 @@ class Chassis(ChassisBase):
             A string containing the hardware serial number for this
             chassis.
         """
-        return self.sys_eeprom.serial_number_str()
+        return self._eeprom.serial_number_str()
 
     def get_system_eeprom_info(self):
         """
@@ -170,7 +171,7 @@ class Chassis(ChassisBase):
             OCP ONIE TlvInfo EEPROM format and values are their corresponding
             values.
         """
-        return self.sys_eeprom.system_eeprom_info()
+        return self._eeprom.system_eeprom_info()
 
     def get_reboot_cause(self):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan.py
@@ -33,6 +33,10 @@ class Fan(FanBase):
             # from 1
             self.fantrayindex = fantray_index + 1
             self.fanindex = fan_index + 1
+            self.fan_presence_reg = "fan{}_fault".format(
+                        2 * self.fantrayindex - 1)
+            self.fan_status_reg = "fan{}_alarm".format(
+                        2 * self.fantrayindex - 1)
             self.get_fan_speed_reg = "fan{}_input".format(
                         2 * self.fantrayindex - 1)
             self.get_fan_dir_reg = "fan{}_airflow".format(
@@ -43,7 +47,9 @@ class Fan(FanBase):
         else:
             # PSU Fan index starts from 11
             self.fanindex = fan_index + 10
+            self.fan_presence_reg = "fan{}_fault".format(self.fanindex)
             self.get_fan_speed_reg = "fan{}_input".format(self.fanindex)
+            self.get_fan_dir_reg = "fan{}_airflow".format(self.fanindex)
             self.max_fan_speed = MAX_S6100_PSU_FAN_SPEED
 
     def _get_pmc_register(self, reg_name):
@@ -84,6 +90,9 @@ class Fan(FanBase):
         """
         # For Serial number "US-01234D-54321-25A-0123-A00", the part
         # number is "01234D"
+        if self.is_psu_fan:
+            return 'NA'
+
         fan_serialno = self._get_pmc_register(self.fan_serialno_reg)
         if (fan_serialno != 'ERR') and self.get_presence():
             if (len(fan_serialno.split('-')) > 1):
@@ -102,6 +111,9 @@ class Fan(FanBase):
             string: Serial number of FAN
         """
         # Sample Serial number format "US-01234D-54321-25A-0123-A00"
+        if self.is_psu_fan:
+            return 'NA'
+
         fan_serialno = self._get_pmc_register(self.fan_serialno_reg)
         if (fan_serialno == 'ERR') or not self.get_presence():
             fan_serialno = 'NA'
@@ -115,11 +127,11 @@ class Fan(FanBase):
             bool: True if fan is present, False if not
         """
         status = False
-        fantray_presence = self._get_pmc_register(self.get_fan_speed_reg)
+        fantray_presence = self._get_pmc_register(self.fan_presence_reg)
         if (fantray_presence != 'ERR'):
             fantray_presence = int(fantray_presence, 10)
-        if (fantray_presence > 0):
-            status = True
+            if (~fantray_presence & 0b1):
+                status = True
 
         return status
 
@@ -130,11 +142,18 @@ class Fan(FanBase):
             bool: True if FAN is operating properly, False if not
         """
         status = False
-        fantray_status = self._get_pmc_register(self.get_fan_speed_reg)
-        if (fantray_status != 'ERR'):
-            fantray_status = int(fantray_status, 10)
-            if (fantray_status > 5000):
-                status = True
+        if self.is_psu_fan:
+            fantray_status = self._get_pmc_register(self.get_fan_speed_reg)
+            if (fantray_status != 'ERR'):
+                fantray_status = int(fantray_status, 10)
+                if (fantray_status > 5000):
+                    status = True
+        else:
+            fantray_status = self._get_pmc_register(self.fan_status_reg)
+            if (fantray_status != 'ERR'):
+                fantray_status = int(fantray_status, 10)
+                if (~fantray_status & 0b1):
+                    status = True
 
         return status
 
@@ -216,10 +235,17 @@ class Fan(FanBase):
         Returns:
             A string, one of the predefined STATUS_LED_COLOR_* strings.
         """
-        if self.get_status():
-            return self.STATUS_LED_COLOR_GREEN
+        if self.is_psu_fan:
+            # No LED available for PSU Fan
+            return None
         else:
-            return self.STATUS_LED_COLOR_OFF
+            if self.get_presence():
+                if self.get_status():
+                    return self.STATUS_LED_COLOR_GREEN
+                else:
+                    return self.STATUS_LED_COLOR_AMBER
+            else:
+                return self.STATUS_LED_COLOR_OFF
 
     def get_target_speed(self):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/module.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/module.py
@@ -14,6 +14,7 @@ try:
     from sonic_platform_base.module_base import ModuleBase
     from sonic_platform.sfp import Sfp
     from sonic_platform.component import Component
+    from sonic_platform.eeprom import Eeprom
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -55,7 +56,7 @@ class Module(ModuleBase):
         self.port_start = (self.index - 1) * 16
         self.port_end = (self.index * 16) - 1
         self.port_i2c_line = self.IOM_I2C_MAPPING[self.index]
-        self.eeprom_tlv_dict = dict()
+        self._eeprom = Eeprom(iom_eeprom=True, i2c_line=self.port_i2c_line)
 
         self.iom_status_reg = "iom_status"
         self.iom_presence_reg = "iom_presence"
@@ -108,7 +109,7 @@ class Module(ModuleBase):
         Returns:
             string: The name of the device
         """
-        return "IOM{}: 16xQSFP+".format(self.index)
+        return "IOM{}: {}".format(self.index, self._eeprom.modelstr())
 
     def get_presence(self):
         """
@@ -133,7 +134,7 @@ class Module(ModuleBase):
         Returns:
             string: part number of module
         """
-        return 'NA'
+        return self._eeprom.part_number_str()
 
     def get_serial(self):
         """
@@ -142,7 +143,7 @@ class Module(ModuleBase):
         Returns:
             string: Serial number of module
         """
-        return 'NA'
+        return self._eeprom.serial_str()
 
     def get_status(self):
         """
@@ -178,7 +179,7 @@ class Module(ModuleBase):
         Returns:
             A string containing the hardware serial number for this module.
         """
-        return 'NA'
+        return self._eeprom.serial_number_str()
 
     def get_system_eeprom_info(self):
         """
@@ -192,4 +193,4 @@ class Module(ModuleBase):
                   ‘0x24’:’001c0f000fcd0a’, ‘0x25’:’02/03/2018 16:22:00’,
                   ‘0x26’:’01’, ‘0x27’:’REV01’, ‘0x28’:’AG9064-C2358-16G’}
         """
-        return self.eeprom_tlv_dict
+        return self._eeprom.system_eeprom_info()

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/platform_sensors.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/platform_sensors.py
@@ -262,8 +262,8 @@ def print_psu(psu):
         psu_fan_present = int(get_pmc_register('fan11_fault'))
         input_voltage = float(get_pmc_register('in29_input')) / 1000
         output_voltage = float(get_pmc_register('in30_input')) / 1000
-        input_current = float(get_pmc_register('curr601_input')) / 100
-        output_current = float(get_pmc_register('curr602_input')) /100
+        input_current = float(get_pmc_register('curr601_input')) / 1000
+        output_current = float(get_pmc_register('curr602_input')) / 1000
         input_power = float(get_pmc_register('power1_input')) / 1000000
         output_power = float(get_pmc_register('power2_input')) / 1000000
 	if (input_power != 0):
@@ -275,8 +275,8 @@ def print_psu(psu):
         psu_fan_present = int(get_pmc_register('fan12_fault'))
         input_voltage = float(get_pmc_register('in31_input')) / 1000
         output_voltage = float(get_pmc_register('in32_input')) / 1000
-        input_current = float(get_pmc_register('curr701_input')) / 100
-        output_current = float(get_pmc_register('curr702_input')) / 100
+        input_current = float(get_pmc_register('curr701_input')) / 1000
+        output_current = float(get_pmc_register('curr702_input')) / 1000
         input_power = float(get_pmc_register('power3_input')) / 1000000
         output_power = float(get_pmc_register('power4_input')) / 1000000
 	if (input_power != 0):

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
@@ -94,7 +94,7 @@ class Chassis(ChassisBase):
 
         ChassisBase.__init__(self)
         # Initialize EEPROM
-        self.sys_eeprom = Eeprom()
+        self._eeprom = Eeprom()
         for i in range(MAX_Z9100_FANTRAY):
             for j in range(MAX_Z9100_FAN):
                 fan = Fan(i, j)
@@ -137,7 +137,7 @@ class Chassis(ChassisBase):
         Returns:
             string: The name of the chassis
         """
-        return self.sys_eeprom.modelstr()
+        return self._eeprom.modelstr()
 
     def get_presence(self):
         """
@@ -153,7 +153,7 @@ class Chassis(ChassisBase):
         Returns:
             string: Model/part number of chassis
         """
-        return self.sys_eeprom.part_number_str()
+        return self._eeprom.part_number_str()
 
     def get_serial(self):
         """
@@ -161,7 +161,7 @@ class Chassis(ChassisBase):
         Returns:
             string: Serial number of chassis
         """
-        return self.sys_eeprom.serial_str()
+        return self._eeprom.serial_str()
 
     def get_status(self):
         """
@@ -180,7 +180,7 @@ class Chassis(ChassisBase):
             A string containing the MAC address in the format
             'XX:XX:XX:XX:XX:XX'
         """
-        return self.sys_eeprom.base_mac_addr()
+        return self._eeprom.base_mac_addr()
 
     def get_serial_number(self):
         """
@@ -189,7 +189,7 @@ class Chassis(ChassisBase):
         Returns:
             A string containing the hardware serial number for this chassis.
         """
-        return self.sys_eeprom.serial_number_str()
+        return self._eeprom.serial_number_str()
 
     def get_system_eeprom_info(self):
         """
@@ -200,7 +200,7 @@ class Chassis(ChassisBase):
             OCP ONIE TlvInfo EEPROM format and values are their corresponding
             values.
         """
-        return self.sys_eeprom.system_eeprom_info()
+        return self._eeprom.system_eeprom_info()
 
     def get_reboot_cause(self):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/fan.py
@@ -33,6 +33,10 @@ class Fan(FanBase):
             # from 1
             self.fantrayindex = fantray_index + 1
             self.fanindex = fan_index + 1
+            self.fan_presence_reg = "fan{}_fault".format(
+               2 * (self.fantrayindex - 1) + (self.fanindex - 1) + 1 )
+            self.fan_status_reg = "fan{}_alarm".format(
+               2 * (self.fantrayindex - 1) + (self.fanindex - 1) + 1 )
             self.get_fan_speed_reg = "fan{}_input".format(
                2 * (self.fantrayindex - 1) + (self.fanindex - 1) + 1 )
             self.get_fan_dir_reg = "fan{}_airflow".format(
@@ -43,7 +47,9 @@ class Fan(FanBase):
         else:
             # PSU Fan index starts from 11
             self.fanindex = fan_index + 10
+            self.fan_presence_reg = "fan{}_fault".format(self.fanindex)
             self.get_fan_speed_reg = "fan{}_input".format(self.fanindex)
+            self.get_fan_dir_reg = "fan{}_airflow".format(self.fanindex)
             self.max_fan_speed = MAX_Z9100_PSU_FAN_SPEED
 
     def _get_pmc_register(self, reg_name):
@@ -83,6 +89,9 @@ class Fan(FanBase):
         """
         # For Serial number "US-01234D-54321-25A-0123-A00", the part
         # number is "01234D"
+        if self.is_psu_fan:
+            return 'NA'
+
         fan_serialno = self._get_pmc_register(self.fan_serialno_reg)
         if (fan_serialno != 'ERR') and self.get_presence():
             if (len(fan_serialno.split('-')) > 1):
@@ -101,6 +110,9 @@ class Fan(FanBase):
             string: Serial number of FAN
         """
         # Sample Serial number format "US-01234D-54321-25A-0123-A00"
+        if self.is_psu_fan:
+            return 'NA'
+
         fan_serialno = self._get_pmc_register(self.fan_serialno_reg)
         if (fan_serialno == 'ERR') or not self.get_presence():
             fan_serialno = 'NA'
@@ -114,11 +126,11 @@ class Fan(FanBase):
             bool: True if fan is present, False if not
         """
         status = False
-        fantray_presence = self._get_pmc_register(self.get_fan_speed_reg)
+        fantray_presence = self._get_pmc_register(self.fan_presence_reg)
         if (fantray_presence != 'ERR'):
             fantray_presence = int(fantray_presence, 10)
-        if (fantray_presence > 0):
-            status = True
+            if (~fantray_presence & 0b1):
+                status = True
 
         return status
 
@@ -129,11 +141,18 @@ class Fan(FanBase):
             bool: True if FAN is operating properly, False if not
         """
         status = False
-        fantray_status = self._get_pmc_register(self.get_fan_speed_reg)
-        if (fantray_status != 'ERR'):
-            fantray_status = int(fantray_status, 10)
-            if (fantray_status > 5000):
-                status = True
+        if self.is_psu_fan:
+            fantray_status = self._get_pmc_register(self.get_fan_speed_reg)
+            if (fantray_status != 'ERR'):
+                fantray_status = int(fantray_status, 10)
+                if (fantray_status > 5000):
+                    status = True
+        else:
+            fantray_status = self._get_pmc_register(self.fan_status_reg)
+            if (fantray_status != 'ERR'):
+                fantray_status = int(fantray_status, 10)
+                if (~fantray_status & 0b1):
+                    status = True
 
         return status
 
@@ -215,10 +234,17 @@ class Fan(FanBase):
         Returns:
             A string, one of the predefined STATUS_LED_COLOR_* strings.
         """
-        if self.get_status():
-            return self.STATUS_LED_COLOR_GREEN
+        if self.is_psu_fan:
+            # No LED available for PSU Fan
+            return None
         else:
-            return self.STATUS_LED_COLOR_OFF
+            if self.get_presence():
+                if self.get_status():
+                    return self.STATUS_LED_COLOR_GREEN
+                else:
+                    return self.STATUS_LED_COLOR_AMBER
+            else:
+                return self.STATUS_LED_COLOR_OFF
 
     def get_target_speed(self):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixed empty chassis's _sfp_list in DellEMC S6100.
- Implemented platform2.0 API support for DellEMC S6100 IO Module Eeprom data.
- Implemented PSU Fan specific changes in platform2.0 API for DellEMC platforms [S6100, S6000, Z9100].

**- How I did it**
- In DellEMC S6100, extended the chassis's _sfp_list with module's sfp_list.
- Attach at24 driver for accessing the DellEMC S6100 IO Module Eeprom and retrieve the data through platform2.0 API.
- Made changes for handling PSU Fan in platform2.0 API.
 
**- How to verify it**

Wrote python script to load Chassis class and then call the APIs accordingly.
UT Logs - [S6100_logs.txt](https://github.com/Azure/sonic-buildimage/files/3836049/S6100_logs.txt), [S6000_logs.txt](https://github.com/Azure/sonic-buildimage/files/3836050/S6000_logs.txt), [Z9100_logs.txt](https://github.com/Azure/sonic-buildimage/files/3836052/Z9100_logs.txt)
Test Script -  [test_py.txt](https://github.com/Azure/sonic-buildimage/files/3836099/test_py.txt)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC : Platform2.0 API - xcvrd support for Platform2.0 in DellEMC S6100 and other API changes

**- A picture of a cute animal (not mandatory but encouraged)**
