### PR TITLE
[sonic_daemon_base] Add REDIS_TIMEOUT_MSECS back which is removed by mistake

### DIFF
--- a/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
+++ b/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
@@ -13,6 +13,7 @@ except ImportError, e:
 #
 # Constants ====================================================================
 #
+REDIS_TIMEOUT_MSECS = 0
 
 # Platform root directory inside docker
 PLATFORM_ROOT_DOCKER = '/usr/share/sonic/platform'


### PR DESCRIPTION
* Add REDIS_TIMEOUT_MSECS back which is removed by mistake


Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com