### PR TITLE
[broadcom]: respect the current network namespace when creating netdev

### DIFF
--- a/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+++ b/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
@@ -5148,6 +5148,10 @@ bkn_init_ndev(u8 *mac, char *name)
         strncpy(dev->name, name, IFNAMSIZ-1);
     }
 
+#ifdef CONFIG_NET_NS
+    dev_net_set(dev, current->nsproxy->net_ns);
+#endif
+
     /* Register the kernel Ethernet device */
     if (register_netdev(dev)) {
         DBG_WARN(("Error registering Ethernet device.\n"));


### PR DESCRIPTION
Broadcom-Switch/OpenNSL#26

Signed-off-by: Wataru Ishida <ishida@nel-america.com>