### PR TITLE
[NTP] Revert change in PR 2598

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -322,10 +322,6 @@ fi
 ## Disable kexec supported reboot which was installed by default
 sudo sed -i 's/LOAD_KEXEC=true/LOAD_KEXEC=false/' $FILESYSTEM_ROOT/etc/default/kexec
 
-## Modifty ntp default configuration: disable initial jump (add -x), and disable
-## jump when time difference is greater than 1000 seconds (remove -g).
-sudo sed -i "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/" $FILESYSTEM_ROOT/etc/default/ntp
-
 ## Remove sshd host keys, and will regenerate on first sshd start
 sudo rm -f $FILESYSTEM_ROOT/etc/ssh/ssh_host_*_key*
 sudo cp files/sshd/host-ssh-keygen.sh $FILESYSTEM_ROOT/usr/local/bin/


### PR DESCRIPTION
**- What I did**

We believe that the supervisord issue in face of clock rolling backwards
has been addressed. Therefore reverting change 2598 to allow ntp sync
to right clock at the start up time.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
