### PR TITLE
[Juniper QFX5210] Fix Python errors

### DIFF
--- a/platform/broadcom/sonic-platform-modules-juniper/qfx5210/utils/juniper_qfx5210_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-juniper/qfx5210/utils/juniper_qfx5210_monitor.py
@@ -587,7 +587,7 @@ class device_monitor(object):
             masterLED_file = open(MASTER_LED_PATH, 'r+')
         except IOError as e:
             logging.error('device_monitor: unable to open Master LED file: %s', str(e))
-            return False
+            return
         masterLED_file.write(str(master_led_value))
         masterLED_file.close() 
 
@@ -596,7 +596,7 @@ class device_monitor(object):
             systemLED_file = open(SYSTEM_LED_PATH, 'r+')
         except IOError as e:
             logging.error('device_monitor: unable to open System LED file: %s', str(e))
-            return False
+            return
         systemLED_file.write(str(system_led_value))
         systemLED_file.close() 
         pass

--- a/platform/broadcom/sonic-platform-modules-juniper/qfx5210/utils/juniper_qfx5210_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-juniper/qfx5210/utils/juniper_qfx5210_monitor.py
@@ -599,7 +599,6 @@ class device_monitor(object):
             return
         systemLED_file.write(str(system_led_value))
         systemLED_file.close() 
-        pass
 
     def manage_device(self):
         thermal = QFX5210_ThermalUtil()


### PR DESCRIPTION
- `__init__` method cannot return a value
- Also remove unnecessary 'pass' statement