### PR TITLE
[quagga]: Increase netlink receive buffer for zebra

### DIFF
--- a/dockers/docker-fpm-quagga/supervisord.conf
+++ b/dockers/docker-fpm-quagga/supervisord.conf
@@ -31,7 +31,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:zebra]
-command=/usr/lib/quagga/zebra -A 127.0.0.1
+command=/usr/lib/quagga/zebra -A 127.0.0.1 -s 2097152
 priority=4
 autostart=false
 autorestart=false


### PR DESCRIPTION
Otherwise we see following messages from zebra sometimes
zebra[60]: netlink-listen recvmsg overrun: No buffer space available

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Increased netlink socket receive buffer size for zebra. Otherwise we receive following messages sometimes:
`zebra[60]: netlink-listen recvmsg overrun: No buffer space available`

**- How I did it**
Used -s command line parameter of zebra 

**- How to verify it**
Build an image and run it. Currently I didn't find how we can check receive buffer size from the command line. I'll update the pr if I find the way.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
