### PR TITLE
[MultiDB] : add persistence field for each redis instance

### DIFF
--- a/dockers/docker-database/database_config.json
+++ b/dockers/docker-database/database_config.json
@@ -3,7 +3,8 @@
         "redis":{
             "hostname" : "127.0.0.1",
             "port" : 6379,
-            "unix_socket_path" : "/var/run/redis/redis.sock"
+            "unix_socket_path" : "/var/run/redis/redis.sock",
+            "persistence" : "yes"
         }
     },
     "DATABASES" : {

--- a/dockers/docker-database/database_config.json
+++ b/dockers/docker-database/database_config.json
@@ -4,7 +4,7 @@
             "hostname" : "127.0.0.1",
             "port" : 6379,
             "unix_socket_path" : "/var/run/redis/redis.sock",
-            "persistence" : "yes"
+            "persistence_for_warm_boot" : "yes"
         }
     },
     "DATABASES" : {


### PR DESCRIPTION
* add "persistence" field for each redis instance in database_config.json
* we will use this information to decide if saving redis instance data while warm/fast reboot
    * before multiDB changes, SONiC uses "redis-cli save " to save all the data into rdb file on default instance on port 6379
    * with multiDB changes, we plan to implement "sonic-db-cli save" to save all data to corresponding rdb files on all listed redis instances which has "persistence" field set "yes"
  
Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com