### PR TITLE
[caclmgrd] Log error message if IPv4 ACL table contains IPv6 rule and vice-versa

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -354,6 +354,19 @@ class ControlPlaneAclManager(object):
                                   ("DST_IP" in rule_props and rule_props["DST_IP"])):
                                 table_ip_version = 4
 
+                        if ((("SRC_IPV6" in rule_props and rule_props["SRC_IPV6"]) or
+                            ("DST_IPV6" in rule_props and rule_props["DST_IPV6"])) and
+                            (table_ip_version == 4)):
+                            log_error("CtrlPlane ACL table {} is a IPv4 based table and rule {} is a IPV6 rule!"
+                                                          .format(table_name, rule_id))
+                            sys.exit(1)
+                        elif ((("SRC_IP" in rule_props and rule_props["SRC_IP"]) or
+                            ("DST_IP" in rule_props and rule_props["DST_IP"])) and
+                            (table_ip_version == 6)):
+                            log_error("CtrlPlane ACL table {} is a IPv6 based table and rule {} is a IPV4 rule!"
+                                                          .format(table_name, rule_id))
+                            sys.exit(1)
+
                 # If we were unable to determine whether this ACL table contains
                 # IPv4 or IPv6 rules, log a message and skip processing this table.
                 if not table_ip_version:

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -366,11 +366,11 @@ class ControlPlaneAclManager(object):
                                 table_ip_version = 4
 
                         if (self.is_rule_ipv6(rule_props) and (table_ip_version == 4)):
