### PR TITLE
[platform]:Fix as7726 read thermal sensor issue

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/classes/thermalutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/classes/thermalutil.py
@@ -55,41 +55,38 @@ class ThermalUtil(object):
             THERMAL_NUM_5_IDX: ['54', '4c'],
            }
     thermal_sysfspath ={
-    THERMAL_NUM_1_IDX: ["/sys/bus/i2c/devices/55-0048/hwmon/hwmon4/temp1_input"],
-    THERMAL_NUM_2_IDX: ["/sys/bus/i2c/devices/55-0049/hwmon/hwmon5/temp1_input"],  
-    THERMAL_NUM_3_IDX: ["/sys/bus/i2c/devices/55-004a/hwmon/hwmon6/temp1_input"],
-    THERMAL_NUM_4_IDX: ["/sys/bus/i2c/devices/55-004b/hwmon/hwmon7/temp1_input"],        
-    THERMAL_NUM_5_IDX: ["/sys/bus/i2c/devices/54-004c/hwmon/hwmon3/temp1_input"],     
+    THERMAL_NUM_1_IDX: ["/sys/bus/i2c/devices/55-0048/hwmon/hwmon*/temp1_input"],  
+    THERMAL_NUM_2_IDX: ["/sys/bus/i2c/devices/55-0049/hwmon/hwmon*/temp1_input"],  
+    THERMAL_NUM_3_IDX: ["/sys/bus/i2c/devices/55-004a/hwmon/hwmon*/temp1_input"],
+    THERMAL_NUM_4_IDX: ["/sys/bus/i2c/devices/55-004b/hwmon/hwmon*/temp1_input"],        
+    THERMAL_NUM_5_IDX: ["/sys/bus/i2c/devices/54-004c/hwmon/hwmon*/temp1_input"],     
     }
-
-    #def __init__(self):
+  
     def _get_thermal_val(self, thermal_num):
         if thermal_num < self.THERMAL_NUM_1_IDX or thermal_num > self.THERMAL_NUM_MAX:
             logging.debug('GET. Parameter error. thermal_num, %d', thermal_num)
             return None
        
         device_path = self.get_thermal_to_device_path(thermal_num)
-        if(os.path.isfile(device_path)):                
-            for filename in glob.glob(device_path):
-                try:
-                    val_file = open(filename, 'r')
-                except IOError as e:
-                    logging.error('GET. unable to open file: %s', str(e))
-                    return None
+        
+        for filename in glob.glob(device_path):
+            try:
+                val_file = open(filename, 'r')
+            except IOError as e:
+                logging.error('GET. unable to open file: %s', str(e))
+                return None
             content = val_file.readline().rstrip()
             if content == '':
                 logging.debug('GET. content is NULL. device_path:%s', device_path)
                 return None
             try:
-		        val_file.close()
+	            val_file.close()
             except:
                 logging.debug('GET. unable to close file. device_path:%s', device_path)
                 return None      
             return int(content)
-            
-        else:
-            print "No such device_path=%s"%device_path
-            return 0
+        
+        return 0
 
     def get_num_thermals(self):
         return self.THERMAL_NUM_MAX
@@ -116,16 +113,10 @@ class ThermalUtil(object):
 
 def main():
     thermal = ThermalUtil()
-    print "termal1=%d" %thermal._get_thermal_val(1)
-    print "termal2=%d" %thermal._get_thermal_val(2)
-    print "termal3=%d" %thermal._get_thermal_val(3)
-    print "termal4=%d" %thermal._get_thermal_val(4)
-    print "termal5=%d" %thermal._get_thermal_val(5)    
-#
-#    print 'get_size_node_map : %d' % thermal.get_size_node_map()
-#    print 'get_size_path_map : %d' % thermal.get_size_path_map()
-#    for x in range(thermal.get_idx_thermal_start(), thermal.get_num_thermals()+1):
-#        print thermal.get_thermal_to_device_path(x)
-#
+    logging.debug('termal1=%d', thermal._get_thermal_val(1))
+    logging.debug('termal2=%d', thermal._get_thermal_val(2))
+    logging.debug('termal3=%d', thermal._get_thermal_val(3))
+    logging.debug('termal4=%d', thermal._get_thermal_val(4))
+    logging.debug('termal5=%d', thermal._get_thermal_val(5))
 if __name__ == '__main__':
     main()

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/classes/thermalutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/classes/thermalutil.py
@@ -113,10 +113,10 @@ class ThermalUtil(object):
 
 def main():
     thermal = ThermalUtil()
