### PR TITLE
  [NAT] : Removed requires dependency on swss

### DIFF
--- a/files/build_templates/nat.service.j2
+++ b/files/build_templates/nat.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=NAT container
-Requires=updategraph.service swss.service
+Requires=updategraph.service
 After=updategraph.service swss.service syncd.service
 Before=ntp-config.service
 StartLimitIntervalSec=1200


### PR DESCRIPTION
Removed swss service for Requires list for NAT.

This PR is to fix for the issue https://github.com/Azure/sonic-buildimage/issues/4473

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>

