### PR TITLE
Removing explicit libyang plugin path settings

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/rest-server.sh
+++ b/dockers/docker-sonic-mgmt-framework/rest-server.sh
@@ -46,7 +46,5 @@ echo "REST_SERVER_ARGS = $REST_SERVER_ARGS"
 
 
 export CVL_SCHEMA_PATH=/usr/sbin/schema
-export LIBYANG_EXTENSIONS_PLUGINS_DIR=/usr/lib/x86_64-linux-gnu/libyang/extensions
-export LIBYANG_USER_TYPES_PLUGINS_DIR=/usr/lib/x86_64-linux-gnu/libyang/user_types
 
 exec /usr/sbin/rest_server ${REST_SERVER_ARGS}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixes #4059 

**- How I did it**
Removed explicit libyang plugin path settings in rest-server.sh file which starts the REST server. 

Libyang debian package installs the extensions in standard location as per build time configuration (install prefix is set in patch/libyang.patch). If plugin directory is not set, libyang explicitly searches the plugins in LYEXT_PLUGINS_DIR which is populated during build. The plugins are installed in LYEXT_PLUGINS_DIR itself through debian package installation.

 $ grep -nr LYEXT_PLUGINS_DIR src/
src/plugin_config.h.in:18:#define LYEXT_PLUGINS_DIR "@EXTENSIONS_PLUGINS_DIR_MACRO@" /**< directory with YANG extension plugins */
src/plugins.c:420:        pluginsdir = LYEXT_PLUGINS_DIR;


**- How to verify it**
Once system is ready, just check REST server is able to serve REST API request. Alternatively, just change some configuration using KLISH based sonic-cli and it should be successfully changed. sonic-cli calls REST server internally.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Removed explicit path settings for libyang extension and user types plugins.

**- A picture of a cute animal (not mandatory but encouraged)**
