### PR TITLE
[services] sflow service sets swss service as Requisite=, not Requires=

### DIFF
--- a/files/build_templates/sflow.service.j2
+++ b/files/build_templates/sflow.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=sFlow container
-Requires=swss.service
+Requisite=swss.service
 After=swss.service syncd.service
 Before=ntp-config.service
 StartLimitIntervalSec=1200


### PR DESCRIPTION
The sflow service should not start unless the swss service is started. However, if this service is not started, the sflow service should not attempt to start them, instead it should simply fail to start. Using Requisite=, we will achieve this behavior, whereas using Requires= will cause the required service to be started.