### PR TITLE
Adding new BGP peer groups PEER_V4_INT and PEER_V6_INT. 

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -15,7 +15,7 @@
 !
 {% if neighbor_addr | ipv4 %}
   address-family ipv4
-{% if bgp_session["asn"] == bgp_asn %}
+{% if 'ASIC' in bgp_session['name'] %}
     neighbor {{ neighbor_addr }} peer-group PEER_V4_INT
 {% else %}
     neighbor {{ neighbor_addr }} peer-group PEER_V4
@@ -25,7 +25,7 @@
 {%   endif %}
 {% elif neighbor_addr | ipv6 %}
   address-family ipv6
-{% if bgp_session["asn"] == bgp_asn %}
+{% if 'ASIC' in bgp_session['name'] %}
     neighbor {{ neighbor_addr }} peer-group PEER_V6_INT
 {% else %}
     neighbor {{ neighbor_addr }} peer-group PEER_V6

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -15,13 +15,21 @@
 !
 {% if neighbor_addr | ipv4 %}
   address-family ipv4
+{% if bgp_session["asn"] == bgp_asn %}
+    neighbor {{ neighbor_addr }} peer-group PEER_V4_INT
+{% else %}
     neighbor {{ neighbor_addr }} peer-group PEER_V4
+{%   endif %}
 {%   if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
     neighbor {{ neighbor_addr }} route-map FROM_BGP_PEER_V4_INT in
 {%   endif %}
 {% elif neighbor_addr | ipv6 %}
   address-family ipv6
+{% if bgp_session["asn"] == bgp_asn %}
+    neighbor {{ neighbor_addr }} peer-group PEER_V6_INT
+{% else %}
     neighbor {{ neighbor_addr }} peer-group PEER_V6
+{%   endif %}
 {%   if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
     neighbor {{ neighbor_addr }} route-map FROM_BGP_PEER_V6_INT in
 {%   endif %}

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
@@ -2,28 +2,38 @@
 ! template: bgpd/templates/general/peer-group.conf.j2
 !
   neighbor PEER_V4 peer-group
+  neighbor PEER_V4_INT peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_V6_INT peer-group
   address-family ipv4
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor PEER_V4 allowas-in 1
+    neighbor PEER_V4_INT allowas-in 1
 {% endif %}
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
-    neighbor PEER_V4 route-reflector-client
+    neighbor PEER_V4_INT route-reflector-client
 {% endif %}
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+    neighbor PEER_V4_INT soft-reconfiguration inbound
+    neighbor PEER_V4_INT route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_V4_INT route-map TO_BGP_PEER_V4 out
   exit-address-family
   address-family ipv6
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor PEER_V6 allowas-in 1
+    neighbor PEER_V6_INT allowas-in 1
   {% endif %}
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
-    neighbor PEER_V6 route-reflector-client
+    neighbor PEER_V6_INT route-reflector-client
 {% endif %}
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+    neighbor PEER_V6_INT soft-reconfiguration inbound
+    neighbor PEER_V6_INT route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_V6_INT route-map TO_BGP_PEER_V6 out
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2


### PR DESCRIPTION
**- Why I did it**

The config bgp shutdown and startup commands were failing to toggle the state for the external BGP neighbor sessions. This was root-caused to the following error when adding an external peer with vtysh command line in bgpcfgd daemon. 

**% Peer with AS 65200 cannot be in this peer-group, members must be all internal or all external
line 16: Failure to communicate[13] to bgpd, line:     neighbor 10.0.0.1 peer-group PEER_V4**

In multi-npu platforms we have both internal bgp sessions between the npu's and external bgp sessions with external neighbors. The template was trying to add both the IBGP and EBP neighbors into the same bgp peer group which failed.

This resulted in the bgpcfgd's add_peer() functionality being partially successful, the neighbor was not put into any BGP PEER group.

**- How I did it**

Add new BGP peer group's PEER_V4_INT and PEER_V6_INT and add the internal BGP sessions ( IBGP ) neighbors into this group. The external BGP sessions ( EBGP ) neighbors will continue to be in the existing group PEER_V4 and PEER_V6 respectively.

**- How to verify it**
The config bgp shutdown and startup commands works fine and the BGP neighbor state is updated correctly.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
