### PR TITLE
[ntp] disable ntp long jump

### DIFF
--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -26,12 +26,7 @@ function modify_ntp_default
 sonic-cfggen -d -t /usr/share/sonic/templates/ntp.conf.j2 >/etc/ntp.conf
 
 get_database_reboot_type
-if [[ x"${reboot_type}" == x"cold" ]]; then
-    echo "Enabling NTP long jump for reboot type ${reboot_type} ..."
-    modify_ntp_default "s/NTPD_OPTS='-x'/NTPD_OPTS='-g'/"
-else
-    echo "Disabling NTP long jump for reboot type ${reboot_type} ..."
-    modify_ntp_default "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"
-fi
+echo "Disabling NTP long jump for reboot type ${reboot_type} ..."
+modify_ntp_default "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"
 
 systemctl restart ntp


### PR DESCRIPTION
**- Why I did it**

Found another syncd timing issue related to clock going backwards.
To be safe disable the ntp long jump.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

