### PR TITLE
Update .gitignore for platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,16 @@ src/**/debian/stamp-autotools-files
 
 # .o files
 src/**/*.o
+
+# platform
+platform/**/*.egg-info
+platform/**/*-none-any.whl
+platform/**/.pybuild
+platform/**/debian/*
+platform/**/build
+platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/ipmihelper.py
+platform/broadcom/sonic-platform-modules-dell/s6100/modules/dell_ich.c
+platform/broadcom/sonic-platform-modules-dell/s6100/modules/dell_s6100_lpc.c
+platform/broadcom/sonic-platform-modules-dell/z9100/modules/dell_ich.c
+platform/broadcom/sonic-platform-modules-dell/z9100/modules/dell_mailbox.c
+platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/ipmihelper.py


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Update .gitignore to skip all the generated files by different platforms on broadcom asics. It would be nice to update it to other platforms.

**- How I did it**
Updated .gitignore

**- How to verify it**
$ make all
$ git status

Before the output was:
```
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)

	modified:   src/redis-dump-load (untracked content)
	modified:   src/sonic-linux-kernel (untracked content)
	modified:   src/sonic-mgmt-framework (untracked content)
	modified:   src/sonic-sairedis (untracked content)
	modified:   src/sonic-swss (untracked content)
	modified:   src/sonic-swss-common (untracked content)

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	platform/broadcom/sonic-platform-modules-accton/as4630_54pe.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as5712_54x.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as5812_54t.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as5812_54x.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as5835_54t.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as5835_54x.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as6712_32x.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as7312_54x.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as7312_54xs.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as7315_27xb.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as7326_56x.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as7712_32x.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as7716_32x.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as7716_32xb.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as7726_32x.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as7816_64x.egg-info/
	platform/broadcom/sonic-platform-modules-accton/as9716_32d.egg-info/
	platform/broadcom/sonic-platform-modules-accton/build/
	platform/broadcom/sonic-platform-modules-accton/debian/.debhelper/
	platform/broadcom/sonic-platform-modules-accton/debian/files
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as4630-54pe/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5712-54x/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5812-54t/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5812-54x/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54t/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54x/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as6712-32x/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7312-54x/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7312-54xs/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7315-27xb/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7712-32x/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7716-32x/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7716-32xb/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7726-32x/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7816-64x/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as9716-32d/
	platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-minipack/
	platform/broadcom/sonic-platform-modules-alphanetworks/build/
	platform/broadcom/sonic-platform-modules-alphanetworks/debian/.debhelper/
	platform/broadcom/sonic-platform-modules-alphanetworks/debian/files
	platform/broadcom/sonic-platform-modules-alphanetworks/debian/sonic-platform-alphanetworks-snh60a0-320fv2/
	platform/broadcom/sonic-platform-modules-alphanetworks/debian/sonic-platform-alphanetworks-snh60b0-640f/
	platform/broadcom/sonic-platform-modules-alphanetworks/snh60a0_320fv2.egg-info/
	platform/broadcom/sonic-platform-modules-alphanetworks/snh60b0_640f.egg-info/
	platform/broadcom/sonic-platform-modules-brcm-xlr-gts/.pybuild/
	platform/broadcom/sonic-platform-modules-brcm-xlr-gts/debian/.debhelper/
	platform/broadcom/sonic-platform-modules-brcm-xlr-gts/debian/files
	platform/broadcom/sonic-platform-modules-brcm-xlr-gts/debian/sonic-platform-brcm-xlr-gts.debhelper.log
	platform/broadcom/sonic-platform-modules-brcm-xlr-gts/debian/sonic-platform-brcm-xlr-gts.postinst.debhelper
	platform/broadcom/sonic-platform-modules-brcm-xlr-gts/debian/sonic-platform-brcm-xlr-gts.postrm.debhelper
	platform/broadcom/sonic-platform-modules-brcm-xlr-gts/debian/sonic-platform-brcm-xlr-gts.prerm.debhelper
	platform/broadcom/sonic-platform-modules-brcm-xlr-gts/debian/sonic-platform-brcm-xlr-gts.substvars
	platform/broadcom/sonic-platform-modules-brcm-xlr-gts/debian/sonic-platform-brcm-xlr-gts/
	platform/broadcom/sonic-platform-modules-cel/debian/.debhelper/
	platform/broadcom/sonic-platform-modules-cel/debian/files
	platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010/
	platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton/
	platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-seastone2/
	platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-silverstone/
	platform/broadcom/sonic-platform-modules-cel/dx010/build/
	platform/broadcom/sonic-platform-modules-cel/dx010/modules/sonic_platform-1.0-py2-none-any.whl
	platform/broadcom/sonic-platform-modules-cel/dx010/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-cel/haliburton/build/
	platform/broadcom/sonic-platform-modules-cel/haliburton/modules/sonic_platform-1.0-py2-none-any.whl
	platform/broadcom/sonic-platform-modules-cel/haliburton/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-cel/silverstone/build/
	platform/broadcom/sonic-platform-modules-cel/silverstone/modules/sonic_platform-1.0-py2-none-any.whl
	platform/broadcom/sonic-platform-modules-cel/silverstone/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-dell/debian/.debhelper/
	platform/broadcom/sonic-platform-modules-dell/debian/files
	platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s5232f/
	platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s5248f/
	platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6000/
	platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100/
	platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9100/
	platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9264f/
	platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f/
	platform/broadcom/sonic-platform-modules-dell/s5232f/build/
	platform/broadcom/sonic-platform-modules-dell/s5232f/modules/sonic_platform-1.0-py2-none-any.whl
	platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/ipmihelper.py
	platform/broadcom/sonic-platform-modules-dell/s6000/build/
	platform/broadcom/sonic-platform-modules-dell/s6000/modules/sonic_platform-1.0-py2-none-any.whl
	platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-dell/s6100/build/
	platform/broadcom/sonic-platform-modules-dell/s6100/modules/dell_ich.c
	platform/broadcom/sonic-platform-modules-dell/s6100/modules/dell_s6100_lpc.c
	platform/broadcom/sonic-platform-modules-dell/s6100/modules/sonic_platform-1.0-py2-none-any.whl
	platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-dell/z9100/build/
	platform/broadcom/sonic-platform-modules-dell/z9100/modules/dell_ich.c
	platform/broadcom/sonic-platform-modules-dell/z9100/modules/dell_mailbox.c
	platform/broadcom/sonic-platform-modules-dell/z9100/modules/sonic_platform-1.0-py2-none-any.whl
	platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-dell/z9264f/build/
	platform/broadcom/sonic-platform-modules-dell/z9264f/modules/sonic_platform-1.0-py2-none-any.whl
	platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/ipmihelper.py
	platform/broadcom/sonic-platform-modules-delta/debian/.debhelper/
	platform/broadcom/sonic-platform-modules-delta/debian/files
	platform/broadcom/sonic-platform-modules-delta/debian/platform-modules-ag5648/
	platform/broadcom/sonic-platform-modules-delta/debian/platform-modules-ag9032v1/
	platform/broadcom/sonic-platform-modules-delta/debian/platform-modules-ag9032v2a/
	platform/broadcom/sonic-platform-modules-delta/debian/platform-modules-ag9064/
	platform/broadcom/sonic-platform-modules-delta/debian/platform-modules-agc032/
	platform/broadcom/sonic-platform-modules-delta/debian/platform-modules-et-6248brb/
	platform/broadcom/sonic-platform-modules-ingrasys/debian/.debhelper/
	platform/broadcom/sonic-platform-modules-ingrasys/debian/files
	platform/broadcom/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s8810-32q/
	platform/broadcom/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s8900-54xc/
	platform/broadcom/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s8900-64xc/
	platform/broadcom/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9100/
	platform/broadcom/sonic-platform-modules-ingrasys/debian/sonic-platform-ingrasys-s9200-64x/
	platform/broadcom/sonic-platform-modules-inventec/d6356/build/
	platform/broadcom/sonic-platform-modules-inventec/d6356/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-inventec/d6356/utils/sonic_platform-1.0-py2-none-any.whl
	platform/broadcom/sonic-platform-modules-inventec/d7054q28b/build/
	platform/broadcom/sonic-platform-modules-inventec/d7054q28b/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-inventec/d7054q28b/utils/sonic_platform-1.0-py2-none-any.whl
	platform/broadcom/sonic-platform-modules-inventec/debian/.debhelper/
	platform/broadcom/sonic-platform-modules-inventec/debian/files
	platform/broadcom/sonic-platform-modules-inventec/debian/platform-modules-d6254qs/
	platform/broadcom/sonic-platform-modules-inventec/debian/platform-modules-d6356/
	platform/broadcom/sonic-platform-modules-inventec/debian/platform-modules-d6556/
	platform/broadcom/sonic-platform-modules-inventec/debian/platform-modules-d7032q28b/
	platform/broadcom/sonic-platform-modules-inventec/debian/platform-modules-d7054q28b/
	platform/broadcom/sonic-platform-modules-inventec/debian/platform-modules-d7264q28b/
	platform/broadcom/sonic-platform-modules-juniper/build/
	platform/broadcom/sonic-platform-modules-juniper/debian/.debhelper/
	platform/broadcom/sonic-platform-modules-juniper/debian/files
	platform/broadcom/sonic-platform-modules-juniper/debian/sonic-platform-juniper-qfx5200/
	platform/broadcom/sonic-platform-modules-juniper/debian/sonic-platform-juniper-qfx5210/
	platform/broadcom/sonic-platform-modules-juniper/sonic_platform.egg-info/
	platform/broadcom/sonic-platform-modules-quanta/build/
	platform/broadcom/sonic-platform-modules-quanta/debian/.debhelper/
	platform/broadcom/sonic-platform-modules-quanta/debian/files
	platform/broadcom/sonic-platform-modules-quanta/debian/sonic-platform-quanta-ix1b-32x/
	platform/broadcom/sonic-platform-modules-quanta/debian/sonic-platform-quanta-ix7-32x/
	platform/broadcom/sonic-platform-modules-quanta/debian/sonic-platform-quanta-ix8-56x/
	platform/broadcom/sonic-platform-modules-quanta/debian/sonic-platform-quanta-ix8c-56x/
	platform/broadcom/sonic-platform-modules-quanta/debian/sonic-platform-quanta-ix9-32x/
	platform/broadcom/sonic-platform-modules-quanta/ix1b_32x.egg-info/
	platform/broadcom/sonic-platform-modules-quanta/ix7_32x.egg-info/
	platform/broadcom/sonic-platform-modules-quanta/ix8_56x.egg-info/
	platform/broadcom/sonic-platform-modules-quanta/ix8c_56x.egg-info/
	platform/broadcom/sonic-platform-modules-quanta/ix9_32x.egg-info/

no changes added to commit (use "git add" and/or "git commit -a")
```

After output is
```
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)

	modified:   .gitignore
	modified:   src/redis-dump-load (untracked content)
	modified:   src/sonic-linux-kernel (untracked content)
	modified:   src/sonic-mgmt-framework (untracked content)
	modified:   src/sonic-sairedis (untracked content)
	modified:   src/sonic-swss (untracked content)
	modified:   src/sonic-swss-common (untracked content)

no changes added to commit (use "git add" and/or "git commit -a")
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
