### PR TITLE
[kvm]: disable pmon daemons on kvm vs platform

### DIFF
--- a/device/virtual/x86_64-kvm_x86_64-r0/pmon_daemon_control.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/pmon_daemon_control.json
@@ -1,0 +1,7 @@
+{
+    "skip_ledd": true,
+    "skip_xcvrd": true,
+    "skip_psud": true,
+    "skip_syseepromd": true,
+    "skip_thermalctld": true
+}


### PR DESCRIPTION
hardware daemons are not supported in kvm vs platform now

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why do I do it**
hardware daemons are not supported in kvm vs platform now

**- How I did it**
add `pmon_daemon_control.json` for kvm vs platform.

**- How to verify it**
```
admin@vlab-01:/usr/share/sonic/device/x86_64-kvm_x86_64-r0$ docker exec -it pmon bash   
root@vlab-01:/# supervisorctl status
fancontrol                       STOPPED   Not started
lm-sensors                       STOPPED   Not started
rsyslogd                         RUNNING   pid 23, uptime 0:03:09
start.sh                         EXITED    Apr 22 09:07 AM
supervisor-proc-exit-listener    RUNNING   pid 17, uptime 0:03:10
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
