### PR TITLE
Using pci device id to identify the ASIC on sai_switch_create

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -42,7 +42,7 @@ from portconfig import get_port_config
 from sonic_device_util import get_machine_info
 from sonic_device_util import get_platform_info
 from sonic_device_util import get_system_mac
-from sonic_device_util import get_npu_id_from_name
+from sonic_device_util import get_npu_id_from_name, get_npu_pci_device_id
 from config_samples import generate_sample_config
 from config_samples import get_available_config
 from swsssdk import SonicV2Connector, ConfigDBConnector, SonicDBConfig 
@@ -304,7 +304,8 @@ def main():
             }}}
         # The ID needs to be passed to the SAI to identify the asic.
         if asic_name is not None:
-            hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=asic_id)
+            device_id = get_npu_pci_device_id(asic_id)
+            hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
         deep_update(data, hardware_data)
 
     if args.template is not None:

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -43,7 +43,7 @@ from sonic_device_util import get_machine_info
 from sonic_device_util import get_platform_info
 from sonic_device_util import get_system_mac
 from sonic_device_util import get_npu_id_from_name
-from sonic_device_util import get_npu_pci_device_id
+from sonic_device_util import get_npu_device_id
 from config_samples import generate_sample_config
 from config_samples import get_available_config
 from swsssdk import SonicV2Connector, ConfigDBConnector, SonicDBConfig 
@@ -305,10 +305,10 @@ def main():
             }}}
         # The ID needs to be passed to the SAI to identify the asic.
         if asic_name is not None:
-            device_id = get_npu_pci_device_id(asic_id)
-            # if the pci_id obtained is None, exit with error
+            device_id = get_npu_device_id(asic_id)
+            # if the device_id obtained is None, exit with error
             if device_id is None:
-                print('Failed to get pci ID for', asic_name, file=sys.stderr)
+                print('Failed to get device ID for', asic_name, file=sys.stderr)
                 sys.exit(1)
             hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
         deep_update(data, hardware_data)

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -42,7 +42,8 @@ from portconfig import get_port_config
 from sonic_device_util import get_machine_info
 from sonic_device_util import get_platform_info
 from sonic_device_util import get_system_mac
-from sonic_device_util import get_npu_id_from_name, get_npu_pci_device_id
+from sonic_device_util import get_npu_id_from_name
+from sonic_device_util import get_npu_pci_device_id
 from config_samples import generate_sample_config
 from config_samples import get_available_config
 from swsssdk import SonicV2Connector, ConfigDBConnector, SonicDBConfig 
@@ -304,9 +305,11 @@ def main():
             }}}
         # The ID needs to be passed to the SAI to identify the asic.
         if asic_name is not None:
-            pci_id = get_npu_pci_device_id(asic_id)
-            # if the pci_id obtained is None, use the asic_id itself.
-            device_id = asic_id if pci_id is None else pci_id
+            device_id = get_npu_pci_device_id(asic_id)
+            # if the pci_id obtained is None, exit with error
+            if device_id is None:
+                print('Failed to get pci ID for', asic_name)
+                sys.exit(1)
             hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
         deep_update(data, hardware_data)
 

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -308,7 +308,7 @@ def main():
             device_id = get_npu_pci_device_id(asic_id)
             # if the pci_id obtained is None, exit with error
             if device_id is None:
-                print('Failed to get pci ID for', asic_name)
+                print('Failed to get pci ID for', asic_name, file=sys.stderr)
                 sys.exit(1)
             hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
         deep_update(data, hardware_data)

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -304,7 +304,9 @@ def main():
             }}}
         # The ID needs to be passed to the SAI to identify the asic.
         if asic_name is not None:
-            device_id = get_npu_pci_device_id(asic_id)
+            pci_id = get_npu_pci_device_id(asic_id)
+            # if the pci_id obtained is None, use the asic_id itself.
+            device_id = asic_id if pci_id is None else pci_id
             hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
         deep_update(data, hardware_data)
 

