### PR TITLE
[caclmgrd] Add support to allow/deny any IP/IPv6 protocol packets coming to CPU based on source IP

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -85,11 +85,7 @@ class ControlPlaneAclManager(object):
             "ip_protocols": ["tcp"],
             "dst_ports": ["22"]
         },
-        "IP_ANY": {
-            "ip_protocols": ["any"],
-            "dst_ports": ["0"]
-        },
-        "IPV6_ANY": {
+        "ANY": {
             "ip_protocols": ["any"],
             "dst_ports": ["0"]
         }

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -376,11 +376,11 @@ class ControlPlaneAclManager(object):
                     for ip_protocol in ip_protocols:
                         for dst_port in dst_ports:
                             rule_cmd = "ip6tables" if table_ip_version == 6 else "iptables"
-                            if ip_protocol != "any":
-                                rule_cmd += " -A INPUT -p {}".format(ip_protocol)
-                            else:
-                                rule_cmd += " -A INPUT "
 
+                            rule_cmd += " -A INPUT"
+                            if ip_protocol != "any":
+                                rule_cmd += " -p {}".format(ip_protocol)
+ 
                             if "SRC_IPV6" in rule_props and rule_props["SRC_IPV6"]:
                                 rule_cmd += " -s {}".format(rule_props["SRC_IPV6"])
                             elif "SRC_IP" in rule_props and rule_props["SRC_IP"]:

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -84,6 +84,14 @@ class ControlPlaneAclManager(object):
         "SSH": {
             "ip_protocols": ["tcp"],
             "dst_ports": ["22"]
+        },
+        "IP_ANY": {
+            "ip_protocols": ["any"],
+            "dst_ports": ["0"]
+        },
+        "IPV6_ANY": {
+            "ip_protocols": ["any"],
+            "dst_ports": ["0"]
         }
     }
 
@@ -368,14 +376,18 @@ class ControlPlaneAclManager(object):
                     for ip_protocol in ip_protocols:
                         for dst_port in dst_ports:
                             rule_cmd = "ip6tables" if table_ip_version == 6 else "iptables"
-                            rule_cmd += " -A INPUT -p {}".format(ip_protocol)
+                            if ip_protocol != "any":
+                                rule_cmd += " -A INPUT -p {}".format(ip_protocol)
+                            else:
+                                rule_cmd += " -A INPUT "
 
                             if "SRC_IPV6" in rule_props and rule_props["SRC_IPV6"]:
                                 rule_cmd += " -s {}".format(rule_props["SRC_IPV6"])
                             elif "SRC_IP" in rule_props and rule_props["SRC_IP"]:
                                 rule_cmd += " -s {}".format(rule_props["SRC_IP"])
 
-                            rule_cmd += " --dport {}".format(dst_port)
+                            if dst_port != "0":
+                                rule_cmd += " --dport {}".format(dst_port)
 
                             # If there are TCP flags present and ip protocol is TCP, append them
                             if ip_protocol == "tcp" and "TCP_FLAGS" in rule_props and rule_props["TCP_FLAGS"]:

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -386,6 +386,7 @@ class ControlPlaneAclManager(object):
                             elif "SRC_IP" in rule_props and rule_props["SRC_IP"]:
                                 rule_cmd += " -s {}".format(rule_props["SRC_IP"])
 
+                            # Destination port 0 is reserved/unused port, so, using it to apply the rule to all ports.
                             if dst_port != "0":
                                 rule_cmd += " --dport {}".format(dst_port)
 


### PR DESCRIPTION
**- Why I did it**
Need support to allow/deny packets coming to CPU based on source IP.
**- How I did it**
Added the ANY to allow/deny any protocol packets matching the source IP.
**- How to verify it**
Loaded the CTRLPLANE ACL configs with just source IP and verified the iptable rules in the kernel.

**- A picture of a cute animal (not mandatory but encouraged)**


UT:

