### PR TITLE
Loopback Interface changes for multi ASIC devices

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -8,21 +8,13 @@
 ! TSA configuration
 !
 ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/32
-{% if multi_npu()  == true %}
-  ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/32
-{% endif %}
 !
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
 ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | replace('/128', '/64') | ip_network }}/64
 {% endif %}
-{% if multi_npu() == true %}
-{% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") != 'None' %}
-  ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | replace('/128', '/64') | ip_network }}/64
-{% endif %}
-{% endif %}
 !
 !
-{% if multi_npu() == true %}
+{% if multi_npu() %}
 route-map HIDE_INTERNAL permit 10
   set community local-AS
 !
@@ -45,7 +37,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
 !
 {# set router-id #}
-{% if multi_npu()  == true %}
+{% if multi_npu() %}
   bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}
 {% else %}
   bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}
@@ -53,7 +45,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
 {# advertise loopback #}
   network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/32
-{% if multi_npu() == true  %}
+{% if multi_npu()  %}
   network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/32 route-map HIDE_INTERNAL
 {% endif %}
 !
@@ -62,7 +54,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64
   exit-address-family
 {% endif %}
-{% if multi_npu() == true %}
+{% if multi_npu() %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") != 'None' %}
   address-family ipv6
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/64 route-map HIDE_INTERNAL

--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -14,7 +14,7 @@ ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTE
 {% endif %}
 !
 !
-{% if multi_npu() %}
+{% if multi_asic() %}
 route-map HIDE_INTERNAL permit 10
   set community local-AS
 !
@@ -37,7 +37,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
 !
 {# set router-id #}
-{% if multi_npu() %}
+{% if multi_asic() %}
   bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}
 {% else %}
   bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}
@@ -45,7 +45,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
 {# advertise loopback #}
   network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/32
-{% if multi_npu()  %}
+{% if multi_asic()  %}
   network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/32 route-map HIDE_INTERNAL
 {% endif %}
 !
@@ -54,7 +54,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64
   exit-address-family
 {% endif %}
-{% if multi_npu() %}
+{% if multi_asic() %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") != 'None' %}
   address-family ipv6
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/64 route-map HIDE_INTERNAL

--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -9,15 +9,15 @@
 !
 ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/32
 {% if multi_npu()  == true %}
-  ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback1") | ip }}/32
+  ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/32
 {% endif %}
 !
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
 ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | replace('/128', '/64') | ip_network }}/64
 {% endif %}
 {% if multi_npu() == true %}
-{% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback1") != 'None' %}
-  ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback1") | replace('/128', '/64') | ip_network }}/64
+{% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") != 'None' %}
+  ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | replace('/128', '/64') | ip_network }}/64
 {% endif %}
 {% endif %}
 !
@@ -46,7 +46,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
 {# set router-id #}
 {% if multi_npu()  == true %}
-  bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback1") | ip }}
+  bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}
 {% else %}
   bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}
 {% endif %}
