### PR TITLE
Fixbug: EVPN issue in FRR template

### DIFF
--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -477,6 +477,15 @@ class VlanInterfaceMgr(InterfaceMgr):
         )
 
 
+class PortChannelInterfaceMgr(InterfaceMgr):
+    def __init__(self, daemon, directory):
+        super(PortChannelInterfaceMgr, self).__init__(
+            daemon,
+            directory,
+            swsscommon.CFG_LAG_INTF_TABLE_NAME
+        )
+
+
 def wait_for_bgpd():
     # wait for 20 seconds
     stop_time = datetime.datetime.now() + datetime.timedelta(seconds=20)
@@ -498,6 +507,7 @@ def main():
         InterfaceMgr,
         LoopbackInterfaceMgr,
         VlanInterfaceMgr,
+        PortChannelInterfaceMgr,
     ]
     wait_for_bgpd()
     daemon = Daemon()

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -293,21 +293,22 @@ class BGPPeerMgr(Manager):
             cmd = None
 
             if "local_addr" not in data:
-                syslog.syslog(syslog.LOG_ERR, 'Peer {}. Error in missing required attribute "local_addr"'.format(key))
-                return False
+                syslog.syslog(syslog.LOG_WARNING, 'Peer {}. Error in missing required attribute "local_addr"'.format(key))
+            else:
 
-            # Check if this route is belong to a vnet
-            interfaces = self.directory.get_slot("interface")
-            target_interface = None
-            for metadata in interfaces.values():
-                if metadata["ip"] == data["local_addr"]:
-                    target_interface = metadata
-            if target_interface is None:
-                return False
-            elif target_interface.has_key("vnet_name") and target_interface["vnet_name"]:
-                # Ignore the route that is in a vnet
-                syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, target_interface["vnet_name"]))
-                return True
+                # Check if this route is belong to a vnet
+                interfaces = self.directory.get_slot("interface")
+                target_interface = None
+                for metadata in interfaces.values():
+                    if metadata["ip"] == data["local_addr"]:
+                        target_interface = metadata
+                        break
+                if target_interface is None:
+                    return False
+                elif target_interface.has_key("vnet_name") and target_interface["vnet_name"]:
+                    # Ignore the route that is in a vnet
+                    syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, target_interface["vnet_name"]))
+                    return True
 
             neigmeta = self.directory.get_slot("neigmeta")
             if 'name' in data and data["name"] not in neigmeta:
@@ -467,6 +468,15 @@ class LoopbackInterfaceMgr(InterfaceMgr):
         )
 
 
+class VlanInterfaceMgr(InterfaceMgr):
+    def __init__(self, daemon, directory):
+        super(VlanInterfaceMgr, self).__init__(
+            daemon,
+            directory,
+            swsscommon.CFG_VLAN_INTF_TABLE_NAME
+        )
+
+
 def wait_for_bgpd():
     # wait for 20 seconds
     stop_time = datetime.datetime.now() + datetime.timedelta(seconds=20)
@@ -487,6 +497,7 @@ def main():
         BGPPeerMgr,
         InterfaceMgr,
         LoopbackInterfaceMgr,
+        VlanInterfaceMgr,
     ]
     wait_for_bgpd()
     daemon = Daemon()

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -296,29 +296,16 @@ class BGPPeerMgr(Manager):
             if "local_addr" not in data:
                 syslog.syslog(syslog.LOG_WARNING, 'Peer {}. Error in missing required attribute "local_addr"'.format(key))
             else:
-                # The route that belongs to a vnet cannot be advertised by the default BGP session.
-                # So we need to check whether this route belongs to a vnet.
-                local_addresses = self.directory.get_slot("local_addresses")
-                # Check if the information for the local address of this route has been set
-                # Which means we can find the interface for this route by its local address
-                # We can only process this route message when the local address was set
-                if data["local_addr"] not in local_addresses:
+                # The bgp session that belongs to a vnet cannot be advertised as the default BGP session.
+                # So we need to check whether this bgp session belongs to a vnet.
+                interface = self.get_local_interface(data["local_addr"])
+                if not interface:
                     return False
