### PR TITLE
[MultiDB]except src and dockers : replace redis-cli with sonic-db-cli and use new DBConnector

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -22,8 +22,6 @@ SFP_MODULE_THRESHOLD_WIDTH = 56
 SFP_I2C_PAGE_SIZE = 256
 
 # parameters for DB connection 
-REDIS_HOSTNAME = "localhost"
-REDIS_PORT = 6379
 REDIS_TIMEOUT_USECS = 0
 
 # parameters for SFP presence
@@ -190,10 +188,9 @@ class SfpUtil(SfpUtilBase):
 
         if self.db_sel == None:
             from swsscommon import swsscommon
-            self.state_db = swsscommon.DBConnector(swsscommon.STATE_DB,
-                                             REDIS_HOSTNAME,
-                                             REDIS_PORT,
-                                             REDIS_TIMEOUT_USECS)
+            self.state_db = swsscommon.DBConnector("STATE_DB",
+                                                   REDIS_TIMEOUT_USECS,
+                                                   True))
 
             # Subscribe to state table for SFP change notifications
             self.db_sel = swsscommon.Select()

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -63,20 +63,20 @@ function preStartAction()
         docker cp /tmp/dump.rdb database:/var/lib/redis/
     fi
 {%- elif docker_container_name == "snmp" %}
-    docker exec -i database redis-cli -n 6 HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
-    vrfenabled=`/usr/bin/redis-cli -n 4 hget "MGMT_VRF_CONFIG|vrf_global" mgmtVrfEnabled`
-    v1SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestIp`
-    v1SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestPort`
-    v1Vrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" vrf`
-    v1Comm=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" Community`
-    v2SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" DestIp`
-    v2SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" DestPort`
-    v2Vrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" vrf`
-    v2Comm=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" Community`
-    v3SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestIp`
-    v3SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestPort`
-    v3Vrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" vrf`
-    v3Comm=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" Community`
+    sonic-db-cli STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
+    vrfenabled=`sonic-db-cli CONFIG_DB hget "MGMT_VRF_CONFIG|vrf_global" mgmtVrfEnabled`
+    v1SnmpTrapIp=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v1TrapDest" DestIp`
+    v1SnmpTrapPort=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v1TrapDest" DestPort`
+    v1Vrf=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v1TrapDest" vrf`
+    v1Comm=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v1TrapDest" Community`
+    v2SnmpTrapIp=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v2TrapDest" DestIp`
+    v2SnmpTrapPort=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v2TrapDest" DestPort`
+    v2Vrf=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v2TrapDest" vrf`
+    v2Comm=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v2TrapDest" Community`
+    v3SnmpTrapIp=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v3TrapDest" DestIp`
+    v3SnmpTrapPort=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v3TrapDest" DestPort`
+    v3Vrf=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v3TrapDest" vrf`
+    v3Comm=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v3TrapDest" Community`
 
     if [ "${v1SnmpTrapIp}" != "" ]
     then
@@ -113,7 +113,7 @@ function preStartAction()
     fi
 
     echo -n "" > /tmp/snmpagentaddr.yml
-    keys=`/usr/bin/redis-cli -n 4 keys "SNMP_AGENT_ADDRESS_CONFIG|*"`
+    keys=`sonic-db-cli CONFIG_DB keys "SNMP_AGENT_ADDRESS_CONFIG|*"`
     count=1
     for key in $keys;do
         ip=`echo $key|cut -d "|" -f2`
@@ -151,10 +151,10 @@ function postStartAction()
 
         if [[ "$BOOT_TYPE" == "fast" ]]; then
             # set the key to expire in 3 minutes
-            redis-cli -n 6 SET "FAST_REBOOT|system" "1" "EX" "180"
+            sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "1" "EX" "180"
         fi
 
-        redis-cli -n 4 SET "CONFIG_DB_INITIALIZED" "1"
+        sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
     fi
 
     if [[ -x /usr/bin/db_migrator.py ]]; then

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -25,7 +25,6 @@
 ###########################################################################
 
 # Initialize constants
-CONFIG_DB_INDEX=4
 UPDATEGRAPH_CONF=/etc/sonic/updategraph.conf
 CONFIG_DB_JSON=/etc/sonic/config_db.json
 MINGRAPH_FILE=/etc/sonic/minigraph.xml
@@ -107,9 +106,9 @@ reload_minigraph()
     if [ ! -f /etc/sonic/init_cfg.json ]; then
         echo "{}" > /etc/sonic/init_cfg.json
     fi
