### PR TITLE
Increasing the startsecs for teamsyncd in supervisor.conf

### DIFF
--- a/dockers/docker-teamd/supervisord.conf
+++ b/dockers/docker-teamd/supervisord.conf
@@ -36,6 +36,7 @@ stderr_logfile=syslog
 [program:teamsyncd]
 command=/usr/bin/teamsyncd
 priority=3
+startsecs=5
 autostart=false
 autorestart=false
 stdout_logfile=syslog


### PR DESCRIPTION
**- What I did**
Updating the startsecs=5sec for teamsyncd to make the time for which …the process needs to stay up before declaring the startup successful.

**- How I did it**
Added the statement  startsecs=5sec for teamsyncd process in supervisor.conf file in teamd docker.

**- How to verify it**
Back to back config reloads was tried.

**- Description for the changelog**
As per the current implementation in teamsyncd, When a TeamPortSync object is created, if there is a failure in team_init/team_alloc, it is retried 3 times with a sleep of 1 sec in between. So the teamsyncd could take upto 3 secs for coming up in case it hits the error. Hence increasing the startsecs to 5sec, so that supervisord will recognize the failure of teamsyncd and try starting again.

**- A picture of a cute animal (not mandatory but encouraged)**