### PR TITLE
[device/accton] Fix Python error for wedge100bf_32x

### DIFF
--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/plugins/pltfm_mgr_rpc/__init__.py
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/plugins/pltfm_mgr_rpc/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['ttypes', 'constants', 'pltfm_mgr_rpc']
+__all__ = ['ttypes', 'pltfm_mgr_rpc']


### PR DESCRIPTION
Remove undefined export, "constants"