-    logging.debug('termal1=%d', thermal._get_thermal_val(1))
-    logging.debug('termal2=%d', thermal._get_thermal_val(2))
-    logging.debug('termal3=%d', thermal._get_thermal_val(3))
-    logging.debug('termal4=%d', thermal._get_thermal_val(4))
-    logging.debug('termal5=%d', thermal._get_thermal_val(5))
+    logging.debug('thermal1=%d', thermal._get_thermal_val(1))
+    logging.debug('thermal2=%d', thermal._get_thermal_val(2))
+    logging.debug('thermal3=%d', thermal._get_thermal_val(3))
+    logging.debug('thermal4=%d', thermal._get_thermal_val(4))
+    logging.debug('thermal5=%d', thermal._get_thermal_val(5))
 if __name__ == '__main__':
     main()

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor.py
@@ -124,15 +124,12 @@ class device_monitor(object):
         sys_handler = handler = logging.handlers.SysLogHandler(address = '/dev/log')
         sys_handler.setLevel(logging.WARNING)       
         logging.getLogger('').addHandler(sys_handler)
-
-        #logging.debug('SET. logfile:%s / loglevel:%d', log_file, log_level)
           
     def get_state_from_fan_policy(self, temp, policy):
         state=0
         
         logging.debug('temp=%d', temp)
         for i in range(0, len(policy)):
-            #logging.debug('policy[%d][0]=%d, policy[%d][1]=%d, policy[%d][2]=%d', i,policy[i][0],i, policy[i][1], i, policy[i][2])
             if temp > policy[i][2]:
                 if temp <= policy[i][3]:
                     state =i
@@ -141,7 +138,6 @@ class device_monitor(object):
                     break
         
         return state
-    
 
     def manage_fans(self):
        
@@ -156,8 +152,7 @@ class device_monitor(object):
         LEVEL_FAN_MID=1       
         LEVEL_FAN_MAX=2
         LEVEL_TEMP_HIGH=3
-        LEVEL_TEMP_CRITICAL=4  
-        
+        LEVEL_TEMP_CRITICAL=4
         
         fan_policy_f2b = {
            LEVEL_FAN_DEF:       [38,  0x4, 0,     38000],
@@ -212,16 +207,14 @@ class device_monitor(object):
             temp_get= (temp3 + temp4)/2  # Use (sensor_LM75_4a + sensor_LM75_4b) /2 
         ori_state=fan_policy_state
         
-        #temp_test_data=temp_test_data+1000
-        #temp_get = temp_get + temp_test_data
-        #print "Unit test:temp_get=%d"%temp_get
+        if test_temp!=0:
+            temp_test_data=temp_test_data+1000
+            temp_get = temp_get + temp_test_data
+            logging.debug('Unit test:temp_get=%d', temp_get)
         
         fan_policy_state=self.get_state_from_fan_policy(temp_get, fan_policy)
-        #print "temp3=%d"%temp3
-        #print "temp4=%d"%temp4
-        #print "temp_get=%d"%temp_get
-                        
-        logging.debug('lm75_48=%d, lm75_49=%d, lm75_4a=%d, lm_4b=%d, lm_4b=%d', temp1,temp2,temp3,temp4,temp5)
+                                
+        logging.debug('lm75_48=%d, lm75_49=%d, lm75_4a=%d, lm_4b=%d, lm_4c=%d', temp1,temp2,temp3,temp4,temp5)
         logging.debug('ori_state=%d, fan_policy_state=%d', ori_state, fan_policy_state)
         new_pwm = fan_policy[fan_policy_state][0]
         if fan_fail==0:
@@ -244,12 +237,8 @@ class device_monitor(object):
             else:
                 fan_fail=0
         
-        #if fan_policy_state == ori_state:            
-        #    return True 
-        #else:
         new_state = fan_policy_state
-        
-        #logging.warning('Temperature high alarm testing')       
+          
         if ori_state==LEVEL_FAN_DEF:            
            if new_state==LEVEL_TEMP_HIGH:
                if alarm_state==0:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix as7726 read thermal sensor issue.
**- How I did it**
Due to linux create hwmonN node number, N isn't fixed.  So modify to use  "*"  to let thermal.py can correct sysfs.  For example, use  /sys/bus/i2c/devices/55-0048/hwmon/hwmon*/temp1_input to instead of /sys/bus/i2c/devices/55-0048/hwmon/hwmon4/temp1_input
**- How to verify it**
Reboot DUT, and check as7726-32x-platform-monitor.service.
root@sonic:/home/admin# systemctl status as7726-32x-platform-monitor.service -l
● as7726-32x-platform-monitor.service - Accton AS7726-32X Platform Monitoring se
   Loaded: loaded (/lib/systemd/system/as7726-32x-platform-monitor.service; enab
   Active: active (running) since Mon 2020-02-10 06:54:34 UTC; 1min 10s ago
  Process: 640 ExecStartPre=/usr/local/bin/accton_as7726_32x_util.py install 

For error case, that will log as below ,
Feb 10 03:50:30 sonic accton_as7726_32x_monitor.py[7998]: No such device_path=/s**
Feb 10 03:50:30 sonic accton_as7726_32x_monitor.py[7998]: No such device_path=/s**
Feb 10 03:50:30 sonic accton_as7726_32x_monitor.py[7998]: No such device_path=/s**
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
