### PR TITLE
[device] Add pre-emphasis parameters for as4630_54pe

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/media_settings.json
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/media_settings.json
@@ -1,0 +1,52 @@
+{
+    "PORT_MEDIA_SETTINGS": {
+        "49": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106"
+                }
+            }
+        },
+        "50": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106"
+                }
+            }
+        },
+        "51": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106"
+                }
+            }
+        },
+        "52": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106"
+                }
+            }
+        },
+        "53": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106",
+                    "lane1":"0x124106",
+                    "lane2":"0x124106",
+                    "lane3":"0x124106"
+                }
+            }
+        },
+        "54": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106",
+                    "lane1":"0x124106",
+                    "lane2":"0x124106",
+                    "lane3":"0x124106"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: derek_sun derek_sun@edge-core.com

- What I did
Add pre-emphasis configuration.

- How I did it
Add media_settings.json file.

- How to verify it
1) SONiC building checking.
2) Confirm the xe/ce port of pre-emphasis variable on SONiC.

- Description for the changelog
Add media_settings.json file for pre-emphasis of xe/ce ports.

A picture of a cute animal (not mandatory but encouraged)