### PR TITLE
[chassis]: support virtual-chassis setup in vs docker

### DIFF
--- a/files/scripts/remove_chassisdb_config
+++ b/files/scripts/remove_chassisdb_config
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+import json
+import os
+import syslog
+import argparse
+
+database_config_file = "/var/run/redis/sonic-db/database_config.json"
+redis_chassis = 'redis_chassis'
+chassis_db = 'CHASSIS_DB'
+
+def main():
+    parser=argparse.ArgumentParser(description=
+          "Remove chassis_db config from database-config.json")
+    parser.add_argument("-j", "--json", help="databse-config json file", nargs='?',
+          const=database_config_file)
+    args = parser.parse_args()
+    jsonfile = ""
+    if args.json != None:
+        jsonfile = args.json
+    else:
+       return
+    data = {}
+    if os.path.isfile(jsonfile):
+        with open(jsonfile, "r") as read_file:
+            data = json.load(read_file)
+    else:
+       syslog.syslog(syslog.LOG_ERR,
+            'config file {} does notexist'.format(jsonfile))
+       return
+    if 'INSTANCES' in data and redis_chassis in data['INSTANCES']:
+       del data['INSTANCES'][redis_chassis]
+    if 'DATABASES' in data and chassis_db in data['DATABASES']:
+       del data['DATABASES'][chassis_db]
+    with open(jsonfile, "w") as write_file:
+       json.dump(data, write_file, indent=4, separators=(',', ': '))
+    syslog.syslog(syslog.LOG_INFO,
+       'remove chassis_db from config file {}'.format(jsonfile))
+
+if __name__ == "__main__":
+    main()

--- a/platform/vs/docker-sonic-vs.mk
+++ b/platform/vs/docker-sonic-vs.mk
@@ -34,7 +34,8 @@ $(DOCKER_SONIC_VS)_FILES += $(CONFIGDB_LOAD_SCRIPT) \
                             $(ARP_UPDATE_SCRIPT) \
                             $(BUFFERS_CONFIG_TEMPLATE) \
                             $(QOS_CONFIG_TEMPLATE) \
-                            $(SONIC_VERSION)
+                            $(SONIC_VERSION) \
+                            $(RM_CHASSISDB_CONFIG_SCRIPT)
 
 $(DOCKER_SONIC_VS)_LOAD_DOCKERS += $(DOCKER_CONFIG_ENGINE_BUSTER)
 SONIC_DOCKER_IMAGES += $(DOCKER_SONIC_VS)

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -119,13 +119,16 @@ RUN sed -ri 's/^(save .*$)/# \1/g;                                              
             ' /etc/redis/redis.conf
 
 COPY ["50-default.conf", "/etc/rsyslog.d/"]
-COPY ["start.sh", "orchagent.sh", "/usr/bin/"]
+COPY ["start.sh", "orchagent.sh", "files/remove_chassisdb_config", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/configdb-load.sh", "/usr/bin/"]
 COPY ["files/arp_update", "/usr/bin/"]
 COPY ["files/buffers_config.j2", "files/qos_config.j2", "/usr/share/sonic/templates/"]
 COPY ["files/sonic_version.yml", "/etc/sonic/"]
 COPY ["database_config.json", "/etc/default/sonic-db/"]
+COPY ["hostname.j2", "/usr/share/sonic/templates/"]
+COPY ["default_chassis_cfg.json", "/etc/default/sonic-db/"]
+COPY ["chassis_db.py", "/usr/bin/"]
 
 # Workaround the tcpdump issue
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump

--- a/platform/vs/docker-sonic-vs/chassis_db.py
+++ b/platform/vs/docker-sonic-vs/chassis_db.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import swsssdk
+import json
+chassisdb = swsssdk.SonicV2Connector(host='10.0.0.200', port='6380')
+chassisdb.connect(chassisdb.CHASSIS_DB)
+fname='/usr/share/sonic/virtual_chassis/chassis_db.json'
+with open(fname) as f:
+   js = json.load(f)
+   client=chassisdb.get_redis_client(chassisdb.CHASSIS_DB)
+   for h, table in js.items():
+      for k, v in table.items():
+         client.hset(h, k, v)

--- a/platform/vs/docker-sonic-vs/database_config.json
+++ b/platform/vs/docker-sonic-vs/database_config.json
@@ -4,6 +4,12 @@
             "hostname" : "127.0.0.1",
             "port" : 6379,
             "unix_socket_path" : "/var/run/redis/redis.sock"
+        },
+
+        "redis_chassis":{
+            "hostname" : "redis_chassis.server",
+            "port": 6380,
+            "unix_socket_path": "/var/run/redis/redis_chassis.sock"
         }
     },
     "DATABASES" : {
@@ -51,6 +57,11 @@
             "id" : 7,
             "separator": "|",
             "instance" : "redis"
+        },
+        "CHASSIS_DB" : {
+            "id" : 8,
+            "separator": "|",
+            "instance" : "redis_chassis"
         }
     },
     "VERSION" : "1.0"

