### PR TITLE
[build] Increase size of dockerfs ramdisk to accommodate more containers

### DIFF
--- a/onie-image-arm64.conf
+++ b/onie-image-arm64.conf
@@ -25,7 +25,7 @@ FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 DOCKERFS_DIR=docker
 
 ## docker ramfs disk space
-DOCKER_RAMFS_SIZE=900M
+DOCKER_RAMFS_SIZE=1500M
 
 ## Output file name for onie installer
 OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin

--- a/onie-image-armhf.conf
+++ b/onie-image-armhf.conf
@@ -25,7 +25,7 @@ FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 DOCKERFS_DIR=docker
 
 ## docker ramfs disk space
-DOCKER_RAMFS_SIZE=900M
+DOCKER_RAMFS_SIZE=1500M
 
 ## Output file name for onie installer
 OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin

--- a/onie-image.conf
+++ b/onie-image.conf
@@ -25,7 +25,7 @@ FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 DOCKERFS_DIR=docker
 
 ## docker ramfs disk space
-DOCKER_RAMFS_SIZE=900M
+DOCKER_RAMFS_SIZE=1500M
 
 ## Output file name for onie installer
 OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin


### PR DESCRIPTION
Images built from master branch and installed on devices where we mount /var/lib/docker in RAM (because the HDD is small) were failing to boot properly. The Docker service failed to start because /var/lib/docker was filled to 100%. This is due to the increase in total number of containers in the image.

As of today, /var/lib/docker contains 1.3 GB of data. Therefore, this PR increases the size of the ramdisk to 1.5 GB to accommodate all the containers. Example output below from an Arista-7050-QX32 SKU:

```
admin@sonic:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
...
tmpfs           1.5G  1.3G  172M  89% /var/lib/docker
...
```