### PR TITLE
[Monit] Use the string "/usr/bin/syncd\s" to monitor the syncd process

### DIFF
--- a/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
+++ b/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd"
+check process syncd matching "/usr/bin/syncd\s"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
+++ b/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
@@ -4,7 +4,7 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check process syncd matching "/usr/bin/syncd"
+check process syncd matching "/usr/bin/syncd\s"
     if does not exist for 5 times within 5 cycles then alert
 
 check process dsserve matching "/usr/bin/dsserve /usr/bin/syncd"

--- a/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
+++ b/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd"
+check process syncd matching "/usr/bin/syncd\s"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
+++ b/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd"
+check process syncd matching "/usr/bin/syncd\s"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd"
+check process syncd matching "/usr/bin/syncd\s"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd"
+check process syncd matching "/usr/bin/syncd\s"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd"
+check process syncd matching "/usr/bin/syncd\s"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
+++ b/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd"
+check process syncd matching "/usr/bin/syncd\s"
     if does not exist for 5 times within 5 cycles then alert

--- a/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
+++ b/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
@@ -4,7 +4,7 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check process syncd matching "/usr/bin/syncd"
+check process syncd matching "/usr/bin/syncd\s"
     if does not exist for 5 times within 5 cycles then alert
 
 check process dsserve matching "/usr/bin/dsserve /usr/bin/syncd"


### PR DESCRIPTION
**- Why I did it**
After discussed with Joe, we use the string "/usr/bin/syncd\s" in Monit configuration file to monitor 
syncd process on Broadcom and Mellanox. Due to my careless, I did not find this bug during the 
previous testing. If we use the string "/usr/bin/syncd" in Monit configuration file to monitor the 
syncd process, Monit will not detect whether syncd process is running or not. 

If we ran the command  `sudo monit procmactch “/usr/bin/syncd”` on Broadcom, there will be three 
processes in syncd container which matched this "/usr/bin/syncd": `/bin/bash /usr/bin/syncd.sh
wait`, `/usr/bin/dsserve /usr/bin/syncd –diag -u -p /etc/sai.d/sai.profile` and `/usr/bin/syncd –diag -
u -p /etc/sai.d/said.profile`. Monit will select the processes with the highest uptime (at there 
`/bin/bash /usr/bin/syncd.sh wait`) to match and did not select `/usr/bin/syncd –diag -u -p
/etc/sai.d/said.profile` to match. 

Similarly, On Mellanox Monit will also select the process with the highest uptime (at there 
`/bin/bash /usr/bin/syncd.sh wait`) to match and did not select `/usr/bin/syncd –diag -u -p
/etc/sai.d/said.profile` to match.

That is why Monit is unable to detect whether syncd process is running or not if we use the string “/usr/bin/syncd” in Monit configuration file. If we use the string "/usr/bin/syncd\s" in Monit configuration file, Monit can filter out the process `/bin/bash /usr/bin/syncd.sh wait` and thus can correctly monitor the syncd process.

**- How I did it**

**- How to verify it**

