### PR TITLE
[Services] Restart Sflow service upon unexpected critical process exit.

### DIFF
--- a/dockers/docker-sflow/Dockerfile.j2
+++ b/dockers/docker-sflow/Dockerfile.j2
@@ -29,5 +29,7 @@ RUN sed -ri '/^DAEMON_ARGS=""/c DAEMON_ARGS="-c /var/log/hsflowd.crash"' /etc/in
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
+COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
+COPY ["critical_processes", "/etc/supervisor"]
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-sflow/Dockerfile.j2
+++ b/dockers/docker-sflow/Dockerfile.j2
@@ -32,4 +32,5 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
+
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-sflow/Dockerfile.j2
+++ b/dockers/docker-sflow/Dockerfile.j2
@@ -32,5 +32,4 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-sflow/critical_processes
+++ b/dockers/docker-sflow/critical_processes
@@ -1,0 +1,1 @@
+sflowmgrd

--- a/dockers/docker-sflow/supervisord.conf
+++ b/dockers/docker-sflow/supervisord.conf
@@ -3,6 +3,12 @@ logfile_maxbytes=1MB
 logfile_backups=2
 nodaemon=true
 
+[eventlistener:supervisor-proc-exit-listener]
+command=/usr/bin/supervisor-proc-exit-listener
+events=PROCESS_STATE_EXITED
+autostart=true
+autorestart=unexpected
+
 [program:start.sh]
 command=/usr/bin/start.sh
 priority=1

--- a/files/build_templates/sflow.service.j2
+++ b/files/build_templates/sflow.service.j2
@@ -3,12 +3,16 @@ Description=sFlow container
 Requires=swss.service
 After=swss.service
 Before=ntp-config.service
+StartLimitIntervalSec=1200
+StartLimitBurst=3
 
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/rules/docker-sflow.mk
+++ b/rules/docker-sflow.mk
@@ -32,4 +32,4 @@ $(DOCKER_SFLOW)_RUN_OPT += -v /host/warmboot:/var/warmboot
 
 $(DOCKER_SFLOW)_BASE_IMAGE_FILES += psample:/usr/bin/psample
 $(DOCKER_SFLOW)_BASE_IMAGE_FILES += sflowtool:/usr/bin/sflowtool
-
+$(DOCKER_SFLOW)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
- What I did
Restart Sflow service if one of critical processes running in Sflow container exited or crashed abnormally.

- How I did it
Generally I follow the framework created by Joe to implement this feature in Sflow container.
**First**, add supervisor-proc-exit-listener event listener option in Supervisord configuration file in Sflow docker container. Supervisord will read a list of critical processes for which to monitor the unexpected crashed and exited.
**Second**, configure Sflow .service to always auto-restart the service if it stops, with a delay of 30 seconds. Also set a rate limit of 3 restarts within 20 minutes (1200 seconds).

- How to verify it
On your switch device, please use _docker ps_ command to list all running docker containers.
Then use _docker exec -it container_id bash_ to login target container. Typing _top_ command
on the shell will display all the processes dynamically and you will spot the process id of one
of the critical processes. Finally type the command _kill -9 process_id_ to terminate one process.
After exiting the container, you can use _watch -n 1 docker ps_ to dynamically see the restart
of Sflow container.