### PR TITLE
[dhcpmon] Filter DHCP O/A Messages of Neighboring Vlans

### DIFF
--- a/src/dhcpmon/src/dhcp_device.c
+++ b/src/dhcpmon/src/dhcp_device.c
@@ -90,17 +90,21 @@ static dhcp_device_counters_t glob_counters_snapshot[DHCP_DIR_COUNT] = {
 };
 
 /**
- * @code handle_dhcp_option_53(context, dhcp_option, dir);
+ * @code handle_dhcp_option_53(context, dhcp_option, dir, iphdr);
  *
  * @brief handle the logic related to DHCP option 53
  *
  * @param context       Device (interface) context
  * @param dhcp_option   pointer to DHCP option buffer space
  * @param dir           packet direction
+ * @param iphdr         pointer to packet IP header
  *
  * @return none
  */
-static void handle_dhcp_option_53(dhcp_device_context_t *context, const u_char *dhcp_option, dhcp_packet_direction_t dir)
+static void handle_dhcp_option_53(dhcp_device_context_t *context,
+                                  const u_char *dhcp_option,
+                                  dhcp_packet_direction_t dir,
+                                  struct ip *iphdr)
 {
     switch (dhcp_option[2])
     {
@@ -112,7 +116,8 @@ static void handle_dhcp_option_53(dhcp_device_context_t *context, const u_char *
         break;
     case 2:
         context->counters[dir].offer++;
-        if ((!context->is_uplink && dir == DHCP_TX) || (context->is_uplink && dir == DHCP_RX)) {
+        if (((context->loopback_ip == iphdr->ip_dst.s_addr) && (context->is_uplink && dir == DHCP_RX)) ||
+            (!context->is_uplink && dir == DHCP_TX)) {
             glob_counters[dir].offer++;
         }
         break;
@@ -124,13 +129,13 @@ static void handle_dhcp_option_53(dhcp_device_context_t *context, const u_char *
         break;
     case 5:
         context->counters[dir].ack++;
-        if ((!context->is_uplink && dir == DHCP_TX) || (context->is_uplink && dir == DHCP_RX)) {
+        if (((context->loopback_ip == iphdr->ip_dst.s_addr) && (context->is_uplink && dir == DHCP_RX)) ||
+            (!context->is_uplink && dir == DHCP_TX)) {
             glob_counters[dir].ack++;
         }
         break;
     case 4: // type: Decline
-    case 6 ... 8:
-        // type: NAK, Release, Inform
+    case 6 ... 8: // type: NAK, Release, Inform
         break;
     default:
         syslog(LOG_WARNING, "handle_dhcp_option_53(%s): Unknown DHCP option 53 type %d", context->intf, dhcp_option[2]);
@@ -146,7 +151,6 @@ static void handle_dhcp_option_53(dhcp_device_context_t *context, const u_char *
  * @param fd            socket to read from
  * @param event         libevent triggered event
  * @param arg           user provided argument for callback (interface context)
- * @param packet        pointer to packet data
  *
  * @return none
  */
@@ -158,6 +162,7 @@ static void read_callback(int fd, short event, void *arg)
     while ((event == EV_READ) &&
            ((buffer_sz = recv(fd, context->buffer, context->snaplen, MSG_DONTWAIT)) > 0)) {
         struct ether_header *ethhdr = (struct ether_header*) context->buffer;
+        struct ip *iphdr = (struct ip*) (context->buffer + IP_START_OFFSET);
         struct udphdr *udp = (struct udphdr*) (context->buffer + UDP_START_OFFSET);
         int dhcp_option_offset = DHCP_START_OFFSET + DHCP_OPTIONS_HEADER_SIZE;
 
@@ -181,7 +186,7 @@ static void read_callback(int fd, short event, void *arg)
                 {
                 case 53:
                     if (offset < (dhcp_option_sz + 2)) {
-                        handle_dhcp_option_53(context, &dhcp_option[offset], dir);
+                        handle_dhcp_option_53(context, &dhcp_option[offset], dir, iphdr);
                     }
                     stop_dhcp_processing = 1; // break while loop since we are only interested in Option 53
                     break;
@@ -260,31 +265,21 @@ static void dhcp_print_counters(dhcp_device_counters_t *counters)
 }
 
 /**
- * @code init_socket(context, intf, snaplen, base);
+ * @code init_socket(context, intf);
  *
  * @brief initializes socket, bind it to interface and bpf prgram, and
  *        associate with libevent base
  *
  * @param context           pointer to device (interface) context
  * @param intf              interface name
- * @param snaplen           length of packet capture
- * @param base              libevent base
  *
  * @return 0 on success, otherwise for failure
  */
-static int init_socket(dhcp_device_context_t *context,
-                       const char *intf,
-                       size_t snaplen,
-                       struct event_base *base)
+static int init_socket(dhcp_device_context_t *context, const char *intf)
 {
     int rv = -1;
 
     do {
-        if (snaplen < UDP_START_OFFSET + sizeof(struct udphdr) + DHCP_OPTIONS_HEADER_SIZE) {
-            syslog(LOG_ALERT, "init_socket(%s): snap length is too low to capture DHCP options", intf);
-            break;
-        }
-
         context->sock = socket(AF_PACKET, SOCK_RAW | SOCK_NONBLOCK, htons(ETH_P_ALL));
         if (context->sock < 0) {
             syslog(LOG_ALERT, "socket: failed to open socket with '%s'\n", strerror(errno));
@@ -300,25 +295,6 @@ static int init_socket(dhcp_device_context_t *context,
             syslog(LOG_ALERT, "bind: failed to bind to interface '%s' with '%s'\n", intf, strerror(errno));
             break;
         }
-
-        if (setsockopt(context->sock, SOL_SOCKET, SO_ATTACH_FILTER, &dhcp_sock_bfp, sizeof(dhcp_sock_bfp)) != 0) {
-            syslog(LOG_ALERT, "setsockopt: failed to attach filter with '%s'\n", strerror(errno));
-            break;
-        }
-
-        context->buffer = (uint8_t *) malloc(snaplen);
-        if (context->buffer == NULL) {
-            syslog(LOG_ALERT, "malloc: failed to allocate memory for socket buffer '%s'\n", strerror(errno));
-            break;
-        }
-        context->snaplen = snaplen;
-
-        struct event *ev = event_new(base, context->sock, EV_READ | EV_PERSIST, read_callback, context);
-        if (ev == NULL) {
-            syslog(LOG_ALERT, "event_new: failed to allocate memory for libevent event '%s'\n", strerror(errno));
-            break;
-        }
-        event_add(ev, NULL);
 
         strncpy(context->intf, intf, sizeof(context->intf) - 1);
         context->intf[sizeof(context->intf) - 1] = '\0';
@@ -377,15 +353,32 @@ static int initialize_intf_mac_and_ip_addr(dhcp_device_context_t *context)
 }
 
 /**
- * @code dhcp_device_init(context, intf, snaplen, is_uplink, base);
+ * @code dhcp_device_get_ip(context);
+ *
+ * @brief Accessor method
+ *
+ * @param context       pointer to device (interface) context
+ *
+ * @return interface IP
+ */
+int dhcp_device_get_ip(dhcp_device_context_t *context, in_addr_t *ip)
+{
+    int rv = -1;
+
+    if (context != NULL && ip != NULL) {
+        *ip = context->ip;
+        rv = 0;
+    }
+
+    return rv;
+}
+
+/**
+ * @code dhcp_device_init(context, intf, is_uplink);
  *
  * @brief initializes device (interface) that handles packet capture per interface.
  */
-int dhcp_device_init(dhcp_device_context_t **context,
-                     const char *intf,
-                     int snaplen,
-                     uint8_t is_uplink,
-                     struct event_base *base)
+int dhcp_device_init(dhcp_device_context_t **context, const char *intf, uint8_t is_uplink)
 {
     int rv = -1;
     dhcp_device_context_t *dev_context = NULL;
@@ -394,8 +387,8 @@ int dhcp_device_init(dhcp_device_context_t **context,
 
         dev_context = (dhcp_device_context_t *) malloc(sizeof(dhcp_device_context_t));
         if (dev_context != NULL) {
-            if ((init_socket(dev_context, intf, snaplen, base) == 0) &&
-                (initialize_intf_mac_and_ip_addr(dev_context) == 0 )    ) {
+            if ((init_socket(dev_context, intf) == 0) &&
+                (initialize_intf_mac_and_ip_addr(dev_context) == 0)) {
 
                 dev_context->is_uplink = is_uplink;
 
@@ -410,6 +403,56 @@ int dhcp_device_init(dhcp_device_context_t **context,
             syslog(LOG_ALERT, "malloc: failed to allocated device context memory for '%s'", dev_context->intf);
         }
     }
+
+    return rv;
+}
+
+/**
+ * @code dhcp_device_start_capture(context, snaplen, base, loopback_ip);
+ *
+ * @brief starts packet capture on this interface
+ */
+int dhcp_device_start_capture(dhcp_device_context_t *context,
+                              size_t snaplen,
+                              struct event_base *base,
+                              in_addr_t loopback_ip)
+{
+    int rv = -1;
+
+    do {
+        if (context == NULL) {
+            syslog(LOG_ALERT, "NULL interface context pointer'\n");
+            break;
+        }
+
+        if (snaplen < UDP_START_OFFSET + sizeof(struct udphdr) + DHCP_OPTIONS_HEADER_SIZE) {
+            syslog(LOG_ALERT, "dhcp_device_start_capture(%s): snap length is too low to capture DHCP options", context);
+            break;
+        }
+
+        context->loopback_ip = loopback_ip;
+
+        context->buffer = (uint8_t *) malloc(snaplen);
+        if (context->buffer == NULL) {
+            syslog(LOG_ALERT, "malloc: failed to allocate memory for socket buffer '%s'\n", strerror(errno));
+            break;
+        }
+        context->snaplen = snaplen;
+
+        if (setsockopt(context->sock, SOL_SOCKET, SO_ATTACH_FILTER, &dhcp_sock_bfp, sizeof(dhcp_sock_bfp)) != 0) {
+            syslog(LOG_ALERT, "setsockopt: failed to attach filter with '%s'\n", strerror(errno));
+            break;
+        }
+
+        struct event *ev = event_new(base, context->sock, EV_READ | EV_PERSIST, read_callback, context);
+        if (ev == NULL) {
+            syslog(LOG_ALERT, "event_new: failed to allocate memory for libevent event '%s'\n", strerror(errno));
+            break;
+        }
+        event_add(ev, NULL);
+
+        rv = 0;
+    } while (0);
 
     return rv;
 }

--- a/src/dhcpmon/src/dhcp_device.c
+++ b/src/dhcpmon/src/dhcp_device.c
@@ -41,14 +41,14 @@
  **/
 typedef enum
 {
-   DHCP_MESSAGE_TYPE_DISCOVER       = 1,
-   DHCP_MESSAGE_TYPE_OFFER          = 2,
-   DHCP_MESSAGE_TYPE_REQUEST        = 3,
-   DHCP_MESSAGE_TYPE_DECLINE        = 4,
-   DHCP_MESSAGE_TYPE_ACK            = 5,
-   DHCP_MESSAGE_TYPE_NAK            = 6,
-   DHCP_MESSAGE_TYPE_RELEASE        = 7,
-   DHCP_MESSAGE_TYPE_INFORM         = 8
+    DHCP_MESSAGE_TYPE_DISCOVER = 1,
+    DHCP_MESSAGE_TYPE_OFFER    = 2,
+    DHCP_MESSAGE_TYPE_REQUEST  = 3,
+    DHCP_MESSAGE_TYPE_DECLINE  = 4,
+    DHCP_MESSAGE_TYPE_ACK      = 5,
+    DHCP_MESSAGE_TYPE_NAK      = 6,
+    DHCP_MESSAGE_TYPE_RELEASE  = 7,
+    DHCP_MESSAGE_TYPE_INFORM   = 8
 } dhcp_message_type;
 
 #define OP_LDHA     (BPF_LD  | BPF_H   | BPF_ABS)   /** bpf ldh Abs */

--- a/src/dhcpmon/src/dhcp_device.c
+++ b/src/dhcpmon/src/dhcp_device.c
@@ -111,36 +111,38 @@ static void handle_dhcp_option_53(dhcp_device_context_t *context,
                                   uint8_t *dhcphdr)
 {
     in_addr_t giaddr;
-    giaddr = ntohl(dhcphdr[DHCP_GIADDR_OFFSET] << 24 | dhcphdr[DHCP_GIADDR_OFFSET + 1] << 16 |
-                   dhcphdr[DHCP_GIADDR_OFFSET + 2] << 8 | dhcphdr[DHCP_GIADDR_OFFSET + 3]);
     switch (dhcp_option[2])
     {
     case 1:
+        giaddr = ntohl(dhcphdr[DHCP_GIADDR_OFFSET] << 24 | dhcphdr[DHCP_GIADDR_OFFSET + 1] << 16 |
+                       dhcphdr[DHCP_GIADDR_OFFSET + 2] << 8 | dhcphdr[DHCP_GIADDR_OFFSET + 3]);
         context->counters[dir].discover++;
-        if (((context->loopback_ip == giaddr) && (context->is_uplink && dir == DHCP_TX)) ||
-            ((!context->is_uplink && dir == DHCP_RX) && (iphdr->ip_dst.s_addr == INADDR_BROADCAST) &&
-             (iphdr->ip_src.s_addr == INADDR_ANY))) {
+        if ((context->loopback_ip == giaddr && context->is_uplink && dir == DHCP_TX) ||
+            (!context->is_uplink && dir == DHCP_RX && iphdr->ip_dst.s_addr == INADDR_BROADCAST &&
+             iphdr->ip_src.s_addr == INADDR_ANY)) {
             glob_counters[dir].discover++;
         }
         break;
     case 2:
         context->counters[dir].offer++;
-        if (((context->loopback_ip == iphdr->ip_dst.s_addr) && (context->is_uplink && dir == DHCP_RX)) ||
+        if ((context->loopback_ip == iphdr->ip_dst.s_addr && context->is_uplink && dir == DHCP_RX) ||
             (!context->is_uplink && dir == DHCP_TX)) {
             glob_counters[dir].offer++;
         }
         break;
     case 3:
+        giaddr = ntohl(dhcphdr[DHCP_GIADDR_OFFSET] << 24 | dhcphdr[DHCP_GIADDR_OFFSET + 1] << 16 |
+                       dhcphdr[DHCP_GIADDR_OFFSET + 2] << 8 | dhcphdr[DHCP_GIADDR_OFFSET + 3]);
         context->counters[dir].request++;
-        if (((context->loopback_ip == giaddr) && (context->is_uplink && dir == DHCP_TX)) ||
-            ((!context->is_uplink && dir == DHCP_RX) && (iphdr->ip_dst.s_addr == INADDR_BROADCAST) &&
-             (iphdr->ip_src.s_addr == INADDR_ANY))) {
+        if ((context->loopback_ip == giaddr && context->is_uplink && dir == DHCP_TX) ||
+            (!context->is_uplink && dir == DHCP_RX && iphdr->ip_dst.s_addr == INADDR_BROADCAST &&
+             iphdr->ip_src.s_addr == INADDR_ANY)) {
             glob_counters[dir].request++;
         }
         break;
     case 5:
         context->counters[dir].ack++;
-        if (((context->loopback_ip == iphdr->ip_dst.s_addr) && (context->is_uplink && dir == DHCP_RX)) ||
+        if ((context->loopback_ip == iphdr->ip_dst.s_addr && context->is_uplink && dir == DHCP_RX) ||
             (!context->is_uplink && dir == DHCP_TX)) {
             glob_counters[dir].ack++;
         }

--- a/src/dhcpmon/src/dhcp_device.c
+++ b/src/dhcpmon/src/dhcp_device.c
@@ -117,15 +117,14 @@ static void handle_dhcp_option_53(dhcp_device_context_t *context,
         giaddr = ntohl(dhcphdr[DHCP_GIADDR_OFFSET] << 24 | dhcphdr[DHCP_GIADDR_OFFSET + 1] << 16 |
                        dhcphdr[DHCP_GIADDR_OFFSET + 2] << 8 | dhcphdr[DHCP_GIADDR_OFFSET + 3]);
         context->counters[dir].discover++;
-        if ((context->loopback_ip == giaddr && context->is_uplink && dir == DHCP_TX) ||
-            (!context->is_uplink && dir == DHCP_RX && iphdr->ip_dst.s_addr == INADDR_BROADCAST &&
-             iphdr->ip_src.s_addr == INADDR_ANY)) {
+        if ((context->vlan_ip == giaddr && context->is_uplink && dir == DHCP_TX) ||
+            (!context->is_uplink && dir == DHCP_RX && iphdr->ip_dst.s_addr == INADDR_BROADCAST)) {
             glob_counters[dir].discover++;
         }
         break;
     case 2:
         context->counters[dir].offer++;
-        if ((context->loopback_ip == iphdr->ip_dst.s_addr && context->is_uplink && dir == DHCP_RX) ||
+        if ((context->vlan_ip == iphdr->ip_dst.s_addr && context->is_uplink && dir == DHCP_RX) ||
             (!context->is_uplink && dir == DHCP_TX)) {
             glob_counters[dir].offer++;
         }
@@ -134,15 +133,14 @@ static void handle_dhcp_option_53(dhcp_device_context_t *context,
         giaddr = ntohl(dhcphdr[DHCP_GIADDR_OFFSET] << 24 | dhcphdr[DHCP_GIADDR_OFFSET + 1] << 16 |
                        dhcphdr[DHCP_GIADDR_OFFSET + 2] << 8 | dhcphdr[DHCP_GIADDR_OFFSET + 3]);
         context->counters[dir].request++;
-        if ((context->loopback_ip == giaddr && context->is_uplink && dir == DHCP_TX) ||
-            (!context->is_uplink && dir == DHCP_RX && iphdr->ip_dst.s_addr == INADDR_BROADCAST &&
-             iphdr->ip_src.s_addr == INADDR_ANY)) {
+        if ((context->vlan_ip == giaddr && context->is_uplink && dir == DHCP_TX) ||
+            (!context->is_uplink && dir == DHCP_RX && iphdr->ip_dst.s_addr == INADDR_BROADCAST)) {
             glob_counters[dir].request++;
         }
         break;
     case 5:
         context->counters[dir].ack++;
-        if ((context->loopback_ip == iphdr->ip_dst.s_addr && context->is_uplink && dir == DHCP_RX) ||
+        if ((context->vlan_ip == iphdr->ip_dst.s_addr && context->is_uplink && dir == DHCP_RX) ||
             (!context->is_uplink && dir == DHCP_TX)) {
             glob_counters[dir].ack++;
         }
@@ -422,14 +420,14 @@ int dhcp_device_init(dhcp_device_context_t **context, const char *intf, uint8_t 
 }
 
 /**
- * @code dhcp_device_start_capture(context, snaplen, base, loopback_ip);
+ * @code dhcp_device_start_capture(context, snaplen, base, vlan_ip);
  *
  * @brief starts packet capture on this interface
  */
 int dhcp_device_start_capture(dhcp_device_context_t *context,
                               size_t snaplen,
                               struct event_base *base,
-                              in_addr_t loopback_ip)
+                              in_addr_t vlan_ip)
 {
     int rv = -1;
 
@@ -444,7 +442,7 @@ int dhcp_device_start_capture(dhcp_device_context_t *context,
             break;
         }
 
-        context->loopback_ip = loopback_ip;
+        context->vlan_ip = vlan_ip;
 
         context->buffer = (uint8_t *) malloc(snaplen);
         if (context->buffer == NULL) {

--- a/src/dhcpmon/src/dhcp_device.c
+++ b/src/dhcpmon/src/dhcp_device.c
@@ -33,6 +33,8 @@
 #define DHCP_START_OFFSET (UDP_START_OFFSET + sizeof(struct udphdr))
 /** Start of DHCP Options segment of a captured frame */
 #define DHCP_OPTIONS_HEADER_SIZE 240
+/** Offset of DHCP GIADDR */
+#define DHCP_GIADDR_OFFSET 24
 
 #define OP_LDHA     (BPF_LD  | BPF_H   | BPF_ABS)   /** bpf ldh Abs */
 #define OP_LDHI     (BPF_LD  | BPF_H   | BPF_IND)   /** bpf ldh Ind */
@@ -109,7 +111,8 @@ static void handle_dhcp_option_53(dhcp_device_context_t *context,
                                   uint8_t *dhcphdr)
 {
     in_addr_t giaddr;
-    giaddr = ntohl(dhcphdr[24] << 24 | dhcphdr[25] << 16 | dhcphdr[26] << 8 | dhcphdr[27]);
+    giaddr = ntohl(dhcphdr[DHCP_GIADDR_OFFSET] << 24 | dhcphdr[DHCP_GIADDR_OFFSET + 1] << 16 |
+                   dhcphdr[DHCP_GIADDR_OFFSET + 2] << 8 | dhcphdr[DHCP_GIADDR_OFFSET + 3]);
     switch (dhcp_option[2])
     {
     case 1:

--- a/src/dhcpmon/src/dhcp_device.h
+++ b/src/dhcpmon/src/dhcp_device.h
@@ -49,7 +49,7 @@ typedef struct
     int sock;                       /** Raw socket associated with this device/interface */
     in_addr_t ip;                   /** network address of this device (interface) */
     uint8_t mac[ETHER_ADDR_LEN];    /** hardware address of this device (interface) */
-    in_addr_t loopback_ip;          /** Vlan loopback IP address */
+    in_addr_t vlan_ip;              /** Vlan IP address */
     uint8_t is_uplink;              /** north interface? */
     char intf[IF_NAMESIZE];         /** device (interface) name */
     uint8_t *buffer;                /** buffer used to read socket data */
@@ -88,21 +88,21 @@ int dhcp_device_init(dhcp_device_context_t **context,
                      uint8_t is_uplink);
 
 /**
- * @code dhcp_device_start_capture(context, snaplen, base, loopback_ip);
+ * @code dhcp_device_start_capture(context, snaplen, base, vlan_ip);
  *
  * @brief starts packet capture on this interface
  *
  * @param context           pointer to device (interface) context
  * @param snaplen           length of packet capture
  * @param base              pointer to libevent base
- * @param loopback_ip       vlan loopback IP address
+ * @param vlan_ip           vlan IP address
  *
  * @return 0 on success, otherwise for failure
  */
 int dhcp_device_start_capture(dhcp_device_context_t *context,
                               size_t snaplen,
                               struct event_base *base,
-                              in_addr_t loopback_ip);
+                              in_addr_t vlan_ip);
 
 /**
  * @code dhcp_device_shutdown(context);

--- a/src/dhcpmon/src/dhcp_device.h
+++ b/src/dhcpmon/src/dhcp_device.h
@@ -49,6 +49,7 @@ typedef struct
     int sock;                       /** Raw socket associated with this device/interface */
     in_addr_t ip;                   /** network address of this device (interface) */
     uint8_t mac[ETHER_ADDR_LEN];    /** hardware address of this device (interface) */
+    in_addr_t loopback_ip;          /** Vlan loopback IP address */
     uint8_t is_uplink;              /** north interface? */
     char intf[IF_NAMESIZE];         /** device (interface) name */
     uint8_t *buffer;                /** buffer used to read socket data */
@@ -60,23 +61,48 @@ typedef struct
 } dhcp_device_context_t;
 
 /**
- * @code dhcp_device_init(context, intf, snaplen, timeout_ms, is_uplink, base);
+ * @code dhcp_device_get_ip(context, ip);
+ *
+ * @brief Accessor method
+ *
+ * @param context       pointer to device (interface) context
+ * @param ip(out)       pointer to device IP
+ *
+ * @return 0 on success, otherwise for failure
+ */
+int dhcp_device_get_ip(dhcp_device_context_t *context, in_addr_t *ip);
+
+/**
+ * @code dhcp_device_init(context, intf, is_uplink);
  *
  * @brief initializes device (interface) that handles packet capture per interface.
  *
  * @param context(inout)    pointer to device (interface) context
  * @param intf              interface name
- * @param snaplen           length of packet capture
  * @param is_uplink         uplink interface
- * @param base              pointer to libevent base
  *
  * @return 0 on success, otherwise for failure
  */
 int dhcp_device_init(dhcp_device_context_t **context,
                      const char *intf,
-                     int snaplen,
-                     uint8_t is_uplink,
-                     struct event_base *base);
+                     uint8_t is_uplink);
+
+/**
+ * @code dhcp_device_start_capture(context, snaplen, base, loopback_ip);
+ *
+ * @brief starts packet capture on this interface
+ *
+ * @param context           pointer to device (interface) context
+ * @param snaplen           length of packet capture
+ * @param base              pointer to libevent base
+ * @param loopback_ip       vlan loopback IP address
+ *
+ * @return 0 on success, otherwise for failure
+ */
+int dhcp_device_start_capture(dhcp_device_context_t *context,
+                              size_t snaplen,
+                              struct event_base *base,
+                              in_addr_t loopback_ip);
 
 /**
  * @code dhcp_device_shutdown(context);

--- a/src/dhcpmon/src/dhcp_devman.c
+++ b/src/dhcpmon/src/dhcp_devman.c
@@ -82,7 +82,7 @@ void dhcp_devman_shutdown()
 }
 
 /**
- * @code dhcp_devman_add_intf(name, uplink);
+ * @code dhcp_devman_add_intf(name, is_uplink);
  *
  * @brief adds interface to the device manager.
  */

--- a/src/dhcpmon/src/dhcp_devman.c
+++ b/src/dhcpmon/src/dhcp_devman.c
@@ -32,6 +32,19 @@ static uint32_t dhcp_num_north_intf = 0;
  *  This IP is used to filter Offer/Ack packet coming from DHCP server */
 static in_addr_t vlan_ip = 0;
 
+/** vlan interface name */
+static char vlan_intf[IF_NAMESIZE] = "Undefined";
+
+/**
+ * @code dhcp_devman_get_vlan_intf();
+ *
+ * Accessor method
+ */
+const char* dhcp_devman_get_vlan_intf()
+{
+    return vlan_intf;
+}
+
 /**
  * @code dhcp_devman_init();
  *
@@ -91,6 +104,9 @@ int dhcp_devman_add_intf(const char *name, uint8_t is_uplink)
         rv = dhcp_device_init(&dev->dev_context, dev->name, dev->is_uplink);
         if (rv == 0 && !is_uplink) {
             rv = dhcp_device_get_ip(dev->dev_context, &vlan_ip);
+
+            strncpy(vlan_intf, name, sizeof(vlan_intf) - 1);
+            vlan_intf[sizeof(vlan_intf) - 1] = '\0';
         }
 
         LIST_INSERT_HEAD(&intfs, dev, entry);

--- a/src/dhcpmon/src/dhcp_devman.c
+++ b/src/dhcpmon/src/dhcp_devman.c
@@ -28,9 +28,9 @@ static uint32_t dhcp_num_south_intf = 0;
 /** dhcp_num_north_intf number of north interfaces */
 static uint32_t dhcp_num_north_intf = 0;
 
-/** Loopback interface IP address corresponding vlan downlink IP
- *  This IP is used to filter Offer/Ack packet coming from DHCp servers */
-static in_addr_t loopback_ip = 0;
+/** On Device  vlan interface IP address corresponding vlan downlink IP
+ *  This IP is used to filter Offer/Ack packet coming from DHCP server */
+static in_addr_t vlan_ip = 0;
 
 /**
  * @code dhcp_devman_init();
@@ -90,7 +90,7 @@ int dhcp_devman_add_intf(const char *name, uint8_t is_uplink)
 
         rv = dhcp_device_init(&dev->dev_context, dev->name, dev->is_uplink);
         if (rv == 0 && !is_uplink) {
-            rv = dhcp_device_get_ip(dev->dev_context, &loopback_ip);
+            rv = dhcp_device_get_ip(dev->dev_context, &vlan_ip);
         }
 
         LIST_INSERT_HEAD(&intfs, dev, entry);
@@ -114,7 +114,7 @@ int dhcp_devman_start_capture(size_t snaplen, struct event_base *base)
 
     if ((dhcp_num_south_intf == 1) && (dhcp_num_north_intf >= 1)) {
         LIST_FOREACH(int_ptr, &intfs, entry) {
-            rv = dhcp_device_start_capture(int_ptr->dev_context, snaplen, base, loopback_ip);
+            rv = dhcp_device_start_capture(int_ptr->dev_context, snaplen, base, vlan_ip);
             if (rv == 0) {
                 syslog(LOG_INFO,
                        "Capturing DHCP packets on interface %s, ip: 0x%08x, mac [%02x:%02x:%02x:%02x:%02x:%02x] \n",

--- a/src/dhcpmon/src/dhcp_devman.h
+++ b/src/dhcpmon/src/dhcp_devman.h
@@ -36,24 +36,24 @@ void dhcp_devman_shutdown();
  *
  * @brief adds interface to the device manager.
  *
- * @param name interface name
- * @param is_uplink true for uplink (north) interface
+ * @param name              interface name
+ * @param is_uplink         true for uplink (north) interface
  *
  * @return 0 on success, nonzero otherwise
  */
 int dhcp_devman_add_intf(const char *name, uint8_t is_uplink);
 
 /**
- * @code dhcp_devman_start_capture(snaplen, timeout_ms);
+ * @code dhcp_devman_start_capture(snaplen, base);
  *
  * @brief start packet capture on the devman interface list
  *
- * @param snaplen packet    capture snap length
+ * @param snaplen packet    packet capture snap length
  * @param base              libevent base
  *
  * @return 0 on success, nonzero otherwise
  */
-int dhcp_devman_start_capture(int snaplen, struct event_base *base);
+int dhcp_devman_start_capture(size_t snaplen, struct event_base *base);
 
 /**
  * @code dhcp_devman_get_status();

--- a/src/dhcpmon/src/dhcp_devman.h
+++ b/src/dhcpmon/src/dhcp_devman.h
@@ -32,6 +32,15 @@ void dhcp_devman_init();
 void dhcp_devman_shutdown();
 
 /**
+ * @code dhcp_devman_get_vlan_intf();
+ *
+ * @brief Accessor method
+ *
+ * @return pointer to vlan ip interface name
+ */
+const char* dhcp_devman_get_vlan_intf();
+
+/**
  * @code dhcp_devman_add_intf(name, uplink);
  *
  * @brief adds interface to the device manager.

--- a/src/dhcpmon/src/dhcp_mon.c
+++ b/src/dhcpmon/src/dhcp_mon.c
@@ -67,7 +67,8 @@ static void timeout_callback(evutil_socket_t fd, short event, void *arg)
     {
     case DHCP_MON_STATUS_UNHEALTHY:
         if (++count > dhcp_unhealthy_max_count) {
-            syslog(LOG_ALERT, "dhcpmon detected disparity in DHCP Relay behavior. Check failure count: %d\n", count);
+            syslog(LOG_ALERT, "dhcpmon detected disparity in DHCP Relay behavior. Failure count: %d for vlan: '%s'\n",
+                   count, dhcp_devman_get_vlan_intf());
             dhcp_devman_print_status();
         }
         break;

--- a/src/dhcpmon/src/dhcp_mon.c
+++ b/src/dhcpmon/src/dhcp_mon.c
@@ -36,13 +36,13 @@ static struct event *ev_sigterm;
  *
  * @param fd        libevent socket
  * @param event     event triggered
- * @param arg       pointer user provided context (libevent base)
+ * @param arg       pointer to user provided context (libevent base)
  *
  * @return none
  */
 static void signal_callback(evutil_socket_t fd, short event, void *arg)
 {
-    syslog(LOG_ALERT, "Received signal %d\n", event);
+    syslog(LOG_ALERT, "Received signal %s\n", strsignal(fd));
     dhcp_devman_print_status();
     dhcp_mon_stop();
 }
@@ -151,7 +151,7 @@ void dhcp_mon_shutdown()
  *
  * @brief start monitoring DHCP Relay
  */
-int dhcp_mon_start(int snaplen)
+int dhcp_mon_start(size_t snaplen)
 {
     int rv = -1;
 

--- a/src/dhcpmon/src/dhcp_mon.c
+++ b/src/dhcpmon/src/dhcp_mon.c
@@ -67,7 +67,7 @@ static void timeout_callback(evutil_socket_t fd, short event, void *arg)
     {
     case DHCP_MON_STATUS_UNHEALTHY:
         if (++count > dhcp_unhealthy_max_count) {
-            syslog(LOG_ALERT, "DHCP Relay is not healthy after %d health checks\n", count);
+            syslog(LOG_ALERT, "dhcpmon detected disparity in DHCP Relay behavior. Check failure count: %d\n", count);
             dhcp_devman_print_status();
         }
         break;

--- a/src/dhcpmon/src/dhcp_mon.c
+++ b/src/dhcpmon/src/dhcp_mon.c
@@ -68,6 +68,7 @@ static void timeout_callback(evutil_socket_t fd, short event, void *arg)
     case DHCP_MON_STATUS_UNHEALTHY:
         if (++count > dhcp_unhealthy_max_count) {
             syslog(LOG_ALERT, "DHCP Relay is not healthy after %d health checks\n", count);
+            dhcp_devman_print_status();
         }
         break;
     case DHCP_MON_STATUS_HEALTHY:

--- a/src/dhcpmon/src/dhcp_mon.h
+++ b/src/dhcpmon/src/dhcp_mon.h
@@ -40,7 +40,7 @@ void dhcp_mon_shutdown();
  *
  * @return 0 upon success, otherwise upon failure
  */
-int dhcp_mon_start(int snaplen);
+int dhcp_mon_start(size_t snaplen);
 
 /**
  * @code dhcp_mon_stop();

--- a/src/dhcpmon/src/main.c
+++ b/src/dhcpmon/src/main.c
@@ -21,7 +21,7 @@
 #include "dhcp_devman.h"
 
 /** dhcpmon_default_snaplen: default snap length of packet being captured */
-static const uint32_t dhcpmon_default_snaplen = 65535;
+static const size_t dhcpmon_default_snaplen = 65535;
 /** dhcpmon_default_health_check_window: default value for a time window, during which DHCP DORA packet counts are being
  *  collected */
 static const uint32_t dhcpmon_default_health_check_window = 12;
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
     int i;
     int window_interval = dhcpmon_default_health_check_window;
     int max_unhealthy_count = dhcpmon_default_unhealthy_max_count;
-    uint32_t snaplen = dhcpmon_default_snaplen;
+    size_t snaplen = dhcpmon_default_snaplen;
     int make_daemon = 0;
 
     setlogmask(LOG_UPTO(LOG_INFO));


### PR DESCRIPTION
**- Why I did it**
1. This code fixes a bug where two or more vlans exist. Cross contamination
happens for DHCP packets Offer/Ack when received on shared northbound links.
The code filters out those packet based on dst IP equal Vlan loopback IP.

2. Also, Fixed a bug where libevent event id was being printed instead of signal id.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- How to verify it**
pytest test_dhcp_relay.py --testbed=testbed --inventory=../ansible/str --testbed_file=../ansible/testbed.csv --host-pattern=all --module-path=../ansible/library 

***-Using single Vlan
logs from syslog:
Apr 23 04:52:59.710434 str-s6100-acs-2 NOTICE dhcp_relay#dhcpmon[52]: DHCP Discover rx: 2, tx:96, Offer rx: 2, tx:2, Request rx: 2, tx:96, ACK rx: 2, tx:2

Apr 23 04:54:25.390030 str-s6100-acs-2 NOTICE dhcp_relay#dhcpmon[51]: DHCP Discover rx: 1, tx:48, Offer rx: 1, tx:1, Request rx: 1, tx:48, ACK rx: 1, tx:1

***-Using two vlans:
ansible-playbook config_sonic_basedon_testbed.yml -i str -l str-s6100-acs-2 -e testbed_name=vms7-t0-s6100 --vault-password-file=../.vault-file -e deploy=true -e vlan_config=two_vlan_a

Apr 23 08:05:35.444937 str-s6100-acs-2 ALERT dhcp_relay#dhcpmon[58]: Received signal Terminated
Apr 23 08:05:35.444937 str-s6100-acs-2 NOTICE dhcp_relay#dhcpmon[58]: DHCP Discover rx: 2, tx:96, Offer rx: 2, tx:2, Request rx: 2, tx:96, ACK rx: 2, tx:2
Apr 23 08:05:35.444937 str-s6100-acs-2 ALERT dhcp_relay#dhcpmon[57]: Received signal Terminated
Apr 23 08:05:35.444937 str-s6100-acs-2 NOTICE dhcp_relay#dhcpmon[57]: DHCP Discover rx: 2, tx:96, Offer rx: 2, tx:2, Request rx: 2, tx:96, ACK rx: 2, tx:2

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
