### PR TITLE
[LLDP] Enable/disable container auto-restart based on configuration.

### DIFF
--- a/dockers/docker-lldp-sv2/Dockerfile.j2
+++ b/dockers/docker-lldp-sv2/Dockerfile.j2
@@ -40,7 +40,7 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["lldpd.conf.j2", "/usr/share/sonic/templates/"]
 COPY ["lldpd", "/etc/default/"]
 COPY ["lldpmgrd", "/usr/bin/"]
-COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
+COPY ["supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-lldp-sv2/supervisor-proc-exit-listener
+++ b/dockers/docker-lldp-sv2/supervisor-proc-exit-listener
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import os
+import signal
+import sys
+import syslog
+import swsssdk
+
+from supervisor import childutils
+
+CONTAINER_NAME = 'lldp'
+
+# Contents of file should be the names of critical processes (as defined in
+# supervisor.conf file), one per line
+CRITICAL_PROCESSES_FILE = '/etc/supervisor/critical_processes'
+
+# This table in database contains the features for container and each feature
+# for a row will be configured a state or number.
+CONTAINER_FEATURE_TABLE_NAME = 'CONTAINER_FEATURE'
+
+def main():
+    # Read the list of critical processes from a file
+    with open(CRITICAL_PROCESSES_FILE, 'r') as f:
+        critical_processes = [line.rstrip('\n') for line in f]
+
+    while True:
+        # Transition from ACKNOWLEDGED to READY
+        childutils.listener.ready()
+
+        line = sys.stdin.readline()
+        headers = childutils.get_headers(line)
+        payload = sys.stdin.read(int(headers['len']))
+
+        # Transition from READY to ACKNOWLEDGED
+        childutils.listener.ok()
+
+        # We only care about PROCESS_STATE_EXITED events
+        if headers['eventname'] == 'PROCESS_STATE_EXITED':
+            payload_headers, payload_data = childutils.eventdata(payload + '\n')
+
+            expected = int(payload_headers['expected'])
+            processname = payload_headers['processname']
+            groupname = payload_headers['groupname']
+
+            config_db = swsssdk.ConfigDBConnector()
+            config_db.connect()
+            docker_config = config_db.get_table(CONTAINER_FEATURE_TABLE_NAME)
+            if docker_config and docker_config.has_key(CONTAINER_NAME):
+                restart_feature = docker_config[CONTAINER_NAME].get('auto_restart')
+
+            # If auto-restart feature is enabled and a critical process exited unexpectedly, terminate supervisor
+            if restart_feature == 'enabled' and expected == 0 and (processname in critical_processes or groupname in critical_processes):
+                MSG_FORMAT_STR = "Process {} exited unxepectedly. Terminating supervisor..."
+                msg = MSG_FORMAT_STR.format(payload_headers['processname'])
+                syslog.syslog(syslog.LOG_INFO, msg)
+                os.kill(os.getppid(), signal.SIGTERM)
+
+if __name__ == "__main__":
+    main()

--- a/rules/docker-lldp-sv2.mk
+++ b/rules/docker-lldp-sv2.mk
@@ -31,4 +31,3 @@ $(DOCKER_LLDP_SV2)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_LLDP_SV2)_BASE_IMAGE_FILES += lldpctl:/usr/bin/lldpctl
 $(DOCKER_LLDP_SV2)_BASE_IMAGE_FILES += lldpcli:/usr/bin/lldpcli
 $(DOCKER_LLDP_SV2)_BASE_IMAGE_FILES += monit_lldp:/etc/monit/conf.d
-$(DOCKER_LLDP_SV2)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
- What I did
Currently we already have the auto-restart features for each docker container. That means if a critical
process exited abnormally or crashed, this event will be captured and then the corresponding
container will be restarted. Right now, we want to add a knob/switch for this feature in LLDP such that the developer can dynamically turn on/off it during testing new docker images.

- How I did it
We will create a table in the database container. In this table, we store the current state of
auto-restart feature for LLDP. Initially, the state of this feature will be enabled.
The event listener will dynamically read the state from database container and then decide whether
restart the container based on it once receive the event showing a critical process exited.
The user can use the existing interface (TBD) to modify this state from enabled to disabled or
vice versa.

- How to verify it
I manually created a table in the database container called CONTAINER_FEATURE. In this table, each
container will have its corresponding state row such as the initial state of auto-restart for LLDP is in the 'enabled' status.