### PR TITLE
[AS9716-32D]:Support 0x57 and 0x56 eeprom

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/plugins/eeprom.py
+++ b/device/accton/x86_64-accton_as9716_32d-r0/plugins/eeprom.py
@@ -14,6 +14,13 @@ try:
 except ImportError, e:
     raise ImportError (str(e) + "- required module not found")
 
+def eeprom_check():
+    filepath="/sys/bus/i2c/devices/0-0057/eeprom"    
+    if os.path.isfile(filepath):
+        return 1 #now board, 0x57
+    else:
+        return 0 #now board, 0x56
+    
 class board(eeprom_tlvinfo.TlvInfoDecoder):
     _TLV_INFO_MAX_LEN = 256
     def __init__(self, name, path, cpld_root, ro):

--- a/device/accton/x86_64-accton_as9716_32d-r0/plugins/eeprom.py
+++ b/device/accton/x86_64-accton_as9716_32d-r0/plugins/eeprom.py
@@ -24,5 +24,11 @@ def eeprom_check():
 class board(eeprom_tlvinfo.TlvInfoDecoder):
     _TLV_INFO_MAX_LEN = 256
     def __init__(self, name, path, cpld_root, ro):
-        self.eeprom_path = "/sys/bus/i2c/devices/0-0056/eeprom"
+        ret=eeprom_check()
+        if ret==1:
+            self.eeprom_path = "/sys/bus/i2c/devices/0-0057/eeprom"
+        else:
+            self.eeprom_path = "/sys/bus/i2c/devices/0-0056/eeprom"
+
         super(board, self).__init__(self.eeprom_path, 0, '', True)
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
[AS9716-32D]:Add to support 0x57 and 0x56 eeprom
**- How I did it**
Modify accton_as9716_32d_util.py and eeprom.py to check i2c 0x57 exist or not. If yes, it is new board. So create 0x57 sysfs. If no, create 0x56 for old board.  For eeprom.py that check 0x57 and 0x56 sysfs to provide information to caller.
**- How to verify it**
root@sonic:/home/admin# decode-syseeprom
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 53
TLV Name             Code Len Value
-------------------- ---- --- -----
ONIE Version         0x29  13 2018.08.00.03
Base MAC Address     0x24   6 80:A2:35:C6:69:22
Vendor Name          0x2D   9 ACCTON_EC
Diag Version         0x2E  11 0b.01.00.15
CRC-32               0xFE   4 0x894390A7
(checksum valid)
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
