### PR TITLE
[Marvell] ARM64 Uboot Fit Image for Marvell SONIC image

### DIFF
--- a/platform/marvell-arm64/sonic_fit.its
+++ b/platform/marvell-arm64/sonic_fit.its
@@ -1,0 +1,55 @@
+/dts-v1/;
+  
+/ {
+    description = "U-Boot fitImage for SONIC Marvell Arm64";
+    #address-cells = <1>;
+  
+    images {
+        kernel@0 {
+            description = "Linux Kernel";
+            data = /incbin/("/boot/vmlinuz-4.9.0-9-2-arm64");
+            type = "kernel";
+            arch = "arm64";
+            os = "linux";
+            compression = "none";
+            load = <0x6000000>;
+            entry = <0x6000000>;
+            hash@1 {
+                algo = "sha1";
+            };
+        };
+        fdt@0 {
+            description = "Flattened Device Tree blob";
+            data = /incbin/("/boot/armada-7020-comexpress.dtb");
+            type = "flat_dt";
+            arch = "arm64";
+            compression = "none";
+            hash@1 {
+                algo = "sha1";
+            };
+        };
+        ramdisk@0 {
+            description = "ramdisk";
+            data = /incbin/("/boot/initrd.img-4.9.0-9-2-arm64");
+            type = "ramdisk";
+            arch = "arm64";
+            os = "linux";
+            compression = "gzip";
+            hash@1 {
+                algo = "sha1";
+            };
+        };
+    };
+    configurations {
+        default = "conf@1";
+        conf@1 {
+            description = "Boot Linux kernel with FDT blob + ramdisk";
+            kernel = "kernel@0";
+            fdt = "fdt@0";
+            ramdisk = "ramdisk@0";
+            hash@1 {
+                algo = "sha1";
+            };
+        };
+    };
+};


### PR DESCRIPTION
marvell sonic arm64 uboot fit flattened blob file. 
Used by uboot as refered in this change
https://github.com/Azure/sonic-buildimage/pull/4043/files#diff-f6372e5829e59e22aa068273c238ba83

Signed-off-by: Antony Rheneus <arheneus@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
