### PR TITLE
[barefoot]: Update SDE to 9.2.0 pre-release debian package

### DIFF
--- a/platform/barefoot/bfn-platform.mk
+++ b/platform/barefoot/bfn-platform.mk
@@ -1,5 +1,5 @@
-BFN_PLATFORM = bfnplatform_9.1.0.fddc672_deb9.deb
-$(BFN_PLATFORM)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/rel_9_1/$(BFN_PLATFORM)"
+BFN_PLATFORM = bfnplatform_20200205_deb9.deb
+$(BFN_PLATFORM)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/$(BFN_PLATFORM)"
 
 SONIC_ONLINE_DEBS += $(BFN_PLATFORM)
 $(BFN_SAI_DEV)_DEPENDS += $(BFN_PLATFORM)

--- a/platform/barefoot/bfn-sai.mk
+++ b/platform/barefoot/bfn-sai.mk
@@ -1,5 +1,5 @@
-BFN_SAI = bfnsdk_9.1.0.fddc672_deb9.deb
-$(BFN_SAI)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/rel_9_1/$(BFN_SAI)"
+BFN_SAI = bfnsdk_20200205_deb9.deb
+$(BFN_SAI)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/$(BFN_SAI)"
 
 $(BFN_SAI)_DEPENDS += $(LIBNL_GENL3_DEV)
 $(BFN_SAI)_RDEPENDS += $(LIBNL_GENL3)


### PR DESCRIPTION
**- What I did**
Updated BFN SDE to 9.2.0 pre-release package