### PR TITLE
[sonic_daemon_base]Fix error: DaemonBase: object has no attribute 'syslog' #4034

### DIFF
--- a/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
+++ b/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
@@ -102,15 +102,15 @@ class DaemonBase(object):
     # Signal handler
     def signal_handler(self, sig, frame):
         if sig == signal.SIGHUP:
-            self.syslog.syslog(self.syslog.LOG_INFO, "Caught SIGHUP - ignoring...")
+            syslog.syslog(syslog.LOG_INFO, "Caught SIGHUP - ignoring...")
         elif sig == signal.SIGINT:
-            self.syslog.syslog(self.syslog.LOG_INFO, "Caught SIGINT - exiting...")
+            syslog.syslog(syslog.LOG_INFO, "Caught SIGINT - exiting...")
             sys.exit(128 + sig)
         elif sig == signal.SIGTERM:
-            self.syslog.syslog(self.syslog.LOG_INFO, "Caught SIGTERM - exiting...")
+            syslog.syslog(syslog.LOG_INFO, "Caught SIGTERM - exiting...")
             sys.exit(128 + sig)
         else:
-            self.syslog.syslog(self.syslog.LOG_WARNING, "Caught unhandled signal '" + sig + "'")
+            syslog.syslog(syslog.LOG_WARNING, "Caught unhandled signal '" + sig + "'")
 
     # Returns platform and hwsku
     def get_platform_and_hwsku(self):


### PR DESCRIPTION
**- What I did**
Fix error: DaemonBase: object has no attribute 'syslog' [#4034](https://github.com/Azure/sonic-buildimage/issues/4034)

**- How I did it**
syslog is not a member of class DaemonBase, so remove the "self." in DaemonBase.
See [issuecomment-575678314](https://github.com/Azure/sonic-buildimage/issues/4034#issuecomment-575678314) for detail.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
