### PR TITLE
DellEMC: S5232 Fix transceiver change event bug

### DIFF
--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
@@ -237,7 +237,7 @@ class SfpUtil(SfpUtilBase):
 
         return True
 
-    def get_transceiver_change_event(self):
+    def get_transceiver_change_event(self,timeout=0):
         port_dict = {}
         while True:
             for port_num in range(self.port_start, (self.port_end + 1)):

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
@@ -8,13 +8,42 @@ try:
     import sys
     import getopt
     import time
+    import io
     from sonic_sfp.sfputilbase import SfpUtilBase
     from os import *
     from mmap import *
-
+    from sonic_sfp.sff8436 import sff8436InterfaceId
+    from sonic_sfp.sff8436 import sff8436Dom
+    from sonic_sfp.sff8472 import sff8472InterfaceId
+    from sonic_sfp.sff8472 import sff8472Dom
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
+QSFP_DOM_REV_OFFSET = 1
+QSFP_DOM_REV_WIDTH = 1
+QSFP_TEMPE_OFFSET = 22
+QSFP_TEMPE_WIDTH = 2
+QSFP_VOLT_OFFSET = 26
+QSFP_VOLT_WIDTH = 2
+QSFP_CHANNL_MON_OFFSET = 34
+QSFP_CHANNL_MON_WIDTH = 16
+QSFP_CHANNL_MON_WITH_TX_POWER_WIDTH = 24
+QSFP_MODULE_THRESHOLD_OFFSET = 128
+QSFP_MODULE_THRESHOLD_WIDTH = 24
+QSFP_CHANNL_THRESHOLD_OFFSET = 176
+QSFP_CHANNL_THRESHOLD_WIDTH = 16
+QSFP_CHANNL_MON_MASK_OFFSET = 242
+QSFP_CHANNL_MON_MASK_WIDTH = 4
+
+SFP_TEMPE_OFFSET = 96
+SFP_TEMPE_WIDTH = 2
+SFP_VOLT_OFFSET = 98
+SFP_VOLT_WIDTH = 2
+SFP_MODULE_THRESHOLD_OFFSET = 0
+SFP_MODULE_THRESHOLD_WIDTH = 56
+
+XCVR_DOM_CAPABILITY_OFFSET = 92
+XCVR_DOM_CAPABILITY_WIDTH = 1
 
 class SfpUtil(SfpUtilBase):
     """Platform-specific SfpUtil class"""
@@ -225,3 +254,288 @@ class SfpUtil(SfpUtilBase):
                     return True, port_dict
 
             time.sleep(0.5)
