### PR TITLE
Revert "[dhcp_relay] Add extra sleep before starting relay agent processes"

### DIFF
--- a/dockers/docker-dhcp-relay/start.sh
+++ b/dockers/docker-dhcp-relay/start.sh
@@ -16,12 +16,6 @@ if [ $(supervisorctl status | grep -c "^isc-dhcp-relay:") -gt 0 ]; then
     # lifetime of the process.
     /usr/bin/wait_for_intf.sh
 
-    # Allow a bit more time for interfaces to settle before starting the
-    # relay agent processes.
-    # FIXME: Remove/decrease this once we determine how to prevent future race
-    # conditions here.
-    sleep 180
-
     # Start all DHCP relay agent(s)
     supervisorctl start isc-dhcp-relay:*
 fi


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#3824

This temporary change should no longer be necessary, as the root cause of the issue should now be addressed via https://github.com/Azure/sonic-buildimage/pull/3851

(The same fix was merged to the 201811 branch via https://github.com/Azure/sonic-buildimage/pull/3852)