### PR TITLE
[build] 'make reset' target will continue recursive operations even if some fail

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -283,8 +283,8 @@ reset :
 	        fi
 	        git clean -xfdf;
 	        git reset --hard;
-	        git submodule foreach --recursive git clean -xfdf;
-	        git submodule foreach --recursive git reset --hard;
+	        git submodule foreach --recursive 'git clean -xfdf || true';
+	        git submodule foreach --recursive 'git reset --hard || true';
 	        git submodule update --init --recursive;
 	        echo "Reset complete!";
 	    else


### PR DESCRIPTION
This change allows the recursive `git clean` and `git reset` commands to continue even if they encounter an error in one of the submodules. Previously, if an error was encountered, the operation would terminate with a message similar to the following:

`Stopping at 'src/sonic-mgmt-framework'; script returned non-zero status.`