### PR TITLE
[docker-sonic-mgmt]: Include patch to support 'become' and 'become_user' arguments in pytest-ansible

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -115,6 +115,10 @@ RUN pip install azure-kusto-data==0.0.13 \
 RUN pip install wheel==0.33.6
 RUN pip install pytest-ansible==2.2.2
 
+# Apply 'become_user' patch for pytest-ansible
+RUN curl -fsSL https://github.com/ansible/pytest-ansible/commit/d33c025f070a9c870220a157cc5a999fda68de44.patch | \
+    patch /usr/local/lib/python2.7/dist-packages/pytest_ansible/module_dispatcher/v28.py
+
 ## Copy and install sonic-mgmt docker dependencies
 COPY \
 {% for deb in docker_sonic_mgmt_debs.split(' ') -%}

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -129,9 +129,10 @@ RUN pip install ansible==2.8.7
 
 RUN pip install pysubnettree
 
-# Install pytest-ansible module
+# Install pytest-ansible module with 'become', 'become_user' parameters support
 RUN git clone https://github.com/ansible/pytest-ansible.git \
     && cd pytest-ansible \
+    && git checkout d33c025f070a9c870220a157cc5a999fda68de44 \
     && python setup.py install \
     && cd .. \
     && rm -fr pytest-ansible

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -111,13 +111,7 @@ RUN apt-get update                  \
 RUN pip install azure-kusto-data==0.0.13 \
                 azure-kusto-ingest==0.0.13
 
-# Install pytest-ansible module
 RUN pip install wheel==0.33.6
-RUN pip install pytest-ansible==2.2.2
-
-# Apply 'become_user' patch for pytest-ansible
-RUN curl -fsSL https://github.com/ansible/pytest-ansible/commit/d33c025f070a9c870220a157cc5a999fda68de44.patch | \
-    patch /usr/local/lib/python2.7/dist-packages/pytest_ansible/module_dispatcher/v28.py
 
 ## Copy and install sonic-mgmt docker dependencies
 COPY \
@@ -134,6 +128,13 @@ debs/{{ deb }}{{' '}}
 RUN pip install ansible==2.8.7
 
 RUN pip install pysubnettree
+
+# Install pytest-ansible module
+RUN git clone https://github.com/ansible/pytest-ansible.git \
+    && cd pytest-ansible \
+    && python setup.py install \
+    && cd .. \
+    && rm -fr pytest-ansible
 
 RUN mkdir /var/run/sshd
 EXPOSE 22


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

- To support 'become' and 'become_user' arguments in pytest-ansible in 'docker-sonic-mgmt'

Required by [sonic-mgmt/PR1702](https://github.com/Azure/sonic-mgmt/pull/1702) : [pytest] Convert interface naming mode test to pytest

**- How I did it**

Apply [pytest-ansible/PR46](https://github.com/ansible/pytest-ansible/commit/d33c025f070a9c870220a157cc5a999fda68de44) patch to pytest-ansible while building 'docker-sonic-mgmt'.

**- How to verify it**

Use 'become', 'become_user' arguments in pytest script to login as a different user into host device. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[docker-sonic-mgmt]: Include patch to support 'become' and 'become_user' arguments in pytest-ansible

**- A picture of a cute animal (not mandatory but encouraged)**
