### PR TITLE
[ntp] enable/disable NTP long jump according to reboot type

### DIFF
--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -7,8 +7,8 @@ reboot_type='cold'
 
 function get_database_reboot_type()
 {
-    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
-    SYSTEM_FAST_START=`/usr/bin/redis-cli -n 6 get "FAST_REBOOT|system"`
+    SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_FAST_START=`sonic-db-cli STATE_DB get "FAST_REBOOT|system"`
 
     if [[ x"${SYSTEM_WARM_START}" == x"true" ]]; then
         reboot_type='warm'

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -2,7 +2,7 @@
 
 reboot_type='cold'
 
-function get_databaes_reboot_type()
+function get_database_reboot_type()
 {
     SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
     SYSTEM_FAST_START=`/usr/bin/redis-cli -n 6 get "FAST_REBOOT|system"`
@@ -16,7 +16,7 @@ function get_databaes_reboot_type()
 
 sonic-cfggen -d -t /usr/share/sonic/templates/ntp.conf.j2 >/etc/ntp.conf
 
-get_databaes_reboot_type
+get_database_reboot_type
 if [[ x"${reboot_type}" == x"cold" ]]; then
     echo "Enabling NTP long jump for reboot type ${reboot_type} ..."
     sed -i "s/NTPD_OPTS='-x'/NTPD_OPTS='-g'/" /etc/default/ntp

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
 
+reboot_type='cold'
+
+function get_databaes_reboot_type()
+{
+    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_FAST_START=`/usr/bin/redis-cli -n 6 get "FAST_REBOOT|system"`
+
+    if [[ x"${SYSTEM_WARM_START}" == x"true" ]]; then
+        reboot_type='warm'
+    elif [[ x"${SYSTEM_FAST_START}" == x"1" ]]; then
+        reboot_type='fast'
+    fi
+}
+
 sonic-cfggen -d -t /usr/share/sonic/templates/ntp.conf.j2 >/etc/ntp.conf
+
+get_databaes_reboot_type
+if [[ x"${reboot_type}" == x"cold" ]]; then
+    echo "Enabling NTP long jump for reboot type ${reboot_type} ..."
+    sed -i "s/NTPD_OPTS='-x'/NTPD_OPTS='-g'/" /etc/default/ntp
+else
+    echo "Disabling NTP long jump for reboot type ${reboot_type} ..."
+    sed -i "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/" /etc/default/ntp
+fi
 
 systemctl restart ntp


### PR DESCRIPTION
**- Why I did it**
NTP long jump could still causing unexpected failures. It is more dangerous after fast/warm reboot when reliability is on the line.

**- How I did it**
- Enable NTP long jump after cold reboot.
- Disable NTP long jump after warrm/fast reboot.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
cold reboot:
May 12 04:20:12.791159 str-7260cx3-acs-1 INFO systemd[1]: Starting Update NTP configuration...
May 12 04:20:13.928988 str-7260cx3-acs-1 INFO ntp-config.sh[3829]: Enabling NTP long jump for reboot type cold ...
admin@str-7260cx3-acs-1:$ cat /etc/default/ntp 
NTPD_OPTS='-g'

warm reboot:
May 12 04:37:45.971592 str-7260cx3-acs-1 INFO systemd[1]: Starting Update NTP configuration...
May 12 04:37:47.329887 str-7260cx3-acs-1 INFO ntp-config.sh[3933]: Disabling NTP long jump for reboot type warm ...
admin@str-7260cx3-acs-1:$ cat /etc/default/ntp 
NTPD_OPTS='-x'
fast reboot:
May 12 04:40:39.773005 str-7260cx3-acs-1 INFO systemd[1]: Starting Update NTP configuration...
May 12 04:40:40.860081 str-7260cx3-acs-1 INFO ntp-config.sh[3787]: Disabling NTP long jump for reboot type fast ...
admin@str-7260cx3-acs-1:$ cat /etc/default/ntp 
NTPD_OPTS='-x'