### PR TITLE
[Mellanox] update eeprom.py plugin

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/eeprom.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/eeprom.py
@@ -21,6 +21,7 @@ try:
     from cStringIO import StringIO
     from sonic_eeprom import eeprom_base
     from sonic_eeprom import eeprom_tlvinfo
+    from sonic_device_util import get_machine_info
     import subprocess
 except ImportError, e:
     raise ImportError (str(e) + "- required module not found")
@@ -34,6 +35,14 @@ def log_error(msg):
     syslog.syslog(syslog.LOG_ERR, msg)
     syslog.closelog()
 
+
+machine_info = get_machine_info()
+onie_platform = machine_info['onie_platform']
+if 'simx' in onie_platform:
+    platform_path = os.path.join('/usr/share/sonic/device', onie_platform)
+    subprocess.check_call(['/usr/bin/xxd', '-r', '-p', 'syseeprom.hex', 'syseeprom.bin'], cwd=platform_path)
+    CACHE_FILE = os.path.join(platform_path, 'syseeprom.bin')
+
 class board(eeprom_tlvinfo.TlvInfoDecoder):
 
     _TLV_INFO_MAX_LEN = 256
@@ -45,12 +54,12 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
                 time.sleep(1)
             else:
                 break  
-                      
+
         if not (os.path.exists(EEPROM_SYMLINK) or os.path.isfile(CACHE_FILE)):
             log_error("Nowhere to read syseeprom from! No symlink or cache file found")
             raise RuntimeError("No syseeprom symlink or cache file found")
 
-        self.eeprom_path = EEPROM_SYMLINK
+        self.eeprom_path = EEPROM_SYMLINK if 'simx' not in onie_platform else CACHE_FILE
         super(board, self).__init__(self.eeprom_path, 0, '', True)
 
     def decode_eeprom(self, e):
@@ -60,3 +69,4 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
         decode_output = sys.stdout.getvalue()
         sys.stdout = original_stdout
         print(decode_output.replace('\0', ''))
+


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add logic which makes plugin read eeprom from hexdump on Mellanox SimX.
This will eliminate the need to patch the hardware managment package, adding a mock of the eeprom.
For real switch there is no change.
**- How I did it**

**- How to verify it**

# decode-syseeprom
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
