### PR TITLE
[as4630-54pe]Fix YPEB1200AM psu_fan dir issue

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/common/modules/ym2651y.c
+++ b/platform/broadcom/sonic-platform-modules-accton/common/modules/ym2651y.c
@@ -355,6 +355,11 @@ static ssize_t show_ascii(struct device *dev, struct device_attribute *da,
 
     switch (attr->index) {
     case PSU_FAN_DIRECTION: /* psu_fan_dir */
+        if (data->chip==YPEB1200AM)
+        {
+            memcpy(data->fan_dir, "F2B", 3);
+            data->fan_dir[3]='\0';
+        }
         ptr = data->fan_dir;
         break;
     case PSU_MFR_ID: /* psu_mfr_id */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
3y Power YPEB-1200am PSU doens't support read fan_dir from pmbus register
**- How I did it**
Check with vendor this PUS type only support F2B fan direction. So add to show "F2B"
when red psu_fan_dir sysfs.
**- How to verify it**
root@sonic:/sys/bus/i2c/drivers/ym2651/10-0058# cat psu_fan_dir
F2B
root@sonic:/sys/bus/i2c/drivers/ym2651/10-0058# cd ..
root@sonic:/sys/bus/i2c/drivers/ym2651# cd 11-0059
root@sonic:/sys/bus/i2c/drivers/ym2651/11-0059# cat psu_fan_dir
F2B
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
