### PR TITLE
[docker-base-stretch]: move common packages into docker-base-stretch

### DIFF
--- a/dockers/docker-base-stretch/Dockerfile.j2
+++ b/dockers/docker-base-stretch/Dockerfile.j2
@@ -54,7 +54,12 @@ RUN apt-get update &&        \
         libjemalloc1         \
         liblua5.1-0          \
         lua-bitop            \
-        lua-cjson
+        lua-cjson            \
+# common dependencies
+        libpython2.7         \
+        libdaemon0           \
+        libdbus-1-3          \
+        libjansson4
 
 # ip and ifconfig utility missing in docker for arm arch
 RUN apt-get -y install       \

--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -14,12 +14,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install required packages
 RUN apt-get update   && \
     apt-get install -y  \
-        libdbus-1-3     \
-        libdaemon0      \
-        libjansson4     \
         libc-ares2      \
         iproute2        \
-        libpython2.7    \
         libjson-c3      \
         logrotate       \
         libunwind8

--- a/dockers/docker-iccpd/Dockerfile.j2
+++ b/dockers/docker-iccpd/Dockerfile.j2
@@ -7,20 +7,8 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update      && \
-    apt-get install -f -y  \
-    libdbus-1-3            \
-    libdaemon0             \
-    libpython2.7           \
-    # Install redis-tools dependencies
-    # TODO: implicitly install dependencies
-    libatomic1             \
-    libjemalloc1           \
-    liblua5.1-0            \
-    lua-bitop              \
-    lua-cjson
-
-RUN apt-get -y install ebtables
+RUN RUN apt-get update && \
+        apt-get install -y ebtables
 RUN apt-get -y install -f kmod
 
 COPY \

--- a/dockers/docker-iccpd/Dockerfile.j2
+++ b/dockers/docker-iccpd/Dockerfile.j2
@@ -7,8 +7,8 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN RUN apt-get update && \
-        apt-get install -y ebtables
+RUN apt-get update && \
+    apt-get install -y ebtables
 RUN apt-get -y install -f kmod
 
 COPY \

--- a/dockers/docker-nat/Dockerfile.j2
+++ b/dockers/docker-nat/Dockerfile.j2
@@ -13,15 +13,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ## TODO: implicitly install dependencies
 RUN apt-get update        \
 && apt-get install -f -y \
-       libdbus-1-3       \
-       libdaemon0        \
-       libjansson4       \
-       libpython2.7      \
-       libatomic1        \
-       libjemalloc1      \
-       liblua5.1-0       \
-       lua-bitop         \
-       lua-cjson         \
        libelf1           \
        libmnl0           \
        bridge-utils      \

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -11,10 +11,6 @@ RUN apt-get update &&       \
     apt-get install -f -y   \
         ifupdown            \
         arping              \
-        libdbus-1-3         \
-        libdaemon0          \
-        libjansson4         \
-        libpython2.7        \
         iproute2            \
         ndisc6              \
         tcpdump             \

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -11,7 +11,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update &&   \
     apt-get install -y  \
         python-pip      \
-        libpython2.7    \
         ipmitool        \
         librrd8         \
         librrd-dev      \

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -7,11 +7,7 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update      && \
-    apt-get install -f -y  \
-        libdbus-1-3        \
-        libdaemon0         \
-        libjansson4
+RUN apt-get update
 
 {% if docker_sonic_telemetry_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -7,12 +7,7 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update      && \
-    apt-get install -f -y  \
-        libdbus-1-3        \
-        libdaemon0         \
-        libjansson4        \
-        libpython2.7
+RUN apt-get update
 
 {% if docker_teamd_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -27,18 +27,10 @@ RUN apt-get install -y net-tools \
                        libboost-thread1.62.0 \
                        libgmp10 \
                        libjudydebian1 \
-                       libdaemon0 \
-                       libjansson4 \
-                       libatomic1 \
-                       libjemalloc1 \
-                       liblua5.1-0 \
-                       lua-bitop  \
-                       lua-cjson \
                        openssh-client \
                        openssh-server \
                        libc-ares2 \
                        iproute \
-                       libpython2.7 \
                        grub2-common \
                        python-click-default-group \
                        python-click \


### PR DESCRIPTION
libpython2.7, libdaemon0, libdbus-1-3, libjansson4 are common
across different containers. move them into docker-base-stretch

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
