### PR TITLE
[sonic-cfggen] MGMT Interface configuration

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -64,6 +64,8 @@ iface {{ port }} inet6 dhcp
 iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     address {{ prefix | ip }}
     netmask {{ prefix | netmask if prefix | ipv4 else prefix | prefixlen }}
+    network {{ prefix | network }}
+    broadcast {{ prefix | broadcast }}
 {%     set vrf_table = 'default' %}
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
 {%     set vrf_table = '5000' %}

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -286,7 +286,7 @@ def main():
         env.filters['unique_name'] = unique_name
         env.filters['pfx_filter'] = pfx_filter
         env.filters['ip_network'] = ip_network
-        for attr in ['ip', 'network', 'prefixlen', 'netmask']:
+        for attr in ['ip', 'network', 'prefixlen', 'netmask', 'broadcast']:
             env.filters[attr] = partial(prefix_attr, attr)
         template = env.get_template(template_file)
         print(template.render(sort_data(data)))

--- a/src/sonic-config-engine/tests/sample_output/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/interfaces
@@ -12,6 +12,8 @@ auto eth0
 iface eth0 inet static
     address 10.0.0.100
     netmask 255.255.255.0
+    network 10.0.0.0
+    broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
     up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
@@ -24,6 +26,8 @@ iface eth0 inet static
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
+    network 2603:10e2:0:2902::
+    broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201

--- a/src/sonic-config-engine/tests/sample_output/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/mvrf_interfaces
@@ -21,6 +21,8 @@ auto eth0
 iface eth0 inet static
     address 10.0.0.100
     netmask 255.255.255.0
+    network 10.0.0.0
+    broadcast 10.0.0.255
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules
@@ -37,6 +39,8 @@ iface eth0 inet static
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
+    network 2603:10e2:0:2902::
+    broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules


### PR DESCRIPTION
update network and broadcast address in /etc/network/interfaces

Before:
root@sonic:/home/admin# ifconfig eth0
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.28.32.73  netmask 255.255.254.0  broadcast 0.0.0.0 <<<<<

After:
root@sonic:~# ifconfig eth0
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.28.32.73  netmask 255.255.254.0  broadcast 10.28.33.255 <<<<<

Signed-off-by: Antony Rheneus <arheneus@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