-    redis-cli -n $CONFIG_DB_INDEX FLUSHDB
+    sonic-db-cli CONFIG_DB FLUSHDB
     sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
-    redis-cli -n $CONFIG_DB_INDEX SET "CONFIG_DB_INITIALIZED" "1"
+    sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
     if [ -f /etc/sonic/acl.json ]; then
         acl-loader update full /etc/sonic/acl.json
     fi
@@ -138,7 +137,7 @@ function copy_config_files_and_directories()
 # Check if SONiC swich has booted after a warm reboot request
 check_system_warm_boot()
 {
-    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
     # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
     if [[ x"$SYSTEM_WARM_START" == x"true" ]]; then
         WARM_BOOT="true"
@@ -187,7 +186,7 @@ load_config()
         return 1
     fi
 
-    redis-cli -n $CONFIG_DB_INDEX FLUSHDB
+    sonic-db-cli CONFIG_DB FLUSHDB
     sonic-cfggen -j ${CONFIG_FILE} --write-to-db
     if [ $? -ne 0 ]; then
         return $?
@@ -198,7 +197,7 @@ load_config()
         /usr/bin/db_migrator.py -o migrate
     fi
 
-    redis-cli -n $CONFIG_DB_INDEX SET "CONFIG_DB_INITIALIZED" "1"
+    sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
     return 0
 }
 

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -1,16 +1,14 @@
 #!/bin/bash
 
-CONFIG_DB_INDEX=4
-
 reload_minigraph()
 {
     echo "Reloading minigraph..."
     if [ ! -f /etc/sonic/init_cfg.json ]; then
         echo "{}" > /etc/sonic/init_cfg.json
     fi
-    redis-cli -n $CONFIG_DB_INDEX FLUSHDB
+    sonic-db-cli CONFIG_DB FLUSHDB
     sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
-    redis-cli -n $CONFIG_DB_INDEX SET "CONFIG_DB_INITIALIZED" "1"
+    sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
     if [ -f /etc/sonic/acl.json ]; then
         acl-loader update full /etc/sonic/acl.json
     fi
@@ -77,9 +75,9 @@ if [ "$src" = "dhcp" ]; then
         else
             cp -f /tmp/device_meta.json /etc/sonic/config_db.json
         fi
-        redis-cli -n $CONFIG_DB_INDEX FLUSHDB
+        sonic-db-cli CONFIG_DB FLUSHDB
         sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
-        redis-cli -n $CONFIG_DB_INDEX SET "CONFIG_DB_INITIALIZED" "1"
+        sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
         if [ "$dhcp_as_static" = "true" ]; then
             sed -i "/enabled=/d" /etc/sonic/updategraph.conf
             echo "enabled=false" >> /etc/sonic/updategraph.conf

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -20,7 +20,7 @@ function debug()
 
 function check_warm_boot()
 {
-    WARM_BOOT=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    WARM_BOOT=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
 }
 
 
@@ -29,12 +29,10 @@ function wait_for_database_service()
     debug "Wait for database to become ready..."
 
     # Wait for redis server start before database clean
-    until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]];
-        do sleep 1;
-    done
+    /usr/bin/docker exec database ping_pong_db_insts
 
     # Wait for configDB initialization
-    until [[ $(/usr/bin/docker exec database redis-cli -n 4 GET "CONFIG_DB_INITIALIZED") ]];
+    until [[ $(sonic-db-cli CONFIG_DB GET "CONFIG_DB_INITIALIZED") ]];
         do sleep 1;
     done
 
@@ -44,7 +42,7 @@ function wait_for_database_service()
 
 function get_component_state()
 {
-    /usr/bin/redis-cli -n 6 hget "WARM_RESTART_TABLE|$1" state
+    sonic-db-cli STATE_DB hget "WARM_RESTART_TABLE|$1" state
 }
 
 

--- a/files/scripts/configdb-load.sh
+++ b/files/scripts/configdb-load.sh
@@ -10,4 +10,4 @@ if [ -r /etc/sonic/config_db.json ]; then
     sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
 fi
 
