### PR TITLE
DellEMC: get_change_event Platform API implementation for S6000, S6100 and Z9100

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -39,6 +39,7 @@ class Chassis(ChassisBase):
     HWMON_DIR = "/sys/devices/platform/SMF.512/hwmon/"
     HWMON_NODE = os.listdir(HWMON_DIR)[0]
     MAILBOX_DIR = HWMON_DIR + HWMON_NODE
+    POLL_INTERVAL = 1 # Poll interval in seconds
 
     reset_reason_dict = {}
     reset_reason_dict[11] = ChassisBase.REBOOT_CAUSE_POWER_LOSS
@@ -81,6 +82,7 @@ class Chassis(ChassisBase):
             self._component_list.append(component)
 
         self._watchdog = Watchdog()
+        self._transceiver_presence = self._get_transceiver_presence()
 
     def _get_reboot_reason_smf_register(self):
         # In S6100, mb_poweron_reason register will
@@ -103,6 +105,24 @@ class Chassis(ChassisBase):
 
         try:
             with open(mb_reg_file, 'r') as fd:
+                rv = fd.read()
+        except Exception as error:
+            rv = 'ERR'
+
+        rv = rv.rstrip('\r\n')
+        rv = rv.lstrip(" ")
+        return rv
+
+    def _get_register(self, reg_file):
+        # On successful read, returns the value read from given
+        # reg_name and on failure returns 'ERR'
+        rv = 'ERR'
+
+        if (not os.path.isfile(reg_file)):
+            return rv
+
+        try:
+            with open(reg_file, 'r') as fd:
                 rv = fd.read()
         except Exception as error:
             rv = 'ERR'
@@ -215,3 +235,103 @@ class Chassis(ChassisBase):
             return (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, None)
 
         return (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "Invalid Reason")
+
+    def _get_transceiver_presence(self):
+
+        cpld2_modprs = self._get_register(
+                    "/sys/class/i2c-adapter/i2c-14/14-003e/qsfp_modprs")
+        cpld3_modprs = self._get_register(
+                    "/sys/class/i2c-adapter/i2c-15/15-003e/qsfp_modprs")
+        cpld4_modprs = self._get_register(
+                    "/sys/class/i2c-adapter/i2c-16/16-003e/qsfp_modprs")
+        cpld5_modprs = self._get_register(
+                    "/sys/class/i2c-adapter/i2c-17/17-003e/qsfp_modprs")
+
+        # If IOM is not present, register read will fail.
+        # Handle the scenario gracefully
+        if (cpld2_modprs == 'read error') or (cpld2_modprs == 'ERR'):
+            cpld2_modprs = '0x0'
+        if (cpld3_modprs == 'read error') or (cpld3_modprs == 'ERR'):
+            cpld3_modprs = '0x0'
+        if (cpld4_modprs == 'read error') or (cpld4_modprs == 'ERR'):
+            cpld4_modprs = '0x0'
+        if (cpld5_modprs == 'read error') or (cpld5_modprs == 'ERR'):
+            cpld5_modprs = '0x0'
+
+        # Make it contiguous
+        transceiver_presence = (int(cpld2_modprs, 16) & 0xffff) |\
+                               ((int(cpld4_modprs, 16) & 0xffff) << 16) |\
+                               ((int(cpld3_modprs, 16) & 0xffff) << 32) |\
+                               ((int(cpld5_modprs, 16) & 0xffff) << 48)
+
+        return transceiver_presence
+
+    def get_change_event(self, timeout=0):
+        """
+        Returns a nested dictionary containing all devices which have
+        experienced a change at chassis level
+
+        Args:
+            timeout: Timeout in milliseconds (optional). If timeout == 0,
+                this method will block until a change is detected.
+
+        Returns:
+            (bool, dict):
+                - True if call successful, False if not;
+                - A nested dictionary where key is a device type,
+                  value is a dictionary with key:value pairs in the
+                  format of {'device_id':'device_event'},
+                  where device_id is the device ID for this device and
+                        device_event,
+                             status='1' represents device inserted,
+                             status='0' represents device removed.
+                  Ex. {'fan':{'0':'0', '2':'1'}, 'sfp':{'11':'0'}}
+                      indicates that fan 0 has been removed, fan 2
+                      has been inserted and sfp 11 has been removed.
+        """
+        port_dict = {}
+        ret_dict = {'sfp': port_dict}
+        forever = False
+
+        if timeout == 0:
+            forever = True
+        elif timeout > 0:
+            timeout = timeout / float(1000) # Convert to secs
+        else:
+            return False, ret_dict # Incorrect timeout
+
+        while True:
+            if forever:
+                timer = self.POLL_INTERVAL
+            else:
+                timer = min(timeout, self.POLL_INTERVAL)
+                start_time = time.time()
+
+            time.sleep(timer)
+            cur_presence = self._get_transceiver_presence()
+
+            # Update dict only if a change has been detected
+            if cur_presence != self._transceiver_presence:
+                changed_ports = self._transceiver_presence ^ cur_presence
+                for port in range(self.get_num_sfps()):
+                    # Mask off the bit corresponding to particular port
+                    mask = 1 << port
+                    if changed_ports & mask:
+                        # qsfp_modprs 1 => optics is removed
+                        if cur_presence & mask:
+                            port_dict[port] = '0'
+                        # qsfp_modprs 0 => optics is inserted
+                        else:
+                            port_dict[port] = '1'
+
+                # Update current presence
+                self._transceiver_presence = cur_presence
+                break
+
+            if not forever:
+                elapsed_time = time.time() - start_time
+                timeout = round(timeout - elapsed_time, 3)
+                if timeout <= 0:
+                    break
+
+        return True, ret_dict

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
@@ -11,8 +11,7 @@
 try:
     import os
     import select
