### PR TITLE
[201911][Juniper QFX5210] Fix Python errors

### DIFF
--- a/platform/broadcom/sonic-platform-modules-juniper/qfx5210/utils/juniper_qfx5210_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-juniper/qfx5210/utils/juniper_qfx5210_monitor.py
@@ -468,7 +468,7 @@ class device_monitor(object):
             masterLED_file = open(MASTER_LED_PATH, 'r+')
         except IOError as e:
             print "Error: unable to open file: %s" % str(e)
-            return False
+            return
         masterLED_file.write(str(master_led_value))
         masterLED_file.close() 
 
@@ -477,10 +477,9 @@ class device_monitor(object):
             systemLED_file = open(SYSTEM_LED_PATH, 'r+')
         except IOError as e:
             print "Error: unable to open file: %s" % str(e)
-            return False
+            return
         systemLED_file.write(str(system_led_value))
         systemLED_file.close() 
-        pass
 
     def manage_device(self):
         thermal = QFX5210_ThermalUtil()


### PR DESCRIPTION
- Backport of https://github.com/Azure/sonic-buildimage/pull/4394 for the 201911 branch
- `__init__` method cannot return a value
- Also remove unnecessary 'pass' statement