### PR TITLE
Log using /dev/log directly - no rsyslogd daemon inside container. DO NOT MERGE

### DIFF
--- a/dockers/docker-fpm-frr/start.sh
+++ b/dockers/docker-fpm-frr/start.sh
@@ -27,9 +27,9 @@ chmod 0755 /usr/sbin/bgp-unisolate
 mkdir -p /var/sonic
 echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status
 
-rm -f /var/run/rsyslogd.pid
+#rm -f /var/run/rsyslogd.pid
 
-supervisorctl start rsyslogd
+#supervisorctl start rsyslogd
 
 supervisorctl start bgpcfgd
 

--- a/dockers/docker-orchagent/start.sh
+++ b/dockers/docker-orchagent/start.sh
@@ -13,9 +13,9 @@ fi
 
 export platform=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
 
-rm -f /var/run/rsyslogd.pid
+#rm -f /var/run/rsyslogd.pid
 
-supervisorctl start rsyslogd
+#supervisorctl start rsyslogd
 
 supervisorctl start orchagent
 

--- a/platform/vs/README.gns3.md
+++ b/platform/vs/README.gns3.md
@@ -1,0 +1,17 @@
+HOWTO Create a GNS3 Appliance File (.gns3a)
+
+
+Execute the command sonic-gns3.sh
+
+
+For instance: 
+
+./sonic-gns3a.sh -h
+
+sonic-gns3a.sh [ -r <ReleaseNumber> ] -b <SONiC VS image: sonic-vs.image>
+e.g.: sonic-gns3a.sh -r 1.1 -b <store_path>/sonic-vs.img
+
+For more information about GNS3, please refer to:
+
+https://gns3.com/
+

--- a/platform/vs/sonic-gns3a.sh
+++ b/platform/vs/sonic-gns3a.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# This script creates a .gns3a SONiC appliance file
+IMGFILE="sonic-vs.image"
+RELEASE="latest"
+
+usage() {
+    echo "`basename $0` [ -r <ReleaseNumber> ] -b <SONiC VS image: sonic-vs.image>"
+    echo "e.g.: `basename $0` -r 1.1 -b <store_path>/sonic-vs.image"
+    exit 0
+}
+
+while getopts "r:b:h" arg; do
+  case $arg in
+    h)
+	usage
+	;;
+    r)
+	RELEASE=$OPTARG
+	;;
+    b)
+	IMGFILE=$OPTARG
+	;;
+  esac
+done
+
+if [ ! -e ${IMGFILE} ]; then
+    echo "ERROR: ${IMGFILE} not found"
+    exit 2
+fi
+
+
+MD5SUMIMGFILE=`md5sum  ${IMGFILE} | cut -f 1 -d " "`
+LENIMGFILE=`stat -c %s ${IMGFILE}`
+GNS3APPNAME="SONiC-${RELEASE}.gns3a"
+NAMEIMGFILE=`basename $IMGFILE`
+
+echo "
+{
+    \"name\": \"SONiC\",
+    \"category\": \"router\",
+    \"description\": \"SONiC Virtual Switch/Router\n\",
+    \"vendor_name\": \"SONiC\",
+    \"vendor_url\": \"https://azure.github.io/SONiC/\",
+    \"product_name\": \"SONiC\",
+    \"product_url\": \"https://azure.github.io/SONiC/\",
+    \"registry_version\": 3,
+    \"status\": \"experimental\",
+    \"maintainer\": \"SONiC\",
+    \"maintainer_email\": \"sonicproject@googlegroups.com\",
+    \"usage\": \"Supports SONiC release: ${RELEASE}\",
+    \"qemu\": {
+        \"adapter_type\": \"e1000\",
+        \"adapters\": 10,
+        \"ram\": 2048,
+        \"hda_disk_interface\": \"virtio\",
+        \"arch\": \"x86_64\",
+        \"console_type\": \"telnet\",
+        \"boot_priority\": \"d\",
+        \"kvm\": \"require\"
+    },
+    \"images\": [
+        {
+            \"filename\": \"${NAMEIMGFILE}\",
+            \"version\": \"${RELEASE}\",
+            \"md5sum\": \"${MD5SUMIMGFILE}\",
+            \"filesize\": ${LENIMGFILE}
+        }
+    ],
+    \"versions\": [
+        {
+            \"name\": \"${RELEASE}\",
+            \"images\": {
+                \"hda_disk_image\": \"${NAMEIMGFILE}\"
+            }
+        }
+    ]
+}
+
+" > ${GNS3APPNAME}
+

--- a/rules/docker-fpm-frr.mk
+++ b/rules/docker-fpm-frr.mk
@@ -25,6 +25,7 @@ $(DOCKER_FPM_FRR)_CONTAINER_NAME = bgp
 $(DOCKER_FPM_FRR)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/sonic/frr:/etc/frr:rw
+$(DOCKER_FPM_FRR)_RUN_OPT += -v /run/systemd/journal/dev-log:/dev/log:rw
 
 $(DOCKER_FPM_FRR)_BASE_IMAGE_FILES += vtysh:/usr/bin/vtysh
 $(DOCKER_FPM_FRR)_BASE_IMAGE_FILES += TSA:/usr/bin/TSA

--- a/rules/docker-orchagent.mk
+++ b/rules/docker-orchagent.mk
@@ -32,6 +32,8 @@ $(DOCKER_ORCHAGENT)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interf
 $(DOCKER_ORCHAGENT)_RUN_OPT += -v /host/machine.conf:/host/machine.conf:ro
 $(DOCKER_ORCHAGENT)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_ORCHAGENT)_RUN_OPT += -v /var/log/swss:/var/log/swss:rw
+$(DOCKER_ORCHAGENT)_RUN_OPT += -v /run/systemd/journal/dev-log:/dev/log:rw
+
 
 $(DOCKER_ORCHAGENT)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel
 $(DOCKER_ORCHAGENT)_FILES += $(ARP_UPDATE_SCRIPT) $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Bind mount host side  /run/systemd/journal/dev-log to container /dev/log 
**- How I did it**
N/A
**- How to verify it**
Run logger inside container (or verify logs from SWSS container, e.g. orchagent)
Restart rsyslog on host side: systemctl restart rsyslog
Verify that inode of /run/systemd/journal/dev-log does not change (ls -li)
"logger" inside container is still able to create log messages to the host side
Note that  /run/systemd/journal/dev-log is created by "init" - so it will not change, regardless of whether rsyslogd host side is restarted

root@sonic:/home/admin# netstat -pn | grep dev-log
unix  15     [ ]         DGRAM                    10082    1/init               /run/systemd/journal/dev-log

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
