### PR TITLE
[sonic-buildimage] Fix build issue for docker-dhcp-relay-dbg.gz

### DIFF
--- a/build_debug_docker_j2.sh
+++ b/build_debug_docker_j2.sh
@@ -28,7 +28,7 @@ debs/{{ deb }}{{' '}}
 {% if $3 is defined %}
 {% if $3|length %}
 
-RUN apt-get install -f -y \
+RUN apt-get update && apt-get install -f -y \
 {% for dbg in $3.split(' ') -%}
 {{ dbg }}{{' '}}
 {%- endfor %}


### PR DESCRIPTION
[sonic-buildimage] Fix build issue for docker-dhcp-relay-dbg.gz. Issue is coming because some of debian package not able to fetch.

Signed-off-by: Abhishek <abdosi@microsoft.com>

- What I did
Jinja Template file for Debug Dockers to do apt-get update

- How I did it
Update file build_debug_docker_j2.sh

- How to verify it
Locally Compiled the build 
