### PR TITLE
[build]: install cmake 3.13.2

### DIFF
--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -249,9 +249,6 @@ RUN apt-get update && apt-get install -y \
         python3-yaml \
 # For lockfile
         procmail \
-# For gtest
-        libgtest-dev \
-        cmake \
 # For pam_tacplus build
         autoconf-archive \
 # For iproute2
@@ -382,6 +379,21 @@ RUN apt-get install -y vim
 # Install rsyslog
 RUN apt-get install -y rsyslog
 
+RUN apt-get install -y libgtest-dev
+# Install cmake/cmake-data 3.13.2-1_bpo9+1
+# latest cmake 3.16.3 break the build libyang 1.0.73
+RUN wget -O cmake-data_3.13.2-1_bpo9+1_all.deb "https://sonicstorage.blob.core.windows.net/packages/cmake/cmake-data_3.13.2-1_bpo9%2B1_all.deb?st=2020-03-27T02%3A22%3A24Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=Xby%2Bm3OZOjPB%2FSlDbHD65yDcPzAgoys%2FA3vK8RB4BzA%3D"
+RUN dpkg -i cmake-data_3.13.2-1_bpo9+1_all.deb
+{% if CONFIGURED_ARCH == "armhf" %}
+RUN wget -O cmake_3.13.2-1_bpo9+1_armhf.deb "https://sonicstorage.blob.core.windows.net/packages/cmake/cmake_3.13.2-1_bpo9%2B1_armhf.deb?st=2020-03-27T02%3A29%3A41Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=sWt7kxrFumn020d2GeutGJ716cuQsFwmAmgU%2BJ0kqnk%3D"
+RUN dpkg -i cmake_3.13.2-1_bpo9+1_armhf.deb
+{% elif CONFIGURED_ARCH == "arm64" %}
+RUN wget -O cmake_3.13.2-1_bpo9+1_arm64.deb "https://sonicstorage.blob.core.windows.net/packages/cmake/cmake_3.13.2-1_bpo9%2B1_arm64.deb?st=2020-03-27T02%3A28%3A38Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=rrHMkLi29aI8yH6s52ILCY8VcEbNFrzYT2DmC5RwOgs%3D"
+RUN dpkg -i cmake_3.13.2-1_bpo9+1_arm64.deb
+{% else %}
+RUN wget -O cmake_3.13.2-1_bpo9+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/cmake/cmake_3.13.2-1_bpo9%2B1_amd64.deb?st=2020-03-27T02%3A27%3A21Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=4MvmmDBQuicFEJYakLm7xCNU19yJ8GIP4ankFSnITKY%3D"
+RUN dpkg -i cmake_3.13.2-1_bpo9+1_amd64.deb
+{% endif %}
 RUN cd /usr/src/gtest && cmake . && make -C /usr/src/gtest
 
 RUN mkdir /var/run/sshd

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -380,19 +380,21 @@ RUN apt-get install -y vim
 RUN apt-get install -y rsyslog
 
 RUN apt-get install -y libgtest-dev
+RUN apt-get install -y libarchive13 librhash0
+RUN apt-get -t stretch-backports install -y libuv1
 # Install cmake/cmake-data 3.13.2-1_bpo9+1
 # latest cmake 3.16.3 break the build libyang 1.0.73
 RUN wget -O cmake-data_3.13.2-1_bpo9+1_all.deb "https://sonicstorage.blob.core.windows.net/packages/cmake/cmake-data_3.13.2-1_bpo9%2B1_all.deb?st=2020-03-27T02%3A22%3A24Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=Xby%2Bm3OZOjPB%2FSlDbHD65yDcPzAgoys%2FA3vK8RB4BzA%3D"
-RUN dpkg -i cmake-data_3.13.2-1_bpo9+1_all.deb
+RUN dpkg -i cmake-data_3.13.2-1_bpo9+1_all.deb || apt-get install -f
 {% if CONFIGURED_ARCH == "armhf" %}
 RUN wget -O cmake_3.13.2-1_bpo9+1_armhf.deb "https://sonicstorage.blob.core.windows.net/packages/cmake/cmake_3.13.2-1_bpo9%2B1_armhf.deb?st=2020-03-27T02%3A29%3A41Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=sWt7kxrFumn020d2GeutGJ716cuQsFwmAmgU%2BJ0kqnk%3D"
-RUN dpkg -i cmake_3.13.2-1_bpo9+1_armhf.deb
+RUN dpkg -i cmake_3.13.2-1_bpo9+1_armhf.deb || apt-get install -f
 {% elif CONFIGURED_ARCH == "arm64" %}
 RUN wget -O cmake_3.13.2-1_bpo9+1_arm64.deb "https://sonicstorage.blob.core.windows.net/packages/cmake/cmake_3.13.2-1_bpo9%2B1_arm64.deb?st=2020-03-27T02%3A28%3A38Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=rrHMkLi29aI8yH6s52ILCY8VcEbNFrzYT2DmC5RwOgs%3D"
-RUN dpkg -i cmake_3.13.2-1_bpo9+1_arm64.deb
+RUN dpkg -i cmake_3.13.2-1_bpo9+1_arm64.deb || apt-get install -f
 {% else %}
 RUN wget -O cmake_3.13.2-1_bpo9+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/cmake/cmake_3.13.2-1_bpo9%2B1_amd64.deb?st=2020-03-27T02%3A27%3A21Z&se=2100-03-26T19%3A00%3A00Z&sp=rl&sv=2018-03-28&sr=b&sig=4MvmmDBQuicFEJYakLm7xCNU19yJ8GIP4ankFSnITKY%3D"
-RUN dpkg -i cmake_3.13.2-1_bpo9+1_amd64.deb
+RUN dpkg -i cmake_3.13.2-1_bpo9+1_amd64.deb || apt-get install -f
 {% endif %}
 RUN cd /usr/src/gtest && cmake . && make -C /usr/src/gtest
 


### PR DESCRIPTION
…-sloppy

- debhelper requires cmake (>= 3.9)
- cmake v13.6.3 requires libarchive13 (>= 3.3.3)
- libarchive13 (3.4.0-2~bpo9+1) is in stretch-backports-sloppy

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
locally build sonic-slave-stretch docker

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
