### PR TITLE
[build] Enable telemetry service by default

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -18,9 +18,9 @@
         }
     },
     "FEATURE": {
-{%- for feature in ["sflow", "telemetry"] %}
+{%- for feature, status in [("sflow", "disabled"), ("telemetry", "enabled")] %}
         "{{feature}}": {
-            "status": "disabled"
+            "status": "{{status}}"
         }{% if not loop.last %},{% endif -%}
 {% endfor %}
     },


### PR DESCRIPTION
**- Why I did it**
To ensure telemetry service is enabled by default after installing a fresh SONiC image

**- How I did it**
Set telemetry feature status to "enabled" when generating init_cfg.json file