### PR TITLE
[broadcom]: fix KNET MTU setting with Linux Kernel > 4.10.0

### DIFF
--- a/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+++ b/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
@@ -5128,6 +5128,10 @@ bkn_init_ndev(u8 *mac, char *name)
     if (dev->mtu == 0) {
         dev->mtu = rx_buffer_size;
     }
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0))
+    dev->min_mtu = 68;
+    dev->max_mtu = rx_buffer_size;
+#endif
 
     /* Device vectors */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,29))


### PR DESCRIPTION
We need to set min_mtu/max_mtu properly to support MTU setting

https://github.com/torvalds/linux/commit/61e84623

Signed-off-by: Wataru Ishida <ishida@nel-america.com>