### PR TITLE
[201911][Mellanox]converting SKU based utils to Platform based utils 

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -33,15 +33,15 @@ SYSTEM_NOT_READY = 'system_not_ready'
 SYSTEM_READY = 'system_become_ready'
 SYSTEM_FAIL = 'system_fail'
 
-GET_HWSKU_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku"
+GET_PLATFORM_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.platform"
 
 # Ethernet<n> <=> sfp<n+SFP_PORT_NAME_OFFSET>
 SFP_PORT_NAME_OFFSET = 1
 SFP_PORT_NAME_CONVENTION = "sfp{}"
 
-# magic code defnition for port number, qsfp port position of each hwsku
+# magic code defnition for port number, qsfp port position of each Platform
 # port_position_tuple = (PORT_START, QSFP_PORT_START, PORT_END, PORT_IN_BLOCK, EEPROM_OFFSET)
-hwsku_dict = {'ACS-MSN2700': 0, 'Mellanox-SN2700': 0, 'Mellanox-SN2700-D48C8': 0, 'LS-SN2700':0, 'ACS-MSN2740': 0, 'ACS-MSN2100': 1, 'ACS-MSN2410': 2, 'ACS-MSN2010': 3, 'ACS-MSN3700': 0, 'ACS-MSN3700C': 0, 'ACS-MSN3800': 4, 'Mellanox-SN3800-D112C8': 4, 'ACS-MSN4700': 0, 'ACS-MSN3420': 5, 'ACS-MSN4600C': 4}
+platform_dict = {'x86_64-mlnx_msn2700-r0': 0, 'x86_64-mlnx_msn2740-r0': 0, 'x86_64-mlnx_msn2100-r0': 1, 'x86_64-mlnx_msn2410-r0': 2, 'x86_64-mlnx_msn2010-r0': 3, 'x86_64-mlnx_msn3420-r0':5, 'x86_64-mlnx_msn3700-r0': 0, 'x86_64-mlnx_msn3700c-r0': 0, 'x86_64-mlnx_msn3800-r0': 4, 'x86_64-mlnx_msn4600c':4, 'x86_64-mlnx_msn4700-r0': 0}
 port_position_tuple_list = [(0, 0, 31, 32, 1), (0, 0, 15, 16, 1), (0, 48, 55, 56, 1), (0, 18, 21, 22, 1), (0, 0, 63, 64, 1), (0, 48, 59, 60, 1)]
 
 def log_info(msg, also_print_to_console=False):
@@ -86,14 +86,14 @@ class SfpUtil(SfpUtilBase):
         print "dependency on sysfs has been removed"
         raise Exception() 
 
-    def get_port_position_tuple_by_sku_name(self):
-        p = subprocess.Popen(GET_HWSKU_CMD, shell=True, stdout=subprocess.PIPE)
+    def get_port_position_tuple_by_platform_name(self):
+        p = subprocess.Popen(GET_PLATFORM_CMD, shell=True, stdout=subprocess.PIPE)
         out, err = p.communicate()
-        position_tuple = port_position_tuple_list[hwsku_dict[out.rstrip('\n')]]
+        position_tuple = port_position_tuple_list[platform_dict[out.rstrip('\n')]]
         return position_tuple
 
     def __init__(self):
-        port_position_tuple = self.get_port_position_tuple_by_sku_name()
+        port_position_tuple = self.get_port_position_tuple_by_platform_name()
         self.PORT_START = port_position_tuple[0]
         self.QSFP_PORT_START = port_position_tuple[1]
         self.PORT_END = port_position_tuple[2]

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -52,9 +52,9 @@ logger = Logger()
 SYSTEM_STATUS_LED_GREEN_FILE = '/run/hw-management/led/led_status_green'
 LED_ON = '1'
 
-# magic code defnition for port number, qsfp port position of each hwsku
+# magic code defnition for port number, qsfp port position of each Platform
 # port_position_tuple = (PORT_START, QSFP_PORT_START, PORT_END, PORT_IN_BLOCK, EEPROM_OFFSET)
