### PR TITLE
The change of port mac would trigger teamd to send LACP pdu instantly

### DIFF
--- a/src/libteam/patch/0011-teamd-Send-lacp-pdu-when-system-id-changed.patch
+++ b/src/libteam/patch/0011-teamd-Send-lacp-pdu-when-system-id-changed.patch
@@ -1,0 +1,41 @@
+From c45b4b2be82c960eb01fc884480f1ef9a6a2c1a6 Mon Sep 17 00:00:00 2001
+From: "jianjun.dong" <jianjun.dong@nephosinc.com>
+Date: Fri, 15 Nov 2019 00:47:40 -0800
+Subject: [PATCH] [PATCH] [libteam]: When change HW addr, send LACP PDU
+
+---
+ teamd/teamd_runner_lacp.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 23c8949..ea8e229 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -1200,11 +1200,15 @@ static int lacp_port_partner_update(struct lacp_port *lacp_port)
+ 	return 0;
+ }
+ 
++static int lacpdu_send(struct lacp_port *lacp_port);
++
+ static void lacp_port_actor_system_update(struct lacp_port *lacp_port)
+ {
+ 	struct lacpdu_info *actor = &lacp_port->actor;
+ 
+ 	memcpy(actor->system, lacp_port->ctx->hwaddr, ETH_ALEN);
++	teamd_log_dbg("Actor system id changed, send lacp pdu from %s.", lacp_port->tdport->ifname);
++	lacpdu_send(lacp_port);
+ }
+ 
+ static int lacp_portname_to_port_id(const char* name)
+@@ -1255,8 +1259,6 @@ static void lacp_port_actor_update(struct lacp_port *lacp_port)
+ 	lacp_port->actor.state = state;
+ }
+ 
+-static int lacpdu_send(struct lacp_port *lacp_port);
+-
+ static int lacp_port_set_state(struct lacp_port *lacp_port,
+ 			       enum lacp_port_state new_state)
+ {
+-- 
+2.11.0
+

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -8,3 +8,4 @@
 0008-libteam-Add-warm_reboot-mode.patch
 0009-Fix-ifinfo_link_with_port-race-condition-with-newlink.patch
 0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch
+0011-teamd-Send-lacp-pdu-when-system-id-changed.patch


### PR DESCRIPTION
Signed-off-by: shine.chen <shine.chen@mediatek.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In MCLAG scenario when keep-alive connection between active and standby node is down , standby node port mac will be changed to his original mac. After host node receives LACP pdu from standby node, it will remove the local port connected to standby node from port-channel and switch all traffic to active node. But In existed teamd implementation when  the port src mac is changed it doesn't send LACP pdu instantly , but wait for timer event. It would cause host still forward half of the traffic to standby node for quite a long period( maybe up to 30 seconds). During this period these traffic would be dropped.  So we add a patch for teamd here. The change of port mac would trigger teamd to send LACP pdu instantly.

**- How I did it**
The change of port mac would trigger teamd to send LACP pdu instantly.

**- How to verify it**
After apply this patch the disruptive time decrease to less than 20ms.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
