### PR TITLE
[device] Remove linkscan_led_fw.bin file on as7326_56x

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/led_proc_init.soc
+++ b/device/accton/x86_64-accton_as7326_56x-r0/led_proc_init.soc
@@ -1,6 +1,6 @@
 #led auto off
 #led stop
-m0 load 0 0x0 /usr/share/sonic/platform/linkscan_led_fw.bin
+#m0 load 0 0x0 /usr/share/sonic/platform/linkscan_led_fw.bin
 m0 load 0 0x3800 /usr/share/sonic/platform/custom_led.bin
 led auto on
 led start


### PR DESCRIPTION
Signed-off-by: derek_sun derek_sun@edge-core.com

**- What I did**
No execute linkscan LED binary files.

**- How I did it**
Remove linkscan_led_fw.bin command line in led_proc_init.soc file.

**- How to verify it**
1) Broadcom shell command: led and led status
2) Front port LED checking.
3) Broadcom shell command: ps
    checking port link-up status.

**- Description for the changelog**
Modify led_proc_init.soc for led linkscan procedure on as7326_56x.

**- A picture of a cute animal (not mandatory but encouraged)**