### PR TITLE
Add sonic-ztp as a submodule to sonic-buildimage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -69,3 +69,6 @@
 [submodule "Switch-SDK-drivers"]
 	path = platform/mellanox/sdk-src/sx-kernel/Switch-SDK-drivers
 	url = https://github.com/Mellanox/Switch-SDK-drivers
+[submodule "src/sonic-ztp"]
+	path = src/sonic-ztp
+	url = https://github.com/Azure/sonic-ztp


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added sonic-ztp repo as a submodule to sonic-buildimage

**- How I did it**
cd sonic-buildimage
git submodule add https://github.com/Azure/sonic-ztp src/sonic-ztp

**- How to verify it**
cd sonic-buildimage
make init
ls src/sonic-ztp/*
git submodule status src/sonic-ztp
 374c9e804a9f434cdb58fa7afe0c3f6201bfe56f src/sonic-ztp (heads/master)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add sonic-ztp as a submodule to sonic-buildimage

**- A picture of a cute animal (not mandatory but encouraged)**
