### PR TITLE
[minigraph.py] Fix telemetry server key name

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -630,7 +630,7 @@ def parse_xml(filename, platform=None, port_config_file=None):
         },
         'x509': {
             'server_crt': '/etc/sonic/telemetry/streamingtelemetryserver.cer',
-            'server_key': '/etc/sonic/telemetry/streamingtelemetryclient.key',
+            'server_key': '/etc/sonic/telemetry/streamingtelemetryserver.key',
             'ca_crt': '/etc/sonic/telemetry/dsmsroot.cer'
         }
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed incorrect server key name
**- How I did it**

**- How to verify it**
Verified against the sonic image to start telemetry container using correct cert and key
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
