### PR TITLE
[201811][isc-dhcp-relay] Patch to allow DHCP relay agent to discover interfaces even if they are down

### DIFF
--- a/src/isc-dhcp/patch/0013-Don-t-skip-down-interfaces-when-discovering-interfac.patch
+++ b/src/isc-dhcp/patch/0013-Don-t-skip-down-interfaces-when-discovering-interfac.patch
@@ -1,0 +1,32 @@
+From 422b08d47dca630396fa38d4239b9c0847dd4fb5 Mon Sep 17 00:00:00 2001
+From: Joe LeVeque <jolevequ@microsoft.com>
+Date: Fri, 6 Dec 2019 06:09:17 +0000
+Subject: [PATCH] Don't skip down interfaces when discovering interfaces in
+ relay mode
+
+When discovering interfaces in relay mode, don't skip interfaces just
+because they're down. If we fail to discover the interfaces because they
+are down when the relay starts, but then are brought up at a later point
+in time, the relay will discard any packets received on them because it
+didn't discover the interface(s) when it started up.
+---
+ common/discover.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/common/discover.c b/common/discover.c
+index bf82735..f57e3ef 100644
+--- a/common/discover.c
++++ b/common/discover.c
+@@ -1014,7 +1014,8 @@ discover_interfaces(int state) {
+ 		      info.flags & IFF_LOOPBACK ||
+ 		      info.flags & IFF_POINTOPOINT) && !tmp) ||
+ 		    (!(info.flags & IFF_UP) &&
+-		     state != DISCOVER_UNCONFIGURED))
++		     state != DISCOVER_UNCONFIGURED &&
++		     state != DISCOVER_RELAY))
+ 			continue;
+ 		
+ 		/* If there isn't already an interface by this name,
+-- 
+2.17.1
+

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -11,3 +11,4 @@
 0010-Add-enable-use-sockets-to-configure-flags-in-debian-.patch
 0011-Bugfix-Ensure-HAVE_SO_BINDTODEVICE-has-a-chance-to-b.patch
 0012-If-destination-of-BOOTREQUEST-is-directed-broadcast-.patch
+0013-Don-t-skip-down-interfaces-when-discovering-interfac.patch


### PR DESCRIPTION
**- What I did**

Patch isc-dhcp-relay in order to allow the relay agent to discover configured interfaces even if they are down.

Without this patch, the relay agent will not discover configured  interfaces if they are down when the relay agent starts up. If the interface(s) then get brought up after the relay started, the relay will discard packets received on these interfaces and log the message, `Discarding packet received on <iface_name> interface that has no IPv4 address assigned.` This led to race conditions when starting SONiC (or loading configuration). To resolve this, the relay agent would need to be restarted with all configured interfaces up. 

With this patch, the relay agent will discover all configured interfaces, whether or not they are up at the time the relay agent starts. Thus, the state of the configured interfaces can be down when the relay agent starts and brought up during the lifetime of the relay agent process, and the relay agent will relay packets as expected; it will not discard them.

This PR backports https://github.com/Azure/sonic-buildimage/pull/3851 to the 201811 branch.

**- How to verify it**

1. Stop DHCP relay service (`systemctl stop dhcp_relay.service`)
2. Ensure all configured relay interfaces are up
3. Start DHCP relay service (`systemctl start dhcp_relay.service`). Wait for the container to spawn the dhcrelay process(es).
4. a. Begin DHCP packet capture on each configured interface (`tcpdump -ne -i <iface_name> port 67 or 68` or similar command)
    b. Craft and send DHCP Discover or Request packet to the switch on the downlink (the DHCP relay test in the sonic-mgmt repo can be helpful here)
    c. Check packet capture to confirm the packet was relayed to all configured destination IP addresses on each configured uplink interface
    d. Craft and send DHCP Offer or Ack packet in on each uplink (again, the DHCP relay test in the sonic-mgmt repo can be helpful here)
    e. Check packet capture to confirm the packet was relayed to all configured destination IP addresses on each configured uplink interface
    f. Check /var/log/syslog to ensure that no `Discarding packet received on <iface_name> interface that has no IPv4 address assigned.` messages were logged
5. Stop DHCP relay service (`systemctl stop dhcp_relay.service`)
6. Bring all configured relay interfaces down
7. Start DHCP relay service (`systemctl start dhcp_relay.service`). Wait for the container to spawn the dhcrelay process(es).
8. Bring all configured relay interfaces up
9. Repeat step 4
10. Stop DHCP relay service (`systemctl stop dhcp_relay.service`)
11. Ensure all configured relay interfaces are up
12. Start DHCP relay service (`systemctl start dhcp_relay.service`). Wait for the container to spawn the dhcrelay process(es).
13. For each uplink interface:
    a. Bring down the interface on the switch, wait for a few seconds, then bring the interface back up
    b. Repeat step 4
14. For each uplink interface:
    a. Bring down the connected interface on the neighboring switch, wait for a few seconds, then bring the interface on the neighboring switch back up
    b. Repeat step 4