### PR TITLE
[mellanox] Add fwutil platform components files

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/platform_components.json
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/platform_components.json
@@ -1,0 +1,10 @@
+{
+    "chassis": {
+        "x86_64-mlnx_msn2010-r0": {
+            "component": {
+                "BIOS": { },
+                "CPLD": { }
+            }
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/platform_components.json
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/platform_components.json
@@ -1,0 +1,10 @@
+{
+    "chassis": {
+        "x86_64-mlnx_msn2100-r0": {
+            "component": {
+                "BIOS": { },
+                "CPLD": { }
+            }
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/platform_components.json
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/platform_components.json
@@ -1,0 +1,10 @@
+{
+    "chassis": {
+        "x86_64-mlnx_msn2410-r0": {
+            "component": {
+                "BIOS": { },
+                "CPLD": { }
+            }
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_components.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_components.json
@@ -1,0 +1,10 @@
+{
+    "chassis": {
+        "x86_64-mlnx_msn2700-r0": {
+            "component": {
+                "BIOS": { },
+                "CPLD": { }
+            }
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/platform_components.json
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/platform_components.json
@@ -1,0 +1,10 @@
+{
+    "chassis": {
+        "x86_64-mlnx_msn2740-r0": {
+            "component": {
+                "BIOS": { },
+                "CPLD": { }
+            }
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/platform_components.json
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/platform_components.json
@@ -1,0 +1,10 @@
+{
+    "chassis": {
+        "x86_64-mlnx_msn3700-r0": {
+            "component": {
+                "BIOS": { },
+                "CPLD": { }
+            }
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/platform_components.json
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/platform_components.json
@@ -1,0 +1,10 @@
+{
+    "chassis": {
+        "x86_64-mlnx_msn3700c-r0": {
+            "component": {
+                "BIOS": { },
+                "CPLD": { }
+            }
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/platform_components.json
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/platform_components.json
@@ -1,0 +1,10 @@
+{
+    "chassis": {
+        "x86_64-mlnx_msn3800-r0": {
+            "component": {
+                "BIOS": { },
+                "CPLD": { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

These stubs are required for `fwutil update` feature:
```
root@sonic:/home/admin# fwutil update
Chassis                 Module    Component    Firmware    Version                  Status      Info
----------------------  --------  -----------  ----------  -----------------------  ----------  ------
x86_64-mlnx_msn3800-r0  N/A       BIOS         N/A         0ACLH004_02.02.007_9600  up-to-date  N/A
                                  CPLD         N/A         5.3.3.1                  up-to-date  N/A
New firmware will be installed, continue? [y/N]: y

Summary:

Chassis                 Module    Component    Status
----------------------  --------  -----------  ----------
x86_64-mlnx_msn3800-r0  N/A       BIOS         up-to-date
                                  CPLD         up-to-date

```

Without `platform_components.json` fwutil will produce error message:
```
root@sonic:/home/admin# fwutil update
Error: [Errno 2] No such file or directory: '/usr/share/sonic/device/x86_64-mlnx_msn3800-r0/platform_components.json'. Aborting...
Aborted!
```

**- What I did**
* Added fwutil platform components configuration files

**- How I did it**
* N/A

**- How to verify it**
1. make configure PLATFORM=mellanox
2. make target/sonic-mellanox.bin

**- Description for the changelog**
* N/A

**- A picture of a cute animal (not mandatory but encouraged)**
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```