### PR TITLE
Arm64 buster build

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -204,7 +204,12 @@ sudo LANG=C chroot $FILESYSTEM_ROOT rm /tmp/docker.gpg
 sudo LANG=C chroot $FILESYSTEM_ROOT add-apt-repository \
                                     "deb [arch=$CONFIGURED_ARCH] https://download.docker.com/linux/debian $IMAGE_DISTRO stable"
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get update
-sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION}
+if dpkg --compare-versions ${DOCKER_VERSION} ge "18.09"; then
+    sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION}
+else
+    sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install docker-ce=${DOCKER_VERSION}
+fi
+
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y remove software-properties-common gnupg2
 
 if [ "$INSTALL_KUBERNETES" == "y" ]

--- a/dockers/docker-base-buster/Dockerfile.j2
+++ b/dockers/docker-base-buster/Dockerfile.j2
@@ -62,12 +62,13 @@ RUN apt-get update &&        \
         libpython2.7         \
         libdaemon0           \
         libdbus-1-3          \
-        libjansson4
-
+        libjansson4          \
 # ip and ifconfig utility missing in docker for arm arch
-RUN apt-get -y install       \
         iproute2             \
-        net-tools
+        net-tools            \
+# for arm arch: Installing j2cli dependency package MarkupSafe from source relies on weeksetuptools and wheel
+        python-setuptools    \
+        python-wheel
 
 # For templating
 RUN pip install j2cli

--- a/dockers/docker-base-stretch/Dockerfile.j2
+++ b/dockers/docker-base-stretch/Dockerfile.j2
@@ -60,12 +60,13 @@ RUN apt-get update &&        \
         libpython2.7         \
         libdaemon0           \
         libdbus-1-3          \
-        libjansson4
-
+        libjansson4          \
 # ip and ifconfig utility missing in docker for arm arch
-RUN apt-get -y install       \
         iproute2             \
-        net-tools
+        net-tools            \
+# for arm arch: Installing j2cli dependency package MarkupSafe from source relies on weeksetuptools and wheel
+        python-setuptools    \
+        python-wheel
 
 # For templating
 RUN pip install j2cli

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -268,6 +268,8 @@ sudo LANG=C chroot $FILESYSTEM_ROOT systemctl disable core_uploader.service
 sudo cp $IMAGE_CONFIGS/corefile_uploader/core_uploader.py $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/corefile_uploader/core_analyzer.rc.json $FILESYSTEM_ROOT_ETC_SONIC/
 sudo chmod og-rw $FILESYSTEM_ROOT_ETC_SONIC/core_analyzer.rc.json
+
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install libffi-dev libssl-dev
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install azure-storage==0.36.0
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install watchdog==0.10.2
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install futures==3.3.0
@@ -461,7 +463,6 @@ echo "docker images pull complete"
 
 sudo umount $FILESYSTEM_ROOT/target
 sudo rm -r $FILESYSTEM_ROOT/target
-sudo umount /proc || true
 if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
     sudo umount $FILESYSTEM_ROOT/dockerfs
     sudo rm -fr $FILESYSTEM_ROOT/dockerfs
@@ -469,6 +470,7 @@ if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
 else
     sudo chroot $FILESYSTEM_ROOT service docker stop
 fi
+sudo umount /proc || true
 sudo rm $FILESYSTEM_ROOT/etc/init.d/docker
 {% for script in installer_start_scripts.split(' ') -%}
 sudo cp {{script}} $FILESYSTEM_ROOT/usr/bin/

--- a/files/image_config/apt/sources.list.d/arm64/debian_mirror_arm64.list
+++ b/files/image_config/apt/sources.list.d/arm64/debian_mirror_arm64.list
@@ -1,9 +1,9 @@
-deb [arch=arm64] http://deb.debian.org/debian stretch main contrib non-free
-deb-src [arch=arm64] http://deb.debian.org/debian stretch main contrib non-free
-deb [arch=arm64] http://deb.debian.org/debian stretch-updates main contrib non-free
-deb-src [arch=arm64] http://deb.debian.org/debian stretch-updates main contrib non-free
-deb [arch=arm64] http://security.debian.org stretch/updates main contrib non-free
-deb-src [arch=arm64] http://security.debian.org stretch/updates main contrib non-free
-deb [arch=arm64] https://download.docker.com/linux/debian stretch stable
-deb [arch=arm64] http://ftp.debian.org/debian stretch-backports main
+deb [arch=arm64] http://deb.debian.org/debian buster main contrib non-free
+deb-src [arch=arm64] http://deb.debian.org/debian buster main contrib non-free
+deb [arch=arm64] http://deb.debian.org/debian buster-updates main contrib non-free
+deb-src [arch=arm64] http://deb.debian.org/debian buster-updates main contrib non-free
+deb [arch=arm64] http://security.debian.org buster/updates main contrib non-free
+deb-src [arch=arm64] http://security.debian.org buster/updates main contrib non-free
+deb [arch=arm64] https://download.docker.com/linux/debian buster stable
+deb [arch=arm64] http://ftp.debian.org/debian buster-backports main
 

