### PR TITLE
[devices]: Fix the clock setting on arista 7280

### DIFF
--- a/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C28S8/jr2-a7280cr3-32p4-28x100G-8x10G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C28S8/jr2-a7280cr3-32p4-28x100G-8x10G.config.bcm
@@ -277,11 +277,15 @@ bcm_stat_interval.BCM8869X=1000
 mem_cache_enable_ecc.BCM8869X=1
 mem_cache_enable_parity.BCM8869X=1
 
-serdes_nif_clk_freq_in.BCM8869X=2
-serdes_nif_clk_freq_out.BCM8869X=1
+serdes_nif_clk_freq_in.BCM8869X_A0=2
+serdes_nif_clk_freq_out.BCM8869X_A0=1
+serdes_fabric_clk_freq_in.BCM8869X_A0=2
+serdes_fabric_clk_freq_out.BCM8869X_A0=1
 
-serdes_fabric_clk_freq_in.BCM8869X=2
-serdes_fabric_clk_freq_out.BCM8869X=1
+serdes_nif_clk_freq_in.BCM8869X=1
+serdes_nif_clk_freq_out.BCM8869X=bypass
+serdes_fabric_clk_freq_in.BCM8869X=1
+serdes_fabric_clk_freq_out.BCM8869X=bypass
 
 dram_phy_tune_mode_on_init.BCM8869X=RUN_TUNE
 

--- a/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C40/jr2-a7280cr3-32p4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C40/jr2-a7280cr3-32p4-40x100G.config.bcm
@@ -281,11 +281,15 @@ bcm_stat_interval.BCM8869X=1000
 mem_cache_enable_ecc.BCM8869X=1
 mem_cache_enable_parity.BCM8869X=1
 
-serdes_nif_clk_freq_in.BCM8869X=2
-serdes_nif_clk_freq_out.BCM8869X=1
+serdes_nif_clk_freq_in.BCM8869X_A0=2
+serdes_nif_clk_freq_out.BCM8869X_A0=1
+serdes_fabric_clk_freq_in.BCM8869X_A0=2
+serdes_fabric_clk_freq_out.BCM8869X_A0=1
 
-serdes_fabric_clk_freq_in.BCM8869X=2
-serdes_fabric_clk_freq_out.BCM8869X=1
+serdes_nif_clk_freq_in.BCM8869X=1
+serdes_nif_clk_freq_out.BCM8869X=bypass
+serdes_fabric_clk_freq_in.BCM8869X=1
+serdes_fabric_clk_freq_out.BCM8869X=bypass
 
 dram_phy_tune_mode_on_init.BCM8869X=RUN_TUNE
 

--- a/src/sonic-device-data/tests/config_checker
+++ b/src/sonic-device-data/tests/config_checker
@@ -31,7 +31,7 @@ def check_file(file_name):
                 p = line.split("=", 1)[0]
 
                 # Remove trailing chip name "bcm8869x"
-                p = re.sub(r"\.bcm8869x(_adapter)?$", "", p)
+                p = re.sub(r"\.bcm8869x(_adapter|_[a-z]\d)?$", "", p)
                 # Remove trailing unit ".<number>$"
                 p = re.sub(r"\.[0-9]+$", '', p)
                 # Remove trailing port name


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix the the serdes nif/fabric clock setting for the ASIC chip with revision B0/B1 on Arista 7280. It is still backward compatible with A0.

**- A picture of a cute animal (not mandatory but encouraged)**
