### PR TITLE
[monit_syncd][bfn] Use correct syncd launch parameters in monit_syncd

### DIFF
--- a/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
+++ b/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd --diag"
+check process syncd matching "/usr/bin/syncd -u -p /tmp/sai.profile"
     if does not exist for 5 times within 5 cycles then alert


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>


**- What I did**
Fixed launch parameters in monit_syncd for BFN platform so now error log about syncd not running do0esn't wrognly appear when syncd is up.

**- How I did it**

**- How to verify it**
Run SONiC on BFN box and verify there is no "'syncd' process is not running" error log when syncd is up and running

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
