### PR TITLE
[build][systemd] Mask disabled services by default

### DIFF
--- a/files/build_scripts/mask_disabled_services.py
+++ b/files/build_scripts/mask_disabled_services.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+
+INIT_CFG_FILE_PATH = '/etc/sonic/init_cfg.json'
+
+with open(INIT_CFG_FILE_PATH) as init_cfg_file:
+    init_cfg = json.load(init_cfg_file)
+    if 'FEATURE' in init_cfg:
+        for feature_name, feature_props in init_cfg['FEATURE'].items():
+            if 'status' in feature_props and feature_props['status'] == 'disabled':
+                subprocess.run(['systemctl', 'mask', '{}.service'.format(feature_name)])

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -27,6 +27,7 @@ set -x -e
 CONFIGURED_ARCH=$([ -f .arch ] && cat .arch || echo amd64)
 
 . functions.sh
+BUILD_SCRIPTS_DIR=files/build_scripts
 BUILD_TEMPLATES=files/build_templates
 IMAGE_CONFIGS=files/image_config
 SCRIPTS_DIR=files/scripts
@@ -560,20 +561,7 @@ sudo chmod 750 $FILESYSTEM_ROOT/etc/sonic/frr
 {%- endif %}
 
 # Mask services which are disabled by default
-MASK_SERVICES_SCRIPT=/tmp/mask_services.py
-sudo tee $FILESYSTEM_ROOT/$MASK_SERVICES_SCRIPT > /dev/null <<EOF
-#!/usr/bin/env python3
-
-import json
-import subprocess
-
-with open('/etc/sonic/init_cfg.json') as init_cfg_file:
-    init_cfg = json.load(init_cfg_file)
-    if 'FEATURE' in init_cfg:
-        for feature_name, feature_props in init_cfg['FEATURE'].items():
-            if 'status' in feature_props and feature_props['status'] == 'disabled':
-                subprocess.run(['systemctl', 'mask', '{}.service'.format(feature_name)])
-EOF
-sudo chmod a+x $FILESYSTEM_ROOT/$MASK_SERVICES_SCRIPT
-sudo LANG=C chroot $FILESYSTEM_ROOT $MASK_SERVICES_SCRIPT
-sudo rm -rf $FILESYSTEM_ROOT/$MASK_SERVICES_SCRIPT
+sudo cp $BUILD_SCRIPTS_DIR/mask_disabled_services.py $FILESYSTEM_ROOT/tmp/
+sudo chmod a+x $FILESYSTEM_ROOT/tmp/mask_disabled_services.py
+sudo LANG=C chroot $FILESYSTEM_ROOT /tmp/mask_disabled_services.py
+sudo rm -rf $FILESYSTEM_ROOT/tmp/mask_disabled_services.py

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -558,3 +558,22 @@ sudo chown -R $FRR_USER_UID:$FRR_USER_GID $FILESYSTEM_ROOT/etc/sonic/frr
 sudo chmod -R 640 $FILESYSTEM_ROOT/etc/sonic/frr/
 sudo chmod 750 $FILESYSTEM_ROOT/etc/sonic/frr
 {%- endif %}
+
+# Mask services which are disabled by default
+MASK_SERVICES_SCRIPT=/tmp/mask_services.py
+sudo tee $FILESYSTEM_ROOT/$MASK_SERVICES_SCRIPT > /dev/null <<EOF
+#!/usr/bin/env python3
+
+import json
+import subprocess
+
+with open('/etc/sonic/init_cfg.json') as init_cfg_file:
+    init_cfg = json.load(init_cfg_file)
+    if 'FEATURE' in init_cfg:
+        for feature_name, feature_props in init_cfg['FEATURE'].items():
+            if 'status' in feature_props and feature_props['status'] == 'disabled':
+                subprocess.run(['systemctl', 'mask', '{}.service'.format(feature_name)])
+EOF
+sudo chmod a+x $FILESYSTEM_ROOT/$MASK_SERVICES_SCRIPT
+sudo LANG=C chroot $FILESYSTEM_ROOT $MASK_SERVICES_SCRIPT
+sudo rm -rf $FILESYSTEM_ROOT/$MASK_SERVICES_SCRIPT


### PR DESCRIPTION
When building the SONiC image, used systemd to mask all services which are set to "disabled" in init_cfg.json.

This PR depends on https://github.com/Azure/sonic-utilities/pull/944, otherwise `config load_minigraph will fail when trying to restart disabled services.