### PR TITLE
[201811][ntp] enable/disable NTP long jump according to reboot type

### DIFF
--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -1,5 +1,37 @@
 #!/bin/bash
 
+ntp_default_file='/etc/default/ntp'
+ntp_temp_file='/tmp/ntp.orig'
+
+reboot_type='cold'
+
+function get_database_reboot_type()
+{
+    SYSTEM_WARM_START=`/usr/bin/redis-cli -n 6 hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_FAST_START=`/usr/bin/redis-cli -n 6 get "FAST_REBOOT|system"`
+
+    if [[ x"${SYSTEM_WARM_START}" == x"true" ]]; then
+        reboot_type='warm'
+    elif [[ x"${SYSTEM_FAST_START}" == x"1" ]]; then
+        reboot_type='fast'
+    fi
+}
+
+function modify_ntp_default
+{
+    cp ${ntp_default_file} ${ntp_temp_file}
+    sed -e "$1" ${ntp_temp_file} >${ntp_default_file}
+}
+
 sonic-cfggen -d -t /usr/share/sonic/templates/ntp.conf.j2 >/etc/ntp.conf
+
+get_database_reboot_type
+if [[ x"${reboot_type}" == x"cold" ]]; then
+    echo "Enabling NTP long jump for reboot type ${reboot_type} ..."
+    modify_ntp_default "s/NTPD_OPTS='-x'/NTPD_OPTS='-g'/"
+else
+    echo "Disabling NTP long jump for reboot type ${reboot_type} ..."
+    modify_ntp_default "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"
+fi
 
 systemctl restart ntp


### PR DESCRIPTION
**- Why I did it**
- This PR is 201811 edition of https://github.com/Azure/sonic-buildimage/pull/4577.
- Latest review comments on above PR cannot be cherry-picked into 201811.

**- How I did it**
- Enable NTP long jump after cold reboot.
- Disable NTP long jump after warrm/fast reboot.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Please see information on https://github.com/Azure/sonic-buildimage/pull/4577