### PR TITLE
[docker-base-stretch]: Do not check expire for stretch-backports repo

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -107,7 +107,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT mount proc /proc -t proc
 
 ## Pointing apt to public apt mirrors and getting latest packages, needed for latest security updates
 sudo cp files/apt/sources.list.$CONFIGURED_ARCH $FILESYSTEM_ROOT/etc/apt/sources.list
-sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages}} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
+sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages},no-check-valid-until} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
 sudo LANG=C chroot $FILESYSTEM_ROOT bash -c 'apt-mark auto `apt-mark showmanual`'
 
 ## Note: set lang to prevent locale warnings in your chroot

--- a/dockers/docker-base-stretch/Dockerfile.j2
+++ b/dockers/docker-base-stretch/Dockerfile.j2
@@ -34,6 +34,7 @@ COPY ["sources.list.arm64", "/etc/apt/sources.list"]
 COPY ["sources.list", "/etc/apt/sources.list"]
 {% endif %}
 COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
+COPY ["aptconf_archive_expired_release", "/etc/apt/apt.conf.d"]
 
 # Update apt cache and
 # pre-install fundamental packages

--- a/dockers/docker-base-stretch/aptconf_archive_expired_release
+++ b/dockers/docker-base-stretch/aptconf_archive_expired_release
@@ -1,0 +1,3 @@
+# Instruct apt-get to override expired releases repo list for jessie archives
+
+Acquire::Check-Valid-Until "0";

--- a/files/apt/apt.conf.d/no-check-valid-until
+++ b/files/apt/apt.conf.d/no-check-valid-until
@@ -1,0 +1,1 @@
+Acquire::Check-Valid-Until "false";


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
