### PR TITLE
[procdockerstatsd] Fix CMD field in dB

### DIFF
--- a/files/image_config/procdockerstatsd/procdockerstatsd
+++ b/files/image_config/procdockerstatsd/procdockerstatsd
@@ -41,8 +41,8 @@ class ProcDockerStats:
 
     def __init__(self):
         self.state_db = swsssdk.SonicV2Connector(host=REDIS_HOSTIP)
-        self.state_db.connect("STATE_DB") 
-    
+        self.state_db.connect("STATE_DB")
+
     def run_command(self, cmd):
         proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         (stdout, stderr) = proc.communicate()
@@ -75,7 +75,7 @@ class ProcDockerStats:
             # To remove extra space before UID
             val = list(filter(None, values1))
             # Merging extra columns created due to space in cmd ouput
-            val[8:] = [''.join(val[8:])] 
+            val[8:] = [' '.join(val[8:])]
             process_data = dict(zip(keylist, val))
             process_data_list.append(process_data)
         return process_data_list
@@ -109,10 +109,10 @@ class ProcDockerStats:
         for row in dict_list[0:]:
             cid = row.get('CONTAINER ID')
             if cid:
-                key = 'DOCKER_STATS|' + str(cid) 
+                key = 'DOCKER_STATS|' + str(cid)
                 dockerdict[key] = {}
                 dockerdict[key]['NAME'] = row.get('NAME')
-                
+
                 splitcol = row.get('CPU %')
                 cpu = re.split("%", str(splitcol))
                 dockerdict[key]['CPU%'] = str(cpu[0])
@@ -131,7 +131,7 @@ class ProcDockerStats:
                 netio = re.split(" / ", str(splitcol))
                 dockerdict[key]['NET_IN_BYTES'] = str(self.convert_to_bytes(netio[0]))
                 dockerdict[key]['NET_OUT_BYTES'] = str(self.convert_to_bytes(netio[1]))
-                
+
                 splitcol = row.get('BLOCK I/O')
                 blockio = re.split(" / ", str(splitcol))
                 dockerdict[key]['BLOCK_IN_BYTES'] = str(self.convert_to_bytes(blockio[0]))


### PR DESCRIPTION
* Fix the CMD for the PROCESSSTATS entries so that
  there is a space between the command name and the
  arguments.

Signed-off-by: Garrick He <garrick_he@dell.com>

**- What I did**
Fixed a minor issue in the procdockerstatsd script so there is a space between the command name and arguments in the CMD field for PROCESSSTATS entries

**- How I did it**
minor script fix

**- How to verify it**
See UT:
Picked a process with arguments from 'ps -ef'
`root     20897  8261  0 Mar23 pts/0    00:03:38 /usr/bin/buffermgrd -l /usr/share/sonic/hwsku/pg_profile_lookup.ini`

BEFORE FIX:
```
admin@sonic:~/procdockerstatd$ redis-cli -n 6 HGETALL "PROCESS_STATS|20897"
 1) "%MEM"
 2) "0.0"
 3) "STIME"
 4) "Mar23"
 5) "CMD"
 6) "/usr/bin/buffermgrd-l/usr/share/sonic/hwsku/pg_profile_lookup.ini"
 7) "TIME"
 8) "00:03:38"
 9) "UID"
10) "0"
11) "%CPU"
12) "0.0"
13) "PPID"
14) "8261"
15) "TT"
16) "pts/0"
admin@sonic:~/procdockerstatd$
```

AFTER FIX:
```
admin@sonic:~/procdockerstatd$ redis-cli -n 6 HGETALL "PROCESS_STATS|20897"
 1) "%MEM"
 2) "0.0"
 3) "STIME"
 4) "Mar23"
 5) "CMD"
 6) "/usr/bin/buffermgrd -l /usr/share/sonic/hwsku/pg_profile_lookup.ini"
 7) "TIME"
 8) "00:03:38"
 9) "UID"
10) "0"
11) "%CPU"
12) "0.0"
13) "PPID"
14) "8261"
15) "TT"
16) "pts/0"
admin@sonic:~/procdockerstatd$
```
**- Description for the changelog**
```
* Fix the CMD for the PROCESSSTATS entries so that
  there is a space between the command name and the
  arguments.
```
Signed-off-by: Garrick He <garrick_he@dell.com>


**- A picture of a cute animal (not mandatory but encouraged)**
