### PR TITLE
[Sflow] Enable/disable container auto-restart based on configuration.

### DIFF
--- a/dockers/docker-sflow/Dockerfile.j2
+++ b/dockers/docker-sflow/Dockerfile.j2
@@ -29,7 +29,7 @@ RUN sed -ri '/^DAEMON_ARGS=""/c DAEMON_ARGS="-c /var/log/hsflowd.crash"' /etc/in
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
-COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
+COPY ["supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-sflow/supervisor-proc-exit-listener
+++ b/dockers/docker-sflow/supervisor-proc-exit-listener
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import os
+import signal
+import sys
+import syslog
+import swsssdk
+
+from supervisor import childutils
+
+CONTAINER_NAME = 'sflow'
+
+# Contents of file should be the names of critical processes (as defined in
+# supervisor.conf file), one per line
+CRITICAL_PROCESSES_FILE = '/etc/supervisor/critical_processes'
+
+# This table in database contains the features for container and each 
+# feature for a row will be configured a state or number.
+CONTAINER_FEATURE_TABLE_NAME = 'CONTAINER_FEATURE'
+
+def main():
+    # Read the list of critical processes from a file
+    with open(CRITICAL_PROCESSES_FILE, 'r') as f:
+        critical_processes = [line.rstrip('\n') for line in f]
+
+    while True:
+        # Transition from ACKNOWLEDGED to READY
+        childutils.listener.ready()
+
+        line = sys.stdin.readline()
+        headers = childutils.get_headers(line)
+        payload = sys.stdin.read(int(headers['len']))
+
+        # Transition from READY to ACKNOWLEDGED
+        childutils.listener.ok()
+
+        # We only care about PROCESS_STATE_EXITED events
+        if headers['eventname'] == 'PROCESS_STATE_EXITED':
+            payload_headers, payload_data = childutils.eventdata(payload + '\n')
+
+            expected = int(payload_headers['expected'])
+            processname = payload_headers['processname']
+            groupname = payload_headers['groupname']
+
+            config_db = swsssdk.ConfigDBConnector()
+            config_db.connect()
+            docker_config = config_db.get_table(CONTAINER_FEATURE_TABLE_NAME)
+            if docker_config and docker_config.has_key(CONTAINER_NAME):
+                restart_feature = docker_config[CONTAINER_NAME].get('auto_restart')
+
+            # If auto-restart feature is enabled and a critical process exited unexpectedly, terminate supervisor
+            if restart_feature == 'enabled' and expected == 0 and (processname in critical_processes or groupname in critical_processes):
+                MSG_FORMAT_STR = "Process {} exited unxepectedly. Terminating supervisor..."
+                msg = MSG_FORMAT_STR.format(payload_headers['processname'])
+                syslog.syslog(syslog.LOG_INFO, msg)
+                os.kill(os.getppid(), signal.SIGTERM)
+
+if __name__ == "__main__":
+    main()

--- a/rules/docker-sflow.mk
+++ b/rules/docker-sflow.mk
@@ -33,4 +33,3 @@ $(DOCKER_SFLOW)_RUN_OPT += -v /host/warmboot:/var/warmboot
 $(DOCKER_SFLOW)_BASE_IMAGE_FILES += psample:/usr/bin/psample
 $(DOCKER_SFLOW)_BASE_IMAGE_FILES += sflowtool:/usr/bin/sflowtool
 $(DOCKER_SFLOW)_BASE_IMAGE_FILES += monit_sflow:/etc/monit/conf.d
-$(DOCKER_SFLOW)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
- What I did
Currently we already have the auto-restart features for each docker container. That means if a critical
process exited abnormally or crashed, this event will be captured and then the corresponding
container will be restarted. Right now, we want to add a knob/switch for this feature in sflow such that the developer can dynamically turn on/off it during testing new docker images.

- How I did it
We will create a table in the database container. In this table, we store the current state of
auto-restart feature for sflow. Initially, the state of this feature will be enabled.
The event listener will dynamically read the state from database container and then decide whether
restart the container based on it once receive the event showing a critical process exited.
The user can use the existing interface (TBD) to modify this state from enabled to disabled or
vice versa.

- How to verify it
I manually created a table in the database container called CONTAINER_FEATURE. In this table, each
container will have its corresponding state row such as the initial state of auto-restart for sflow is in the 'enabled' status.