### PR TITLE
[process-reboot-cause] If software reboot cause is unknown add note if first boot into new image

### DIFF
--- a/files/image_config/process-reboot-cause/process-reboot-cause
+++ b/files/image_config/process-reboot-cause/process-reboot-cause
@@ -12,6 +12,8 @@ try:
     import sys
     import syslog
     import re
+
+    import sonic_device_util
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
 
@@ -35,7 +37,6 @@ REBOOT_TYPE_KEXEC_PATTERN_WARM = ".*SONIC_BOOT_TYPE=(warm|fastfast).*"
 REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
 
 REBOOT_CAUSE_UNKNOWN = "Unknown"
-REBOOT_CAUSE_SONIC_IMAGE_INSTALL = "SONiC image installation"
 
 
 # ========================== Syslog wrappers ==========================
@@ -84,7 +85,9 @@ def find_software_reboot_cause():
 
     if os.path.isfile(FIRST_BOOT_PLATFORM_FILE):
         if software_reboot_cause == REBOOT_CAUSE_UNKNOWN:
-            software_reboot_cause = REBOOT_CAUSE_SONIC_IMAGE_INSTALL
+            version_info = sonic_device_util.get_sonic_version_info()
+            build_version = version_info['build_version'] if version_info else "unknown"
+            software_reboot_cause += " (First boot of SONiC version {})".format(build_version)
         os.remove(FIRST_BOOT_PLATFORM_FILE)
 
     return software_reboot_cause

--- a/files/image_config/process-reboot-cause/process-reboot-cause
+++ b/files/image_config/process-reboot-cause/process-reboot-cause
@@ -82,6 +82,8 @@ def find_software_reboot_cause():
         log_info("Reboot cause file {} not found".format(REBOOT_CAUSE_FILE))
 
     if os.path.isfile(FIRST_BOOT_PLATFORM_FILE):
+        if software_reboot_cause == UNKNOWN_REBOOT_CAUSE:
+            software_reboot_cause = "SONiC image installation"
         os.remove(FIRST_BOOT_PLATFORM_FILE)
 
     return software_reboot_cause

--- a/files/image_config/process-reboot-cause/process-reboot-cause
+++ b/files/image_config/process-reboot-cause/process-reboot-cause
@@ -34,7 +34,8 @@ REBOOT_TYPE_KEXEC_FILE = "/proc/cmdline"
 REBOOT_TYPE_KEXEC_PATTERN_WARM = ".*SONIC_BOOT_TYPE=(warm|fastfast).*"
 REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
 
-UNKNOWN_REBOOT_CAUSE = "Unknown"
+REBOOT_CAUSE_UNKNOWN = "Unknown"
+REBOOT_CAUSE_SONIC_IMAGE_INSTALL = "SONiC image installation"
 
 
 # ========================== Syslog wrappers ==========================
@@ -72,7 +73,7 @@ def parse_warmfast_reboot_from_proc_cmdline():
 
 
 def find_software_reboot_cause():
-    software_reboot_cause = UNKNOWN_REBOOT_CAUSE
+    software_reboot_cause = REBOOT_CAUSE_UNKNOWN
 
     if os.path.isfile(REBOOT_CAUSE_FILE):
         with open(REBOOT_CAUSE_FILE, "r") as cause_file:
@@ -82,8 +83,8 @@ def find_software_reboot_cause():
         log_info("Reboot cause file {} not found".format(REBOOT_CAUSE_FILE))
 
     if os.path.isfile(FIRST_BOOT_PLATFORM_FILE):
-        if software_reboot_cause == UNKNOWN_REBOOT_CAUSE:
-            software_reboot_cause = "SONiC image installation"
+        if software_reboot_cause == REBOOT_CAUSE_UNKNOWN:
+            software_reboot_cause = REBOOT_CAUSE_SONIC_IMAGE_INSTALL
         os.remove(FIRST_BOOT_PLATFORM_FILE)
 
     return software_reboot_cause
@@ -150,7 +151,7 @@ def main():
         os.remove(PREVIOUS_REBOOT_CAUSE_FILE)
 
     # Set a default previous reboot cause
-    previous_reboot_cause = UNKNOWN_REBOOT_CAUSE
+    previous_reboot_cause = REBOOT_CAUSE_UNKNOWN
 
     # 1. Check if the previous reboot was warm/fast reboot by testing whether there is "fast|fastfast|warm" in /proc/cmdline
     proc_cmdline_reboot_cause = find_proc_cmdline_reboot_cause()
@@ -190,7 +191,7 @@ def main():
 
     # Write a new default reboot cause file for the next reboot
     with open(REBOOT_CAUSE_FILE, "w") as cause_file:
-        cause_file.write(UNKNOWN_REBOOT_CAUSE)
+        cause_file.write(REBOOT_CAUSE_UNKNOWN)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If no software reboot cause can be determined (i.e., `REBOOT_CAUSE_FILE` doesn't exist), and `FIRST_BOOT_PLATFORM_FILE` exists, it is very likely the device just booted up after a fresh SONiC image installation. In this case, we add a note in the reboot cause string.