### PR TITLE
Fix the error that 'sensord' daemon cannot be spawn correctly in pmon container

### DIFF
--- a/src/lm-sensors/0002-Patch-to-peform-dh_installinit-to-include-sensord.in.patch
+++ b/src/lm-sensors/0002-Patch-to-peform-dh_installinit-to-include-sensord.in.patch
@@ -1,0 +1,23 @@
+From b11fd3d516b62c01513d289bc901820aa150c63e Mon Sep 17 00:00:00 2001
+From: Charlie Chen <charlie_chen@edge-core.com>
+Date: Wed, 1 Apr 2020 06:59:06 +0000
+Subject: Patch to peform dh_installinit to include sensord.install in the
+ packed deb
+
+Signed-off-by: Charlie Chen <charlie_chen@edge-core.com>
+---
+ debian/rules | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/lm-sensors/lm-sensors-3.4.0/debian/rules b/src/lm-sensors/lm-sensors-3.4.0/debian/rules
+index 5ebda06..1d77e28 100755
+--- a/src/lm-sensors/lm-sensors-3.4.0/debian/rules
++++ b/src/lm-sensors/lm-sensors-3.4.0/debian/rules
+@@ -56,3 +56,4 @@ override_dh_auto_install-arch:
+ 
+ override_dh_installinit-arch:
+ 	dh_installinit -plm-sensors --no-start
++	dh_installinit -psensord --no-start
+-- 
+2.17.1
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
This commit fixes #4021 (Sensord not able to start up on  both master and 201911 branches)

**- What I did**
Investigate the reason that "sensord" cannot be spawned correctly through the execution of "service sensord start" in the file "lm-sensors.sh". It is found that the required init script for 'sensord' is missing in the pmon container. The required init script is not found in the built "sensord_3.4.0-4_amd64.deb" either.

**- How I did it**
Add the new patch file for "lm-sensors" to perform dh_installinit to include "sensord.init" in the packed deb. So that the missing init script file for 'sensord' will be included in the created 'sensord' deb.

**- How to verify it**
Execute "target/debs/stretch/sensord_3.4.0-4_amd64.deb" after applying this commit and upload the new "sensord_3.4.0-4_amd64.deb" to the pmon container on AS7712-32X. Execute "dpkg -i sensord_3.4.0-4_amd64.deb" in the pmon container.

Here is the output of 'ps -x' in the pmon container before installing the new 'sensord' deb.
```
root@sonic:~# ps x
  PID TTY      STAT   TIME COMMAND
    1 pts/0    Ss+    0:21 /usr/bin/python /usr/bin/supervisord
   56 pts/0    S      0:00 python /usr/bin/supervisor-proc-exit-listener
   61 pts/0    Sl    12:35 /usr/sbin/rsyslogd -n
   77 pts/0    S      0:36 /bin/bash /usr/sbin/fancontrol
  165 pts/0    Sl     2:54 /usr/bin/python /usr/bin/xcvrd
  174 pts/0    D      3:08 /usr/bin/python /usr/bin/psud
  186 pts/0    S      0:38 /usr/bin/python /usr/bin/syseepromd
  244 pts/0    D    142:28 /usr/bin/python /usr/bin/xcvrd
18499 pts/1    Ss     0:00 bash
18584 pts/0    S      0:00 sleep 10
18585 pts/1    R+     0:00 ps x
```
Here is the outout of the files under the directory '/etc/init.d' before and after installing the new 'sensord' deb in pmon container.
```
root@sonic:~# ls /etc/init.d
fancontrol  hwclock.sh  ipmievd  lm-sensors  procps  rsyslog  smartmontools
root@sonic:~# dpkg -i sensord_3.4.0-4_amd64.deb
(Reading database ... 11126 files and directories currently installed.)
Preparing to unpack sensord_3.4.0-4_amd64.deb ...
Unpacking sensord (1:3.4.0-4) over (1:3.4.0-4) ...
Setting up sensord (1:3.4.0-4) ...

Configuration file '/etc/default/sensord', does not exist on system.
Installing new config file as you requested.

Configuration file '/etc/init.d/sensord', does not exist on system.
Installing new config file as you requested.

root@sonic:~# ls /etc/init.d
fancontrol  hwclock.sh  ipmievd  lm-sensors  procps  rsyslog  sensord  smartmontools
```

Here is the output in the pmon container after reboot the DUT. It is found that "/usr/sbin/sensord" is running now.
```
root@sonic:/# ps x
  PID TTY      STAT   TIME COMMAND
    1 pts/0    Ss+    0:00 /usr/bin/python /usr/bin/supervisord
   59 pts/0    S      0:00 python /usr/bin/supervisor-proc-exit-listener
   64 pts/0    Sl     0:01 /usr/sbin/rsyslogd -n
   82 ?        Ss     0:00 /usr/sbin/sensord -f daemon
   83 pts/0    S      0:00 /bin/bash /usr/sbin/fancontrol
  171 pts/0    Sl     0:00 /usr/bin/python /usr/bin/xcvrd
  180 pts/0    D      0:00 /usr/bin/python /usr/bin/psud
  190 pts/0    S      0:00 /usr/bin/python /usr/bin/syseepromd
  250 pts/0    R      0:07 /usr/bin/python /usr/bin/xcvrd
  263 pts/1    Ss     0:00 bash
  273 pts/0    S      0:00 sleep 10
  275 pts/1    R+     0:00 ps x

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**