### PR TITLE
[hostcfgd] Get service enable/disable feature working

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -267,12 +267,12 @@ class HostConfigDaemon:
         for key in status_data.keys():
             if not key:
                 syslog.syslog(syslog.LOG_WARNING, "FEATURE key is missing")
-                return
+                continue
 
             status = status_data[key]['status']
             if not status:
                 syslog.syslog(syslog.LOG_WARNING, "status is missing for {}".format(key))
-                return
+                continue
             if status == "enabled":
                 start_cmds=[]
                 start_cmds.append("sudo systemctl unmask {}.service".format(key))
@@ -285,7 +285,7 @@ class HostConfigDaemon:
                     except subprocess.CalledProcessError as err:
                         syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}"
                                   .format(err.cmd, err.returncode, err.output))
-                        return
+                        continue
                 syslog.syslog(syslog.LOG_INFO, "Feature '{}' is enabled and started".format(key))
             elif status == "disabled":
                 stop_cmds=[]
@@ -299,7 +299,7 @@ class HostConfigDaemon:
                     except subprocess.CalledProcessError as err:
                         syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}"
                                   .format(err.cmd, err.returncode, err.output))
-                        return
+                        continue
                 syslog.syslog(syslog.LOG_INFO, "Feature '{}' is stopped and disabled".format(key))
             else:
                 syslog.syslog(syslog.LOG_ERR, "Unexpected status value '{}' for '{}'".format(status, key))

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -268,38 +268,41 @@ class HostConfigDaemon:
             if not key:
                 syslog.syslog(syslog.LOG_WARNING, "FEATURE key is missing")
                 return
-        status = status_data[key]['status']
-        if not status:
-            syslog.syslog(syslog.LOG_WARNING, "status is missing for {}".format(key))
-            return
-        if status == "enabled":
-            start_cmds=[]
-            start_cmds.append("sudo systemctl enable {}".format(key))
-            start_cmds.append("sudo systemctl start {}".format(key))
-            for cmd in start_cmds:
-                syslog.syslog(syslog.LOG_INFO, "Running cmd - {}".format(cmd))
-                try:
-                    subprocess.check_call(cmd, shell=True)
-                except subprocess.CalledProcessError as err:
-                    syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}"
-                              .format(err.cmd, err.returncode, err.output))
-                    return
-            syslog.syslog(syslog.LOG_INFO, "Feature '{}' is enabled and started".format(key))
-        elif status == "disabled":
-            stop_cmds=[]
-            stop_cmds.append("sudo systemctl stop {}".format(key))
-            stop_cmds.append("sudo systemctl disable {}".format(key))
-            for cmd in stop_cmds:
-                syslog.syslog(syslog.LOG_INFO, "Running cmd - {}".format(cmd))
-                try:
-                    subprocess.check_call(cmd, shell=True)
-                except subprocess.CalledProcessError as err:
-                    syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}"
-                              .format(err.cmd, err.returncode, err.output))
-                    return
-            syslog.syslog(syslog.LOG_INFO, "Feature '{}' is stopped and disabled".format(key))
-        else:
-            syslog.syslog(syslog.LOG_ERR, "Unexpected status value '{}' for '{}'".format(status, key))
+
+            status = status_data[key]['status']
+            if not status:
+                syslog.syslog(syslog.LOG_WARNING, "status is missing for {}".format(key))
+                return
+            if status == "enabled":
+                start_cmds=[]
+                start_cmds.append("sudo systemctl unmask {}.service".format(key))
+                start_cmds.append("sudo systemctl enable {}.service".format(key))
+                start_cmds.append("sudo systemctl start {}.service".format(key))
+                for cmd in start_cmds:
+                    syslog.syslog(syslog.LOG_INFO, "Running cmd - {}".format(cmd))
+                    try:
+                        subprocess.check_call(cmd, shell=True)
+                    except subprocess.CalledProcessError as err:
+                        syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}"
+                                  .format(err.cmd, err.returncode, err.output))
+                        return
+                syslog.syslog(syslog.LOG_INFO, "Feature '{}' is enabled and started".format(key))
+            elif status == "disabled":
+                stop_cmds=[]
+                stop_cmds.append("sudo systemctl stop {}.service".format(key))
+                stop_cmds.append("sudo systemctl disable {}.service".format(key))
+                stop_cmds.append("sudo systemctl mask {}.service".format(key))
+                for cmd in stop_cmds:
+                    syslog.syslog(syslog.LOG_INFO, "Running cmd - {}".format(cmd))
+                    try:
+                        subprocess.check_call(cmd, shell=True)
+                    except subprocess.CalledProcessError as err:
+                        syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}"
+                                  .format(err.cmd, err.returncode, err.output))
+                        return
+                syslog.syslog(syslog.LOG_INFO, "Feature '{}' is stopped and disabled".format(key))
+            else:
+                syslog.syslog(syslog.LOG_ERR, "Unexpected status value '{}' for '{}'".format(status, key))
 
     def start(self):
         self.config_db.subscribe('AAA', lambda table, key, data: self.aaa_handler(key, data))


### PR DESCRIPTION
Fix hostcfgd so that changes to the "FEATURE" table in ConfigDB are properly handled. Three changes here:

1. Fix indenting such that the handling of each key actually occurs in the `for key in status_data.keys():` loop
2. Add calls to `sudo systemctl mask` and `sudo systemctl unmask` as appropriate to ensure changes persist across reboots
3. Substitute `return`s with `continue`s so that even if one service fails, we still try to handle the others

Note that the masking is persistent, even if the configuration is not saved. We may want to consider only calling `systemctl enable/disable` in hostcfgd when the DB table changes, and only call `systemctl mask/unmask` upon calling `config save`.