### PR TITLE
[mellanox]: Align platform API: change CPLD version representation

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -154,7 +154,7 @@ class Chassis(ChassisBase):
         # Initialize component list
         from sonic_platform.component import ComponentBIOS, ComponentCPLD
         self._component_list.append(ComponentBIOS())
-        self._component_list.append(ComponentCPLD())
+        self._component_list.extend(ComponentCPLD.get_component_list())
 
 
     def get_name(self):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -18,9 +18,7 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
-EMPTY = ''
 ZERO = '0'
-COMMA = ','
 NEWLINE = '\n'
 
 class Component(ComponentBase):
@@ -242,6 +240,9 @@ class ComponentCPLD(Component):
     CPLD_VERSION_MAX_LENGTH = 2
     CPLD_VERSION_MINOR_MAX_LENGTH = 2
 
+    CPLD_PART_NUMBER_DEFAULT = ZERO
+    CPLD_VERSION_MINOR_DEFAULT = ZERO
+
     CPLD_UPDATE_COMMAND = 'cpldupdate --dev {} {}'
     CPLD_INSTALL_SUCCESS_FLAG = 'PASS!'
 
@@ -271,10 +272,10 @@ class ComponentCPLD(Component):
         version_minor = self._read_generic_file(version_minor_file, self.CPLD_VERSION_MINOR_MAX_LENGTH, True)
 
         if part_number is None:
-            part_number = ZERO
+            part_number = self.CPLD_PART_NUMBER_DEFAULT
 
         if version_minor is None:
-            version_minor = ZERO
+            version_minor = self.CPLD_VERSION_MINOR_DEFAULT
 
         part_number = part_number.rstrip(NEWLINE).zfill(self.CPLD_PART_NUMBER_MAX_LENGTH)
         version = version.rstrip(NEWLINE).zfill(self.CPLD_VERSION_MAX_LENGTH)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -23,10 +23,6 @@ ZERO = '0'
 COMMA = ','
 NEWLINE = '\n'
 
-#components definitions
-COMPONENT_BIOS = "BIOS"
-COMPONENT_CPLD = "CPLD"
-
 class Component(ComponentBase):
     def __init__(self):
         self.name = None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
This PR introduces new CPLD version representation for Mellanox platforms:
CPLD<part_number>_REV<major_version><minor_version>

part_number - six digits
major_version - two digits
minor_version - two digits

Example: `CPLD000000_REV0500`

Note: if Part Number or Minor Version is missing, zeros will be printed

**- What I did**
* Updated CPLD version representation

**- How I did it**
* N/A

**- How to verify it**
1. make configure PLATFORM=mellanox
2. make target/sonic-mellanox.bin

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

**- Previous fwutil output**
```bash
root@sonic:/home/admin# fwutil show status
Chassis                 Module    Component    Version                  Description
----------------------  --------  -----------  -----------------------  ---------------------------------------
x86_64-mlnx_msn3800-r0  N/A       BIOS         0ACLH004_02.02.003_9600  BIOS - Basic Input/Output System
                                  CPLD         5.3.3.1                  CPLD - includes all CPLDs in the switch
```

**- New fwutil output**
```bash
root@sonic:/home/admin# fwutil show status
Chassis                 Module    Component    Version                   Description
----------------------  --------  -----------  ------------------------  ---------------------------------------
x86_64-mlnx_msn3800-r0  N/A       BIOS         0ACLH004_02.02.003_9600   BIOS - Basic Input/Output System
                                  CPLD1        CPLD000000_REV0500        CPLD - Complex Programmable Logic Device
                                  CPLD2        CPLD000000_REV0300        CPLD - Complex Programmable Logic Device
                                  CPLD3        CPLD000000_REV0300        CPLD - Complex Programmable Logic Device
                                  CPLD4        CPLD000000_REV0100        CPLD - Complex Programmable Logic Device
```

**- A picture of a cute animal (not mandatory but encouraged)**
```bash
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```