### PR TITLE
Fix "/host unmount failure" during reboot 

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -216,6 +216,11 @@ sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.d/* $FILESYSTEM_ROOT/etc/rsyslog.d/
 echo "rsyslog-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
+#copy syslog override files
+sudo mkdir -p $FILESYSTEM_ROOT/etc/systemd/system/syslog.socket.d
+sudo cp $IMAGE_CONFIGS/syslog/override.conf $FILESYSTEM_ROOT/etc/systemd/system/syslog.socket.d/override.conf
+sudo cp $IMAGE_CONFIGS/syslog/host_umount.sh $FILESYSTEM_ROOT/usr/bin/
+
 # Copy logrotate.d configuration files
 sudo cp -f $IMAGE_CONFIGS/logrotate/logrotate.d/* $FILESYSTEM_ROOT/etc/logrotate.d/
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -216,7 +216,7 @@ sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.d/* $FILESYSTEM_ROOT/etc/rsyslog.d/
 echo "rsyslog-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
-#copy syslog override files
+# Copy syslog override files
 sudo mkdir -p $FILESYSTEM_ROOT/etc/systemd/system/syslog.socket.d
 sudo cp $IMAGE_CONFIGS/syslog/override.conf $FILESYSTEM_ROOT/etc/systemd/system/syslog.socket.d/override.conf
 sudo cp $IMAGE_CONFIGS/syslog/host_umount.sh $FILESYSTEM_ROOT/usr/bin/

--- a/files/image_config/syslog/host_umount.sh
+++ b/files/image_config/syslog/host_umount.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#This script is invoked at the closure of syslog socket during reboot
-#This will stop journal services, unmount /var/log and delete loop device 
-#associated to /host to ensure proper unmount of /host
+# This script is invoked at the closure of syslog socket during reboot
+# This will stop journal services, unmount /var/log and delete loop device 
+# associated to /host to ensure proper unmount of /host
 
 journal_stop() {
     systemctl stop systemd-journald.service
@@ -14,17 +14,18 @@ delete_loop_device() {
     umount /var/log
     if [[ $? -ne 0 ]]
     then
-	exit 0
+        exit 0
     fi
     losetup -d /dev/loop1
 }
 
 case "$1" in
     journal_stop|delete_loop_device)
-	$1
-	;;
+        $1
+        ;;
     *)
-	echo "Usage: $0 {journal_stop|delete_loop_device}"
-	;;
+        echo "Usage: $0 {journal_stop|delete_loop_device}" >&2
+        exit 1
+        ;;
 esac
 

--- a/files/image_config/syslog/host_umount.sh
+++ b/files/image_config/syslog/host_umount.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#This script is invoked at the closure of syslog socket during reboot
+#This will stop journal services, unmount /var/log and delete loop device 
+#associated to /host to ensure proper unmount of /host
+
+journal_stop() {
+    systemctl stop systemd-journald.service
+    systemctl stop systemd-journald.socket
+    systemctl stop systemd-journald-audit.socket
+    systemctl stop systemd-journald-dev-log.socket
+}
+
+delete_loop_device() {
+    umount /var/log
+    if [[ $? -ne 0 ]]
+    then
+	exit 0
+    fi
+    losetup -d /dev/loop1
+}
+
+case "$1" in
+    journal_stop|delete_loop_device)
+	$1
+	;;
+    *)
+	echo "Usage: $0 {journal_stop|delete_loop_device}"
+	;;
+esac
+

--- a/files/image_config/syslog/override.conf
+++ b/files/image_config/syslog/override.conf
@@ -1,0 +1,7 @@
+[Unit]
+After=var-log.mount host.mount
+
+[Socket]
+ExecStopPre=/usr/bin/host_umount.sh journal_stop
+ExecStopPost=/usr/bin/host_umount.sh delete_loop_device
+

--- a/files/image_config/syslog/override.conf
+++ b/files/image_config/syslog/override.conf
@@ -4,4 +4,3 @@ After=var-log.mount host.mount
 [Socket]
 ExecStopPre=/usr/bin/host_umount.sh journal_stop
 ExecStopPost=/usr/bin/host_umount.sh delete_loop_device
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
During /sbin/reboot, the /host unmount failure happened.
**- How I did it**
The /var/log is mounted as a separate ext4 filesystem. This ext4 filesystem is associated with a loop device and mounted along with root partition.This loop device association needs to be detached after unmounting /var/log which systemd is not performing. 
The script to stop the journal services, unmount /var/log and detele the loop device has been invoked at the closure of syslog.socket.

**- How to verify it**
I have verified the 100 iterations of reboot and confirmed issue has been fixed in all dell platforms.
Once the device is up, have checked if the /var/log, host partitions has been mounted properly.
Fast-boot, warm-boot and normal reboot has also been verified.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:

-->
Fixed the /host unmount failure issue.
Attaching the logs of 100 iterations in S6100 device.

**- A picture of a cute animal (not mandatory but encouraged)**

[logs_S6100.txt](https://github.com/Azure/sonic-buildimage/files/4597483/logs_S6100.txt)
