### PR TITLE
[telemetry]: move default certs location from metadata to telemetry

### DIFF
--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -1,34 +1,46 @@
 #!/usr/bin/env bash
 
-# Try to read telemetry and x509 config from ConfigDB.
+# Try to read telemetry and certs config from ConfigDB.
 # Use default value if no valid config exists
 X509=`sonic-cfggen -d -v "DEVICE_METADATA['x509']"`
-TELEMETRY=`sonic-cfggen -d -v 'TELEMETRY.keys() | join(" ") if TELEMETRY'`
+gnmi=`sonic-cfggen -d -v "TELEMETRY['gnmi']"`
+certs=`sonic-cfggen -d -v "TELEMETRY['certs']"`
 
 TELEMETRY_ARGS=" -logtostderr"
 export CVL_SCHEMA_PATH=/usr/sbin/schema
 
-if [ -n "$X509" ]; then
-	SERVER_CRT=`sonic-cfggen -d -v "DEVICE_METADATA['x509']['server_crt']"`
-	SERVER_KEY=`sonic-cfggen -d -v "DEVICE_METADATA['x509']['server_key']"`
-	if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
-		TELEMETRY_ARGS+=" --insecure"
-	else
+if [ -n "$certs" ]; then
+    SERVER_CRT=`sonic-cfggen -d -v "TELEMETRY['certs']['server_crt']"`
+    SERVER_KEY=`sonic-cfggen -d -v "TELEMETRY['certs']['server_key']"`
+    if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
+        TELEMETRY_ARGS+=" --insecure"
+    else
         TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
-else
-	TELEMETRY_ARGS+=" --insecure"
-fi
 
-if [ -n "$X509" ]; then
-	CA_CRT=`sonic-cfggen -d -v "DEVICE_METADATA['x509']['ca_crt']"`
-	if [ ! -z $CA_CRT ]; then
-	    TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
-	fi
+    CA_CRT=`sonic-cfggen -d -v "TELEMETRY['certs']['ca_crt']"`
+    if [ ! -z $CA_CRT ]; then
+        TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
+    fi
+elif [ -n "$X509" ]; then
+    SERVER_CRT=`sonic-cfggen -d -v "DEVICE_METADATA['x509']['server_crt']"`
+    SERVER_KEY=`sonic-cfggen -d -v "DEVICE_METADATA['x509']['server_key']"`
+    if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
+        TELEMETRY_ARGS+=" --insecure"
+    else
+        TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
+    fi
+
+    CA_CRT=`sonic-cfggen -d -v "DEVICE_METADATA['x509']['ca_crt']"`
+    if [ ! -z $CA_CRT ]; then
+        TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
+    fi
+else
+    TELEMETRY_ARGS+=" --insecure"
 fi
 
 # If no configuration entry exists for TELEMETRY, create one default port
-if [ -z $TELEMETRY ]; then
+if [ -z "$gnmi" ]; then
     sonic-db-cli CONFIG_DB hset "TELEMETRY|gnmi" port 8080
 fi
 
@@ -37,14 +49,14 @@ TELEMETRY_ARGS+=" --port $PORT"
 
 CLIENT_AUTH=`sonic-cfggen -d -v "TELEMETRY['gnmi']['client_auth']"`
 if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
-	TELEMETRY_ARGS+=" --allow_no_client_auth"
+    TELEMETRY_ARGS+=" --allow_no_client_auth"
 fi
 
 LOG_LEVEL=`sonic-cfggen -d -v "TELEMETRY['gnmi']['log_level']"`
 if [ ! -z $LOG_LEVEL ]; then
-	TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
+    TELEMETRY_ARGS+=" -v=$LOG_LEVEL"
 else
-	TELEMETRY_ARGS+=" -v=2"
+    TELEMETRY_ARGS+=" -v=2"
 fi
 
 exec /usr/sbin/telemetry ${TELEMETRY_ARGS}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -636,11 +636,6 @@ def parse_xml(filename, platform=None, port_config_file=None):
         'hostname': hostname,
         'hwsku': hwsku,
         'type': current_device['type']
-        },
-        'x509': {
-            'server_crt': '/etc/sonic/telemetry/streamingtelemetryserver.cer',
-            'server_key': '/etc/sonic/telemetry/streamingtelemetryserver.key',
-            'ca_crt': '/etc/sonic/telemetry/dsmsroot.cer'
         }
     }
     results['BGP_NEIGHBOR'] = bgp_sessions
@@ -829,6 +824,11 @@ def parse_xml(filename, platform=None, port_config_file=None):
             'client_auth': 'true',
             'port': '50051',
             'log_level': '2'
+        },
+        'certs': {
+            'server_crt': '/etc/sonic/telemetry/streamingtelemetryserver.cer',
+            'server_key': '/etc/sonic/telemetry/streamingtelemetryserver.key',
+            'ca_crt': '/etc/sonic/telemetry/dsmsroot.cer'
         }
     }
 


### PR DESCRIPTION

maintains backward compatibility to search original x509 location
when telemetry table does not have certs

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
move default certs location from metadata to telemetry

**- How I did it**

**- How to verify it**
create certs in telemtry table and check

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