-                local_address = local_addresses[data["local_addr"]]
-                interfaces = self.directory.get_slot("interfaces")
-                # Check if the information for the interface of this local address has set
-                # Which means we can determine whether this route belongs to a vnet
-                # Because the vnet name will be set in the interface
-                # Ref:https://github.com/Azure/SONiC/blob/master/doc/vxlan/Vxlan_hld.md#212-vnetinterface-table
-                if local_address.has_key("interface") and local_address["interface"] in interfaces:
-                    interface = interfaces[local_address["interface"]]
-                    # Check if this route is belong to a vnet
-                    if interface.has_key("vnet_name") and interface["vnet_name"]:
-                        # Ignore the route that is in a vnet
-                        syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, interface["vnet_name"]))
-                        return True
-                else:
-                    return False
+                vnet = self.get_vnet(interface)
+                if vnet:
+                    # Ignore the bgp session that is in a vnet
+                    syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, vnet))
+                    return True
 
             neigmeta = self.directory.get_slot("neigmeta")
             if 'name' in data and data["name"] not in neigmeta:
@@ -392,6 +379,25 @@ class BGPPeerMgr(Manager):
         os.remove(tmp_filename)
         return rc == 0
 
+    def get_local_interface(self, local_addr):
+        local_addresses = self.directory.get_slot("local_addresses")
+        # Check if the local address of this bgp session has been set
+        if local_addr not in local_addresses:
+            return None
+        local_address = local_addresses[local_addr]
+        interfaces = self.directory.get_slot("interfaces")
+        # Check if the information for the interface of this local address has been set
+        if local_address.has_key("interface") and local_address["interface"] in interfaces:
+            return interfaces[local_address["interface"]]
+        else:
+            return None
+
+    def get_vnet(self, interface):
+        if interface.has_key("vnet_name") and interface["vnet_name"]:
+            return interface["vnet_name"]
+        else:
+            return None
+
     @staticmethod
     def normalize_key(key):
         if '|' not in key:
@@ -420,17 +426,6 @@ class BGPPeerMgr(Manager):
         return peers
 
 
-def prefix_attr(attr, value):
-    if not value:
-        return None
-    else:
-        try:
-            prefix = netaddr.IPNetwork(str(value))
-        except:
-            return None
-    return str(getattr(prefix, attr))
-
-
 class InterfaceMgr(Manager):
     def __init__(self, daemon, directory, interface_table = swsscommon.CFG_INTF_TABLE_NAME):
         super(InterfaceMgr, self).__init__(
@@ -450,8 +445,13 @@ class InterfaceMgr(Manager):
         if '|' in key:
             data = {}
             data["interface"], network = key.split('|', 1)
-            data["prefixlen"] = prefix_attr("prefixlen", network)
-            ip = prefix_attr("ip", network)
+            try:
+                network = netaddr.IPNetwork(str(network))
+            except:
+                syslog.syslog(syslog.LOG_WARNING, 'Subnet {} format is wrong'.format(network))
+                return False
+            data["prefixlen"] = str(network.prefixlen)
+            ip = str(network.ip)
             self.directory.put("local_addresses", ip, data)
         else:
             self.directory.put("interfaces", key, data)
@@ -460,7 +460,12 @@ class InterfaceMgr(Manager):
     def del_handler(self, key):
         if '|' in key:
             _, network = key.split('|', 1)
-            ip = prefix_attr("ip", network)
+            try:
+                network = netaddr.IPNetwork(str(network))
+            except:
+                syslog.syslog(syslog.LOG_WARNING, 'Subnet {} format is wrong'.format(network))
+                return False
+            ip = str(network.ip)
             self.directory.remove("local_addresses", ip)
         else:
             self.directory.remove("interfaces", key)

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -272,6 +272,7 @@ class BGPPeerMgr(Manager):
             [
                 ("meta", "localhost/bgp_asn"),
                 ("neigmeta", ""),
+                ("interface", "")
             ],
             "CONFIG_DB",
             swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME
@@ -290,6 +291,24 @@ class BGPPeerMgr(Manager):
         vrf, nbr = key.split('|', 1)
         if key not in self.peers:
             cmd = None
+
+            if "local_addr" not in data:
+                syslog.syslog(syslog.LOG_ERR, 'Peer {}. Error in missing required attribute "local_addr"'.format(key))
+                return False
+
+            # Check if this route is belong to a vnet
+            interfaces = self.directory.get_slot("interface")
+            target_interface = None
+            for metadata in interfaces.values():
+                if metadata["ip"] == data["local_addr"]:
+                    target_interface = metadata
+            if target_interface is None:
+                return False
+            elif target_interface.has_key("vnet_name") and target_interface["vnet_name"]:
+                # Ignore the route that is in a vnet
+                syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, data))
+                return True
+
             neigmeta = self.directory.get_slot("neigmeta")
             if 'name' in data and data["name"] not in neigmeta:
                 return False
