### PR TITLE
[201811] add submodule for telemetry avoiding breaking in previous release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -67,3 +67,6 @@
 [submodule "src/redis-dump-load"]
 	path = src/redis-dump-load
 	url = https://github.com/p/redis-dump-load.git
+[submodule "src/telemetry/sonic-telemetry"]
+	path = src/telemetry/sonic-telemetry
+	url = https://github.com/Azure/sonic-telemetry.git

--- a/src/telemetry/Makefile
+++ b/src/telemetry/Makefile
@@ -2,9 +2,11 @@ export GOPATH=/tmp/go
 
 INSTALL := /usr/bin/install
 
-all: sonic-telemetry
+all: telemetry
 
-sonic-telemetry:
+telemetry:
+	mkdir -p ${GOPATH}/src/github.com/Azure/
+	cp -a sonic-telemetry ${GOPATH}/src/github.com/Azure/
 	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/telemetry
 	/usr/local/go/bin/go get -v github.com/Azure/sonic-telemetry/dialout/dialout_client_cli
 


### PR DESCRIPTION
* today telemetry always pull the latest version , which causes the previous release using the latest codes (SHOULD NOT)

* add submodule for telemetry for previous releases

* current latest master is already handled via submodule 

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com