### PR TITLE
bgp template changes for new multi Asic minigraph

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -14,7 +14,7 @@ ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTE
 {% endif %}
 !
 !
-{% if DEVICE_METADATA['localhost']['type'] == 'InternalFrontend' %}
+{% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' %}
 route-map HIDE_INTERNAL permit 10
   set community local-AS
 !
@@ -62,7 +62,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endblock vlan_advertisement %}
 !
 !
-{% if DEVICE_METADATA['localhost']['type'] == 'InternalFrontend' %}
+{% if DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
   redistribute connected route-map HIDE_INTERNAL
 {% endif %}
 !

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -27,7 +27,7 @@
 {%   endif %}
 {% endif %}
 !
-{% if bgp_session['rrclient'] | int != 0  %}
+{% if bgp_session['rrclient'] | int != 0 %}
     neighbor {{ neighbor_addr }} route-reflector-client
 {% endif %}
 !
@@ -35,7 +35,7 @@
     neighbor {{ neighbor_addr }} next-hop-self
 {% endif %}
 {% if 'ASIC' in bgp_session['name'] %}
-  neighbor {{ neighbor_addr }} next-hop-self force
+    neighbor {{ neighbor_addr }} next-hop-self force
 {% endif %}
 !
 {% if bgp_session["asn"] == bgp_asn and CONFIG_DB__DEVICE_METADATA['localhost']['type'] == "SpineChassisFrontendRouter" %}

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -27,12 +27,15 @@
 {%   endif %}
 {% endif %}
 !
-{% if bgp_session['rrclient'] | int != 0 or CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
+{% if bgp_session['rrclient'] | int != 0  %}
     neighbor {{ neighbor_addr }} route-reflector-client
 {% endif %}
 !
 {% if bgp_session['nhopself'] | int != 0 %}
     neighbor {{ neighbor_addr }} next-hop-self
+{% endif %}
+{% if 'ASIC' in bgp_session['name'] %}
+  neighbor {{ neighbor_addr }} next-hop-self force
 {% endif %}
 !
 {% if bgp_session["asn"] == bgp_asn and CONFIG_DB__DEVICE_METADATA['localhost']['type'] == "SpineChassisFrontendRouter" %}

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -16,18 +16,18 @@
 {% if neighbor_addr | ipv4 %}
   address-family ipv4
     neighbor {{ neighbor_addr }} peer-group PEER_V4
-{%   if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'InternalBackend' %}
+{%   if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
     neighbor {{ neighbor_addr }} route-map FROM_BGP_PEER_V4_INT in
 {%   endif %}
 {% elif neighbor_addr | ipv6 %}
   address-family ipv6
     neighbor {{ neighbor_addr }} peer-group PEER_V6
-{%   if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'InternalBackend' %}
+{%   if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
     neighbor {{ neighbor_addr }} route-map FROM_BGP_PEER_V6_INT in
 {%   endif %}
 {% endif %}
 !
-{% if bgp_session['rrclient'] | int != 0 %}
+{% if bgp_session['rrclient'] | int != 0 or CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
     neighbor {{ neighbor_addr }} route-reflector-client
 {% endif %}
 !

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
@@ -7,6 +7,9 @@
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor PEER_V4 allowas-in 1
 {% endif %}
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
+    neighbor PEER_V4 route-reflector-client
+{% endif %}
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
@@ -14,6 +17,9 @@
   address-family ipv6
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor PEER_V6 allowas-in 1
+  {% endif %}
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
+    neighbor PEER_V6 route-reflector-client
 {% endif %}
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
@@ -15,7 +15,7 @@ route-map FROM_BGP_PEER_V6 permit 100
 !
 route-map TO_BGP_PEER_V6 permit 100
 !
-{% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'InternalBackend' %}
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
 route-map FROM_BGP_PEER_V4_INT permit 2
  set originator-id {{ loopback0_ipv4 | ip }}
 !


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Align the bgp templates with new minigraph generated for multi NPU platforms

**- How I did it**
change the references to 'type' field to 'sub_role' 
change the references to 'InternalFrontend' and 'InternalBackend' to 'FrontEnd' and 'BackEnd' respectively


**- How to verify it**
Check if the configuration is generated properly on multi NPU platforms

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
change the references to 'type' field to 'sub_role' 
change the references to 'InternalFrontend' and 'InternalBackend' to 'FrontEnd' and 'BackEnd' respectively
add a statement to reflect route-reflector for backend asics
Add a change to set "next-hop-self force" configuration for internal BGP session in multi asic platform.

**- A picture of a cute animal (not mandatory but encouraged)**
