### PR TITLE
[sonic-netns-exec]: use "$@" to reflects all positional parameters as they were set initially 

### DIFF
--- a/files/scripts/sonic-netns-exec
+++ b/files/scripts/sonic-netns-exec
@@ -6,7 +6,7 @@
 NS="$1"
 shift
 if [ "$NS" != "" ]; then
-    ip netns exec $NS $@
+    ip netns exec $NS "$@"
 else
-    $@
+    "$@"
 fi

--- a/files/scripts/sonic-netns-exec
+++ b/files/scripts/sonic-netns-exec
@@ -5,7 +5,7 @@
 # sonic-netns-exec <namespace name> <command to be executed>
 NS="$1"
 shift
-if [ "$NS" != "" ]; then
+if [ ! -z "$NS" ]; then
     ip netns exec $NS "$@"
 else
     "$@"


### PR DESCRIPTION
Signed-off-by: SuvarnaMeenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
fixes https://github.com/Azure/sonic-buildimage/issues/4367
**- What I did**
*Issue:*
sonic-netns-exec fails to execute below command in swss.sh:
```
_function clean_up_tables()_
{
    sonic-netns-exec "$NET_NS" sonic-db-cli $1 EVAL "
    local tables = {$2}
    for i = 1, table.getn(tables) do
        local matches = redis.call('KEYS', tables[i])
        for j,name in ipairs(matches) do
            redis.call('DEL', name)
        end
    end" 0
}
```
This command fails with error " redis.exceptions.ResponseError: value is not an integer or out of range" .

*Root cause:*

When sonic-netns-exec executes the above function, argument passed to sonic-db-cli is NOT executed as a single script.

The argument is passed as separate keywords to sonic-db-cli, as below:
```
['EVAL', 'local', 'tables', '=', "{'PORT_TABLE*'}", 'for', 'i', '=', '1,', 'table.getn(tables)', 'do', 'local', 'matches', '=', "redis.call('KEYS',", 'tables[i])', 'for', 'j,name', 'in', 'ipairs(matches)', 'do', "redis.call('DEL',", 'name)', 'end', 'end', '0']
```

**- How I did it**
To make sure that the parameters are passed as they were set initially, fix sonic-netns-exec to use double quoted `"$@"`, where `"$@"` is `"$1" "$2" "$3" ... "${N}"`

After fix, the argument passed to sonic-db-cli is as below:

Argument passed to sonic-db-cli:
```
['EVAL', "\n    local tables = {'PORT_TABLE*'}\n    for i = 1, table.getn(tables) do\n        local matches = redis.call('KEYS', tables[i])\n        for j,name in ipairs(matches) do\n            redis.call('DEL', name)\n        end\n    end", '0']
```

**- How to verify it**
Load VS image and create vs testbed with T0 topology.
Do a config reload -y
Run test_announce_routes.py - this was failing before fix as vlan1000 interface was down, after fix this passes.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
