### PR TITLE
[device] as7326-56x: Fix the default low power mode on issue

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/plugins/sfputil.py
@@ -175,12 +175,13 @@ class SfpUtil(SfpUtilBase):
             eeprom.seek(93)
             lpmode = ord(eeprom.read(1))
 
-            if ((lpmode & 0x3) == 0x1):
-                return False # High Power Mode if "Power override" bit is 1 and "Power set" bit is 0
+            if ((lpmode & 0x3) == 0x3):
+                return True # Low Power Mode if "Power override" bit is 1 and "Power set" bit is 1
             else:
-                return True # Low Power Mode if one of the following conditions is matched:
-                            # 1. Power override" bit is 0
-                            # 2. Power override" bit is 1 and "Power set" bit is 1
+                return False # High Power Mode if one of the following conditions is matched:
+                             # 1. "Power override" bit is 0
+                             # 2. "Power override" bit is 1 and "Power set" bit is 0 
+
         except IOError as e:
             print "Error: unable to open file: %s" % str(e)
             return False


### PR DESCRIPTION
CPU: Intel Broadwell-DE XeonD-1518 1.6G 4 Core
MAC: Broadcom Trident3 BCM56873
BMC: None

What I did
Modify default lpmode in sfputil.py for as7326-56x.

How I did it
Change the default lpmode from Low Power Mode to High in get_low_power_mode() of sfputil.py

How to verify it
sfputil show lpmode
sfputil lpmode off
sfputil lpmode on

Description for the changelog
Access eeprom from transceiver to get/set lpmode status
If "Power override" bit is not set, return the H/W pin status depended on H/W design.
For as7326-56x, this pin is pulled low which is High Power Mode.
If "Power override" bit is set, retrun the S/W lpmode status read from eeprom.

Below is the Power Mode Truth Table defined in sff-8436

LPMode_Pin Power_overide_Bit Power_set_Bit Module_Power_Allowed
1 0 X Low Power
0 0 X High Power
X 1 1 Low Power
X 1 0 High Power
