### PR TITLE
[init_cfg.json] Add new FEATURE and CONTAINER_FEATURE tables

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -17,7 +17,7 @@
 {% endfor %}
         }
     },
-    "Feature": {
+    "FEATURE": {
 {%- for feature in ["sflow", "telemetry"] %}
         "{{feature}}": {
             "status": "disabled"
@@ -25,8 +25,8 @@
 {% endfor %}
     },
     "CONTAINER_FEATURE": {
-{%- for container in ["teamd", "swss", "syncd", "pmon", "lldp", "bgp", "dhcp-relay",
-                      "radv", "sflow", "snmp", "telemetry", "database"] %}
+{%- for container in ["bgp", "database", "dhcp-relay", "lldp", "pmon", "radv", "sflow",
+                      "snmp", "swss", "syncd", "teamd", "telemetry"] %}
         "{{container}}": {
             "auto_restart": "disabled",
             "high_mem_alert": "disabled"

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -20,6 +20,39 @@
     "CONTAINER_FEATURE": {
         "teamd": {
             "auto_restart": "enabled"
+        },
+        "swss": {
+            "auto_restart": "enabled"
+        },
+        "syncd": {
+            "auto_restart": "enabled"
+        },
+        "pmon": {
+            "auto_restart": "enabled"
+        },
+        "lldp": {
+            "auto_restart": "enabled"
+        },
+        "bgp": {
+            "auto_restart": "enabled"
+        },
+        "dhcp-relay": {
+            "auto_restart": "enabled"
+        },
+        "database": {
+            "auto_restart": "enabled"
+        },
+        "radv": {
+            "auto_restart": "enabled"
+        },
+        "sflow": {
+            "auto_restart": "enabled"
+        },
+        "snmp": {
+            "auto_restart": "enabled"
+        },
+        "telemetry": {
+            "auto_restart": "enabled"
         }
     }
 }

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -18,41 +18,12 @@
         }
     },
     "CONTAINER_FEATURE": {
-        "teamd": {
-            "auto_restart": "enabled"
-        },
-        "swss": {
-            "auto_restart": "enabled"
-        },
-        "syncd": {
-            "auto_restart": "enabled"
-        },
-        "pmon": {
-            "auto_restart": "enabled"
-        },
-        "lldp": {
-            "auto_restart": "enabled"
-        },
-        "bgp": {
-            "auto_restart": "enabled"
-        },
-        "dhcp-relay": {
-            "auto_restart": "enabled"
-        },
-        "database": {
-            "auto_restart": "enabled"
-        },
-        "radv": {
-            "auto_restart": "enabled"
-        },
-        "sflow": {
-            "auto_restart": "enabled"
-        },
-        "snmp": {
-            "auto_restart": "enabled"
-        },
-        "telemetry": {
-            "auto_restart": "enabled"
-        }
+{%- for container in ["teamd", "swss", "syncd", "pmon", "lldp", "bgp", "dhcp-relay",
+                      "radv", "sflow", "snmp", "telemetry", "database"] %}
+        "{{container}}": {
+            "auto_restart": "disabled",
+            "high_mem_alert": "disabled"
+        }{% if not loop.last %},{% endif -%}
+{% endfor %}
     }
 }

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -25,7 +25,7 @@
 {% endfor %}
     },
     "CONTAINER_FEATURE": {
-{%- for container in ["bgp", "database", "dhcp-relay", "lldp", "pmon", "radv", "sflow",
+{%- for container in ["bgp", "database", "dhcp_relay", "lldp", "pmon", "radv", "rest-api", "sflow",
                       "snmp", "swss", "syncd", "teamd", "telemetry"] %}
         "{{container}}": {
             "auto_restart": "disabled",

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -17,6 +17,13 @@
 {% endfor %}
         }
     },
+    "Feature": {
+{%- for feature in ["sflow", "telemetry"] %}
+        "{{feature}}": {
+            "status": "disabled"
+        }{% if not loop.last %},{% endif -%}
+{% endfor %}
+    },
     "CONTAINER_FEATURE": {
 {%- for container in ["teamd", "swss", "syncd", "pmon", "lldp", "bgp", "dhcp-relay",
                       "radv", "sflow", "snmp", "telemetry", "database"] %}

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -16,5 +16,10 @@
             "{{crm_res}}_high_threshold": "85"{% if not loop.last %},{% endif -%}
 {% endfor %}
         }
+    },
+    "CONTAINER_FEATURE": {
+        "teamd": {
+            "auto_restart": "enabled"
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

**- What I did**
I created a table named CONTAINER_FEATURE in which the auto-restart feature of each container is
currently set to be "enabled". This table will be used to initialize the Config_DB.

**- How I did it**

**- How to verify it**

