### PR TITLE
[MultiDB] (./dockers dir) : replace redis-cli with sonic-db-cli and use new DBConnector

### DIFF
--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-STATE_DB_IDX="6"
-
 function wait_until_iface_ready
 {
     IFACE_NAME=$1
@@ -12,7 +10,7 @@ function wait_until_iface_ready
     # Wait for the interface to come up
     # (i.e., interface is present in STATE_DB and state is "ok")
     while true; do
-        RESULT=$(redis-cli -n ${STATE_DB_IDX} HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
+        RESULT=$(sonic-db-cli STATE_DB HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
         if [ x"$RESULT" == x"ok" ]; then
             break
         fi

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -87,7 +87,7 @@ class Daemon(object):
         self.subscribers = set()
 
     def add_manager(self, db_name, table_name, callback):
-        db = swsscommon.SonicDBConfig::getDbId(db_name)
+        db = swsscommon.SonicDBConfig.getDbId(db_name)
         if db not in self.db_connectors:
             self.db_connectors[db] = swsscommon.DBConnector(db_name, 0)
 

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -86,9 +86,10 @@ class Daemon(object):
         self.callbacks = defaultdict(lambda : defaultdict(list)) # db -> table -> []
         self.subscribers = set()
 
-    def add_manager(self, db, table_name, callback):
+    def add_manager(self, db_name, table_name, callback):
+        db = swsscommon.SonicDBConfig::getDbId(db_name)
         if db not in self.db_connectors:
-            self.db_connectors[db] = swsscommon.DBConnector(db, swsscommon.DBConnector.DEFAULT_UNIXSOCKET, 0)
+            self.db_connectors[db] = swsscommon.DBConnector(db_name, 0)
 
         if table_name not in self.callbacks[db]:
             conn = self.db_connectors[db]
@@ -223,7 +224,7 @@ class BGPDeviceMetaMgr(Manager):
             daemon,
             directory,
             [],
-            swsscommon.CONFIG_DB,
+            "CONFIG_DB",
             swsscommon.CFG_DEVICE_METADATA_TABLE_NAME
         )
 
@@ -248,7 +249,7 @@ class BGPNeighborMetaMgr(Manager):
             daemon,
             directory,
             [],
-            swsscommon.CONFIG_DB,
+            "CONFIG_DB",
             swsscommon.CFG_DEVICE_NEIGHBOR_METADATA_TABLE_NAME
         )
 
@@ -270,7 +271,7 @@ class BGPPeerMgr(Manager):
                 ("meta", "localhost/bgp_asn"),
                 ("neigmeta", ""),
             ],
-            swsscommon.CONFIG_DB,
+            "CONFIG_DB",
             swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME
         )
         self.peers = self.load_peers()

--- a/dockers/docker-lldp-sv2/lldpmgrd
+++ b/dockers/docker-lldp-sv2/lldpmgrd
@@ -84,22 +84,18 @@ class LldpManager(object):
         pending_cmds: Dictionary where key is port name, value is pending
                       LLDP configuration command to run
     """
-    REDIS_HOSTNAME = "localhost"
-    REDIS_PORT = 6379
     REDIS_TIMEOUT_MS = 0
 
     def __init__(self):
         # Open a handle to the Config database
-        self.config_db = swsscommon.DBConnector(swsscommon.CONFIG_DB,
-                                                self.REDIS_HOSTNAME,
-                                                self.REDIS_PORT,
-                                                self.REDIS_TIMEOUT_MS)
+        self.config_db = swsscommon.DBConnector("CONFIG_DB",
+                                                self.REDIS_TIMEOUT_MS,
+                                                True)
 
         # Open a handle to the Application database
-        self.appl_db = swsscommon.DBConnector(swsscommon.APPL_DB,
-                                                self.REDIS_HOSTNAME,
-                                                self.REDIS_PORT,
-                                                self.REDIS_TIMEOUT_MS)
+        self.appl_db = swsscommon.DBConnector("APPL_DB",
+                                              self.REDIS_TIMEOUT_MS,
+                                              True)
 
         self.pending_cmds = {}
 

--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -43,11 +43,11 @@ HWSKU=`sonic-cfggen -d -v "DEVICE_METADATA['localhost']['hwsku']"`
 
 # Don't load json config if system warm start or
 # swss docker warm start is enabled, the data already exists in appDB.
-SYSTEM_WARM_START=`redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
-SWSS_WARM_START=`redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|swss" enable`
+SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+SWSS_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|swss" enable`
 if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; then
   # We have to make sure db data has not been flushed.
-  RESTORE_COUNT=`redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restore_count`
+  RESTORE_COUNT=`sonic-db-cli STATE_DB hget "WARM_RESTART_TABLE|orchagent" restore_count`
   if [[ -n "$RESTORE_COUNT" ]] && [[ "$RESTORE_COUNT" != "0" ]]; then
     exit 0
   fi

--- a/dockers/docker-router-advertiser/wait_for_intf.sh.j2
+++ b/dockers/docker-router-advertiser/wait_for_intf.sh.j2
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-STATE_DB_IDX="6"
-
 VLAN_TABLE_PREFIX="VLAN_TABLE"
 
 function wait_until_iface_ready
@@ -14,7 +12,7 @@ function wait_until_iface_ready
     # Wait for the interface to come up
     # (i.e., interface is present in STATE_DB and state is "ok")
     while true; do
-        RESULT=$(redis-cli -n ${STATE_DB_IDX} HGET "${TABLE_PREFIX}|${IFACE}" "state" 2> /dev/null)
+        RESULT=$(sonic-db-cli STATE_DB HGET "${TABLE_PREFIX}|${IFACE}" "state" 2> /dev/null)
         if [ x"$RESULT" == x"ok" ]; then
             break
         fi

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -29,7 +29,7 @@ fi
 
 # If no configuration entry exists for TELEMETRY, create one default port
 if [ -z $TELEMETRY ]; then
-    redis-cli -n 4 hset "TELEMETRY|gnmi" port 8080
+    sonic-db-cli CONFIG_DB hset "TELEMETRY|gnmi" port 8080
 fi
 
 PORT=`sonic-cfggen -d -v "TELEMETRY['gnmi']['port']"`

--- a/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-STATE_DB_IDX="6"
-
 function wait_until_iface_ready
 {
     IFACE_NAME=$1
@@ -12,7 +10,7 @@ function wait_until_iface_ready
     # Wait for the interface to come up
     # (i.e., interface is present in STATE_DB and state is "ok")
     while true; do
-        RESULT=$(redis-cli -n ${STATE_DB_IDX} HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
+        RESULT=$(sonic-db-cli "STATE_DB" HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
         if [ x"$RESULT" == x"ok" ]; then
             break
         fi

--- a/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
@@ -10,7 +10,7 @@ function wait_until_iface_ready
     # Wait for the interface to come up
     # (i.e., interface is present in STATE_DB and state is "ok")
     while true; do
-        RESULT=$(sonic-db-cli "STATE_DB" HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
+        RESULT=$(sonic-db-cli STATE_DB HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
         if [ x"$RESULT" == x"ok" ]; then
             break
         fi


### PR DESCRIPTION
this commit made changes in sonic-buildimage/dockers/ directory:

* replace redis-cli with sonic-db-cli
* replace old DBConnector with new DBConnector 
* vs tests passed, loaded on DUT, looks good, script works fine.

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com