### PR TITLE
[libsaibcm] Update pointer to Broadcom SAI debian package

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_3.7.4.2_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.4.2_amd64.deb?sv=2015-04-05&sr=b&sig=Iqgd1HDmXOa%2F2OEnez1D4dQ4wVICZlnvVOYao1FYlio%3D&se=2034-01-14T18%3A51%3A07Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_3.7.4.2_amd64.deb
+BRCM_SAI = libsaibcm_3.7.4.2-2_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.4.2-2_amd64.deb?sv=2015-04-05&sr=b&sig=sl819d71a%2BcgrDtOt%2BmywfSL9N2EQS58qMJFq0aKqo8%3D&se=2034-02-11T20%3A28%3A46Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_3.7.4.2-2_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.4.2_amd64.deb?sv=2015-04-05&sr=b&sig=cbQJOwQcILWYbjuI3LObY6H7bvCNijKfEkdAIrm3Q64%3D&se=2034-01-14T18%3A49%3A15Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.4.2-2_amd64.deb?sv=2015-04-05&sr=b&sig=cvOpP0PWFVmBNeYLMkxyI4BFBQf1DopD32t%2B3AkJHRg%3D&se=2034-02-11T20%3A27%3A46Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
**- Why I did it**
The last BRCM SAI debian package missed including a dependency for libprotobuf, causing some processes to not run. (https://github.com/Azure/sonic-buildimage/issues/4682)

**- How I did it**
Added libprotobuf dependency in BRCM SAI debian package. 

**- How to verify it**
Loaded sonic-broadcom.bin in BRCM chipset, verified all the processes are up and running.
```
admin@str-s6000-acs-8:~$ docker exec -it syncd bash
root@str-s6000-acs-8:/#  ldd /usr/bin/syncd
        linux-vdso.so.1 (0x00007fff3c285000)
        libsaimetadata.so.0 => /usr/lib/x86_64-linux-gnu/libsaimetadata.so.0 (0x00007f5f3b857000)
        libsaimeta.so.0 => /usr/lib/x86_64-linux-gnu/libsaimeta.so.0 (0x00007f5f3b4ab000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f5f3b2a7000)
        libhiredis.so.0.14 => /usr/lib/x86_64-linux-gnu/libhiredis.so.0.14 (0x00007f5f3b097000)
        libswsscommon.so.0 => /usr/lib/x86_64-linux-gnu/libswsscommon.so.0 (0x00007f5f3ae1f000)
        libsai.so.1 => /usr/lib/libsai.so.1 (0x00007f5f32c71000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f5f32a54000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f5f326d2000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f5f323ce000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f5f321b7000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f5f31e18000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f5f3bd9e000)
        libnl-genl-3.so.200 => /lib/x86_64-linux-gnu/libnl-genl-3.so.200 (0x00007f5f31c11000)
        libnl-nf-3.so.200 => /usr/lib/x86_64-linux-gnu/libnl-nf-3.so.200 (0x00007f5f319f8000)
        libnl-route-3.so.200 => /usr/lib/x86_64-linux-gnu/libnl-route-3.so.200 (0x00007f5f31773000)
        libnl-3.so.200 => /lib/x86_64-linux-gnu/libnl-3.so.200 (0x00007f5f31551000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f5f31349000)
        libprotobuf.so.10 => /usr/lib/x86_64-linux-gnu/libprotobuf.so.10 (0x00007f5f30ed8000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f5f30cbe000)
root@str-s6000-acs-8:/# ldd /usr/lib/libsai.so.1
        linux-vdso.so.1 (0x00007fff191c3000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f5073611000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f50733f4000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f50731ec000)
        libprotobuf.so.10 => /usr/lib/x86_64-linux-gnu/libprotobuf.so.10 (0x00007f5072d7b000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f50729f9000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f50726f5000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f5072356000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f507213f000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f507b9c3000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f5071f25000)

admin@str-s6000-acs-8:~$ show ver

SONiC Software Version: SONiC.master.0-dirty-20200604.215057
Distribution: Debian 10.4
Kernel: 4.19.0-6-amd64
Build commit: 9f77e2e7
Build date: Fri Jun  5 01:21:24 UTC 2020
Built by: samaddik@samaddik-vm-01

Platform: x86_64-dell_s6000_s1220-r0
HwSKU: Force10-S6000
ASIC: broadcom
Serial Number: Platform did not indicate serial number
Uptime: 17:13:32 up 22 min,  1 user,  load average: 1.09, 1.56, 1.77

```

**- Description for the changelog**
[libsaibcm] Update pointer to BRCM SAI debian package.


**- A picture of a cute animal (not mandatory but encouraged)**
