### PR TITLE
Change to enable redistribute connected on Frontend asics instead of backend asics

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -62,7 +62,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endblock vlan_advertisement %}
 !
 !
-{% if DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
+{% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' %}
   redistribute connected route-map HIDE_INTERNAL
 {% endif %}
 !


### PR DESCRIPTION

Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Change to enable redistribute connected on Frontend asics instead of backend asics
**- How I did it**
Modify the condition to check for sub_role is FrontEnd instead on BackEnd
**- How to verify it**
Load on multi npu platform and verify is connected routes are distributed on Frontend asics