### PR TITLE
[DPB Seastone] On boarding DPB feature to Seastone HWSKUs

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/hwsku.json
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-10-50/hwsku.json
@@ -1,0 +1,100 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet52": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet60": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet68": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet76": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet84": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet92": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet100": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet108": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet116": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet124": {
+            "default_brkout_mode": "2x50G"
+        }
+    }
+}

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-25-50/hwsku.json
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-25-50/hwsku.json
@@ -1,0 +1,100 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet52": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet60": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet68": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet76": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet84": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet92": {
+            "default_brkout_mode": "4x25G[10G]"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet100": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet108": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet116": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet124": {
+            "default_brkout_mode": "2x50G"
+        }
+    }
+}

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50-40/hwsku.json
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50-40/hwsku.json
@@ -1,0 +1,100 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet52": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet60": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet68": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet76": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet84": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet92": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet100": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet108": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet116": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet124": {
+            "default_brkout_mode": "1x100G[40G]"
+        }
+    }
+}

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50/hwsku.json
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010-50/hwsku.json
@@ -1,0 +1,100 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet52": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet60": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet68": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet76": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet84": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet92": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet100": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet108": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet116": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "2x50G"
+        },
+        "Ethernet124": {
+            "default_brkout_mode": "2x50G"
+        }
+    }
+}

--- a/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/hwsku.json
+++ b/device/celestica/x86_64-cel_seastone-r0/Seastone-DX010/hwsku.json
@@ -1,0 +1,100 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet52": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet60": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet68": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet76": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet84": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet92": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet100": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet108": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet116": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet124": {
+            "default_brkout_mode": "1x100G[40G]"
+        }
+    }
+}

