### PR TITLE
[docker-frr] Load frr.conf automatically with split mode

### DIFF
--- a/dockers/docker-fpm-frr/start.sh
+++ b/dockers/docker-fpm-frr/start.sh
@@ -38,12 +38,12 @@ if [[ $(sonic-cfggen -d -v 'WARM_RESTART.bgp.bgp_eoiu') == 'true' ]]; then
     supervisorctl start bgp_eoiu_marker
 fi
 
-# Start Quagga processes
+# Start Quagga/FRR processes
 supervisorctl start zebra
 supervisorctl start staticd
 supervisorctl start bgpd
 
-if [ "$CONFIG_TYPE" == "unified" ]; then
+if [ "$CONFIG_TYPE" == "unified" ] || [ "$CONFIG_TYPE" == "split" ]; then
     supervisorctl start vtysh_b
 fi
 


### PR DESCRIPTION
[docker-frr] Load frr.conf automatically with split mode

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

This should be back-ported to 201911 branch.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
In case "docker_routing_config_mode": "split", the frr.conf was not loaded automatically today.
This PR is to fix that so it would load the frr.conf automatically

**- How I did it**
start.sh in docker frr to load the frr.conf automatically

**- How to verify it**
Before the fix, not frr.conf was loaded.  After the fix, frr.conf was loaded.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
