### PR TITLE
[mellanox]: Align CPLD component with latest hw-mgmt

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -232,7 +232,7 @@ class ComponentCPLD(Component):
     CPLD_NUMBER_FILE = '/var/run/hw-management/config/cpld_num'
     CPLD_PART_NUMBER_FILE = '/var/run/hw-management/system/cpld{}_pn'
     CPLD_VERSION_FILE = '/var/run/hw-management/system/cpld{}_version'
-    CPLD_VERSION_MINOR_FILE = '/var/run/hw-management/system/cpld{}_version_minor'
+    CPLD_VERSION_MINOR_FILE = '/var/run/hw-management/system/cpld{}_version_min'
 
     CPLD_NUMBER_MAX_LENGTH = 1
     CPLD_PART_NUMBER_MAX_LENGTH = 6


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
* To fix CPLD minor version representation

**- How I did it**
* Fixed Mellanox platform API

**- How to verify it**
1. fwutil show status
```
root@sonic:/home/admin# fwutil show status
Chassis                  Module    Component    Version                  Description
-----------------------  --------  -----------  -----------------------  ----------------------------------------
x86_64-mlnx_msn3700c-r0  N/A       BIOS         0ACLH004_02.02.007_9600  BIOS - Basic Input/Output System
                                   CPLD1        CPLD000120_REV0223       CPLD - Complex Programmable Logic Device
                                   CPLD2        CPLD000162_REV0800       CPLD - Complex Programmable Logic Device
                                   CPLD3        CPLD000106_REV0100       CPLD - Complex Programmable Logic Device
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```