@@ -390,6 +409,64 @@ class BGPPeerMgr(Manager):
         return peers
 
 
+def prefix_attr(attr, value):
+    if not value:
+        return None
+    else:
+        try:
+            prefix = netaddr.IPNetwork(str(value))
+        except:
+            return None
+    return str(getattr(prefix, attr))
+
+
+class InterfaceMgr(Manager):
+    def __init__(self, daemon, directory, interface_table = swsscommon.CFG_INTF_TABLE_NAME):
+        super(InterfaceMgr, self).__init__(
+            daemon,
+            directory,
+            [],
+            "CONFIG_DB",
+            interface_table
+        )
+        self.interfaces = {}
+
+    def set_handler(self, key, data):
+        # There are two entries for an interface in CFG_INTF_TABLE.
+        # One of them is to specify ip and prefix.
+        # In this case, the key contains '|', like "Ethernet0|192.168.0.6/30".
+        # Another one is to specify whether this interface belongs to a vnet
+        # In this case, the key only includes the interface name
+        if '|' in key:
+            key, network = key.split('|', 1)
+            data["ip"] = prefix_attr("ip", network)
+            data["prefixlen"] = prefix_attr("prefixlen", network)
+
+        # Put the interface data into directory only if two entries have both been set
+        # Otherwise cache the first come entry
+        if key in self.interfaces:
+            self.interfaces[key].update(data)
+            self.directory.put("interface", key, self.interfaces[key])
+            del self.interfaces[key]
+        else:
+            self.interfaces[key] = data
+        return True
+
+    def del_handler(self, key):
+        if '|' in key:
+            key, _ = key.split('|', 1)
+        self.directory.remove("interface", key)
+
+
+class LoopbackInterfaceMgr(InterfaceMgr):
+    def __init__(self, daemon, directory):
+        super(LoopbackInterfaceMgr, self).__init__(
+            daemon,
+            directory,
+            swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME
+        )
+
+
 def wait_for_bgpd():
     # wait for 20 seconds
     stop_time = datetime.datetime.now() + datetime.timedelta(seconds=20)
@@ -408,6 +485,8 @@ def main():
         BGPDeviceMetaMgr,
         BGPNeighborMetaMgr,
         BGPPeerMgr,
+        InterfaceMgr,
+        LoopbackInterfaceMgr,
     ]
     wait_for_bgpd()
     daemon = Daemon()

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -298,10 +298,10 @@ class BGPPeerMgr(Manager):
             else:
                 # The bgp session that belongs to a vnet cannot be advertised as the default BGP session.
                 # So we need to check whether this bgp session belongs to a vnet.
-                interface = self.get_local_interface(data["local_addr"])
+                interface = InterfaceMgr.get_local_interface(self.directory, data["local_addr"])
                 if not interface:
                     return False
-                vnet = self.get_vnet(interface)
+                vnet = InterfaceMgr.get_vnet(interface)
                 if vnet:
                     # Ignore the bgp session that is in a vnet
                     syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, vnet))
@@ -379,25 +379,6 @@ class BGPPeerMgr(Manager):
         os.remove(tmp_filename)
         return rc == 0
 
-    def get_local_interface(self, local_addr):
-        local_addresses = self.directory.get_slot("local_addresses")
-        # Check if the local address of this bgp session has been set
-        if local_addr not in local_addresses:
-            return None
-        local_address = local_addresses[local_addr]
-        interfaces = self.directory.get_slot("interfaces")
-        # Check if the information for the interface of this local address has been set
-        if local_address.has_key("interface") and local_address["interface"] in interfaces:
-            return interfaces[local_address["interface"]]
-        else:
-            return None
-
-    def get_vnet(self, interface):
-        if interface.has_key("vnet_name") and interface["vnet_name"]:
-            return interface["vnet_name"]
-        else:
-            return None
-
     @staticmethod
     def normalize_key(key):
         if '|' not in key:
