### PR TITLE
[ntp]: Add configuration to avoid ntpd from panic and exit

### DIFF
--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -5,6 +5,10 @@
 
 # /etc/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
 
+# To avoid ntpd from panic and exit if the drift betweeb new time and
+# current system time is large.
+tinker panic 0
+
 driftfile /var/lib/ntp/ntp.drift
 
 

--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -5,7 +5,7 @@
 
 # /etc/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
 
-# To avoid ntpd from panic and exit if the drift betweeb new time and
+# To avoid ntpd from panic and exit if the drift between new time and
 # current system time is large.
 tinker panic 0
 


### PR DESCRIPTION
**- What I did**
Add configuration to avoid ntpd from panic and exit if the drift between new time and current system time is large.
**- How I did it**
Added "tinker panic 0" in ntp.conf file.

**- How to verify it**
[this assumes that there is a valid NTP server IP in config_db/ntp.conf]
1. Change the current system time to a bad time with a large drift from time in ntp server; drift should be greater than 1000s.
2. Reboot the device.

Before the fix:
3. upon reboot, ntp-config service comes up fine, ntp service goes to active(exited) state without any error message. This is because the offset between new time (from ntp server) and the current system time is very large, ntpd goes to panic mode and exits. The system continues to show the bad time.

After the fix:
3. Upon reboot, ntp-config comes up fine, ntp services comes up from and stays in active (running)  state. The system clock gets synced with the ntp server time.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