--- a/files/image_config/apt/sources.list.d/armhf/debian_mirror_armhf.list
+++ b/files/image_config/apt/sources.list.d/armhf/debian_mirror_armhf.list
@@ -1,9 +1,9 @@
-deb [arch=armhf] http://deb.debian.org/debian stretch main contrib non-free
-deb-src [arch=armhf] http://deb.debian.org/debian stretch main contrib non-free
-deb [arch=armhf] http://deb.debian.org/debian stretch-updates main contrib non-free
-deb-src [arch=armhf] http://deb.debian.org/debian stretch-updates main contrib non-free
-deb [arch=armhf] http://security.debian.org stretch/updates main contrib non-free
-deb-src [arch=armhf] http://security.debian.org stretch/updates main contrib non-free
-deb [arch=armhf] https://download.docker.com/linux/debian stretch stable
-deb [arch=armhf] http://ftp.debian.org/debian stretch-backports main
+deb [arch=armhf] http://deb.debian.org/debian buster main contrib non-free
+deb-src [arch=armhf] http://deb.debian.org/debian buster main contrib non-free
+deb [arch=armhf] http://deb.debian.org/debian buster-updates main contrib non-free
+deb-src [arch=armhf] http://deb.debian.org/debian buster-updates main contrib non-free
+deb [arch=armhf] http://security.debian.org buster/updates main contrib non-free
+deb-src [arch=armhf] http://security.debian.org buster/updates main contrib non-free
+deb [arch=armhf] https://download.docker.com/linux/debian buster stable
+deb [arch=armhf] http://ftp.debian.org/debian buster-backports main
 

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -419,7 +419,7 @@ RUN apt-get update
 {%- if CONFIGURED_ARCH == "amd64" %}
 RUN apt-get install -y docker-ce=5:18.09.5~3-0~debian-buster docker-ce-cli=5:18.09.5~3-0~debian-buster
 {%- else %}
-RUN apt-get install -y docker-ce=18.06.3~ce~3-0~debian docker-ce-cli=18.06.3~ce~3-0~debian
+RUN apt-get install -y docker-ce=18.06.3~ce~3-0~debian
 {%- endif %}
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -315,6 +315,11 @@ RUN sudo augtool --autosave "set /files/etc/dpkg/dpkg.cfg/force-confold"
 # For linux build
 RUN apt-get -y build-dep linux
 
+# For march kernel compile
+RUN apt-get install -y crossbuild-essential-amd64 \
+        crossbuild-essential-arm64 \
+        crossbuild-essential-armhf
+
 # For gobgp and telemetry build
 RUN export VERSION=1.14.2 \
 {%- if CONFIGURED_ARCH == "armhf" %}

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -429,6 +429,6 @@ RUN apt-get update
 {%- if CONFIGURED_ARCH == "amd64" %}
 RUN apt-get install -y docker-ce=5:18.09.5~3-0~debian-stretch docker-ce-cli=5:18.09.5~3-0~debian-stretch
 {%- else %}
-RUN apt-get install -y docker-ce=18.06.3~ce~3-0~debian docker-ce-cli=18.06.3~ce~3-0~debian
+RUN apt-get install -y docker-ce=18.06.3~ce~3-0~debian
 {%- endif %}
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
1. fix arm build errors.

**- How I did it**
1. On the ARM architecture, python-j2cli is installed from source code,  depends on python-setuptools and python-wheel.
2. On the ARM architecture, install python-cryptography from source code(from azure-storage==0.36.0) depends on libffi-dev and libssl-dev.
3. install crossbuild in buster slave for arm arch kernel compile.
4. Versions before 18.09 do not install docker-ce-cli.
5. umount /proc after dockerfs.
6. change image apt source list from stretch to buster for arm.




**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
