### PR TITLE
NOS to SONiC migration fixes

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -82,10 +82,6 @@ update_mgmt_interface_macaddr() {
 
     log_migration "eth0 mac in EEPROM after update:"
     ethtool -e eth0 offset $ethtool_offset length 6 >> /host/migration/migration.log
-
-    # Update the 70-persistent-net.rules with the new mac for eth0
-    log_migration "/etc/udev/rules.d/70-persistent-net.rules : replacing $old_mac with $new_mac for eth0"
-    sed -i "/eth0/ s/ATTR{address}==\"$old_mac\"/ATTR{address}==\"$new_mac\"/g" /etc/udev/rules.d/70-persistent-net.rules
 }
 
 firsttime_exit() {

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -109,7 +109,10 @@ mount --bind ${rootmnt}/host/$image_dir/boot ${rootmnt}/boot
 ## Mount loop device or tmpfs for /var/log
 onie_platform=""
 aboot_platform=""
-. ${rootmnt}/host/machine.conf
+if [ -f ${rootmnt}/host/machine.conf ]; then
+  . ${rootmnt}/host/machine.conf
+fi
+
 if [ X"$aboot_platform" = X"x86_64-arista_7050_qx32"  ] ||
    [ X"$aboot_platform" = X"x86_64-arista_7050_qx32s" ] ||
    [ X"$aboot_platform" = X"x86_64-arista_7060_cx32s" ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
While migrating to SONiC 20181130, identified a couple of issues:
1. union-mount needs /host/machine.conf parameters for vendor specific checks : however, in case of migration, the /host/machine.conf is extracted from ONIE only in https://github.com/Azure/sonic-buildimage/blob/master/files/image_config/platform/rc.local#L127. 
2. Since grub.cfg is updated to have net.ifnames=0 biosdevname=0, 70-persistent-net.rules changes are no longer required.

**- How I did it**
1. Check for /host/machine.conf in union-mount.
2. Remove 70-persistent-net.rules changes in rc.local

**- How to verify it**

Perform a migration to SONiC and check the errors no longer exist.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
NOS to SONiC migration fixes
**- A picture of a cute animal (not mandatory but encouraged)**
