### PR TITLE
[orchagent] Use mac address from config_db instead of from eth0

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -4,7 +4,10 @@
 # vendor specific code.
 export platform=`sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type`
 
-MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
+MAC_ADDRESS=`sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'`
+if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then
+    MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
+fi
 
 # Create a folder for SwSS record files
 mkdir -p /var/log/swss

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -4,9 +4,10 @@
 # vendor specific code.
 export platform=`sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type`
 
-MAC_ADDRESS=`sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'`
+MAC_ADDRESS=$(sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac')
 if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then
-    MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
+    MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
+    logger "Mac address not found in Device Metadata, Falling back to eth0"
 fi
 
 # Create a folder for SwSS record files

--- a/platform/p4/docker-sonic-p4/orchagent.sh
+++ b/platform/p4/docker-sonic-p4/orchagent.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
+MAC_ADDRESS=`sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'`
+if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then
+    MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
+fi
 
 # Create a folder for SsWW record files
 mkdir -p /var/log/swss

--- a/platform/p4/docker-sonic-p4/orchagent.sh
+++ b/platform/p4/docker-sonic-p4/orchagent.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-MAC_ADDRESS=`sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'`
+MAC_ADDRESS=$(sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac')
 if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then
-    MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
+    MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
+    logger "Mac address not found in Device Metadata, Falling back to eth0"
 fi
 
 # Create a folder for SsWW record files

--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -6,7 +6,10 @@ else
     export platform=$fake_platform
 fi
 
-MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
+MAC_ADDRESS=`sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'`
+if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then
+    MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
+fi
 
 # Create a folder for SwSS record files
 mkdir -p /var/log/swss

--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -6,9 +6,10 @@ else
     export platform=$fake_platform
 fi
 
-MAC_ADDRESS=`sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac'`
+MAC_ADDRESS=$(sonic-cfggen -d -v 'DEVICE_METADATA.localhost.mac')
 if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then
-    MAC_ADDRESS=`ip link show eth0 | grep ether | awk '{print $2}'`
+    MAC_ADDRESS=$(ip link show eth0 | grep ether | awk '{print $2}')
+    logger "Mac address not found in Device Metadata, Falling back to eth0"
 fi
 
 # Create a folder for SwSS record files


### PR DESCRIPTION
**- What I did**
Due to hardware issues, sometimes eth0 mac is found to be different from config_db mac. In this case, the switch mac in hardware was programmed as a different mac w.r.t interface mac addresses in kernel. This results in packet drops in hardware due to mac mismatch

**- How I did it**
Modified start script

**- How to verify it**
Change config_db mac and test

**- Description for the changelog**

```
redis-cli -n 4 hset "DEVICE_METADATA|localhost" mac "00:00:aa:bb:cc:dd"
ps -aux | grep orch
root      1419  /usr/bin/orchagent -d /var/log/swss -b 8192 -m 00:00:aa:bb:cc:dd

redis-cli -n 4 hset "DEVICE_METADATA|localhost" mac "None"
ps -aux | grep orch
root       793  /usr/bin/orchagent -d /var/log/swss -b 8192 -m 4c:76:25:f0:89:40

redis-cli -n 4 del "DEVICE_METADATA|localhost" 
root@str-z9100-acs-2:/# /usr/bin/orchagent.sh 
jinja2.exceptions.UndefinedError: 'DEVICE_METADATA' is undefined
```

**- A picture of a cute animal (not mandatory but encouraged)**
