### PR TITLE
[BFN] Disabled thermalctld for Barefoot platforms

### DIFF
--- a/device/barefoot/x86_64-accton_as9516bf_32d-r0/pmon_daemon_control.json
+++ b/device/barefoot/x86_64-accton_as9516bf_32d-r0/pmon_daemon_control.json
@@ -1,6 +1,8 @@
 {
+    "skip_thermalctld": true,
+    "skip_fancontrol": true,
     "skip_ledd": true,
     "skip_xcvrd": false,
     "skip_psud": false,
-    "skip_syseepromd": false 
+    "skip_syseepromd": false
 }

--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/pmon_daemon_control.json
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/pmon_daemon_control.json
@@ -1,4 +1,5 @@
 {
+    "skip_thermalctld": true,
     "skip_fancontrol": true,
     "skip_ledd": true,
     "skip_xcvrd": false,

--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/pmon_daemon_control.json
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/pmon_daemon_control.json
@@ -1,4 +1,5 @@
 {
+    "skip_thermalctld": true,
     "skip_fancontrol": true,
     "skip_ledd": true,
     "skip_xcvrd": false,


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <akokhan@barefootnetworks.com>

**- Why I did it**
To avoid logs flooding
```
sonic INFO pmon#thermalctld: Starting up...
sonic INFO pmon#supervisord: thermalctld Traceback (most recent call last):
sonic INFO pmon#supervisord: thermalctld   File "/usr/bin/thermalctld", line 590, in <module>
sonic INFO pmon#supervisord: thermalctld     main()
sonic INFO pmon#supervisord: thermalctld   File "/usr/bin/thermalctld", line 586, in main
sonic INFO pmon#supervisord: thermalctld     thermal_control.run()
sonic INFO pmon#supervisord: thermalctld   File "/usr/bin/thermalctld", line 547, in run
sonic INFO pmon#supervisord: thermalctld     import sonic_platform.platform
sonic INFO pmon#supervisord: thermalctld ImportError: No module named sonic_platform.platform
```
**- How I did it**
Added skip_thermalctld

**- How to verify it**


