### PR TITLE
Fix vrf test failed after frr update to 7.2

### DIFF
--- a/src/sonic-frr/patch/0005-nexthops-compare-vrf-only-if-ip-type.patch
+++ b/src/sonic-frr/patch/0005-nexthops-compare-vrf-only-if-ip-type.patch
@@ -1,0 +1,73 @@
+From 2f0b5aef66316b47d2cc8ac18453600621a6a317 Mon Sep 17 00:00:00 2001
+From: Tyler Li <tyler.li@mediatek.com>
+Date: Thu, 14 Nov 2019 23:46:52 -0800
+Subject: [PATCH] nexthops compare vrf only if ip type
+
+---
+ lib/nexthop.c | 12 ++++++------
+ lib/zclient.c | 12 ++++++------
+ 2 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/lib/nexthop.c b/lib/nexthop.c
+index cf5bed3d6..7d9f646c9 100644
+--- a/lib/nexthop.c
++++ b/lib/nexthop.c
+@@ -105,12 +105,6 @@ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
+ {
+ 	int ret = 0;
+ 
+-	if (next1->vrf_id < next2->vrf_id)
+-		return -1;
+-
+-	if (next1->vrf_id > next2->vrf_id)
+-		return 1;
+-
+ 	if (next1->type < next2->type)
+ 		return -1;
+ 
+@@ -120,6 +114,12 @@ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
+ 	switch (next1->type) {
+ 	case NEXTHOP_TYPE_IPV4:
+ 	case NEXTHOP_TYPE_IPV6:
++		if (next1->vrf_id < next2->vrf_id)
++			return -1;
++
++		if (next1->vrf_id > next2->vrf_id)
++			return 1;
++
+ 		ret = _nexthop_gateway_cmp(next1, next2);
+ 		if (ret != 0)
+ 			return ret;
+diff --git a/lib/zclient.c b/lib/zclient.c
+index c739af043..0d37c46d1 100644
+--- a/lib/zclient.c
++++ b/lib/zclient.c
+@@ -783,12 +783,6 @@ static int zapi_nexthop_cmp_no_labels(const struct zapi_nexthop *next1,
+ {
+ 	int ret = 0;
+ 
+-	if (next1->vrf_id < next2->vrf_id)
+-		return -1;
+-
+-	if (next1->vrf_id > next2->vrf_id)
+-		return 1;
+-
+ 	if (next1->type < next2->type)
+ 		return -1;
+ 
+@@ -798,6 +792,12 @@ static int zapi_nexthop_cmp_no_labels(const struct zapi_nexthop *next1,
+ 	switch (next1->type) {
+ 	case NEXTHOP_TYPE_IPV4:
+ 	case NEXTHOP_TYPE_IPV6:
++		if (next1->vrf_id < next2->vrf_id)
++			return -1;
++
++		if (next1->vrf_id > next2->vrf_id)
++			return 1;
++
+ 		ret = nexthop_g_addr_cmp(next1->type, &next1->gate,
+ 					 &next2->gate);
+ 		if (ret != 0)
+-- 
+2.11.0
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -2,4 +2,5 @@
 0002-Reduce-severity-of-Vty-connected-from-message.patch
 0003-Use-vrf_id-for-vrf-not-tabled_id.patch
 0004-Allow-BGP-attr-NEXT_HOP-to-be-0.0.0.0-due-to-allevia.patch
+0005-nexthops-compare-vrf-only-if-ip-type.patch
 0006-changes-for-making-snmp-socket-non-blocking.patch


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix zebra crash bug, add a frr patch.

**- How I did it**
In patch change nexthops compare function, only when nexthop type ip, compare vrf first.

**- How to verify it**
VS tests pass, I have test locally.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
