### PR TITLE
[device]Add check exception case when read port present fail

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/plugins/sfputil.py
@@ -70,16 +70,15 @@ class SfpUtil(SfpUtilBase):
         present_path = self.BASE_CPLD_PATH + "module_present_" + str(port_num)
         self.__port_to_is_present = present_path
 
+        content="0"
         try:
             val_file = open(self.__port_to_is_present)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)
+            print "Error: unable to access file: %s" % str(e)
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5712_54x-r0/plugins/sfputil.py
@@ -144,16 +144,15 @@ class SfpUtil(SfpUtilBase):
         present_path = present_path + "module_present_" + str(port_num)
         self.__port_to_is_present = present_path
 
+        content="0"
         try:
             val_file = open(self.__port_to_is_present)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+       
         if content == "1":
             return True
 
@@ -175,16 +174,15 @@ class SfpUtil(SfpUtilBase):
         q = self.qsfp_sb_remap(port_num)
         lp_mode_path = lp_mode_path + str(q)
         
+        content="0"
         try:
             val_file = open(lp_mode_path)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as5812_54t-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5812_54t-r0/plugins/sfputil.py
@@ -105,16 +105,15 @@ class SfpUtil(SfpUtilBase):
         present_path = present_path + "module_present_" + str(port_num)            
         self.__port_to_is_present = present_path
 
+        content="0"
         try:
             val_file = open(self.__port_to_is_present)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 
@@ -129,16 +128,15 @@ class SfpUtil(SfpUtilBase):
         lp_mode_path = lp_mode_path + "module_lp_mode_" 
         lp_mode_path = lp_mode_path + str(port_num)
         
+        content="0"
         try:
             val_file = open(lp_mode_path)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
             print "Error: unable to open file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as5812_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5812_54x-r0/plugins/sfputil.py
@@ -158,16 +158,15 @@ class SfpUtil(SfpUtilBase):
         present_path = present_path + "module_present_" + str(port_num)            
         self.__port_to_is_present = present_path
 
+        content="0"
         try:
             val_file = open(self.__port_to_is_present)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 
@@ -189,16 +188,15 @@ class SfpUtil(SfpUtilBase):
         q = self.qsfp_sb_remap(port_num)
         lp_mode_path = lp_mode_path + str(q)
         
+        content = "0"
         try:
             val_file = open(lp_mode_path)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
             print "Error: unable to open file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+       
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as5835_54t-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5835_54t-r0/plugins/sfputil.py
@@ -100,16 +100,15 @@ class SfpUtil(SfpUtilBase):
         path = "/sys/bus/i2c/devices/3-0062/module_present_{0}"
         port_ps = path.format(cage_num)
 
+        content="0"
         try:
             val_file = open(port_ps)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+      
         if content == "1":
             return True
 
@@ -131,8 +130,7 @@ class SfpUtil(SfpUtilBase):
 
         content = val_file.readline().rstrip()
         val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as5835_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/plugins/sfputil.py
@@ -167,16 +167,15 @@ class SfpUtil(SfpUtilBase):
         path = "/sys/bus/i2c/devices/{0}/module_present_{1}"
         port_ps = path.format(cpld_ps, cage_num)
 
+        content = "0"
         try:
             val_file = open(port_ps)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 
@@ -201,8 +200,7 @@ class SfpUtil(SfpUtilBase):
 
         content = val_file.readline().rstrip()
         val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as6712_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as6712_32x-r0/plugins/sfputil.py
@@ -127,16 +127,15 @@ class SfpUtil(SfpUtilBase):
 
         self.__port_to_is_present = present_path
 
+        content="0"
         try:
             val_file = open(self.__port_to_is_present)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+       
         if content == "1":
             return True
 
@@ -150,16 +149,15 @@ class SfpUtil(SfpUtilBase):
         _path = cpld_path + "/module_lp_mode_" 
         _path += str(self._port_to_i2c_mapping[port_num][0])
 
+        content="0"
         try:
             reg_file = open(_path)