--- a/device/celestica/x86_64-cel_seastone-r0/platform.json
+++ b/device/celestica/x86_64-cel_seastone-r0/platform.json
@@ -1,0 +1,196 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "index": "1,1,1,1",
+            "lanes": "65,66,67,68",
+            "alias_at_lanes": "Eth1/1, Eth1/2, Eth1/3, Eth1/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet4": {
+            "index": "2,2,2,2",
+            "lanes": "69,70,71,72",
+            "alias_at_lanes": "Eth2/1, Eth2/2, Eth2/3, Eth2/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet8": {
+            "index": "3,3,3,3",
+            "lanes": "73,74,75,76",
+            "alias_at_lanes": "Eth3/1, Eth3/2, Eth3/3, Eth3/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet12": {
+            "index": "4,4,4,4",
+            "lanes": "77,78,79,80",
+            "alias_at_lanes": "Eth4/1, Eth4/2, Eth4/3, Eth4/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet16": {
+            "index": "5,5,5,5",
+            "lanes": "33,34,35,36",
+            "alias_at_lanes": "Eth5/1, Eth5/2, Eth5/3, Eth5/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet20": {
+            "index": "6,6,6,6",
+            "lanes": "37,38,39,40",
+            "alias_at_lanes": "Eth6/1, Eth6/2, Eth6/3, Eth6/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet24": {
+            "index": "7,7,7,7",
+            "lanes": "41,42,43,44",
+            "alias_at_lanes": "Eth7/1, Eth7/2, Eth7/3, Eth7/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet28": {
+            "index": "8,8,8,8",
+            "lanes": "45,46,47,48",
+            "alias_at_lanes": "Eth8/1, Eth8/2, Eth8/3, Eth8/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet32": {
+            "index": "9,9,9,9",
+            "lanes": "49,50,51,52",
+            "alias_at_lanes": "Eth9/1, Eth9/2, Eth9/3, Eth9/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet36": {
+            "index": "10,10,10,10",
+            "lanes": "53,54,55,56",
+            "alias_at_lanes": "Eth10/1, Eth10/2, Eth10/3, Eth10/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet40": {
+            "index": "11,11,11,11",
+            "lanes": "57,58,59,60",
+            "alias_at_lanes": "Eth11/1, Eth11/2, Eth11/3, Eth11/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet44": {
+            "index": "12,12,12,12",
+            "lanes": "61,62,63,64",
+            "alias_at_lanes": "Eth12/1, Eth12/2, Eth12/3, Eth12/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet48": {
+            "index": "13,13,13,13",
+            "lanes": "81,82,83,84",
+            "alias_at_lanes": "Eth13/1, Eth13/2, Eth13/3, Eth13/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet52": {
+            "index": "14,14,14,14",
+            "lanes": "85,86,87,88",
+            "alias_at_lanes": "Eth14/1, Eth14/2, Eth14/3, Eth14/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet56": {
+            "index": "15,15,15,15",
+            "lanes": "89,90,91,92",
+            "alias_at_lanes": "Eth15/1, Eth15/2, Eth15/3, Eth15/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet60": {
+            "index": "16,16,16,16",
+            "lanes": "93,94,95,96",
+            "alias_at_lanes": "Eth16/1, Eth16/2, Eth16/3, Eth16/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet64": {
+            "index": "17,17,17,17",
+            "lanes": "97,98,99,100",
+            "alias_at_lanes": "Eth17/1, Eth17/2, Eth17/3, Eth17/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet68": {
+            "index": "18,18,18,18",
+            "lanes": "101,102,103,104",
+            "alias_at_lanes": "Eth18/1, Eth18/2, Eth18/3, Eth18/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet72": {
+            "index": "19,19,19,19",
+            "lanes": "105,106,107,108",
+            "alias_at_lanes": "Eth19/1, Eth19/2, Eth19/3, Eth19/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet76": {
+            "index": "20,20,20,20",
+            "lanes": "109,110,111,112",
+            "alias_at_lanes": "Eth20/1, Eth20/2, Eth20/3, Eth20/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet80": {
+            "index": "21,21,21,21",
+            "lanes": "1,2,3,4",
+            "alias_at_lanes": "Eth21/1, Eth21/2, Eth21/3, Eth21/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet84": {
+            "index": "22,22,22,22",
+            "lanes": "5,6,7,8",
+            "alias_at_lanes": "Eth22/1, Eth22/2, Eth22/3, Eth22/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet88": {
+            "index": "23,23,23,23",
+            "lanes": "9,10,11,12",
+            "alias_at_lanes": "Eth23/1, Eth23/2, Eth23/3, Eth23/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet92": {
+            "index": "24,24,24,24",
+            "lanes": "13,14,15,16",
+            "alias_at_lanes": "Eth24/1, Eth24/2, Eth24/3, Eth24/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet96": {
+            "index": "25,25,25,25",
+            "lanes": "17,18,19,20",
+            "alias_at_lanes": "Eth25/1, Eth25/2, Eth25/3, Eth25/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet100": {
+            "index": "26,26,26,26",
+            "lanes": "21,22,23,24",
+            "alias_at_lanes": "Eth26/1, Eth26/2, Eth26/3, Eth26/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet104": {
+            "index": "27,27,27,27",
+            "lanes": "25,26,27,28",
+            "alias_at_lanes": "Eth27/1, Eth27/2, Eth27/3, Eth27/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet108": {
+            "index": "28,28,28,28",
+            "lanes": "29,30,31,32",
+            "alias_at_lanes": "Eth28/1, Eth28/2, Eth28/3, Eth28/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet112": {
+            "index": "29,29,29,29",
+            "lanes": "113,114,115,116",
+            "alias_at_lanes": "Eth29/1, Eth29/2, Eth29/3, Eth29/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet116": {
+            "index": "30,30,30,30",
+            "lanes": "117,118,119,120",
+            "alias_at_lanes": "Eth30/1, Eth30/2, Eth30/3, Eth30/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet120": {
+            "index": "31,31,31,31",
+            "lanes": "121,122,123,124",
+            "alias_at_lanes": "Eth31/1, Eth31/2, Eth31/3, Eth31/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet124": {
+            "index": "32,32,32,32",
+            "lanes": "125,126,127,128",
+            "alias_at_lanes": "Eth32/1, Eth32/2, Eth32/3, Eth32/4",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        }
+    }
+}


### PR DESCRIPTION
[DPB Seastone] On boarding DPB feature to Seastone HWSKUs

This include the platform.json for Seastone platform and
individual hwsku.json for each HWSKU

port_config.ini will be removed once the CLI/parser library etc changes are merged

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
On boarding DPB feature to Seastone HWSKUs

**- How I did it**
Add platform.json for Seastone and hwsku.json files to relevant HWSKUs.

**- How to verify it**
```
sudo sonic-cfggen -H -k Seastone-DX010 --preset=t1 > config_db.json
sudo config reload config_db.json -y

show interface status:

admin@lnos-x1-a-csw03:~$ show interfaces status 
  Interface            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  ---------------  -------  -----  -----  -------  ------  ------  -------  ------  ----------
  Ethernet0      65,66,67,68     100G   9100    N/A   Eth1/1  routed    down       up     N/A         N/A
  Ethernet4      69,70,71,72     100G   9100    N/A   Eth2/1  routed    down       up     N/A         N/A
  Ethernet8      73,74,75,76     100G   9100    N/A   Eth3/1  routed    down       up     N/A         N/A
 Ethernet12      77,78,79,80     100G   9100    N/A   Eth4/1  routed    down       up     N/A         N/A
 Ethernet16      33,34,35,36     100G   9100    N/A   Eth5/1  routed    down       up     N/A         N/A
 Ethernet20      37,38,39,40     100G   9100    N/A   Eth6/1  routed    down       up     N/A         N/A
 Ethernet24      41,42,43,44     100G   9100    N/A   Eth7/1  routed    down       up     N/A         N/A
 Ethernet28      45,46,47,48     100G   9100    N/A   Eth8/1  routed    down       up     N/A         N/A
 Ethernet32      49,50,51,52     100G   9100    N/A   Eth9/1  routed    down       up     N/A         N/A
 Ethernet36      53,54,55,56     100G   9100    N/A  Eth10/1  routed    down       up     N/A         N/A
 Ethernet40      57,58,59,60     100G   9100    N/A  Eth11/1  routed    down       up     N/A         N/A
 Ethernet44      61,62,63,64     100G   9100    N/A  Eth12/1  routed    down       up     N/A         N/A
 Ethernet48      81,82,83,84     100G   9100    N/A  Eth13/1  routed    down       up     N/A         N/A
 Ethernet52      85,86,87,88     100G   9100    N/A  Eth14/1  routed    down       up     N/A         N/A
 Ethernet56      89,90,91,92     100G   9100    N/A  Eth15/1  routed    down       up     N/A         N/A
 Ethernet60      93,94,95,96     100G   9100    N/A  Eth16/1  routed    down       up     N/A         N/A
 Ethernet64     97,98,99,100     100G   9100    N/A  Eth17/1  routed    down       up     N/A         N/A
 Ethernet68  101,102,103,104     100G   9100    N/A  Eth18/1  routed    down       up     N/A         N/A
 Ethernet72  105,106,107,108     100G   9100    N/A  Eth19/1  routed      up       up     N/A         N/A
 Ethernet76  109,110,111,112     100G   9100    N/A  Eth20/1  routed    down       up     N/A         N/A
 Ethernet80          1,2,3,4     100G   9100    N/A  Eth21/1  routed    down       up     N/A         N/A
 Ethernet84          5,6,7,8     100G   9100    N/A  Eth22/1  routed    down       up     N/A         N/A
 Ethernet88       9,10,11,12     100G   9100    N/A  Eth23/1  routed    down       up     N/A         N/A
 Ethernet92      13,14,15,16     100G   9100    N/A  Eth24/1  routed    down       up     N/A         N/A
 Ethernet96      17,18,19,20     100G   9100    N/A  Eth25/1  routed    down       up     N/A         N/A
Ethernet100      21,22,23,24     100G   9100    N/A  Eth26/1  routed    down       up     N/A         N/A
Ethernet104      25,26,27,28     100G   9100    N/A  Eth27/1  routed    down       up     N/A         N/A
Ethernet108      29,30,31,32     100G   9100    N/A  Eth28/1  routed    down       up     N/A         N/A
Ethernet112  113,114,115,116     100G   9100    N/A  Eth29/1  routed    down       up     N/A         N/A
Ethernet116  117,118,119,120     100G   9100    N/A  Eth30/1  routed    down       up     N/A         N/A
Ethernet120  121,122,123,124     100G   9100    N/A  Eth31/1  routed    down       up     N/A         N/A
Ethernet124  125,126,127,128     100G   9100    N/A  Eth32/1  routed    down       up     N/A         N/A

```

**Breakout to 2x50G:**
```
admin@lnos-x1-a-csw03:~$ sudo config interface breakout Ethernet0 2x50G -y -f

Running Breakout Mode : 1x100G[40G] 
Target Breakout Mode : 2x50G

Ports to be deleted : 
 {
    "Ethernet0": "100000"
}
Ports to be added : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet0": "100000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-vlan']
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, BGP_NEIGHBOR, VERSIONS, DEVICE_METADATA, FEATURE, LOCK, BREAKOUT_CFG, CRM, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "1x100G[40G]"
    }
  }
}
Do you wish to Continue? [y/N]: y
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
admin@lnos-x1-a-csw03:~$ 
admin@lnos-x1-a-csw03:~$ 
admin@lnos-x1-a-csw03:~$ show interfaces status 
  Interface            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  ---------------  -------  -----  -----  -------  ------  ------  -------  ------  ----------
  Ethernet0            65,66      50G    N/A    N/A   Eth1/1  routed    down       up     N/A         N/A
  Ethernet2            67,68      50G   9100    N/A   Eth1/3  routed    down       up     N/A         N/A
  
admin@lnos-x1-a-csw03:~$ bcmcmd ps
ps
                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   2   50G  FD   SW  No   Forward          None   FA    KR2  9412    No      
       xe1( 69)  !ena   1     -       SW  No   Forward          None   FA   None  9122    No      

```

**Breakout to 4x25G[10G]:**
```
admin@lnos-x1-a-csw03:~$ sudo config interface breakout Ethernet0 4x25G[10G] -y -f

Running Breakout Mode : 2x50G 
Target Breakout Mode : 4x25G[10G]

Ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
}
Ports to be added : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "50000", 
    "Ethernet0": "50000"
} 
Final list of ports to be added :  
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-vlan']
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, BGP_NEIGHBOR, VERSIONS, DEVICE_METADATA, FEATURE, LOCK, BREAKOUT_CFG, CRM, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "2x50G"
    }
  }
}
Do you wish to Continue? [y/N]: y
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.

admin@lnos-x1-a-csw03:~$ show interfaces status 
  Interface            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  ---------------  -------  -----  -----  -------  ------  ------  -------  ------  ----------
  Ethernet0               65      25G    N/A    N/A   Eth1/1  routed    down       up     N/A         N/A
  Ethernet1               66      25G   9100    N/A   Eth1/2  routed    down       up     N/A         N/A
  Ethernet2               67      25G    N/A    N/A   Eth1/3  routed    down       up     N/A         N/A
  Ethernet3               68      25G   9100    N/A   Eth1/4  routed    down       up     N/A         N/A

admin@lnos-x1-a-csw03:~$ bcmcmd ps
ps
                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       xe0( 68)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe1( 69)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No      
       xe2( 70)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9412    No      
       xe3( 71)  down   1   25G  FD   SW  No   Forward          None   FA     KR  9122    No   

```

**Breakin back to 1x100G[40G]:**
```
admin@lnos-x1-a-csw03:~$ sudo config interface breakout Ethernet0 1x10G[40G] -y -f
[ERROR] Target mode 1x10G[40G] is not available for the port Ethernet0
Aborted!
admin@lnos-x1-a-csw03:~$ sudo config interface breakout Ethernet0 1x100G[40G] -y -f

Running Breakout Mode : 4x25G[10G] 
Target Breakout Mode : 1x100G[40G]

Ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
}
Ports to be added : 
 {
    "Ethernet0": "100000"
}

After running Logic to limit the impact

Final list of ports to be deleted : 
 {
    "Ethernet2": "25000", 
    "Ethernet3": "25000", 
    "Ethernet0": "25000", 
    "Ethernet1": "25000"
} 
Final list of ports to be added :  
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-extension', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-vlan']
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, BGP_NEIGHBOR, VERSIONS, DEVICE_METADATA, FEATURE, LOCK, FLEX_COUNTER_TABLE, BREAKOUT_CFG, CRM, 
Below Config can not be verified, It may cause harm to the system
 {
  "BREAKOUT_CFG": {
    "Ethernet0": {
      "brkout_mode": "4x25G[10G]"
    }
  }
}
Do you wish to Continue? [y/N]: y
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
admin@lnos-x1-a-csw03:~$ show interfaces status 
  Interface            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin    Type    Asym PFC
-----------  ---------------  -------  -----  -----  -------  ------  ------  -------  ------  ----------
  Ethernet0      65,66,67,68     100G    N/A    N/A   Eth1/1  routed    down       up     N/A         N/A

admin@lnos-x1-a-csw03:~$ bcmcmd ps
ps
                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
       ce0( 68)  down   4  100G  FD   SW  No   Forward          None   FA    KR4  9412    No      
       xe0( 69)  !ena   1     -       SW  No   Forward          None   FA   None  9122    No      
       xe1( 70)  !ena   2     -       SW  No   Forward          None   FA   None  9412    No      
       xe2( 71)  !ena   1     -       SW  No   Forward          None   FA   None  9122    No  
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
