### PR TITLE
Add a port index mapper service for sFlow

### DIFF
--- a/dockers/docker-sflow/Dockerfile.j2
+++ b/dockers/docker-sflow/Dockerfile.j2
@@ -12,6 +12,9 @@ RUN apt-get update      && \
             dmidecode      \
             libmnl0=1.0.4-2
 
+RUN pip install \
+        pyroute2==0.5.3
+
 {% if docker_sflow_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("debs/", docker_sflow_debs.split(' '), "/debs/") }}
@@ -30,5 +33,6 @@ RUN sed -ri '/^DAEMON_ARGS=""/c DAEMON_ARGS="-c /var/log/hsflowd.crash"' /etc/in
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
+COPY ["port_index_mapper.py", "/usr/bin"]
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-sflow/port_index_mapper.py
+++ b/dockers/docker-sflow/port_index_mapper.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+
+""" port_index_mapper
+    A mapper service that watches for NetLink NEWLINK and DELLINKs
+    to construct a PORT_INDEX_TABLE in state DB which includes the
+    interface name, the interface index and the ifindex.
+
+    Note : Currently supports only interfaces supported by port_util.
+"""
+
+import os
+import sys
+import syslog
+import signal
+import traceback
+from pyroute2 import IPDB
+from swsssdk import SonicV2Connector, port_util
+
+RTM_NEWLINK = 16
+RTM_DELLINK = 17
+
+PORT_INDEX_TABLE_NAME = 'PORT_INDEX_TABLE'
+SYSLOG_IDENTIFIER = 'port_index_mapper'
+
+ipdb = None
+state_db = None
+
+def interface_callback(ipdb, nlmsg, action):
+    global state_db
+
+    try:
+        msgtype = nlmsg['header']['type']
+        if (msgtype != RTM_NEWLINK and msgtype != RTM_DELLINK):
+            return
+
+        # filter out unwanted messages
+        change = nlmsg['change']
+        if (change != 0xFFFFFFFF):
+            return
+    
+        attrs = nlmsg['attrs']
+        for list in attrs:
+            if list[0] == 'IFLA_IFNAME':
+                ifname = list[1]
+                break
+            else:
+                return
+    
+        # Extract the port index from the interface name
+        index = port_util.get_index_from_str(ifname)
+        if index is None:
+            return
+    
+        _hash = '{}|{}'.format(PORT_INDEX_TABLE_NAME, ifname)
+    
+        if msgtype == RTM_NEWLINK:
+            state_db.set(state_db.STATE_DB, _hash, 'index', str(index))
+            state_db.set(state_db.STATE_DB, _hash, 'ifindex', nlmsg['index'])
+        elif msgtype == RTM_DELLINK:
+            state_db.delete(state_db.STATE_DB, _hash)
+
+    except Exception, e:
+        t = sys.exc_info()[2]
+        traceback.print_tb(t)
+        syslog.syslog(syslog.LOG_CRIT, "%s" % str(e))
+        os.kill(os.getpid(), signal.SIGTERM)
+
+def main():
+    global state_db, ipdb
+    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db.connect(state_db.STATE_DB, False)
+
+    ipdb = IPDB()
+
+    # Initialize the table at startup.
+    ifnames = ipdb.by_name.keys()
+    for ifname in ifnames:
+        index = port_util.get_index_from_str(ifname)
+        if index is None:
+            continue
+        ifindex = ipdb.interfaces[ifname]['index']
+        _hash = '{}|{}'.format(PORT_INDEX_TABLE_NAME, ifname)
+        state_db.set(state_db.STATE_DB, _hash, 'index', str(index))
+        state_db.set(state_db.STATE_DB, _hash, 'ifindex', str(ifindex))
+
+    ipdb.register_callback(interface_callback)
+
+    signal.pause()
+
+def signal_handler(signum, frame):
+    syslog.syslog(syslog.LOG_NOTICE, "got signal %d" % signum)
+    sys.exit(0)
+
+if __name__ == '__main__':
+    rc = 0
+    try:
+        syslog.openlog(SYSLOG_IDENTIFIER)
+        signal.signal(signal.SIGTERM, signal_handler)
+        signal.signal(signal.SIGINT, signal_handler)
+        main()
+    except Exception, e:
+        t = sys.exc_info()[2]
+        traceback.print_tb(t)
+        syslog.syslog(syslog.LOG_CRIT, "%s" % str(e))
+        rc = -1
+    finally:
+        if ipdb is not None:
+            ipdb.release()
+        else:
+            syslog.syslog(syslog.LOG_ERR, "ipdb undefined in signal_handler")
+
+        syslog.closelog()
+        sys.exit(rc)
+

--- a/dockers/docker-sflow/supervisord.conf
+++ b/dockers/docker-sflow/supervisord.conf
@@ -35,3 +35,13 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
+
+[program:port_index_mapper]
+command=/usr/bin/port_index_mapper.py
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=rsyslogd:running


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

sFlow generates both counter samples and flow samples. While the counter samples contain the ifName, the flow samples have only the interface index - and the index is the Linux ifindex (and not the SONiC port index (as is typically seen in the PORT_TABLE). Any external application (sflow collector  / end user) then has to map the index to port index (that's obtained from IF-MIB, say) which is not intuitive. 

The SAI driver generates the samples using the Linux indexing scheme. While it is possible to address the issue from SAI driver/SDK perspective, we believe providing a mapping service and letting applications handle the mapping may be a more flexible alternative (which could benefit other applications in future).

**- How I did it**

Introduce a port_index_mapper script in sflow docker which will:
1. Use IPDB to construct the initial PORT_INDEX_TABLE table in the STATE DB.
2. Register a callback that will watch for RTM_NEWLINK/RTM_DELLINK and update the table accordingly.

Note that this currently supports only interfaces supported by port_util.

**- How to verify it**

1. Checked that the PORT_INDEX_TABLE gets populated by the script at startup (redis-cli -n 6 keys "PORT_INDEX_TABLE*")
2. Used scripts to add/remove port channels to verify changes to the table entries.

Verify that the index/ifindex mapping matches that of "ip link show".

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add a port index mapper service for sFlow

**- A picture of a cute animal (not mandatory but encouraged)**
