### PR TITLE
[DellEMC] S6100-Fix i2C ISMT issue

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/fast-reboot_plugin
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/fast-reboot_plugin
@@ -4,3 +4,4 @@ if [[ -d /sys/devices/platform/SMF.512/hwmon/ ]]; then
     cd /sys/devices/platform/SMF.512/hwmon/*
     echo 0xcc > mb_poweron_reason
 fi
+/usr/local/bin/s6100_i2c_enumeration.sh deinit & > /dev/null

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/pcisysfs.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/pcisysfs.py
@@ -1,0 +1,91 @@
+#! /usr/bin/python
+
+import struct
+import sys
+import getopt
+from os import *
+from mmap import *
+
+def usage():
+   	''' This is the Usage Method '''
+
+   	print '\t\t pcisysfs.py  --get --offset <offset> --res <resource>'
+   	print '\t\t pcisysfs.py --set --val <val>  --offset <offset> --res <resource>'
+        sys.exit(1)
+
+def pci_mem_read(mm,offset):
+    mm.seek(offset)
+    read_data_stream=mm.read(4)
+    print ""
+    reg_val=struct.unpack('I',read_data_stream)
+    print "reg_val read:%x"%reg_val
+    return reg_val
+
+def pci_mem_write(mm,offset,data):
+    mm.seek(offset)
+    #print "data to write:%x"%data
+    mm.write(struct.pack('I',data))
+
+def pci_set_value(resource,val,offset):
+    fd=open(resource,O_RDWR)
+    mm=mmap(fd,0)
+    pci_mem_write(mm,offset,val)
+    close(fd)
+
+def pci_get_value(resource,offset):
+    fd=open(resource,O_RDWR)
+    mm=mmap(fd,0)
+    pci_mem_read(mm,offset)
+    close(fd)
+
+def main(argv):
+
+    ''' The main function will read the user input from the
+    command line argument and  process the request  '''
+
+    opts = ''
+    val = ''
+    choice = ''
+    resource = ''
+    offset = ''
+
+    try:
+        opts, args = getopt.getopt(argv, "hgsv:" , \
+        ["val=","res=","offset=","help", "get", "set"])
+	
+    except getopt.GetoptError:
+        usage()
+
+    for opt,arg in opts:
+
+        if opt in ('-h','--help'):
+            choice = 'help'
+
+        elif opt in ('-g', '--get'):
+            choice = 'get'
+
+        elif opt in ('-s', '--set'):
+            choice = 'set'
+
+        elif opt ==  '--res':
+            resource = arg
+
+        elif opt ==  '--val':
+            val = int(arg,16)
+
+        elif opt ==  '--offset':
+            offset = int(arg,16)
+
+    if choice == 'set' and val != '' and offset !='' and resource !='':
+        pci_set_value(resource,val,offset)
+
+    elif choice == 'get' and offset != '' and resource !='':
+        pci_get_value(resource,offset)
+
+    else:
+        usage()
+
+#Calling the main method
+if __name__ == "__main__":
+	main(sys.argv[1:])
+

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_bitbang_reset.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_bitbang_reset.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Script to unfreeze a stuck I2C controller, by bit-banging a STOP cycle on the bus
+
+bit_bang_recovery()
+{
+
+# Clear the ERRSTS
+pcisysfs.py --set --val 0xffffffff --offset 0x018 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+#Enable I2C bit-banging
+pcisysfs.py --set --val 0x80000000 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+while true;do
+    # Bit-bang an I2C STOP cycle
+
+    # SCL=0, SDA=0
+    pcisysfs.py --set --val 0x80000000 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+    sleep 0.01
+
+    # SCL=1, SDA=0
+    pcisysfs.py --set --val 0x80000002 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+    sleep 0.01
+
+    # SCL=1, SDA=1
+    pcisysfs.py --set --val 0x80000003 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+    sleep 1
+
+    # Check I2C DBSTS register
+    mctrl=$((`pcisysfs.py --get --offset 0x108 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+    msts=$((`pcisysfs.py --get --offset 0x10c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+    dbsts=$((`pcisysfs.py --get --offset 0x38c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+    msts_ip=$((msts&0x1))
+    
+    mctrl=$((10#$mctrl))
+    if [ $msts_ip = 0 ]; then
+	logger -p NOTICE "I2C_bitbang-Bit banging done on I2C bus"
+	logger -p NOTICE "After I2C_bitbang- MCTRL:$(printf "0x%x" $mctrl)","MSTS:$(printf "0x%x" $msts)","DBSTS:$(printf "0x%x" $dbsts)"
+	break
+    fi
+done
+
+#Disable I2C bit-banging
+pcisysfs.py --set --val 0x00000003 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+}
+
+mctrl=$((`pcisysfs.py --get --offset 0x108 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+msts=$((`pcisysfs.py --get --offset 0x10c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+dbsts=$((`pcisysfs.py --get --offset 0x38c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+logger -p NOTICE "Before I2C_bitbang- MCTRL:$(printf "0x%x" $mctrl)","MSTS:$(printf "0x%x" $msts)","DBSTS:$(printf "0x%x" $dbsts)"
+sleep 2
+bit_bang_recovery

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_bitbang_reset.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_bitbang_reset.sh
@@ -11,7 +11,9 @@ pcisysfs.py --set --val 0xffffffff --offset 0x018 --res /sys/devices/pci0000\:00
 #Enable I2C bit-banging
 pcisysfs.py --set --val 0x80000000 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
 
-while true;do
+count=1
+while [ $count -le 9 ];
+do
     # Bit-bang an I2C STOP cycle
 
     # SCL=0, SDA=0
@@ -41,6 +43,7 @@ while true;do
 	logger -p NOTICE "After I2C_bitbang- MCTRL:$(printf "0x%x" $mctrl)","MSTS:$(printf "0x%x" $msts)","DBSTS:$(printf "0x%x" $dbsts)"
 	break
     fi
+    count=$(( $count + 1 ))
 done
 
 #Disable I2C bit-banging

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_i2c_enumeration.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_i2c_enumeration.sh
@@ -245,6 +245,7 @@ if [[ "$1" == "init" ]]; then
     sys_eeprom "new_device"
     switch_board_eeprom "new_device"
     switch_board_cpld "new_device"
+    /usr/local/bin/s6100_bitbang_reset.sh
     switch_board_qsfp_mux "new_device"
     switch_board_sfp "new_device"
     switch_board_qsfp "new_device"


### PR DESCRIPTION
**- What I did**
Fixed "ismt_smbus 0000:00:13.0: completion wait timed out" issue in Dell S6100.

**- How I did it**
-I2C channels,MUX are not closed properly and data line is held by I2C slave devices.
-Do peripheral deinit before reboot.
-As a preventive measure, I2C bitbang  is done before attaching I2C devices.
-Log ISMT registers in syslog before and after applying bitbang.

**- How to verify it**
Run a script that does fastboot,warmboot,cold boot and power cycle continuously.
Test logs:
[ismt_logs.zip](https://github.com/Azure/sonic-buildimage/files/4442100/ismt_logs.zip)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
