### PR TITLE
[build]: add sonic-slave-run to run any cmds inside sonic-slave

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -251,6 +251,16 @@ sonic-slave-bash :
 	    $(DOCKER_BUILD) ; }
 	@$(DOCKER_RUN) -t $(SLAVE_IMAGE):$(SLAVE_TAG) bash
 
+sonic-slave-run :
+	@$(OVERLAY_MODULE_CHECK)
+	@docker inspect --type image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) &> /dev/null || \
+	    { echo Image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Building... ; \
+	    $(DOCKER_BASE_BUILD) ; }
+	@docker inspect --type image $(SLAVE_IMAGE):$(SLAVE_TAG) &> /dev/null || \
+	    { echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
+	    $(DOCKER_BUILD) ; }
+	@$(DOCKER_RUN) -t $(SLAVE_IMAGE):$(SLAVE_TAG) bash -c "$(SONIC_RUN_CMDS)"
+
 showtag:
 	@echo $(SLAVE_IMAGE):$(SLAVE_TAG)
 	@echo $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG)


### PR DESCRIPTION


Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
add target to allow run any cmds inside sonic-slave docker

**- How I did it**
check the pr.

**- How to verify it**
example:

```
SONIC_RUN_CMDS="gzip -d -c target/sonic-vs.img.gz > target/sonic-vs.img;\
qemu-img convert target/sonic-vs.img -O vhdx -o subformat=dynamic target/sonic-vs.vhdx"\
 BLDENV=buster make -f Makefile.work sonic-slave-run
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
