### PR TITLE
Fix read fan_fault=1 and send log when fan insert sometimes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor_fan.py
@@ -19,6 +19,7 @@
 # HISTORY:
 #    mm/dd/yyyy (A.D.)
 #    5/15/2019:  Jostar create for as4630-54pe
+#    9/25/2019:  Jostar fix that get fan_fault=1 when fan_insert and read cpld
 # ------------------------------------------------------------------
 
 try:
@@ -108,12 +109,8 @@ class device_monitor(object):
             logging.getLogger('').addHandler(console)
 
         sys_handler = logging.handlers.SysLogHandler(address = '/dev/log')
-        #sys_handler.setLevel(logging.WARNING)       
         sys_handler.setLevel(logging.INFO)       
         logging.getLogger('').addHandler(sys_handler)
-        
-
-        #logging.debug('SET. logfile:%s / loglevel:%d', log_file, log_level)
         
     def manage_fan(self):      
         
@@ -144,6 +141,7 @@ class device_monitor(object):
                 if fan_state[idx]!=0:
                     fan_state[idx]=FAN_STATE_REMOVE
                     logging.warning("Alarm for FAN-%d absent is detected", idx+1)  
+                    fan_status_state[idx]=FAN_STATUS_NORMAL
                                     
         for idx in range (0, self.fan_num):           
             node = self.fan_path + self.fault[idx]
@@ -154,13 +152,15 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_status_state[idx]!=FAN_STATUS_FAULT:                    
                     if fan_state[idx] == FAN_STATE_INSERT:
                         logging.warning("Alarm for FAN-%d failed is detected", idx+1);
                         fan_status_state[idx]=FAN_STATUS_FAULT
             else:
+                if fan_status_state[idx]==FAN_STATUS_FAULT and fan_state[idx] == FAN_STATE_INSERT:
+                    logging.info("FAN-%d becomes operational", idx+1)
+                   
                 fan_status_state[idx]=FAN_STATUS_NORMAL
       
         return True

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_monitor_fan.py
@@ -19,6 +19,7 @@
 # HISTORY:
 #    mm/dd/yyyy (A.D.)
 #    5/27/2019:  Brandon_Chuang create
+#    9/25/2019:  Jostar fix that get fan_fault=1 when fan_insert and read cpld
 # ------------------------------------------------------------------
 
 try:
@@ -72,9 +73,6 @@ fan_status_state=[2, 2, 2, 2, 2, 2]  #init state=2, fault=1, normal=0
 # Make a class we can use to capture stdout and sterr in the log
 class device_monitor(object):
 
-    #/sys/bus/i2c/devices/3-0063
-    #fan1_present, fan5_present
-
     def __init__(self, log_file, log_level):
         
         self.fan_num = 5
@@ -115,12 +113,8 @@ class device_monitor(object):
             logging.getLogger('').addHandler(console)
 
         sys_handler = logging.handlers.SysLogHandler(address = '/dev/log')
-        #sys_handler.setLevel(logging.WARNING)       
         sys_handler.setLevel(logging.INFO)       
         logging.getLogger('').addHandler(sys_handler)
-        
-
-        #logging.debug('SET. logfile:%s / loglevel:%d', log_file, log_level)
         
     def manage_fan(self):      
         
@@ -142,7 +136,6 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_state[idx]!=1:
                     fan_state[idx]=FAN_STATE_INSERT
@@ -151,6 +144,7 @@ class device_monitor(object):
                 if fan_state[idx]!=0:
                     fan_state[idx]=FAN_STATE_REMOVE
                     logging.warning("Alarm for FAN-%d absent is detected", idx+1)  
+                    fan_status_state[idx]=FAN_STATUS_NORMAL
                                     
         for idx in range (0, self.fan_num):           
             node = self.fan_path + self.fault[idx]
@@ -161,13 +155,15 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_status_state[idx]!=FAN_STATUS_FAULT:                    
                     if fan_state[idx] == FAN_STATE_INSERT:
                         logging.warning("Alarm for FAN-%d failed is detected", idx+1);
                         fan_status_state[idx]=FAN_STATUS_FAULT
             else:
+                if fan_status_state[idx]==FAN_STATUS_FAULT and fan_state[idx] == FAN_STATE_INSERT:
+                    logging.info("FAN-%d becomes operational", idx+1)
+                   
                 fan_status_state[idx]=FAN_STATUS_NORMAL
       
         return True

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_monitor_fan.py
@@ -19,6 +19,7 @@
 # HISTORY:
 #    mm/dd/yyyy (A.D.)
 #    5/27/2019:  Brandon_Chuang create
+#    9/25/2019:  Jostar fix that get fan_fault=1 when fan_insert and read cpld
 # ------------------------------------------------------------------
 
 try:
