### PR TITLE
Bug fix: #4011 #4012 - "show run acl", "show run interfaces" - traceback when no ACL_RULE/INTERFACE is present.

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -295,10 +295,10 @@ def main():
         template = jinja2.Template('{{' + args.var + '}}')
         print(template.render(data))
 
-    if args.var_json != None:
+    if args.var_json != None and args.var_json in data:
         if args.key != None:
             print(json.dumps(FormatConverter.to_serialized(data[args.var_json], args.key), indent=4, cls=minigraph_encoder))
-        elif args.var_json in data:
+        else:
             print(json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder))
 
     if args.write_to_db:

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -298,7 +298,7 @@ def main():
     if args.var_json != None:
         if args.key != None:
             print(json.dumps(FormatConverter.to_serialized(data[args.var_json], args.key), indent=4, cls=minigraph_encoder))
-        else:
+        elif args.var_json in data:
             print(json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder))
 
     if args.write_to_db:

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -330,3 +330,16 @@ class TestCfgGen(TestCase):
                 output = subprocess.check_output("sed -i \'s/%s/%s/g\' %s" % (BACKEND_TOR_ROUTER, TOR_ROUTER, self.sample_graph_simple), shell=True)
 
             self.test_jinja_expression(self.sample_graph_simple, TOR_ROUTER)
+
+
+    def test_show_run_acl(self):
+        argument = '-a \'{"key1":"value"}\' --var-json ACL_RULE'
+        output = self.run_script(argument)
+        self.assertEqual(output, '')
+
+    
+    def test_show_run_interfaces(self):
+        argument = '-a \'{"key1":"value"}\' --var-json INTERFACE'
+        output = self.run_script(argument)
+        self.assertEqual(output, '')
+

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -331,15 +331,12 @@ class TestCfgGen(TestCase):
 
             self.test_jinja_expression(self.sample_graph_simple, TOR_ROUTER)
 
-
     def test_show_run_acl(self):
         argument = '-a \'{"key1":"value"}\' --var-json ACL_RULE'
         output = self.run_script(argument)
         self.assertEqual(output, '')
 
-    
     def test_show_run_interfaces(self):
         argument = '-a \'{"key1":"value"}\' --var-json INTERFACE'
         output = self.run_script(argument)
         self.assertEqual(output, '')
-


### PR DESCRIPTION
Signed-off-by: Noa Or <noaor@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fix bug #4011 - "show run acl" returns traceback when no ACL_RULE is present in configuration.
- Fix bug #4012 - "show run interfaces" returns traceback when no INTERFACE is present in configuration

**- How I did it**
Change logic in main to take data only if the var given in var_json appears in DB.

**- How to verify it**
- Make sure running configuration doesn't contain ACL_RULE:
`show run all | grep -r '"ACL_RULE"'`
should print nothing.
- run command:
`show run acl`
Nothing should be printed and no error should appear.

- Make sure running configuration doesn't contain INTERFACE:
`show run all | grep -r '"INTERFACE"'`
should print nothing.
- run command:
`show run interfaces`
Nothing should be printed and no error should appear.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A

**- A picture of a cute animal (not mandatory but encouraged)**