### PR TITLE
DellEMC: utility to set onie modes from NOS

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/common/onie_mode_set
+++ b/platform/broadcom/sonic-platform-modules-dell/common/onie_mode_set
@@ -1,0 +1,90 @@
+#!/bin/bash
+#scrit to set onie boot modes from NOS
+# modes supported rescue/install/uninstall
+
+VERBOSE=no
+ONIEPATH="/mnt/onie-boot"
+
+unset ONIE_MODE
+
+function set_onie_boot()
+{
+    # If reboot to ONIE is requested, set the ONIE boot mode (update/install/uninstall/rescue)
+    # and reboot.
+    
+    # Exit if not superuser
+    if [[ "$EUID" -ne 0 ]]; then
+        echo "This command must be run as root" >&2
+        exit 1
+    fi
+
+    # Mount ONIE partition if not already mounted
+    if ! grep -qs '/mnt/onie-boot ' /proc/mounts; then
+        mkdir -p ${ONIEPATH}
+        mount LABEL=ONIE-BOOT ${ONIEPATH} || ERR=$?
+        if [[ ${ERR} -ne 0 ]]; then
+            VERBOSE=yes debug "Failed to mount ONIE partition."
+            exit 1
+        fi
+    fi
+
+    # Set mode
+    ${ONIEPATH}/onie/tools/bin/onie-boot-mode -o ${ONIE_MODE} || ERR=$?
+    if [[ ${ERR} -ne 0 ]]; then
+        VERBOSE=yes debug "Failed to set ONIE boot mode. Ensure that mode is valid"
+        exit 1
+    fi
+
+    # Set next boot to ONIE
+    grub-editenv /host/grub/grubenv set next_entry=ONIE || ERR=$?
+    if [[ ${ERR} -ne 0 ]]; then
+        VERBOSE=yes debug "Failed to set next boot to ONIE."
+        exit 1
+    fi
+    echo "next boot mode set to onie - ${ONIE_MODE}"
+
+}
+
+
+function debug()
+{
+    if [[ x"${VERBOSE}" == x"yes" ]]; then
+        echo `date` $@
+    fi
+    logger "$@"
+}
+
+
+SCRIPT=$0
+
+function show_help_and_exit()
+{
+    echo "Usage ${SCRIPT} [options]"
+    echo "    This script will set modes in onie rescue/uninstall/install."
+    echo " "
+    echo "    Available options:"
+    echo "        -h, -? : getting this help"
+    echo "        -o [mode]    : boot into ONIE"
+
+    exit 0
+}
+
+function parse_options()
+{
+    while getopts "h?vo:" opt; do
+        case $opt in
+            h|\? )
+                show_help_and_exit
+                ;;
+            o )
+                ONIE_MODE=$OPTARG
+                set_onie_boot
+                ;;
+            v )
+                VERBOSE=yes
+                ;;
+        esac
+    done
+}
+
+parse_options $@

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s5232f.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s5232f.install
@@ -8,3 +8,4 @@ s5232f/cfg/s5232f-modules.conf etc/modules-load.d
 s5232f/systemd/platform-modules-s5232f.service etc/systemd/system
 common/platform_reboot usr/share/sonic/device/x86_64-dellemc_s5232f_c3538-r0
 common/fw-updater usr/local/bin
+common/onie_mode_set usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s5248f.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s5248f.install
@@ -8,3 +8,4 @@ s5248f/cfg/s5248f-modules.conf etc/modules-load.d
 s5248f/systemd/platform-modules-s5248f.service etc/systemd/system
 common/platform_reboot usr/share/sonic/device/x86_64-dellemc_s5248f_c3538-r0
 common/fw-updater usr/local/bin
+common/onie_mode_set usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -14,3 +14,4 @@ s6100/systemd/platform-modules-s6100.service etc/systemd/system
 s6100/systemd/s6100-lpc-monitor.service etc/systemd/system
 tools/flashrom/flashrom usr/local/bin/
 common/fw-updater usr/local/bin
+common/onie_mode_set usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9100.install
@@ -12,3 +12,4 @@ z9100/cfg/z9100-modules.conf etc/modules-load.d
 z9100/systemd/platform-modules-z9100.service etc/systemd/system
 z9100/systemd/z9100-lpc-monitor.service etc/systemd/system
 common/fw-updater usr/local/bin
+common/onie_mode_set usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9264f.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9264f.install
@@ -8,3 +8,4 @@ z9264f/cfg/z9264f-modules.conf etc/modules-load.d
 z9264f/systemd/platform-modules-z9264f.service etc/systemd/system
 common/platform_reboot usr/share/sonic/device/x86_64-dellemc_z9264f_c3538-r0
 common/fw-updater usr/local/bin
+common/onie_mode_set usr/local/bin


### PR DESCRIPTION
This common utility would set next boot option as onie mode and
when reboot is triggered it would reboot the box into that specific onie mode.

Current support modes are rescue/install/uninstall

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

A new script added to DellEMC platforms which could support in setting onie modes from NOS and reboot into the mode once. This could help in installing NOS, firmware update etc. Helpful in automation with out any manual intervention.

**- How to verify it**

verified on DellEMC platforms.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
