### PR TITLE
Revert "[swss.sh] When starting, call 'systemctl restart' on dependents, not 'systemctl start'"

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -85,9 +85,7 @@ start_peer_and_dependent_services() {
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         /bin/systemctl start ${PEER}
         for dep in ${DEPENDENT}; do
-            # Here we call `systemctl restart` on each dependent service instead of `systemctl start` to
-            # ensure the services actually get stopped and started in case they were not previously stopped.
-            /bin/systemctl restart ${dep}
+            /bin/systemctl start ${dep}
         done
     fi
 }


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#3807

This change introduced a race condition at boot up time to allow teamd to restart. And the consequence is that lags are not configured with IP addresses.