### PR TITLE
[swss.sh] When starting, call 'systemctl restart' on dependents, not 'systemctl start'

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -85,7 +85,9 @@ start_peer_and_dependent_services() {
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         /bin/systemctl start ${PEER}
         for dep in ${DEPENDENT}; do
-            /bin/systemctl start ${dep}
+            # Here we call `systemctl restart` on each dependent service instead of `systemctl start` to
+            # ensure the services actually get stopped and started in case they were not previously stopped.
+            /bin/systemctl restart ${dep}
         done
     fi
 }


### PR DESCRIPTION
**- What I did**

When SwSS starts in non-warm-boot mode, it also starts its dependent services (currently radv and teamd). Previously, it did so by calling `systemctl start`. However, in the case that the dependent services had not previously been stopped, `systemctl start` would basically become a no-op, as it would see the service(s) were already started and do nothing. However, the expected behavior is for the dependent services to start anew, thus this patch changes the behavior to calling `systemctl restart`, which will first stop the dependent services if they are already running, then start them.