-redis-cli -n 4 SET "CONFIG_DB_INITIALIZED" "1"
+sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -30,8 +30,8 @@ function unlock_service_state_change()
 
 function check_warm_boot()
 {
-    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
-    SERVICE_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
+    SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SERVICE_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
     # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
     if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
         WARM_BOOT="true"
@@ -43,12 +43,10 @@ function check_warm_boot()
 function wait_for_database_service()
 {
     # Wait for redis server start before database clean
-    until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]];
-        do sleep 1;
-    done
+    /usr/bin/docker exec database ping_pong_db_insts
 
     # Wait for configDB initialization
-    until [[ $(/usr/bin/docker exec database redis-cli -n 4 GET "CONFIG_DB_INITIALIZED") ]];
+    until [[ $(sonic-db-cli CONFIG_DB GET "CONFIG_DB_INITIALIZED") ]];
         do sleep 1;
     done
 }
@@ -65,7 +63,7 @@ function getBootType()
         ;;
     *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         # check that the key exists
-        if [[ $(redis-cli -n 6 GET "FAST_REBOOT|system") == "1" ]]; then
+        if [[ $(sonic-db-cli STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
             TYPE='fast'
         else
             TYPE='cold'

--- a/platform/barefoot/sonic-platform-modules-ingrasys/s9180-32x/utils/qsfp_monitor.sh
+++ b/platform/barefoot/sonic-platform-modules-ingrasys/s9180-32x/utils/qsfp_monitor.sh
@@ -65,7 +65,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
+        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/barefoot/sonic-platform-modules-ingrasys/s9280-64x/utils/qsfp_monitor.sh
+++ b/platform/barefoot/sonic-platform-modules-ingrasys/s9280-64x/utils/qsfp_monitor.sh
@@ -66,7 +66,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
+        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/broadcom/sonic-platform-modules-ingrasys/s8810-32q/utils/qsfp_monitor.sh
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/s8810-32q/utils/qsfp_monitor.sh
@@ -65,7 +65,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
+        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/broadcom/sonic-platform-modules-ingrasys/s8900-54xc/utils/qsfp_monitor.sh
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/s8900-54xc/utils/qsfp_monitor.sh
@@ -67,7 +67,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
+        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/broadcom/sonic-platform-modules-ingrasys/s8900-64xc/utils/qsfp_monitor.sh
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/s8900-64xc/utils/qsfp_monitor.sh
@@ -67,7 +67,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
+        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/broadcom/sonic-platform-modules-ingrasys/s9100/utils/qsfp_monitor.sh
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/s9100/utils/qsfp_monitor.sh
@@ -65,7 +65,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
+        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/broadcom/sonic-platform-modules-ingrasys/s9200-64x/utils/qsfp_monitor.sh
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/s9200-64x/utils/qsfp_monitor.sh
@@ -66,7 +66,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
+        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/nephos/sonic-platform-modules-ingrasys/s9130-32x/utils/qsfp_monitor.sh
+++ b/platform/nephos/sonic-platform-modules-ingrasys/s9130-32x/utils/qsfp_monitor.sh
@@ -65,7 +65,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
+        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/nephos/sonic-platform-modules-ingrasys/s9230-64x/utils/qsfp_monitor.sh
+++ b/platform/nephos/sonic-platform-modules-ingrasys/s9230-64x/utils/qsfp_monitor.sh
@@ -66,7 +66,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
+        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/vs/tests/teamd/test_portchannel.py
+++ b/platform/vs/tests/teamd/test_portchannel.py
@@ -4,8 +4,8 @@ import re
 import json
 
 def test_PortChannel(dvs, testlog):
-    appldb = swsscommon.DBConnector("APPL_DB", 0)
-    statdb = swsscommon.DBConnector("STATE_DB", 0)
+    appldb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+    statdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
 
     # create the lag
     dvs.runcmd("config portchannel add PortChannel0001")

--- a/platform/vs/tests/teamd/test_portchannel.py
+++ b/platform/vs/tests/teamd/test_portchannel.py
@@ -4,8 +4,8 @@ import re
 import json
 
 def test_PortChannel(dvs, testlog):
-    appldb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
-    statdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
+    appldb = swsscommon.DBConnector("APPL_DB", 0)
+    statdb = swsscommon.DBConnector("STATE_DB", 0)
 
     # create the lag
     dvs.runcmd("config portchannel add PortChannel0001")


### PR DESCRIPTION
this commit made changes in sonic-buildimage module directory except ./dockers/(this is done in another PR) amd ./src/(will do in next PR)

replace redis-cli with sonic-db-cli
replace old DBConnector with new DBConnector
vs tests passed, loaded on DUT, looks good, script works fine.

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com