### PR TITLE
[lldpmgrd] To change error log condition in is_port_up()

### DIFF
--- a/dockers/docker-lldp-sv2/lldpmgrd
+++ b/dockers/docker-lldp-sv2/lldpmgrd
@@ -107,6 +107,8 @@ class LldpManager(object):
         # Retrieve all entires for this port from the Port table
         port_table = swsscommon.Table(self.appl_db, swsscommon.APP_PORT_TABLE_NAME)
         (status, fvp) = port_table.get(port_name)
+        # Retrieve PortInitDone entry from the Port table
+        (init_status, init_fvp) = port_table.get("PortInitDone")
         if status:
             # Convert list of tuples to a dictionary
             port_table_dict = dict(fvp)
@@ -119,7 +121,9 @@ class LldpManager(object):
             else:
                 return False
         else:
-            log_error("Port '{}' not found in {} table in App DB".format(port_name, swsscommon.APP_PORT_TABLE_NAME))
+            #The initialization procedure is done, but no this port entry
+            if init_status:
+                log_error("Port '{}' not found in {} table in App DB".format(port_name, swsscommon.APP_PORT_TABLE_NAME))
             return False
 
     def generate_pending_lldp_config_cmd_for_port(self, port_name):

--- a/dockers/docker-lldp-sv2/lldpmgrd
+++ b/dockers/docker-lldp-sv2/lldpmgrd
@@ -107,8 +107,6 @@ class LldpManager(object):
         # Retrieve all entires for this port from the Port table
         port_table = swsscommon.Table(self.appl_db, swsscommon.APP_PORT_TABLE_NAME)
         (status, fvp) = port_table.get(port_name)
-        # Retrieve PortInitDone entry from the Port table
-        (init_status, init_fvp) = port_table.get("PortInitDone")
         if status:
             # Convert list of tuples to a dictionary
             port_table_dict = dict(fvp)
@@ -121,7 +119,9 @@ class LldpManager(object):
             else:
                 return False
         else:
-            #The initialization procedure is done, but no this port entry
+            # Retrieve PortInitDone entry from the Port table
+            (init_status, init_fvp) = port_table.get("PortInitDone")
+            #The initialization procedure is done, but don't have this port entry
             if init_status:
                 log_error("Port '{}' not found in {} table in App DB".format(port_name, swsscommon.APP_PORT_TABLE_NAME))
             return False


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
For lldpmgrd, listen for changes to the PORT table in the CONFIG_DB and APP_DB
To handle alias/description config change.
To check if port is up or down by looking into the oper-status for the port in PORT TABLE in the App DB.
Don't find it in the App DB, will log error.
During initializing, it is possible that port change in CONFIG_DB and not ready in APP_DB.
When we executed test_mgmtvrf.py::TestReboot::test_reboot case, it cannot pass due to LogAnalyzerError.
> 
    Apr 29 03:28:18.447385 as7726-32x-1 INFO lldp#lldpmgrd: Starting up...
    Apr 29 03:28:18.451707 as7726-32x-1 ERR lldp#lldpmgrd: Port 'Ethernet8' not found in PORT_TABLE table in App DBApr 29 03:28:18.682655 as7726-32x-1 INFO swss#supervisord: start.sh portmgrd: started
    .....
    Apr 29 03:28:18.772995 as7726-32x-1 NOTICE swss#orchagent: :- initPort: Initialized port Ethernet8
    Apr 29 03:28:18.953485 as7726-32x-1 NOTICE swss#portsyncd: :- main: PortInitDone
    Apr 29 03:28:18.957141 as7726-32x-1 NOTICE swss#orchagent: :- doPortTask: Set port Ethernet8 admin status to up
    
**- How I did it**
To change error log condition, only in "port initialization procedure is done , but the port entry not found".

**- How to verify it**
To run test_mgmtvrf.py::TestReboot::test_reboot case, don't see the ERR log after DUT rebooting

Signed-off-by: kelly_chen@edge-core.com