--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -44,6 +44,32 @@ def get_npu_id_from_name(npu_name):
     else:
         return None
 
+def get_npu_pci_device_id(npu_id):
+    platform = get_platform_info(get_machine_info())
+    if not platform:
+        return None
+
+    asic_conf_file_path = os.path.join(SONIC_DEVICE_PATH, platform, ASIC_CONF_FILENAME)
+    if not os.path.isfile(asic_conf_file_path):
+        return None
+
+    # In a multi-npu device we need to have the file "asic.conf" updated with the asic instance
+    # and the corresponding pci id. Below is an eg: for a 2 ASIC platform/sku.
+    # PCI_ID_ASIC_0=03:00.0
+    # PCI_ID_ASIC_1=04:00.0
+    pci_device_str = "PCI_ID_ASIC_{}".format(npu_id)
+
+    with open(asic_conf_file_path) as asic_conf_file:
+        for line in asic_conf_file:
+            tokens = line.split('=')
+            if len(tokens) < 2:
+               continue
+            if tokens[0] == pci_device_str:
+                pci_id = tokens[1].strip()
+                return pci_id
+
+    return None
+
 def get_num_npus():
     platform = get_platform_info(get_machine_info())
     if not platform:

--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -44,7 +44,7 @@ def get_npu_id_from_name(npu_name):
     else:
         return None
 
-def get_npu_pci_device_id(npu_id):
+def get_npu_device_id(npu_id):
     platform = get_platform_info(get_machine_info())
     if not platform:
         return None
@@ -54,19 +54,19 @@ def get_npu_pci_device_id(npu_id):
         return None
 
     # In a multi-npu device we need to have the file "asic.conf" updated with the asic instance
-    # and the corresponding pci id. Below is an eg: for a 2 ASIC platform/sku.
-    # PCI_ID_ASIC_0=03:00.0
-    # PCI_ID_ASIC_1=04:00.0
-    pci_device_str = "PCI_ID_ASIC_{}".format(npu_id)
+    # and the corresponding device id which could be pci_id. Below is an eg: for a 2 ASIC platform/sku.
+    # DEV_ID_ASIC_0=03:00.0
+    # DEV_ID_ASIC_1=04:00.0
+    device_str = "DEV_ID_ASIC_{}".format(npu_id)
 
     with open(asic_conf_file_path) as asic_conf_file:
         for line in asic_conf_file:
             tokens = line.split('=')
             if len(tokens) < 2:
                continue
-            if tokens[0] == pci_device_str:
-                pci_id = tokens[1].strip()
-                return pci_id
+            if tokens[0] == device_str:
+                device_id = tokens[1].strip()
+                return device_id
 
     return None
 


### PR DESCRIPTION
**- Why I did it**
The broadcom SAI takes in the pci device ID's  to identify the ASIC instead of the instance ID going forward from 3.7.5.1. Currently it supports only one particular multi-asic device ( Wider support for more multi-asic platforms is to come later )

Introducing this change in 201911 branch.

**- How I did it**
To incorporate this, the following changes are proposed.
* Update the "asic.conf" to include the PCI device ids for the ASIC's. Sample "asic.conf" is as below. Here in this eg: the ASIC_ID 0 has the  PCI id 03:00.0, ASIC_ID 1 has the  PCI id 04:00.0 .. etc.
NUM_ASIC=n
DEV_ID_ASIC_0=03:00.0
DEV_ID_ASIC_1=04:00.0
DEV_ID_ASIC_2=05:00.0

* Introduced an API get_npu_pci_device_id() which will get the PCI id for a given npu id

**- How to verify it**

* Verifyed on a multi-asic device that the pci id is generated in the "asic_id" field in the DEVICE_METADATA in  database/configdb. 
* Verifed that the orchagent process starts with the PCI device id for the "-i" parameter, stays stable and interface status is ok.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
