### PR TITLE
DellEMC: optoe driver support in S6000,S6100,Z9100

### DIFF
--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/sfputil.py
@@ -362,11 +362,11 @@ class SfpUtil(SfpUtilBase):
 
             sfpd_obj = sff8436Dom()
             if sfpd_obj is None:
-                return None
+                return transceiver_dom_info_dict
 
             sfpi_obj = sff8436InterfaceId()
             if sfpi_obj is None:
-                return None
+                return transceiver_dom_info_dict
 
             # QSFP capability byte parse, through this byte can know whether it support tx_power or not.
             # TODO: in the future when decided to migrate to support SFF-8636 instead of SFF-8436,
@@ -376,25 +376,25 @@ class SfpUtil(SfpUtilBase):
             if qsfp_dom_capability_raw is not None:
                 qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
             else:
-                return None
+                return transceiver_dom_info_dict
 
             dom_temperature_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_TEMPE_OFFSET), QSFP_TEMPE_WIDTH)
 	    if dom_temperature_raw is not None:
                 dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
             else:
-                return None
+                return transceiver_dom_info_dict
 
             dom_voltage_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_VOLT_OFFSET), QSFP_VOLT_WIDTH)
             if dom_voltage_raw is not None:
                 dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
             else:
-                return None
+                return transceiver_dom_info_dict
 
             qsfp_dom_rev_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_DOM_REV_OFFSET), QSFP_DOM_REV_WIDTH)
             if qsfp_dom_rev_raw is not None:
                 qsfp_dom_rev_data = sfpd_obj.parse_sfp_dom_rev(qsfp_dom_rev_raw, 0)
             else:
-                return None
+                return transceiver_dom_info_dict
 
             transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
             transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
@@ -409,7 +409,7 @@ class SfpUtil(SfpUtilBase):
                 if dom_channel_monitor_raw is not None:
                     dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params(dom_channel_monitor_raw, 0)
                 else:
-                    return None
+                    return transceiver_dom_info_dict
 
 	        transceiver_dom_info_dict['tx1power'] = 'N/A'
                 transceiver_dom_info_dict['tx2power'] = 'N/A'
@@ -433,7 +433,7 @@ class SfpUtil(SfpUtilBase):
             transceiver_dom_info_dict['tx4bias'] = dom_channel_monitor_data['data']['TX4Bias']['value']
 
         else:
-	   offset = 0
+	   offset = 256
            file_path = self._get_port_eeprom_path(port_num, self.DOM_EEPROM_ADDR)
            if not self._sfp_eeprom_present(file_path, 0):
                return None
@@ -452,21 +452,21 @@ class SfpUtil(SfpUtilBase):
         if dom_temperature_raw is not None:
             dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
         else:
-           return None
+           return transceiver_dom_info_dict
 
         dom_voltage_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_VOLT_OFFSET), 
 										SFP_VOLT_WIDTH)
         if dom_voltage_raw is not None:
              dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
         else: 
-             return None
+             return transceiver_dom_info_dict
 
         dom_channel_monitor_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_MODULE_THRESHOLD_OFFSET), 
 									SFP_MODULE_THRESHOLD_WIDTH)
         if dom_channel_monitor_raw is not None:
            dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params(dom_channel_monitor_raw, 0)
         else:
-           return None
+           return transceiver_dom_info_dict
 
         try:
            sysfsfile_eeprom.close()
@@ -519,11 +519,11 @@ class SfpUtil(SfpUtilBase):
 
             sfpd_obj = sff8436Dom()
             if sfpd_obj is None:
-                return None
+                return transceiver_dom_threshold_info_dict
 
             # Dom Threshold data starts from offset 384
             # Revert offset back to 0 once data is retrieved