@@ -469,6 +450,27 @@ class InterfaceMgr(Manager):
             self.directory.remove("local_addresses", ip)
         else:
             self.directory.remove("interfaces", key)
+
+    @staticmethod
+    def get_local_interface(directory, local_addr):
+        local_addresses = directory.get_slot("local_addresses")
+        # Check if the local address of this bgp session has been set
+        if local_addr not in local_addresses:
+            return None
+        local_address = local_addresses[local_addr]
+        interfaces = directory.get_slot("interfaces")
+        # Check if the information for the interface of this local address has been set
+        if local_address.has_key("interface") and local_address["interface"] in interfaces:
+            return interfaces[local_address["interface"]]
+        else:
+            return None
+
+    @staticmethod
+    def get_vnet(interface):
+        if interface.has_key("vnet_name") and interface["vnet_name"]:
+            return interface["vnet_name"]
+        else:
+            return None
 
 
 class LoopbackInterfaceMgr(InterfaceMgr):

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -304,7 +304,14 @@ class BGPPeerMgr(Manager):
                 vnet = InterfaceMgr.get_vnet(interface)
                 if vnet:
                     # Ignore the bgp session that is in a vnet
-                    syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, vnet))
+                    syslog.syslog(
+                            syslog.LOG_INFO,
+                            'Ignore the BGP peer {} as the interface {} is in vnet {}'.format(
+                                key,
+                                interface,
+                                vnet
+                            )
+                        )
                     return True
 
             neigmeta = self.directory.get_slot("neigmeta")
@@ -426,7 +433,13 @@ class InterfaceMgr(Manager):
             try:
                 network = netaddr.IPNetwork(str(network))
             except:
-                syslog.syslog(syslog.LOG_WARNING, 'Subnet {} format is wrong'.format(network))
+                syslog.syslog(
+                        syslog.LOG_WARNING,
+                        'Subnet {} format is wrong for interface {}'.format(
+                            network,
+                            data["interface"]
+                        )
+                    )
                 return False
             data["prefixlen"] = str(network.prefixlen)
             ip = str(network.ip)
@@ -437,11 +450,17 @@ class InterfaceMgr(Manager):
 
     def del_handler(self, key):
         if '|' in key:
-            _, network = key.split('|', 1)
+            interface, network = key.split('|', 1)
             try:
                 network = netaddr.IPNetwork(str(network))
             except:
-                syslog.syslog(syslog.LOG_WARNING, 'Subnet {} format is wrong'.format(network))
+                syslog.syslog(
+                        syslog.LOG_WARNING,
+                        'Subnet {} format is wrong for interface {}'.format(
+                            network,
+                            interface
+                        )
+                    )
                 return False
             ip = str(network.ip)
             self.directory.remove("local_addresses", ip)

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -481,6 +481,13 @@ class InterfaceMgr(Manager):
 
     @staticmethod
     def get_local_interface(directory, local_addr):
+        """
+        @summary: Get interface according to the local address from the directory
+        @param directory: Directory object that stored metadata of interfaces
+        @param local_addr: Local address of the interface
+        @return: Return the metadata of the interface with the local address
+                 If the interface has not been set, return None
+        """
         local_addresses = directory.get_slot("local_addresses")
         # Check if the local address of this bgp session has been set
         if local_addr not in local_addresses:
@@ -495,6 +502,12 @@ class InterfaceMgr(Manager):
 
     @staticmethod
     def get_vnet(interface):
+        """
+        @summary: Get the VNet name of the interface
+        @param interface: The metadata of the interface
+        @return: Return the vnet name of the interface if this interface belongs to a vnet,
+                 Otherwise return None
+        """
         if interface.has_key("vnet_name") and interface["vnet_name"]:
             return interface["vnet_name"]
         else:

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -296,7 +296,8 @@ class BGPPeerMgr(Manager):
             if "local_addr" not in data:
                 syslog.syslog(syslog.LOG_WARNING, 'Peer {}. Error in missing required attribute "local_addr"'.format(key))
             else:
-
+                # The route that belongs to a vnet cannot be advertised by the default BGP session.
+                # So we need to check whether this route belongs to a vnet.
                 local_addresses = self.directory.get_slot("local_addresses")
                 # Check if the information for the local address of this route has been set
                 # Which means we can find the interface for this route by its local address

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -306,7 +306,7 @@ class BGPPeerMgr(Manager):
                 return False
             elif target_interface.has_key("vnet_name") and target_interface["vnet_name"]:
                 # Ignore the route that is in a vnet
