### PR TITLE
sFlow : disable sflow docker by default

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -392,6 +392,10 @@ if [ -f {{service}} ]; then
     echo "{{service}}" | sudo tee -a $GENERATED_SERVICE_FILE
 fi
 {% endfor %}
+
+# Remove services that are to be disabled by default
+sudo sed -i '/sflow.service/d' $GENERATED_SERVICE_FILE
+
 sudo LANG=C chroot $FILESYSTEM_ROOT fuser -km /sys || true
 sudo LANG=C chroot $FILESYSTEM_ROOT umount -lf /sys
 {% endif %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Removed sflow from generated_services.conf so that sonic-generator does not enable sflow at startup. Note that this is a workaround until the "features" infrastructure can be fully utilized.

**- How I did it**

After generation of service file, remove sflow.

**- How to verify it**

Inspect fsroot/etc/sonic/generated_services.conf after build and /etc/sonic/generated_services.conf.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Remove sflow from list of services started at bootup.

**- A picture of a cute animal (not mandatory but encouraged)**