-hwsku_dict_port = {'ACS-MSN2010': 3, 'ACS-MSN2100': 1, 'ACS-MSN2410': 2, 'ACS-MSN2700': 0, 'Mellanox-SN2700': 0, 'Mellanox-SN2700-D48C8': 0, 'LS-SN2700':0, 'ACS-MSN2740': 0, 'ACS-MSN3700': 0, 'ACS-MSN3700C': 0, 'ACS-MSN3800': 4, 'Mellanox-SN3800-D112C8': 4, 'ACS-MSN4700': 0, 'ACS-MSN3420': 5, 'ACS-MSN4600C': 4}
+platform_dict_port = {'x86_64-mlnx_msn2010-r0': 3, 'x86_64-mlnx_msn2100-r0': 1, 'x86_64-mlnx_msn2410-r0': 2, 'x86_64-mlnx_msn2700-r0': 0, 'x86_64-mlnx_lssn2700':0, 'x86_64-mlnx_msn2740-r0': 0, 'x86_64-mlnx_msn3420-r0':5, 'x86_64-mlnx_msn3700-r0': 0, 'x86_64-mlnx_msn3700C-r0': 0, 'x86_64-mlnx_msn3800-r0': 4, 'x86_64-mlnx_msn4600c-r0':4, 'x86_64-mlnx_msn4700-r0': 0}
 port_position_tuple_list = [(0, 0, 31, 32, 1), (0, 0, 15, 16, 1), (0, 48, 55, 56, 1), (0, 18, 21, 22, 1), (0, 0, 63, 64, 1), (0, 48, 59, 60, 1)]
 
 class Chassis(ChassisBase):
@@ -63,7 +63,7 @@ class Chassis(ChassisBase):
     def __init__(self):
         super(Chassis, self).__init__()
 
-        # Initialize SKU name
+        # Initialize SKU name and Platform name
         self.sku_name = self._get_sku_name()
         self.platform_name = self._get_platform_name()
         mi = get_machine_info()
@@ -91,7 +91,7 @@ class Chassis(ChassisBase):
         # Initialize PSU list
         self.psu_module = Psu
         for index in range(MLNX_NUM_PSU):
-            psu = Psu(index, self.sku_name)
+            psu = Psu(index, self.platform_name)
             self._psu_list.append(psu)
 
 
@@ -129,7 +129,7 @@ class Chassis(ChassisBase):
         self.sfp_module = SFP
 
         # Initialize SFP list
-        port_position_tuple = self._get_port_position_tuple_by_sku_name()
+        port_position_tuple = self._get_port_position_tuple_by_platform_name()
         self.PORT_START = port_position_tuple[0]
         self.QSFP_PORT_START = port_position_tuple[1]
         self.PORT_END = port_position_tuple[2]
@@ -148,7 +148,7 @@ class Chassis(ChassisBase):
     def initialize_thermals(self):
         from sonic_platform.thermal import initialize_thermals
         # Initialize thermals
-        initialize_thermals(self.sku_name, self._thermal_list, self._psu_list)
+        initialize_thermals(self.platform_name, self._thermal_list, self._psu_list)
 
 
     def initialize_eeprom(self):
@@ -260,8 +260,8 @@ class Chassis(ChassisBase):
         return out.rstrip('\n')
 
 
-    def _get_port_position_tuple_by_sku_name(self):
-        position_tuple = port_position_tuple_list[hwsku_dict_port[self.sku_name]]
+    def _get_port_position_tuple_by_platform_name(self):
+        position_tuple = port_position_tuple_list[platform_dict_port[self.platform_name]]
         return position_tuple
 
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -28,11 +28,11 @@ PSU_POWER = "power"
 # SKUs with unplugable PSUs:
 # 1. don't have psuX_status and should be treated as always present
 # 2. don't have voltage, current and power values
-hwsku_dict_with_unplugable_psu = ['ACS-MSN2010', 'ACS-MSN2100']
+platform_dict_with_unplugable_psu = ['x86_64-mlnx_msn2010-r0', 'x86_64-mlnx_msn2100-r0']
 
 # in most SKUs the file psuX_curr, psuX_volt and psuX_power contain current, voltage and power data respectively. 
 # but there are exceptions which will be handled by the following dictionary
