### PR TITLE
multiDB : add database_config.json into vs images

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -106,6 +106,7 @@ COPY ["files/configdb-load.sh", "/usr/bin/"]
 COPY ["files/arp_update", "/usr/bin/"]
 COPY ["files/buffers_config.j2", "files/qos_config.j2", "/usr/share/sonic/templates/"]
 COPY ["files/sonic_version.yml", "/etc/sonic/"]
+COPY ["database_config.json", "/etc/default/sonic-db/"]
 
 # Workaround the tcpdump issue
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump

--- a/platform/vs/docker-sonic-vs/database_config.json
+++ b/platform/vs/docker-sonic-vs/database_config.json
@@ -1,0 +1,57 @@
+{
+    "INSTANCES": {
+        "redis":{
+            "hostname" : "127.0.0.1",
+            "port" : 6379,
+            "unix_socket_path" : "/var/run/redis/redis.sock"
+        }
+    },
+    "DATABASES" : {
+        "APPL_DB" : {
+            "id" : 0,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "ASIC_DB" : {
+            "id" : 1,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "COUNTERS_DB" : {
+            "id" : 2,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "LOGLEVEL_DB" : {
+            "id" : 3,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "CONFIG_DB" : {
+            "id" : 4,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "PFC_WD_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "FLEX_COUNTER_DB" : {
+            "id" : 5,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "STATE_DB" : {
+            "id" : 6,
+            "separator": "|",
+            "instance" : "redis"
+        },
+        "SNMP_OVERLAY_DB" : {
+            "id" : 7,
+            "separator": "|",
+            "instance" : "redis"
+        }
+    },
+    "VERSION" : "1.0"
+}

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -29,7 +29,8 @@ rm -f /var/run/rsyslogd.pid
 
 supervisorctl start rsyslogd
 
-mkdir -p /var/run/redis
+mkdir -p /var/run/redis/sonic-db
+cp /etc/default/sonic-db/database_config.json /var/run/redis/sonic-db/
 
 supervisorctl start redis-server
 


### PR DESCRIPTION
* like what we did in docker-database running on DUT, on vs image we should have the database_config.json in place as well
* vs image has a default startup config at /etc/default/sonic-db/
* after mount /var/run/redis, in start.sh we copy startup config to running config at /var/run/redis/sonic-db/

* verified when running vs  tests, we can see the file mounted at /var/run/redis-vs/{sw-name}/sonic-db on host which is mapping to /var/run/redis/sonic-db/ on vs
```
dzhang@30-57-186-217:~/MS_VS/sonic-buildimage$ ls /var/run/redis-vs/heuristic_haibt/sonic-db/database_config.json 
/var/run/redis-vs/heuristic_haibt/sonic-db/database_config.json
dzhang@30-57-186-217:~/MS_VS/sonic-buildimage$ 
```
