### PR TITLE
[apt] Instruct apt-get to NOT check the "Valid Until" date in Release files

### DIFF
--- a/dockers/docker-base-stretch/Dockerfile.j2
+++ b/dockers/docker-base-stretch/Dockerfile.j2
@@ -34,7 +34,7 @@ COPY ["sources.list.arm64", "/etc/apt/sources.list"]
 COPY ["sources.list", "/etc/apt/sources.list"]
 {% endif %}
 COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
-COPY ["aptconf_archive_expired_release", "/etc/apt/apt.conf.d"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 
 # Update apt cache and
 # pre-install fundamental packages

--- a/dockers/docker-base-stretch/aptconf_archive_expired_release
+++ b/dockers/docker-base-stretch/aptconf_archive_expired_release
@@ -1,3 +1,0 @@
-# Instruct apt-get to override expired releases repo list for jessie archives
-
-Acquire::Check-Valid-Until "0";

--- a/dockers/docker-base-stretch/no-check-valid-until
+++ b/dockers/docker-base-stretch/no-check-valid-until
@@ -1,0 +1,4 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
+Acquire::Check-Valid-Until "false";

--- a/dockers/docker-base/Dockerfile.j2
+++ b/dockers/docker-base/Dockerfile.j2
@@ -32,7 +32,7 @@ COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
 COPY ["sources.list.armhf", "/etc/apt/sources.list"]
 {% elif CONFIGURED_ARCH == "arm64" %}
 COPY ["sources.list.arm64", "/etc/apt/sources.list"]
-COPY ["aptconf_archive_expired_release", "/etc/apt/apt.conf.d"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 {% else %}
 COPY ["sources.list", "/etc/apt/sources.list"]
 {% endif %}

--- a/dockers/docker-base/aptconf_archive_expired_release
+++ b/dockers/docker-base/aptconf_archive_expired_release
@@ -1,3 +1,0 @@
-# Instruct apt-get to override expired releases repo list for jessie archives
-
-Acquire::Check-Valid-Until "0";

--- a/dockers/docker-base/no-check-valid-until
+++ b/dockers/docker-base/no-check-valid-until
@@ -1,0 +1,4 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
+Acquire::Check-Valid-Until "false";

--- a/files/apt/apt.conf.d/no-check-valid-until
+++ b/files/apt/apt.conf.d/no-check-valid-until
@@ -1,1 +1,4 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
 Acquire::Check-Valid-Until "false";

--- a/sonic-slave-jessie/Dockerfile.j2
+++ b/sonic-slave-jessie/Dockerfile.j2
@@ -8,6 +8,8 @@ FROM debian:jessie
 
 MAINTAINER johnar@microsoft.com
 
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+
 ## Remove retired jessie-updates repo
 RUN sed -i '/http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 

--- a/sonic-slave-jessie/no-check-valid-until
+++ b/sonic-slave-jessie/no-check-valid-until
@@ -1,0 +1,4 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
+Acquire::Check-Valid-Until "false";

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -8,6 +8,8 @@ FROM debian:stretch
 
 MAINTAINER gulv@microsoft.com
 
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+
 RUN echo "deb [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb-src [arch=amd64] http://debian-archive.trafficmanager.net/debian/ stretch main contrib non-free" >> /etc/apt/sources.list && \
         echo "deb [arch=amd64] http://debian-archive.trafficmanager.net/debian-security/ stretch/updates main contrib non-free" >> /etc/apt/sources.list && \

--- a/sonic-slave-stretch/no-check-valid-until
+++ b/sonic-slave-stretch/no-check-valid-until
@@ -1,0 +1,4 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
+Acquire::Check-Valid-Until "false";


### PR DESCRIPTION
This is an addendum to https://github.com/Azure/sonic-buildimage/pull/3958, which also instructs apt to ignore the "Valid Until" date in Release files inside the slave containers, making a complete solution, much like the previously abandoned PR https://github.com/Azure/sonic-buildimage/pull/2609. This patch also unifies file names and contents.

When the Debian team archives a repo, it stops updating the "Valid Until" date, thus apt-get will not apply updates for that repo unless we explicitly tell it to ignore the "Valid Until" date. Also, this has become an issue with active (i.e., non-archived) repos twice in the past year because the Debian folks seem to occasionally let the expiration lapse before updating the date. This will cause SONiC builds to fail with a message like `E: Release file for http://debian-archive.trafficmanager.net/debian-security/dists/jessie/updates/InRelease is expired (invalid since 3d 3h 11min 20s). Updates for this repository will not be applied.` until the dates have been updated and propagated to all mirrors. With this patch, SONiC should no longer be affected by lapsed "Valid Until" dates, whether they be accidental or purposeful.