+            content = reg_file.readline().rstrip()
+            reg_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = reg_file.readline().rstrip()
-        reg_file.close()
-
-        # content is a string, either "0" or "1"
+    
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as7116_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/plugins/sfputil.py
@@ -126,14 +126,15 @@ class SfpUtil(SfpUtilBase):
         path = "/sys/bus/i2c/devices/{0}-0050/sfp_is_present"
         port_ps = path.format(self._port_to_i2c_mapping[port_num])
 
-          
+        reg_value = '0'
         try:
             reg_file = open(port_ps)
+            reg_value = reg_file.readline().rstrip()
+            reg_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)
+            print "Error: unable to access file: %s" % str(e)
             return False
-
-        reg_value = reg_file.readline().rstrip()
+        
         if reg_value == '1':
             return True
 

--- a/device/accton/x86_64-accton_as7212_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7212_54x-r0/plugins/sfputil.py
@@ -97,14 +97,15 @@ class sfputil(SfpUtilBase):
         path = "/sys/bus/i2c/devices/{0}-0050/sfp_is_present"
         port_ps = path.format(self.port_to_i2c_mapping[port_num+1])
 
-          
+        reg_value = '0'
         try:
             reg_file = open(port_ps)
+            reg_value = reg_file.readline().rstrip()
+            reg_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)
+            print "Error: unable to access file: %s" % str(e)
             return False
-
-        reg_value = reg_file.readline().rstrip()
+        
         if reg_value == '1':
             return True
 

--- a/device/accton/x86_64-accton_as7312_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/plugins/sfputil.py
@@ -142,16 +142,15 @@ class SfpUtil(SfpUtilBase):
         path = "/sys/bus/i2c/devices/{0}/module_present_{1}"
         port_ps = path.format(cpld_ps, port_num)
 
+        content = "0"
         try:
             val_file = open(port_ps)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as7312_54xs-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7312_54xs-r0/plugins/sfputil.py
@@ -142,14 +142,14 @@ class SfpUtil(SfpUtilBase):
         path = "/sys/bus/i2c/devices/{0}/module_present_{1}"
         port_ps = path.format(cpld_ps, port_num)
 
+        content = "0"
         try:
             val_file = open(port_ps)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
 
         # content is a string, either "0" or "1"
         if content == "1":

--- a/device/accton/x86_64-accton_as7315_27xb-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7315_27xb-r0/plugins/sfputil.py
@@ -114,16 +114,15 @@ class SfpUtil(SfpUtilBase):
         index = ((port_num-1)%24) +1 
         port_ps = path.format(cpld_ps, index)
 
+        content = "0"
         try:
             val_file = open(port_ps)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as7326_56x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/plugins/sfputil.py
@@ -145,16 +145,15 @@ class SfpUtil(SfpUtilBase):
         path = "/sys/bus/i2c/devices/{0}/module_present_{1}"
         port_ps = path.format(cpld_ps, port_num)
 
+        content="0"
         try:
             val_file = open(port_ps)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)
+            print "Error: unable to access file: %s" % str(e)
             return False
 
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as7512_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7512_32x-r0/plugins/sfputil.py
@@ -39,14 +39,15 @@ class SfpUtil(SfpUtilBase):
         path = "/sys/bus/i2c/devices/{0}-0050/sfp_is_present"
         port_ps = path.format(port_num+18)
 
-
+        reg_value = '0'
         try:
             reg_file = open(port_ps)
+            reg_value = reg_file.readline().rstrip()
+            reg_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)
+            print "Error: unable to access file: %s" % str(e)
             return False
-
-        reg_value = reg_file.readline().rstrip()
+       
         if reg_value == '1':
             return True
 

--- a/device/accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7712_32x-r0/plugins/sfputil.py
@@ -96,13 +96,15 @@ class SfpUtil(SfpUtilBase):
         path = "/sys/bus/i2c/devices/4-0060/module_present_{0}"
         port_ps = path.format(port_num)
 
+        reg_value = '0'
         try:
             reg_file = open(port_ps)
