### PR TITLE
[fast-reboot] fixes Azure/sonic-buildimage#4006

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -151,6 +151,8 @@ stop() {
 
     if [[ x"$WARM_BOOT" == x"true" ]]; then
         TYPE=warm
+    elif [[ $(redis-cli -n 6 GET "FAST_REBOOT|system") == "1" ]]; then
+        TYPE=fast
     else
         TYPE=cold
     fi


### PR DESCRIPTION
Fixes Azure/sonic-buildimage#4006

1. Azure/sonic-utilities#780, save fast-reboot state into the db when execute fast-reboot(aligned with Azure/sonic-buildimage#3741)
2. (This PR)during the syncd service stop stage, `sonic-buildimage/files/scripts/syncd.sh` could detect the `FAST` mode by the saved state, and request syncd to trigger fast shutdown.