### PR TITLE
Fix service and container name to be same for Restapi

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -25,7 +25,7 @@
 {% endfor %}
     },
     "CONTAINER_FEATURE": {
-{%- for container in ["bgp", "database", "dhcp_relay", "lldp", "pmon", "radv", "rest-api", "sflow",
+{%- for container in ["bgp", "database", "dhcp_relay", "lldp", "pmon", "radv", "restapi", "sflow",
                       "snmp", "swss", "syncd", "teamd", "telemetry"] %}
         "{{container}}": {
             "auto_restart": "disabled",

--- a/rules/docker-restapi.mk
+++ b/rules/docker-restapi.mk
@@ -16,7 +16,7 @@ SONIC_STRETCH_DOCKERS += $(DOCKER_RESTAPI)
 SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_RESTAPI)
 endif
 
-$(DOCKER_RESTAPI)_CONTAINER_NAME = rest-api
+$(DOCKER_RESTAPI)_CONTAINER_NAME = restapi
 $(DOCKER_RESTAPI)_RUN_OPT += --cap-add NET_ADMIN --privileged -t
 $(DOCKER_RESTAPI)_RUN_OPT += -v /var/run/redis/redis.sock:/var/run/redis/redis.sock
 $(DOCKER_RESTAPI)_RUN_OPT += -p=8090:8090/tcp


### PR DESCRIPTION
**- What I did**
Service file `files/build_templates/restapi.service.j2` must be same as container name.
Kept the name in sync with existing Sonic containers

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
