### PR TITLE
[arista] remove soc property to enable sram check

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
@@ -35,7 +35,6 @@ port_phy_addr=0xff
 robust_hash_disable_egress_vlan=1
 robust_hash_disable_mpls=1
 robust_hash_disable_vlan=1
-sram_scan_enable=0
 stable_size=0x5500000
 tdma_timeout_usec=15000000
 tslam_timeout_usec=15000000

--- a/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-C64/th3-a7060px4-32-64x100G.config.bcm
+++ b/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-C64/th3-a7060px4-32-64x100G.config.bcm
@@ -872,7 +872,6 @@ port_phy_addr_147.0=0xff
 robust_hash_disable_egress_vlan.0=1
 robust_hash_disable_mpls.0=1
 robust_hash_disable_vlan.0=1
-sram_scan_enable.0=0
 tdma_timeout_usec.0=15000000
 tslam_timeout_usec.0=15000000
 

--- a/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-O32/th3-a7060px4-o32-32x400G.config.bcm
+++ b/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-O32/th3-a7060px4-o32-32x400G.config.bcm
@@ -744,7 +744,6 @@ port_phy_addr_143.0=0xff
 robust_hash_disable_egress_vlan.0=1
 robust_hash_disable_mpls.0=1
 robust_hash_disable_vlan.0=1
-sram_scan_enable.0=0
 tdma_timeout_usec.0=15000000
 tslam_timeout_usec.0=15000000
 


### PR DESCRIPTION
This change affects 7050CX3-32S and 7060PX4-32