+
+    def get_transceiver_dom_info_dict(self, port_num):
+        transceiver_dom_info_dict = {}
+
+        dom_info_dict_keys = ['temperature', 'voltage',  'rx1power',
+                              'rx2power',    'rx3power', 'rx4power',
+                              'tx1bias',     'tx2bias',  'tx3bias',
+                              'tx4bias',     'tx1power', 'tx2power',
+                              'tx3power',    'tx4power',
+                             ]
+        transceiver_dom_info_dict = dict.fromkeys(dom_info_dict_keys, 'N/A')
+
+        if port_num in self.qsfp_ports:
+            offset = 0
+            offset_xcvr = 128
+            file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
+            if not self._sfp_eeprom_present(file_path, 0):
+                return None
+
+            try:
+                sysfsfile_eeprom = io.open(file_path, mode="rb", buffering=0)
+            except IOError:
+                print("Error: reading sysfs file %s" % file_path)
+                return None
+
+            sfpd_obj = sff8436Dom()
+            if sfpd_obj is None:
+                return transceiver_dom_info_dict
+
+            sfpi_obj = sff8436InterfaceId()
+            if sfpi_obj is None:
+                return transceiver_dom_info_dict
+
+            # QSFP capability byte parse, through this byte can know whether it support tx_power or not.
+            # TODO: in the future when decided to migrate to support SFF-8636 instead of SFF-8436,
+            # need to add more code for determining the capability and version compliance
+            # in SFF-8636 dom capability definitions evolving with the versions.
+            qsfp_dom_capability_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
+            if qsfp_dom_capability_raw is not None:
+                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+            else:
+                return transceiver_dom_info_dict
+
+            dom_temperature_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_TEMPE_OFFSET), QSFP_TEMPE_WIDTH)
+            if dom_temperature_raw is not None:
+                dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
+            else:
+                return transceiver_dom_info_dict
+
+            dom_voltage_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_VOLT_OFFSET), QSFP_VOLT_WIDTH)
+            if dom_voltage_raw is not None:
+                dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
+            else:
+                return transceiver_dom_info_dict
+
+            qsfp_dom_rev_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_DOM_REV_OFFSET), QSFP_DOM_REV_WIDTH)
+            if qsfp_dom_rev_raw is not None:
+                qsfp_dom_rev_data = sfpd_obj.parse_sfp_dom_rev(qsfp_dom_rev_raw, 0)
+            else:
+                return transceiver_dom_info_dict
+
+            transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
+            transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
+
+            # The tx_power monitoring is only available on QSFP which compliant with SFF-8636
+            # and claimed that it support tx_power with one indicator bit.
+            dom_channel_monitor_data = {}
+            qsfp_dom_rev = qsfp_dom_rev_data['data']['dom_rev']['value']
+            qsfp_tx_power_support = qspf_dom_capability_data['data']['Tx_power_support']['value']
+            if (qsfp_dom_rev[0:8] != 'SFF-8636' or (qsfp_dom_rev[0:8] == 'SFF-8636' and qsfp_tx_power_support != 'on')):
+                dom_channel_monitor_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_CHANNL_MON_OFFSET), QSFP_CHANNL_MON_WIDTH)
+                if dom_channel_monitor_raw is not None:
+                    dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params(dom_channel_monitor_raw, 0)
+                else:
+                    return transceiver_dom_info_dict
+
+                transceiver_dom_info_dict['tx1power'] = 'N/A'
+                transceiver_dom_info_dict['tx2power'] = 'N/A'
+                transceiver_dom_info_dict['tx3power'] = 'N/A'
+                transceiver_dom_info_dict['tx4power'] = 'N/A'
+            try:
+                sysfsfile_eeprom.close()
+            except IOError:
+                print("Error: closing sysfs file %s" % file_path)
+                return None
+
+            transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
+            transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
+            transceiver_dom_info_dict['rx1power'] = dom_channel_monitor_data['data']['RX1Power']['value']
+            transceiver_dom_info_dict['rx2power'] = dom_channel_monitor_data['data']['RX2Power']['value']
+            transceiver_dom_info_dict['rx3power'] = dom_channel_monitor_data['data']['RX3Power']['value']
+            transceiver_dom_info_dict['rx4power'] = dom_channel_monitor_data['data']['RX4Power']['value']
+            transceiver_dom_info_dict['tx1bias'] = dom_channel_monitor_data['data']['TX1Bias']['value']
+            transceiver_dom_info_dict['tx2bias'] = dom_channel_monitor_data['data']['TX2Bias']['value']
+            transceiver_dom_info_dict['tx3bias'] = dom_channel_monitor_data['data']['TX3Bias']['value']
+            transceiver_dom_info_dict['tx4bias'] = dom_channel_monitor_data['data']['TX4Bias']['value']
+
+        else:
+	   offset = 256
+           file_path = self._get_port_eeprom_path(port_num, self.DOM_EEPROM_ADDR)
+           if not self._sfp_eeprom_present(file_path, 0):
+               return None
+
+        try:
+           sysfsfile_eeprom = io.open(file_path,"rb",0)
+        except IOError:
+           print("Error: reading sysfs file %s" % file_path)
+           return None
+           
+        sfpd_obj = sff8472Dom(None,1)
+        if sfpd_obj is None:
+            return transceiver_dom_info_dict
+
+        dom_temperature_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_TEMPE_OFFSET), 
+										SFP_TEMPE_WIDTH)
+        if dom_temperature_raw is not None:
+            dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
+        else:
+           return transceiver_dom_info_dict
+
+        dom_voltage_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_VOLT_OFFSET), 
+										SFP_VOLT_WIDTH)
+        if dom_voltage_raw is not None:
+             dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
+        else: 
+             return transceiver_dom_info_dict
+
+        dom_channel_monitor_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_MODULE_THRESHOLD_OFFSET), 
+									SFP_MODULE_THRESHOLD_WIDTH)
+        if dom_channel_monitor_raw is not None:
+           dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params(dom_channel_monitor_raw, 0)
+        else:
+           return transceiver_dom_info_dict
+
+        try:
+           sysfsfile_eeprom.close()
+        except IOError:
+           print("Error: closing sysfs file %s" % file_path)
+           return None
+
+        transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
+        transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
+        transceiver_dom_info_dict['rx1power'] = dom_channel_monitor_data['data']['RXPower']['value']
+        transceiver_dom_info_dict['rx2power'] = 'N/A'
+        transceiver_dom_info_dict['rx3power'] = 'N/A'
+        transceiver_dom_info_dict['rx4power'] = 'N/A'
+        transceiver_dom_info_dict['tx1bias'] = dom_channel_monitor_data['data']['TXBias']['value']
+        transceiver_dom_info_dict['tx2bias'] = 'N/A'
+        transceiver_dom_info_dict['tx3bias'] = 'N/A'
+        transceiver_dom_info_dict['tx4bias'] = 'N/A'
+        transceiver_dom_info_dict['tx1power'] = dom_channel_monitor_data['data']['TXPower']['value']
+        transceiver_dom_info_dict['tx2power'] = 'N/A'
+        transceiver_dom_info_dict['tx3power'] = 'N/A'
+        transceiver_dom_info_dict['tx4power'] = 'N/A'
+
+	return transceiver_dom_info_dict
+ 
+    def get_transceiver_dom_threshold_info_dict(self, port_num):
+        transceiver_dom_threshold_info_dict = {}
+        dom_info_dict_keys = ['temphighalarm',    'temphighwarning',
+                              'templowalarm',     'templowwarning',
+                              'vcchighalarm',     'vcchighwarning',
+                              'vcclowalarm',      'vcclowwarning',
+                              'rxpowerhighalarm', 'rxpowerhighwarning',
+                              'rxpowerlowalarm',  'rxpowerlowwarning',
+                              'txpowerhighalarm', 'txpowerhighwarning',
+                              'txpowerlowalarm',  'txpowerlowwarning',
+                              'txbiashighalarm',  'txbiashighwarning',
+                              'txbiaslowalarm',   'txbiaslowwarning'
+                             ]
+        transceiver_dom_threshold_info_dict = dict.fromkeys(dom_info_dict_keys, 'N/A')
+
+        if port_num in self.qsfp_ports:
+            file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
+            if not self._sfp_eeprom_present(file_path, 0):
+                return None
+
+            try:
+                sysfsfile_eeprom = io.open(file_path, mode="rb", buffering=0)
+            except IOError:
+                print("Error: reading sysfs file %s" % file_path)
+                return None
+
+            sfpd_obj = sff8436Dom()
+            if sfpd_obj is None:
+                return transceiver_dom_threshold_info_dict
+
+            # Dom Threshold data starts from offset 384
+            # Revert offset back to 0 once data is retrieved
+            offset = 384
+            dom_module_threshold_raw = self._read_eeprom_specific_bytes(
+                                     sysfsfile_eeprom,
+                                     (offset + QSFP_MODULE_THRESHOLD_OFFSET),
+                                     QSFP_MODULE_THRESHOLD_WIDTH)
+            if dom_module_threshold_raw is not None:
+                dom_module_threshold_data = sfpd_obj.parse_module_threshold_values(dom_module_threshold_raw, 0)
+            else:
+                return transceiver_dom_threshold_info_dict
+
+            dom_channel_threshold_raw = self._read_eeprom_specific_bytes(
+                                      sysfsfile_eeprom,
+                                      (offset + QSFP_CHANNL_THRESHOLD_OFFSET),
+                                 QSFP_CHANNL_THRESHOLD_WIDTH)
+            if dom_channel_threshold_raw is not None:
+                dom_channel_threshold_data = sfpd_obj.parse_channel_threshold_values(dom_channel_threshold_raw, 0)
+            else:
+                return transceiver_dom_threshold_info_dict
+
+            try:
+                sysfsfile_eeprom.close()
+            except IOError:
+                print("Error: closing sysfs file %s" % file_path)
+                return None
+
+            # Threshold Data
+            transceiver_dom_threshold_info_dict['temphighalarm'] = dom_module_threshold_data['data']['TempHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['temphighwarning'] = dom_module_threshold_data['data']['TempHighWarning']['value']
+            transceiver_dom_threshold_info_dict['templowalarm'] = dom_module_threshold_data['data']['TempLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['templowwarning'] = dom_module_threshold_data['data']['TempLowWarning']['value']
+            transceiver_dom_threshold_info_dict['vcchighalarm'] = dom_module_threshold_data['data']['VccHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['vcchighwarning'] = dom_module_threshold_data['data']['VccHighWarning']['value']
+            transceiver_dom_threshold_info_dict['vcclowalarm'] = dom_module_threshold_data['data']['VccLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['vcclowwarning'] = dom_module_threshold_data['data']['VccLowWarning']['value']
+            transceiver_dom_threshold_info_dict['rxpowerhighalarm'] = dom_channel_threshold_data['data']['RxPowerHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['rxpowerhighwarning'] = dom_channel_threshold_data['data']['RxPowerHighWarning']['value']
+            transceiver_dom_threshold_info_dict['rxpowerlowalarm'] = dom_channel_threshold_data['data']['RxPowerLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['rxpowerlowwarning'] = dom_channel_threshold_data['data']['RxPowerLowWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiashighalarm'] = dom_channel_threshold_data['data']['TxBiasHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['txbiashighwarning'] = dom_channel_threshold_data['data']['TxBiasHighWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowalarm'] = dom_channel_threshold_data['data']['TxBiasLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowwarning'] = dom_channel_threshold_data['data']['TxBiasLowWarning']['value']
+
+        else:
+            offset = 256
+            file_path = self._get_port_eeprom_path(port_num, self.DOM_EEPROM_ADDR)
+            if not self._sfp_eeprom_present(file_path, 0):
+                return None
+
+            try:
+                sysfsfile_eeprom = io.open(file_path,"rb",0)
+            except IOError:
+                print("Error: reading sysfs file %s" % file_path)
+                return None
+            
+            sfpd_obj = sff8472Dom(None,1)
+            if sfpd_obj is None:
+                return transceiver_dom_threshold_info_dict
+            
+            dom_module_threshold_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, 
+                                             (offset + SFP_MODULE_THRESHOLD_OFFSET), SFP_MODULE_THRESHOLD_WIDTH)
+            
+            if dom_module_threshold_raw is not None:
+                dom_module_threshold_data = sfpd_obj.parse_alarm_warning_threshold(dom_module_threshold_raw, 0)
+            else:
+                return transceiver_dom_threshold_info_dict
+
+            try:
+                sysfsfile_eeprom.close()
+            except IOError:
+                print("Error: closing sysfs file %s" % file_path)
+                return None
+
+            #Threshold Data
+            transceiver_dom_threshold_info_dict['temphighalarm'] = dom_module_threshold_data['data']['TempHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['templowalarm'] = dom_module_threshold_data['data']['TempLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['temphighwarning'] = dom_module_threshold_data['data']['TempHighWarning']['value']
+            transceiver_dom_threshold_info_dict['templowwarning'] = dom_module_threshold_data['data']['TempLowWarning']['value']
+            transceiver_dom_threshold_info_dict['vcchighalarm'] = dom_module_threshold_data['data']['VoltageHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['vcclowalarm'] = dom_module_threshold_data['data']['VoltageLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['vcchighwarning'] = dom_module_threshold_data['data']['VoltageHighWarning']['value']
+            transceiver_dom_threshold_info_dict['vcclowwarning'] = dom_module_threshold_data['data']['VoltageLowWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiashighalarm'] = dom_module_threshold_data['data']['BiasHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowalarm'] = dom_module_threshold_data['data']['BiasLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['txbiashighwarning'] = dom_module_threshold_data['data']['BiasHighWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowwarning'] = dom_module_threshold_data['data']['BiasLowWarning']['value']
+            transceiver_dom_threshold_info_dict['txpowerhighalarm'] = dom_module_threshold_data['data']['TXPowerHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['txpowerlowalarm'] = dom_module_threshold_data['data']['TXPowerLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['txpowerhighwarning'] = dom_module_threshold_data['data']['TXPowerHighWarning']['value']
+            transceiver_dom_threshold_info_dict['txpowerlowwarning'] = dom_module_threshold_data['data']['TXPowerLowWarning']['value']
+            transceiver_dom_threshold_info_dict['rxpowerhighalarm'] = dom_module_threshold_data['data']['RXPowerHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['rxpowerlowalarm'] = dom_module_threshold_data['data']['RXPowerLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['rxpowerhighwarning'] = dom_module_threshold_data['data']['RXPowerHighWarning']['value']
+            transceiver_dom_threshold_info_dict['rxpowerlowwarning'] = dom_module_threshold_data['data']['RXPowerLowWarning']['value']
+            
+        return transceiver_dom_threshold_info_dict

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
@@ -49,8 +49,8 @@ class SfpUtil(SfpUtilBase):
     """Platform-specific SfpUtil class"""
 
     PORT_START = 1
-    PORT_END = 64
-    PORTS_IN_BLOCK = 64
+    PORT_END = 34
+    PORTS_IN_BLOCK = 32
 
     BASE_RES_PATH = "/sys/bus/pci/devices/0000:04:00.0/resource0"
 

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
@@ -334,6 +334,18 @@ class SfpUtil(SfpUtilBase):
                 transceiver_dom_info_dict['tx2power'] = 'N/A'
                 transceiver_dom_info_dict['tx3power'] = 'N/A'
                 transceiver_dom_info_dict['tx4power'] = 'N/A'
+            else:
+                dom_channel_monitor_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_CHANNL_MON_OFFSET), QSFP_CHANNL_MON_WITH_TX_POWER_WIDTH)
+                if dom_channel_monitor_raw is not None:
+                    dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params_with_tx_power(dom_channel_monitor_raw, 0)
+                else:
+                    return None
+
+                transceiver_dom_info_dict['tx1power'] = dom_channel_monitor_data['data']['TX1Power']['value']
+                transceiver_dom_info_dict['tx2power'] = dom_channel_monitor_data['data']['TX2Power']['value']
+                transceiver_dom_info_dict['tx3power'] = dom_channel_monitor_data['data']['TX3Power']['value']
+                transceiver_dom_info_dict['tx4power'] = dom_channel_monitor_data['data']['TX4Power']['value']
+
             try:
                 sysfsfile_eeprom.close()
             except IOError:
@@ -352,7 +364,7 @@ class SfpUtil(SfpUtilBase):
             transceiver_dom_info_dict['tx4bias'] = dom_channel_monitor_data['data']['TX4Bias']['value']
 
         else:
-	   offset = 256
+           offset = 256
            file_path = self._get_port_eeprom_path(port_num, self.DOM_EEPROM_ADDR)
            if not self._sfp_eeprom_present(file_path, 0):
                return None

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/plugins/sfputil.py
@@ -9,13 +9,44 @@ try:
     import sys
     import getopt
     import time
+    import io
     from sonic_sfp.sfputilbase import SfpUtilBase
     from os import *
     from mmap import *
+    from sonic_sfp.sff8436 import sff8436InterfaceId
+    from sonic_sfp.sff8436 import sff8436Dom
+    from sonic_sfp.sff8472 import sff8472InterfaceId
+    from sonic_sfp.sff8472 import sff8472Dom
 
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
+#definitions of the offset and width for values in DOM info eeprom
+QSFP_DOM_REV_OFFSET = 1
+QSFP_DOM_REV_WIDTH = 1
+QSFP_TEMPE_OFFSET = 22
+QSFP_TEMPE_WIDTH = 2
+QSFP_VOLT_OFFSET = 26
+QSFP_VOLT_WIDTH = 2
+QSFP_CHANNL_MON_OFFSET = 34
+QSFP_CHANNL_MON_WIDTH = 16
+QSFP_CHANNL_MON_WITH_TX_POWER_WIDTH = 24
+QSFP_MODULE_THRESHOLD_OFFSET = 128
+QSFP_MODULE_THRESHOLD_WIDTH = 24
+QSFP_CHANNL_THRESHOLD_OFFSET = 176
+QSFP_CHANNL_THRESHOLD_WIDTH = 16
+QSFP_CHANNL_MON_MASK_OFFSET = 242
+QSFP_CHANNL_MON_MASK_WIDTH = 4
+
+SFP_TEMPE_OFFSET = 96
+SFP_TEMPE_WIDTH = 2
+SFP_VOLT_OFFSET = 98
+SFP_VOLT_WIDTH = 2
+SFP_MODULE_THRESHOLD_OFFSET = 0
+SFP_MODULE_THRESHOLD_WIDTH = 56
+
+XCVR_DOM_CAPABILITY_OFFSET = 92
+XCVR_DOM_CAPABILITY_WIDTH = 1
 
 class SfpUtil(SfpUtilBase):
     """Platform-specific SfpUtil class"""
@@ -287,3 +318,289 @@ class SfpUtil(SfpUtilBase):
                     return True, port_dict
 
             time.sleep(0.5)
+    
+     def get_transceiver_dom_info_dict(self, port_num):
+        transceiver_dom_info_dict = {}
+
+        dom_info_dict_keys = ['temperature', 'voltage',  'rx1power',
+                              'rx2power',    'rx3power', 'rx4power',
+                              'tx1bias',     'tx2bias',  'tx3bias',
+                              'tx4bias',     'tx1power', 'tx2power',
+                              'tx3power',    'tx4power',
+                             ]
+        transceiver_dom_info_dict = dict.fromkeys(dom_info_dict_keys, 'N/A')
+
+        if port_num in self.qsfp_ports:
+            offset = 0
+            offset_xcvr = 128
+            file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
+            if not self._sfp_eeprom_present(file_path, 0):
+                return None
+
+            try:
+                sysfsfile_eeprom = io.open(file_path, mode="rb", buffering=0)
+            except IOError:
+                print("Error: reading sysfs file %s" % file_path)
+                return None
+
+            sfpd_obj = sff8436Dom()
+            if sfpd_obj is None:
+                return transceiver_dom_info_dict
+
+            sfpi_obj = sff8436InterfaceId()
+            if sfpi_obj is None:
+                return transceiver_dom_info_dict
+
+            # QSFP capability byte parse, through this byte can know whether it support tx_power or not.
+            # TODO: in the future when decided to migrate to support SFF-8636 instead of SFF-8436,
+            # need to add more code for determining the capability and version compliance
+            # in SFF-8636 dom capability definitions evolving with the versions.
+            qsfp_dom_capability_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
+            if qsfp_dom_capability_raw is not None:
+                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+            else:
+                return transceiver_dom_info_dict
+
+            dom_temperature_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_TEMPE_OFFSET), QSFP_TEMPE_WIDTH)
+            if dom_temperature_raw is not None:
+                dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
+            else:
+                return transceiver_dom_info_dict
+
+            dom_voltage_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_VOLT_OFFSET), QSFP_VOLT_WIDTH)
+            if dom_voltage_raw is not None:
+                dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
+            else:
+                return transceiver_dom_info_dict
+
+            qsfp_dom_rev_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_DOM_REV_OFFSET), QSFP_DOM_REV_WIDTH)
+            if qsfp_dom_rev_raw is not None:
+                qsfp_dom_rev_data = sfpd_obj.parse_sfp_dom_rev(qsfp_dom_rev_raw, 0)
+            else:
+                return transceiver_dom_info_dict
+
+            transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
+            transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
+
+            # The tx_power monitoring is only available on QSFP which compliant with SFF-8636
+            # and claimed that it support tx_power with one indicator bit.
+            dom_channel_monitor_data = {}
+            qsfp_dom_rev = qsfp_dom_rev_data['data']['dom_rev']['value']
+            qsfp_tx_power_support = qspf_dom_capability_data['data']['Tx_power_support']['value']
+            if (qsfp_dom_rev[0:8] != 'SFF-8636' or (qsfp_dom_rev[0:8] == 'SFF-8636' and qsfp_tx_power_support != 'on')):
+                dom_channel_monitor_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_CHANNL_MON_OFFSET), QSFP_CHANNL_MON_WIDTH)
+                if dom_channel_monitor_raw is not None:
+                    dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params(dom_channel_monitor_raw, 0)
+                else:
+                    return transceiver_dom_info_dict
+
+	        transceiver_dom_info_dict['tx1power'] = 'N/A'
+                transceiver_dom_info_dict['tx2power'] = 'N/A'
+                transceiver_dom_info_dict['tx3power'] = 'N/A'
+                transceiver_dom_info_dict['tx4power'] = 'N/A'
+            try:
+                sysfsfile_eeprom.close()
+            except IOError:
+                print("Error: closing sysfs file %s" % file_path)
+                return None
+
+            transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
+            transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
+            transceiver_dom_info_dict['rx1power'] = dom_channel_monitor_data['data']['RX1Power']['value']
+            transceiver_dom_info_dict['rx2power'] = dom_channel_monitor_data['data']['RX2Power']['value']
+            transceiver_dom_info_dict['rx3power'] = dom_channel_monitor_data['data']['RX3Power']['value']
+            transceiver_dom_info_dict['rx4power'] = dom_channel_monitor_data['data']['RX4Power']['value']
+            transceiver_dom_info_dict['tx1bias'] = dom_channel_monitor_data['data']['TX1Bias']['value']
+            transceiver_dom_info_dict['tx2bias'] = dom_channel_monitor_data['data']['TX2Bias']['value']
+            transceiver_dom_info_dict['tx3bias'] = dom_channel_monitor_data['data']['TX3Bias']['value']
+            transceiver_dom_info_dict['tx4bias'] = dom_channel_monitor_data['data']['TX4Bias']['value']
+
+        else:
+           offset = 256
+           file_path = self._get_port_eeprom_path(port_num, self.DOM_EEPROM_ADDR)
+           if not self._sfp_eeprom_present(file_path, 0):
+               return None
+
+        try:
+           sysfsfile_eeprom = io.open(file_path,"rb",0)
+        except IOError:
+           print("Error: reading sysfs file %s" % file_path)
+           return None
+           
+        sfpd_obj = sff8472Dom(None,1)
+        if sfpd_obj is None:
+            return transceiver_dom_info_dict
+
+        dom_temperature_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_TEMPE_OFFSET),
+									SFP_TEMPE_WIDTH) 
+        
+	if dom_temperature_raw is not None:
+            dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
+        else:
+            return transceiver_dom_info_dict
+
+        dom_voltage_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_VOLT_OFFSET), 
+										SFP_VOLT_WIDTH)
+        if dom_voltage_raw is not None:
+             dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
+        else: 
+             return transceiver_dom_info_dict
+
+        dom_channel_monitor_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_MODULE_THRESHOLD_OFFSET), 
+									SFP_MODULE_THRESHOLD_WIDTH)
+        if dom_channel_monitor_raw is not None:
+           dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params(dom_channel_monitor_raw, 0)
+        else:
+           return transceiver_dom_info_dict
+
+        try:
+           sysfsfile_eeprom.close()
+        except IOError:
+           print("Error: closing sysfs file %s" % file_path)
+           return None
+
+        transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
+        transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
+        transceiver_dom_info_dict['rx1power'] = dom_channel_monitor_data['data']['RXPower']['value']
+        transceiver_dom_info_dict['rx2power'] = 'N/A'
+        transceiver_dom_info_dict['rx3power'] = 'N/A'
+        transceiver_dom_info_dict['rx4power'] = 'N/A'
+        transceiver_dom_info_dict['tx1bias'] = dom_channel_monitor_data['data']['TXBias']['value']
+        transceiver_dom_info_dict['tx2bias'] = 'N/A'
+        transceiver_dom_info_dict['tx3bias'] = 'N/A'
+        transceiver_dom_info_dict['tx4bias'] = 'N/A'
+        transceiver_dom_info_dict['tx1power'] = dom_channel_monitor_data['data']['TXPower']['value']
+        transceiver_dom_info_dict['tx2power'] = 'N/A'
+        transceiver_dom_info_dict['tx3power'] = 'N/A'
+        transceiver_dom_info_dict['tx4power'] = 'N/A'
+
+	return transceiver_dom_info_dict
+ 
+    def get_transceiver_dom_threshold_info_dict(self, port_num):
+        transceiver_dom_threshold_info_dict = {}
+        dom_info_dict_keys = ['temphighalarm',    'temphighwarning',
+                              'templowalarm',     'templowwarning',
+                              'vcchighalarm',     'vcchighwarning',
+                              'vcclowalarm',      'vcclowwarning',
+                              'rxpowerhighalarm', 'rxpowerhighwarning',
+                              'rxpowerlowalarm',  'rxpowerlowwarning',
+                              'txpowerhighalarm', 'txpowerhighwarning',
+                              'txpowerlowalarm',  'txpowerlowwarning',
+                              'txbiashighalarm',  'txbiashighwarning',
+                              'txbiaslowalarm',   'txbiaslowwarning'
+                             ]
+        transceiver_dom_threshold_info_dict = dict.fromkeys(dom_info_dict_keys, 'N/A')
+
+        if port_num in self.qsfp_ports:
+	    file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
+            if not self._sfp_eeprom_present(file_path, 0):
+                return None
+
+            try:
+                sysfsfile_eeprom = io.open(file_path, mode="rb", buffering=0)
+            except IOError:
+                print("Error: reading sysfs file %s" % file_path)
+                return None
+
+            sfpd_obj = sff8436Dom()
+            if sfpd_obj is None:
+                return transceiver_dom_threshold_info_dict
+
+            # Dom Threshold data starts from offset 384
+            # Revert offset back to 0 once data is retrieved
+            offset = 384
+            dom_module_threshold_raw = self._read_eeprom_specific_bytes(
+                                     sysfsfile_eeprom,
+                                     (offset + QSFP_MODULE_THRESHOLD_OFFSET),
+                                     QSFP_MODULE_THRESHOLD_WIDTH)
+            if dom_module_threshold_raw is not None:
+                dom_module_threshold_data = sfpd_obj.parse_module_threshold_values(dom_module_threshold_raw, 0)
+            else:
+                return transceiver_dom_threshold_info_dict
+
+            dom_channel_threshold_raw = self._read_eeprom_specific_bytes(
+                                      sysfsfile_eeprom,
+                                      (offset + QSFP_CHANNL_THRESHOLD_OFFSET),
+                                 QSFP_CHANNL_THRESHOLD_WIDTH)
+            if dom_channel_threshold_raw is not None:
+                dom_channel_threshold_data = sfpd_obj.parse_channel_threshold_values(dom_channel_threshold_raw, 0)
+            else:
+                return transceiver_dom_threshold_info_dict
+
+            try:
+                sysfsfile_eeprom.close()
+            except IOError:
+                print("Error: closing sysfs file %s" % file_path)
+                return None
+
+            # Threshold Data
+            transceiver_dom_threshold_info_dict['temphighalarm'] = dom_module_threshold_data['data']['TempHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['temphighwarning'] = dom_module_threshold_data['data']['TempHighWarning']['value']
+            transceiver_dom_threshold_info_dict['templowalarm'] = dom_module_threshold_data['data']['TempLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['templowwarning'] = dom_module_threshold_data['data']['TempLowWarning']['value']
+            transceiver_dom_threshold_info_dict['vcchighalarm'] = dom_module_threshold_data['data']['VccHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['vcchighwarning'] = dom_module_threshold_data['data']['VccHighWarning']['value']
+            transceiver_dom_threshold_info_dict['vcclowalarm'] = dom_module_threshold_data['data']['VccLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['vcclowwarning'] = dom_module_threshold_data['data']['VccLowWarning']['value']
+            transceiver_dom_threshold_info_dict['rxpowerhighalarm'] = dom_channel_threshold_data['data']['RxPowerHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['rxpowerhighwarning'] = dom_channel_threshold_data['data']['RxPowerHighWarning']['value']
+            transceiver_dom_threshold_info_dict['rxpowerlowalarm'] = dom_channel_threshold_data['data']['RxPowerLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['rxpowerlowwarning'] = dom_channel_threshold_data['data']['RxPowerLowWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiashighalarm'] = dom_channel_threshold_data['data']['TxBiasHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['txbiashighwarning'] = dom_channel_threshold_data['data']['TxBiasHighWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowalarm'] = dom_channel_threshold_data['data']['TxBiasLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowwarning'] = dom_channel_threshold_data['data']['TxBiasLowWarning']['value']
+
+        else:
+            offset = 256
+            file_path = self._get_port_eeprom_path(port_num, self.DOM_EEPROM_ADDR)
+            if not self._sfp_eeprom_present(file_path, 0):
+                return None
+
+            try:
+                sysfsfile_eeprom = io.open(file_path,"rb",0)
+            except IOError:
+                print("Error: reading sysfs file %s" % file_path)
+                return None
+            
+            sfpd_obj = sff8472Dom(None,1)
+            if sfpd_obj is None:
+                return transceiver_dom_threshold_info_dict
+            
+            dom_module_threshold_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, 
+                                             (offset + SFP_MODULE_THRESHOLD_OFFSET), SFP_MODULE_THRESHOLD_WIDTH)
+            
+            if dom_module_threshold_raw is not None:
+                dom_module_threshold_data = sfpd_obj.parse_alarm_warning_threshold(dom_module_threshold_raw, 0)
+            else:
+                return transceiver_dom_threshold_info_dict
+
+            try:
+                sysfsfile_eeprom.close()
+            except IOError:
+                print("Error: closing sysfs file %s" % file_path)
+                return None
+
+            #Threshold Data
+            transceiver_dom_threshold_info_dict['temphighalarm'] = dom_module_threshold_data['data']['TempHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['templowalarm'] = dom_module_threshold_data['data']['TempLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['temphighwarning'] = dom_module_threshold_data['data']['TempHighWarning']['value']
+            transceiver_dom_threshold_info_dict['templowwarning'] = dom_module_threshold_data['data']['TempLowWarning']['value']
+            transceiver_dom_threshold_info_dict['vcchighalarm'] = dom_module_threshold_data['data']['VoltageHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['vcclowalarm'] = dom_module_threshold_data['data']['VoltageLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['vcchighwarning'] = dom_module_threshold_data['data']['VoltageHighWarning']['value']
+            transceiver_dom_threshold_info_dict['vcclowwarning'] = dom_module_threshold_data['data']['VoltageLowWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiashighalarm'] = dom_module_threshold_data['data']['BiasHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowalarm'] = dom_module_threshold_data['data']['BiasLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['txbiashighwarning'] = dom_module_threshold_data['data']['BiasHighWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowwarning'] = dom_module_threshold_data['data']['BiasLowWarning']['value']
+            transceiver_dom_threshold_info_dict['txpowerhighalarm'] = dom_module_threshold_data['data']['TXPowerHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['txpowerlowalarm'] = dom_module_threshold_data['data']['TXPowerLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['txpowerhighwarning'] = dom_module_threshold_data['data']['TXPowerHighWarning']['value']
+            transceiver_dom_threshold_info_dict['txpowerlowwarning'] = dom_module_threshold_data['data']['TXPowerLowWarning']['value']
+            transceiver_dom_threshold_info_dict['rxpowerhighalarm'] = dom_module_threshold_data['data']['RXPowerHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['rxpowerlowalarm'] = dom_module_threshold_data['data']['RXPowerLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['rxpowerhighwarning'] = dom_module_threshold_data['data']['RXPowerHighWarning']['value']
+            transceiver_dom_threshold_info_dict['rxpowerlowwarning'] = dom_module_threshold_data['data']['RXPowerLowWarning']['value']
+            
+        return transceiver_dom_threshold_info_dict

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/plugins/sfputil.py
@@ -394,10 +394,22 @@ class SfpUtil(SfpUtilBase):
                 else:
                     return transceiver_dom_info_dict
 
-	        transceiver_dom_info_dict['tx1power'] = 'N/A'
+                transceiver_dom_info_dict['tx1power'] = 'N/A'
                 transceiver_dom_info_dict['tx2power'] = 'N/A'
                 transceiver_dom_info_dict['tx3power'] = 'N/A'
                 transceiver_dom_info_dict['tx4power'] = 'N/A'
+            else:
+                dom_channel_monitor_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + QSFP_CHANNL_MON_OFFSET), QSFP_CHANNL_MON_WITH_TX_POWER_WIDTH)
+                if dom_channel_monitor_raw is not None:
+                    dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params_with_tx_power(dom_channel_monitor_raw, 0)
+                else:
+                    return None
+
+                transceiver_dom_info_dict['tx1power'] = dom_channel_monitor_data['data']['TX1Power']['value']
+                transceiver_dom_info_dict['tx2power'] = dom_channel_monitor_data['data']['TX2Power']['value']
+                transceiver_dom_info_dict['tx3power'] = dom_channel_monitor_data['data']['TX3Power']['value']
+                transceiver_dom_info_dict['tx4power'] = dom_channel_monitor_data['data']['TX4Power']['value']
+
             try:
                 sysfsfile_eeprom.close()
             except IOError:
@@ -434,7 +446,7 @@ class SfpUtil(SfpUtilBase):
         dom_temperature_raw = self._read_eeprom_specific_bytes(sysfsfile_eeprom, (offset + SFP_TEMPE_OFFSET),
 									SFP_TEMPE_WIDTH) 
         
-	if dom_temperature_raw is not None:
+        if dom_temperature_raw is not None:
             dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
         else:
             return transceiver_dom_info_dict
@@ -492,7 +504,7 @@ class SfpUtil(SfpUtilBase):
         transceiver_dom_threshold_info_dict = dict.fromkeys(dom_info_dict_keys, 'N/A')
 
         if port_num in self.qsfp_ports:
-	    file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
+            file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
             if not self._sfp_eeprom_present(file_path, 0):
                 return None
 

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/sfputil.py
@@ -348,7 +348,7 @@ class SfpUtil(SfpUtilBase):
         transceiver_dom_info_dict = dict.fromkeys(dom_info_dict_keys, 'N/A')
 
 	if port_num in self.qsfp_ports:
-	    offset = 0
+            offset = 0
             offset_xcvr = 128
             file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
             if not self._sfp_eeprom_present(file_path, 0):
@@ -415,7 +415,7 @@ class SfpUtil(SfpUtilBase):
                 transceiver_dom_info_dict['tx2power'] = 'N/A'
                 transceiver_dom_info_dict['tx3power'] = 'N/A'
                 transceiver_dom_info_dict['tx4power'] = 'N/A'
-	    try:
+            try:
                 sysfsfile_eeprom.close()
             except IOError:
                 print("Error: closing sysfs file %s" % file_path)
@@ -433,7 +433,7 @@ class SfpUtil(SfpUtilBase):
             transceiver_dom_info_dict['tx4bias'] = dom_channel_monitor_data['data']['TX4Bias']['value']
 
         else:
-	   offset = 256
+           offset = 256
            file_path = self._get_port_eeprom_path(port_num, self.DOM_EEPROM_ADDR)
            if not self._sfp_eeprom_present(file_path, 0):
                return None
@@ -507,7 +507,7 @@ class SfpUtil(SfpUtilBase):
         transceiver_dom_threshold_info_dict = dict.fromkeys(dom_info_dict_keys, 'N/A')
 
         if port_num in self.qsfp_ports:
-	    file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
+            file_path = self._get_port_eeprom_path(port_num, self.IDENTITY_EEPROM_ADDR)
             if not self._sfp_eeprom_present(file_path, 0):
                 return None
 
@@ -578,7 +578,7 @@ class SfpUtil(SfpUtilBase):
                 print("Error: reading sysfs file %s" % file_path)
                 return None
             
-	    sfpd_obj = sff8472Dom(None,1)
+            sfpd_obj = sff8472Dom(None,1)
             if sfpd_obj is None:
                 return transceiver_dom_threshold_info_dict
             
@@ -608,7 +608,7 @@ class SfpUtil(SfpUtilBase):
             transceiver_dom_threshold_info_dict['txbiashighalarm'] = dom_module_threshold_data['data']['BiasHighAlarm']['value']
             transceiver_dom_threshold_info_dict['txbiaslowalarm'] = dom_module_threshold_data['data']['BiasLowAlarm']['value']
             transceiver_dom_threshold_info_dict['txbiashighwarning'] = dom_module_threshold_data['data']['BiasHighWarning']['value']
- 	    transceiver_dom_threshold_info_dict['txbiaslowwarning'] = dom_module_threshold_data['data']['BiasLowWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowwarning'] = dom_module_threshold_data['data']['BiasLowWarning']['value']
             transceiver_dom_threshold_info_dict['txpowerhighalarm'] = dom_module_threshold_data['data']['TXPowerHighAlarm']['value']
             transceiver_dom_threshold_info_dict['txpowerlowalarm'] = dom_module_threshold_data['data']['TXPowerLowAlarm']['value']
             transceiver_dom_threshold_info_dict['txpowerhighwarning'] = dom_module_threshold_data['data']['TXPowerHighWarning']['value']

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/scripts/s5232f_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/scripts/s5232f_platform.sh
@@ -51,7 +51,7 @@ switch_board_qsfp_mux() {
     sleep 2
 }
 
-#Attach/Detach 64 instances of EEPROM driver QSFP ports
+#Attach/Detach 32 instances of EEPROM driver QSFP ports
 #eeprom can dump data using below command
 switch_board_qsfp() {
         case $1 in
@@ -60,12 +60,32 @@ switch_board_qsfp() {
                         do
                             echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
                         done
-                        echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-34/$1
-                        echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-35/$1
                         ;;
  
         "delete_device")
-                        for ((i=2;i<=41;i++));
+                        for ((i=2;i<=33;i++));
+                        do
+                            echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+                        done
+                        ;;
+
+        *)              echo "s5232f_platform: switch_board_qsfp: invalid command !"
+                        ;;
+    esac
+}
+
+#Attach 2 instances of EEPROM driver SFP ports
+switch_board_sfp() {
+        case $1 in
+        "new_device")
+                        for ((i=34;i<=35;i++));
+                        do
+                            echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+                        done
+                        ;;
+
+        "delete_device")
+                        for ((i=34;i<=35;i++));
                         do
                             echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
                         done
@@ -105,6 +125,7 @@ if [ "$1" == "init" ]; then
     sys_eeprom "new_device"
     switch_board_qsfp_mux "new_device"
     switch_board_qsfp "new_device"
+    switch_board_sfp "new_device"
     switch_board_modsel
     switch_board_led_default
     python /usr/bin/qsfp_irq_enable.py
@@ -113,7 +134,7 @@ elif [ "$1" == "deinit" ]; then
     sys_eeprom "delete_device"
     switch_board_qsfp "delete_device"
     switch_board_qsfp_mux "delete_device"
-
+    switch_board_sfp "delete_device"
     modprobe -r i2c-mux-pca954x
     modprobe -r i2c-dev
 else

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/scripts/s5232f_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/scripts/s5232f_platform.sh
@@ -56,10 +56,12 @@ switch_board_qsfp_mux() {
 switch_board_qsfp() {
         case $1 in
         "new_device")
-                        for ((i=2;i<=41;i++));
+                        for ((i=2;i<=33;i++));
                         do
-                            echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+                            echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
                         done
+                        echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-34/$1
+                        echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-35/$1
                         ;;
  
         "delete_device")

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/scripts/s5248f_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/scripts/s5248f_platform.sh
@@ -58,7 +58,7 @@ switch_board_qsfp() {
         "new_device")
                         for ((i=2;i<=57;i++));
                         do
-                            echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+                            echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
                         done
                         ;;
  

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/sfp.py
@@ -44,7 +44,7 @@ info_dict_keys = ['type', 'hardwarerev', 'serialnum',
                   'manufacturename', 'modelname', 'Connector',
                   'encoding', 'ext_identifier', 'ext_rateselect_compliance',
                   'cable_type', 'cable_length', 'nominal_bit_rate',
-                  'specification_compliance', ,'type_abbrv_name','vendor_date', 'vendor_oui']
+                  'specification_compliance','type_abbrv_name','vendor_date', 'vendor_oui']
 
 dom_dict_keys = ['rx_los',       'tx_fault',   'reset_status',
                  'power_lpmode', 'tx_disable', 'tx_disable_channel',


### PR DESCRIPTION
**- What I did**
xcvrd returns the following error in get_transceiver_change_event() as timeout argument is not used.

Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/bin/xcvrd", line 795, in task_worker
    status, port_dict = _wrapper_get_transceiver_change_event(timeout)
  File "/usr/bin/xcvrd", line 158, in _wrapper_get_transceiver_change_event
    return platform_sfputil.get_transceiver_change_event(timeout)
TypeError: get_transceiver_change_event() takes exactly 1 argument (2 given

**- How I did it**
Use timeout argument in get_transceiver_change_event(). 
**- How to verify it**
Run xcvrd and check whether any error is returned.
**- Description for the changelog**
Use timeout argument in get_transceiver_change_event() as xcvrd passes the timeout value.