### PR TITLE
[caclmgrd] Fix application of IPv6 service ACL rules (part 2)

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -225,7 +225,9 @@ class ControlPlaneAclManager(object):
                             rule_cmd = "ip6tables" if table_ip_version == 6 else "iptables"
                             rule_cmd += " -A INPUT -p {}".format(ip_protocol)
 
-                            if "SRC_IP" in rule_props and rule_props["SRC_IP"]:
+                            if "SRC_IPV6" in rule_props and rule_props["SRC_IPV6"]:
+                                rule_cmd += " -s {}".format(rule_props["SRC_IPV6"])
+                            elif "SRC_IP" in rule_props and rule_props["SRC_IP"]:
                                 rule_cmd += " -s {}".format(rule_props["SRC_IP"])
 
                             rule_cmd += " --dport {}".format(dst_port)


### PR DESCRIPTION
Addendum to https://github.com/Azure/sonic-buildimage/pull/3917. This change somehow did not get added into that PR. That PR fixes the determination of whether a table contains IPv4 or IPv6 rules, whereas this PR ensures that if a table contains IPv6 rules, the IPv6 source address gets applied.