### PR TITLE
SONiC configuration migration enhancements

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -42,6 +42,7 @@ LINUX_KERNEL_VERSION=4.9.0-11-2
 ## Working directory to prepare the file system
 FILESYSTEM_ROOT=./fsroot
 PLATFORM_DIR=platform
+export INSTALLER_MIGRATION_HOOKS=installer-migration-hooks
 ## Hostname for the linux image
 HOSTNAME=sonic
 DEFAULT_USERINFO="Default admin user,,,"
@@ -66,6 +67,7 @@ if [[ -d $FILESYSTEM_ROOT ]]; then
     sudo rm -rf $FILESYSTEM_ROOT || die "Failed to clean chroot directory"
 fi
 mkdir -p $FILESYSTEM_ROOT
+mkdir -p $FILESYSTEM_ROOT/$INSTALLER_MIGRATION_HOOKS
 mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR
 mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/x86_64-grub
 touch $FILESYSTEM_ROOT/$PLATFORM_DIR/firsttime
@@ -558,11 +560,11 @@ sudo rm -f $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS
 ## Note: -x to skip directories on different file systems, such as /proc
 sudo du -hsx $FILESYSTEM_ROOT
 sudo mkdir -p $FILESYSTEM_ROOT/var/lib/docker
-sudo mksquashfs $FILESYSTEM_ROOT $FILESYSTEM_SQUASHFS -e boot -e var/lib/docker -e $PLATFORM_DIR
+sudo mksquashfs $FILESYSTEM_ROOT $FILESYSTEM_SQUASHFS -e boot -e var/lib/docker -e $PLATFORM_DIR -e $INSTALLER_MIGRATION_HOOKS
 
 ## Compress docker files
 pushd $FILESYSTEM_ROOT && sudo tar czf $OLDPWD/$FILESYSTEM_DOCKERFS -C ${DOCKERFS_PATH}var/lib/docker .; popd
 
-## Compress together with /boot, /var/lib/docker and $PLATFORM_DIR as an installer payload zip file
-pushd $FILESYSTEM_ROOT && sudo zip $OLDPWD/$ONIE_INSTALLER_PAYLOAD -r boot/ $PLATFORM_DIR/; popd
+## Compress together with /boot, /var/lib/docker $PLATFORM_DIR and $INSTALLER_MIGRATION_HOOKS as an installer payload zip file
+pushd $FILESYSTEM_ROOT && sudo zip $OLDPWD/$ONIE_INSTALLER_PAYLOAD -r boot/ $PLATFORM_DIR/ $INSTALLER_MIGRATION_HOOKS; popd
 sudo zip -g $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS $FILESYSTEM_DOCKERFS

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -287,6 +287,32 @@ sudo cp $IMAGE_CONFIGS/config-setup/config-setup $FILESYSTEM_ROOT/usr/bin/config
 echo "config-setup.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable config-setup.service
 
