### PR TITLE
[grub]: Allow ONiE oneshot boot for FW update

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -555,15 +555,21 @@ EOF
 # Add the logic to support grub-reboot and grub-set-default
 cat <<EOF >> $grub_cfg
 if [ -s \$prefix/grubenv ]; then
-  load_env
+    load_env
 fi
-if [ "\${saved_entry}" ] ; then
-   set default="\${saved_entry}"
+if [ "\${saved_entry}" ]; then
+    set default="\${saved_entry}"
 fi
-if [ "\${next_entry}" ] ; then
-   set default="\${next_entry}"
-   set next_entry=
-   save_env next_entry
+if [ "\${next_entry}" ]; then
+    set default="\${next_entry}"
+    unset next_entry
+    save_env next_entry
+fi
+if [ "\${onie_entry}" ]; then
+    set next_entry="\${default}"
+    set default="\${onie_entry}"
+    unset onie_entry
+    save_env onie_entry next_entry
 fi
 
 EOF


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

This small improvement enables ONiE oneshoot boot for various firmware update operations
(BIOS, CPLD, etc.):
https://opencomputeproject.github.io/onie/design-spec/firmware_update.html

The new flow allows to avoid the certain types of issues:
```bash
root@sonic:/home/admin# sonic_installer list
Current: SONiC-OS-HEAD.140-fc36ca6e
Next: SONiC-OS-HEAD.140-fc36ca6e
Available:
SONiC-OS-HEAD.140-fc36ca6e
SONiC-OS-HEAD.5-386619ac
root@sonic:/home/admin# grub-editenv /host/grub/grubenv set next_entry=2
root@sonic:/home/admin# sonic_installer list
Traceback (most recent call last):
  File "/usr/bin/sonic_installer", line 12, in <module>
    sys.exit(cli())
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/sonic_installer/main.py", line 380, in list
    nextimage = get_next_image()
  File "/usr/lib/python2.7/dist-packages/sonic_installer/main.py", line 194, in get_next_image
    next_image = images[next_image_index]
IndexError: list index out of range

```

Example:
```bash
root@sonic:/home/admin# sonic_installer list
Current: SONiC-OS-HEAD.140-fc36ca6e
Next: SONiC-OS-HEAD.140-fc36ca6e
Available:
SONiC-OS-HEAD.140-fc36ca6e
SONiC-OS-HEAD.5-386619ac
root@sonic:/home/admin# grub-editenv /host/grub/grubenv set onie_entry=2
root@sonic:/home/admin# sonic_installer set_next_boot SONiC-OS-HEAD.5-386619ac
Command: grub-reboot --boot-directory=/host 1
root@sonic:/home/admin# grub-editenv /host/grub/grubenv list
saved_entry=0
next_entry=1
onie_entry=2
root@sonic:/home/admin# sonic_installer list
Current: SONiC-OS-HEAD.140-fc36ca6e
Next: SONiC-OS-HEAD.5-386619ac
Available:
SONiC-OS-HEAD.140-fc36ca6e
SONiC-OS-HEAD.5-386619ac
```


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Added ONiE oneshoot boot feature

**- How I did it**
* Modified grub configuration

**- How to verify it**
1. grub-editenv /host/grub/grubenv set onie_entry=<onie_entry_index>

**- Description for the changelog**
* N/A

**- A picture of a cute animal (not mandatory but encouraged)**
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```