### PR TITLE
[Service] Allow monit system tool to monitor the critical processes status running in various SONiC containers.

### DIFF
--- a/files/image_config/monit/monitrc
+++ b/files/image_config/monit/monitrc
@@ -293,6 +293,8 @@ set httpd unixsocket /var/run/monit.sock and
 #
    include /etc/monit/conf.d/*
    include /etc/monit/conf-enabled/*
+  
+   include /etc/monit/proc_stat
 #
 check filesystem root-overlay with path /
   if space usage > 90% for 5 times within 10 cycles then alert

--- a/files/image_config/monit/proc_stat
+++ b/files/image_config/monit/proc_stat
@@ -1,16 +1,4 @@
 ###############################################################################
-## Monit control file
-###############################################################################
-##
-## Comments begin with a '#' and extend through the end of the line. Keywords
-## are case insensitive. All path's MUST BE FULLY QUALIFIED, starting with '/'.
-##
-## Below you will find examples of some frequently used statements. For
-## information about the control file and a complete list of statements and
-## options, please have a look in the Monit manual.
-##
-##
-###############################################################################
 ## Global section
 ###############################################################################
 ##
@@ -26,12 +14,6 @@
 #
 # set logfile /var/log/monit.log
 set logfile syslog
-#
-#
-## Set the location of the Monit lock file which stores the process id of the
-## running Monit instance. By default this file is stored in $HOME/.monit.pid
-#
-# set pidfile /var/run/monit.pid
 #
 ## Set the location of the Monit id file which stores the unique id for the
 ## Monit instance. The id is generated and stored on first Monit start. By
@@ -50,239 +32,15 @@ set logfile syslog
 #
 #
 
-## Set limits for various tests. The following example shows the default values:
-##
-# set limits {
-#     programOutput:     512 B,      # check program's output truncate limit
-#     sendExpectBuffer:  256 B,      # limit for send/expect protocol test
-#     fileContentBuffer: 512 B,      # limit for file content test
-#     httpContentBuffer: 1 MB,       # limit for HTTP content test
-#     networkTimeout:    5 seconds   # timeout for network I/O
-#     programTimeout:    300 seconds # timeout for check program
-#     stopTimeout:       30 seconds  # timeout for service stop
-#     startTimeout:      30 seconds  # timeout for service start
-#     restartTimeout:    30 seconds  # timeout for service restart
-# }
-
-## Set global SSL options (just most common options showed, see manual for
-## full list).
-#
-# set ssl {
-#     verify     : enable, # verify SSL certificates (disabled by default but STRONGLY RECOMMENDED)
-#     selfsigned : allow   # allow self signed SSL certificates (reject by default)
-# }
-#
-#
-## Set the list of mail servers for alert delivery. Multiple servers may be
-## specified using a comma separator. If the first mail server fails, Monit
-# will use the second mail server in the list and so on. By default Monit uses
-# port 25 - it is possible to override this with the PORT option.
-#
-# set mailserver mail.bar.baz,               # primary mailserver
-#                backup.bar.baz port 10025,  # backup mailserver on port 10025
-#                localhost                   # fallback relay
-#
-#
-## By default Monit will drop alert events if no mail servers are available.
-## If you want to keep the alerts for later delivery retry, you can use the
-## EVENTQUEUE statement. The base directory where undelivered alerts will be
-## stored is specified by the BASEDIR option. You can limit the queue size
-## by using the SLOTS option (if omitted, the queue is limited by space
-## available in the back end filesystem).
-#
   set eventqueue
       basedir /var/lib/monit/events # set the base directory where events will be stored
       slots 100                     # optionally limit the queue size
 #
 #
-## Send status and events to M/Monit (for more informations about M/Monit
-## see https://mmonit.com/). By default Monit registers credentials with
-## M/Monit so M/Monit can smoothly communicate back to Monit and you don't
-## have to register Monit credentials manually in M/Monit. It is possible to
-## disable credential registration using the commented out option below.
-## Though, if safety is a concern we recommend instead using https when
-## communicating with M/Monit and send credentials encrypted. The password
-## should be URL encoded if it contains URL-significant characters like
-## ":", "?", "@".
-#
-# set mmonit http://monit:monit@192.168.1.10:8080/collector
-#     # and register without credentials     # Don't register credentials
-#
-#
-## Monit by default uses the following format for alerts if the the mail-format
-## statement is missing::
-## --8<--
-## set mail-format {
-##   from:    Monit <monit@$HOST>
-##   subject: monit alert --  $EVENT $SERVICE
-##   message: $EVENT Service $SERVICE
-##                 Date:        $DATE
-##                 Action:      $ACTION
-##                 Host:        $HOST
-##                 Description: $DESCRIPTION
-##
-##            Your faithful employee,
-##            Monit
-## }
-## --8<--
-##
-## You can override this message format or parts of it, such as subject
-## or sender using the MAIL-FORMAT statement. Macros such as $DATE, etc.
-## are expanded at runtime. For example, to override the sender, use:
-#
-# set mail-format { from: monit@foo.bar }
-#
-#
-## You can set alert recipients whom will receive alerts if/when a
-## service defined in this file has errors. Alerts may be restricted on
-## events by using a filter as in the second example below.
-#
-# set alert sysadm@foo.bar                       # receive all alerts
-#
-## Do not alert when Monit starts, stops or performs a user initiated action.
-## This filter is recommended to avoid getting alerts for trivial cases.
-#
-# set alert your-name@your.domain not on { instance, action }
-#
-#
-## Monit has an embedded HTTP interface which can be used to view status of
-## services monitored and manage services from a web interface. The HTTP
-## interface is also required if you want to issue Monit commands from the
-## command line, such as 'monit status' or 'monit restart service' The reason
-## for this is that the Monit client uses the HTTP interface to send these
-## commands to a running Monit daemon. See the Monit Wiki if you want to
 ## enable SSL for the HTTP interface.
 #
 set httpd unixsocket /var/run/monit.sock and
      allow localhost        # allow localhost to connect to the server and
-#
-###############################################################################
-## Services
-###############################################################################
-##
-## Check general system resources such as load average, cpu and memory
-## usage. Each test specifies a resource, conditions and the action to be
-## performed should a test fail.
-#
-#  check system $HOST
-#    if loadavg (1min) > 4 then alert
-#    if loadavg (5min) > 2 then alert
-#    if cpu usage > 95% for 10 cycles then alert
-#    if memory usage > 75% then alert
-#    if swap usage > 25% then alert
-#
-#
-## Check if a file exists, checksum, permissions, uid and gid. In addition
-## to alert recipients in the global section, customized alert can be sent to
-## additional recipients by specifying a local alert handler. The service may
-## be grouped using the GROUP option. More than one group can be specified by
-## repeating the 'group name' statement.
-#
-#  check file apache_bin with path /usr/local/apache/bin/httpd
-#    if failed checksum and
-#       expect the sum 8f7f419955cefa0b33a2ba316cba3659 then unmonitor
-#    if failed permission 755 then unmonitor
-#    if failed uid root then unmonitor
-#    if failed gid root then unmonitor
-#    alert security@foo.bar on {
-#           checksum, permission, uid, gid, unmonitor
-#        } with the mail-format { subject: Alarm! }
-#    group server
-#
-#
-## Check that a process is running, in this case Apache, and that it respond
-## to HTTP and HTTPS requests. Check its resource usage such as cpu and memory,
-## and number of children. If the process is not running, Monit will restart
-## it by default. In case the service is restarted very often and the
-## problem remains, it is possible to disable monitoring using the TIMEOUT
-## statement. This service depends on another service (apache_bin) which
-## is defined above.
-#
-#  check process apache with pidfile /usr/local/apache/logs/httpd.pid
-#    start program = "/etc/init.d/httpd start" with timeout 60 seconds
-#    stop program  = "/etc/init.d/httpd stop"
-#    if cpu > 60% for 2 cycles then alert
-#    if cpu > 80% for 5 cycles then restart
-#    if totalmem > 200.0 MB for 5 cycles then restart
-#    if children > 250 then restart
-#    if loadavg(5min) greater than 10 for 8 cycles then stop
-#    if failed host www.tildeslash.com port 80 protocol http
-#       and request "/somefile.html"
-#    then restart
-#    if failed port 443 protocol https with timeout 15 seconds then restart
-#    if 3 restarts within 5 cycles then unmonitor
-#    depends on apache_bin
-#    group server
-#
-#
-## Check filesystem permissions, uid, gid, space and inode usage. Other services,
-## such as databases, may depend on this resource and an automatically graceful
-## stop may be cascaded to them before the filesystem will become full and data
-## lost.
-#
-#  check filesystem datafs with path /dev/sdb1
-#    start program  = "/bin/mount /data"
-#    stop program  = "/bin/umount /data"
-#    if failed permission 660 then unmonitor
-#    if failed uid root then unmonitor
-#    if failed gid disk then unmonitor
-#    if space usage > 80% for 5 times within 15 cycles then alert
-#    if space usage > 99% then stop
-#    if inode usage > 30000 then alert
-#    if inode usage > 99% then stop
-#    group server
-#
-#
-## Check a file's timestamp. In this example, we test if a file is older
-## than 15 minutes and assume something is wrong if its not updated. Also,
-## if the file size exceed a given limit, execute a script
-#
-#  check file database with path /data/mydatabase.db
-#    if failed permission 700 then alert
-#    if failed uid data then alert
-#    if failed gid data then alert
-#    if timestamp > 15 minutes then alert
-#    if size > 100 MB then exec "/my/cleanup/script" as uid dba and gid dba
-#
-#
-## Check directory permission, uid and gid.  An event is triggered if the
-## directory does not belong to the user with uid 0 and gid 0.  In addition,
-## the permissions have to match the octal description of 755 (see chmod(1)).
-#
-#  check directory bin with path /bin
-#    if failed permission 755 then unmonitor
-#    if failed uid 0 then unmonitor
-#    if failed gid 0 then unmonitor
-#
-#
-## Check a remote host availability by issuing a ping test and check the
-## content of a response from a web server. Up to three pings are sent and
-## connection to a port and an application level network check is performed.
-#
-#  check host myserver with address 192.168.1.1
-#    if failed ping then alert
-#    if failed port 3306 protocol mysql with timeout 15 seconds then alert
-#    if failed port 80 protocol http
-#       and request /some/path with content = "a string"
-#    then alert
-#
-#
-## Check a network link status (up/down), link capacity changes, saturation
-## and bandwidth usage.
-#
-#  check network public with interface eth0
-#    if failed link then alert
-#    if changed link then alert
-#    if saturation > 90% then alert
-#    if download > 10 MB/s then alert
-#    if total uploaded > 1 GB in last hour then alert
-#
-#
-## Check custom program status output.
-#
-#  check program myscript with path /usr/local/bin/myscript.sh
-#    if status != 0 then alert
-#
 #
 ###############################################################################
 ## Includes all the critical processes running in SONiC containers.

--- a/files/image_config/monit/proc_stat
+++ b/files/image_config/monit/proc_stat
@@ -1,46 +1,9 @@
-###############################################################################
-## Global section
-###############################################################################
-##
-## Start Monit in the background (run as a daemon):
 #
   set daemon 60            # check services at 1-minute intervals
 #   with start delay 240    # optional: delay the first check by 4-minutes (by
 #                           # default Monit check immediately after Monit start)
-#
-#
-## Set syslog logging. If you want to log to a standalone log file instead,
-## specify the full path to the log file
-#
-# set logfile /var/log/monit.log
 set logfile syslog
-#
-## Set the location of the Monit id file which stores the unique id for the
-## Monit instance. The id is generated and stored on first Monit start. By
-## default the file is placed in $HOME/.monit.id.
-#
-# set idfile /var/.monit.id
-  set idfile /var/lib/monit/id
-#
-## Set the location of the Monit state file which saves monitoring states
-## on each cycle. By default the file is placed in $HOME/.monit.state. If
-## the state file is stored on a persistent filesystem, Monit will recover
-## the monitoring state across reboots. If it is on temporary filesystem, the
-## state will be lost on reboot which may be convenient in some situations.
-#
-  set statefile /var/lib/monit/state
-#
-#
-
-  set eventqueue
-      basedir /var/lib/monit/events # set the base directory where events will be stored
-      slots 100                     # optionally limit the queue size
-#
-#
-## enable SSL for the HTTP interface.
-#
-set httpd unixsocket /var/run/monit.sock and
-     allow localhost        # allow localhost to connect to the server and
+set idfile /var/lib/monit/id
 #
 ###############################################################################
 ## Includes all the critical processes running in SONiC containers.

--- a/files/image_config/monit/proc_stat
+++ b/files/image_config/monit/proc_stat
@@ -1,0 +1,401 @@
+###############################################################################
+## Monit control file
+###############################################################################
+##
+## Comments begin with a '#' and extend through the end of the line. Keywords
+## are case insensitive. All path's MUST BE FULLY QUALIFIED, starting with '/'.
+##
+## Below you will find examples of some frequently used statements. For
+## information about the control file and a complete list of statements and
+## options, please have a look in the Monit manual.
+##
+##
+###############################################################################
+## Global section
+###############################################################################
+##
+## Start Monit in the background (run as a daemon):
+#
+  set daemon 60            # check services at 1-minute intervals
+#   with start delay 240    # optional: delay the first check by 4-minutes (by
+#                           # default Monit check immediately after Monit start)
+#
+#
+## Set syslog logging. If you want to log to a standalone log file instead,
+## specify the full path to the log file
+#
+# set logfile /var/log/monit.log
+set logfile syslog
+#
+#
+## Set the location of the Monit lock file which stores the process id of the
+## running Monit instance. By default this file is stored in $HOME/.monit.pid
+#
+# set pidfile /var/run/monit.pid
+#
+## Set the location of the Monit id file which stores the unique id for the
+## Monit instance. The id is generated and stored on first Monit start. By
+## default the file is placed in $HOME/.monit.id.
+#
+# set idfile /var/.monit.id
+  set idfile /var/lib/monit/id
+#
+## Set the location of the Monit state file which saves monitoring states
+## on each cycle. By default the file is placed in $HOME/.monit.state. If
+## the state file is stored on a persistent filesystem, Monit will recover
+## the monitoring state across reboots. If it is on temporary filesystem, the
+## state will be lost on reboot which may be convenient in some situations.
+#
+  set statefile /var/lib/monit/state
+#
+#
+
+## Set limits for various tests. The following example shows the default values:
+##
+# set limits {
+#     programOutput:     512 B,      # check program's output truncate limit
+#     sendExpectBuffer:  256 B,      # limit for send/expect protocol test
+#     fileContentBuffer: 512 B,      # limit for file content test
+#     httpContentBuffer: 1 MB,       # limit for HTTP content test
+#     networkTimeout:    5 seconds   # timeout for network I/O
+#     programTimeout:    300 seconds # timeout for check program
+#     stopTimeout:       30 seconds  # timeout for service stop
+#     startTimeout:      30 seconds  # timeout for service start
+#     restartTimeout:    30 seconds  # timeout for service restart
+# }
+
+## Set global SSL options (just most common options showed, see manual for
+## full list).
+#
+# set ssl {
+#     verify     : enable, # verify SSL certificates (disabled by default but STRONGLY RECOMMENDED)
+#     selfsigned : allow   # allow self signed SSL certificates (reject by default)
+# }
+#
+#
+## Set the list of mail servers for alert delivery. Multiple servers may be
+## specified using a comma separator. If the first mail server fails, Monit
+# will use the second mail server in the list and so on. By default Monit uses
+# port 25 - it is possible to override this with the PORT option.
+#
+# set mailserver mail.bar.baz,               # primary mailserver
+#                backup.bar.baz port 10025,  # backup mailserver on port 10025
+#                localhost                   # fallback relay
+#
+#
+## By default Monit will drop alert events if no mail servers are available.
+## If you want to keep the alerts for later delivery retry, you can use the
+## EVENTQUEUE statement. The base directory where undelivered alerts will be
+## stored is specified by the BASEDIR option. You can limit the queue size
+## by using the SLOTS option (if omitted, the queue is limited by space
+## available in the back end filesystem).
+#
+  set eventqueue
+      basedir /var/lib/monit/events # set the base directory where events will be stored
+      slots 100                     # optionally limit the queue size
+#
+#
+## Send status and events to M/Monit (for more informations about M/Monit
+## see https://mmonit.com/). By default Monit registers credentials with
+## M/Monit so M/Monit can smoothly communicate back to Monit and you don't
+## have to register Monit credentials manually in M/Monit. It is possible to
+## disable credential registration using the commented out option below.
+## Though, if safety is a concern we recommend instead using https when
+## communicating with M/Monit and send credentials encrypted. The password
+## should be URL encoded if it contains URL-significant characters like
+## ":", "?", "@".
+#
+# set mmonit http://monit:monit@192.168.1.10:8080/collector
+#     # and register without credentials     # Don't register credentials
+#
+#
+## Monit by default uses the following format for alerts if the the mail-format
+## statement is missing::
+## --8<--
+## set mail-format {
+##   from:    Monit <monit@$HOST>
+##   subject: monit alert --  $EVENT $SERVICE
+##   message: $EVENT Service $SERVICE
+##                 Date:        $DATE
+##                 Action:      $ACTION
+##                 Host:        $HOST
+##                 Description: $DESCRIPTION
+##
+##            Your faithful employee,
+##            Monit
+## }
+## --8<--
+##
+## You can override this message format or parts of it, such as subject
+## or sender using the MAIL-FORMAT statement. Macros such as $DATE, etc.
+## are expanded at runtime. For example, to override the sender, use:
+#
+# set mail-format { from: monit@foo.bar }
+#
+#
+## You can set alert recipients whom will receive alerts if/when a
+## service defined in this file has errors. Alerts may be restricted on
+## events by using a filter as in the second example below.
+#
+# set alert sysadm@foo.bar                       # receive all alerts
+#
+## Do not alert when Monit starts, stops or performs a user initiated action.
+## This filter is recommended to avoid getting alerts for trivial cases.
+#
+# set alert your-name@your.domain not on { instance, action }
+#
+#
+## Monit has an embedded HTTP interface which can be used to view status of
+## services monitored and manage services from a web interface. The HTTP
+## interface is also required if you want to issue Monit commands from the
+## command line, such as 'monit status' or 'monit restart service' The reason
+## for this is that the Monit client uses the HTTP interface to send these
+## commands to a running Monit daemon. See the Monit Wiki if you want to
+## enable SSL for the HTTP interface.
+#
+set httpd unixsocket /var/run/monit.sock and
+     allow localhost        # allow localhost to connect to the server and
+#
+###############################################################################
+## Services
+###############################################################################
+##
+## Check general system resources such as load average, cpu and memory
+## usage. Each test specifies a resource, conditions and the action to be
+## performed should a test fail.
+#
+#  check system $HOST
+#    if loadavg (1min) > 4 then alert
+#    if loadavg (5min) > 2 then alert
+#    if cpu usage > 95% for 10 cycles then alert
+#    if memory usage > 75% then alert
+#    if swap usage > 25% then alert
+#
+#
+## Check if a file exists, checksum, permissions, uid and gid. In addition
+## to alert recipients in the global section, customized alert can be sent to
+## additional recipients by specifying a local alert handler. The service may
+## be grouped using the GROUP option. More than one group can be specified by
+## repeating the 'group name' statement.
+#
+#  check file apache_bin with path /usr/local/apache/bin/httpd
+#    if failed checksum and
+#       expect the sum 8f7f419955cefa0b33a2ba316cba3659 then unmonitor
+#    if failed permission 755 then unmonitor
+#    if failed uid root then unmonitor
+#    if failed gid root then unmonitor
+#    alert security@foo.bar on {
+#           checksum, permission, uid, gid, unmonitor
+#        } with the mail-format { subject: Alarm! }
+#    group server
+#
+#
+## Check that a process is running, in this case Apache, and that it respond
+## to HTTP and HTTPS requests. Check its resource usage such as cpu and memory,
+## and number of children. If the process is not running, Monit will restart
+## it by default. In case the service is restarted very often and the
+## problem remains, it is possible to disable monitoring using the TIMEOUT
+## statement. This service depends on another service (apache_bin) which
+## is defined above.
+#
+#  check process apache with pidfile /usr/local/apache/logs/httpd.pid
+#    start program = "/etc/init.d/httpd start" with timeout 60 seconds
+#    stop program  = "/etc/init.d/httpd stop"
+#    if cpu > 60% for 2 cycles then alert
+#    if cpu > 80% for 5 cycles then restart
+#    if totalmem > 200.0 MB for 5 cycles then restart
+#    if children > 250 then restart
+#    if loadavg(5min) greater than 10 for 8 cycles then stop
+#    if failed host www.tildeslash.com port 80 protocol http
+#       and request "/somefile.html"
+#    then restart
+#    if failed port 443 protocol https with timeout 15 seconds then restart
+#    if 3 restarts within 5 cycles then unmonitor
+#    depends on apache_bin
+#    group server
+#
+#
+## Check filesystem permissions, uid, gid, space and inode usage. Other services,
+## such as databases, may depend on this resource and an automatically graceful
+## stop may be cascaded to them before the filesystem will become full and data
+## lost.
+#
+#  check filesystem datafs with path /dev/sdb1
+#    start program  = "/bin/mount /data"
+#    stop program  = "/bin/umount /data"
+#    if failed permission 660 then unmonitor
+#    if failed uid root then unmonitor
+#    if failed gid disk then unmonitor
+#    if space usage > 80% for 5 times within 15 cycles then alert
+#    if space usage > 99% then stop
+#    if inode usage > 30000 then alert
+#    if inode usage > 99% then stop
+#    group server
+#
+#
+## Check a file's timestamp. In this example, we test if a file is older
+## than 15 minutes and assume something is wrong if its not updated. Also,
+## if the file size exceed a given limit, execute a script
+#
+#  check file database with path /data/mydatabase.db
+#    if failed permission 700 then alert
+#    if failed uid data then alert
+#    if failed gid data then alert
+#    if timestamp > 15 minutes then alert
+#    if size > 100 MB then exec "/my/cleanup/script" as uid dba and gid dba
+#
+#
+## Check directory permission, uid and gid.  An event is triggered if the
+## directory does not belong to the user with uid 0 and gid 0.  In addition,
+## the permissions have to match the octal description of 755 (see chmod(1)).
+#
+#  check directory bin with path /bin
+#    if failed permission 755 then unmonitor
+#    if failed uid 0 then unmonitor
+#    if failed gid 0 then unmonitor
+#
+#
+## Check a remote host availability by issuing a ping test and check the
+## content of a response from a web server. Up to three pings are sent and
+## connection to a port and an application level network check is performed.
+#
+#  check host myserver with address 192.168.1.1
+#    if failed ping then alert
+#    if failed port 3306 protocol mysql with timeout 15 seconds then alert
+#    if failed port 80 protocol http
+#       and request /some/path with content = "a string"
+#    then alert
+#
+#
+## Check a network link status (up/down), link capacity changes, saturation
+## and bandwidth usage.
+#
+#  check network public with interface eth0
+#    if failed link then alert
+#    if changed link then alert
+#    if saturation > 90% then alert
+#    if download > 10 MB/s then alert
+#    if total uploaded > 1 GB in last hour then alert
+#
+#
+## Check custom program status output.
+#
+#  check program myscript with path /usr/local/bin/myscript.sh
+#    if status != 0 then alert
+#
+#
+###############################################################################
+## Includes all the critical processes running in SONiC containers.
+###############################################################################
+
+# For syncd container.
+check process syncd matching "/usr/bin/syncd --diag"
+	if does not exist then alert
+
+check process dsserve matching "/usr/bin/dsserve"
+	if does not exist then alert
+
+# For SNMP container.
+check process snmpd matching "/usr/sbin/snmpd"
+	if does not exist then alert
+
+check process snmpd_subagent matching "python3.6 -m sonic_ax_impl"
+	if does not exist then alert
+
+# For Teamd container.
+check process teamd matching "/usr/bin/teamd -r -t"
+	if does not exist then alert
+
+check process teammgrd matching "/usr/bin/teammgrd"
+	if does not exist then alert
+
+check process teamsyncd matching "/usr/bin/teamsyncd"
+	if does not exist then alert
+
+#check process xcvrd matching "xcvrd"
+#if does not exist then alert
+
+# For DHCP_Relay container.
+check process dhcprelay matching "/usr/sbin/dhcrelay"
+	if does not exist then alert
+#
+# For Pmon container.
+check process ledd matching "/usr/bin/python /usr/bin/ledd"
+	if does not exist then alert
+
+check process fancontrol matching "/bin/bash /usr/sbin/fancontrol"
+	if does not exist then alert
+
+check process psud matching "/usr/bin/python /usr/bin/psud"
+	if does not exist then alert
+
+check process syseepromd matching "/usr/bin/python /usr/bin/syseepromd"
+	if does not exist then alert
+
+# For LLDP container.
+check process lldpd_monitor matching "lldpd: monitor."
+	if does not exist then alert
+
+check process lldp_syncd matching "python2 -m lldp_syncd"
+	if does not exist then alert
+
+check process lldpmgrd matching "python /usr/bin/lldpmgrd"
+	if does not exist then alert
+
+# For BGP container.
+check process zebra matching "/usr/lib/frr/zebra"
+	if does not exist then alert
+
+check process fpmsyncd matching "fpmsyncd"
+	if does not exist then alert
+
+check process bgpd matching "/usr/lib/frr/bgpd"
+	if does not exist then alert
+
+check process bgpcfgd matching "python /usr/bin/bgpcfgd"
+	if does not exist then alert
+
+check process staticd matching "/usr/lib/frr/staticd"
+	if does not exist then alert
+
+# For swss container.
+check process orchagent matching "/usr/bin/orchagent -d /var/log/swss"
+	if does not exist then alert
+
+check process portsyncd matching "/usr/bin/portsyncd -p"
+	if does not exist then alert
+
+check process neighsyncd matching "/usr/bin/neighsyncd"
+	if does not exist then alert
+
+check process vrfmgrd matching "/usr/bin/vrfmgrd"
+	if does not exist then alert
+
+check process vlanmgrd matching "/usr/bin/vlanmgrd"
+	if does not exist then alert
+
+check process intfmgrd matching "/usr/bin/intfmgrd"
+	if does not exist then alert
+
+check process portmgrd matching "/usr/bin/portmgrd"
+	if does not exist then alert
+
+check process buffermgrd matching "/usr/bin/buffermgrd -l"
+	if does not exist then alert
+
+check process nbrmgrd matching "/usr/bin/nbrmgrd"
+	if does not exist then alert
+
+check process vxlanmgrd matching "/usr/bin/vxlanmgrd"
+	if does not exist then alert
+
+# For database container
+check process redis_server matching "/usr/bin/redis-server"
+	if does not exist then alert
+
+# For telemetry container
+check process telemetry matching "/usr/sbin/telemetry -logtostderr --insecure"
+	if does not exist then alert
+
+check process dialout_client matching "/usr/sbin/dialout_client_cli -insecure -logtostderr"
+	if does not exist then alert


### PR DESCRIPTION
**- What I did**
I added a new configuration file called proc_stat which can enable monit to
detect the status of all critical processes running in various docker containers. Specifically,
monit will detect whether a process is in the dead or live state. If a process which
is monitored went into the dead state or it failed to start, then monit will write an
alert into syslog. Currently monit will periodically monitor all the process in the period
60 seconds. We can set a different value for this period.

**- How I did it**
I created this configuration file according to the file named monitrc.

**- How to verify it**
In the host, we can list the critical processes running in each docker container using 
the command **docker top container_id**. After that, we deliberately kill a process
using the command **kill -9 proc_id**. Then we can review the syslog file and will see an
alert message showing process_name is not running.

