### PR TITLE
Rename the config.bcm due to that it just allow 1st row of TH2 to be …

### DIFF
--- a/device/accton/x86_64-accton_as7816_64x-r0/Accton-AS7816-64X/sai.profile
+++ b/device/accton/x86_64-accton_as7816_64x-r0/Accton-AS7816-64X/sai.profile
@@ -1,1 +1,1 @@
-SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th2-as7816-64x100G.config.bcm
+SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th2-as7816-64x25G-48x100G_row1.config.bcm

--- a/device/accton/x86_64-accton_as7816_64x-r0/Accton-AS7816-64X/th2-as7816-64x25G-48x100G_row1.config.bcm
+++ b/device/accton/x86_64-accton_as7816_64x-r0/Accton-AS7816-64X/th2-as7816-64x25G-48x100G_row1.config.bcm
@@ -26,20 +26,21 @@ max_vp_lags=0
 miim_intr_enable=0
 module_64ports=1
 oversubscribe_mode=1
+port_flex_enable=1
 
 #add loopback port
 # port 33 is the first loopback port
-portmap_33=260:10
+#portmap_33=260:10
 # port 66 is the first management port
-portmap_66=257:10
+#portmap_66=257:10
 # port 67 is the second loopback port
-portmap_67=261:10
+#portmap_67=261:10
 # port 100 is the second management port
-portmap_100=259:10
+#portmap_100=259:10
 # port 101 is the third loopback port
-portmap_101=262:10
+#portmap_101=262:10
 # port 135 is the fourth loopback port
-portmap_135=263:10
+#portmap_135=263:10
 
 #Port0
 #FC18


### PR DESCRIPTION
…breakout

- What I did
  1. Rename the config.bcm to th2-as7816-64x25G-48x100G_row1.config.bcm,
     due to that it just allow 1st row of TH2 to be breakout
  2. Add port_flex_enable to support dynamic port breakout.
  3. Remove the loopback port due to it would make syncd terminate.
     => The port_config.ini doesn't include the loopback ports.
        When portsorch start, it would compare the ports in SDK and port_config.ini.
        Portsorch would remove the loopback ports due to the loopback ports didn't been defined in port_config.ini
        But the broadcom SAI doesn't support remove port for th2.
        So it would return fail and syncd would terminate.

- How I did it

- How to verify it
  Run with the new SONiC image and syncd would not terminate

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
