### PR TITLE
[syncd.sh] remove chipdown on mellanox

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -111,7 +111,6 @@ start() {
                 /bin/systemctl stop pmon
                 debug "pmon is active while syncd starting, stop it first"
             fi
-            /usr/bin/hw-management.sh chipdown
         fi
 
         if [[ x"$BOOT_TYPE" == x"fast" ]]; then


### PR DESCRIPTION
ASIC reset events are captured by hw-mgmt and hw-mgmt calls chipup/chipdown internally without OS iteraction

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
