### PR TITLE
[accton/as5835-54x] Fix sfp related function like tx_disable

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_util.py
@@ -213,6 +213,10 @@ sfp_map =  [42,43,44,45,46,47,48,49,50,51,
 
 qsfp_start = 48
 
+#For sideband signals of SFP/QSFP modules.
+cpld_of_module = {'3-0061': list(range(0,38)),
+                  '3-0062': list(range(38,54)) }
+
 mknod =[                 
 'echo pca9548 0x77 > /sys/bus/i2c/devices/i2c-1/new_device',
 'echo pca9548 0x70 > /sys/bus/i2c/devices/i2c-2/new_device' ,
@@ -427,10 +431,12 @@ def devices_info():
                         ALL_DEVICE[key][node].append(path) 
                 elif  'sfp' == key:
                     for k in range(0,DEVICE_NO[key]):
-                        node = key+str(k+1)
-                        path = i2c_prefix+ str(sfp_map[k])+ buses[i]+"/"+ nodes[j]                
-                        my_log(node+": "+ path)
-                        ALL_DEVICE[key][node].append(path)                                        
+                        for lk in cpld_of_module:
+                            if k in cpld_of_module[lk]:
+                                node = key+str(k+1)
+                                path = i2c_prefix + lk + "/"+ nodes[j] + str(k+1)
+                                my_log(node+": "+ path)
+                                ALL_DEVICE[key][node].append(path)
                 else:
                     node = key+str(i+1)
                     path = i2c_prefix+ buses[i]+"/"+ nodes[j]                


### PR DESCRIPTION
* Fixing incorrect sfp path inside the accton_as5835_54x_util.py

Signed-off-by: kuanyu_chen <kuanyu_chen@edge-core.com>

**- Why I did it**

The tx_disable function isn't work for the accton_ax5835-54x device.

**- How I did it**

Fix the incorrect path of the sfp node path inside the util file.

**- How to verify it**

Test with
"sudo accton_as5835_54x_util.py show"
"sudo accton_as5835_54x_util.py set sfp"

There should see correct value for module_present and module_tx_disable. And should able to set it.

**- Description for the changelog**

Fix sfp function of the accton_as5835_54x_util.py.