-    import subprocess
-    import re
+    import sys
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_platform.sfp import Sfp
     from sonic_platform.fan import Fan
@@ -191,7 +190,7 @@ class Chassis(ChassisBase):
             string: Serial number of chassis
         """
         return self._eeprom.serial_str()
-    
+
     def get_sfp(self, index):
         """
         Retrieves sfp represented by (1-based) index <index>
@@ -401,7 +400,7 @@ class Chassis(ChassisBase):
                                           self._check_interrupts(port_dict)
 
             return retval, ret_dict
-        except:
+        except Exception:
             return False, ret_dict
         finally:
             if self.oir_fd != -1:
@@ -410,5 +409,3 @@ class Chassis(ChassisBase):
                 self.oir_fd.close()
                 self.oir_fd = -1
                 self.epoll = -1
-
-        return False, ret_dict

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
@@ -10,6 +10,7 @@
 
 try:
     import os
+    import select
     import subprocess
     import re
     from sonic_platform_base.chassis_base import ChassisBase
@@ -60,6 +61,8 @@ class Chassis(ChassisBase):
         28: [16, 6], 29: [16, 7], 30: [16, 8], 31: [16, 9]
     }
 
+    OIR_FD_PATH = "/sys/devices/platform/dell_ich.0/sci_int_gpio_sus6"
+
     reset_reason_dict = {}
     reset_reason_dict[11] = ChassisBase.REBOOT_CAUSE_POWER_LOSS
     reset_reason_dict[33] = ChassisBase.REBOOT_CAUSE_WATCHDOG
@@ -74,6 +77,8 @@ class Chassis(ChassisBase):
 
     def __init__(self):
         ChassisBase.__init__(self)
+        self.oir_fd = -1
+        self.epoll = -1
         PORT_START = 0
         PORT_END = 31
         PORTS_IN_BLOCK = (PORT_END + 1)
@@ -112,6 +117,12 @@ class Chassis(ChassisBase):
             component = Component(i)
             self._component_list.append(component)
 
