### PR TITLE
[config engine] For l2 preset, use admin_status: up by default

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -51,6 +51,7 @@ def generate_l2_config(data):
     data['VLAN']['Vlan1000'].setdefault('members', vp)
     data['VLAN_MEMBER'] = {}
     for port in natsorted(data['PORT'].keys()):
+        data['PORT'][port].setdefault('admin_status', 'up')
         data['VLAN_MEMBER']['Vlan1000|{}'.format(port)] = {'tagging_mode': 'untagged'}
     return data
 


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated the l2 preset config generator to specify 'admin_status': 'up' for every port by default.
The use of setdefault() ensures that if port already has some admin_status set, the original value will not be overwritten.

**- How I did it**

**- How to verify it**

sonic-cfggen -H -p -k $HWSKU --preset l2

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
