### PR TITLE
[docker-iccp]: do not mount kernel module into iccp container

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -231,9 +231,6 @@ start() {
 {%- if docker_container_name != "database" %}
         -v /usr/share/sonic/device/$PLATFORM/$HWSKU/$DEV:/usr/share/sonic/hwsku:ro \
 {%- endif %}
-{%- if docker_container_name == "iccpd" %}
-        -v /lib/modules:/lib/modules:ro \
-{%- endif %}
 {%- if sonic_asic_platform != "mellanox" %}
         --tmpfs /tmp \
 {%- endif %}
@@ -255,7 +252,7 @@ wait() {
 stop() {
     docker stop {{docker_container_name}}$DEV
 {%- if docker_container_name == "database" %}
-    if [ "$DEV" ]; then 
+    if [ "$DEV" ]; then
         ip netns delete "$NET_NS"
     fi
 {%- endif %}
@@ -266,7 +263,7 @@ DEV=$2 # namespace/device number to operate on
 if [ "$DEV" ]; then
     NET_NS="asic$DEV" #name of the network namespace
 else
-    NET_NS=""    
+    NET_NS=""
 fi
 
 case "$1" in


### PR DESCRIPTION
kernel module should be loaded outside container

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