-                syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, data))
+                syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, target_interface["vnet_name"]))
                 return True
 
             neigmeta = self.directory.get_slot("neigmeta")

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -272,7 +272,8 @@ class BGPPeerMgr(Manager):
             [
                 ("meta", "localhost/bgp_asn"),
                 ("neigmeta", ""),
-                ("interface", "")
+                ("local_addresses", ""),
+                ("interfaces", ""),
             ],
             "CONFIG_DB",
             swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME
@@ -297,18 +298,19 @@ class BGPPeerMgr(Manager):
             else:
 
                 # Check if this route is belong to a vnet
-                interfaces = self.directory.get_slot("interface")
-                target_interface = None
-                for metadata in interfaces.values():
-                    if metadata["ip"] == data["local_addr"]:
-                        target_interface = metadata
-                        break
-                if target_interface is None:
+                local_addresses = self.directory.get_slot("local_addresses")
+                if data["local_addr"] not in local_addresses:
                     return False
-                elif target_interface.has_key("vnet_name") and target_interface["vnet_name"]:
-                    # Ignore the route that is in a vnet
-                    syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, target_interface["vnet_name"]))
-                    return True
+                local_address = local_addresses[data["local_addr"]]
+                interfaces = self.directory.get_slot("interfaces")
+                if local_address.has_key("interface") and local_address["interface"] in interfaces:
+                    interface = interfaces[local_address["interface"]]
+                    if interface.has_key("vnet_name") and interface["vnet_name"]:
+                        # Ignore the route that is in a vnet
+                        syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, interface["vnet_name"]))
+                        return True
+                else:
+                    return False
 
             neigmeta = self.directory.get_slot("neigmeta")
             if 'name' in data and data["name"] not in neigmeta:
@@ -430,33 +432,25 @@ class InterfaceMgr(Manager):
             "CONFIG_DB",
             interface_table
         )
-        self.interfaces = {}
 
     def set_handler(self, key, data):
-        # There are two entries for an interface in CFG_INTF_TABLE.
-        # One of them is to specify ip and prefix.
-        # In this case, the key contains '|', like "Ethernet0|192.168.0.6/30".
-        # Another one is to specify whether this interface belongs to a vnet
-        # In this case, the key only includes the interface name
         if '|' in key:
-            key, network = key.split('|', 1)
-            data["ip"] = prefix_attr("ip", network)
+            data = {}
+            data["interface"], network = key.split('|', 1)
             data["prefixlen"] = prefix_attr("prefixlen", network)
-
-        # Put the interface data into directory only if two entries have both been set
-        # Otherwise cache the first come entry
-        if key in self.interfaces:
-            self.interfaces[key].update(data)
-            self.directory.put("interface", key, self.interfaces[key])
-            del self.interfaces[key]
+            ip = prefix_attr("ip", network)
+            self.directory.put("local_addresses", ip, data)
         else:
-            self.interfaces[key] = data
+            self.directory.put("interfaces", key, data)
         return True
 
     def del_handler(self, key):
         if '|' in key:
-            key, _ = key.split('|', 1)
-        self.directory.remove("interface", key)
+            _, network = key.split('|', 1)
+            ip = prefix_attr("ip", network)
+            self.directory.remove("local_addresses", ip)
+        else:
+            self.directory.remove("interfaces", key)
 
 
 class LoopbackInterfaceMgr(InterfaceMgr):

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -300,6 +300,12 @@ class BGPPeerMgr(Manager):
                 # So we need to check whether this bgp session belongs to a vnet.
                 interface = InterfaceMgr.get_local_interface(self.directory, data["local_addr"])
                 if not interface:
+                    syslog.syslog(syslog.LOG_INFO,
+                            'Peer {} with local address {} wait for the corresponding interface to be set'.format(
+                                key,
+                                data["local_addr"]
+                            )
+                        )
                     return False
                 vnet = InterfaceMgr.get_vnet(interface)
                 if vnet:
@@ -316,6 +322,12 @@ class BGPPeerMgr(Manager):
 
             neigmeta = self.directory.get_slot("neigmeta")
             if 'name' in data and data["name"] not in neigmeta:
