### PR TITLE
[caclmgrd] Don't limit iptables connection tracking to TCP

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -258,9 +258,9 @@ class ControlPlaneAclManager(object):
         iptables_cmds.append("ip6tables -A INPUT -s ::1 -i lo -j ACCEPT")
 
         # Add iptables/ip6tables commands to allow all incoming packets from established
-        # TCP sessions or new TCP sessions which are related to established TCP sessions
-        iptables_cmds.append("iptables -A INPUT -p tcp -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
-        iptables_cmds.append("ip6tables -A INPUT -p tcp -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
+        # connections or new connections which are related to established connections
+        iptables_cmds.append("iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
+        iptables_cmds.append("ip6tables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
 
         # Add iptables/ip6tables commands to allow bidirectional ICMPv4 ping and traceroute
         # TODO: Support processing ICMPv4 service ACL rules, and remove this blanket acceptance


### PR DESCRIPTION
- Don't limit iptables connection tracking to TCP protocol; allow connection tracking for all protocols. This allows services like NTP, which is UDP-based, to receive replies from an NTP server even if the port is blocked, as long as it is in reply to a request sent from the device itself.