### PR TITLE
[fancontrol] Restart process upon unexpected exit, not entire pmon container

### DIFF
--- a/dockers/docker-platform-monitor/critical_processes
+++ b/dockers/docker-platform-monitor/critical_processes
@@ -1,4 +1,3 @@
-fancontrol
 ledd
 xcvrd
 psud

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -40,7 +40,6 @@ command=/usr/sbin/fancontrol
 priority=4
 autostart=false
 autorestart=unexpected
-exitcodes=0
 startsecs=10
 stopwaitsecs=10
 stdout_logfile=syslog

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -39,7 +39,10 @@ startsecs=0
 command=/usr/sbin/fancontrol
 priority=4
 autostart=false
-autorestart=false
+autorestart=unexpected
+exitcodes=0
+startsecs=10
+stopwaitsecs=10
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -40,10 +40,9 @@ command=/usr/sbin/fancontrol
 priority=4
 autostart=false
 autorestart=unexpected
-startsecs=10
-stopwaitsecs=10
 stdout_logfile=syslog
 stderr_logfile=syslog
+startsecs=10
 
 {% if not skip_ledd %}
 [program:ledd]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove fancontrol from critical process list for pmon
Add restart logic of fancontrol for unexpected exit cases

**- How I did it**
Configure the supervisord.conf for pmon to restart the fancontrol

**- How to verify it**
Login to pmon
Run 'kill -9 <pid of fancontrol>; rm /var/run/fancontrol.pid'
Check if fancontrol restarted

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add restart configuration of fancontrol for pmon.


**- A picture of a cute animal (not mandatory but encouraged)**
