### PR TITLE
Sleep done before mismatch handler

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -47,6 +47,7 @@ while /bin/true; do
       eval `eval $ip6cmd`
   done
 
+  # sleep here before handling the mismatch as it is not required during startup
   sleep 300
 
   # refresh neighbor entries from APP_DB in case of mismatch with kernel

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -47,6 +47,8 @@ while /bin/true; do
       eval `eval $ip6cmd`
   done
 
+  sleep 300
+
   # refresh neighbor entries from APP_DB in case of mismatch with kernel
   DBNEIGH=$(sonic-db-cli APPL_DB keys NEIGH_TABLE*)
   KERNEIGH4=$(ip -4 neigh show | grep Vlan | cut -d ' ' -f 1,3  --output-delimiter=',')
@@ -67,5 +69,4 @@ while /bin/true; do
       fi
   done
 
-  sleep 300
 done


### PR DESCRIPTION
**- What I did**
A simple measure to run mismatch handler after a timeout during bootup and not immediately.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
