### PR TITLE
Fix docker restapi start issue, undefined error

### DIFF
--- a/dockers/docker-sonic-restapi/restapi.sh
+++ b/dockers/docker-sonic-restapi/restapi.sh
@@ -3,7 +3,10 @@
 RESTAPI_ARGS=""
 while true
 do
-    client_auth=`sonic-cfggen -d -v "RESTAPI['config']['client_auth']"`
+    has_client_auth=$(sonic-cfggen -d -v "1 if RESTAPI and RESTAPI['config']")
+    if [ "$has_client_auth" == "1" ]; then
+        client_auth=$(sonic-cfggen -d -v "RESTAPI['config']['client_auth']")
+    fi
     if [[ $client_auth == 'true' ]]; then
         certs=`sonic-cfggen -d -v "RESTAPI['certs']"`
         allow_insecure=`sonic-cfggen -d -v "RESTAPI['config']['allow_insecure']"`

--- a/rules/docker-restapi.mk
+++ b/rules/docker-restapi.mk
@@ -18,7 +18,6 @@ endif
 
 $(DOCKER_RESTAPI)_CONTAINER_NAME = restapi
 $(DOCKER_RESTAPI)_RUN_OPT += --cap-add NET_ADMIN --privileged -t
-$(DOCKER_RESTAPI)_RUN_OPT += --network="host"
 $(DOCKER_RESTAPI)_RUN_OPT += -v /var/run/redis/redis.sock:/var/run/redis/redis.sock
 $(DOCKER_RESTAPI)_RUN_OPT += -v /etc/sonic/certificates:/etc/sonic/certificates:ro
 $(DOCKER_RESTAPI)_RUN_OPT += -p=8081:8081/tcp


### PR DESCRIPTION
**- Why I did it**

1. Fix the error during restapi start
```
Apr 24 01:10:  str-01 INFO restapi.sh: docker: network "host" is specified multiple times.
```
2. Fix a jinja exception undefined error
```
Apr 24 01:25: str-01 INFO restapi#: Traceback (most recent call last):
Apr 24 01:25: str-01 INFO restapi#: File "/usr/local/bin/sonic-cfggen", line 318, in <module>
Apr 24 01:25: str-01 INFO restapi#: main()
Apr 24 01:25: str-01 INFO restapi#: return obj[argument]
Apr 24 01:25: str-01 INFO restapi#: jinja2.exceptions.UndefinedError: 'RESTAPI' is undefined
```
**- How I did it**
Code fix

**- How to verify it**
Run `restapi `docker 


**- A picture of a cute animal (not mandatory but encouraged)**
