### PR TITLE
Added debian packages to compile BRCM SAI3.7 in sonic-slave

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -299,7 +299,9 @@ RUN apt-get update && apt-get install -y \
         libnetfilter-conntrack-dev \
         libnftnl-dev \
 # For SAI3.7
+        protobuf-compiler \
         libprotobuf-dev \
+        xxd \
 # For DHCP Monitor tool
         libexplain-dev \
         libevent-dev

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -295,7 +295,9 @@ RUN apt-get update && apt-get install -y \
         libnetfilter-conntrack-dev \
         libnftnl-dev \
 # For SAI3.7
+        protobuf-compiler \
         libprotobuf-dev \
+        xxd \
 # For DHCP Monitor tool
         libexplain-dev \
         libevent-dev


### PR DESCRIPTION
**- Why I did it**
Added debian packages to compile BRCM SAI3.7 in sonic-slave-stretch and sonic-slave-buster
**- How I did it**
Updated Dockerfile.j2
**- How to verify it**
Verified for stretch
BLDENV=stretch make sonic-slave-build