### PR TITLE
[init_cfg.json] Maintain a separate init_cfg.json.j2 template file

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -13,7 +13,7 @@
                     "acl_group", "acl_entry", "acl_counter", "fdb_entry"] %}
             "{{crm_res}}_threshold_type": "percentage",
             "{{crm_res}}_low_threshold": "70",
-            "{{crm_res}}_high_threshold": "85"{% if not loop.last %}, {% endif -%}
+            "{{crm_res}}_high_threshold": "85"{% if not loop.last %},{% endif -%}
 {% endfor %}
         }
     }

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -1,13 +1,13 @@
  {
-        "DEVICE_METADATA": {
-            "localhost": {
-                "default_bgp_status": {% if shutdown_bgp_on_start == "y" %}"down"{% else %}"up"{% endif %},
-                "default_pfcwd_status": {% if enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %}
-            }
-        },
-        "CRM": {
-            "Config": {
-                "polling_interval": "300",
+    "DEVICE_METADATA": {
+        "localhost": {
+            "default_bgp_status": {% if shutdown_bgp_on_start == "y" %}"down"{% else %}"up"{% endif %},
+            "default_pfcwd_status": {% if enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %}
+        }
+    },
+    "CRM": {
+        "Config": {
+            "polling_interval": "300",
 {%- for crm_res in ["ipv4_route", "ipv6_route", "ipv4_nexthop", "ipv6_nexthop", "ipv4_neighbor",
                     "ipv6_neighbor", "nexthop_group_member", "nexthop_group", "acl_table",
                     "acl_group", "acl_entry", "acl_counter", "fdb_entry"] %}

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -1,18 +1,20 @@
- {"DEVICE_METADATA": 
-    { "localhost": 
-        { "default_bgp_status": {% if shutdown_bgp_on_start == "y" %}"down"{% else %}"up"{% endif %}, 
-          "default_pfcwd_status": {% if enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %}  
-        } 
-    },
-    {%- print ' "CRM": 
-        { "Config": { "polling_interval": "300", ' %}
-            {%- for crm_res in ["ipv4_route", "ipv6_route", "ipv4_nexthop", "ipv6_nexthop", 
-                                "ipv4_neighbor", "ipv6_neighbor", "nexthop_group_member", 
-                                "nexthop_group", "acl_table", "acl_group", "acl_entry", "acl_counter", "fdb_entry"] -%}
-                    "{{crm_res}}_threshold_type": "percentage", 
-                    "{{crm_res}}_low_threshold": "70", 
-                    "{{crm_res}}_high_threshold": "85"{% if not loop.last %}, {% endif %}
-            {%- endfor %} 
+ {
+        "DEVICE_METADATA": {
+            "localhost": {
+                "default_bgp_status": {% if shutdown_bgp_on_start == "y" %}"down"{% else %}"up"{% endif %},
+                "default_pfcwd_status": {% if enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %}
+            }
+        },
+        "CRM": {
+            "Config": {
+                "polling_interval": "300",
+{%- for crm_res in ["ipv4_route", "ipv6_route", "ipv4_nexthop", "ipv6_nexthop", "ipv4_neighbor",
+                    "ipv6_neighbor", "nexthop_group_member", "nexthop_group", "acl_table",
+                    "acl_group", "acl_entry", "acl_counter", "fdb_entry"] %}
+            "{{crm_res}}_threshold_type": "percentage",
+            "{{crm_res}}_low_threshold": "70",
+            "{{crm_res}}_high_threshold": "85"{% if not loop.last %}, {% endif -%}
+{% endfor %}
         }
     }
 }

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -1,4 +1,4 @@
- {
+{
     "DEVICE_METADATA": {
         "localhost": {
             "default_bgp_status": {% if shutdown_bgp_on_start == "y" %}"down"{% else %}"up"{% endif %},

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -1,0 +1,5 @@
+ {"DEVICE_METADATA": { "localhost": { "default_bgp_status": {% if shutdown_bgp_on_start == "y" %}"down"{% else %}"up"{% endif %}, "default_pfcwd_status": {% if enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %}  } },
+{%- print ' "CRM": { "Config": { "polling_interval": "300", ' %}
+{%- for crm_res in ["ipv4_route", "ipv6_route", "ipv4_nexthop", "ipv6_nexthop", "ipv4_neighbor", "ipv6_neighbor", "nexthop_group_member", "nexthop_group", "acl_table", "acl_group", "acl_entry", "acl_counter", "fdb_entry"] -%}
+"{{crm_res}}_threshold_type": "percentage", "{{crm_res}}_low_threshold": "70", "{{crm_res}}_high_threshold": "85"{% if not loop.last %}, {% endif %}
+{%- endfor %} } } }

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -1,5 +1,18 @@
- {"DEVICE_METADATA": { "localhost": { "default_bgp_status": {% if shutdown_bgp_on_start == "y" %}"down"{% else %}"up"{% endif %}, "default_pfcwd_status": {% if enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %}  } },
-{%- print ' "CRM": { "Config": { "polling_interval": "300", ' %}
-{%- for crm_res in ["ipv4_route", "ipv6_route", "ipv4_nexthop", "ipv6_nexthop", "ipv4_neighbor", "ipv6_neighbor", "nexthop_group_member", "nexthop_group", "acl_table", "acl_group", "acl_entry", "acl_counter", "fdb_entry"] -%}
-"{{crm_res}}_threshold_type": "percentage", "{{crm_res}}_low_threshold": "70", "{{crm_res}}_high_threshold": "85"{% if not loop.last %}, {% endif %}
-{%- endfor %} } } }
+ {"DEVICE_METADATA": 
+    { "localhost": 
+        { "default_bgp_status": {% if shutdown_bgp_on_start == "y" %}"down"{% else %}"up"{% endif %}, 
+          "default_pfcwd_status": {% if enable_pfcwd_on_start == "y" %}"enable"{% else %}"disable"{% endif %}  
+        } 
+    },
+    {%- print ' "CRM": 
+        { "Config": { "polling_interval": "300", ' %}
+            {%- for crm_res in ["ipv4_route", "ipv6_route", "ipv4_nexthop", "ipv6_nexthop", 
+                                "ipv4_neighbor", "ipv6_neighbor", "nexthop_group_member", 
+                                "nexthop_group", "acl_table", "acl_group", "acl_entry", "acl_counter", "fdb_entry"] -%}
+                    "{{crm_res}}_threshold_type": "percentage", 
+                    "{{crm_res}}_low_threshold": "70", 
+                    "{{crm_res}}_high_threshold": "85"{% if not loop.last %}, {% endif %}
+            {%- endfor %} 
+        }
+    }
+}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -254,6 +254,7 @@ sudo cp $IMAGE_CONFIGS/hostname/hostname-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/misc/docker-wait-any $FILESYSTEM_ROOT/usr/bin/
 
 # Copy updategraph script and service file
+j2 files/build_templates/init_cfg.json.j2 | sudo tee $FILESYSTEM_ROOT/etc/sonic/init_cfg.json
 j2 files/build_templates/updategraph.service.j2 | sudo tee $FILESYSTEM_ROOT/etc/systemd/system/updategraph.service
 sudo cp $IMAGE_CONFIGS/updategraph/updategraph $FILESYSTEM_ROOT/usr/bin/
 echo "updategraph.service" | sudo tee -a $GENERATED_SERVICE_FILE
@@ -264,11 +265,6 @@ sudo bash -c "echo dhcp_as_static=true >> $FILESYSTEM_ROOT/etc/sonic/updategraph
 {% else %}
 sudo bash -c "echo enabled=false > $FILESYSTEM_ROOT/etc/sonic/updategraph.conf"
 {% endif %}
-sudo bash -c "echo '{ \"DEVICE_METADATA\": { \"localhost\": { \"default_bgp_status\": {% if shutdown_bgp_on_start == "y" %}\"down\"{% else %}\"up\"{% endif %}, \"default_pfcwd_status\": {% if enable_pfcwd_on_start == "y" %}\"enable\"{% else %}\"disable\"{% endif %}  } },
-{%- print ' \\"CRM\\": { \\"Config\\": { \\"polling_interval\\": \\"300\\", ' %}
-{%- for crm_res in ["ipv4_route", "ipv6_route", "ipv4_nexthop", "ipv6_nexthop", "ipv4_neighbor", "ipv6_neighbor", "nexthop_group_member", "nexthop_group", "acl_table", "acl_group", "acl_entry", "acl_counter", "fdb_entry"] -%}
-\"{{crm_res}}_threshold_type\": \"percentage\", \"{{crm_res}}_low_threshold\": \"70\", \"{{crm_res}}_high_threshold\": \"85\"{% if not loop.last %}, {% endif %}
-{%- endfor %} } } }' >> $FILESYSTEM_ROOT/etc/sonic/init_cfg.json"
 
 # Copy config-setup script and service file
 j2 files/build_templates/config-setup.service.j2 | sudo tee $FILESYSTEM_ROOT/etc/systemd/system/config-setup.service

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -265,7 +265,7 @@ sudo bash -c "echo dhcp_as_static=true >> $FILESYSTEM_ROOT/etc/sonic/updategraph
 sudo bash -c "echo enabled=false > $FILESYSTEM_ROOT/etc/sonic/updategraph.conf"
 {% endif %}
 
-# Generate initial SONiC configureation file
+# Generate initial SONiC configuration file
 j2 files/build_templates/init_cfg.json.j2 | sudo tee $FILESYSTEM_ROOT/etc/sonic/init_cfg.json
 
 # Copy config-setup script and service file

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -254,7 +254,6 @@ sudo cp $IMAGE_CONFIGS/hostname/hostname-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/misc/docker-wait-any $FILESYSTEM_ROOT/usr/bin/
 
 # Copy updategraph script and service file
-j2 files/build_templates/init_cfg.json.j2 | sudo tee $FILESYSTEM_ROOT/etc/sonic/init_cfg.json
 j2 files/build_templates/updategraph.service.j2 | sudo tee $FILESYSTEM_ROOT/etc/systemd/system/updategraph.service
 sudo cp $IMAGE_CONFIGS/updategraph/updategraph $FILESYSTEM_ROOT/usr/bin/
 echo "updategraph.service" | sudo tee -a $GENERATED_SERVICE_FILE
@@ -265,6 +264,9 @@ sudo bash -c "echo dhcp_as_static=true >> $FILESYSTEM_ROOT/etc/sonic/updategraph
 {% else %}
 sudo bash -c "echo enabled=false > $FILESYSTEM_ROOT/etc/sonic/updategraph.conf"
 {% endif %}
+
+# Generate initial SONiC configureation file
+j2 files/build_templates/init_cfg.json.j2 | sudo tee $FILESYSTEM_ROOT/etc/sonic/init_cfg.json
 
 # Copy config-setup script and service file
 j2 files/build_templates/config-setup.service.j2 | sudo tee $FILESYSTEM_ROOT/etc/systemd/system/config-setup.service


### PR DESCRIPTION
**- What I did**
We created a separate init_cfg.json.j2 file instead of generating it in the sonic_debian_extension.j2. After that, we can put new configuration info into file such as the auto-restart feature of each docker container we introduced recently.

**- How I did it**
Remove the part of code from sonic_debian_extension.j2 and put it in new file init_cfg.json.j2.

**- How to verify it**


