### PR TITLE
[FRR]there is no need to checkout master branch after compiling frr.

### DIFF
--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -21,7 +21,6 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git checkout $(FRR_BRANCH)
 	stg branch --delete $(STG_BRANCH)
 	git rev-parse --short HEAD | xargs git checkout
-	git checkout master
 	git branch -D $(FRR_BRANCH)
 	popd
 	mv $(DERIVED_TARGET) $* $(DEST)/


### PR DESCRIPTION
Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 the frr submodule should restore to the detach status with the right commit id.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
