### PR TITLE
modified down rules to pre-down rules to ensure that default route is…

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -54,7 +54,6 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-    pre-down ip link set dev eth0 nomaster
     down cgdelete -g l3mdev:mgmt
 {% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
@@ -69,7 +68,6 @@ iface eth0 inet dhcp
     vrf mgmt
     up cgcreate -g l3mdev:mgmt
     up cgset -r l3mdev.master-device=mgmt mgmt
-    pre-down ip link set dev eth0 nomaster
     down cgdelete -g l3mdev:mgmt
 {% endif %}
 {% endif %}

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -9,19 +9,19 @@
 auto mgmt
 iface mgmt
     vrf-table 5000
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
+# The loopback network interface for mgmt VRF that is required for applications like NTP
+    up ip link add lo-m type dummy
+    up ip link set dev lo-m master mgmt
+    up ip addr add 127.0.0.1/8 dev lo-m
+    up ip link set lo-m up
+    down ip link delete dev lo-m
+{% endif %}
 {% endif %}
 {% block loopback %}
 # The loopback network interface
 auto lo
 iface lo inet loopback
-{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-# The loopback network interface for mgmt VRF that is required for applications like NTP
-    up ip link add lo-m type dummy
-    up ip addr add 127.0.0.1/8 dev lo-m
-    up ip link set lo-m up
-    up ip link set dev lo-m master mgmt
-	down ip link delete dev lo-m
-{% endif %}
 {% endblock loopback %}
 {% block mgmt_interface %}
 
@@ -50,14 +50,15 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     up ip rule add to {{ route }} table {{ vrf_table }}
 {% endfor %}
     # management port down rules
-    down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }}
-    down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
-    down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
+    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }}
+    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
+    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
+    pre-down ip link set dev eth0 nomaster
     down cgdelete -g l3mdev:mgmt
 {% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    down ip rule delete to {{ route }} table {{ vrf_table }}
+    pre-down ip rule delete to {{ route }} table {{ vrf_table }}
 {% endfor %}
 {# TODO: COPP policy type rules #}
 {% endfor %}
@@ -68,6 +69,7 @@ iface eth0 inet dhcp
     vrf mgmt
     up cgcreate -g l3mdev:mgmt
     up cgset -r l3mdev.master-device=mgmt mgmt
+    pre-down ip link set dev eth0 nomaster
     down cgdelete -g l3mdev:mgmt
 {% endif %}
 {% endif %}

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -5,11 +5,11 @@
 # file: /etc/network/interfaces
 #
 {% endblock banner %}
+{% block mgmt_vrf %}
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
 auto mgmt
 iface mgmt
     vrf-table 5000
-{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
 # The loopback network interface for mgmt VRF that is required for applications like NTP
     up ip link add lo-m type dummy
     up ip link set dev lo-m master mgmt
@@ -17,7 +17,7 @@ iface mgmt
     up ip link set lo-m up
     down ip link delete dev lo-m
 {% endif %}
-{% endif %}
+{% endblock mgmt_vrf %}
 {% block loopback %}
 # The loopback network interface
 auto lo

--- a/src/sonic-config-engine/tests/sample_output/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/interfaces
@@ -18,9 +18,9 @@ iface eth0 inet static
     up ip -4 route add 10.0.0.0/24 dev eth0 table default
     up ip -4 rule add from 10.0.0.100/32 table default
     # management port down rules
-    down ip -4 route delete default via 10.0.0.1 dev eth0 table default
-    down ip -4 route delete 10.0.0.0/24 dev eth0 table default
-    down ip -4 rule delete from 10.0.0.100/32 table default
+    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table default
+    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table default
+    pre-down ip -4 rule delete from 10.0.0.100/32 table default
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -30,9 +30,9 @@ iface eth0 inet6 static
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
     up ip -6 rule add from 2603:10e2:0:2902::8/128 table default
     # management port down rules
-    down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table default
-    down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
-    down ip -6 rule delete from 2603:10e2:0:2902::8/128 table default
+    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table default
+    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
+    pre-down ip -6 rule delete from 2603:10e2:0:2902::8/128 table default
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/mvrf_interfaces
@@ -6,15 +6,15 @@
 auto mgmt
 iface mgmt
     vrf-table 5000
+# The loopback network interface for mgmt VRF that is required for applications like NTP
+    up ip link add lo-m type dummy
+    up ip link set dev lo-m master mgmt
+    up ip addr add 127.0.0.1/8 dev lo-m
+    up ip link set lo-m up
+    down ip link delete dev lo-m
 # The loopback network interface
 auto lo
 iface lo inet loopback
-# The loopback network interface for mgmt VRF that is required for applications like NTP
-    up ip link add lo-m type dummy
-    up ip addr add 127.0.0.1/8 dev lo-m
-    up ip link set lo-m up
-    up ip link set dev lo-m master mgmt
-	down ip link delete dev lo-m
 
 # The management network interface
 auto eth0
@@ -30,9 +30,9 @@ iface eth0 inet static
     up cgcreate -g l3mdev:mgmt
     up cgset -r l3mdev.master-device=mgmt mgmt
     # management port down rules
-    down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
-    down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
-    down ip -4 rule delete from 10.0.0.100/32 table 5000
+    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
+    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
+    pre-down ip -4 rule delete from 10.0.0.100/32 table 5000
     down cgdelete -g l3mdev:mgmt
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
@@ -46,9 +46,9 @@ iface eth0 inet6 static
     up cgcreate -g l3mdev:mgmt
     up cgset -r l3mdev.master-device=mgmt mgmt
     # management port down rules
-    down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
-    down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
-    down ip -6 rule delete from 2603:10e2:0:2902::8/128 table 5000
+    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
+    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
+    pre-down ip -6 rule delete from 2603:10e2:0:2902::8/128 table 5000
     down cgdelete -g l3mdev:mgmt
 #
 source /etc/network/interfaces.d/*

--- a/src/sonic-config-engine/tests/sample_output/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/mvrf_interfaces
@@ -33,6 +33,7 @@ iface eth0 inet static
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
     pre-down ip -4 rule delete from 10.0.0.100/32 table 5000
+    pre-down ip link set dev eth0 nomaster
     down cgdelete -g l3mdev:mgmt
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
@@ -49,6 +50,7 @@ iface eth0 inet6 static
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
     pre-down ip -6 rule delete from 2603:10e2:0:2902::8/128 table 5000
+    pre-down ip link set dev eth0 nomaster
     down cgdelete -g l3mdev:mgmt
 #
 source /etc/network/interfaces.d/*

--- a/src/sonic-config-engine/tests/sample_output/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/mvrf_interfaces
@@ -33,7 +33,6 @@ iface eth0 inet static
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
     pre-down ip -4 rule delete from 10.0.0.100/32 table 5000
-    pre-down ip link set dev eth0 nomaster
     down cgdelete -g l3mdev:mgmt
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
@@ -50,7 +49,6 @@ iface eth0 inet6 static
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
     pre-down ip -6 rule delete from 2603:10e2:0:2902::8/128 table 5000
-    pre-down ip link set dev eth0 nomaster
     down cgdelete -g l3mdev:mgmt
 #
 source /etc/network/interfaces.d/*


### PR DESCRIPTION
**- What I did**  
When management VRF is deleted, zebra was crashing as specified in the [gitissue3798](https://github.com/Azure/sonic-buildimage/issues/3798). As discussed in the issue, it has got two parts. One part is to fix the crash in FRR, which will happen in the future. Other part is to ensure that default route is deleted just before interface is brought down by using "pre-down" commands instead of "down" commands, which will avoid the zebra crash. Irrespective of this change, FRR will be fixed to avoid the crash in zebra code. 

**- How I did it**  
Changed "down" commands to "pre-down" commands.

**- How to verify it**  
Executed management VRF test cases specified in the [sonic-mgmt PR1210](https://github.com/Azure/sonic-mgmt/pull/1210) and verified that they are passing. 

**- Description for the changelog**
Changed the commands given under "down" to "pre-down"
