### PR TITLE
Add redistribution connected for ipv6 also for Frontend ASICs

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -63,7 +63,10 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
 !
 {% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' %}
-  redistribute connected route-map HIDE_INTERNAL
+  address-family ipv4
+    redistribute connected route-map HIDE_INTERNAL
+  address-family ipv6
+    redistribute connected route-map HIDE_INTERNAL
 {% endif %}
 !
 {% if constants.bgp.maximum_paths.enabled is defined and constants.bgp.maximum_paths.enabled %}

--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -65,8 +65,10 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' %}
   address-family ipv4
     redistribute connected route-map HIDE_INTERNAL
+  exit-address-family
   address-family ipv6
     redistribute connected route-map HIDE_INTERNAL
+  exit-address-family
 {% endif %}
 !
 {% if constants.bgp.maximum_paths.enabled is defined and constants.bgp.maximum_paths.enabled %}


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
On  Frontend asics the ipv6 redistribute connected routes configuration is missing for ipv6
**- How I did it**
Add the redistribute connected routes config in the template
**- How to verify it**
Check the configuration is generated.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
