### PR TITLE
Fix the continous syseepromd autorestart issue on 201911

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/pmon_daemon_control.json
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/pmon_daemon_control.json
@@ -1,4 +1,3 @@
 {
-    "skip_ledd": true,
-    "skip_syseepromd": true
+    "skip_ledd": true
 }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/pmon_daemon_control.json
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/pmon_daemon_control.json
@@ -1,3 +1,4 @@
 {
-    "skip_ledd": true
+    "skip_ledd": true,
+    "skip_syseepromd": true
 }

--- a/dockers/docker-platform-monitor/critical_processes
+++ b/dockers/docker-platform-monitor/critical_processes
@@ -1,4 +1,3 @@
 ledd
 xcvrd
 psud
-syseepromd

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -82,10 +82,10 @@ startsecs=0
 command=/usr/bin/syseepromd
 priority=8
 autostart=false
-autorestart=true
+autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=0
+startsecs=10
 {% endif %}
 
 {% if not skip_thermalctld %}
@@ -93,8 +93,8 @@ startsecs=0
 command=/usr/bin/thermalctld
 priority=9
 autostart=false
-autorestart=true
+autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=0
+startsecs=10
 {% endif %}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
To fix the continuous restart of syseepromd even for the expected exit case.
**- How I did it**
Remove syseepromd from the critical process of pmon docker
Fix supervisor autorestart configuration of syseepromd
**- How to verify it**
Start pmon and see if pmon restarts when syseepromd exits with status 0 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Before enabling the syseepromd, ensure if   def update_eeprom_db(self, e): is implemented for the platform.
Throwing too much error messages and failing to start the syseepromd and causing CPU peak
**- A picture of a cute animal (not mandatory but encouraged)**