+# Copy config migration hooks
+sudo mkdir -p $FILESYSTEM_ROOT/etc/config-setup/config-migration-pre-hooks.d
+if [ -d $IMAGE_CONFIGS/config-setup/migration-hooks-pre ]; then
+    sudo cp $IMAGE_CONFIGS/config-setup/migration-hooks-pre/*  $FILESYSTEM_ROOT/etc/config-setup/config-migration-pre-hooks.d/
+fi
+sudo mkdir -p $FILESYSTEM_ROOT/etc/config-setup/config-migration-post-hooks.d
+if [ -d $IMAGE_CONFIGS/config-setup/migration-hooks-post ]; then
+    sudo cp $IMAGE_CONFIGS/config-setup/migration-hooks-post/*  $FILESYSTEM_ROOT/etc/config-setup/config-migration-post-hooks.d/
+fi
+if [ ! -z $INSTALLER_MIGRATION_HOOKS ] && [ -d $IMAGE_CONFIGS/config-setup/$INSTALLER_MIGRATION_HOOKS ]; then
+    sudo cp $IMAGE_CONFIGS/config-setup/$INSTALLER_MIGRATION_HOOKS/*  $FILESYSTEM_ROOT/$INSTALLER_MIGRATION_HOOKS/
+fi
+
+for hook_dir in $FILESYSTEM_ROOT/etc/config-setup/config-migration-pre-hooks.d \
+                $FILESYSTEM_ROOT/etc/config-setup/config-migration-post-hooks.d \
+                $FILESYSTEM_ROOT/$INSTALLER_MIGRATION_HOOKS ; do
+    if [ -d $hook_dir ]; then
+        for hook in $(ls -1 $hook_dir/*.j2); do
+            hook_full_filename=$(basename $hook)
+            hook_file="${hook_full_filename%.*}"
+            j2 $hook | sudo tee $hook_dir/$hook_file
+            sudo rm -f $hook
+        done
+    fi
+done
+
 # Copy SNMP configuration files
 sudo cp $IMAGE_CONFIGS/snmp/snmp.yml $FILESYSTEM_ROOT/etc/sonic/
 

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -33,7 +33,10 @@ FACTORY_DEFAULT_HOOKS=/etc/config-setup/factory-default-hooks.d
 CONFIG_PRE_MIGRATION_HOOKS=/etc/config-setup/config-migration-pre-hooks.d
 CONFIG_POST_MIGRATION_HOOKS=/etc/config-setup/config-migration-post-hooks.d
 CONFIG_SETUP_VAR_DIR=/var/lib/config-setup
+CONFIG_SETUP_TMP_DIR=/var/run/config-setup
+CONFIG_PRE_INSTALLER_MIGRATION_HOOKS=${CONFIG_SETUP_TMP_DIR}/installer-migration-hooks
 CONFIG_SETUP_PRE_MIGRATION_FLAG=${CONFIG_SETUP_VAR_DIR}/pending_pre_migration
+CONFIG_PRE_INSTALLER_MIGRATION_FLAG=${CONFIG_SETUP_VAR_DIR}/pending_pre_installer_migration
 CONFIG_SETUP_POST_MIGRATION_FLAG=${CONFIG_SETUP_VAR_DIR}/pending_post_migration
 CONFIG_SETUP_INITIALIZATION_FLAG=${CONFIG_SETUP_VAR_DIR}/pending_initialization
 
@@ -247,7 +250,7 @@ generate_config()
 #    is created
 #  - If updategraph is enabled and ZTP is disabled, updategraph initializes
 #    configuration
-do_config_intialization()
+do_config_initialization()
 {
     if  ! updategraph_is_enabled ; then
         if ! ztp_is_enabled ; then
@@ -259,6 +262,10 @@ do_config_intialization()
 
     if  ztp_is_enabled ; then
         echo "No configuration detected, initiating zero touch provisioning..."
+        # Generate and load factory default configuration
+        generate_config factory ${CONFIG_DB_JSON}
+        # Remove any default configuration that was created so that ZTP can be performed
+        rm -f ${CONFIG_DB_JSON}
         generate_config ztp ${TMP_ZTP_CONFIG_DB_JSON}
         load_config ${TMP_ZTP_CONFIG_DB_JSON}
         rm -f ${TMP_ZTP_CONFIG_DB_JSON}
@@ -267,15 +274,28 @@ do_config_intialization()
     rm -f /tmp/pending_config_initialization
 }
 
-# Restore config-setup post migration hooks from a backup copy
-copy_post_migration_hooks()
+# Restore config-setup migration hooks from a backup copy. If the current image has a hook script
+# with the same filename as the backup hook being restored, it will not be overwritten.
+copy_migration_hooks()
 {
     BACKUP_DIR=/etc/sonic/old_config/config-migration-post-hooks.d
     if [ -d ${BACKUP_DIR} ]; then
         [ -d ${CONFIG_POST_MIGRATION_HOOKS} ] || mkdir -p ${CONFIG_POST_MIGRATION_HOOKS}
         for hook in $(ls -1 ${BACKUP_DIR}) ; do
+            # Copy the hook script only if it is not present in the destination directory
             if [ ! -e ${CONFIG_POST_MIGRATION_HOOKS}/$hook ]; then
                 cp -ar ${BACKUP_DIR}/$hook ${CONFIG_POST_MIGRATION_HOOKS}
+            fi
+        done
+    fi
+
+    BACKUP_DIR=/etc/sonic/old_config/config-migration-pre-hooks.d
+    if [ -d ${BACKUP_DIR} ]; then
+        [ -d ${CONFIG_PRE_MIGRATION_HOOKS} ] || mkdir -p ${CONFIG_PRE_MIGRATION_HOOKS}
+        for hook in $(ls -1 ${BACKUP_DIR}) ; do
+            # Copy the hook script only if it is not present in the destination directory
+            if [ ! -e ${CONFIG_PRE_MIGRATION_HOOKS}/$hook ]; then
+                cp -ar ${BACKUP_DIR}/$hook ${CONFIG_PRE_MIGRATION_HOOKS}
             fi
         done
     fi
@@ -291,8 +311,8 @@ do_config_migration()
     # Migrate all configuration files from old to new
     copy_config_files_and_directories $copy_list
 
-    # Migrate post-migration hooks
-    copy_post_migration_hooks
+    # Migrate migration hooks
+    copy_migration_hooks
 
     # Execute custom hooks if present
     run_hookdir ${CONFIG_POST_MIGRATION_HOOKS} ${CONFIG_SETUP_POST_MIGRATION_FLAG}
@@ -331,9 +351,19 @@ do_config_backup()
     rm -rf /host/old_config
     cp -ar /etc/sonic /host/old_config
     [ -d ${CONFIG_POST_MIGRATION_HOOKS} ] && cp -arL ${CONFIG_POST_MIGRATION_HOOKS} /host/old_config
+    [ -d ${CONFIG_PRE_MIGRATION_HOOKS} ] && cp -arL ${CONFIG_PRE_MIGRATION_HOOKS} /host/old_config
 
-    # Execute custom hooks if present
+    # Execute custom pre hooks if present
     run_hookdir ${CONFIG_PRE_MIGRATION_HOOKS} ${CONFIG_SETUP_PRE_MIGRATION_FLAG}
+    # Execute installer hooks that are copied over by the SONiC installer image
+    if [ -d ${CONFIG_PRE_INSTALLER_MIGRATION_HOOKS} ]; then
+        run_hookdir ${CONFIG_PRE_INSTALLER_MIGRATION_HOOKS} ${CONFIG_PRE_INSTALLER_MIGRATION_FLAG}
+    else
+        # Execute installer hooks that are included along with the current image version
+        SONIC_VERSION=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version)
+        CONFIG_PRE_INSTALLER_MIGRATION_HOOKS_ON_DISK="/host/image-${SONIC_VERSION}/installer-migration-hooks"
+        run_hookdir ${CONFIG_PRE_INSTALLER_MIGRATION_HOOKS_ON_DISK} ${CONFIG_PRE_INSTALLER_MIGRATION_FLAG}
+    fi
 }
 
 # Process switch bootup event
@@ -350,12 +380,12 @@ boot_config()
     fi
 
     if [ -e /tmp/pending_config_initialization ] || [ -e  ${CONFIG_SETUP_INITIALIZATION_FLAG} ]; then
-        do_config_intialization
+        do_config_initialization
     fi
 
     # If no startup configuration is found, create a configuration to be used
     if [ ! -e ${CONFIG_DB_JSON} ]; then
-        do_config_intialization
+        do_config_initialization
         # force ZTP to restart
         if  ztp_is_enabled ; then
             ztp_status=$(ztp status -c)

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -494,6 +494,12 @@ else
     unzip -op $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
 fi
 
+if [ "$install_env" != "onie" ] && [ -d $demo_mnt/$image_dir/$INSTALLER_MIGRATION_HOOKS ]; then
+    rm -rf /var/run/config-setup/$INSTALLER_MIGRATION_HOOKS
+    mkdir -p /var/run/config-setup
+    cp -Rvf $demo_mnt/$image_dir/$INSTALLER_MIGRATION_HOOKS /var/run/config-setup
+fi
+
 if [ "$install_env" = "onie" ]; then
     # Store machine description in target file system
     if [ -f /etc/machine-build.conf ]; then

--- a/onie-image-arm64.conf
+++ b/onie-image-arm64.conf
@@ -21,6 +21,9 @@ ONIE_INSTALLER_PAYLOAD=fs.zip
 ## Filename for docker file system 
 FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 
+## Directory containing configuration migration hooks that are part of the onie installer
+INSTALLER_MIGRATION_HOOKS=installer-migration-hooks
+
 ## docker directory on the root filesystem
 DOCKERFS_DIR=docker
 

--- a/onie-image-armhf.conf
+++ b/onie-image-armhf.conf
@@ -21,6 +21,9 @@ ONIE_INSTALLER_PAYLOAD=fs.zip
 ## Filename for docker file system 
 FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 
+## Directory containing configuration migration hooks that are part of the onie installer
+INSTALLER_MIGRATION_HOOKS=installer-migration-hooks
+
 ## docker directory on the root filesystem
 DOCKERFS_DIR=docker
 

--- a/onie-image.conf
+++ b/onie-image.conf
@@ -21,6 +21,9 @@ ONIE_INSTALLER_PAYLOAD=fs.zip
 ## Filename for docker file system 
 FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 
+## Directory containing configuration migration hooks that are part of the onie installer
+INSTALLER_MIGRATION_HOOKS=installer-migration-hooks
+
 ## docker directory on the root filesystem
 DOCKERFS_DIR=docker
 


### PR DESCRIPTION
The following new features are being added to the config-setup service:
1. Provide a second set of configuration pre hooks as part of the installer
image. This allows the user to fix issues caused by the migration-pre
scripts already installed on the switch.

2. Both the config-migration-pre and config-migration-post are migrated to
the newly installed image. This allows end user installed scripts to be
carried over to the newly installed image automatically to make it easier
for subsequent configuration migrations.

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Implemented new features as defined in https://github.com/Azure/SONiC/pull/590

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
