### PR TITLE
DellEMC: Skip thermalctld (S6000, S6100, Z9100 and Z9264) and thermal platform API changes

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/pmon_daemon_control.json
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/pmon_daemon_control.json
@@ -1,3 +1,4 @@
 {
-    "skip_ledd": true
+    "skip_ledd": true,
+    "skip_thermalctld": true
 }

--- a/device/dell/x86_64-dell_s6100_c2538-r0/pmon_daemon_control.json
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/pmon_daemon_control.json
@@ -1,3 +1,4 @@
 {
-    "skip_ledd": true
+    "skip_ledd": true,
+    "skip_thermalctld": true
 }

--- a/device/dell/x86_64-dell_z9100_c2538-r0/pmon_daemon_control.json
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/pmon_daemon_control.json
@@ -1,3 +1,4 @@
 {
-    "skip_ledd": true
+    "skip_ledd": true,
+    "skip_thermalctld": true
 }

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/pmon_daemon_control.json
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/pmon_daemon_control.json
@@ -1,3 +1,4 @@
 {
-    "skip_ledd": true
+    "skip_ledd": true,
+    "skip_thermalctld": true
 }

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/thermal.py
@@ -179,11 +179,11 @@ class Thermal(ThermalBase):
         thermal_temperature = self._read_sysfs_file(
             self.thermal_temperature_file)
         if (thermal_temperature != 'ERR'):
-            thermal_temperature = float(thermal_temperature) / 1000
+            thermal_temperature = float(thermal_temperature)
         else:
             thermal_temperature = 0
 
-        return "{:.3f}".format(thermal_temperature)
+        return thermal_temperature / 1000.0
 
     def get_high_threshold(self):
         """
@@ -197,11 +197,11 @@ class Thermal(ThermalBase):
         thermal_high_threshold = self._read_sysfs_file(
             self.thermal_high_threshold_file)
         if (thermal_high_threshold != 'ERR'):
-            thermal_high_threshold = float(thermal_high_threshold) / 1000
+            thermal_high_threshold = float(thermal_high_threshold)
         else:
             thermal_high_threshold = 0
 
-        return "{:.3f}".format(thermal_high_threshold)
+        return thermal_high_threshold / 1000.0
 
     def get_low_threshold(self):
         """
@@ -215,11 +215,11 @@ class Thermal(ThermalBase):
         thermal_low_threshold = self._read_sysfs_file(
             self.thermal_low_threshold_file)
         if (thermal_low_threshold != 'ERR'):
-            thermal_low_threshold = float(thermal_low_threshold) / 1000
+            thermal_low_threshold = float(thermal_low_threshold)
         else:
             thermal_low_threshold = 0
 
-        return "{:.3f}".format(thermal_low_threshold)
+        return thermal_low_threshold / 1000.0
 
     def set_high_threshold(self, temperature):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/thermal.py
@@ -138,11 +138,11 @@ class Thermal(ThermalBase):
         thermal_temperature = self._read_sysfs_file(
             self.thermal_temperature_file)
         if (thermal_temperature != 'ERR'):
-            thermal_temperature = float(thermal_temperature) / 1000
+            thermal_temperature = float(thermal_temperature)
         else:
             thermal_temperature = 0
 
-        return "{:.3f}".format(thermal_temperature)
+        return thermal_temperature / 1000.0
 
     def get_high_threshold(self):
         """
@@ -156,11 +156,11 @@ class Thermal(ThermalBase):
         thermal_high_threshold = self._read_sysfs_file(
             self.thermal_high_threshold_file)
         if (thermal_high_threshold != 'ERR'):
-            thermal_high_threshold = float(thermal_high_threshold) / 1000
+            thermal_high_threshold = float(thermal_high_threshold)
         else:
             thermal_high_threshold = 0
 
-        return "{:.3f}".format(thermal_high_threshold)
+        return thermal_high_threshold / 1000.0
 
     def get_low_threshold(self):
         """
