### PR TITLE
Moved utility functions for multi-npu platforms from sonic-utilities to sonic_device_util.py

### DIFF
--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -25,6 +25,8 @@ SONIC_DEVICE_PATH = '/usr/share/sonic/device'
 NPU_NAME_PREFIX = 'asic'
 NAMESPACE_PATH_GLOB = '/run/netns/*'
 ASIC_CONF_FILENAME = 'asic.conf'
+FRONTEND_ASIC_SUB_ROLE = 'FrontEnd'
+BACKEND_ASIC_SUB_ROLE = 'BackEnd'
 def get_machine_info():
     if not os.path.isfile('/host/machine.conf'):
         return None
@@ -45,7 +47,7 @@ def get_npu_id_from_name(npu_name):
 
 def get_num_npus():
     platform = get_platform_info(get_machine_info())
-    if platform is None:
+    if not platform:
         return 1
     asic_conf_file_path = os.path.join(SONIC_DEVICE_PATH, platform, ASIC_CONF_FILENAME)
     if not os.path.isfile(asic_conf_file_path):
@@ -89,10 +91,7 @@ def get_platform():
 
 def is_multi_npu():
     num_npus = get_num_npus()
-    if num_npus > 1:
-        return True
-    else:
-        return False
+    return (num_npus > 1)
 
 def get_all_namespaces():
     """
@@ -112,9 +111,9 @@ def get_all_namespaces():
             config_db.connect()
 
             metadata = config_db.get_table('DEVICE_METADATA')
-            if metadata['localhost']['sub_role'] == 'FrontEnd':
+            if metadata['localhost']['sub_role'] == FRONTEND_ASIC_SUB_ROLE:
                 front_ns.append(namespace)
-            elif metadata['localhost']['sub_role'] == 'BackEnd':
+            elif metadata['localhost']['sub_role'] == BACKEND_ASIC_SUB_ROLE:
                 back_ns.append(namespace)
 
     return {'front_ns':front_ns, 'back_ns':back_ns}

--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -57,7 +57,7 @@ def get_num_npus():
                continue
             if tokens[0].lower() == 'num_asic':
                 num_npus = tokens[1].strip()
-        return num_npus
+        return int(num_npus)
 
 def get_namespaces():
     """

--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -5,6 +5,9 @@ import subprocess
 import re
 from natsort import natsorted
 import glob
+from swsssdk import ConfigDBConnector
+from swsssdk import SonicDBConfig
+
 DOCUMENTATION = '''
 ---
 module: sonic_device_util
@@ -21,6 +24,7 @@ to have it shared with multiple applications.
 SONIC_DEVICE_PATH = '/usr/share/sonic/device'
 NPU_NAME_PREFIX = 'asic'
 NAMESPACE_PATH_GLOB = '/run/netns/*'
+ASIC_CONF_FILENAME = 'asic.conf'
 def get_machine_info():
     if not os.path.isfile('/host/machine.conf'):
         return None
@@ -41,7 +45,7 @@ def get_npu_id_from_name(npu_name):
 
 def get_num_npus():
     platform = get_platform_info(get_machine_info())
-    asic_conf_file_path = os.path.join(SONIC_DEVICE_PATH, platform, 'asic.conf')
+    asic_conf_file_path = os.path.join(SONIC_DEVICE_PATH, platform, ASIC_CONF_FILENAME)
     if not os.path.isfile(asic_conf_file_path):
         return 1
     with open(asic_conf_file_path) as asic_conf_file:
@@ -63,6 +67,55 @@ def get_namespaces():
         ns = os.path.basename(path)
         ns_list.append(ns)
     return natsorted(ns_list)
+
+def get_hwsku():
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    metadata = config_db.get_table('DEVICE_METADATA')
+    return metadata['localhost']['hwsku']
+
+def get_platform():
+    if not os.path.isfile('/host/machine.conf'):
+        return ''
+ 
+    with open('/host/machine.conf') as machine_conf:
+        for line in machine_conf:
+            tokens = line.split('=')
+            if tokens[0].strip() == 'onie_platform' or tokens[0].strip() == 'aboot_platform':
+                return tokens[1].strip()
+    return ''
+
+def is_multi_npu():
+    num_npus = get_num_npus()
+    if num_npus > 1:
+        return True
+    else:
+        return False
+
+def get_all_namespaces():
+    """
+    In case of Multi-Asic platform, Each ASIC will have a linux network namespace created.
+    So we loop through the databases in different namespaces and depending on the sub_role
+    decide whether this is a front end ASIC/namespace or a back end one.
+    """
+    front_ns = []
+    back_ns = []
+    num_npus = get_num_npus()
+    SonicDBConfig.load_sonic_global_db_config()
+    
+    if is_multi_npu():
+        for npu in range(num_npus):
+            namespace = "{}{}".format(NPU_NAME_PREFIX, npu)
+            config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+            config_db.connect()
+
+            metadata = config_db.get_table('DEVICE_METADATA')
+            if metadata['localhost']['sub_role'] == 'FrontEnd':
+                front_ns.append(namespace)
+            elif metadata['localhost']['sub_role'] == 'BackEnd':
+                back_ns.append(namespace)
+
+    return {'front_ns':front_ns, 'back_ns':back_ns}
 
 def get_platform_info(machine_info):
     if machine_info != None:

--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -45,6 +45,8 @@ def get_npu_id_from_name(npu_name):
 
 def get_num_npus():
     platform = get_platform_info(get_machine_info())
+    if platform is None:
+        return 1
     asic_conf_file_path = os.path.join(SONIC_DEVICE_PATH, platform, ASIC_CONF_FILENAME)
     if not os.path.isfile(asic_conf_file_path):
         return 1

--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -5,8 +5,7 @@ import subprocess
 import re
 from natsort import natsorted
 import glob
-from swsssdk import ConfigDBConnector
-from swsssdk import SonicDBConfig
+from swsssdk import ConfigDBConnector, SonicDBConfig
 
 DOCUMENTATION = '''
 ---


### PR DESCRIPTION
**- Why I did it**
Moved utility functions for multi-npu platforms from sonic-utilities  config/main.py to sonic_device_util.py so that they can be used by any module. Also updated the code based on existing API's. This PR is needed with sonic-utlities PR: 
https://github.com/Azure/sonic-utilities/pull/908

**- How I did it**
Moving the API's()

**- How to verify it**
Manually Verfiied on Multi-NPU Platforms.