@@ -72,9 +73,6 @@ fan_status_state=[2, 2, 2, 2, 2, 2]  #init state=2, fault=1, normal=0
 # Make a class we can use to capture stdout and sterr in the log
 class device_monitor(object):
 
-    #/sys/bus/i2c/devices/3-0063
-    #fan1_present, fan5_present
-
     def __init__(self, log_file, log_level):
         
         self.fan_num = 5
@@ -115,12 +113,8 @@ class device_monitor(object):
             logging.getLogger('').addHandler(console)
 
         sys_handler = logging.handlers.SysLogHandler(address = '/dev/log')
-        #sys_handler.setLevel(logging.WARNING)       
         sys_handler.setLevel(logging.INFO)       
         logging.getLogger('').addHandler(sys_handler)
-        
-
-        #logging.debug('SET. logfile:%s / loglevel:%d', log_file, log_level)
         
     def manage_fan(self):      
         
@@ -142,7 +136,6 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_state[idx]!=1:
                     fan_state[idx]=FAN_STATE_INSERT
@@ -151,6 +144,7 @@ class device_monitor(object):
                 if fan_state[idx]!=0:
                     fan_state[idx]=FAN_STATE_REMOVE
                     logging.warning("Alarm for FAN-%d absent is detected", idx+1)  
+                    fan_status_state[idx]=FAN_STATUS_NORMAL
                                     
         for idx in range (0, self.fan_num):           
             node = self.fan_path + self.fault[idx]
@@ -161,13 +155,15 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_status_state[idx]!=FAN_STATUS_FAULT:                    
                     if fan_state[idx] == FAN_STATE_INSERT:
                         logging.warning("Alarm for FAN-%d failed is detected", idx+1);
                         fan_status_state[idx]=FAN_STATUS_FAULT
             else:
+                if fan_status_state[idx]==FAN_STATUS_FAULT and fan_state[idx] == FAN_STATE_INSERT:
+                    logging.info("FAN-%d becomes operational", idx+1)
+                   
                 fan_status_state[idx]=FAN_STATUS_NORMAL
       
         return True

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor_fan.py
@@ -19,6 +19,7 @@
 # HISTORY:
 #    mm/dd/yyyy (A.D.)
 #    7/2/2018:  Jostar create for as7326-56x
+#    9/25/2019:   Jostar fix that get fan_fault=1 when fan_insert and read cpld
 # ------------------------------------------------------------------
 
 try:
@@ -72,9 +73,6 @@ fan_status_state=[2, 2, 2, 2, 2, 2, 2]  #init state=2, fault=1, normal=0
 # Make a class we can use to capture stdout and sterr in the log
 class device_monitor(object):
 
-    #/sys/bus/i2c/devices/11-0066
-    #fan1_present, fan6_present
-
     def __init__(self, log_file, log_level):
         
         self.fan_num = 6
@@ -117,12 +115,8 @@ class device_monitor(object):
             logging.getLogger('').addHandler(console)
 
         sys_handler = logging.handlers.SysLogHandler(address = '/dev/log')
-        #sys_handler.setLevel(logging.WARNING)       
         sys_handler.setLevel(logging.INFO)       
         logging.getLogger('').addHandler(sys_handler)
-        
-
-        #logging.debug('SET. logfile:%s / loglevel:%d', log_file, log_level)
         
     def manage_fan(self):      
         
@@ -144,7 +138,6 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_state[idx]!=1:
                     fan_state[idx]=FAN_STATE_INSERT
@@ -153,6 +146,7 @@ class device_monitor(object):
                 if fan_state[idx]!=0:
                     fan_state[idx]=FAN_STATE_REMOVE
                     logging.warning("Alarm for FAN-%d absent is detected", idx+1)  
+                    fan_status_state[idx]=FAN_STATUS_NORMAL
                                     
         for idx in range (0, self.fan_num):           
             node = self.fan_path + self.fault[idx]
@@ -163,13 +157,15 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_status_state[idx]!=FAN_STATUS_FAULT:                    
                     if fan_state[idx] == FAN_STATE_INSERT:
                         logging.warning("Alarm for FAN-%d failed is detected", idx+1);
                         fan_status_state[idx]=FAN_STATUS_FAULT
             else:
+                if fan_status_state[idx]==FAN_STATUS_FAULT and fan_state[idx] == FAN_STATE_INSERT:
+                    logging.info("FAN-%d becomes operational", idx+1)
+                   
                 fan_status_state[idx]=FAN_STATUS_NORMAL
       
         return True

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor_fan.py
@@ -18,7 +18,8 @@
 # ------------------------------------------------------------------
 # HISTORY:
 #    mm/dd/yyyy (A.D.)
