### PR TITLE
[as7816-64x] Support different PSU sequence for any CPLD version

### DIFF
--- a/device/accton/x86_64-accton_as7816_64x-r0/plugins/psuutil.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/plugins/psuutil.py
@@ -29,6 +29,25 @@ class PsuUtil(PsuBase):
             2: "9-0050",
         }
 
+    def get_psu_mapping(self, index):
+        if index is None:
+            return False
+
+        for id in self.psu_mapping:
+            psu_name = str()
+            node = self.psu_path + self.psu_mapping[id] + "/name"
+
+            try:
+                with open(node, 'r') as psu_name_fd:
+                    psu_name = psu_name_fd.read()
+            except IOError:
+	            return False
+
+            if psu_name.find("as7816_64x_psu" + str(index)) != -1:
+                return self.psu_mapping[id]
+
+        return str()
+
     def get_num_psus(self):
         return len(self.psu_mapping)
 
@@ -37,7 +56,7 @@ class PsuUtil(PsuBase):
             return False
 
         status = 0
-        node = self.psu_path + self.psu_mapping[index]+self.psu_oper_status
+        node = self.psu_path + self.get_psu_mapping(index) + self.psu_oper_status
         try:
             with open(node, 'r') as power_status:
                 status = int(power_status.read())
@@ -51,7 +70,7 @@ class PsuUtil(PsuBase):
             return False
 
         status = 0
-        node = self.psu_path + self.psu_mapping[index] + self.psu_presence
+        node = self.psu_path + self.get_psu_mapping(index) + self.psu_presence
         try:
             with open(node, 'r') as presence_status:
                 status = int(presence_status.read())

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_util.py
@@ -147,6 +147,38 @@ def ir3570_check():
         return -1
     return ret
 
+def psu_index_check():
+    version = 0
+    CPLD1_VERSION="/sys/bus/i2c/devices/19-0060/version"
+    try:
+        with open(CPLD1_VERSION, 'r') as cpld_version:
+            version = int(cpld_version.read())
+    except IOError:
+        return False
+
+    cpld_id = "NULL"
+    CPLD1_ID="/sys/bus/i2c/devices/10-0053/cpld_id"
+    if os.path.exists(CPLD1_ID):
+        try:
+            with open(CPLD1_ID, 'r') as cpld_id_fd:
+                cpld_id = cpld_id_fd.read()
+        except IOError:
+            return False
+
+    at_found = 0
+    if cpld_id.find("AT") != -1:
+        at_found = 1
+    elif (version == 5) and (cpld_id.find("NULL") != -1):
+        at_found = 1
+
+    if (at_found):
+        log_os_system('echo 0x53 > /sys/bus/i2c/devices/i2c-10/delete_device', 1)
+        log_os_system('echo 0x50 > /sys/bus/i2c/devices/i2c-9/delete_device', 1)
+        log_os_system('echo as7816_64x_psu1 0x50 > /sys/bus/i2c/devices/i2c-9/new_device', 1)
+        log_os_system('echo as7816_64x_psu2 0x53 > /sys/bus/i2c/devices/i2c-10/new_device', 1)
+
+    return True
+
 def  show_eeprom_help():
     cmd =  sys.argv[0].split("/")[-1]+ " "  + args[0]
     print  "    use \""+ cmd + " 1-64 \" to dump sfp# eeprom"
@@ -282,6 +314,8 @@ def device_install():
             print output
             if FORCE == 0:                
                 return status  
+
+    psu_index_check()
 
     for i in range(0,len(sfp_map)):
         path = "/sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/new_device"


### PR DESCRIPTION
Signed-off-by: brandon_chuang <brandon_chuang@edge-core.com>

**- What I did**
Implement the CPLD version check for different PSU sequence.

**- How I did it**
Read the CPLD version from driver and check CPLD version at the driver installing utility.
When psuutil is invoked, find the appropriate psu directory for the given psu index.

**- How to verify it**
psuutil status

**- Description for the changelog**