### PR TITLE
Install protobuf-compiler to syncd docker for broadcom platform

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
@@ -15,6 +15,8 @@ debs/{{ deb }}{{' '}}
 {%- endfor -%}
 debs/
 
+RUN apt-get install -y --no-install-recommends protobuf-compiler
+
 # Install locally-built Debian packages and implicitly install their dependencies
 {{ install_debian_packages(docker_syncd_brcm_debs.split(' ')) }}
 


### PR DESCRIPTION
libprotobuf.so.0 in protobuf-compiler is needed for libsai.so.1.

Signed-off-by: Masaru OKI <masaru.oki@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"fixes #4682 "

Please provide the following information:
-->

**- Why I did it**
syncd has abnormaly exited because missing libprotobuf.so.0 in syncd docker.
libprotobuf.so.0 is referenced by libsai.so.1 for broadcom platform.

**- How I did it**
protobuf-compiler package includes libprotobuf.so.0.
Install protobuf-compiler package when create syncd docker image.

**- How to verify it**
`show interfaces status` on broadcom platform.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