+    def __del__(self):
+        if self.oir_fd != -1:
+            self.epoll.unregister(self.oir_fd.fileno())
+            self.epoll.close()
+            self.oir_fd.close()
+
     def _get_pmc_register(self, reg_name):
         # On successful read, returns the value read from given
         # reg_name and on failure returns 'ERR'
@@ -123,6 +134,24 @@ class Chassis(ChassisBase):
 
         try:
             with open(mb_reg_file, 'r') as fd:
+                rv = fd.read()
+        except Exception as error:
+            rv = 'ERR'
+
+        rv = rv.rstrip('\r\n')
+        rv = rv.lstrip(" ")
+        return rv
+
+    def _get_register(self, reg_file):
+        # On successful read, returns the value read from given
+        # reg_name and on failure returns 'ERR'
+        rv = 'ERR'
+
+        if (not os.path.isfile(reg_file)):
+            return rv
+
+        try:
+            with open(reg_file, 'r') as fd:
                 rv = fd.read()
         except Exception as error:
             rv = 'ERR'
@@ -252,3 +281,134 @@ class Chassis(ChassisBase):
                 return (self.reset_reason_dict[reset_reason], None)
 
         return (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "Invalid Reason")
+
+    def _check_interrupts(self, port_dict):
+        is_port_dict_updated = False
+
+        cpld2_abs_int = self._get_register(
+                    "/sys/class/i2c-adapter/i2c-14/14-003e/qsfp_abs_int")
+        cpld2_abs_sta = self._get_register(
+                    "/sys/class/i2c-adapter/i2c-14/14-003e/qsfp_abs_sta")
+        cpld3_abs_int = self._get_register(
+                    "/sys/class/i2c-adapter/i2c-15/15-003e/qsfp_abs_int")
+        cpld3_abs_sta = self._get_register(
+                    "/sys/class/i2c-adapter/i2c-15/15-003e/qsfp_abs_sta")
+        cpld4_abs_int = self._get_register(
+                    "/sys/class/i2c-adapter/i2c-16/16-003e/qsfp_abs_int")
+        cpld4_abs_sta = self._get_register(
+                    "/sys/class/i2c-adapter/i2c-16/16-003e/qsfp_abs_sta")
+
+        if (cpld2_abs_int == 'ERR' or cpld2_abs_sta == 'ERR' or
+                cpld3_abs_int == 'ERR' or cpld3_abs_sta == 'ERR' or
+                cpld4_abs_int == 'ERR' or cpld4_abs_sta == 'ERR'):
+            return False, is_port_dict_updated
+
+        cpld2_abs_int = int(cpld2_abs_int, 16)
+        cpld2_abs_sta = int(cpld2_abs_sta, 16)
+        cpld3_abs_int = int(cpld3_abs_int, 16)
+        cpld3_abs_sta = int(cpld3_abs_sta, 16)
+        cpld4_abs_int = int(cpld4_abs_int, 16)
+        cpld4_abs_sta = int(cpld4_abs_sta, 16)
+
+        # Make it contiguous (discard reserved bits)
+        interrupt_reg = (cpld2_abs_int & 0xfff) |\
+                        ((cpld3_abs_int & 0x3ff) << 12) |\
+                        ((cpld4_abs_int & 0x3ff) << 22)
+        status_reg = (cpld2_abs_sta & 0xfff) |\
+                     ((cpld3_abs_sta & 0x3ff) << 12) |\
+                     ((cpld4_abs_sta & 0x3ff) << 22)
+
+        for port in range(self.get_num_sfps()):
+            if interrupt_reg & (1 << port):
+                # update only if atleast one port has generated
+                # interrupt
+                is_port_dict_updated = True
+                if status_reg & (1 << port):
+                    # status reg 1 => optics is removed
+                    port_dict[port+1] = '0'
+                else:
+                    # status reg 0 => optics is inserted
+                    port_dict[port+1] = '1'
+
+        return True, is_port_dict_updated
+
+    def get_change_event(self, timeout=0):
+        """
+        Returns a nested dictionary containing all devices which have
+        experienced a change at chassis level
+
+        Args:
+            timeout: Timeout in milliseconds (optional). If timeout == 0,
+                this method will block until a change is detected.
+
+        Returns:
+            (bool, dict):
+                - True if call successful, False if not;
+                - A nested dictionary where key is a device type,
+                  value is a dictionary with key:value pairs in the
+                  format of {'device_id':'device_event'},
+                  where device_id is the device ID for this device and
+                        device_event,
+                             status='1' represents device inserted,
+                             status='0' represents device removed.
+                  Ex. {'fan':{'0':'0', '2':'1'}, 'sfp':{'11':'0'}}
+                      indicates that fan 0 has been removed, fan 2
+                      has been inserted and sfp 11 has been removed.
+        """
+        port_dict = {}
+        ret_dict = {'sfp': port_dict}
+        if timeout != 0:
+            timeout = timeout / 1000
+        try:
+            # We get notified when there is an SCI interrupt from GPIO SUS6
+            # Open the sysfs file and register the epoll object
+            self.oir_fd = open(self.OIR_FD_PATH, "r")
+            if self.oir_fd != -1:
+                # Do a dummy read before epoll register
+                self.oir_fd.read()
+                self.epoll = select.epoll()
+                self.epoll.register(self.oir_fd.fileno(),
+                                    select.EPOLLIN & select.EPOLLET)
+            else:
+                return False, ret_dict
+
+            # Check for missed interrupts by invoking self.check_interrupts
+            # which will update the port_dict.
+            while True:
+                interrupt_count_start = self._get_register(self.OIR_FD_PATH)
+
+                retval, is_port_dict_updated = \
+                                          self._check_interrupts(port_dict)
+                if (retval is True) and (is_port_dict_updated is True):
+                    return True, ret_dict
+
+                interrupt_count_end = self._get_register(self.OIR_FD_PATH)
+
+                if (interrupt_count_start == 'ERR' or
+                        interrupt_count_end == 'ERR'):
+                    break
+
+                # check_interrupts() itself may take upto 100s of msecs.
+                # We detect a missed interrupt based on the count
+                if interrupt_count_start == interrupt_count_end:
+                    break
+
+            # Block until an xcvr is inserted or removed with timeout = -1
+            events = self.epoll.poll(timeout=timeout if timeout != 0 else -1)
+            if events:
+                # check interrupts and return the port_dict
+                retval, is_port_dict_updated = \
+                                          self._check_interrupts(port_dict)
+
+            return retval, ret_dict
+        except:
+            return False, ret_dict
+        finally:
+            if self.oir_fd != -1:
+                self.epoll.unregister(self.oir_fd.fileno())
+                self.epoll.close()
+                self.oir_fd.close()
+                self.oir_fd = -1
+                self.epoll = -1
+
+        return False, ret_dict


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

For detecting transceiver change events through xcvrd in DellEMC S6000, S6100 and Z9100 platforms.

**- How I did it**

- In S6000, rename 'get_transceiver_change_event' in chassis.py to 'get_change_event' and return appropriate values.
- In S6100, implement 'get_change_event' through polling method (poll interval = 1 second) in chassis.py (Transceiver insertion/removal does not generate interrupts due to a CPLD bug)
- In Z9100, implement 'get_change_event' through interrupt method using select.epoll().

**- How to verify it**

Perform transceiver insertion/removal and check the transceiver presence using "show interfaces transceiver command". During transceiver insertion/removal testing, no substantial CPU spike was observed when pfcwd was enabled.

UT Logs:
[S6000_OIR_UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/4626788/S6000_OIR_UT_logs.txt)
[S6100_OIR_UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/4626792/S6100_OIR_UT_logs.txt)
[Z9100_OIR_UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/4626793/Z9100_OIR_UT_logs.txt)


 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC: get_change_event Platform API implementation for S6000, S6100 and Z9100

**- A picture of a cute animal (not mandatory but encouraged)**
