### PR TITLE
Revert "[MultiDB]except src and dockers : replace redis-cli with sonic-db-cli and use new DBConnector"

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -22,6 +22,8 @@ SFP_MODULE_THRESHOLD_WIDTH = 56
 SFP_I2C_PAGE_SIZE = 256
 
 # parameters for DB connection 
+REDIS_HOSTNAME = "localhost"
+REDIS_PORT = 6379
 REDIS_TIMEOUT_USECS = 0
 
 # parameters for SFP presence
@@ -188,9 +190,10 @@ class SfpUtil(SfpUtilBase):
 
         if self.db_sel == None:
             from swsscommon import swsscommon
-            self.state_db = swsscommon.DBConnector("STATE_DB",
-                                                   REDIS_TIMEOUT_USECS,
-                                                   True))
+            self.state_db = swsscommon.DBConnector(swsscommon.STATE_DB,
+                                             REDIS_HOSTNAME,
+                                             REDIS_PORT,
+                                             REDIS_TIMEOUT_USECS)
 
             # Subscribe to state table for SFP change notifications
             self.db_sel = swsscommon.Select()

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -63,20 +63,20 @@ function preStartAction()
         docker cp /tmp/dump.rdb database:/var/lib/redis/
     fi
 {%- elif docker_container_name == "snmp" %}
-    sonic-db-cli STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
-    vrfenabled=`sonic-db-cli CONFIG_DB hget "MGMT_VRF_CONFIG|vrf_global" mgmtVrfEnabled`
-    v1SnmpTrapIp=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v1TrapDest" DestIp`
-    v1SnmpTrapPort=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v1TrapDest" DestPort`
-    v1Vrf=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v1TrapDest" vrf`
-    v1Comm=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v1TrapDest" Community`
-    v2SnmpTrapIp=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v2TrapDest" DestIp`
-    v2SnmpTrapPort=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v2TrapDest" DestPort`
-    v2Vrf=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v2TrapDest" vrf`
-    v2Comm=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v2TrapDest" Community`
-    v3SnmpTrapIp=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v3TrapDest" DestIp`
-    v3SnmpTrapPort=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v3TrapDest" DestPort`
-    v3Vrf=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v3TrapDest" vrf`
-    v3Comm=`sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v3TrapDest" Community`
+    docker exec -i database redis-cli -n 6 HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
+    vrfenabled=`/usr/bin/redis-cli -n 4 hget "MGMT_VRF_CONFIG|vrf_global" mgmtVrfEnabled`
+    v1SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestIp`
+    v1SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestPort`
+    v1Vrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" vrf`
+    v1Comm=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" Community`
+    v2SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" DestIp`
+    v2SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" DestPort`
+    v2Vrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" vrf`
+    v2Comm=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v2TrapDest" Community`
+    v3SnmpTrapIp=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestIp`
+    v3SnmpTrapPort=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" DestPort`
+    v3Vrf=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" vrf`
+    v3Comm=`/usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v3TrapDest" Community`
 
     if [ "${v1SnmpTrapIp}" != "" ]
     then
@@ -113,7 +113,7 @@ function preStartAction()
     fi
 
     echo -n "" > /tmp/snmpagentaddr.yml
-    keys=`sonic-db-cli CONFIG_DB keys "SNMP_AGENT_ADDRESS_CONFIG|*"`
+    keys=`/usr/bin/redis-cli -n 4 keys "SNMP_AGENT_ADDRESS_CONFIG|*"`
     count=1
     for key in $keys;do
         ip=`echo $key|cut -d "|" -f2`
@@ -151,10 +151,10 @@ function postStartAction()
 
         if [[ "$BOOT_TYPE" == "fast" ]]; then
             # set the key to expire in 3 minutes
-            sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "1" "EX" "180"
+            redis-cli -n 6 SET "FAST_REBOOT|system" "1" "EX" "180"
         fi
 
-        sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
+        redis-cli -n 4 SET "CONFIG_DB_INITIALIZED" "1"
     fi
 
     if [[ -x /usr/bin/db_migrator.py ]]; then

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -25,6 +25,7 @@
 ###########################################################################
 
 # Initialize constants
+CONFIG_DB_INDEX=4
 UPDATEGRAPH_CONF=/etc/sonic/updategraph.conf
 CONFIG_DB_JSON=/etc/sonic/config_db.json
 MINGRAPH_FILE=/etc/sonic/minigraph.xml
@@ -106,9 +107,9 @@ reload_minigraph()
     if [ ! -f /etc/sonic/init_cfg.json ]; then
         echo "{}" > /etc/sonic/init_cfg.json
     fi
-    sonic-db-cli CONFIG_DB FLUSHDB
+    redis-cli -n $CONFIG_DB_INDEX FLUSHDB
     sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
-    sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
+    redis-cli -n $CONFIG_DB_INDEX SET "CONFIG_DB_INITIALIZED" "1"
     if [ -f /etc/sonic/acl.json ]; then
         acl-loader update full /etc/sonic/acl.json
     fi
