### PR TITLE
modified ntp script to hide the error related to cfggen during bootup

### DIFF
--- a/files/image_config/ntp/ntp
+++ b/files/image_config/ntp/ntp
@@ -50,7 +50,7 @@ case $1 in
 		fi
 		(
 			flock -w 180 9
-			vrfEnabled=$(/usr/local/bin/sonic-cfggen -d -v 'MGMT_VRF_CONFIG["vrf_global"]["mgmtVrfEnabled"]')
+			vrfEnabled=$(/usr/local/bin/sonic-cfggen -d -v 'MGMT_VRF_CONFIG["vrf_global"]["mgmtVrfEnabled"]' 2> /dev/null)
 			if [ "$vrfEnabled" = "true" ]
 			then
 				log_daemon_msg "Starting NTP server in mgmt-vrf" "ntpd"


### PR DESCRIPTION
This PR is to handle the issue [3527](https://github.com/Azure/sonic-buildimage/issues/3527). 
When device boots up, NTP throws a traceback as explained in the issue 3527.

1) Traceback will be seen when MGMT_VRF_CONFIG does not exist in the database. Traceback is coming from the script “/etc/init.d/ntp”.
2) Traceback does not affect the NTP functionality with/without management VRF. When MGMT_VRF_CONFIG does not exist or when MGMT_VRF_CONFIG’s mgmtVrfEnabled is configured to “false”, “NTP” will be started in the “default VRF” context, which is working fine even with this traceback.
3)This traceback error will be hidden by redirecting the error to /dev/null without affecting functionality. 

-->
**- What I did**
Modified files/image_config/ntp/ntp file to redirect the error returned by sonic-cfggen  to /dev/null.

**- How to verify it**
Rebooted device and verified that the traceback error is not seen in the journalctl. Tested NTP without management VRF and with management VRF and confirmed that it works fine.

**- Description for the changelog**
Modified files/image_config/ntp/ntp file to redirect the error returned by sonic-cfggen  to /dev/null.

NOTE: The other issue reported in the issue3527 is related to LOOPBACK_INTERFACE|pfx_filter. That issue is a different issue which is not related to management VRF; it shall be replied accordingly and tracked in separate issue/PR.