### PR TITLE
DellEMC S6000 updated sensors.conf

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/sensors.conf
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/sensors.conf
@@ -7,8 +7,8 @@
 # tmp75-i2c-11-4e is an ambient temperature sensor.
 
 chip "tmp75-*"
-     set temp1_max 50
-     set temp1_max_hyst 25
+     set temp1_max 80
+     set temp1_max_hyst 70
 
 # emc1403-i2c-10-4d has following temperature sensors:
 # temp1: CPU0 external Temp Sensor
@@ -32,5 +32,5 @@ chip "jc42-*"
      set temp1_crit 85
 
 chip "dni_dps460-*"
-     set temp1_max 50
-     set temp2_max 50
+     set temp1_max 80
+     set temp2_max 80


### PR DESCRIPTION
- What I did

Change PSU MAX temperature to 80 degree 
Change tmp75 sensors default temperature value from 25/50 to 70/80 degree.

- How I did it
 Updated sensors.conf for DellEMC S6000.

- How to verify
Execure sensors command 

--- 

Note: This is a forward-port of https://github.com/Azure/sonic-buildimage/pull/3870 which was merged into the 201811 branch a few months ago.