--- a/platform/vs/docker-sonic-vs/default_chassis_cfg.json
+++ b/platform/vs/docker-sonic-vs/default_chassis_cfg.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "chassis_db_address" : "10.8.1.200"
+        }
+    }
+}

--- a/platform/vs/docker-sonic-vs/hostname.j2
+++ b/platform/vs/docker-sonic-vs/hostname.j2
@@ -1,0 +1,3 @@
+{% if DEVICE_METADATA.localhost.chassis_db_address %}
+{{ DEVICE_METADATA.localhost.chassis_db_address }} redis_chassis.server
+{% endif %}

--- a/platform/vs/docker-sonic-vs/supervisord.conf
+++ b/platform/vs/docker-sonic-vs/supervisord.conf
@@ -27,6 +27,14 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
+[program:redis-chassis]
+command=/bin/bash -c "{ [[ -s /var/lib/redis_chassis/dump.rdb ]] || rm -f /var/lib/redis_chassis/dump.rdb; } && mkdir -p /var/lib/redis_chassis && exec /usr/bin/redis-server /etc/redis/redis.conf --bind redis_chassis.server --port 6380 --unixsocket /var/run/redis/redis_chassis.sock --pidfile /var/run/redis/redis_chassis.pid --dir /var/lib/redis_chassis"
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+
 [program:syncd]
 command=/usr/bin/syncd_start.sh
 priority=4

--- a/rules/scripts.mk
+++ b/rules/scripts.mk
@@ -17,9 +17,13 @@ $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)_PATH = files/scripts
 SYSCTL_NET_CONFIG = sysctl-net.conf
 $(SYSCTL_NET_CONFIG)_PATH = files/image_config/sysctl
 
+RM_CHASSISDB_CONFIG_SCRIPT = remove_chassisdb_config
+$(RM_CHASSISDB_CONFIG_SCRIPT)_PATH = files/scripts
+
 SONIC_COPY_FILES += $(CONFIGDB_LOAD_SCRIPT) \
                     $(ARP_UPDATE_SCRIPT) \
                     $(BUFFERS_CONFIG_TEMPLATE) \
                     $(QOS_CONFIG_TEMPLATE) \
                     $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT) \
-                    $(SYSCTL_NET_CONFIG)
+                    $(SYSCTL_NET_CONFIG) \
+                    $(RM_CHASSISDB_CONFIG_SCRIPT)


### PR DESCRIPTION
virtual-chassis test uses multiple vs instances to simulate a
modular switch and a redis-chassis service is required to run in
the vs instance that represents a supervisor card.
This change allows vs docker start redis-chassis service according
to external config file.

Signed-off-by: Honggang Xu <hxu@arista.com>

**- Why I did it**
To support virtual-chassis setup, so that we can test distributed forwarding feature in virtual sonic environment, see `Distributed forwarding in a VOQ architecture HLD` pull request at https://github.com/Azure/SONiC/pull/622

**- How I did it**
The sonic-vs start.sh is enhanced to start new redis_chassis service if external chassis config file found. The config file doesn't exist in current vs environment, start.sh will behave like before. 

**- How to verify it**
The swss/test still pass. The chassis_db service is verified in virtual-chassis topology and tests which are in following PRs.

**- Description for the changelog**
[vs] support chassis_db service in vs


**- A picture of a cute animal (not mandatory but encouraged)**
