### PR TITLE
Fix for issue where image is compile with flag ENABLE_DHCP_GRAPH_SERVICE and loaded it will not able to use existing config_db.json

### DIFF
--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -310,6 +310,8 @@ do_config_migration()
             # Migrate the DB to the latest schema version if needed
             /usr/bin/db_migrator.py -o migrate
         fi
+        # Disable updategraph
+        disable_updategraph
     elif [ -r ${MINGRAPH_FILE} ]; then
         echo "Use minigraph.xml from old system..."
         reload_minigraph


### PR DESCRIPTION
**- Why I did it**
Fix for issue where image is compile with flag ENABLE_DHCP_GRAPH_SERVICE and then we load image and reboot even if there was existing
config_db.json on file system we will still look for DHCP Service for minigraph after reboot and system remain in that state.  We should disable update_graph in such cases. This behavior is similar to what we have in
201811 image.

**- How I did it**
Disable upgdate_graph 
**- How to verify it**
Verified Manually 