### PR TITLE
[grub]: use UUID for root partition

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -592,10 +592,12 @@ if [ "$install_env" = "sonic" ]; then
     onie_menuentry=$(cat /host/grub/grub.cfg | sed "/menuentry ONIE/,/}/!d")
 elif [ "$install_env" = "build" ]; then
     grub_cfg_root=%%SONIC_ROOT%%
-else
-    grub_cfg_root=$(blkid "$demo_dev" | grep -oE "[[:blank:]]UUID=\".*\"" | sed s/\"//g | sed s/\ //g)
-    if [ -z "$grub_cfg_root" ]; then
+else # install_env = "onie"
+    uuid=$(blkid "$demo_dev" | sed -ne 's/.* UUID=\"\([^"]*\)\".*/\1/p')
+    if [ -z "$uuid" ]; then
         grub_cfg_root=$demo_dev
+    else
+        grub_cfg_root=UUID=$uuid
     fi
 fi
 


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
```

                             GNU GRUB  version 2.02

 +----------------------------------------------------------------------------+
 |        insmod part_msdos                                                   |^
 |        insmod ext2                                                         |
 |        linux   /image-uuid.0-dirty-20200418.115911/boot/vmlinuz-4.19.0-6-a\|
 |md64 root=UUID=0530e631-21fa-4707-bbf0-6100631556e3 rw console=tty0 console\|
 |=ttyS0,115200n8 quiet                  net.ifnames=0 biosdevname=0         \|
 |        loop=image-uuid.0-dirty-20200418.115911/fs.squashfs loopfstype=squa\|
 |shfs                                       apparmor=1 security=apparmor var\|
 |log_size=4096 usbcore.autosuspend=-1                                        |
 |        echo    'Loading SONiC-OS OS initial ramdisk ...'                   |
 |        initrd  /image-uuid.0-dirty-20200418.115911/boot/initrd.img-4.19.0-\|
 |6-amd64                                                                     |
 |                                                                            | 
 +----------------------------------------------------------------------------+

```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