@@ -137,7 +138,7 @@ function copy_config_files_and_directories()
 # Check if SONiC swich has booted after a warm reboot request
 check_system_warm_boot()
 {
-    SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
     # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
     if [[ x"$SYSTEM_WARM_START" == x"true" ]]; then
         WARM_BOOT="true"
@@ -186,7 +187,7 @@ load_config()
         return 1
     fi
 
-    sonic-db-cli CONFIG_DB FLUSHDB
+    redis-cli -n $CONFIG_DB_INDEX FLUSHDB
     sonic-cfggen -j ${CONFIG_FILE} --write-to-db
     if [ $? -ne 0 ]; then
         return $?
@@ -197,7 +198,7 @@ load_config()
         /usr/bin/db_migrator.py -o migrate
     fi
 
-    sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
+    redis-cli -n $CONFIG_DB_INDEX SET "CONFIG_DB_INITIALIZED" "1"
     return 0
 }
 

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -1,14 +1,16 @@
 #!/bin/bash
 
+CONFIG_DB_INDEX=4
+
 reload_minigraph()
 {
     echo "Reloading minigraph..."
     if [ ! -f /etc/sonic/init_cfg.json ]; then
         echo "{}" > /etc/sonic/init_cfg.json
     fi
-    sonic-db-cli CONFIG_DB FLUSHDB
+    redis-cli -n $CONFIG_DB_INDEX FLUSHDB
     sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
-    sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
+    redis-cli -n $CONFIG_DB_INDEX SET "CONFIG_DB_INITIALIZED" "1"
     if [ -f /etc/sonic/acl.json ]; then
         acl-loader update full /etc/sonic/acl.json
     fi
@@ -75,9 +77,9 @@ if [ "$src" = "dhcp" ]; then
         else
             cp -f /tmp/device_meta.json /etc/sonic/config_db.json
         fi
-        sonic-db-cli CONFIG_DB FLUSHDB
+        redis-cli -n $CONFIG_DB_INDEX FLUSHDB
         sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
-        sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
+        redis-cli -n $CONFIG_DB_INDEX SET "CONFIG_DB_INITIALIZED" "1"
         if [ "$dhcp_as_static" = "true" ]; then
             sed -i "/enabled=/d" /etc/sonic/updategraph.conf
             echo "enabled=false" >> /etc/sonic/updategraph.conf

--- a/files/scripts/configdb-load.sh
+++ b/files/scripts/configdb-load.sh
@@ -10,4 +10,4 @@ if [ -r /etc/sonic/config_db.json ]; then
     sonic-cfggen -j /etc/sonic/config_db.json --write-to-db
 fi
 
-sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
+redis-cli -n 4 SET "CONFIG_DB_INITIALIZED" "1"

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -31,8 +31,8 @@ function unlock_service_state_change()
 
 function check_warm_boot()
 {
-    SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
-    SERVICE_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
+    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SERVICE_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
     if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
         WARM_BOOT="true"
     else
@@ -43,7 +43,7 @@ function check_warm_boot()
 function validate_restore_count()
 {
     if [[ x"$WARM_BOOT" == x"true" ]]; then
-        RESTORE_COUNT=`sonic-db-cli STATE_DB hget "WARM_RESTART_TABLE|orchagent" restore_count`
+        RESTORE_COUNT=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_TABLE|orchagent" restore_count`
         # We have to make sure db data has not been flushed.
         if [[ -z "$RESTORE_COUNT" ]]; then
             WARM_BOOT="false"
@@ -54,10 +54,12 @@ function validate_restore_count()
 function wait_for_database_service()
 {
     # Wait for redis server start before database clean
-    /usr/bin/docker exec database ping_pong_db_insts
+    until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]];
+        do sleep 1;
+    done
 
     # Wait for configDB initialization
-    until [[ $(sonic-db-cli CONFIG_DB GET "CONFIG_DB_INITIALIZED") ]];
+    until [[ $(/usr/bin/docker exec database redis-cli -n 4 GET "CONFIG_DB_INITIALIZED") ]];
         do sleep 1;
     done
 }
@@ -67,7 +69,7 @@ function wait_for_database_service()
 # $2 the string of a list of table prefixes
 function clean_up_tables()
 {
-    sonic-db-cli $1 EVAL "
+    redis-cli -n $1 EVAL "
     local tables = {$2}
     for i = 1, table.getn(tables) do
         local matches = redis.call('KEYS', tables[i])
@@ -112,11 +114,11 @@ start() {
     # Don't flush DB during warm boot
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         debug "Flushing APP, ASIC, COUNTER, CONFIG, and partial STATE databases ..."
-        sonic-db-cli APPL_DB FLUSHDB
-        sonic-db-cli ASIC_DB FLUSHDB
-        sonic-db-cli COUNTERS_DB FLUSHDB
-        sonic-db-cli FLEX_COUNTER_DB FLUSHDB
-        clean_up_tables STATE_DB "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'LAG_TABLE*', 'LAG_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*', 'FDB_TABLE*'"
+        /usr/bin/docker exec database redis-cli -n 0 FLUSHDB
+        /usr/bin/docker exec database redis-cli -n 1 FLUSHDB
+        /usr/bin/docker exec database redis-cli -n 2 FLUSHDB
+        /usr/bin/docker exec database redis-cli -n 5 FLUSHDB
+        clean_up_tables 6 "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'LAG_TABLE*', 'LAG_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*', 'FDB_TABLE*'"
     fi
 
     # start service docker
@@ -164,7 +166,7 @@ stop() {
     # encountered error, e.g. syncd crashed. And swss needs to
     # be restarted.
     debug "Clearing FAST_REBOOT flag..."
-    clean_up_tables STATE_DB "'FAST_REBOOT*'"
+    clean_up_tables 6 "'FAST_REBOOT*'"
 
     # Unlock has to happen before reaching out to peer service
     unlock_service_state_change

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -30,8 +30,8 @@ function unlock_service_state_change()
 
 function check_warm_boot()
 {
-    SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
-    SERVICE_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
+    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SERVICE_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
     # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
     if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
         WARM_BOOT="true"
@@ -43,10 +43,12 @@ function check_warm_boot()
 function wait_for_database_service()
 {
     # Wait for redis server start before database clean
-    /usr/bin/docker exec database ping_pong_db_insts
+    until [[ $(/usr/bin/docker exec database redis-cli ping | grep -c PONG) -gt 0 ]];
+        do sleep 1;
+    done
 
     # Wait for configDB initialization
-    until [[ $(sonic-db-cli CONFIG_DB GET "CONFIG_DB_INITIALIZED") ]];
+    until [[ $(/usr/bin/docker exec database redis-cli -n 4 GET "CONFIG_DB_INITIALIZED") ]];
         do sleep 1;
     done
 }
@@ -63,7 +65,7 @@ function getBootType()
         ;;
     *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         # check that the key exists
-        if [[ $(sonic-db-cli STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+        if [[ $(redis-cli -n 6 GET "FAST_REBOOT|system") == "1" ]]; then
             TYPE='fast'
         else
             TYPE='cold'

--- a/platform/barefoot/sonic-platform-modules-ingrasys/s9180-32x/utils/qsfp_monitor.sh
+++ b/platform/barefoot/sonic-platform-modules-ingrasys/s9180-32x/utils/qsfp_monitor.sh
@@ -65,7 +65,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
+        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/barefoot/sonic-platform-modules-ingrasys/s9280-64x/utils/qsfp_monitor.sh
+++ b/platform/barefoot/sonic-platform-modules-ingrasys/s9280-64x/utils/qsfp_monitor.sh
@@ -66,7 +66,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
+        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/broadcom/sonic-platform-modules-ingrasys/s8810-32q/utils/qsfp_monitor.sh
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/s8810-32q/utils/qsfp_monitor.sh
@@ -65,7 +65,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
+        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/broadcom/sonic-platform-modules-ingrasys/s8900-54xc/utils/qsfp_monitor.sh
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/s8900-54xc/utils/qsfp_monitor.sh
@@ -67,7 +67,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
+        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/broadcom/sonic-platform-modules-ingrasys/s8900-64xc/utils/qsfp_monitor.sh
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/s8900-64xc/utils/qsfp_monitor.sh
@@ -67,7 +67,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
+        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/broadcom/sonic-platform-modules-ingrasys/s9100/utils/qsfp_monitor.sh
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/s9100/utils/qsfp_monitor.sh
@@ -65,7 +65,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
+        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/broadcom/sonic-platform-modules-ingrasys/s9200-64x/utils/qsfp_monitor.sh
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/s9200-64x/utils/qsfp_monitor.sh
@@ -66,7 +66,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
+        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/nephos/sonic-platform-modules-ingrasys/s9130-32x/utils/qsfp_monitor.sh
+++ b/platform/nephos/sonic-platform-modules-ingrasys/s9130-32x/utils/qsfp_monitor.sh
@@ -65,7 +65,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
+        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
         if [ "$result" == "3" ]; then
             return
         fi

--- a/platform/nephos/sonic-platform-modules-ingrasys/s9230-64x/utils/qsfp_monitor.sh
+++ b/platform/nephos/sonic-platform-modules-ingrasys/s9230-64x/utils/qsfp_monitor.sh
@@ -66,7 +66,7 @@ function _docker_swss_check {
     while true
     do
         # Check if syncd starts
-        result=`sonic-db-cli ASIC_DB HLEN HIDDEN`
+        result=`docker exec -i swss bash -c "echo -en \"SELECT 1\\nHLEN HIDDEN\" | redis-cli | sed -n 2p"` #TBD FIX ME
         if [ "$result" == "3" ]; then
             return
         fi


### PR DESCRIPTION
sonic-db-cli return results is not backward compatible with redis-cli

```
admin@vlab-01:~$ sonic-db-cli CONFIG_DB hget "SNMP_TRAP_CONFIG|v1TrapDest" DestIp              
None
admin@vlab-01:~$ /usr/bin/redis-cli -n 4 hget "SNMP_TRAP_CONFIG|v1TrapDest" DestIp 
(nil)
admin@vlab-01:~$ 
```

Reverts Azure/sonic-buildimage#3928