### PR TITLE
Delay process-reboot-cause service until network connection is stable

### DIFF
--- a/files/build_templates/process-reboot-cause.timer
+++ b/files/build_templates/process-reboot-cause.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Delays process-reboot-cause until network is stably connected
+
+[Timer]
+OnBootSec=1min 30 sec
+Unit=process-reboot-cause.service
+
+[Install]
+WantedBy=timers.target

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -275,6 +275,11 @@ sudo cp $IMAGE_CONFIGS/procdockerstatsd/procdockerstatsd.service  $FILESYSTEM_RO
 echo "procdockerstatsd.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo cp $IMAGE_CONFIGS/procdockerstatsd/procdockerstatsd $FILESYSTEM_ROOT/usr/bin/
 
+# Copy systemd timer configuration
+# It implements delayed start of services
+sudo cp $BUILD_TEMPLATES/process-reboot-cause.timer $FILESYSTEM_ROOT/etc/systemd/system/
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable process-reboot-cause.timer
+
 # Copy process-reboot-cause service files
 sudo cp $IMAGE_CONFIGS/process-reboot-cause/process-reboot-cause.service  $FILESYSTEM_ROOT/etc/systemd/system/
 echo "process-reboot-cause.service" | sudo tee -a $GENERATED_SERVICE_FILE

--- a/files/image_config/process-reboot-cause/process-reboot-cause.service
+++ b/files/image_config/process-reboot-cause/process-reboot-cause.service
@@ -5,6 +5,3 @@ After=rc-local.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/process-reboot-cause
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Delay of starting the process-reboot-cause for sometime until network connection is stable.
Since we noticed the syslog server are missing the reboot cause log messages for most of platforms.

**- How I did it**
Add the systemd timer for process-reboot-cause to delay the start of the service

**- How to verify it**
After adding the systemd timer, reboot the device and wait to see if the log server receives the reboot-cause messages for all platforms

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
