### PR TITLE
[Monit] Delay start of monitoring for 5 minutes

### DIFF
--- a/files/image_config/monit/monitrc
+++ b/files/image_config/monit/monitrc
@@ -17,8 +17,9 @@
 ## Start Monit in the background (run as a daemon):
 #
   set daemon 60             # check services at 1-minute intervals
-#   with start delay 240    # optional: delay the first check by 4-minutes (by
-#                           # default Monit check immediately after Monit start)
+    with start delay 300    # we delay Monit to start monitoring for 5 minutes
+                            # intentionally such that all containers and processes
+                            # have ample time to start up.
 #
 #
 ## Set syslog logging. If you want to log to a standalone log file instead,


### PR DESCRIPTION
**- What I did**
We intentionally delay Monit to start monitoring for 5 minutes such that all containers and 
processes have ample time to start up. Doing this change can prevent Monit from 
generating error message such as no such container or process running.

**- How I did it**

**- How to verify it**


