### PR TITLE
Failed to create Broadcom RPC "syncd" container due to the duplicated "--net" options in the docker create command

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-rpc.mk
+++ b/platform/broadcom/docker-syncd-brcm-rpc.mk
@@ -18,7 +18,7 @@ SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_SYNCD_BRCM_RPC)
 endif
 
 $(DOCKER_SYNCD_BRCM_RPC)_CONTAINER_NAME = syncd
-$(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot
 $(DOCKER_SYNCD_BRCM_RPC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the error that Broadcom RPC syncd container cannot be created.
When starting the Broadcom RPC syncd container, the container cannot be created successfully. It is found the error messages shown below show up in the syslog.

```
Mar 16 09:04:02.301981 as7326-56x INFO syncd.sh[8513]: Creating new syncd container with HWSKU Accton-AS7326-56X
Mar 16 09:04:02.349861 as7326-56x INFO syncd.sh[8513]: docker: network "host" is specified multiple times.
Mar 16 09:04:02.350414 as7326-56x INFO syncd.sh[8513]: See 'docker create --help'.
Mar 16 09:04:02.354694 as7326-56x INFO syncd.sh[8513]: Failed to docker run
```

**- How I did it**
The content shown below is excerpted from the file "usr/bin/syncd.sh" on the DUT(i.e. AS7326-56X).
```
    docker create --net=host --privileged -t -v /host/machine.conf:/etc/machine.conf -v /host/warmboot:/var/warmboot -v /var/run/docker-syncd:/var/run/sswsyncd -v /etc/sonic:/etc/sonic:ro  \
        --net=$NET \
        --log-opt max-size=2M --log-opt max-file=5 \
        -v /var/run/redis:/var/run/redis:rw \
        -v /usr/share/sonic/device/$PLATFORM:/usr/share/sonic/platform:ro \
        -v /usr/share/sonic/device/$PLATFORM/$HWSKU:/usr/share/sonic/hwsku:ro \
        --tmpfs /tmp \
        --tmpfs /var/tmp \
        --name=syncd$DEV docker-syncd-brcm-rpc:latest || {
            echo "Failed to docker run" >&1
            exit 4
    }
```
It is found that there are two "--net" options for the "docker create" command which results in the failure.

In the file "files/build_templates/docker_image_ctl.j2", it adds the option
"--net" to the docker create command through the commit
"abe7ef7e2e2e1215c97cee19a83aab0b130cebe5" (#3856).

Remove the "--net" option in "docker-syncd-brcm-rpc.mk" to avoid
specifying duplicated "--net" options.

**- How to verify it**
After applying the commit in this PR, execute "make target/sonic-broadcom.bin ENABLE_SYNCD_RPC=y" to build the sonic image which contains "rpc" syncd. Install the sonic image on the AS7326-56X and observe whether the "syncd" container can be created without error.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Remove the "--net" option in "docker-syncd-brcm-rpc.mk" to avoid
specifying duplicated "--net" options.

**- A picture of a cute animal (not mandatory but encouraged)**
