### PR TITLE
kubeadm package apt-get install has unmet dependency error on other packages

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -222,6 +222,14 @@ then
     ## Check out the sources list update matches current Debian version
     sudo cp files/image_config/kubernetes/kubernetes.list $FILESYSTEM_ROOT/etc/apt/sources.list.d/
     sudo LANG=C chroot $FILESYSTEM_ROOT apt-get update
+    if [[ $KUBERNETES_VERSION == 1.18.0 ]]; then 
+        # kubeadm 1.18.0 package auto install has some dependency error so install
+        # those package explicitly.
+        sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install kubernetes-cni=0.7.5-00
+        sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install kubelet=1.18.3-00
+        sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install kubectl=1.18.3-00
+    fi
+    # else kubeadm package auto install kubelet & kubectl
     sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install kubeadm=${KUBERNETES_VERSION}-00
     # kubeadm package auto install kubelet & kubectl
 else


### PR DESCRIPTION
**- Why I did it**
kubeadm package apt-get install has unmet dependency error on other packages making build failure.

Error Logs:
========
Reading package lists...
+ sudo LANG=C chroot ./fsroot apt-get -y install kubeadm=1.18.0-00
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 kubeadm : Depends: kubernetes-cni (>= 0.7.5)
E: Unable to correct problems, you have held broken packages.
+ sudo umount ./fsroot/proc


**- How I did it**
Installing packages that have unmet dependency install them explicitly.
**- How to verify it**
Verify build is fine after change.
