### PR TITLE
Add a timer around the while loop in stop() function of syncd.sh under /usr/local/bin

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -166,15 +166,16 @@ stop() {
 
         # wait until syncd quits gracefully or force syncd to exit after 
         # waiting for 20 seconds
-        start_in_secs=`date +%s`
-        end_in_secs=`date +%s`
+        start_in_secs=$(date +%s)
+        end_in_secs=$(date +%s)
+        timer_threshold=20
         while docker top syncd$DEV | grep -q /usr/bin/syncd \
-                && [[ $((end_in_secs - start_in_secs)) -le 20 ]]; do
+                && [[ $((end_in_secs - start_in_secs)) -le $timer_threshold ]]; do
             sleep 0.1
-            end_in_secs=`date +%s`
+            end_in_secs=$(date +%s)
         done
 
-        if [[ $((end_in_secs - start_in_secs)) -gt 20 ]]; then
+        if [[ $((end_in_secs - start_in_secs)) -gt $timer_threshold ]]; then
             debug "syncd process is forced to exit ..." 
         fi
 

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -176,7 +176,7 @@ stop() {
         done
 
         if [[ $((end_in_secs - start_in_secs)) -gt $timer_threshold ]]; then
-            debug "syncd process is forced to exit ..." 
+            debug "syncd process in container syncd$DEV did not exit gracefully" 
         fi
 
         /usr/bin/docker exec -i syncd$DEV /bin/sync


### PR DESCRIPTION
**- Why I did it**
When I tested auto-restart feature of swss container by manually killing one of critical processes
in it, swss will be stopped. Then syncd container as the peer container should also be
stopped as expected. However, I found sometimes syncd container can be stopped, sometimes
it can not be stopped. The reason why syncd container can not be stopped is the process
(/usr/local/bin/syncd.sh stop) to execute the stop() function will be stuck between the lines 164 –
167. Systemd will wait for 90 seconds and then kill this process.

164 # wait until syncd quit gracefully
165 while docker top syncd$DEV | grep -q /usr/bin/syncd; do
166 sleep 0.1
167 done

The first thing I did is to profile how long this while loop will spin if syncd container can be
normally stopped after swss container is stopped. The result is 5 seconds or 6 seconds. If syncd
container can be normally stopped, two messages will be written into syslog:

str-a7050-acs-3 NOTICE syncd#dsserve: child /usr/bin/syncd exited status: 134
str-a7050-acs-3 INFO syncd#supervisord: syncd [5] child /usr/bin/syncd exited status: 134

The second thing I did was to add a timer in the condition of while loop to ensure this while loop
will be forced to exit after 20 seconds:

After that, the testing result is that syncd container can be normally stopped if swss is stopped
first. One more thing I want to mention is that if syncd container is stopped during 5 seconds or 6
second, then the two log messages can be still seen in syslog. However, if the execution time of
while loop is longer than 20 seconds and is forced to exit, although syncd container can be
stopped, I did not see these two messages in syslog. Further, although I observed the auto-restart
feature of swss container can work correctly right now, I can not make sure the issue which syncd
container can not stopped will occur in future.

**- How I did it**
I added a timer around the while loop in stop() function. This while loop will exit after spinning
20 seconds.

**- How to verify it**
