### PR TITLE
[arista] Fix convertfs condition for booting from EOS

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -383,7 +383,7 @@ write_boot_configs() {
 }
 
 run_kexec() {
-    local cmdline="$(cat $cmdline_image | tr '\n' ' ')"
+    local cmdline="$(cat $cmdline_image | tr '\n' ' ') $ENV_EXTRA_CMDLINE"
     local kernel="${KERNEL:-$(find $image_path/boot -name 'vmlinuz-*' -type f | head -n 1)}"
     local initrd="${INITRD:-$(find $image_path/boot -name 'initrd.img-*' -type f | head -n 1)}"
 

--- a/files/initramfs-tools/arista-convertfs.j2
+++ b/files/initramfs-tools/arista-convertfs.j2
@@ -18,6 +18,8 @@ flash_dev=''
 block_flash=''
 aboot_flag=''
 backup_file=''
+prev_os=''
+sonic_fast_reboot=''
 
 # Wait until get the fullpath of flash device, e.g., /dev/sda
 wait_get_flash_dev() {
@@ -133,15 +135,20 @@ for x in "$@"; do
         docker_inram=*)
             docker_inram="${x#docker_inram=}"
             ;;
+        prev_os=*)
+            prev_os="${x#prev_os=}"
+            ;;
         SONIC_BOOT_TYPE=warm*|SONIC_BOOT_TYPE=fast*)
-            # Skip this script for warm-reboot and fast-reboot
-            exit 0
+            sonic_fast_reboot=true
             ;;
     esac
 done
 
 # Check aboot
 [ -z "$aboot_flag" ] && exit 0
+
+# Skip this script for warm-reboot/fast-reboot from sonic
+[ "$sonic_fast_reboot" == true ] && [ "$prev_os" != eos ] && exit 0
 
 # Get flash dev name
 if [ -z "$block_flash" ]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix the issue of incorrectly skipping the convertfs hook when fast-reboot from EOS, by adding an extra kernel cmdline param "prev_os" to differentiate fast-reboot from EOS and from SONiC
 
**- A picture of a cute animal (not mandatory but encouraged)**
