### PR TITLE
[docker-ptf] Build and add gnmi_get

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -140,13 +140,16 @@ RUN ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 RUN mkdir -p /var/log/supervisor
 
 # add dependencies to build gnmi_get
-RUN wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz \
-    && tar xf go1.12.linux-amd64.tar.gz \
-    && export GOROOT = /usr/local/go \
-    && export PATH = $PATH:$GOROOT/bin \
-    && export GOPATH = $HOME/go \
-    && go get github.com/jipanyang/gnxi/gnmi_get
-
+RUN wget -O go.tgz https://dl.google.com/go/go1.12.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go.tgz \
+    && export PATH=$PATH:/usr/local/go/bin \
+    && go version \
+    && mkdir $HOME/go \
+    && export GOPATH=$HOME/go \
+    && go env \
+    && go get github.com/jipanyang/gnxi/gnmi_get \
+    && ls -l $HOME/go/bin
+    
 EXPOSE 22 8009
 
 ENTRYPOINT ["/usr/local/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -142,7 +142,7 @@ RUN mkdir -p /var/log/supervisor
 # add dependencies to build gnmi_get
 RUN wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz \
     && tar xf go1.12.linux-amd64.tar.gz \
-    && export GOROOT = $WORKSPACE/go \
+    && export GOROOT = /usr/local/go \
     && export PATH = $PATH:$GOROOT/bin \
     && export GOPATH = $HOME/go \
     && go get github.com/jipanyang/gnxi/gnmi_get

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -120,8 +120,7 @@ RUN rm -rf /debs \
     && pip install pybrctl pyro4 rpyc yabgp \
     && mkdir -p /opt       \
     && cd /opt             \
-    && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-    && wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz
+    && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py
 
 ## Adjust sshd settings
 RUN mkdir /var/run/sshd \
@@ -141,10 +140,11 @@ RUN ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 RUN mkdir -p /var/log/supervisor
 
 # add dependencies to build gnmi_get
-RUN tar xf go1.12.linux-amd64.tar.gz \
+RUN wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz \
+    && tar xf go1.12.linux-amd64.tar.gz \
     && export GOROOT = $WORKSPACE/go \
-    && export PATH=$PATH:$GOROOT/bin \
-    && export GOPATH=$HOME/go \
+    && export PATH = $PATH:$GOROOT/bin \
+    && export GOPATH = $HOME/go \
     && go get github.com/jipanyang/gnxi/gnmi_get
 
 EXPOSE 22 8009

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -155,8 +155,11 @@ RUN export VERSION=1.14.2 \
  && mkdir /etc/go \
  && export GOPATH=/etc/go \
  && rm go$VERSION.linux-*.tar.gz \
- && go get github.com/jipanyang/gnxi/gnmi_get \
- && ls -l /etc/go/bin
+ && cd /etc/go \
+ && git clone https://github.com/google/gnxi.git \
+ && cd /etc/go/gnxi \
+ && wget https://github.com/lguohan/gnxi/blob/master/gnmi_cli_py/py_gnmicli.py \
+ && ls -l
 
 EXPOSE 22 8009
 

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -140,16 +140,24 @@ RUN ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 RUN mkdir -p /var/log/supervisor
 
 # add dependencies to build gnmi_get
-RUN wget -O go.tgz https://dl.google.com/go/go1.12.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go.tgz \
-    && export PATH=$PATH:/usr/local/go/bin \
-    && go version \
-    && mkdir $HOME/go \
-    && export GOPATH=$HOME/go \
-    && go env \
-    && go get github.com/jipanyang/gnxi/gnmi_get \
-    && ls -l $HOME/go/bin
-    
+RUN export VERSION=1.14.2 \
+{% if CONFIGURED_ARCH == "armhf" %}
+ && wget https://storage.googleapis.com/golang/go$VERSION.linux-armv6l.tar.gz \
+ && tar -C /usr/local -xzf go$VERSION.linux-armv6l.tar.gz \
+{% elif CONFIGURED_ARCH == "arm64" %}
+ && wget https://storage.googleapis.com/golang/go$VERSION.linux-arm64.tar.gz \
+ && tar -C /usr/local -xzf go$VERSION.linux-arm64.tar.gz \
+{% else %}
+ && wget https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz \
+ && tar -C /usr/local -xzf go$VERSION.linux-amd64.tar.gz \
+{% endif %}
+ && export PATH=$PATH:/usr/local/go/bin \
+ && mkdir /etc/go \
+ && export GOPATH=/etc/go \
+ && rm go$VERSION.linux-*.tar.gz \
+ && go get github.com/jipanyang/gnxi/gnmi_get \
+ && ls -l /etc/go/bin
+
 EXPOSE 22 8009
 
 ENTRYPOINT ["/usr/local/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -120,7 +120,8 @@ RUN rm -rf /debs \
     && pip install pybrctl pyro4 rpyc yabgp \
     && mkdir -p /opt       \
     && cd /opt             \
-    && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py
+    && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+    && wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz
 
 ## Adjust sshd settings
 RUN mkdir /var/run/sshd \
@@ -138,6 +139,13 @@ RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
 RUN ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 
 RUN mkdir -p /var/log/supervisor
+
+# add dependencies to build gnmi_get
+RUN tar xf go1.12.linux-amd64.tar.gz \
+    && export GOROOT = $WORKSPACE/go \
+    && export PATH=$PATH:$GOROOT/bin \
+    && export GOPATH=$HOME/go \
+    && go get github.com/jipanyang/gnxi/gnmi_get
 
 EXPOSE 22 8009
 


### PR DESCRIPTION
Download go package 
set up required variables 
go get gnmi_get  to fetch gnmi_get

**- Why I did it**
For telemetry regression test we need gnmi_get(gnmi client) to be present on ptfdocker. Gnmi-server will be present on SONiC DuT. Further, we can access gnmi_get from ptfdocker inside pytest to verify gnmi server streaming data successfully or not. 

**- How I did it**
Added changes to Dockerfile.j2 for ptfdocker
**- How to verify it**
Build logs under target/docker-ptf.gz.log. Logs show :
1. wget has been success with go.tgz
2. output of go env showing mandatory variables set up 
3. output of ls -l /$HOME/go shows gnmi_get present. This verified go get step has been sucessful 

<html>
<head>
^[[0m^[[91m2020-06-06 01:47:33 (84.5 MB/s) - 'go.tgz' saved [127228112/127228112]

^[[0mgo version go1.12 linux/amd64
GOARCH="amd64"
GOBIN=""
GOCACHE="/root/.cache/go-build"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="linux"
GOOS="linux"
GOPATH="/root/go"
GOPROXY=""
GORACE=""
GOROOT="/usr/local/go"
GOTMPDIR=""
GOTOOLDIR="/usr/local/go/pkg/tool/linux_amd64"
GCCGO="gccgo"
CC="gcc"
CXX="g++"
CGO_ENABLED="1"
GOMOD=""
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -m64 -pthread -fmessage-length=0 -fdebug-prefix-map=/tmp/go-build618910343=/tmp/go-build -gno-record-gcc-switches"
total 14752
-rwxr-xr-x 1 root root 15105819 Jun  6 01:48 gnmi_get
Removing intermediate container b14979f76937
 ---> 3675ea45711a
Step 17/19 : EXPOSE 22 8009
 ---> Running in 9120160a690f
</head>
<html>
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
