### PR TITLE
Add PCIe config file of DX010 and E1031

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/plugins/pcie.yaml
+++ b/device/celestica/x86_64-cel_e1031-r0/plugins/pcie.yaml
@@ -1,0 +1,76 @@
+- bus: '00'
+  dev: '00'
+  fn: '0'
+  id: 1f0f
+  name: 'Host bridge: Intel Corporation Atom processor C2000 SoC Transaction Router'
+- bus: '00'
+  dev: '01'
+  fn: '0'
+  id: 1f10
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 1'
+- bus: '00'
+  dev: '02'
+  fn: '0'
+  id: 1f11
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 2'
+- bus: '00'
+  dev: '03'
+  fn: '0'
+  id: 1f12
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 3'
+- bus: '00'
+  dev: '04'
+  fn: '0'
+  id: 1f13
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 4'
+- bus: '00'
+  dev: 0e
+  fn: '0'
+  id: 1f14
+  name: 'Host bridge: Intel Corporation Atom processor C2000 RAS'
+- bus: '00'
+  dev: 0f
+  fn: '0'
+  id: 1f16
+  name: 'IOMMU: Intel Corporation Atom processor C2000 RCEC'
+- bus: '00'
+  dev: '13'
+  fn: '0'
+  id: 1f15
+  name: 'System peripheral: Intel Corporation Atom processor C2000 SMBus 2.0'
+- bus: '00'
+  dev: '14'
+  fn: '0'
+  id: 1f41
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354'
+- bus: '00'
+  dev: '16'
+  fn: '0'
+  id: 1f2c
+  name: 'USB controller: Intel Corporation Atom processor C2000 USB Enhanced Host Controller'
+- bus: '00'
+  dev: '17'
+  fn: '0'
+  id: 1f22
+  name: 'SATA controller: Intel Corporation Atom processor C2000 AHCI SATA2 Controller'
+- bus: '00'
+  dev: 1f
+  fn: '0'
+  id: 1f38
+  name: 'ISA bridge: Intel Corporation Atom processor C2000 PCU'
+- bus: '00'
+  dev: 1f
+  fn: '3'
+  id: 1f3c
+  name: 'SMBus: Intel Corporation Atom processor C2000 PCU SMBus'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: b340
+  name: 'Ethernet controller: Broadcom Limited Device b340'
+- bus: '01'
+  dev: '00'
+  fn: '1'
+  id: b340
+  name: 'Ethernet controller: Broadcom Limited Device b340'
+

--- a/device/celestica/x86_64-cel_seastone-r0/plugins/pcie.yaml
+++ b/device/celestica/x86_64-cel_seastone-r0/plugins/pcie.yaml
@@ -1,0 +1,75 @@
+- bus: '00'
+  dev: '00'
+  fn: '0'
+  id: 1f0c
+  name: 'Host bridge: Intel Corporation Atom processor C2000 SoC Transaction Router'
+- bus: '00'
+  dev: '01'
+  fn: '0'
+  id: 1f10
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 1'
+- bus: '00'
+  dev: '02'
+  fn: '0'
+  id: 1f11
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 2'
+- bus: '00'
+  dev: '03'
+  fn: '0'
+  id: 1f12
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 3'
+- bus: '00'
+  dev: 0e
+  fn: '0'
+  id: 1f14
+  name: 'Host bridge: Intel Corporation Atom processor C2000 RAS'
+- bus: '00'
+  dev: 0f
+  fn: '0'
+  id: 1f16
+  name: 'IOMMU: Intel Corporation Atom processor C2000 RCEC'
+- bus: '00'
+  dev: '13'
+  fn: '0'
+  id: 1f15
+  name: 'System peripheral: Intel Corporation Atom processor C2000 SMBus 2.0'
+- bus: '00'
+  dev: '14'
+  fn: '0'
+  id: 1f41
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354'
+- bus: '00'
+  dev: '16'
+  fn: '0'
+  id: 1f2c
+  name: 'USB controller: Intel Corporation Atom processor C2000 USB Enhanced Host Controller'
+- bus: '00'
+  dev: '17'
+  fn: '0'
+  id: 1f22
+  name: 'SATA controller: Intel Corporation Atom processor C2000 AHCI SATA2 Controller'
+- bus: '00'
+  dev: '18'
+  fn: '0'
+  id: 1f32
+  name: 'SATA controller: Intel Corporation Atom processor C2000 AHCI SATA3 Controller'
+- bus: '00'
+  dev: 1f
+  fn: '0'
+  id: 1f38
+  name: 'ISA bridge: Intel Corporation Atom processor C2000 PCU'
+- bus: '00'
+  dev: 1f
+  fn: '3'
+  id: 1f3c
+  name: 'SMBus: Intel Corporation Atom processor C2000 PCU SMBus'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: b960
+  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56960 Switch ASIC'
+- bus: '01'
+  dev: '00'
+  fn: '1'
+  id: b960
+  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56960 Switch ASIC'


