### PR TITLE
Revert "[snmp] Configure snmp docker hostname from config DB (#2773)"

### DIFF
--- a/dockers/docker-snmp-sv2/start.sh
+++ b/dockers/docker-snmp-sv2/start.sh
@@ -9,17 +9,6 @@ sonic-cfggen -d -y /etc/sonic/snmp.yml -t /usr/share/sonic/templates/snmpd.conf.
 mkdir -p /var/sonic
 echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status
 
-CURRENT_HOSTNAME=`hostname`
-HOSTNAME=`sonic-cfggen -d -v DEVICE_METADATA[\'localhost\'][\'hostname\']`
-
-if [ "$?" == "0" ] && [ "$HOSTNAME" != "" ]; then
-    echo $HOSTNAME > /etc/hostname
-    hostname -F /etc/hostname
-
-    sed -i "/\s$CURRENT_HOSTNAME$/d" /etc/hosts
-    echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
-fi
-
 rm -f /var/run/rsyslogd.pid
 
 supervisorctl start rsyslogd


### PR DESCRIPTION
This reverts commit f2e60f8c9138ab442e5ebea560fc15ab9204df0b.

- [ ] merge after https://github.com/Azure/sonic-buildimage/pull/4241