-                            log_error("CtrlPlane ACL table {} is a IPv4 based table and rule {} is a IPV6 rule!"
+                            log_error("CtrlPlane ACL table {} is a IPv4 based table and rule {} is a IPV6 rule! Ignoring rule."
                                                           .format(table_name, rule_id))
                             acl_rules.pop(rule_props["PRIORITY"])
                         elif (self.is_rule_ipv4(rule_props) and (table_ip_version == 6)):
-                            log_error("CtrlPlane ACL table {} is a IPv6 based table and rule {} is a IPV4 rule!"
+                            log_error("CtrlPlane ACL table {} is a IPv6 based table and rule {} is a IPV4 rule! Ignroing rule."
                                                           .format(table_name, rule_id))
                             acl_rules.pop(rule_props["PRIORITY"])
 

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -55,8 +55,6 @@ def _ip_prefix_in_key(key):
     return (isinstance(key, tuple))
 
 # ============================== Classes ==============================
-class CPACLTblRulesException(Exception):
-    pass
 
 class ControlPlaneAclManager(object):
     """
@@ -370,12 +368,10 @@ class ControlPlaneAclManager(object):
                         if (self.is_rule_ipv6(rule_props) and (table_ip_version == 4)):
                             log_error("CtrlPlane ACL table {} is a IPv4 based table and rule {} is a IPV6 rule!"
                                                           .format(table_name, rule_id))
-                            raise CPACLTblRulesException("Trying to insall IPv6 rule %s in a IPv4 based ACL table"%rule_id)
 
                         elif (self.is_rule_ipv4(rule_props) and (table_ip_version == 6)):
                             log_error("CtrlPlane ACL table {} is a IPv6 based table and rule {} is a IPV4 rule!"
                                                           .format(table_name, rule_id))
-                            raise CPACLTblRulesException("Trying to insall IPv4 rule %s in a IPv6 based ACL table"%rule_id)
 
                 # If we were unable to determine whether this ACL table contains
                 # IPv4 or IPv6 rules, log a message and skip processing this table.

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -55,6 +55,8 @@ def _ip_prefix_in_key(key):
     return (isinstance(key, tuple))
 
 # ============================== Classes ==============================
+class CPACLTblRulesException(Exception):
+    pass
 
 class ControlPlaneAclManager(object):
     """
@@ -220,6 +222,19 @@ class ControlPlaneAclManager(object):
 
         return block_ip2me_cmds
 
+    def is_rule_ipv4(self, rule_props):
+        if (("SRC_IP" in rule_props and rule_props["SRC_IP"]) or
+            ("DST_IP" in rule_props and rule_props["DST_IP"])):
+            return True
+        else:
+            return False
+
+    def is_rule_ipv6(self, rule_props):
+        if (("SRC_IPV6" in rule_props and rule_props["SRC_IPV6"]) or
+            ("DST_IPV6" in rule_props and rule_props["DST_IPV6"])):
+            return True
+        else:
+            return False
 
     def get_acl_rules_and_translate_to_iptables_commands(self):
         """
@@ -354,18 +369,15 @@ class ControlPlaneAclManager(object):
                                   ("DST_IP" in rule_props and rule_props["DST_IP"])):
                                 table_ip_version = 4
 
-                        if ((("SRC_IPV6" in rule_props and rule_props["SRC_IPV6"]) or
-                            ("DST_IPV6" in rule_props and rule_props["DST_IPV6"])) and
-                            (table_ip_version == 4)):
+                        if (self.is_rule_ipv6(rule_props) and (table_ip_version == 4)):
                             log_error("CtrlPlane ACL table {} is a IPv4 based table and rule {} is a IPV6 rule!"
                                                           .format(table_name, rule_id))
-                            sys.exit(1)
-                        elif ((("SRC_IP" in rule_props and rule_props["SRC_IP"]) or
-                            ("DST_IP" in rule_props and rule_props["DST_IP"])) and
-                            (table_ip_version == 6)):
+                            raise CPACLTblRulesException("Trying to insall IPv6 rule %s in a IPv4 based ACL table"%rule_id)
+
+                        elif (self.is_rule_ipv4(rule_props) and (table_ip_version == 6)):
                             log_error("CtrlPlane ACL table {} is a IPv6 based table and rule {} is a IPV4 rule!"
                                                           .format(table_name, rule_id))
-                            sys.exit(1)
+                            raise CPACLTblRulesException("Trying to insall IPv4 rule %s in a IPv6 based ACL table"%rule_id)
 
                 # If we were unable to determine whether this ACL table contains
                 # IPv4 or IPv6 rules, log a message and skip processing this table.

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -368,10 +368,11 @@ class ControlPlaneAclManager(object):
                         if (self.is_rule_ipv6(rule_props) and (table_ip_version == 4)):
                             log_error("CtrlPlane ACL table {} is a IPv4 based table and rule {} is a IPV6 rule!"
                                                           .format(table_name, rule_id))
-
+                            acl_rules.pop(rule_props["PRIORITY"])
                         elif (self.is_rule_ipv4(rule_props) and (table_ip_version == 6)):
                             log_error("CtrlPlane ACL table {} is a IPv6 based table and rule {} is a IPV4 rule!"
                                                           .format(table_name, rule_id))
+                            acl_rules.pop(rule_props["PRIORITY"])
 
                 # If we were unable to determine whether this ACL table contains
                 # IPv4 or IPv6 rules, log a message and skip processing this table.

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -362,11 +362,9 @@ class ControlPlaneAclManager(object):
                         # try to do it now. We attempt to determine heuristically based on
                         # whether the src or dst IP of this rule is an IPv4 or IPv6 address.
                         if not table_ip_version:
-                            if (("SRC_IPV6" in rule_props and rule_props["SRC_IPV6"]) or
-                                ("DST_IPV6" in rule_props and rule_props["DST_IPV6"])):
+                            if self.is_rule_ipv6(rule_props):
                                 table_ip_version = 6
-                            elif (("SRC_IP" in rule_props and rule_props["SRC_IP"]) or
-                                  ("DST_IP" in rule_props and rule_props["DST_IP"])):
+                            elif self.is_rule_ipv4(rule_props):
                                 table_ip_version = 4
 
                         if (self.is_rule_ipv6(rule_props) and (table_ip_version == 4)):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**-What I did? I added condition to check whether a new IPv6 rule is getting added to a IPv4 rule based ACL table and log a syslog. And, the same for IPv4 based rule in a IPv6 based table.

**- How I did it? I added condition with matching table_ip_version against the rule props.

**-How did I verify? I added an IPv6 rule in a ACL table which contains all IPv4 rules and verified it writes a SYSLOG error.

**- Description for the changelog**
A condition check to verify only either IPv4 rules are added or IPv6 rules are added to the Control Plane ACL table.

The previous behavior of the caclmgrd was with both IPV4 rules and IPV6 rules added to the same control plane ACL table, inconsistent ACL rules were getting added and iptables and ip6tables commands were invoked with such inconsistent ACL rules. That is why this restriction of ACL tables can have only IPV4 rules or IPV6 rules.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
SYSLOG if an IPv4 rule is added to IPv6 based ACL table or vice versa.

**- A picture of a cute animal (not mandatory but encouraged)**
