### PR TITLE
[bcm SAI] upgrade Broadcom SAI to version 3.5.3.5-1

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.5.3.4-1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm_3.5.3.4-1_amd64.deb?sv=2015-04-05&sr=b&sig=YWM5jgpf8xVjNyQBo9Kx5CxOTKnnQGumjSiogn6ZY48%3D&se=2033-10-11T20%3A51%3A04Z&sp=r"
+BRCM_SAI = libsaibcm_3.5.3.5-1_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm_3.5.3.5-1_amd64.deb?sv=2015-04-05&sr=b&sig=eZe9zHqIQPE9iC9qqfKo1mtEUN8t21Knk3rTJiBCBNk%3D&se=2034-02-16T17%3A02%3A25Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.5.3.4-1_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.5.3.5-1_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm-dev_3.5.3.4-1_amd64.deb?sv=2015-04-05&sr=b&sig=EmoKe1tSTA2k39xI5kgM6FZMnLETgl75%2B0F9e8XH9N4%3D&se=2033-10-11T20%3A50%3A43Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm-dev_3.5.3.5-1_amd64.deb?sv=2015-04-05&sr=b&sig=uGQ9jcEbi7oyowp7YkCkBjFmR0pYuYeeAdPcWa8Z7zo%3D&se=2034-02-16T17%3A02%3A03Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
Upgrade Broadcom SAI for 201811 branch:

- Broadcom SAI 3.5 GA code drop on 20200608.

Changes:
- CS9533198
- CS10283709
- CS00009716645
- CS00010389861
- CS00010406122
- CS00010503275
- Addressed a few memory leak issues.
- Addressed an array memory allocation issue.
- Addressed assert during SER handling.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

