### PR TITLE
[Services] Restart NAT service upon unexpected critical process exit.

### DIFF
--- a/dockers/docker-nat/Dockerfile.j2
+++ b/dockers/docker-nat/Dockerfile.j2
@@ -38,6 +38,8 @@ RUN apt-get update        \
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["restore_nat_entries.py", "/usr/bin/"]
+COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
+COPY ["critical_processes", "/etc/supervisor"]
 
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs

--- a/dockers/docker-nat/critical_processes
+++ b/dockers/docker-nat/critical_processes
@@ -1,0 +1,2 @@
+natmgrd
+natsyncd

--- a/dockers/docker-nat/supervisord.conf
+++ b/dockers/docker-nat/supervisord.conf
@@ -21,7 +21,7 @@ stderr_logfile=syslog
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
-autorestart=false
+autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
 

--- a/dockers/docker-nat/supervisord.conf
+++ b/dockers/docker-nat/supervisord.conf
@@ -3,6 +3,12 @@ logfile_maxbytes=1MB
 logfile_backups=2
 nodaemon=true
 
+[eventlistener:supervisor-proc-exit-listener]
+command=/usr/bin/supervisor-proc-exit-listener --container-name nat
+events=PROCESS_STATE_EXITED
+autostart=true
+autorestart=unexpected
+
 [program:start.sh]
 command=/usr/bin/start.sh
 priority=1

--- a/files/build_templates/nat.service.j2
+++ b/files/build_templates/nat.service.j2
@@ -3,12 +3,16 @@ Description=NAT container
 Requires=updategraph.service swss.service
 After=updategraph.service swss.service syncd.service
 Before=ntp-config.service
+StartLimitIntervalSec=1200
+StartLimitBurst=3
 
 [Service]
 User={{ sonicadmin_user }}
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target swss.service

--- a/rules/docker-nat.mk
+++ b/rules/docker-nat.mk
@@ -31,4 +31,4 @@ $(DOCKER_NAT)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_NAT)_RUN_OPT += -v /host/warmboot:/var/warmboot
 
 $(DOCKER_NAT)_BASE_IMAGE_FILES += natctl:/usr/bin/natctl
-
+$(DOCKER_NAT)_BASE_IMAGE_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
- What I did
Restart NAT service if one of critical processes running in NAT container exited or crashed abnormally.

- How I did it
Generally I follow the framework created by Joe to implement this feature in NAT container.
**First**, add supervisor-proc-exit-listener event listener option in Supervisord configuration file in NAT docker container. Supervisord will read a list of critical processes for which to monitor the unexpected crashed and exited.
**Second**, configure nat.service to always auto-restart the service if it stops, with a delay of 30 seconds. Also set a rate limit of 3 restarts within 20 minutes (1200 seconds).

- How to verify it
On your switch device, please use `docker ps` command to list all running docker containers.
Then use `docker exec -it container_id bash` to login target container. Typing `top` command
on the shell will display all the processes dynamically and you will spot the process id of one
of the critical processes. Finally type the command` kill -9 process_id` to terminate one process.
After exiting the container, you can use `watch -n 1 docker ps` to dynamically see the restart
of database container.