### PR TITLE
[Juniper][QFX5210] Skip starting 'ledd'

### DIFF
--- a/device/juniper/x86_64-juniper_qfx5210-r0/pmon_daemon_control.json
+++ b/device/juniper/x86_64-juniper_qfx5210-r0/pmon_daemon_control.json
@@ -1,0 +1,3 @@
+{
+    "skip_ledd": true
+}


### PR DESCRIPTION
There is no ledd in qfx5210 platform. This patch skip starting
ledd in pmon container. This also will help in fixing the pmon
container not getting started if there is no ledd running.

Signed-off-by: Ciju Rajan K <crajank@juniper.net>

**- How to verify it**
Pmon comes up fine.

**- Description for the changelog**
Skip starting 'ledd' in QFX5210 platform