+                syslog.syslog(syslog.LOG_INFO,
+                        'Peer {} with neighbor name {} wait for the corresponding neighbor metadata to be set'.format(
+                            key,
+                            data["name"]
+                        )
+                    )
                 return False
             try:
                 cmd = self.templates["add"].render(

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -418,11 +418,8 @@ class InterfaceMgr(Manager):
         )
 
     def set_handler(self, key, data):
-        # There are two types of entries for an interface.
-        # One of them is to specify ip and prefix.
-        # In this case, the key contains '|', like "Ethernet0|192.168.0.6/30".
-        # Another one is to specify whether this interface belongs to a vnet
-        # In this case, the key only includes the interface name.
+        # Interface table can have two keys, 
+        # one with ip prefix and one without ip prefix
         if '|' in key:
             data = {}
             data["interface"], network = key.split('|', 1)

--- a/dockers/docker-fpm-frr/bgpcfgd
+++ b/dockers/docker-fpm-frr/bgpcfgd
@@ -297,14 +297,21 @@ class BGPPeerMgr(Manager):
                 syslog.syslog(syslog.LOG_WARNING, 'Peer {}. Error in missing required attribute "local_addr"'.format(key))
             else:
 
-                # Check if this route is belong to a vnet
                 local_addresses = self.directory.get_slot("local_addresses")
+                # Check if the information for the local address of this route has been set
+                # Which means we can find the interface for this route by its local address
+                # We can only process this route message when the local address was set
                 if data["local_addr"] not in local_addresses:
                     return False
                 local_address = local_addresses[data["local_addr"]]
                 interfaces = self.directory.get_slot("interfaces")
+                # Check if the information for the interface of this local address has set
+                # Which means we can determine whether this route belongs to a vnet
+                # Because the vnet name will be set in the interface
+                # Ref:https://github.com/Azure/SONiC/blob/master/doc/vxlan/Vxlan_hld.md#212-vnetinterface-table
                 if local_address.has_key("interface") and local_address["interface"] in interfaces:
                     interface = interfaces[local_address["interface"]]
+                    # Check if this route is belong to a vnet
                     if interface.has_key("vnet_name") and interface["vnet_name"]:
                         # Ignore the route that is in a vnet
                         syslog.syslog(syslog.LOG_INFO, 'Peer {} in vnet {}'.format(key, interface["vnet_name"]))
@@ -434,6 +441,11 @@ class InterfaceMgr(Manager):
         )
 
     def set_handler(self, key, data):
+        # There are two types of entries for an interface.
+        # One of them is to specify ip and prefix.
+        # In this case, the key contains '|', like "Ethernet0|192.168.0.6/30".
+        # Another one is to specify whether this interface belongs to a vnet
+        # In this case, the key only includes the interface name.
         if '|' in key:
             data = {}
             data["interface"], network = key.split('|', 1)

--- a/dockers/docker-fpm-frr/bgpd.peer.conf.j2
+++ b/dockers/docker-fpm-frr/bgpd.peer.conf.j2
@@ -26,8 +26,7 @@
     neighbor {{ neighbor_addr }} next-hop-self
 {% endif %}
 {% if  bgp_session["asn"] == DEVICE_METADATA['localhost']['bgp_asn']
-   and DEVICE_METADATA['localhost']['type'] == "SpineChassisFrontendRouter"
-   and (not bgp_session.has_key("local_addr") or bgp_session["local_addr"] not in interfaces_in_vnets) %}
+   and DEVICE_METADATA['localhost']['type'] == "SpineChassisFrontendRouter" %}
   address-family l2vpn evpn
     neighbor {{ neighbor_addr }} activate
     advertise-all-vni


### PR DESCRIPTION
**- What I did**
Fixes EVPN issue in FRR template to avoid the routes that belong to VNet are broadcasted by FRR.

**- How I did it**
Add interface manager in BGPCFGD daemon to separate the routes that belong to VNet or not according to interface table in config db.

**- How to verify it**
vtysh -c "show running-config"

**- Description for the changelog**
Fixes EVPN issue in FRR template to avoid the routes that belong to VNet are broadcasted by FRR.


**- A picture of a cute animal (not mandatory but encouraged)**
🦏

Signed-off-by: zegan <zegan@microsoft.com>