### PR TITLE
Add watchdog-control service to disable watchdog during bootup

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -138,6 +138,11 @@ sudo sed -i -e '/^passwd/s/ tacplus//' $FILESYSTEM_ROOT/etc/nsswitch.conf
 # Copy crontabs
 sudo cp -f $IMAGE_CONFIGS/cron.d/* $FILESYSTEM_ROOT/etc/cron.d/
 
+# Copy watchdog-control files
+sudo LANG=C cp $IMAGE_CONFIGS/watchdog-control/watchdog-control.sh $FILESYSTEM_ROOT/usr/local/bin/watchdog-control.sh
+sudo LANG=C cp $IMAGE_CONFIGS/watchdog-control/watchdog-control.service $FILESYSTEM_ROOT/etc/systemd/system/
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable watchdog-control.service
+
 # Copy NTP configuration files and templates
 sudo cp $IMAGE_CONFIGS/ntp/ntp-config.service $FILESYSTEM_ROOT/etc/systemd/system/
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable ntp-config.service

--- a/files/image_config/watchdog-control/watchdog-control.service
+++ b/files/image_config/watchdog-control/watchdog-control.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=watchdog control service
+After=rc-local.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/watchdog-control
+
+[Install]
+WantedBy=multi-user.target

--- a/files/image_config/watchdog-control/watchdog-control.service
+++ b/files/image_config/watchdog-control/watchdog-control.service
@@ -4,7 +4,7 @@ After=rc-local.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/watchdog-control
+ExecStart=/usr/bin/watchdog-control.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/files/image_config/watchdog-control/watchdog-control.service
+++ b/files/image_config/watchdog-control/watchdog-control.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=watchdog control service
-After=rc-local.service
+After=swss.service
 
 [Service]
 Type=simple

--- a/files/image_config/watchdog-control/watchdog-control.sh
+++ b/files/image_config/watchdog-control/watchdog-control.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+VERBOSE=no
+
+function debug()
+{
+    /usr/bin/logger "WATCHDOG-CONTROL : $1"
+    if [[ x"${VERBOSE}" == x"yes" ]]; then
+        echo `date` "- $1"
+    fi
+}
+
+
+function disable_watchdog()
+{
+    # Disable Watchdog Timer
+    debug "Disable Watchdog during the bootup"
+    if [[ -e /usr/local/bin/platform_watchdog_disable.sh ]]; then
+        /usr/local/bin/platform_watchdog_disable.sh
+}
+
+disable_watchdog

--- a/files/image_config/watchdog-control/watchdog-control.sh
+++ b/files/image_config/watchdog-control/watchdog-control.sh
@@ -13,10 +13,9 @@ function debug()
 
 function disable_watchdog()
 {
-    # Disable Watchdog Timer
-    debug "Disabling Watchdog during the bootup"
-    if [[ -e /usr/local/bin/platform_watchdog_disable.sh ]]; then
-        /usr/local/bin/platform_watchdog_disable.sh
+    if [[ -x /usr/bin/watchdog ]]; then
+        debug "Disabling Watchdog during bootup"
+        /usr/bin/watchdog -d
     fi
 }
 

--- a/files/image_config/watchdog-control/watchdog-control.sh
+++ b/files/image_config/watchdog-control/watchdog-control.sh
@@ -4,9 +4,9 @@ VERBOSE=no
 
 function debug()
 {
-    /usr/bin/logger "WATCHDOG-CONTROL : $1"
+    /usr/bin/logger "$0 : $1"
     if [[ x"${VERBOSE}" == x"yes" ]]; then
-        echo `date` "- $1"
+        echo "$(date) $0: $1"
     fi
 }
 
@@ -14,9 +14,10 @@ function debug()
 function disable_watchdog()
 {
     # Disable Watchdog Timer
-    debug "Disable Watchdog during the bootup"
+    debug "Disabling Watchdog during the bootup"
     if [[ -e /usr/local/bin/platform_watchdog_disable.sh ]]; then
         /usr/local/bin/platform_watchdog_disable.sh
+    fi
 }
 
 disable_watchdog


### PR DESCRIPTION
Disable only if it's applicable and the watchdog is enabled.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
