### PR TITLE
[fast-reboot] Back up FDB/ARP/Default routes

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -8,19 +8,19 @@ function fast_reboot {
       if [[ -f /fdb.json ]];
       then
         swssconfig /fdb.json
-        mv /fdb.json /fdb.json.1
+        mv -f /fdb.json /fdb.json.1
       fi
 
       if [[ -f /arp.json ]];
       then
         swssconfig /arp.json
-        mv /arp.json /arp.json.1
+        mv -f /arp.json /arp.json.1
       fi
 
       if [[ -f /default_routes.json ]];
       then
         swssconfig /default_routes.json
-        mv /default_routes.json /default_routes.json.1
+        mv -f /default_routes.json /default_routes.json.1
       fi
 
       ;;

--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -8,19 +8,19 @@ function fast_reboot {
       if [[ -f /fdb.json ]];
       then
         swssconfig /fdb.json
-        rm -f /fdb.json
+        mv /fdb.json /fdb.json.1
       fi
 
       if [[ -f /arp.json ]];
       then
         swssconfig /arp.json
-        rm -f /arp.json
+        mv /arp.json /arp.json.1
       fi
 
       if [[ -f /default_routes.json ]];
       then
         swssconfig /default_routes.json
-        rm -f /default_routes.json
+        mv /default_routes.json /default_routes.json.1
       fi
 
       ;;


### PR DESCRIPTION
FDB/ARP/Default routes files are deleted after swssconfig. This
make debugging/validation of device conversion hard. This PR
save those files in order to facilitate device conversion.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
In order to make verification of device conversion easier.

**- How I did it**
Code change

**- How to verify it**
Verified with debug build that has this change
```
admin@str-s6000-acs-14:~$ sudo find / -name arp.json*
/host/image-taahme_backup-file-during-fast-reboot.0-dirty-20200618.235059/docker/overlay2/522da426044901997983d9c88f77fa14f123f48e2038af11f13bd357123c8c77/diff/arp.json.1
/usr/lib/python2.7/dist-packages/sonic-utilities-tests/filter_fdb_input/arp.json
/var/lib/docker/overlay2/522da426044901997983d9c88f77fa14f123f48e2038af11f13bd357123c8c77/diff/arp.json.1
/var/lib/docker/overlay2/522da426044901997983d9c88f77fa14f123f48e2038af11f13bd357123c8c77/merged/arp.json.1
admin@str-s6000-acs-14:~$ sudo find / -name default_routes.json*
/host/image-taahme_backup-file-during-fast-reboot.0-dirty-20200618.235059/docker/overlay2/522da426044901997983d9c88f77fa14f123f48e2038af11f13bd357123c8c77/diff/default_routes.json.1
/var/lib/docker/overlay2/522da426044901997983d9c88f77fa14f123f48e2038af11f13bd357123c8c77/diff/default_routes.json.1
/var/lib/docker/overlay2/522da426044901997983d9c88f77fa14f123f48e2038af11f13bd357123c8c77/merged/default_routes.json.1
admin@str-s6000-acs-14:~$ sudo find / -name fdb.json*
/host/image-taahme_backup-file-during-fast-reboot.0-dirty-20200618.235059/docker/overlay2/522da426044901997983d9c88f77fa14f123f48e2038af11f13bd357123c8c77/diff/fdb.json.1
/usr/lib/python2.7/dist-packages/sonic-utilities-tests/filter_fdb_input/fdb.json
/var/lib/docker/overlay2/522da426044901997983d9c88f77fa14f123f48e2038af11f13bd357123c8c77/diff/fdb.json.1
/var/lib/docker/overlay2/522da426044901997983d9c88f77fa14f123f48e2038af11f13bd357123c8c77/merged/fdb.json.1
```

**- Description for the changelog**
