### PR TITLE
Enable ipv6 for namespaces in multi-npu system

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -74,6 +74,7 @@ function postStartAction()
 {
 {%- if docker_container_name == "database" %}
     if [ "$DEV" ]; then
+        docker exec -i database$DEV sysctl -w net.ipv6.conf.all.disable_ipv6=0
         link_namespace $DEV
     fi
     # Wait until redis starts


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enable ipv6 in Kernel when dockers are in bridge network. This is applicable for multi-npu platforms.

**- How I did it**

**- How to verify it**
Verify ipv6 is enabled in kernel on single and multi NPU VS platforms.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
