### PR TITLE
[sonic-mgmt] upgrade paramiko to version 2.7.1

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -51,7 +51,7 @@ RUN pip install ipaddr \
                 pysnmp==4.2.5 \
                 jinja2==2.7.2 \
                 cffi==1.10.0 \
-                paramiko==2.1.2 \
+                paramiko==2.7.1 \
                 passlib \
                 ipython==5.4.1 \
                 virtualenv \


### PR DESCRIPTION
**- Why I did it**

spytest requires higher paramiko version. Fix it to 2.7.1.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Built a sonic management docker and run spytest and some ansible tests.