### PR TITLE
[swss service] flush fast-reboot enabled flag upon swss stopping

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -161,6 +161,13 @@ stop() {
     /usr/bin/${SERVICE}.sh stop
     debug "Stopped ${SERVICE} service..."
 
+    # Flush FAST_REBOOT table when swss needs to stop. The only
+    # time when this would take effect is when fast-reboot
+    # encountered error, e.g. syncd crashed. And swss needs to
+    # be restarted.
+    debug "Clearing FAST_REBOOT flag..."
+    clean_up_tables 6 "'FAST_REBOOT*'"
+
     # Unlock has to happen before reaching out to peer service
     unlock_service_state_change
 


### PR DESCRIPTION
**- What I did**

If we need to stop swss during fast-reboot procedure on the boot up path, it means that something went wrong, like syncd/orchagent crashed already, we are stopping and restarting swss/syncd to re-initialize. In this case, we should proceed as if it is a cold reboot.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Instrument code to cause an failure on fast-reboot recovering path. Without the change, syncd/swss will restart 3 times and stuck at failure state until manually resets the state and try again. With the change, the fast reboot fail once and recovered with a cold start automatically.