### PR TITLE
[interfaces-config.sh] Do not bring 'lo' interface down and up

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -37,5 +37,3 @@ systemctl restart networking
 
 # Clean-up created files
 rm -f /tmp/ztp_input.json /tmp/ztp_port_data.json
-
-ifdown lo && ifup lo


### PR DESCRIPTION
We now use "Loopback0" interface as the external loopback interface instead of "lo". Since we no longer configure the "lo" interface, there is no need to bring it down and back up in the interfaces-config.sh script.