### PR TITLE
[pmon][barefoot] Disabled thermalctld pmon daemon

### DIFF
--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/pmon_daemon_control.json
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/pmon_daemon_control.json
@@ -1,4 +1,5 @@
 {
+    "skip_thermalctld": true,
     "skip_ledd": true,
     "skip_xcvrd": false,
     "skip_psud": false,

--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/pmon_daemon_control.json
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/pmon_daemon_control.json
@@ -1,4 +1,5 @@
 {
+    "skip_thermalctld": true,
     "skip_ledd": true,
     "skip_xcvrd": false,
     "skip_psud": false,


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <akokhan@barefootnetworks.com>


**- What I did**
To avoid errors in syslog, added thermalctld  exception into pmon_daemon_control.json
