### PR TITLE
[build] [201911] Increase size of dockerfs ramdisk to accommodate more containers 

### DIFF
--- a/onie-image.conf
+++ b/onie-image.conf
@@ -25,7 +25,7 @@ FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 DOCKERFS_DIR=docker
 
 ## docker ramfs disk space
-DOCKER_RAMFS_SIZE=900M
+DOCKER_RAMFS_SIZE=1300M
 
 ## Output file name for onie installer
 OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin


### PR DESCRIPTION
Images built from 201911 branch and installed on devices where we mount /var/lib/docker in RAM (because the HDD is small) were failing as there was not enough  space to untar docker.tar.gz . This is due to the increase in total number of containers in the image.

As of today, /var/lib/docker contains 1.1 GB of data. Therefore, this PR increases the size of the ramdisk to 1.3 GB to accommodate all the containers as of now and any new container going forward. 
Example output below from an Arista-7050-QX32 SKU:

admin@str-a7050-acs-2:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
.....
tmpfs           1.3G  1.1G  221M  84% /var/lib/docker
.....
Verified all docker running fine and interfaces/bgp are up.