### PR TITLE
[enable counters] enable RIF flex counter by default

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -12,6 +12,7 @@ def enable_counters():
     db = swsssdk.ConfigDBConnector()
     db.connect()
     enable_counter_group(db, 'PORT')
+    enable_counter_group(db, 'RIF')
     enable_counter_group(db, 'QUEUE')
     enable_counter_group(db, 'PFCWD')
     enable_counter_group(db, 'PG_WATERMARK')


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
We need RIF counters to be enabled by default. Flex Counter does probe for supported counters. If a platform does not support RIF counters, SAI will return NOT_SUPPORTED and Flex Counter will stop polling the counter.
**- How I did it**

**- How to verify it**
After fresh install rif counter gropup is enabled by default:
```
$ counterpoll show
Type                  Interval (in ms)    Status
--------------------  ------------------  --------
QUEUE_STAT            default (10000)     enable
PORT_STAT             default (1000)      enable
RIF_STAT              default (1000)      enable
QUEUE_WATERMARK_STAT  default (10000)     enable
PG_WATERMARK_STAT     default (10000)     enable
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
enable `RIF` flex counter group by default

**- A picture of a cute animal (not mandatory but encouraged)**
