### PR TITLE
starting teamd after syncd after reboot

### DIFF
--- a/files/build_templates/teamd.service.j2
+++ b/files/build_templates/teamd.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=TEAMD container
 Requires=updategraph.service
-After=updategraph.service swss.service
+After=updategraph.service swss.service syncd.service
 Before=ntp-config.service
 StartLimitIntervalSec=1200
 StartLimitBurst=3


### PR DESCRIPTION
starting teamd after syncd, is enabling the portchannels to retain ip addresses after reboot

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
starting the teamd service after syncd service, helps the portchannels to retain ip addresses after reboot.
**- How I did it**
with config_db.json having the ip address on portchannel, without fix and with fix one could verify the portchannel getting ip address configured.

**- How to verify it**
refer #4015 
**- Description for the changelog**
this can address the issue #4015 