### PR TITLE
Start RestAPI container when sonic boots

### DIFF
--- a/files/build_templates/restapi.service.j2
+++ b/files/build_templates/restapi.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=RestAPI container
+Requires=updategraph.service
+After=updategraph.service swss.service syncd.service
+Before=ntp-config.service
+
+[Service]
+User={{ sonicadmin_user }}
+ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
+ExecStart=/usr/bin/{{docker_container_name}}.sh wait
+ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/files/build_templates/restapi.service.j2
+++ b/files/build_templates/restapi.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=RestAPI container
 Requires=updategraph.service
-After=updategraph.service swss.service syncd.service
+After=updategraph.service
 Before=ntp-config.service
 
 [Service]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enable RestAPI docker to start when SONiC boots up
**- How I did it**
Add the service file
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
