### PR TITLE
DellEMC: Platform2.0 API enhancements in DellEMC S6000 and other API changes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
@@ -43,6 +43,7 @@ class Chassis(ChassisBase):
     reset_reason_dict[0x6] = ChassisBase.REBOOT_CAUSE_NON_HARDWARE
 
     def __init__(self):
+        ChassisBase.__init__(self)
         # Initialize SFP list
         self.PORT_START = 0
         self.PORT_END = 31

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/eeprom.py
@@ -150,6 +150,10 @@ class Eeprom(TlvInfoDecoder):
         except:
             self.serial_number = 'NA'
             self.part_number = 'NA'
+            if self.is_psu_eeprom:
+                self.psu_type = 'NA'
+            else:
+                self.fan_type = 'NA'
         else:
             (valid, data) = self._get_eeprom_field("PPID")
             if valid:

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan.py
@@ -146,7 +146,7 @@ class Fan(FanBase):
             fantray_status = self._get_pmc_register(self.get_fan_speed_reg)
             if (fantray_status != 'ERR'):
                 fantray_status = int(fantray_status, 10)
-                if (fantray_status > 5000):
+                if (fantray_status > 1000):
                     status = True
         else:
             fantray_status = self._get_pmc_register(self.fan_status_reg)
@@ -163,13 +163,18 @@ class Fan(FanBase):
         Returns:
             A string, either FAN_DIRECTION_INTAKE or FAN_DIRECTION_EXHAUST
             depending on fan direction
+
+        Notes:
+            In DellEMC platforms,
+            - Forward/Exhaust : Air flows from Port side to Fan side.
+            - Reverse/Intake  : Air flows from Fan side to Port side.
         """
-        direction = ['FAN_DIRECTION_INTAKE', 'FAN_DIRECTION_EXHAUST']
+        direction = [self.FAN_DIRECTION_INTAKE, self.FAN_DIRECTION_EXHAUST]
         fan_direction = self._get_pmc_register(self.get_fan_dir_reg)
         if (fan_direction != 'ERR') and self.get_presence():
             fan_direction = int(fan_direction, 10)
         else:
-            return 'N/A'
+            return self.FAN_DIRECTION_NOT_APPLICABLE
         return direction[fan_direction]
 
     def get_speed(self):

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
@@ -73,6 +73,7 @@ class Chassis(ChassisBase):
     power_reason_dict[44] = ChassisBase.REBOOT_CAUSE_INSUFFICIENT_FAN_SPEED
 
     def __init__(self):
+        ChassisBase.__init__(self)
         PORT_START = 0
         PORT_END = 31
         PORTS_IN_BLOCK = (PORT_END + 1)
@@ -92,7 +93,6 @@ class Chassis(ChassisBase):
                            self.PORT_I2C_MAPPING[index][1])
             self._sfp_list.append(sfp_node)
 
-        ChassisBase.__init__(self)
         # Initialize EEPROM
         self._eeprom = Eeprom()
         for i in range(MAX_Z9100_FANTRAY):

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/fan.py
@@ -145,7 +145,7 @@ class Fan(FanBase):
             fantray_status = self._get_pmc_register(self.get_fan_speed_reg)
             if (fantray_status != 'ERR'):
                 fantray_status = int(fantray_status, 10)
-                if (fantray_status > 5000):
+                if (fantray_status > 1000):
                     status = True
         else:
             fantray_status = self._get_pmc_register(self.fan_status_reg)
@@ -162,13 +162,18 @@ class Fan(FanBase):
         Returns:
             A string, either FAN_DIRECTION_INTAKE or FAN_DIRECTION_EXHAUST
             depending on fan direction
+
+        Notes:
+            In DellEMC platforms,
+            - Forward/Exhaust : Air flows from Port side to Fan side.
+            - Reverse/Intake  : Air flows from Fan side to Port side.
         """
-        direction = ['FAN_DIRECTION_INTAKE', 'FAN_DIRECTION_EXHAUST']
+        direction = [self.FAN_DIRECTION_INTAKE, self.FAN_DIRECTION_EXHAUST]
         fan_direction = self._get_pmc_register(self.get_fan_dir_reg)
         if (fan_direction != 'ERR') and self.get_presence():
             fan_direction = int(fan_direction, 10)
         else:
-            return 'N/A'
+            return self.FAN_DIRECTION_NOT_APPLICABLE
         return direction[fan_direction]
 
     def get_speed(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Handle Platform2.0 APIs based on platform driver initialization in DellEMC S6000.
- Fixed _sfp_list, _psu_list , _fan_list initialized to None.
- Return Appropriate values for Fan Direction in DellEMC platforms.

**- How I did it**

- Made changes to return values based on the driver initialization state in DellEMC S6000.
- Use ChassisBase's __init__ to initialize empty lists for different devices (_sfp_list , _psu_list , _fan_list).

**- How to verify it**

Wrote a python script to load Chassis class and then call the APIs accordingly.
UT logs - [UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/4012148/S6000_UT_logs.txt)
Test Script - [platform_test_py.txt](https://github.com/Azure/sonic-buildimage/files/4012152/platform_test_py.txt)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC: Platform2.0 API enhancements in DellEMC S6000 and other API changes

**- A picture of a cute animal (not mandatory but encouraged)**
