### PR TITLE
[interfaces-config.sh] Force lo interface down

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -38,4 +38,4 @@ systemctl restart networking
 # Clean-up created files
 rm -f /tmp/ztp_input.json /tmp/ztp_port_data.json
 
-ifdown lo && ifup lo
+ifdown --force lo && ifup lo


### PR DESCRIPTION
**- What I did**
Force "lo" interface down in interfaces-config.sh to prevent interface-config.service from failing with the following error:

```
-- The result is failed.
systemd[1]: networking.service: Unit entered failed state.
systemd[1]: networking.service: Failed with result 'exit-code'.
interfaces-config.sh[29232]: Job for networking.service failed because the control process exited with error code.
interfaces-config.sh[29232]: See "systemctl status networking.service" and "journalctl -xe" for details.
interfaces-config.sh[29232]: ifdown: interface lo not configured
interfaces-config.sh[29232]: RTNETLINK answers: File exists
interfaces-config.sh[29232]: ifup: failed to bring up lo
systemd[1]: interfaces-config.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: Failed to start Update interfaces configuration.
-- Subject: Unit interfaces-config.service has failed
```

Failure to bring down the interface will result in a failure to subsequently bring the interface back up.

**- How I did it**
Add `--force` flag

**- How to verify it**
Repeatedly test that `systemctl restart interfaces-config.service` doesn't fail to bring down the lo interface.