-            offset = 0
+            offset = 384
             dom_module_threshold_raw = self._read_eeprom_specific_bytes(
                                      sysfsfile_eeprom,
                                      (offset + QSFP_MODULE_THRESHOLD_OFFSET),
@@ -531,7 +531,7 @@ class SfpUtil(SfpUtilBase):
             if dom_module_threshold_raw is not None:
                 dom_module_threshold_data = sfpd_obj.parse_module_threshold_values(dom_module_threshold_raw, 0)
             else:
-                return None
+                return transceiver_dom_threshold_info_dict
 
             dom_channel_threshold_raw = self._read_eeprom_specific_bytes(
                                       sysfsfile_eeprom,
@@ -540,7 +540,7 @@ class SfpUtil(SfpUtilBase):
             if dom_channel_threshold_raw is not None:
                 dom_channel_threshold_data = sfpd_obj.parse_channel_threshold_values(dom_channel_threshold_raw, 0)
             else:
-                return None
+                return transceiver_dom_threshold_info_dict
 
             try:
                 sysfsfile_eeprom.close()
@@ -567,7 +567,7 @@ class SfpUtil(SfpUtilBase):
             transceiver_dom_threshold_info_dict['txbiaslowwarning'] = dom_channel_threshold_data['data']['TxBiasLowWarning']['value']
 
         else:
-            offset = 0
+            offset = 256
             file_path = self._get_port_eeprom_path(port_num, self.DOM_EEPROM_ADDR)
             if not self._sfp_eeprom_present(file_path, 0):
                 return None
@@ -580,7 +580,7 @@ class SfpUtil(SfpUtilBase):
             
 	    sfpd_obj = sff8472Dom(None,1)
             if sfpd_obj is None:
-                return None
+                return transceiver_dom_threshold_info_dict
             
             dom_module_threshold_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, 
                                              (offset + SFP_MODULE_THRESHOLD_OFFSET), SFP_MODULE_THRESHOLD_WIDTH)
@@ -588,7 +588,7 @@ class SfpUtil(SfpUtilBase):
             if dom_module_threshold_raw is not None:
                 dom_module_threshold_data = sfpd_obj.parse_alarm_warning_threshold(dom_module_threshold_raw, 0)
             else:
-                return None
+                return transceiver_dom_threshold_info_dict
 
             try:
                 sysfsfile_eeprom.close()

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
@@ -32,7 +32,7 @@ add_i2c_devices() {
     echo 24c02 0x52 > /sys/class/i2c-adapter/i2c-11/new_device
     echo 24c02 0x53 > /sys/class/i2c-adapter/i2c-11/new_device
     for i in `seq 0 31`; do
-        echo sff8436 0x50 > /sys/class/i2c-adapter/i2c-$((20+i))/new_device
+        echo optoe1 0x50 > /sys/class/i2c-adapter/i2c-$((20+i))/new_device
     done
 }
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py
@@ -44,7 +44,7 @@ info_dict_keys = ['type', 'hardwarerev', 'serialnum',
                   'manufacturename', 'modelname', 'Connector',
                   'encoding', 'ext_identifier', 'ext_rateselect_compliance',
                   'cable_type', 'cable_length', 'nominal_bit_rate',
-                  'specification_compliance', 'vendor_date', 'vendor_oui']
+                  'specification_compliance', 'type_abbrv_name','vendor_date', 'vendor_oui']
 
 dom_dict_keys = ['rx_los',       'tx_fault',   'reset_status',
                  'power_lpmode', 'tx_disable', 'tx_disable_channel',
@@ -87,6 +87,7 @@ sff8436_parser = {
  'nominal_bit_rate': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
  'specification_compliance':
                      [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
+ 'type_abbrv_name' : [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
   'manufacturename': [INFO_OFFSET, 20, 16, 'parse_vendor_name'],
        'vendor_oui': [INFO_OFFSET,  37, 3, 'parse_vendor_oui'],
         'modelname': [INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
@@ -168,6 +169,7 @@ class Sfp(SfpBase):
 
         return eeprom_data
 
+
     def get_transceiver_info(self):
         """
         Retrieves transceiver info of this SFP
@@ -184,6 +186,7 @@ class Sfp(SfpBase):
             ext_id = iface_data['data']['Extended Identifier']['value']
             rate_identifier = iface_data['data']['RateIdentifier']['value']
             identifier = iface_data['data']['type']['value']
+            type_abbrv_name=iface_data['data']['type_abbrv_name']['value']
             bit_rate = str(
                 iface_data['data']['Nominal Bit Rate(100Mbs)']['value'])
 
@@ -195,7 +198,7 @@ class Sfp(SfpBase):
                     cable_type = key
                     cable_length = str(iface_data['data'][key]['value'])
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Date
         vendor_date_data = self._get_eeprom_data('vendor_date')
@@ -209,36 +212,36 @@ class Sfp(SfpBase):
         if (vendor_name_data is not None):
             vendor_name = vendor_name_data['data']['Vendor Name']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor OUI
         vendor_oui_data = self._get_eeprom_data('vendor_oui')
         if (vendor_oui_data is not None):
             vendor_oui = vendor_oui_data['data']['Vendor OUI']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor PN
         vendor_pn_data = self._get_eeprom_data('modelname')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Revision
         vendor_rev_data = self._get_eeprom_data('hardwarerev')
         if (vendor_rev_data is not None):
             vendor_rev = vendor_rev_data['data']['Vendor Rev']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Serial Number
         vendor_sn_data = self._get_eeprom_data('serialnum')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:
-            return None
-
+            return transceiver_info_dict
+	
         # Fill The Dictionary and return
         transceiver_info_dict['type'] = identifier
         transceiver_info_dict['hardwarerev'] = vendor_rev
@@ -256,6 +259,7 @@ class Sfp(SfpBase):
             compliance_code_dict)
         transceiver_info_dict['vendor_date'] = vendor_date
         transceiver_info_dict['vendor_oui'] = vendor_oui
+	transceiver_info_dict['type_abbrv_name']=type_abbrv_name	
 
         return transceiver_info_dict
 
@@ -279,7 +283,7 @@ class Sfp(SfpBase):
             vccHighWarn = module_threshold_data['data']['VccHighWarning']['value']
             vccLowWarn = module_threshold_data['data']['VccLowWarning']['value']
         else:
-            return None
+            return transceiver_dom_threshold_dict
 
         # Channel Threshold
         channel_threshold_data = self._get_eeprom_data('ChannelThreshold')
@@ -293,7 +297,7 @@ class Sfp(SfpBase):
             txBiasHighWarn = channel_threshold_data['data']['TxBiasHighWarning']['value']
             txBiasLowWarn = channel_threshold_data['data']['TxBiasLowWarning']['value']
         else:
-            return None
+            return transceiver_dom_threshold_dict
 
         transceiver_dom_threshold_dict['temphighalarm'] = tempHighAlarm
         transceiver_dom_threshold_dict['templowalarm'] = tempLowAlarm
@@ -367,7 +371,7 @@ class Sfp(SfpBase):
             rx_power = channel_monitor_data['data']['RX4Power']['value']
             rx_power_list.append(rx_power)
         else:
-            return None
+            return transceiver_dom_dict
 
         transceiver_dom_dict['rx_los'] = rx_los
         transceiver_dom_dict['tx_fault'] = tx_fault

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -109,8 +109,8 @@ switch_board_qsfp_mux() {
 #Attach/Detach the SFP modules on PCA9548_2
 switch_board_sfp() {
     case $1 in
-        "new_device")    i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
-                         i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
+        "new_device")    i2c_config "echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
+                         i2c_config "echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
                          ;;
         "delete_device") i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
                          i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
@@ -125,7 +125,7 @@ qsfp_device_mod() {
     case $1 in
         "new_device")    for ((i=$2;i<=$3;i++));
                          do
-                             i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
+                             i2c_config "echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
                          done
                          ;;
         "delete_device") for ((i=$2;i<=$3;i++));

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/sfp.py
@@ -195,49 +195,49 @@ class Sfp(SfpBase):
                     cable_type = key
                     cable_length = str(iface_data['data'][key]['value'])
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Date
         vendor_date_data = self._get_eeprom_data('vendor_date')
         if (vendor_date_data is not None):
             vendor_date = vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Name
         vendor_name_data = self._get_eeprom_data('manufacturename')
         if (vendor_name_data is not None):
             vendor_name = vendor_name_data['data']['Vendor Name']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor OUI
         vendor_oui_data = self._get_eeprom_data('vendor_oui')
         if (vendor_oui_data is not None):
             vendor_oui = vendor_oui_data['data']['Vendor OUI']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor PN
         vendor_pn_data = self._get_eeprom_data('modelname')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Revision
         vendor_rev_data = self._get_eeprom_data('hardwarerev')
         if (vendor_rev_data is not None):
             vendor_rev = vendor_rev_data['data']['Vendor Rev']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Serial Number
         vendor_sn_data = self._get_eeprom_data('serialnum')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Fill The Dictionary and return
         transceiver_info_dict['type'] = identifier
@@ -279,7 +279,7 @@ class Sfp(SfpBase):
             vccHighWarn = module_threshold_data['data']['VccHighWarning']['value']
             vccLowWarn = module_threshold_data['data']['VccLowWarning']['value']
         else:
-            return None
+            return transceiver_dom_threshold_dict
 
         # Channel Threshold
         channel_threshold_data = self._get_eeprom_data('ChannelThreshold')
@@ -293,7 +293,7 @@ class Sfp(SfpBase):
             txBiasHighWarn = channel_threshold_data['data']['TxBiasHighWarning']['value']
             txBiasLowWarn = channel_threshold_data['data']['TxBiasLowWarning']['value']
         else:
-            return None
+            return transceiver_dom_threshold_dict
 
         transceiver_dom_threshold_dict['temphighalarm'] = tempHighAlarm
         transceiver_dom_threshold_dict['templowalarm'] = tempLowAlarm
@@ -367,7 +367,7 @@ class Sfp(SfpBase):
             rx_power = channel_monitor_data['data']['RX4Power']['value']
             rx_power_list.append(rx_power)
         else:
-            return None
+            return transceiver_dom_dict
 
         transceiver_dom_dict['rx_los'] = rx_los
         transceiver_dom_dict['tx_fault'] = tx_fault

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/z9100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/scripts/z9100_platform.sh
@@ -107,8 +107,8 @@ switch_board_qsfp_mux() {
 #Attach/Detach the SFP modules on PCA9548_2
 switch_board_sfp() {
     case $1 in
-        "new_device")    i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
-                         i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
+        "new_device")    i2c_config "echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
+                         i2c_config "echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
                          ;;
         "delete_device") i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
                          i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
@@ -125,7 +125,7 @@ switch_board_qsfp() {
         "new_device")
                         for ((i=18;i<=49;i++));
                         do
-                            i2c_config "echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
+                            i2c_config "echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
                         done
                         ;;
         "delete_device")

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/sfp.py
@@ -44,7 +44,7 @@ info_dict_keys = ['type', 'hardwarerev', 'serialnum',
                   'manufacturename', 'modelname', 'Connector',
                   'encoding', 'ext_identifier', 'ext_rateselect_compliance',
                   'cable_type', 'cable_length', 'nominal_bit_rate',
-                  'specification_compliance', 'vendor_date', 'vendor_oui']
+                  'specification_compliance', ,'type_abbrv_name','vendor_date', 'vendor_oui']
 
 dom_dict_keys = ['rx_los',       'tx_fault',   'reset_status',
                  'power_lpmode', 'tx_disable', 'tx_disable_channel',
@@ -87,6 +87,7 @@ sff8436_parser = {
  'nominal_bit_rate': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
  'specification_compliance':
                      [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
+ 'type_abbrv_name': [INFO_OFFSET,  0,  20, 'parse_sfp_info_bulk'],
   'manufacturename': [INFO_OFFSET, 20, 16, 'parse_vendor_name'],
        'vendor_oui': [INFO_OFFSET,  37, 3, 'parse_vendor_oui'],
         'modelname': [INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
@@ -186,6 +187,7 @@ class Sfp(SfpBase):
             identifier = iface_data['data']['type']['value']
             bit_rate = str(
                 iface_data['data']['Nominal Bit Rate(100Mbs)']['value'])
+            type_abbrv_name=iface_data['data']['type_abbrv_name']['value']
 
             for key in compliance_code_tup:
                 if key in iface_data['data']['Specification compliance']['value']:
@@ -195,49 +197,49 @@ class Sfp(SfpBase):
                     cable_type = key
                     cable_length = str(iface_data['data'][key]['value'])
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Date
         vendor_date_data = self._get_eeprom_data('vendor_date')
         if (vendor_date_data is not None):
             vendor_date = vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Name
         vendor_name_data = self._get_eeprom_data('manufacturename')
         if (vendor_name_data is not None):
             vendor_name = vendor_name_data['data']['Vendor Name']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor OUI
         vendor_oui_data = self._get_eeprom_data('vendor_oui')
         if (vendor_oui_data is not None):
             vendor_oui = vendor_oui_data['data']['Vendor OUI']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor PN
         vendor_pn_data = self._get_eeprom_data('modelname')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Revision
         vendor_rev_data = self._get_eeprom_data('hardwarerev')
         if (vendor_rev_data is not None):
             vendor_rev = vendor_rev_data['data']['Vendor Rev']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Vendor Serial Number
         vendor_sn_data = self._get_eeprom_data('serialnum')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:
-            return None
+            return transceiver_info_dict
 
         # Fill The Dictionary and return
         transceiver_info_dict['type'] = identifier
@@ -256,6 +258,7 @@ class Sfp(SfpBase):
             compliance_code_dict)
         transceiver_info_dict['vendor_date'] = vendor_date
         transceiver_info_dict['vendor_oui'] = vendor_oui
+	transceiver_info_dict['type_abbrv_name']=type_abbrv_name	
 
         return transceiver_info_dict
 
@@ -279,7 +282,7 @@ class Sfp(SfpBase):
             vccHighWarn = module_threshold_data['data']['VccHighWarning']['value']
             vccLowWarn = module_threshold_data['data']['VccLowWarning']['value']
         else:
-            return None
+            return transceiver_dom_threshold_dict
 
         # Channel Threshold
         channel_threshold_data = self._get_eeprom_data('ChannelThreshold')
@@ -293,7 +296,7 @@ class Sfp(SfpBase):
             txBiasHighWarn = channel_threshold_data['data']['TxBiasHighWarning']['value']
             txBiasLowWarn = channel_threshold_data['data']['TxBiasLowWarning']['value']
         else:
-            return None
+            return transceiver_dom_threshold_dict
 
         transceiver_dom_threshold_dict['temphighalarm'] = tempHighAlarm
         transceiver_dom_threshold_dict['templowalarm'] = tempLowAlarm
@@ -367,7 +370,7 @@ class Sfp(SfpBase):
             rx_power = channel_monitor_data['data']['RX4Power']['value']
             rx_power_list.append(rx_power)
         else:
-            return None
+            return transceiver_dom_dict
 
         transceiver_dom_dict['rx_los'] = rx_los
         transceiver_dom_dict['tx_fault'] = tx_fault


### PR DESCRIPTION

**- What I did**

- Changed sff84xx driver to optoe driver.

**- How I did it**

- Changed the platform init script to support optoe driver.

**- How to verify it**

- Check sfp presence,eeprom,dom information and also check whether xcvrd is running fine.
- Reboot the device,do OIR and check sfpshow commands

**- Description for the changelog**

- optoe driver truncates invalid pages(ff) but sff driver doesn't truncate.so,the DOM related calculation made by sff8436 driver will show incorrect data.
- Few optics doesn't support DOM.
- SFP plugins currently returns None for unreadable pages and this'd throw the below mentioned error in sfpshow eeprom --dom.

root@sonic:/sys/class/i2c-adapter/i2c-32/32-0050# sfpshow eeprom -p Ethernet1 -d
Traceback (most recent call last):
File "/usr/bin/sfpshow", line 358, in <module>
cli()
File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in _call_
return self.main(*args, **kwargs)
File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
rv = self.invoke(ctx)
File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
return callback(*args, **kwargs)
File "/usr/bin/sfpshow", line 348, in eeprom
sfp.display_eeprom(port, dump_dom)
File "/usr/bin/sfpshow", line 293, in display_eeprom
out_put = self.convert_interface_sfp_info_to_cli_output_string(self.sdb, interfacename, dump_dom)
File "/usr/bin/sfpshow", line 282, in convert_interface_sfp_info_to_cli_output_string
dom_output = self.convert_dom_to_output_string(sfp_type, dom_info_dict)
File "/usr/bin/sfpshow", line 186, in convert_dom_to_output_string
channel_threshold_align)
File "/usr/bin/sfpshow", line 146, in format_dict_value_to_string
if dom_info_dict is not None and dom_info_dict[key] != 'N/A':
KeyError: 'rxpowerhighalarm'


- To fix it,return dictionary itself with 'N/A' values as it's been handled in sfpshow script. 

- Changed the wrong DOM offset used in Z9264f  


UT logs:
[S6000_UT.txt](https://github.com/Azure/sonic-buildimage/files/3841355/S6000_UT.txt)
[s6100_UT.txt](https://github.com/Azure/sonic-buildimage/files/3841356/s6100_UT.txt)
[Z9100_UT.txt](https://github.com/Azure/sonic-buildimage/files/3841357/Z9100_UT.txt)
[Z9264f_UT.txt](https://github.com/Azure/sonic-buildimage/files/3841358/Z9264f_UT.txt)