-#    7/2/2018:  Jostar create for as7326-56x
+#    7/2/2018:  Jostar create for as7726-32x
+#    9/25/2019:   Jostar fix that get fan_fault=1 when fan_insert and read cpld
 # ------------------------------------------------------------------
 
 try:
@@ -114,12 +115,8 @@ class device_monitor(object):
             logging.getLogger('').addHandler(console)
 
         sys_handler = logging.handlers.SysLogHandler(address = '/dev/log')
-        #sys_handler.setLevel(logging.WARNING)       
         sys_handler.setLevel(logging.INFO)       
         logging.getLogger('').addHandler(sys_handler)
-        
-
-        #logging.debug('SET. logfile:%s / loglevel:%d', log_file, log_level)
         
     def manage_fan(self):      
         
@@ -141,7 +138,6 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_state[idx]!=1:
                     fan_state[idx]=FAN_STATE_INSERT
@@ -150,6 +146,7 @@ class device_monitor(object):
                 if fan_state[idx]!=0:
                     fan_state[idx]=FAN_STATE_REMOVE
                     logging.warning("Alarm for FAN-%d absent is detected", idx+1)  
+                    fan_status_state[idx]=FAN_STATUS_NORMAL
                                     
         for idx in range (0, self.fan_num):           
             node = self.fan_path + self.fault[idx]
@@ -160,13 +157,15 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_status_state[idx]!=FAN_STATUS_FAULT:                    
                     if fan_state[idx] == FAN_STATE_INSERT:
                         logging.warning("Alarm for FAN-%d failed is detected", idx+1);
                         fan_status_state[idx]=FAN_STATUS_FAULT
             else:
+                if fan_status_state[idx]==FAN_STATUS_FAULT and fan_state[idx] == FAN_STATE_INSERT:
+                    logging.info("FAN-%d becomes operational", idx+1)
+                   
                 fan_status_state[idx]=FAN_STATUS_NORMAL
       
         return True

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_monitor_fan.py
@@ -19,6 +19,7 @@
 # HISTORY:
 #    mm/dd/yyyy (A.D.)
 #    12/13/2018:  Jostar create for as9716-32d
+#    9/25/2019:   Jostar fix that get fan_fault=1 when fan_insert and read cpld
 # ------------------------------------------------------------------
 
 try:
@@ -114,12 +115,8 @@ class device_monitor(object):
             logging.getLogger('').addHandler(console)
 
         sys_handler = logging.handlers.SysLogHandler(address = '/dev/log')
-        #sys_handler.setLevel(logging.WARNING)       
         sys_handler.setLevel(logging.INFO)       
         logging.getLogger('').addHandler(sys_handler)
-        
-
-        #logging.debug('SET. logfile:%s / loglevel:%d', log_file, log_level)
         
     def manage_fan(self):      
         
@@ -141,7 +138,6 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_state[idx]!=1:
                     fan_state[idx]=FAN_STATE_INSERT
@@ -150,6 +146,7 @@ class device_monitor(object):
                 if fan_state[idx]!=0:
                     fan_state[idx]=FAN_STATE_REMOVE
                     logging.warning("Alarm for FAN-%d absent is detected", idx+1)  
+                    fan_status_state[idx]=FAN_STATUS_NORMAL
                                     
         for idx in range (0, self.fan_num):           
             node = self.fan_path + self.fault[idx]
@@ -160,13 +157,15 @@ class device_monitor(object):
                 return False
             content = val_file.readline().rstrip()
             val_file.close()
-            # content is a string, either "0" or "1"
             if content == "1":
                 if fan_status_state[idx]!=FAN_STATUS_FAULT:                    
                     if fan_state[idx] == FAN_STATE_INSERT:
                         logging.warning("Alarm for FAN-%d failed is detected", idx+1);
                         fan_status_state[idx]=FAN_STATUS_FAULT
             else:
+                if fan_status_state[idx]==FAN_STATUS_FAULT and fan_state[idx] == FAN_STATE_INSERT:
+                    logging.info("FAN-%d becomes operational", idx+1)
+                
                 fan_status_state[idx]=FAN_STATUS_NORMAL
       
         return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix read fan_fault=1 and send log when fan insert sometimes
**- How I did it**
Add check fan_fault when fan_status=fan_fault . If fan_fault become to zero, log "FAN-N becomes operational"
**- How to verify it**
Run monitor_fan.py. Remove fan from DUT. Insert fan to DUT. Check log as below,
root : INFO FAN-6 present is detected
root : WARNING Alarm for FAN-6 failed is detected
root : INFO FAN-6 becomes operational
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
