### PR TITLE
[ansible] upgrade ansible to 2.8.12

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -127,7 +127,7 @@ RUN dpkg -i \
 debs/{{ deb }}{{' '}}
 {%- endfor %}
 
-RUN pip install ansible==2.8.7
+RUN pip install ansible==2.8.12
 
 RUN pip install pysubnettree
 


### PR DESCRIPTION
**- Why I did it**
Upgrade ansbile to 2.8.12 to pick up security patches and bug fixes.

**- How to verify it**
Built a sonic-mgmt docker and ran some ansible tests.