### PR TITLE
[config_samples.py] 100G port enable fec by default

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -30,6 +30,9 @@ def generate_t1_sample_config(data):
                 'asn': str(peer_asn),
                 'keepalive': '60'
                 }
+        if data['PORT'][port]['speed'] == '100000':
+            data['PORT'][port]['fec'] = 'rs'
+
         port_count += 1
     return data;
 
@@ -52,6 +55,9 @@ def generate_l2_config(data):
     data['VLAN_MEMBER'] = {}
     for port in natsorted(data['PORT'].keys()):
         data['VLAN_MEMBER']['Vlan1000|{}'.format(port)] = {'tagging_mode': 'untagged'}
+        if data['PORT'][port]['speed'] == '100000':
+            data['PORT'][port]['fec'] = 'rs'
+
     return data
 
 _sample_generators = {


### PR DESCRIPTION
Signed-off-by: tengfei <tengfei@asterfusion.com>

**- What I did**
100G port enable fec by default in t1 and l2 template
**- How I did it**
If a port's speed is 100G , the enable fec:rs
**- How to verify it**
Install sonic under onie, then check if fec of 100G port is enable in config_db.json
**- Description for the changelog**
According to the logic of "minigraph.py", the 100G port should enable fec in default
**- A picture of a cute animal (not mandatory but encouraged)**
