### PR TITLE
[docker-fpm-frr]: Enable sending ipv6 prefixes over ipv4 BGPMON session

### DIFF
--- a/dockers/docker-fpm-frr/bgpd.conf.default.j2
+++ b/dockers/docker-fpm-frr/bgpd.conf.default.j2
@@ -24,9 +24,9 @@ route-map TO_BGP_PEER_V4 permit 100
 route-map TO_BGP_PEER_V6 permit 100
 !
 {% if BGP_MONITORS is defined and BGP_MONITORS|length > 0 %}
-route-map FROM_BGPMON_V4 deny 10
+route-map FROM_BGPMON deny 10
 !
-route-map TO_BGPMON_V4 permit 10
+route-map TO_BGPMON permit 10
 !
 {% endif %}
 !
@@ -136,21 +136,24 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endblock bgp_peers_with_range %}
 {% block bgp_monitors %}
 {% if BGP_MONITORS is defined and BGP_MONITORS|length > 0 %}
-  neighbor BGPMON_V4 peer-group
+  neighbor BGPMON peer-group
 {% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 and name == 'Loopback0' %}
-  neighbor BGPMON_V4 update-source {{ prefix | ip }}
+  neighbor BGPMON update-source {{ prefix | ip }}
 {% endif %}
 {% endfor %}
-  neighbor BGPMON_V4 route-map FROM_BGPMON_V4 in
-  neighbor BGPMON_V4 route-map TO_BGPMON_V4 out
-  neighbor BGPMON_V4 send-community
-  neighbor BGPMON_V4 maximum-prefix 1
+  neighbor BGPMON route-map FROM_BGPMON in
+  neighbor BGPMON route-map TO_BGPMON out
+  neighbor BGPMON send-community
+  neighbor BGPMON maximum-prefix 1
 {% for neighbor_addr, bgp_session in BGP_MONITORS.items() %}
   neighbor {{ neighbor_addr }} remote-as {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
-  neighbor {{ neighbor_addr }} peer-group BGPMON_V4
+  neighbor {{ neighbor_addr }} peer-group BGPMON
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
   neighbor {{ neighbor_addr }} activate
+  address-family ipv6
+    neighbor {{ neighbor_addr }} activate
+  exit-address-family
 {% endfor %}
 {% endif %}
 {% endblock bgp_monitors %}

--- a/src/sonic-config-engine/tests/sample_output/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/bgpd_frr.conf
@@ -31,9 +31,9 @@ route-map TO_BGP_PEER_V4 permit 100
 !
 route-map TO_BGP_PEER_V6 permit 100
 !
-route-map FROM_BGPMON_V4 deny 10
+route-map FROM_BGPMON deny 10
 !
-route-map TO_BGPMON_V4 permit 10
+route-map TO_BGPMON permit 10
 !
 !
 route-map ISOLATE permit 10
@@ -73,14 +73,17 @@ router bgp 65100
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
   exit-address-family
-  neighbor BGPMON_V4 peer-group
-  neighbor BGPMON_V4 update-source 10.1.0.32
-  neighbor BGPMON_V4 route-map FROM_BGPMON_V4 in
-  neighbor BGPMON_V4 route-map TO_BGPMON_V4 out
-  neighbor BGPMON_V4 send-community
-  neighbor BGPMON_V4 maximum-prefix 1
+  neighbor BGPMON peer-group
+  neighbor BGPMON update-source 10.1.0.32
+  neighbor BGPMON route-map FROM_BGPMON in
+  neighbor BGPMON route-map TO_BGPMON out
+  neighbor BGPMON send-community
+  neighbor BGPMON maximum-prefix 1
   neighbor 10.20.30.40 remote-as 65100
-  neighbor 10.20.30.40 peer-group BGPMON_V4
+  neighbor 10.20.30.40 peer-group BGPMON
   neighbor 10.20.30.40 description BGPMonitor
   neighbor 10.20.30.40 activate
+  address-family ipv6
+    neighbor 10.20.30.40 activate
+  exit-address-family
 !!

--- a/src/sonic-config-engine/tests/sample_output/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/frr.conf
@@ -63,9 +63,9 @@ route-map TO_BGP_PEER_V4 permit 100
 !
 route-map TO_BGP_PEER_V6 permit 100
 !
-route-map FROM_BGPMON_V4 deny 10
+route-map FROM_BGPMON deny 10
 !
-route-map TO_BGPMON_V4 permit 10
+route-map TO_BGPMON permit 10
 !
 !
 route-map ISOLATE permit 10
@@ -105,14 +105,17 @@ router bgp 65100
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
   exit-address-family
-  neighbor BGPMON_V4 peer-group
-  neighbor BGPMON_V4 update-source 10.1.0.32
-  neighbor BGPMON_V4 route-map FROM_BGPMON_V4 in
-  neighbor BGPMON_V4 route-map TO_BGPMON_V4 out
-  neighbor BGPMON_V4 send-community
-  neighbor BGPMON_V4 maximum-prefix 1
+  neighbor BGPMON peer-group
+  neighbor BGPMON update-source 10.1.0.32
+  neighbor BGPMON route-map FROM_BGPMON in
+  neighbor BGPMON route-map TO_BGPMON out
+  neighbor BGPMON send-community
+  neighbor BGPMON maximum-prefix 1
   neighbor 10.20.30.40 remote-as 65100
-  neighbor 10.20.30.40 peer-group BGPMON_V4
+  neighbor 10.20.30.40 peer-group BGPMON
   neighbor 10.20.30.40 description BGPMonitor
   neighbor 10.20.30.40 activate
+  address-family ipv6
+    neighbor 10.20.30.40 activate
+  exit-address-family
 !!


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added support of sending RIB IPv6 over BGPMON ipv4 session

**- How I did it**
Activated bgpmon peer under ipv6 unicast address family

**- How to verify it**
Build dut and check what prefixes are sent over bgpmon session
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
