### PR TITLE
[MultiDB] daemon base should use multiDB DBConnector

### DIFF
--- a/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
+++ b/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
@@ -14,11 +14,6 @@ except ImportError, e:
 # Constants ====================================================================
 #
 
-# Redis DB information
-REDIS_HOSTNAME = 'localhost'
-REDIS_PORT = 6379
-REDIS_TIMEOUT_MSECS = 0
-
 # Platform root directory inside docker
 PLATFORM_ROOT_DOCKER = '/usr/share/sonic/platform'
 SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
@@ -36,12 +31,11 @@ EEPROM_CLASS_NAME = 'board'
 # Helper functions =============================================================
 #
 
-def db_connect(db):
+def db_connect(db_name):
     from swsscommon import swsscommon
-    return swsscommon.DBConnector(db,
-                                  REDIS_HOSTNAME,
-                                  REDIS_PORT,
-                                  REDIS_TIMEOUT_MSECS)
+    return swsscommon.DBConnector(db_name,
+                                  REDIS_TIMEOUT_MSECS,
+                                  True)
 
 #
 # Helper classes ===============================================================


### PR DESCRIPTION
* Should use new multiDB Connector in daemon base
* When merging this this PR, need to make sure https://github.com/Azure/sonic-platform-daemons/pull/57 is already updated to the latest.  

* update submodule in this PR as well to avoid dependency between  https://github.com/Azure/sonic-platform-daemons/pull/57 and this PR.
  * [MultiDB] shoule use multiDB API (#57)
  * [thermalctld] Fix invalid warning status (#58)
  * [syseepromd] Prevent the syseepromd from termination (#56)

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com