### PR TITLE
[PMON] Extend pmon daemon start control to lm-sensors and fancontrol

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
@@ -1,4 +1,5 @@
 {
-    "skip_ledd": true
+    "skip_ledd": true,
+    "skip_fancontrol": true
 }
 

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -45,6 +45,7 @@ autostart=false
 autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
+startsecs=10
 {% endif %}
 
 {% if not skip_ledd %}

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -26,6 +26,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
+{% if not skip_sensors %}
 [program:lm-sensors]
 command=/usr/bin/lm-sensors.sh
 priority=3
@@ -34,7 +35,9 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=0
+{% endif %}
 
+{% if not skip_fancontrol %}
 [program:fancontrol]
 command=/usr/sbin/fancontrol
 priority=4
@@ -42,7 +45,7 @@ autostart=false
 autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=10
+{% endif %}
 
 {% if not skip_ledd %}
 [program:ledd]

--- a/dockers/docker-platform-monitor/start.sh.j2
+++ b/dockers/docker-platform-monitor/start.sh.j2
@@ -19,6 +19,7 @@ if [ -e /usr/share/sonic/platform/platform_wait ]; then
     fi
 fi
 
+{% if not skip_sensors %}
 # If this platform has an lm-sensors config file, copy it to it's proper place
 # and start lm-sensors
 if [ -e /usr/share/sonic/platform/sensors.conf ]; then
@@ -26,7 +27,9 @@ if [ -e /usr/share/sonic/platform/sensors.conf ]; then
     /bin/cp -f /usr/share/sonic/platform/sensors.conf /etc/sensors.d/
     supervisorctl start lm-sensors
 fi
+{% endif %}
 
+{% if not skip_fancontrol %}
 # If this platform has a fancontrol config file, copy it to it's proper place
 # and start fancontrol
 if [ -e /usr/share/sonic/platform/fancontrol ]; then
@@ -36,6 +39,7 @@ if [ -e /usr/share/sonic/platform/fancontrol ]; then
     /bin/cp -f /usr/share/sonic/platform/fancontrol /etc/
     supervisorctl start fancontrol
 fi
+{% endif %}
 
 
 # If the sonic-platform package is not installed, try to install it


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Extend the PMON daemon start control to lm-sensors and fancontrol.

**- How I did it**
change template docker-pmon.supervisord.conf.j2 and start.sh.j2 to have lm-sensors and fancontrol start scripts and supervisord config file controlled by pmon_daemon_control.json.

the intention is to avoid wrong daemon status in "supervisorctl status" output. For example, on some platform, if there is no fancontrol config file, and it is not ruled out from supervisord conf file and start.sh, we'll see fancontrol in "STOPPED" status from "supervisorctl status" output, which will violate some check in the platform test(check daemon status as expected)

**- How to verify it**
check "supervisorctl status"  inside PMON

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
