### PR TITLE
[soncic-mgmt] Add docker-ce-cli to sonic-mgmt container

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -71,6 +71,19 @@ RUN pip install ipaddr \
     && pip install nnpy    \
     && pip install dpkt
 
+# Install docker-ce-cli
+RUN apt-get update                  \
+    && apt-get install -y           \
+      apt-transport-https           \
+      ca-certificates               \
+      curl                          \
+      gnupg-agent                   \
+      software-properties-common                                                                                   \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -                                     \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"    \
+    && apt-get update                                                                                              \
+    && apt-get install -y docker-ce-cli
+
 # Install Microsoft Azure Kusto Library for Python
 RUN pip install azure-kusto-data==0.0.13 \
                 azure-kusto-ingest==0.0.13


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In the scope of migration from docker shell plugin to docker connection plugin, we need to have docker-ce-cli installed in docker-sonic-mgmt. https://github.com/Azure/sonic-mgmt/pull/1269
Added docker-ce-cli package to docker-sonic-mgmt.
**- How I did it**

**- How to verify it**
```
make configure PLATFORM=generic
make target/docker-sonic-mgmt.gz
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added docker-ce-cli package to docker-sonic-mgmt.

**- A picture of a cute animal (not mandatory but encouraged)**
