### PR TITLE
syslog changes Multi NPU platforms

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -36,6 +36,7 @@ function updateSyslogConf()
         TARGET_IP=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
         CONTAINER_NAME="{{docker_container_name}}$DEV"
         TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
+
         sonic-cfggen  -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
         docker cp $TMP_FILE {{docker_container_name}}$DEV:/etc/rsyslog.conf
         rm -rf $TMP_FILE
@@ -244,10 +245,7 @@ start() {
             done
         fi
         {%- endif %}
-        # single NPU systems and container running on the host network continue to use the json-file as log-driver
-        {%- if '--log-driver=json-file' in docker_image_run_opt or '--log-driver' not in docker_image_run_opt %}
-            LOG_OPTS="--log-opt max-size=2M --log-opt max-file=5"
-        {%- endif %}
+
     else
         # This part of code is applicable for Multi-ASIC platforms. Here we mount the namespace specific
         # redis directory into the docker running in that namespace. Below eg: is for namespace "asic1"
@@ -258,15 +256,6 @@ start() {
             redis_dir=`echo $redis_dir_list | cut -d " " -f $id`
             REDIS_MNT=" -v $redis_dir:$redis_dir:rw "
         fi
-        {%- if '--log-driver=json-file' in docker_image_run_opt %}
-            LOG_OPTS="--log-opt max-size=2M --log-opt max-file=5"
-        {%- else %}
-            # Containers in the docker network will use the syslog-driver as log-driver. This is mainly applicable for Multi NPU system
-            # In this case the syslog service on the host is listening on the docker0 address
-            syslog_address=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
-            LOG_OPTS="--log-driver=syslog --log-opt syslog-address=udp://$syslog_address:514 --log-opt syslog-format=rfc5424 \
-                                          --log-opt syslog-facility=daemon --log-opt tag={{docker_container_name}}$DEV"
-        {%- endif %}
         {%- if docker_container_name == "database" %}
         NET="bridge"
         {%- else %}
@@ -290,7 +279,9 @@ start() {
 {%- if install_debug_image == "y" %}
         -v /src:/src:ro -v /debug:/debug:rw \
 {%- endif %}
-        $LOG_OPTS \
+{%- if '--log-driver=json-file' in docker_image_run_opt or '--log-driver' not in docker_image_run_opt %}
+        --log-opt max-size=2M --log-opt max-file=5 \
+{%- endif %}
 {%- if sonic_asic_platform == "mellanox" %}
 {%- if docker_container_name == "syncd" %}
         -v /var/log/mellanox/sniffer:/var/log/mellanox/sniffer:rw \

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -268,7 +268,7 @@ start() {
 {%- if install_debug_image == "y" %}
         -v /src:/src:ro -v /debug:/debug:rw \
 {%- endif %}
-          $LOG_OPTS \
+        $LOG_OPTS \
 {%- if sonic_asic_platform == "mellanox" %}
 {%- if docker_container_name == "syncd" %}
         -v /var/log/mellanox/sniffer:/var/log/mellanox/sniffer:rw \

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -33,7 +33,7 @@ function updateSyslogConf()
     # running on the namespace to reach the rsyslog service running on the host
     # Also update the container name  
     if [[ ($NUM_ASIC -gt 1) ]]; then
-        TARGET_IP=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
+        TARGET_IP=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
         CONTAINER_NAME="{{docker_container_name}}$DEV"
         TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
 

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -245,7 +245,6 @@ start() {
             done
         fi
         {%- endif %}
-
     else
         # This part of code is applicable for Multi-ASIC platforms. Here we mount the namespace specific
         # redis directory into the docker running in that namespace. Below eg: is for namespace "asic1"
@@ -256,6 +255,7 @@ start() {
             redis_dir=`echo $redis_dir_list | cut -d " " -f $id`
             REDIS_MNT=" -v $redis_dir:$redis_dir:rw "
         fi
+
         {%- if docker_container_name == "database" %}
         NET="bridge"
         {%- else %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -37,7 +37,7 @@ function updateSyslogConf()
         CONTAINER_NAME="{{docker_container_name}}$DEV"
         TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
 
-        sonic-cfggen  -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
+        sonic-cfggen -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
         docker cp $TMP_FILE {{docker_container_name}}$DEV:/etc/rsyslog.conf
         rm -rf $TMP_FILE
     fi

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -228,6 +228,10 @@ start() {
             done
         fi
         {%- endif %}
+        # single NPU systems and container running on the host network continue to use the json-file as log-driver
+        {%- if '--log-driver=json-file' in docker_image_run_opt or '--log-driver' not in docker_image_run_opt %}
+            LOG_OPTS="--log-opt max-size=2M --log-opt max-file=5"
+        {%- endif %}
     else
         # This part of code is applicable for Multi-ASIC platforms. Here we mount the namespace specific
         # redis directory into the docker running in that namespace. Below eg: is for namespace "asic1"
@@ -238,7 +242,9 @@ start() {
             redis_dir=`echo $redis_dir_list | cut -d " " -f $id`
             REDIS_MNT=" -v $redis_dir:$redis_dir:rw "
         fi
-
+        # Containers in the docker network will use the syslog-driver as log-driver. This is mainly applicable for Multi NPU system
+        LOG_OPTS="--log-driver=syslog --log-opt syslog-address=udp://127.0.0.1:514 --log-opt syslog-format=rfc5424 \
+                                       --log-opt syslog-facility=daemon --log-opt tag={{docker_container_name}}$DEV"
         {%- if docker_container_name == "database" %}
         NET="bridge"
         {%- else %}
@@ -262,9 +268,7 @@ start() {
 {%- if install_debug_image == "y" %}
         -v /src:/src:ro -v /debug:/debug:rw \
 {%- endif %}
-{%- if '--log-driver=json-file' in docker_image_run_opt or '--log-driver' not in docker_image_run_opt %}
-        --log-opt max-size=2M --log-opt max-file=5 \
-{%- endif %}
+          $LOG_OPTS \
 {%- if sonic_asic_platform == "mellanox" %}
 {%- if docker_container_name == "syncd" %}
         -v /var/log/mellanox/sniffer:/var/log/mellanox/sniffer:rw \

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -27,6 +27,21 @@ link_namespace() {
 }
 {%- endif %}
 
+function updateSyslogConf()
+{
+    # On multiNPU platforms, change the syslog target ip to docker0 ip to allow logs from containers
+    # running on the namespace to reach the rsyslog service running on the host
+    # Also update the container name  
+    if [[ ($NUM_ASIC -gt 1) ]]; then
+        TARGET_IP=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
+        CONTAINER_NAME="{{docker_container_name}}$DEV"
+        TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
+        sonic-cfggen  -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
+        docker cp $TMP_FILE {{docker_container_name}}$DEV:/etc/rsyslog.conf
+        rm -rf $TMP_FILE
+    fi
+}
+
 function getMountPoint()
 {
     echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.basename(mnts[0]['Source'])" 2>/dev/null
@@ -68,6 +83,7 @@ function preStartAction()
 {%- else %}
     : # nothing
 {%- endif %}
+    updateSyslogConf
 }
 
 function postStartAction()
@@ -242,9 +258,15 @@ start() {
             redis_dir=`echo $redis_dir_list | cut -d " " -f $id`
             REDIS_MNT=" -v $redis_dir:$redis_dir:rw "
         fi
-        # Containers in the docker network will use the syslog-driver as log-driver. This is mainly applicable for Multi NPU system
-        LOG_OPTS="--log-driver=syslog --log-opt syslog-address=udp://127.0.0.1:514 --log-opt syslog-format=rfc5424 \
-                                       --log-opt syslog-facility=daemon --log-opt tag={{docker_container_name}}$DEV"
+        {%- if '--log-driver=json-file' in docker_image_run_opt %}
+            LOG_OPTS="--log-opt max-size=2M --log-opt max-file=5"
+        {%- else %}
+            # Containers in the docker network will use the syslog-driver as log-driver. This is mainly applicable for Multi NPU system
+            # In this case the syslog service on the host is listening on the docker0 address
+            syslog_address=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
+            LOG_OPTS="--log-driver=syslog --log-opt syslog-address=udp://$syslog_address:514 --log-opt syslog-format=rfc5424 \
+                                          --log-opt syslog-facility=daemon --log-opt tag={{docker_container_name}}$DEV"
+        {%- endif %}
         {%- if docker_container_name == "database" %}
         NET="bridge"
         {%- else %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -33,7 +33,7 @@ function updateSyslogConf()
     # running on the namespace to reach the rsyslog service running on the host
     # Also update the container name  
     if [[ ($NUM_ASIC -gt 1) ]]; then
-        TARGET_IP=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
+        TARGET_IP=$(docker network inspect bridge --format={{ "'{{(index .IPAM.Config 0).Gateway}}'" }})
         CONTAINER_NAME="{{docker_container_name}}$DEV"
         TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -235,6 +235,7 @@ echo "warmboot-finalizer.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog-config.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
+sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog-container.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.d/* $FILESYSTEM_ROOT/etc/rsyslog.d/
 echo "rsyslog-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
 

--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -13,12 +13,11 @@ fi
 # on Single NPU platforms we continue to use loopback adddres
 
 if [[ ($NUM_ASIC -gt 1) ]]; then
-    intf="docker0"
+    udp_server_ip=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
 else
-    intf="lo"
+    udp_server_ip=$(ip -o -4 addr list lo scope host | awk '{print $4}' | cut -d/ -f1)
 fi
 
-udp_server_ip=$(ip -o -4 addr list $intf | awk '{print $4}' | cut -d/ -f1)
 sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog.conf.j2 -a "{\"udp_server_ip\": \"$udp_server_ip\"}"  >/etc/rsyslog.conf
 
 systemctl restart rsyslog

--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
 
-sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog.conf.j2 >/etc/rsyslog.conf
+PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+
+# Parse the device specific asic conf file, if it exists
+ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
+if [ -f "$ASIC_CONF" ]; then
+    source $ASIC_CONF
+fi
+
+# On Multi NPU platforms we need to start  the rsyslog server on the docker0 ip address
+# for the syslogs from the containers in the namespaces to work.
+# on Single NPU platforms we continue to use loopback adddres
+
+if [[ ($NUM_ASIC -gt 1) ]]; then
+    intf="docker0"
+else
+    intf="lo"
+fi
+
+udp_server_ip=$(ip -o -4 addr list $intf | awk '{print $4}' | cut -d/ -f1)
+sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog.conf.j2 -a "{\"udp_server_ip\": \"$udp_server_ip\"}"  >/etc/rsyslog.conf
+
 systemctl restart rsyslog

--- a/files/image_config/rsyslog/rsyslog-container.conf.j2
+++ b/files/image_config/rsyslog/rsyslog-container.conf.j2
@@ -1,7 +1,3 @@
-###############################################################################
-# Managed by Ansible
-# file: ansible/roles/acs/templates/rsyslog.conf.j2
-###############################################################################
 #
 #  /etc/rsyslog.conf    Configuration file for rsyslog.
 #
@@ -14,13 +10,19 @@
 #################
 
 $ModLoad imuxsock # provides support for local system logging
-$ModLoad imklog   # provides kernel logging support
+
+#
+# Set a rate limit on messages from the container
+#
+$SystemLogRateLimitInterval 300
+$SystemLogRateLimitBurst 20000
+
+#$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability
 
 # provides UDP syslog reception
-$ModLoad imudp
-$UDPServerAddress {{udp_server_ip}}  #bind to localhost before udp server run
-$UDPServerRun 514
+#$ModLoad imudp
+#$UDPServerRun 514
 
 # provides TCP syslog reception
 #$ModLoad imtcp
@@ -30,6 +32,11 @@ $UDPServerRun 514
 ###########################
 #### GLOBAL DIRECTIVES ####
 ###########################
+
+# Set remote syslog server
+template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% {{container_name}}#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
+*.* action(type="omfwd" target="{{target_ip}}" port="514" protocol="udp" Template="ForwardFormatInContainer")
+
 #
 # Use traditional timestamp format.
 # To enable high precision timestamps, comment out the following line.
@@ -37,13 +44,8 @@ $UDPServerRun 514
 #$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
 # Define a custom template
-$template SONiCFileFormat,"%timegenerated%.%timegenerated:::date-subseconds% %HOSTNAME% %syslogseverity-text:::uppercase% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+$template SONiCFileFormat,"%TIMESTAMP%.%timestamp:::date-subseconds% %HOSTNAME% %syslogseverity-text:::uppercase% {{container_name}}#%syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
 $ActionFileDefaultTemplate SONiCFileFormat
-
-#Set remote syslog server
-{% for server in SYSLOG_SERVER %}
-*.* @[{{ server }}]:514;SONiCFileFormat
-{% endfor %}
 
 #
 # Set the default permissions for all log files.


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Add changes for syslog support for containers running in namespaces on multi NPU platforms.
On Multi NPU platforms

- Rsyslog  service is only running on the host. There is no rsyslog service running in each namespace.
- On multi NPU platforms the rsyslog service on the host will be listening on the docker0 ip address instead of loopback address.  
- The rsyslog.conf on the containers is modified to have omfwd target ip to be docker0 ipaddress instead of loopback ip

No change done for single ASIC platforms

**- How I did it**
- Add new j2 file for the generating the rsyslog.conf inside the containers
- Generate the rsyslog.conf and copy to the containers in the preStartAction function.
- Update the rsyslog-config.sh script to update the rsyslog.conf on the host to listen to docker0 ip address in multi NPU platforms.


**- How to verify it**
Verify the syslogs are generated properly
Sample logs:
```
admin@sonic:~$ sudo grep -i orchagent /var/log/syslog.1
Jun  9 16:18:21.902661 sonic INFO swss4[612] 2020-06-09 16:18:21,902 INFO spawned: 'orchagent' with pid 42#015
Jun  9 16:18:22.142771 sonic INFO swss0[612] 2020-06-09 16:18:22,142 INFO spawned: 'orchagent' with pid 42#015
Jun  9 16:18:22.200722 sonic INFO swss1[612] 2020-06-09 16:18:22,200 INFO spawned: 'orchagent' with pid 36#015
Jun  9 16:18:22.234121 sonic INFO swss5[612] 2020-06-09 16:18:22,233 INFO spawned: 'orchagent' with pid 38#015
Jun  9 16:18:22.612859 sonic INFO swss3[612] 2020-06-09 16:18:22,611 INFO spawned: 'orchagent' with pid 36#015
Jun  9 16:18:22.802017 sonic INFO swss2[612] 2020-06-09 16:18:22,801 INFO spawned: 'orchagent' with pid 37#015
Jun  9 16:18:22.915873 sonic INFO swss4[612] 2020-06-09 16:18:22,911 INFO success: orchagent entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)#015
Jun  9 16:18:23.146156 sonic INFO swss0[612] 2020-06-09 16:18:23,145 INFO success: orchagent entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)#015
Jun  9 16:18:23.211117 sonic INFO swss1[612] 2020-06-09 16:18:23,207 INFO success: orchagent entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)#015
Jun  9 16:18:23.240845 sonic INFO swss5[612] 2020-06-09 16:18:23,236 INFO success: orchagent entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)#015
Jun  9 16:18:23.615436 sonic INFO swss3[612] 2020-06-09 16:18:23,615 INFO success: orchagent entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)#015
Jun  9 16:18:23.808437 sonic INFO swss2[612] 2020-06-09 16:18:23,806 INFO success: orchagent entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)#015
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
