### PR TITLE
[vs] Add dependencies for NAT to docker-sonic-vs

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -51,7 +51,9 @@ RUN apt-get install -y net-tools \
                        apt-utils \
                        psmisc \
                        tcpdump \
-                       python-scapy
+                       python-scapy \
+                       conntrack \
+                       iptables
 
 RUN pip install setuptools
 RUN pip install py2_ipaddress


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

**- What I did**
I added dependencies to support the NAT feature on the virtual switch.

**- How I did it**
Updated build.

**- How to verify it**
There shouldn't be any more messages in the logs like these when using NAT:
```
Mar 12 22:36:14.558935 b24fdad36873 INFO #supervisord: natmgrd sh: 1: /sbin/iptables: not found
Mar 12 22:36:14.562544 b24fdad36873 INFO #supervisord: orchagent sh: 1: /usr/sbin/conntrack: not found
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add dependencies for NAT to docker-sonic-vs

**- A picture of a cute animal (not mandatory but encouraged)**