-hwsku_dict_psu = {'ACS-MSN3700': 1, 'ACS-MSN3700C': 1, 'ACS-MSN3800': 1, 'Mellanox-SN3800-D112C8': 1, 'ACS-MSN4700': 1, 'ACS-MSN3420': 1, 'ACS-MSN4600C': 1}
+platform_dict_psu = {'x86_64-mlnx_msn3420-r0':1, 'x86_64-mlnx_msn3700-r0': 1, 'x86_64-mlnx_msn3700c-r0': 1, 'x86_64-mlnx_msn3800-r0': 1, 'x86_64-mlnx_msn4600c-r0':1, 'x86_64-mlnx_msn4700-r0': 1}
 psu_profile_list = [
     # default filename convention
     {
@@ -40,7 +40,7 @@ psu_profile_list = [
         PSU_VOLTAGE : "power/psu{}_volt",
         PSU_POWER : "power/psu{}_power"
     },
-    # for 3420, 3700, 3700c, 3800, 4700
+    # for 3420, 3700, 3700c, 3800, 4600c, 4700
     {
         PSU_CURRENT : "power/psu{}_curr",
         PSU_VOLTAGE : "power/psu{}_volt_out2",
@@ -50,7 +50,7 @@ psu_profile_list = [
 
 class Psu(PsuBase):
     """Platform-specific Psu class"""
-    def __init__(self, psu_index, sku):
+    def __init__(self, psu_index, platform):
         global psu_list
         PsuBase.__init__(self)
         # PSU is 1-based on Mellanox platform
@@ -62,12 +62,12 @@ class Psu(PsuBase):
         self.psu_oper_status = os.path.join(self.psu_path, psu_oper_status)
         self._name = "PSU{}".format(psu_index + 1)
 
-        if sku in hwsku_dict_psu:
-            filemap = psu_profile_list[hwsku_dict_psu[sku]]
+        if platform in platform_dict_psu:
+            filemap = psu_profile_list[platform_dict_psu[platform]]
         else:
             filemap = psu_profile_list[0]
 
-        if sku in hwsku_dict_with_unplugable_psu:
+        if platform in platform_dict_with_unplugable_psu:
             self.always_presence = True
             self.psu_voltage = None
             self.psu_current = None
@@ -92,7 +92,7 @@ class Psu(PsuBase):
             self.psu_presence = psu_presence
 
         # unplugable PSU has no FAN
-        if sku not in hwsku_dict_with_unplugable_psu:
+        if platform not in platform_dict_with_unplugable_psu:
             fan = Fan(False, psu_index, psu_index, True)
             self._fan_list.append(fan)
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -124,7 +124,7 @@ thermal_api_names = [
     THERMAL_API_GET_HIGH_THRESHOLD
 ]
 
-hwsku_dict_thermal = {'ACS-MSN2700': 0, 'LS-SN2700':0, 'ACS-MSN2740': 3, 'ACS-MSN2100': 1, 'ACS-MSN2410': 2, 'ACS-MSN2010': 4, 'ACS-MSN3700': 5, 'ACS-MSN3700C': 6, 'Mellanox-SN2700': 0, 'Mellanox-SN2700-D48C8': 0, 'ACS-MSN3800': 7, 'Mellanox-SN3800-D112C8': 7, 'ACS-MSN4700': 8, 'ACS-MSN3420': 9, 'ACS-MSN4600C': 9}
+platform_dict_thermal = {'x86_64-mlnx_msn2700-r0': 0, 'x86_64-mlnx_lssn2700-r0':0, 'x86_64-mlnx_msn2740-r0': 3, 'x86_64-mlnx_msn2100-r0': 1, 'x86_64-mlnx_msn2410-r0': 2, 'x86_64-mlnx_msn2010-r0': 4, 'x86_64-mlnx_msn3420-r0':9, 'x86_64-mlnx_msn3700-r0': 5, 'x86_64-mlnx_msn3700c-r0': 6, 'x86_64-mlnx_msn3800-r0': 7, 'x86_64-mlnx_msn4600c-r0':9, 'x86_64-mlnx_msn4700-r0': 8}
 thermal_profile_list = [
     # 2700
     {
@@ -300,9 +300,9 @@ thermal_profile_list = [
 ]
 
 
-def initialize_thermals(sku, thermal_list, psu_list):
+def initialize_thermals(platform, thermal_list, psu_list):
     # create thermal objects for all categories of sensors
-    tp_index = hwsku_dict_thermal[sku]
+    tp_index = platform_dict_thermal[platform]
     thermal_profile = thermal_profile_list[tp_index]
     Thermal.thermal_profile = thermal_profile
     for category in thermal_device_categories_all:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
What I did
I moved all the SKU based variables (dictionaries), functions to Platform based variables and functions in scripts like sfputil.py, chassis.py, psu.py, fan.py and thermal.py

How I did it
I eliminated almost all the references of SKU based dictionaries and functions from these files and instead used Platform based dictionaries and functions.

How to verify it
Used the following commands to verify my changes are working:
sudo sfputil show presence
show platform psustatus
show interface transceiver eeprom Ethernet0
show platform temperature

Description for the changelog

The changes are only in files sfputil.py, chassis.py, fan.py, psu.py and thermal.py and the changes are conversion of dictionaries and functions from SKU based to Platform based.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