```
 root@sonic:/home/admin# cat acl-cfg
{
"ACL_RULE": {
        "IP6_ACL|RULE_1": {
            "IP_PROTOCOL": "any",
            "PACKET_ACTION": "ACCEPT",
            "PRIORITY": "9999",
            "SRC_IPV6": "2001::/64"
        },
        "IP6_ACL|RULE_2": {
            "IP_PROTOCOL": "any",
            "PACKET_ACTION": "ACCEPT",
            "PRIORITY": "9998",
            "SRC_IPV6": "fe80::/10"
        },
        "IP6_ACL|RULE_3": {
            "IP_PROTOCOL": "any",
            "PACKET_ACTION": "ACCEPT",
            "PRIORITY": "9997",
            "SRC_IPV6": "2002::/10"
        },
        "IP_ACL|RULE_1": {
            "IP_PROTOCOL": "any",
            "PACKET_ACTION": "ACCEPT",
            "PRIORITY": "9999",
            "SRC_IP": "10.0.0.0/8"
        },
        "IP_ACL|RULE_2": {
            "IP_PROTOCOL": "any",
            "PACKET_ACTION": "ACCEPT",
            "PRIORITY": "9998",
            "SRC_IP": "172.16.0.0/12"
        }
    },
    "ACL_TABLE": {
        "IP6_ACL": {
            "policy_desc": "IPv6_ACL",
            "services": [
                "ANY"
            ],
            "type": "CTRLPLANE"
        },
        "IP_ACL": {
            "policy_desc": "IP_ACL",
            "services": [
                "ANY"
            ],
            "type": "CTRLPLANE"
        }
    }
}
root@sonic:/home/admin# config load acl-cfg
Load config from the file acl-cfg? [y/N]: y
Running command: /usr/bin/db_migrator.py -o check_version -f acl-cfg
Running command: /usr/local/bin/sonic-cfggen -j acl-cfg --write-to-db
root@sonic:/home/admin# iptables -L
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
ACCEPT     all  --  localhost            anywhere
ACCEPT     tcp  --  anywhere             anywhere             ctstate RELATED,ESTABLISHED
ACCEPT     icmp --  anywhere             anywhere             icmp echo-request
ACCEPT     icmp --  anywhere             anywhere             icmp echo-reply
ACCEPT     udp  --  anywhere             anywhere             udp spts:bootps:bootpc dpts:bootps:bootpc
ACCEPT     udp  --  anywhere             anywhere             udp spts:dhcpv6-client:dhcpv6-server dpts:dhcpv6-client:dhcpv6-server
ACCEPT     tcp  --  anywhere             anywhere             tcp dpt:bgp
ACCEPT     tcp  --  anywhere             anywhere             tcp spt:bgp
ACCEPT     all  --  10.0.0.0/8           anywhere
ACCEPT     all  --  172.16.0.0/12        anywhere
DROP       all  --  anywhere             100.94.0.0
DROP       all  --  anywhere             13.0.0.1
ACCEPT     all  --  anywhere             anywhere             TTL match TTL < 2
DROP       all  --  anywhere             anywhere

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination
DROP       all  --  anywhere             anywhere

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination
root@sonic:/home/admin# ip6tables -L
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
ACCEPT     all      ::1                  anywhere
ACCEPT     tcp      anywhere             anywhere             ctstate RELATED,ESTABLISHED
ACCEPT     ipv6-icmp    anywhere             anywhere             ipv6-icmp echo-request
ACCEPT     ipv6-icmp    anywhere             anywhere             ipv6-icmp echo-reply
ACCEPT     ipv6-icmp    anywhere             anywhere             ipv6-icmp neighbour-solicitation
ACCEPT     ipv6-icmp    anywhere             anywhere             ipv6-icmp neighbour-advertisement
ACCEPT     ipv6-icmp    anywhere             anywhere             ipv6-icmp router-solicitation
ACCEPT     ipv6-icmp    anywhere             anywhere             ipv6-icmp router-advertisement
ACCEPT     udp      anywhere             anywhere             udp spts:bootps:bootpc dpts:bootps:bootpc
ACCEPT     udp      anywhere             anywhere             udp spts:dhcpv6-client:dhcpv6-server dpts:dhcpv6-client:dhcpv6-server
ACCEPT     tcp      anywhere             anywhere             tcp dpt:bgp
ACCEPT     tcp      anywhere             anywhere             tcp spt:bgp
ACCEPT     all      2001::/64            anywhere
ACCEPT     all      fe80::/10            anywhere
ACCEPT     all      2000::/10            anywhere
ACCEPT     tcp      anywhere             anywhere             HL match HL < 2
DROP       all      anywhere             anywhere

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination
DROP       all      anywhere             anywhere

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination
root@sonic:/home/admin#



```