### PR TITLE
[201811][fancontrol] Restart process upon unexpected exit

### DIFF
--- a/dockers/docker-platform-monitor/supervisord.conf
+++ b/dockers/docker-platform-monitor/supervisord.conf
@@ -34,7 +34,6 @@ command=/usr/sbin/fancontrol
 priority=4
 autostart=false
 autorestart=unexpected
-exitcodes=0
 stopwaitsecs=10
 stdout_logfile=syslog
 stderr_logfile=syslog

--- a/dockers/docker-platform-monitor/supervisord.conf
+++ b/dockers/docker-platform-monitor/supervisord.conf
@@ -33,9 +33,12 @@ startsecs=0
 command=/usr/sbin/fancontrol
 priority=4
 autostart=false
-autorestart=false
+autorestart=unexpected
+exitcodes=0
+stopwaitsecs=10
 stdout_logfile=syslog
 stderr_logfile=syslog
+startsecs=10
 
 [program:ledd]
 command=/usr/bin/ledd

--- a/dockers/docker-platform-monitor/supervisord.conf
+++ b/dockers/docker-platform-monitor/supervisord.conf
@@ -34,7 +34,6 @@ command=/usr/sbin/fancontrol
 priority=4
 autostart=false
 autorestart=unexpected
-stopwaitsecs=10
 stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add restart logic of fancontrol for unexpected exit cases

**- How I did it**
 Configure the supervisord.conf for pmon to restart the fancontrol

**- How to verify it**
Login to pmon
Run 'kill -9 ; rm /var/run/fancontrol.pid'
Check if fancontrol restarted

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add restart configuration of fancontrol for pmon.

**- A picture of a cute animal (not mandatory but encouraged)**