### PR DESCRIPTION
**What I did**
Make a PCIe Diag tool for SONiC. This tool including two commands.
Commands added:
       `show platform pcieinfo`          ----->  Show current device PCIe info
       `show platform pcieinfo  -c`     ----->  Check whether the PCIe info is correct
   


**How I did it**

1. Add pcieutil moudle in sonic-utilities:

     Location: sonic-utilities/pcieutil/main.py
     Function: The main function will import the common API pcie_common.py and distinguish current platform

      `get_platform_and_hwsku()`
       Return the platform path like : ` /usr/share/sonic/device/$PLATFORM/plugins`

2. Add  common API in  pcie_common.py:

     Location: sonic_platform_base/sonic_pice/pcie_common.py
     Function: This file is used to fulfill the main interfaces including functions 

     `get_pcie_device() ` 
        Getting current pcie info of the device;
     ` get_pcie_check() `
        Compare the pcie info it got currently with pcie.yaml
     ` dump_conf_yaml() `
        This function is used to generate pcie.yaml which used to record the original pcie info.Also you can make the pcie.yaml manually but should follow the format;
     
3. The pcie.yaml file
  
    location: /usr/share/sonic/device/$PLATFORM/plugins/pcie.yaml
    Function: 
                   Used to record the original PCIe info of the device;
                   Used as a  criterion for judging whether  the PCIe info we get is correct or not;

   how to generate this file?
   Two methods:
      1. Make it manually.But should follow the format;
      2. Use the below command to generate one.
       `pcieutil pcie_generate`
     

      The pcie.yaml is under different path due to different platforms.     
      The common API will load the config file to compare with  PCIe info of current device.If not found, will raise a system warning and exit 
    
4. How should different platform designer do if they need to use this tool.
        Just add a pcie.yaml  under the config file path 
        You can get a general config file and the file path by running command
       ` pcieutil pcie_generate`
        but when you do that ,make sure the PCIe config info is correct


 **New command output** 
`root@sonic:~# show platform pcieinfo `
`==============================Display PCIe Device===============================
`
`......`
`bus:dev.fn 01:00.0 - dev_id=0xb960,  Ethernet controller: Broadcom Limited Device b960 `
`bus:dev.fn 01:00.1 - dev_id=0xb960,  Ethernet controller: Broadcom Limited Device b960 `


`root@sonic:~# show platform pcieinfo -c`
`===============================PCIe Device Check================================`
`Error: [Errno 2] No such file or directory: '/usr/share/sonic/device/x86_64-cel_seastone-r0/plugins/pcie.yaml'`
`Not found config file, please add a config file manually, or generate it by running [pcieutil pcie_generate]`

`root@sonic:~# pcieutil pcie_generate`
`Are you sure to overwrite config file pcie.yaml with current pcie device info? [y/N]: y`
`generate config file pcie.yaml under path /usr/share/sonic/device/x86_64-cel_seastone-r0/plugins`


`root@sonic:~# show platform pcieinfo -c`
`===============================PCIe Device Check================================`
`......`
`PCI Device:  Ethernet controller: Broadcom Limited Device b960 ------------------ [Passed]`
`PCI Device:  Ethernet controller: Broadcom Limited Device b960 ------------------ [Passed]`
`PCIe Device Checking All Test ----------->>> PASSED`

`root@sonic:~# show platform pcieinfo -c`
`===============================PCIe Device Check================================`
`......`
`PCI Device:  Ethernet controller: Broadcom Limited Device b960 ------------------ [Failed]`
`PCI Device:  Ethernet controller: Broadcom Limited Device b960 ------------------ [Passed]`
`PCIe Device Checking All Test ----------->>> FAILED`

