### PR TITLE
Changes to make default route programming correct in multi-npu platforms

### DIFF
--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -10,7 +10,7 @@ CONFIG_TYPE=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["docker_routing_co
 if [[ ! -z "$NAMESPACE_ID" ]]; then
    # FRR is not running in host namespace so we need to delete
    # default gw kernel route added by docker network via eth0 and add it back 
-   # with higer administrative distance so that default route learn
+   # with higher administrative distance so that default route learnt
    # by FRR becomes best route if/when available
    GATEWAY_IP=$(ip route show 0.0.0.0/0 dev eth0 | awk '{print $3}')
    ip route del 0.0.0.0/0 dev eth0
@@ -19,7 +19,7 @@ if [[ ! -z "$NAMESPACE_ID" ]]; then
    # Upon learning about a route that is not originated by FRR we read the metric value as a uint32_t. 
    # The top byte of the value is interpreted as the Administrative Distance and 
    # the low three bytes are read in as the metric.
-   # so here we are programming administrative distace of 210 (210 << 24) > 200 (for routes learn via IBGP)
+   # so here we are programming administrative distance of 210 (210 << 24) > 200 (for routes learnt via IBGP)
    ip route add 0.0.0.0/0 via $GATEWAY_IP dev eth0 metric 3523215360 
 fi
 

--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -9,18 +9,25 @@ CONFIG_TYPE=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["docker_routing_co
 
 if [[ ! -z "$NAMESPACE_ID" ]]; then
    # FRR is not running in host namespace so we need to delete
-   # default gw kernel route added by docker network via eth0 and add it back 
+   # default gw kernel route added by docker network via eth0 and add it back
    # with higher administrative distance so that default route learnt
    # by FRR becomes best route if/when available
    GATEWAY_IP=$(ip route show 0.0.0.0/0 dev eth0 | awk '{print $3}')
-   ip route del 0.0.0.0/0 dev eth0
-   # Ref: http://docs.frrouting.org/en/latest/zebra.html#zebra-vrf
-   # Zebra does treat Kernel routes as special case for the purposes of Admin Distance. \
-   # Upon learning about a route that is not originated by FRR we read the metric value as a uint32_t. 
-   # The top byte of the value is interpreted as the Administrative Distance and 
-   # the low three bytes are read in as the metric.
-   # so here we are programming administrative distance of 210 (210 << 24) > 200 (for routes learnt via IBGP)
-   ip route add 0.0.0.0/0 via $GATEWAY_IP dev eth0 metric 3523215360 
+   #Check if docker default route is there
+   if [[ ! -z "$GATEWAY_IP" ]]; then
+      ip route del 0.0.0.0/0 dev eth0
+      #Make sure route is deleted
+      CHECK_GATEWAY_IP=$(ip route show 0.0.0.0/0 dev eth0 | awk '{print $3}')
+      if [[ -z "$CHECK_GATEWAY_IP" ]]; then
+         # Ref: http://docs.frrouting.org/en/latest/zebra.html#zebra-vrf
+         # Zebra does treat Kernel routes as special case for the purposes of Admin Distance. \
+         # Upon learning about a route that is not originated by FRR we read the metric value as a uint32_t.
+         # The top byte of the value is interpreted as the Administrative Distance and
+         # the low three bytes are read in as the metric.
+         # so here we are programming administrative distance of 210 (210 << 24) > 200 (for routes learnt via IBGP)
+         ip route add 0.0.0.0/0 via $GATEWAY_IP dev eth0 metric 3523215360
+      fi
+   fi
 fi
 
 if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "separated" ]; then

--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -6,6 +6,23 @@ mkdir -p /etc/supervisor/conf.d
 sonic-cfggen -d -t /usr/share/sonic/templates/supervisord/supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
 
 CONFIG_TYPE=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["docker_routing_config_mode"]'`
+
+if [[ ! -z "$NAMESPACE_ID" ]]; then
+   # FRR is not running in host namespace so we need to delete
+   # default gw kernel route added by docker network via eth0 and add it back 
+   # with higer administrative distance so that default route learn
+   # by FRR becomes best route if/when available
+   GATEWAY_IP=$(ip route show 0.0.0.0/0 dev eth0 | awk '{print $3}')
+   ip route del 0.0.0.0/0 dev eth0
+   # Ref: http://docs.frrouting.org/en/latest/zebra.html#zebra-vrf
+   # Zebra does treat Kernel routes as special case for the purposes of Admin Distance. \
+   # Upon learning about a route that is not originated by FRR we read the metric value as a uint32_t. 
+   # The top byte of the value is interpreted as the Administrative Distance and 
+   # the low three bytes are read in as the metric.
+   # so here we are programming administrative distace of 210 (210 << 24) > 200 (for routes learn via IBGP)
+   ip route add 0.0.0.0/0 via $GATEWAY_IP dev eth0 metric 3523215360 
+fi
+
 if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "separated" ]; then
     sonic-cfggen -d -t /usr/share/sonic/templates/bgpd/bgpd.conf.j2 -y /etc/sonic/constants.yml > /etc/frr/bgpd.conf
     sonic-cfggen -d -t /usr/share/sonic/templates/zebra/zebra.conf.j2 > /etc/frr/zebra.conf

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -295,11 +295,9 @@ start() {
         --tmpfs /tmp \
 {%- endif %}
         --tmpfs /var/tmp \
-{%- if docker_container_name == "database" %}
         --env "NAMESPACE_ID"="$DEV" \
         --env "NAMESPACE_PREFIX"="$NAMESPACE_PREFIX" \
         --env "NAMESPACE_COUNT"=$NUM_ASIC \
-{%- endif %}
         --name={{docker_container_name}}$DEV {{docker_image_name}}:latest || {
             echo "Failed to docker run" >&1
             exit 4


### PR DESCRIPTION
**- Why I did it**
Changes to make default route programming correct in multi-npu platforms  where frr is not running in host namespace. 
Change is to set correct administrative distance of default route created by docker container so
that default route learn from FRR has higher priority and classify as best route.

Also made NAMESPACE* environment variable available for all dockers
so that it can be used when needed.

**- How I did it**
Delete and add back default route added by docker network with correct metrics/administrative distance. 

**- How to verify it**

*Before Change*

- vtysh:

```
show ip route 0.0.0.0/0
Routing entry for 0.0.0.0/0
  Known via "kernel", distance 0, metric 0, best
  Last update 00:00:45 ago
  * 240.127.1.1, via eth0

Routing entry for 0.0.0.0/0
  Known via "bgp", distance 200, metric 0
  Last update 06:38:11 ago
    10.1.0.8, via PortChannel4005
    10.1.0.10, via PortChannel4006
```

- Kernel:

```
ip route show 0.0.0.0/0
default via 240.127.1.1 dev eth0
```

*After Change*

- vtysh:

```
show ip route 0.0.0.0/0
Routing entry for 0.0.0.0/0
  Known via "kernel", distance 210, metric 0
  Last update 00:35:10 ago
    240.127.1.1, via eth0

Routing entry for 0.0.0.0/0
  Known via "bgp", distance 200, metric 0, best
  Last update 06:35:45 ago
  * 10.1.0.8, via PortChannel4005
  * 10.1.0.10, via PortChannel4006
```
- Kernel:
```
ip route show 0.0.0.0/0
default proto 186 src 8.0.0.2 metric 20
        nexthop via 10.1.0.8  dev PortChannel4005 weight 1
        nexthop via 10.1.0.10  dev PortChannel4006 weight 1
default via 240.127.1.1 dev eth0 metric 3523215360
```