@@ -54,7 +54,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {# advertise loopback #}
   network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/32
 {% if multi_npu() == true  %}
-  network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback1") | ip }}/32 route-map HIDE_INTERNAL
+  network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/32 route-map HIDE_INTERNAL
 {% endif %}
 !
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
@@ -63,9 +63,9 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   exit-address-family
 {% endif %}
 {% if multi_npu() == true %}
-{% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback1") != 'None' %}
+{% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") != 'None' %}
   address-family ipv6
-    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback1") | ip }}/64 route-map HIDE_INTERNAL
+    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/64 route-map HIDE_INTERNAL
   exit-address-family
 {% endif %}
 {% endif %}

--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -8,13 +8,21 @@
 ! TSA configuration
 !
 ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/32
+{% if multi_npu()  == true %}
+  ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback1") | ip }}/32
+{% endif %}
 !
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
 ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | replace('/128', '/64') | ip_network }}/64
 {% endif %}
+{% if multi_npu() == true %}
+{% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback1") != 'None' %}
+  ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback1") | replace('/128', '/64') | ip_network }}/64
+{% endif %}
+{% endif %}
 !
 !
-{% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' %}
+{% if multi_npu() == true %}
 route-map HIDE_INTERNAL permit 10
   set community local-AS
 !
@@ -37,15 +45,29 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
 !
 {# set router-id #}
+{% if multi_npu()  == true %}
+  bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback1") | ip }}
+{% else %}
   bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}
+{% endif %}
 !
 {# advertise loopback #}
   network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/32
+{% if multi_npu() == true  %}
+  network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback1") | ip }}/32 route-map HIDE_INTERNAL
+{% endif %}
 !
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
   address-family ipv6
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64
   exit-address-family
+{% endif %}
+{% if multi_npu() == true %}
+{% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback1") != 'None' %}
+  address-family ipv6
+    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback1") | ip }}/64 route-map HIDE_INTERNAL
+  exit-address-family
+{% endif %}
 {% endif %}
 {% endblock bgp_init %}
 !

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -251,6 +251,15 @@ def parse_asic_png(png, asic_name, hostname):
                 devices[name] = device_data
     return (neighbors, devices, port_speeds)
 
+def parse_loopback_intf(child):
+    lointfs = child.find(str(QName(ns, "LoopbackIPInterfaces")))
+    lo_intfs = {}
+    for lointf in lointfs.findall(str(QName(ns1, "LoopbackIPInterface"))):
+        intfname = lointf.find(str(QName(ns, "AttachTo"))).text
+        ipprefix = lointf.find(str(QName(ns1, "PrefixStr"))).text
+        lo_intfs[(intfname, ipprefix)] = {}
+    return lo_intfs
+
 def parse_dpg(dpg, hname):
     aclintfs = None
     mgmtintfs = None
@@ -269,7 +278,6 @@ def parse_dpg(dpg, hname):
         """
         if mgmtintfs is None and child.find(str(QName(ns, "ManagementIPInterfaces"))) is not None:
             mgmtintfs = child.find(str(QName(ns, "ManagementIPInterfaces")))
-        
         hostname = child.find(str(QName(ns, "Hostname")))
         if hostname.text.lower() != hname.lower():
             continue
@@ -290,12 +298,7 @@ def parse_dpg(dpg, hname):
             ipprefix = ipintf.find(str(QName(ns, "Prefix"))).text
             intfs[(intfname, ipprefix)] = {}
 
-        lointfs = child.find(str(QName(ns, "LoopbackIPInterfaces")))
-        lo_intfs = {}
-        for lointf in lointfs.findall(str(QName(ns1, "LoopbackIPInterface"))):
-            intfname = lointf.find(str(QName(ns, "AttachTo"))).text
-            ipprefix = lointf.find(str(QName(ns1, "PrefixStr"))).text
-            lo_intfs[(intfname, ipprefix)] = {}
+        lo_intfs =  parse_loopback_intf(child)
 
         mvrfConfigs = child.find(str(QName(ns, "MgmtVrfConfigs")))
         mvrf = {}
@@ -445,6 +448,13 @@ def parse_dpg(dpg, hname):
         return intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, pcs, pc_members, acls, vni
     return None, None, None, None, None, None, None, None, None, None
 
+def parse_host_loopback(dpg, hname):
+    for child in dpg:
+        hostname = child.find(str(QName(ns, "Hostname")))
+        if hostname.text.lower() != hname.lower():
+            continue
+        lo_intfs = parse_loopback_intf(child)
+        return lo_intfs
 
 def parse_cpg(cpg, hname):
     bgp_sessions = {}
@@ -818,6 +828,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None):
     cloudtype = None
     hostname = None
     linkmetas = {}
+    host_lo_intfs = None
 
     # hostname is the asic_name, get the asic_id from the asic_name
     if asic_name is not None:
@@ -859,6 +870,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None):
         else:
             if child.tag == str(QName(ns, "DpgDec")):
                 (intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, pcs, pc_members, acls, vni) = parse_dpg(child, asic_name)
+                host_lo_intfs = parse_host_loopback(child, hostname)
             elif child.tag == str(QName(ns, "CpgDec")):
                 (bgp_sessions, bgp_asn, bgp_peers_with_range, bgp_monitors) = parse_cpg(child, asic_name)
                 enable_internal_bgp_session(bgp_sessions, filename, asic_name)
@@ -922,6 +934,12 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None):
     for lo_intf in lo_intfs:
         results['LOOPBACK_INTERFACE'][lo_intf] = lo_intfs[lo_intf]
         results['LOOPBACK_INTERFACE'][lo_intf[0]] = {}
+
+    if host_lo_intfs is not None:
+        for host_lo_intf in host_lo_intfs:
+            results['LOOPBACK_INTERFACE'][host_lo_intf] = host_lo_intfs[host_lo_intf]
+            results['LOOPBACK_INTERFACE'][host_lo_intf[0]] = {}
+
     results['MGMT_VRF_CONFIG'] = mvrf
 
     phyport_intfs = {}

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -43,6 +43,7 @@ from sonic_device_util import get_machine_info
 from sonic_device_util import get_platform_info
 from sonic_device_util import get_system_mac
 from sonic_device_util import get_npu_id_from_name
+from sonic_device_util import is_multi_npu
 from config_samples import generate_sample_config
 from config_samples import get_available_config
 from swsssdk import SonicV2Connector, ConfigDBConnector, SonicDBConfig 
@@ -325,6 +326,8 @@ def main():
         env.filters['ip_network'] = ip_network
         for attr in ['ip', 'network', 'prefixlen', 'netmask', 'broadcast']:
             env.filters[attr] = partial(prefix_attr, attr)
+        # Pass the is_multi_npu function as global
+        env.globals['multi_npu'] = is_multi_npu
         template = env.get_template(template_file)
         print(template.render(sort_data(data)))
 

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -327,7 +327,7 @@ def main():
         for attr in ['ip', 'network', 'prefixlen', 'netmask', 'broadcast']:
             env.filters[attr] = partial(prefix_attr, attr)
         # Pass the is_multi_npu function as global
-        env.globals['multi_npu'] = is_multi_npu
+        env.globals['multi_asic'] = is_multi_npu
         template = env.get_template(template_file)
         print(template.render(sort_data(data)))
 

--- a/src/sonic-config-engine/sonic_device_util.py
+++ b/src/sonic-config-engine/sonic_device_util.py
@@ -44,12 +44,20 @@ def get_npu_id_from_name(npu_name):
     else:
         return None
 
+def get_asic_conf_file_path(platform):
+    asic_conf_path_candidates = []
+    asic_conf_path_candidates.append(os.path.join('/usr/share/sonic/platform', ASIC_CONF_FILENAME))
+    if platform is not None:
+        asic_conf_path_candidates.append(os.path.join(SONIC_DEVICE_PATH, platform, ASIC_CONF_FILENAME))
+    for asic_conf_file_path in asic_conf_path_candidates:
+        if os.path.isfile(asic_conf_file_path):
+            return asic_conf_file_path
+    return None
+
 def get_num_npus():
     platform = get_platform_info(get_machine_info())
-    if not platform:
-        return 1
-    asic_conf_file_path = os.path.join(SONIC_DEVICE_PATH, platform, ASIC_CONF_FILENAME)
-    if not os.path.isfile(asic_conf_file_path):
+    asic_conf_file_path = get_asic_conf_file_path(platform)
+    if asic_conf_file_path is None:
         return 1
     with open(asic_conf_file_path) as asic_conf_file:
         for line in asic_conf_file:

--- a/src/sonic-config-engine/tests/multi_npu_data/sample-minigraph.xml
+++ b/src/sonic-config-engine/tests/multi_npu_data/sample-minigraph.xml
@@ -387,11 +387,19 @@
         <a:LoopbackIPInterface>
           <ElementType>LoopbackInterface</ElementType>
           <Name>HostIP</Name>
-          <AttachTo>Loopback0</AttachTo>
+          <AttachTo>Loopback1</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
             <b:IPPrefix>8.0.0.0/32</b:IPPrefix>
           </a:Prefix>
           <a:PrefixStr>8.0.0.0/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback1</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FD00:1::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FD00:1::32/128</a:PrefixStr>
         </a:LoopbackIPInterface>
       </LoopbackIPInterfaces>
       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
@@ -457,11 +465,19 @@
         <a:LoopbackIPInterface>
           <ElementType>LoopbackInterface</ElementType>
           <Name>HostIP</Name>
-          <AttachTo>Loopback0</AttachTo>
+          <AttachTo>Loopback1</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
             <b:IPPrefix>8.0.0.1/32</b:IPPrefix>
           </a:Prefix>
           <a:PrefixStr>8.0.0.1/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback1</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FD00:2::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FD00:2::32/128</a:PrefixStr>
         </a:LoopbackIPInterface>
       </LoopbackIPInterfaces>
       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
@@ -526,11 +542,19 @@
         <a:LoopbackIPInterface>
           <ElementType>LoopbackInterface</ElementType>
           <Name>HostIP</Name>
-          <AttachTo>Loopback0</AttachTo>
+          <AttachTo>Loopback1</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
             <b:IPPrefix>8.0.0.4/32</b:IPPrefix>
           </a:Prefix>
           <a:PrefixStr>8.0.0.4/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback1</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FD00:3::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FD00:3::32/128</a:PrefixStr>
         </a:LoopbackIPInterface>
       </LoopbackIPInterfaces>
       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
@@ -580,11 +604,19 @@
         <a:LoopbackIPInterface>
           <ElementType>LoopbackInterface</ElementType>
           <Name>HostIP</Name>
-          <AttachTo>Loopback0</AttachTo>
+          <AttachTo>Loopback1</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
             <b:IPPrefix>8.0.0.5/32</b:IPPrefix>
           </a:Prefix>
           <a:PrefixStr>8.0.0.5/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback1</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FD00:4::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FD00:4::32/128</a:PrefixStr>
         </a:LoopbackIPInterface>
       </LoopbackIPInterfaces>
       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>

--- a/src/sonic-config-engine/tests/multi_npu_data/sample-minigraph.xml
+++ b/src/sonic-config-engine/tests/multi_npu_data/sample-minigraph.xml
@@ -387,7 +387,7 @@
         <a:LoopbackIPInterface>
           <ElementType>LoopbackInterface</ElementType>
           <Name>HostIP</Name>
-          <AttachTo>Loopback1</AttachTo>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
             <b:IPPrefix>8.0.0.0/32</b:IPPrefix>
           </a:Prefix>
@@ -395,7 +395,7 @@
         </a:LoopbackIPInterface>
         <a:LoopbackIPInterface>
           <Name>HostIP1</Name>
-          <AttachTo>Loopback1</AttachTo>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
             <b:IPPrefix>FD00:1::32/128</b:IPPrefix>
           </a:Prefix>
@@ -465,7 +465,7 @@
         <a:LoopbackIPInterface>
           <ElementType>LoopbackInterface</ElementType>
           <Name>HostIP</Name>
-          <AttachTo>Loopback1</AttachTo>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
             <b:IPPrefix>8.0.0.1/32</b:IPPrefix>
           </a:Prefix>
@@ -473,7 +473,7 @@
         </a:LoopbackIPInterface>
         <a:LoopbackIPInterface>
           <Name>HostIP1</Name>
-          <AttachTo>Loopback1</AttachTo>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
             <b:IPPrefix>FD00:2::32/128</b:IPPrefix>
           </a:Prefix>
@@ -542,7 +542,7 @@
         <a:LoopbackIPInterface>
           <ElementType>LoopbackInterface</ElementType>
           <Name>HostIP</Name>
-          <AttachTo>Loopback1</AttachTo>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
             <b:IPPrefix>8.0.0.4/32</b:IPPrefix>
           </a:Prefix>
@@ -550,7 +550,7 @@
         </a:LoopbackIPInterface>
         <a:LoopbackIPInterface>
           <Name>HostIP1</Name>
-          <AttachTo>Loopback1</AttachTo>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
             <b:IPPrefix>FD00:3::32/128</b:IPPrefix>
           </a:Prefix>
@@ -604,7 +604,7 @@
         <a:LoopbackIPInterface>
           <ElementType>LoopbackInterface</ElementType>
           <Name>HostIP</Name>
-          <AttachTo>Loopback1</AttachTo>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.NetMux">
             <b:IPPrefix>8.0.0.5/32</b:IPPrefix>
           </a:Prefix>
@@ -612,7 +612,7 @@
         </a:LoopbackIPInterface>
         <a:LoopbackIPInterface>
           <Name>HostIP1</Name>
-          <AttachTo>Loopback1</AttachTo>
+          <AttachTo>Loopback4096</AttachTo>
           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
             <b:IPPrefix>FD00:4::32/128</b:IPPrefix>
           </a:Prefix>

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -259,18 +259,18 @@ class TestMultiNpuCfgGen(TestCase):
         output = json.loads(self.run_script(argument))
         self.assertDictEqual(output, { \
                              "Loopback0": {},
-                             "Loopback1": {},
+                             "Loopback4096": {},
                              "Loopback0|10.1.0.32/32": {},
                              "Loopback0|FC00:1::32/128": {},
-                             "Loopback1|8.0.0.0/32": {},
-                             "Loopback1|FD00:1::32/128": {}})
+                             "Loopback4096|8.0.0.0/32": {},
+                             "Loopback4096|FD00:1::32/128": {}})
 
         argument = "-m {} -n asic3 --var-json \"LOOPBACK_INTERFACE\"".format(self.sample_graph)
         output = json.loads(self.run_script(argument))
         self.assertDictEqual(output, {\
                                       "Loopback0": {},
-                                      "Loopback1": {},
+                                      "Loopback4096": {},
                                       "Loopback0|10.1.0.32/32": {},
                                       "Loopback0|FC00:1::32/128": {},
-                                      "Loopback1|8.0.0.5/32": {},
-                                      "Loopback1|FD00:4::32/128": {}})
+                                      "Loopback4096|8.0.0.5/32": {},
+                                      "Loopback4096|FD00:4::32/128": {}})

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -245,3 +245,32 @@ class TestMultiNpuCfgGen(TestCase):
         argument = "-m {} -p {} -n asic3 --var-json \"ACL_TABLE\"".format(self.sample_graph, self.port_config[3])
         output = json.loads(self.run_script(argument))
         self.assertDictEqual(output, {})
+
+    def test_loopback_intfs(self):
+        argument = "-m {} --var-json \"LOOPBACK_INTERFACE\"".format(self.sample_graph)
+        output = json.loads(self.run_script(argument))
+        self.assertDictEqual(output, {\
+                "Loopback0": {},
+                "Loopback0|10.1.0.32/32": {},
+                "Loopback0|FC00:1::32/128": {}})
+
+        # The asic configuration should have 2 loopback interfaces
+        argument = "-m {} -n asic0 --var-json \"LOOPBACK_INTERFACE\"".format(self.sample_graph)
+        output = json.loads(self.run_script(argument))
+        self.assertDictEqual(output, { \
+                             "Loopback0": {},
+                             "Loopback1": {},
+                             "Loopback0|10.1.0.32/32": {},
+                             "Loopback0|FC00:1::32/128": {},
+                             "Loopback1|8.0.0.0/32": {},
+                             "Loopback1|FD00:1::32/128": {}})
+
+        argument = "-m {} -n asic3 --var-json \"LOOPBACK_INTERFACE\"".format(self.sample_graph)
+        output = json.loads(self.run_script(argument))
+        self.assertDictEqual(output, {\
+                                      "Loopback0": {},
+                                      "Loopback1": {},
+                                      "Loopback0|10.1.0.32/32": {},
+                                      "Loopback0|FC00:1::32/128": {},
+                                      "Loopback1|8.0.0.5/32": {},
+                                      "Loopback1|FD00:4::32/128": {}})


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
multi ASIC will have 2 Loopback Interfaces
 - Loopback0 has globally unique IP address, which is advertised by the multi ASIC device to its peers. 
   This way all the external devices will see this device as a single device.

 - Loopback4096 is  assigned an IP address which has a scope is within the device. Each ASIC has a different ip address for Loopback4096. This ip address will be used as Router-Id by the bgp instance on multi ASIC devices.

This PR implements this change for multi ASIC devices

**- How I did it**
The following changes are done
  - Update the minigraph parser to update the ASIC configuration with  the host/device Loopback address
 - Update the bgp template to use Loopback1 as router-id and advertise the Loopback4096 address only to internal neighbors if its multi_npu device.
 - Add the route-map HIDE_INTERNAL when advertising the Loopback4096 ip address
 - Update the sonic-cfggen to pass the is_multi_npu function as enviornment global while rendering this templates. 
 - Update the sonic_device_util.py to get_num_npus both on the host and inside the containers. 
 - Added Unit tests for generating Loopback interface configurations for multi ASIC devices

**- How to verify it**

-  Verify if the Loopback interface and bgp configuration are generated properly.
- Verify the internal bgp and external bgp sessions are established.
