### PR TITLE
[Mellanox]Fix issue that syncd rpc docker unable to start

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx-rpc.mk
+++ b/platform/mellanox/docker-syncd-mlnx-rpc.mk
@@ -20,7 +20,7 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_SYNCD_MLNX_RPC)
 endif
 
 $(DOCKER_SYNCD_MLNX_RPC)_CONTAINER_NAME = syncd
-$(DOCKER_SYNCD_MLNX_RPC)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SYNCD_MLNX_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_MLNX_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_MLNX_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_SYNCD_MLNX_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot


### PR DESCRIPTION
**- What I did**
Fix issue that syncd rpc docker unable to start
This is also required for 201911

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