+            reg_value = reg_file.readline().rstrip()
+            reg_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)
+            print "Error: unable to access file: %s" % str(e)
             return False
-
-        reg_value = reg_file.readline().rstrip()
+        
         if reg_value == '1':
             return True
 

--- a/device/accton/x86_64-accton_as7716_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7716_32x-r0/plugins/sfputil.py
@@ -97,16 +97,15 @@ class SfpUtil(SfpUtilBase):
         present_path = self.BASE_CPLD_PATH + "module_present_" + str(port_num)
         self.__port_to_is_present = present_path
 
+        content = "0"
         try:
             val_file = open(self.__port_to_is_present)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as7716_32xb-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7716_32xb-r0/plugins/sfputil.py
@@ -87,16 +87,15 @@ class SfpUtil(SfpUtilBase):
         present_path = self.BASE_CPLD_PATH + "module_present_" + str(port_num+1)
         self.__port_to_is_present = present_path
 
+        content = "0"
         try:
             val_file = open(self.__port_to_is_present)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
         
-        # content is a string, either "0" or "1"
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as7726_32x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/plugins/sfputil.py
@@ -100,16 +100,15 @@ class SfpUtil(SfpUtilBase):
         present_path = self.BASE_CPLD_PATH + "module_present_" + str(port_num)
         self.__port_to_is_present = present_path
 
+        content="0"
         try:
             val_file = open(self.__port_to_is_present)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
-
-        # content is a string, either "0" or "1"
+        
         if content == "1":
             return True
 

--- a/device/accton/x86_64-accton_as7816_64x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/plugins/sfputil.py
@@ -122,13 +122,15 @@ class SfpUtil(SfpUtilBase):
         path = "/sys/bus/i2c/devices/19-0060/module_present_{0}"
         port_ps = path.format(port_num)
           
+        reg_value = '0'
         try:
             reg_file = open(port_ps)
+            reg_value = reg_file.readline().rstrip()
+            reg_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)
+            print "Error: unable to access file: %s" % str(e)
             return False
-
-        reg_value = reg_file.readline().rstrip()
+        
         if reg_value == '1':
             return True
 

--- a/device/accton/x86_64-accton_as9716_32d-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as9716_32d-r0/plugins/sfputil.py
@@ -98,14 +98,14 @@ class SfpUtil(SfpUtilBase):
             present_path = self.BASE_CPLD2_PATH + "module_present_" + str(port_num+1)
         self.__port_to_is_present = present_path
 
+        content="0"
         try:
             val_file = open(self.__port_to_is_present)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
-            print "Error: unable to open file: %s" % str(e)          
+            print "Error: unable to access file: %s" % str(e)          
             return False
-
-        content = val_file.readline().rstrip()
-        val_file.close()
 
         if content == "1":
             return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add check exception case when read port present fail
**- How I did it**
Modify get_psu_presence(). Move read() and close() to "try: ... except IOError:" To avoid when read
port present sysfs fail. This exception will let sfputil.py to exit. So "sfputil show eeprom" can't show other port status.
**- How to verify it**
et I2C CLK/DAGA short in the board(ex:for port1). Or modify cpld drv and let port1 present sysfs to return fail. Do sfputil show eeprom in shell.
Messgse as below,
..........
File "/usr/share/sonic/device/x86_64-accton_as9716_32d-r0/plugins/sfputil.py", line 129, in get_presence
content = val_file.readline().rstrip()
IOError: [Errno 6] No such device or address..
Add check exception code to sfputil.py. Do the same test. Message as below,
root@sonic:/home/admin# sfputil show eeprom
Error: unable to access file: [Errno 6] No such device or address
Ethernet0: SFP EEPROM not detected
Ethernet4: SFP EEPROM not detected

Ethernet8: SFP EEPROM detected
Connector: No separable connector
Encoding: Unspecified
Extended Identifier: Power Class 1(1.5W max)
Extended RateSelect Compliance: QSFP+ Rate Select Version 1
Identifier: QSFP+ or later
Length Cable Assembly(m): 0
................
.............
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
