### PR TITLE
[caclmgrd] Fix application of IPv6 service ACL rules

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -194,13 +194,14 @@ class ControlPlaneAclManager(object):
                             continue
 
                         # If we haven't determined the IP version for this ACL table yet,
-                        # try to do it now. We determine heuristically based on whether the
-                        # src IP is an IPv4 or IPv6 address.
-                        if not table_ip_version and "SRC_IP" in rule_props and rule_props["SRC_IP"]:
-                            ip_addr = ipaddress.IPAddress(rule_props["SRC_IP"].split("/")[0])
-                            if isinstance(ip_addr, ipaddress.IPv6Address):
+                        # try to do it now. We attempt to determine heuristically based on
+                        # whether the src or dst IP of this rule is an IPv4 or IPv6 address.
+                        if not table_ip_version:
+                            if (("SRC_IPV6" in rule_props and rule_props["SRC_IPV6"]) or
+                                ("DST_IPV6" in rule_props and rule_props["DST_IPV6"])):
                                 table_ip_version = 6
-                            elif isinstance(ip_addr, ipaddress.IPv4Address):
+                            elif (("SRC_IP" in rule_props and rule_props["SRC_IP"]) or
+                                  ("DST_IP" in rule_props and rule_props["DST_IP"])):
                                 table_ip_version = 4
 
                 # If we were unable to determine whether this ACL table contains


### PR DESCRIPTION
Caclmgrd was written with the understanding that the "SRC_IP" field of the rule properties would contain either a v4 or v6 IP address, thus we examined the IP address in that field to make an educated guess as to whether the table which contained that rule contained v4 or v6 addresses.

However, this PR: https://github.com/Azure/sonic-utilities/pull/377 broke the logic in caclmgrd, because it now causes the acl-loader application to perform the same check and if the IP address is a v4 address, it inserts it into the "SRC_IP" field as it did previously. However, if the IP address is a v6 address, it inserts the address into a new "SRC_IPV6" field, leaving the "SRC_IP" field empty, which caused the logic in caclmgrd to fail to determine tables which contain IPv6 addresses, therefore not applying IPv6 service ACLs. This was noticed via log messages like the following:

```
WARNING caclmgrd: Unable to determine if ACL table 'IPV6_SNMP_ACL' contains IPv4 or IPv6 rules. Skipping table...
```

This PR now adapts to the new acl-loader logic, and determines whether the table contains v4 or v6 address based on whether the rules in the table contain "SRC_IP"/"DST_IP" fields (v4), or "SRC_IPV6"/"DST_IPV6" fields (v6).