### PR TITLE
Load port led FW for Silverstone!

### DIFF
--- a/device/celestica/x86_64-cel_silverstone-r0/led_proc_init.soc
+++ b/device/celestica/x86_64-cel_silverstone-r0/led_proc_init.soc
@@ -1,2 +1,7 @@
 #The Port LED of Silverstone SONIC can't work well, after the issue is fixed by SAI, The led will start. 
 #led auto on; led start
+linkscan off
+m0 load 0 0x3800 /usr/share/sonic/platform/custom.bin
+sleep 10
+led auto on; led start
+linkscan on


### PR DESCRIPTION
**- What I did**
Add port led FW load
**- How I did it**
load in led_proc_inic.soc
m0 load 0 0x3800 /usr/share/sonic/platform/custom.bin 
**- How to verify it**
Validatation in Silverstone by watching led status
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
