### PR TITLE
[Multiasic]: Mount network namespace on SNMP docker

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -243,7 +243,7 @@ start() {
 {%- if docker_container_name != "database" %}
         -v /usr/share/sonic/device/$PLATFORM/$HWSKU/$DEV:/usr/share/sonic/hwsku:ro \
 {%- endif %}
-{%- if docker_container_name != "snmp" %}
+{%- if docker_container_name == "snmp" %}
         $NET_NS_MOUNT \
 {%- endif %}
 {%- if sonic_asic_platform != "mellanox" %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -199,12 +199,15 @@ start() {
     # TODO: Mellanox will remove the --tmpfs exception after SDK socket path changed in new SDK version
 {%- endif %}
 {%- if docker_container_name == "snmp" %}
-    NET_NS_PATH="/var/run/netns/*"
-    for NS_FILE in $NET_NS_PATH
-    do
-        LINK=`readlink -q $NS_FILE`
-        NET_NS_MOUNT=$NET_NS_MOUNT" -v $LINK:$NS_FILE:ro"
-    done
+    NET_NS_MOUNT=""
+    if [ -d "/var/run/netns/" ]; then
+	NS_PATH="/var/run/netns/*"
+        for NS_FILE in $NS_PATH 
+        do
+            LINK=`readlink -q $NS_FILE`
+            NET_NS_MOUNT=$NET_NS_MOUNT" -v $LINK:$NS_FILE:ro"
+        done
+    fi
 {%- endif %}
     docker create {{docker_image_run_opt}} \
         --net=$NET \

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -142,6 +142,14 @@ start() {
     # Obtain our HWSKU as we will mount directories with these names in each docker
     HWSKU=`sonic-netns-exec "$NET_NS" sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`
     {%- endif %}
+    {%- if docker_container_name == "snmp" %}
+    MOUNTS=`docker inspect -f '{{ .Mounts }}' {{docker_container_name}}`
+    # If previously mounted /var/run/netns exists the remove docker
+    if `echo $MOUNTS | grep --quiet "/var/run/netns"`; then
+        docker rm -f {{docker_container_name}}$DEV
+        echo "Removing {{docker_container_name}}$DEV container to clean-up netns mount."
+    fi
+    {%- endif %}
 
     DOCKERCHECK=`docker inspect --type container {{docker_container_name}}$DEV 2>/dev/null`
     if [ "$?" -eq "0" ]; then

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -201,7 +201,7 @@ start() {
 {%- if docker_container_name == "snmp" %}
     NET_NS_MOUNT=""
     if [ -d "/var/run/netns/" ]; then
-	NS_PATH="/var/run/netns/*"
+        NS_PATH="/var/run/netns/*"
         for NS_FILE in $NS_PATH 
         do
             LINK=`readlink -q $NS_FILE`

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -241,7 +241,7 @@ start() {
         -v /usr/share/sonic/device/$PLATFORM/$HWSKU/$DEV:/usr/share/sonic/hwsku:ro \
 {%- endif %}
 {%- if docker_container_name != "snmp" %}
-        $NET_NS_MOUNT \        
+        $NET_NS_MOUNT \
 {%- endif %}
 {%- if sonic_asic_platform != "mellanox" %}
         --tmpfs /tmp \

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -198,6 +198,14 @@ start() {
 {%- if sonic_asic_platform == "mellanox" %}
     # TODO: Mellanox will remove the --tmpfs exception after SDK socket path changed in new SDK version
 {%- endif %}
+{%- if docker_container_name == "snmp" %}
+    NET_NS_PATH="/var/run/netns/*"
+    for NS_FILE in $NET_NS_PATH
+    do
+        LINK=`readlink -q $NS_FILE`
+        NET_NS_MOUNT=$NET_NS_MOUNT" -v $LINK:$NS_FILE:ro"
+    done
+{%- endif %}
     docker create {{docker_image_run_opt}} \
         --net=$NET \
         --uts=host \{# W/A: this should be set per-docker, for those dockers which really need host's UTS namespace #}
@@ -231,6 +239,9 @@ start() {
         -v /usr/share/sonic/device/$PLATFORM:/usr/share/sonic/platform:ro \
 {%- if docker_container_name != "database" %}
         -v /usr/share/sonic/device/$PLATFORM/$HWSKU/$DEV:/usr/share/sonic/hwsku:ro \
+{%- endif %}
+{%- if docker_container_name != "snmp" %}
+        $NET_NS_MOUNT \        
 {%- endif %}
 {%- if sonic_asic_platform != "mellanox" %}
         --tmpfs /tmp \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
In multi-asic platforms, SNMP docker is running on host network. 
SNMP docker will need to access all network namespaces.

**- How I did it**
Mount all network namespaces from host /var/run/netns directory to SNMP docker.

**- How to verify it**
Single asic platform: No change
multi-asic platform: In SNMP docker, /var/run/netns directory files should be visible.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
