### PR TITLE
[build] No longer install Python 'click-default-group' package

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -171,8 +171,6 @@ sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/python-click*_all.deb || \
 # Install python pexpect used by sonic-utilities consutil
 # using pip install instead to get a more recent version than is available through debian
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install pexpect
-# Install python click-default-group by sonic-utilities
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install click-default-group==1.2
 
 # Install tabulate >= 0.8.1 via pip in order to support multi-line row output for sonic-utilities
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install tabulate==0.8.2

--- a/platform/p4/docker-sonic-p4/Dockerfile.j2
+++ b/platform/p4/docker-sonic-p4/Dockerfile.j2
@@ -39,7 +39,6 @@ RUN apt-get install -y net-tools \
                        iproute \
                        libpython2.7 \
                        grub2-common \
-                       python-click-default-group \
                        python-click \
                        python-natsort \
                        python-tabulate \

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -32,7 +32,6 @@ RUN apt-get install -y net-tools \
                        libc-ares2 \
                        iproute \
                        grub2-common \
-                       python-click-default-group \
                        python-click \
                        python-natsort \
                        python-tabulate \

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -351,7 +351,7 @@ RUN pip install j2cli==0.3.10
 # Remove python-click 6.6
 RUN apt-get purge -y python-click
 # For sonic utilities testing
-RUN pip install click-default-group click natsort tabulate netifaces==0.10.7 fastentrypoints
+RUN pip install click natsort tabulate netifaces==0.10.7 fastentrypoints
 
 # For sonic snmpagent mock testing
 RUN pip3 install mockredispy==2.9.3

--- a/sonic-slave-jessie/Dockerfile.j2
+++ b/sonic-slave-jessie/Dockerfile.j2
@@ -311,7 +311,7 @@ RUN pip install --force-reinstall --upgrade "jinja2>=2.10"
 RUN pip install j2cli==0.3.10
 
 # For sonic utilities testing
-RUN pip install click-default-group click natsort tabulate netifaces==0.10.7 fastentrypoints
+RUN pip install click natsort tabulate netifaces==0.10.7 fastentrypoints
 
 # For supervisor build
 RUN pip install meld3 mock

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -350,7 +350,7 @@ RUN pip install j2cli==0.3.10
 # Remove python-click 6.6
 RUN apt-get purge -y python-click
 # For sonic utilities testing
-RUN pip install click-default-group click natsort tabulate netifaces==0.10.7 fastentrypoints
+RUN pip install click natsort tabulate netifaces==0.10.7 fastentrypoints
 
 # For sonic snmpagent mock testing
 RUN pip3 install mockredispy==2.9.3


### PR DESCRIPTION
All dependencies upon the Python 'click-default-group' package have been removed from sonic-utilities as of https://github.com/Azure/sonic-utilities/pull/903. The submodule was updated to inclue this patch as of https://github.com/Azure/sonic-buildimage/pull/4601, therefore we no longer need to install this package in the SONiC image.