### PR TITLE
[201811] [interfaces-config.sh] Flush the loopback interface addresses

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -18,6 +18,8 @@ fi
 
 [ -f /var/run/dhclient.eth0.pid ] && kill `cat /var/run/dhclient.eth0.pid` && rm -f /var/run/dhclient.eth0.pid
 
+ip addr flush dev lo
+
 systemctl restart networking
 
 ifdown --force lo && ifup lo

--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -18,8 +18,8 @@ fi
 
 [ -f /var/run/dhclient.eth0.pid ] && kill `cat /var/run/dhclient.eth0.pid` && rm -f /var/run/dhclient.eth0.pid
 
-ip addr flush dev lo
-
 systemctl restart networking
 
-ifdown --force lo && ifup lo
+ifdown --force lo
+ip addr flush dev lo
+ifup lo


### PR DESCRIPTION
Flush the loopback interface before configure it

Without this, you may end up with more and more ip addresses
on loopback interface after you change the loopback ip and do config reload

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Flush the loopback interface before configure it

**- How I did it**
Flush the loopback interface before configure it

**- How to verify it**

config_db-1.json:
```
    "LOOPBACK_INTERFACE": {
        "Loopback0|2000::1/128": {
            "family": "IPv6",
            "scope": "global"
        },

        "Loopback0|10.10.10.1/32": {
            "family": "IPv4",
            "scope": "global"
        }
    },
```

config_db-2.json
```
    "LOOPBACK_INTERFACE": {
        "Loopback0|2000::2/128": {
            "family": "IPv6",
            "scope": "global"
        },
        "Loopback0|10.10.10.2/32": {
            "family": "IPv4",
            "scope": "global"
        }
    },
```

After sudo config reload config_db-1.json:

```
admin@sonic:~$ ip addr show lo
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet 10.10.10.1/32 brd 10.10.10.1 scope global lo
       valid_lft forever preferred_lft forever
    inet6 2000::1/128 scope global 
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
```

### **Before the fix:**
 config reload config_db-2.json after config_db-1.json:
```
admin@sonic:~$ ip addr show lo
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet 10.10.10.1/32 brd 10.10.10.1 scope global lo
       valid_lft forever preferred_lft forever
    inet 10.10.10.2/32 brd 10.10.10.2 scope global lo
       valid_lft forever preferred_lft forever
    inet6 2000::2/128 scope global 
       valid_lft forever preferred_lft forever
    inet6 2000::1/128 scope global 
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
```

### **After fix:**
config reload config_db-2.json after config_db-1.json:
```
admin@sonic:~$ ip addr show lo
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet 10.10.10.2/32 brd 10.10.10.2 scope global lo
       valid_lft forever preferred_lft forever
    inet6 2000::2/128 scope global 
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
