### PR TITLE
[sonic-cfggen] Load JSON files before minigraph file

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -233,6 +233,10 @@ def main():
             sys.exit(1)
         deep_update(data, {'PORT': ports})
 
+    for json_file in args.json:
+        with open(json_file, 'r') as stream:
+            deep_update(data, FormatConverter.to_deserialized(json.load(stream)))
+
     if args.minigraph != None:
         minigraph = args.minigraph
         if platform:
@@ -253,10 +257,6 @@ def main():
             else:
                 additional_data = yaml.load(stream)
             deep_update(data, FormatConverter.to_deserialized(additional_data))
-
-    for json_file in args.json:
-        with open(json_file, 'r') as stream:
-            deep_update(data, FormatConverter.to_deserialized(json.load(stream)))
 
     if args.additional_data != None:
         deep_update(data, json.loads(args.additional_data))


### PR DESCRIPTION
**- What I did**

If sonic-cfggen is passed the `-m` argument (to load the minigraph file) along with one or more `-j <json_file>` arguments, load the JSON files *before* loading the minigraph file.

This ensures that the init_cfg.json file is loaded *before* the minigraph, therefore the minigraph can override any default configuration options specified in init_cfg.json. Currently, the behavior is reversed.

Note: This is not an issue if loading loading multiple JSON files, because sonic-cfggen loads them in the left-to-right order they were specified on the command line, therefore providing flexibility for loading JSON files in a specific order. As long as init_cfg.json is specified *before* config_db.json, the values specified in config_db.json will take precedence.

**- How I did it**

**- How to verify it**

1. Create a minigraph.xml file and an init_cfg.json file which have different values for the same key(s).
2. Run `sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db`
3. Run `config save -y`
4. Inspect the resulting config_db.json file to ensure that the value from the minigraph.xml file is the value present, *not* the value from init_cfg.json.