### PR TITLE
Support for connecting to DB in namespace via TCP port in multi-asic platform.

### DIFF
--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -1,7 +1,7 @@
 {
     "INSTANCES": {
         "redis":{
-            "hostname" : "127.0.0.1",
+            "hostname" : "{{HOST_IP}}",
             "port" : 6379,
             "unix_socket_path" : "/var/run/redis{{NAMESPACE_ID}}/redis.sock",
             "persistence_for_warm_boot" : "yes"

--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+# For linux host namespace, in both single and multi ASIC platform use the loopback interface
+# For other namespaces, use eth0 interface which is connected to the docker0 bridge in the host.
+if [[ $NAMESPACE_ID == "" ]]
+then
+    INTFC=lo
+else
+    INTFC=eth0
+    LOOPBACK_IP=127.0.0.1
+fi
+local_ip=$(ip -4 -o addr show $INTFC | awk '{print $4}' | cut -d'/' -f1)
+export HOST_IP=$local_ip
+
 REDIS_DIR=/var/run/redis$NAMESPACE_ID
 mkdir -p $REDIS_DIR/sonic-db
 
@@ -22,6 +34,9 @@ then
 fi
 
 # generate all redis server supervisord configuration file
-sonic-cfggen -j /var/run/redis/sonic-db/database_config.json -t /usr/share/sonic/templates/supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
+# Pass the Loopback IP explicitly in case of namespaces other than the linux host namespace.
+# This is needed as there are applications who hardcoded host=loopback IP in Connector classes.
+# Redis server will then bind on multiple IP addresses viz <loopback ip> , <eth0 ip>
+sonic-cfggen -j /var/run/redis/sonic-db/database_config.json -a "{\"LOOPBACK_IP\":\"$LOOPBACK_IP\"}" -t /usr/share/sonic/templates/supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
 
 exec /usr/bin/supervisord

--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -17,17 +17,13 @@ then
     host_ip=127.0.0.1
 fi
 
-# Export the host_ip as environment variable used in database_config.json.j2 to derive the hostname
-# as defined "hostname" : "{{HOST_IP}}"
-export HOST_IP=$host_ip
-
 REDIS_DIR=/var/run/redis$NAMESPACE_ID
 mkdir -p $REDIS_DIR/sonic-db
 
 if [ -f /etc/sonic/database_config$NAMESPACE_ID.json ]; then
     cp /etc/sonic/database_config$NAMESPACE_ID.json $REDIS_DIR/sonic-db/database_config.json
 else
-    j2 /usr/share/sonic/templates/database_config.json.j2 > $REDIS_DIR/sonic-db/database_config.json
+    HOST_IP=$host_ip j2 /usr/share/sonic/templates/database_config.json.j2 > $REDIS_DIR/sonic-db/database_config.json
 fi
 
 mkdir -p /etc/supervisor/conf.d/

--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -9,7 +9,13 @@ else
     INTFC=eth0
     LOOPBACK_IP=127.0.0.1
 fi
-local_ip=$(ip -4 -o addr show $INTFC | awk '{print $4}' | cut -d'/' -f1)
+local_ip=$(ip -4 -o addr show $INTFC | awk '{print $4}' | cut -d'/' -f1 | head -1)
+
+# if the ip address was not retrieved correctly, put the loopbackIP as the default.
+if [[ $local_ip == "" ]]
+then
+    local_ip=127.0.0.1
+fi
 export HOST_IP=$local_ip
 
 REDIS_DIR=/var/run/redis$NAMESPACE_ID

--- a/dockers/docker-database/supervisord.conf.j2
+++ b/dockers/docker-database/supervisord.conf.j2
@@ -20,7 +20,7 @@ stderr_logfile=syslog
 {% if INSTANCES %}
 {%     for redis_inst, redis_items in INSTANCES.iteritems() %}
 [program: {{ redis_inst }}]
-command=/bin/bash -c "{ [[ -s /var/lib/{{ redis_inst }}/dump.rdb ]] || rm -f /var/lib/{{ redis_inst }}/dump.rdb; } && mkdir -p /var/lib/{{ redis_inst }} && exec /usr/bin/redis-server /etc/redis/redis.conf --port {{ redis_items['port'] }} --unixsocket {{ redis_items['unix_socket_path'] }} --pidfile /var/run/redis/{{ redis_inst }}.pid --dir /var/lib/{{ redis_inst }}"
+command=/bin/bash -c "{ [[ -s /var/lib/{{ redis_inst }}/dump.rdb ]] || rm -f /var/lib/{{ redis_inst }}/dump.rdb; } && mkdir -p /var/lib/{{ redis_inst }} && exec /usr/bin/redis-server /etc/redis/redis.conf --bind {{ LOOPBACK_IP }} {{ redis_items['hostname'] }} --port {{ redis_items['port'] }} --unixsocket {{ redis_items['unix_socket_path'] }} --pidfile /var/run/redis/{{ redis_inst }}.pid --dir /var/lib/{{ redis_inst }}"
 priority=2
 autostart=true
 autorestart=false

--- a/dockers/docker-database/supervisord.conf.j2
+++ b/dockers/docker-database/supervisord.conf.j2
@@ -20,6 +20,11 @@ stderr_logfile=syslog
 {% if INSTANCES %}
 {%     for redis_inst, redis_items in INSTANCES.iteritems() %}
 [program: {{ redis_inst }}]
+{%- if redis_items['hostname'] != '127.0.0.1'-%}
+{%- set LOOPBACK_IP = '127.0.0.1'-%}
+{%- else -%}
+{%- set LOOPBACK_IP = '' -%}
+{%- endif -%}
 command=/bin/bash -c "{ [[ -s /var/lib/{{ redis_inst }}/dump.rdb ]] || rm -f /var/lib/{{ redis_inst }}/dump.rdb; } && mkdir -p /var/lib/{{ redis_inst }} && exec /usr/bin/redis-server /etc/redis/redis.conf --bind {{ LOOPBACK_IP }} {{ redis_items['hostname'] }} --port {{ redis_items['port'] }} --unixsocket {{ redis_items['unix_socket_path'] }} --pidfile /var/run/redis/{{ redis_inst }}.pid --dir /var/lib/{{ redis_inst }}"
 priority=2
 autostart=true

--- a/dockers/docker-database/supervisord.conf.j2
+++ b/dockers/docker-database/supervisord.conf.j2
@@ -20,8 +20,8 @@ stderr_logfile=syslog
 {% if INSTANCES %}
 {%     for redis_inst, redis_items in INSTANCES.iteritems() %}
 [program: {{ redis_inst }}]
-{%- if redis_items['hostname'] != '127.0.0.1'-%}
-{%- set LOOPBACK_IP = '127.0.0.1'-%}
+{% if redis_items['hostname'] != '127.0.0.1' %}
+{%- set LOOPBACK_IP = '127.0.0.1' -%}
 {%- else -%}
 {%- set LOOPBACK_IP = '' -%}
 {%- endif -%}


### PR DESCRIPTION
**- Why I did it**

Currently in multi-asic platform support exists only for using UNIX socket to connect to DB in different namespaces.  There are permission restrictions with the redis unix socket file because of which applications needs to either be running as root user or need to specify sudo to be able to use it.

Certain applications like "show commands" are currently being called without sudo and hence cannot use the redis unix socket to connect to DB in other namespaces. Hence introducing this option to connect using TCP port.
**Note - redis unix socket is still the preferred way due to better performance !!**

 **- How I did it**
Updated the database_config.json.j2 to use HOST_IP which is derived from either loopback interface in case of linux host, or eth0 interface ( which is connected to docker bridge network ) in the other namespaces. 
In the namespaces the redis server is started on multiple IP address (loop back IP and eth0 IP ) with the "bind' option. We have to use the loopback IP as there are multiple applications using host=127.0.0.1 as hardcoding in the connector class object.

**- How to verify it**
Verified with the show/config commands.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
