### PR TITLE
REST server cert configurations (fixes #4291)

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/rest-server.sh
+++ b/dockers/docker-sonic-mgmt-framework/rest-server.sh
@@ -2,23 +2,23 @@
 
 # Startup script for SONiC Management REST Server
 
-SERVER_PORT=
-LOG_LEVEL=
-CLIENT_AUTH=
-SERVER_CRT=
-SERVER_KEY=
-CA_CERT=
-
 # Read basic server settings from REST_SERVER|default entry
 HAS_REST_CONFIG=$(sonic-cfggen -d -v "1 if REST_SERVER and REST_SERVER['default']")
 if [ "$HAS_REST_CONFIG" == "1" ]; then
     SERVER_PORT=$(sonic-cfggen -d -v "REST_SERVER['default']['port']")
     CLIENT_AUTH=$(sonic-cfggen -d -v "REST_SERVER['default']['client_auth']")
     LOG_LEVEL=$(sonic-cfggen -d -v "REST_SERVER['default']['log_level']")
+
+    SERVER_CRT=$(sonic-cfggen -d -v "REST_SERVER['default']['server_crt']")
+    SERVER_KEY=$(sonic-cfggen -d -v "REST_SERVER['default']['server_key']")
+    CA_CRT=$(sonic-cfggen -d -v "REST_SERVER['default']['ca_crt']")
+fi
+
+if [[ -z $SERVER_CRT ]] && [[ -z $SERVER_KEY ]] && [[ -z $CA_CRT ]]; then
+    HAS_X509_CONFIG=$(sonic-cfggen -d -v "1 if DEVICE_METADATA and DEVICE_METADATA['x509']")
 fi
 
 # Read certificate file paths from DEVICE_METADATA|x509 entry.
-HAS_X509_CONFIG=$(sonic-cfggen -d -v "1 if DEVICE_METADATA and DEVICE_METADATA['x509']")
 if [ "$HAS_X509_CONFIG" == "1" ]; then
     SERVER_CRT=$(sonic-cfggen -d -v "DEVICE_METADATA['x509']['server_crt']")
     SERVER_KEY=$(sonic-cfggen -d -v "DEVICE_METADATA['x509']['server_key']")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Mgmt-framework REST and telemetry servers were using `DEVICE_METADATA|x509` table for
server certificate configurations. This table has been deprecated now and telemetry service has already moved its certificate configurations to `TELEMETRY` table. Doing the same for REST service too.
Discussed in bug #4291 

**- How I did it**
Enhanced REST server startup script to read server certificate file path configurations from the existing `REST_SERVER` table. Three more attributes - server_crt, server_key and ca_crt are introduced as described in https://github.com/Azure/SONiC/pull/550.

For backard compatibility, certificate configurations are read from old `DEVICE_METADATA|x509` table if they (server_crt, server_key and ca_crt) are not present in `REST_SERVER` table.

**- How to verify it**
Verified mgmt-framework service startup with following configurations:
1) Mgmt-framework startup without cert configs
2) Mgmt-framework startup with cert configs in REST_SERVER table
3) Mgmt-framework startup with cert configs in x509 table
4) Mgmt-framework startup with cert configs in both REST_SERVER and x509 table. Service should use the configs from REST_SERVER

**- Description for the changelog**
Load certificate configurations for mgmt-framework service from REST_SERVER table.
