### PR TITLE
[docker-ptf]: install tacacs+ server to test tacacs

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -59,7 +59,9 @@ RUN sed --in-place 's/httpredir.debian.org/debian-archive.trafficmanager.net/' /
         python-dev          \
         python-libpcap      \
         python-scapy        \
-        python-six
+        python-six          \
+        tacacs+             \
+        rsyslog
 
 RUN dpkg -i \
 {% for deb in docker_ptf_debs.split(' ') -%}


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
install tacacs+ server to test tacacs

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
