### PR TITLE
[broadcom] knet improvement

### DIFF
--- a/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+++ b/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
@@ -5128,6 +5128,10 @@ bkn_init_ndev(u8 *mac, char *name)
     if (dev->mtu == 0) {
         dev->mtu = rx_buffer_size;
     }
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0))
+    dev->min_mtu = 68;
+    dev->max_mtu = rx_buffer_size;
+#endif
 
     /* Device vectors */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,29))

--- a/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+++ b/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
@@ -5148,6 +5148,10 @@ bkn_init_ndev(u8 *mac, char *name)
         strncpy(dev->name, name, IFNAMSIZ-1);
     }
 
+#ifdef CONFIG_NET_NS
+    dev_net_set(dev, current->nsproxy->net_ns);
+#endif
+
     /* Register the kernel Ethernet device */
     if (register_netdev(dev)) {
         DBG_WARN(("Error registering Ethernet device.\n"));


### PR DESCRIPTION
- fix KNET MTU setting with Linux Kernel > 4.10.0
- respect the current network namespace when creating netdev