### PR TITLE
Fix bug: check port alias even when port_config_file parameter is not provided

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -966,10 +966,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None):
 
     for port_name, port in ports.items():
         # get port alias from port_config.ini
-        if port_config_file:
-            alias = port.get('alias')
-        else:
-            alias = port_name
+        alias = port.get('alias', port_name)
         # generate default 100G FEC
         # Note: FECDisabled only be effective on 100G port right now
         if port.get('speed') == '100000' and linkmetas.get(alias, {}).get('FECDisabled', '').lower() != 'true':


### PR DESCRIPTION
The parse_xml will accept a parameter port_config_file which includes port_name <-> alias mapping. However if this parameter is not provided, it will search the file in a candidate list and find the mapping. So don't depend on the parameter to when checking alias.