### PR TITLE
[DellEMC] Dell Platform Modules Debian Build Error Fix

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/rules
@@ -38,7 +38,7 @@ override_dh_auto_build:
 		fi; \
 		echo "making man page alias $$mod -> $$mod APIs";\
 		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
-	done) \
+	done); \
 	set +e;
 
 override_dh_auto_install:

--- a/platform/broadcom/sonic-platform-modules-dell/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/rules
@@ -39,9 +39,10 @@ override_dh_auto_build:
 		echo "making man page alias $$mod -> $$mod APIs";\
 		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
 	done); \
-	set +e;
+	set +e
 
 override_dh_auto_install:
+	set -e; \
 	(for mod in $(MODULE_DIRS); do \
 		dh_installdirs -pplatform-modules-$${mod} \
 			$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
@@ -51,12 +52,14 @@ override_dh_auto_install:
 			dh_installdirs -pplatform-modules-$${mod} usr/local/bin ; \
 			cp -r $(MOD_SRC_DIR)/$${mod}/scripts/* debian/platform-modules-$${mod}/usr/local/bin; \
 		fi; \
-	done)
+	done); \
+	set +e
 
 override_dh_usrlocal:
 
 override_dh_clean:
 	dh_clean
+	set -e; \
 	(for mod in $(MODULE_DIRS); do \
 		if [ $$mod = "s6100" ]; then \
 			rm -f $(MOD_SRC_DIR)/$${mod}/modules/dell_s6100_lpc.c; \
@@ -81,5 +84,6 @@ override_dh_clean:
 			rm -rf $(MOD_SRC_DIR)/$${mod}/build/*.egg-info; \
 		fi; \
 		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
-	done)
+	done); \
+	set +e
 

--- a/platform/broadcom/sonic-platform-modules-dell/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/rules
@@ -12,6 +12,7 @@ COMMON_DIR := common
 	dh $@
 
 override_dh_auto_build:
+	set -e; \
 	(for mod in $(MODULE_DIRS); do \
 		if [ $$mod = "s6100" ]; then \
 			cp $(COMMON_DIR)/dell_pmc.c $(MOD_SRC_DIR)/$${mod}/modules/dell_s6100_lpc.c; \
@@ -37,7 +38,8 @@ override_dh_auto_build:
 		fi; \
 		echo "making man page alias $$mod -> $$mod APIs";\
 		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
-	done)
+	done) \
+	set +e;
 
 override_dh_auto_install:
 	(for mod in $(MODULE_DIRS); do \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 - Fix for [Azure/sonic-buildimage#4095](https://github.com/Azure/sonic-buildimage/issues/4095)
- Exit status from failed make command(action) didnt reached parent target because the make command is inside the "for" loop.
- Only the exit status of the last command in the last iteration of the for loop is read by parent target.
- This is the reason why dpkg-buildpackage ignored the make error.
-  Fixed the issue with help of "set -e".


**- How I did it**
On branch s6000-build-error
Changes to be committed:
(use "git reset HEAD ..." to unstage)

        modified:   platform/broadcom/sonic-platform-modules-dell/s6000/modules/dell_s6000_platform.c
**- How to verify it**
Attached UT Logs:
Before Fix - [platform-modules-z9100_1.1_amd64.deb-without-fix.log.txt](https://github.com/Azure/sonic-buildimage/files/4153241/platform-modules-z9100_1.1_amd64.deb-without-fix.log.txt)

 
After Fix - [platform-modules-z9100_1.1_amd64.deb-with-fix.log.txt](https://github.com/Azure/sonic-buildimage/files/4153240/platform-modules-z9100_1.1_amd64.deb-with-fix.log.txt)
After Fix and platfrom debian completed with no issues log - [platform-modules-z9100_1.1_amd64.deb-no-error.log.txt](https://github.com/Azure/sonic-buildimage/files/4153441/platform-modules-z9100_1.1_amd64.deb-no-error.log.txt)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[DellEMC] Dell Platform Modules Debian Build Error Fix

**- A picture of a cute animal (not mandatory but encouraged)**
