### PR TITLE
[rsyslog] Add support for IPv6 remote addresses

### DIFF
--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -42,7 +42,7 @@ $ActionFileDefaultTemplate SONiCFileFormat
 
 #Set remote syslog server
 {% for server in SYSLOG_SERVER %}
-*.* @{{ server }}:514;SONiCFileFormat
+*.* @[{{ server }}]:514;SONiCFileFormat
 {% endfor %}
 
 #


### PR DESCRIPTION
**- What I did**

Add support for IPv6 addresses of remote syslog servers in rsyslog.conf.j2 template

**- How I did it**

Enclose server address in square brackets.

According to the [documentation](https://buildmedia.readthedocs.org/media/pdf/rsyslog/stable/rsyslog.pdf), IPv6 addresses must be enclosed in square brackets. However, it also states that IPv4 addresses as well as host names will also work if enclosed in square brackets. Thus, in order to avoid unnecessary conditional logic, all syslog server addresses will be enclosed in square brackets in the generated rsyslog.conf file.

**- How to verify it**

Configure the device to have IPv6 addresses for syslog servers and confirm it works.