### PR TITLE
[dhcp_relay] Add extra sleep before starting relay agent processes

### DIFF
--- a/dockers/docker-dhcp-relay/start.sh
+++ b/dockers/docker-dhcp-relay/start.sh
@@ -16,6 +16,12 @@ if [ $(supervisorctl status | grep -c "^isc-dhcp-relay:") -gt 0 ]; then
     # lifetime of the process.
     /usr/bin/wait_for_intf.sh
 
+    # Allow a bit more time for interfaces to settle before starting the
+    # relay agent processes.
+    # FIXME: Remove/decrease this once we determine how to prevent future race
+    # conditions here.
+    sleep 180
+
     # Start all DHCP relay agent(s)
     supervisorctl start isc-dhcp-relay:*
 fi


### PR DESCRIPTION
Add extra sleep to prevent a race condition where the relay agent processes can start up before all interfaces it listens on are ready.