### PR TITLE
[Monit] Change the full process name of syncd in the monit config file.

### DIFF
--- a/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
+++ b/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd --diag"
+check process syncd matching "/usr/bin/syncd"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
+++ b/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
@@ -4,7 +4,7 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check process syncd matching "/usr/bin/syncd --diag"
+check process syncd matching "/usr/bin/syncd"
     if does not exist for 5 times within 5 cycles then alert
 
 check process dsserve matching "/usr/bin/dsserve /usr/bin/syncd"

--- a/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
+++ b/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd --diag"
+check process syncd matching "/usr/bin/syncd"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
+++ b/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd --diag"
+check process syncd matching "/usr/bin/syncd"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd --diag"
+check process syncd matching "/usr/bin/syncd"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd --diag"
+check process syncd matching "/usr/bin/syncd"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd --diag"
+check process syncd matching "/usr/bin/syncd"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
+++ b/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd --diag"
+check process syncd matching "/usr/bin/syncd"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
+++ b/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
@@ -4,7 +4,7 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check process syncd matching "/usr/bin/syncd --diag"
+check process syncd matching "/usr/bin/syncd"
     if does not exist for 5 times within 5 cycles then alert
 
 check process dsserve matching "/usr/bin/dsserve /usr/bin/syncd"


### PR DESCRIPTION
**- What I did**
Since the syncd process running on different platforms will have the different full path names, we 
change the full path name of process syncd in the monit config file such that it will be universal and is 
not for a specific vendor.

**- How I did it**

**- How to verify it**

