### PR TITLE
[services] Remove explicit dependencies from dhcp_relay service file, control in swss.sh

### DIFF
--- a/files/build_templates/dhcp_relay.service.j2
+++ b/files/build_templates/dhcp_relay.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=DHCP relay container
-Requires=updategraph.service swss.service teamd.service
+Requires=updategraph.service
 After=updategraph.service swss.service syncd.service teamd.service
 Before=ntp-config.service
 StartLimitIntervalSec=1200
@@ -15,4 +15,4 @@ Restart=always
 RestartSec=30
 
 [Install]
-WantedBy=multi-user.target swss.service teamd.service
+WantedBy=multi-user.target

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -2,7 +2,7 @@
 
 SERVICE="swss"
 PEER="syncd"
-DEPENDENT="teamd radv"
+DEPENDENT="teamd radv dhcp_relay"
 DEBUGLOG="/tmp/swss-syncd-debug.log"
 LOCKFILE="/tmp/swss-syncd-lock"
 


### PR DESCRIPTION
Remove swss and teamd services from both the `Requires=` and `WantedBy=` fields of the dhcp_relay service file, and instead control the dhcp_relay service from the swss.sh script along with the teamd and radv services.

Removing the services from `Requires=` field will prevent dhcp_relay from automatically starting teamd when it is started (in case it gets started while teamd is supposed to be shut down), and removing the services from the `WantedBy=` field will prevent dhcp_relay getting started by systemd if swss or teamd get started. Instead, dhcp_relay will only be started by the swss.sh script in the proper order, ensuring that teamd is always started before dhcp_relay.