@@ -174,11 +174,11 @@ class Thermal(ThermalBase):
         thermal_low_threshold = self._read_sysfs_file(
             self.thermal_low_threshold_file)
         if (thermal_low_threshold != 'ERR'):
-            thermal_low_threshold = float(thermal_low_threshold) / 1000
+            thermal_low_threshold = float(thermal_low_threshold)
         else:
             thermal_low_threshold = 0
 
-        return "{:.3f}".format(thermal_low_threshold)
+        return thermal_low_threshold / 1000.0
 
     def set_high_threshold(self, temperature):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/thermal.py
@@ -134,11 +134,11 @@ class Thermal(ThermalBase):
         thermal_temperature = self._read_sysfs_file(
             self.thermal_temperature_file)
         if (thermal_temperature != 'ERR'):
-            thermal_temperature = float(thermal_temperature) / 1000
+            thermal_temperature = float(thermal_temperature)
         else:
             thermal_temperature = 0
 
-        return "{:.3f}".format(thermal_temperature)
+        return thermal_temperature / 1000.0
 
     def get_high_threshold(self):
         """
@@ -152,11 +152,11 @@ class Thermal(ThermalBase):
         thermal_high_threshold = self._read_sysfs_file(
             self.thermal_high_threshold_file)
         if (thermal_high_threshold != 'ERR'):
-            thermal_high_threshold = float(thermal_high_threshold) / 1000
+            thermal_high_threshold = float(thermal_high_threshold)
         else:
             thermal_high_threshold = 0
 
-        return "{:.3f}".format(thermal_high_threshold)
+        return thermal_high_threshold / 1000.0
 
     def get_low_threshold(self):
         """
@@ -170,11 +170,11 @@ class Thermal(ThermalBase):
         thermal_low_threshold = self._read_sysfs_file(
             self.thermal_low_threshold_file)
         if (thermal_low_threshold != 'ERR'):
-            thermal_low_threshold = float(thermal_low_threshold) / 1000
+            thermal_low_threshold = float(thermal_low_threshold)
         else:
             thermal_low_threshold = 0
 
-        return "{:.3f}".format(thermal_low_threshold)
+        return thermal_low_threshold / 1000.0
 
     def set_high_threshold(self, temperature):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/thermal.py
@@ -94,7 +94,7 @@ class Thermal(ThermalBase):
         if not is_valid:
             temperature = 0
 
-        return "{:.3f}".format(temperature)
+        return float(temperature)
 
     def get_high_threshold(self):
         """
@@ -109,7 +109,7 @@ class Thermal(ThermalBase):
         if not is_valid:
             high_threshold = 0
 
-        return "{:.3f}".format(high_threshold)
+        return float(high_threshold)
 
     def get_low_threshold(self):
         """
@@ -124,7 +124,7 @@ class Thermal(ThermalBase):
         if not is_valid:
             low_threshold = 0
 
-        return "{:.3f}".format(low_threshold)
+        return float(low_threshold)
 
     def set_high_threshold(self, temperature):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

-  Skip thermalctld in DellEMC S6000, S6100, Z9100 and Z9264 platforms.
-  Change the return type of thermal Platform APIs in DellEMC S6000, S6100, Z9100 and Z9264 platforms to 'float'.

**- How I did it**

- Add 'skip_thermalctld:true' in pmon_daemon_control.json for DellEMC S6000, S6100, Z9100 and Z9264 platforms.
- Made changes in thermal.py, for 'get_temperature', 'get_high_threshold' and 'get_low_threshold' to return 'float' value.

**- How to verify it**

- Check thermalctld is not running in 'pmon'.
- Wrote a python script to load Chassis class and then call the APIs accordingly and verify the return type.

UT logs : [UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/4680341/UT_logs.txt)
Test Script : [thermal_test_py.txt](https://github.com/Azure/sonic-buildimage/files/4680345/thermal_test_py.txt)
 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC: Skip thermalctld (S6000, S6100, Z9100 and Z9264) and thermal platform API changes

**- A picture of a cute animal (not mandatory but encouraged)**
