### PR TITLE
DellEMC: Z9264-Platform2.0 Implementation [Reboot Cause]

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ["chassis", "sfp", "eeprom"]
+__all__ = ["platform", "chassis", "sfp", "eeprom", "component", "psu", "thermal"]
 from sonic_platform import *
 

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/platform.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/platform.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+#############################################################################
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the platform information
+#
+#############################################################################
+
+try:
+    from sonic_platform_base.platform_base import PlatformBase
+    from sonic_platform.chassis import Chassis
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Platform(PlatformBase):
+    """
+    DELLEMC Platform-specific class
+    """
+
+    def __init__(self):
+        PlatformBase.__init__(self)
+        self._chassis = Chassis()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Implement Reboot Cause platform2.0 API for DellEMC Z9264 platform.

**- How I did it**

- Added get_reboot_cause() API implementation in chassis.py
- Added new file platform.py for platform2.0 API implementation.

**- How to verify it**

Performed different type of reboots and used "show reboot-cause" command to verify.
UT Logs: [UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/4313498/UT_logs.txt)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC: Z9264-Platform2.0 Implementation [Reboot Cause]

**- A picture of a cute animal (not mandatory but encouraged)**