### PR TITLE
[bug]Bug fix of sonic telemetry monitor.

### DIFF
--- a/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
+++ b/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
@@ -4,8 +4,8 @@
 ##  telemetry
 ##  dialout_client
 ###############################################################################
-check process telemetry matching "/usr/sbin/telemetry -logtostderr --insecure"
+check process telemetry matching "/usr/sbin/telemetry"
     if does not exist for 5 times within 5 cycles then alert
 
-check process dialout_client matching "/usr/sbin/dialout_client_cli -insecure -logtostderr"
+check process dialout_client matching "/usr/sbin/dialout_client_cli"
     if does not exist for 5 times within 5 cycles then alert


### PR DESCRIPTION
When telemetry is in secure mode ,the monitor will have error log  of the match string "--insecure". So I modify to be compatiable with insecure mode and secure mode.
