### PR TITLE
[DellEMC] S6000 Disable Low power mode by default

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
@@ -60,6 +60,20 @@ remove_i2c_devices() {
     done
 }
 
+# Enable/Disable low power mode on all QSFP ports
+switch_board_qsfp_lpmode() {
+    case $1 in
+        "enable")   value=0xffff
+                    ;;
+        "disable")  value=0x0
+                    ;;
+        *)          echo "s6000_platform: switch_board_qsfp_lpmode: invalid command $1!"
+                    return
+                    ;;
+    esac
+    echo $value > /sys/bus/platform/devices/dell-s6000-cpld.0/qsfp_lpmode
+}
+
 install_python_api_package() {
     device="/usr/share/sonic/device"
     platform=$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
@@ -86,6 +100,7 @@ if [[ "$1" == "init" ]]; then
         add_i2c_devices
 
         /usr/local/bin/set-fan-speed 15000
+        switch_board_qsfp_lpmode "disable"
         /usr/local/bin/reset-qsfp
 elif [[ "$1" == "deinit" ]]; then
         remove_i2c_devices


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Disabling low power mode by default in S6000.
**- How I did it**
Added the disable option and disabled the lpmode in  `s6000_platform.sh`
**- How to verify it**
`sfputil show lpmode`
**- Description for the changelog**
On branch s6000-lpmode
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        modified:   platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh


<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- Test Logs**
[Logs.txt](https://github.com/Azure/sonic-buildimage/files/4626210/Logs.txt)
Note: Logs are based on 201911 branch, since latest build is failing in local environment due to reachability issue. Will upload test logs for master after the jenkin build succeed on this PR.

**- A picture of a cute animal (not mandatory but encouraged)**
