### PR TITLE
Updated the NAT iptables patch for 4.19 buster

### DIFF
--- a/src/iptables/patch/0001-Passing-fullcone-option-for-SNAT-and-DNAT.patch
+++ b/src/iptables/patch/0001-Passing-fullcone-option-for-SNAT-and-DNAT.patch
@@ -19,7 +19,7 @@ index a14d16f..4bfab98 100644
  
 +/* Temporarily defining here, need to be picked up from the
 + * new kernel header linux/netfilter/nf_nat.h */
-+#define NF_NAT_RANGE_FULLCONE  (1 << 5)
++#define NF_NAT_RANGE_FULLCONE  (1 << 6)
 +
  enum {
  	O_TO_DEST = 0,
@@ -106,7 +106,7 @@ index b7b5fc7..88ff650 100644
  
 +/* Temporarily defining here, need to be picked up from the
 + * new kernel header linux/netfilter/nf_nat.h */
-+#define NF_NAT_RANGE_FULLCONE  (1 << 5)
++#define NF_NAT_RANGE_FULLCONE  (1 << 6)
 +
  enum {
  	O_TO_PORTS = 0,
@@ -181,7 +181,7 @@ index e92d811..9634ba9 100644
  
 +/* Temporarily defining here, need to be picked up from the
 + * new kernel header linux/netfilter/nf_nat.h */
-+#define NF_NAT_RANGE_FULLCONE  (1 << 5)
++#define NF_NAT_RANGE_FULLCONE  (1 << 6)
 +
  enum {
  	O_TO_SRC = 0,


### PR DESCRIPTION
Updated the NAT iptables patch for 4.19 buster

Depends on PR : https://github.com/Azure/sonic-linux-kernel/pull/147

1 Known issue:

With both NAT patch files for 4.19 buster kernel, seeing 1 display issue in iptables like explained below

On Docker NAT, iptables supported version is 1.6.0 and on base OS it’s 1.8.2. So seeing an display issue of which fullcone option is not showing in version 1.8.2 iptables output and no issues in functionality.

Display issue – For example of comparsion:

NAT Docker:
root@sonic:/home/admin# docker exec -it nat bash
root@sonic:/# iptables -t nat -nvL
Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
pkts bytes target     prot opt in     out     source               destination
    0     0 DNAT       all  --  *      *       0.0.0.0/0            0.0.0.0/0            to:1.1.1.1 fullcone

Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
pkts bytes target     prot opt in     out     source               destination

Chain OUTPUT (policy ACCEPT 30 packets, 2749 bytes)
pkts bytes target     prot opt in     out     source               destination

Chain POSTROUTING (policy ACCEPT 30 packets, 2749 bytes)
pkts bytes target     prot opt in     out     source               destination
root@sonic:/#

Base OS:
root@sonic:/home/admin# iptables-legacy -t nat -nvL
Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
pkts bytes target     prot opt in     out     source               destination
    1    36 DNAT       all  --  *      *       0.0.0.0/0            0.0.0.0/0            to:1.1.1.1

Chain INPUT (policy ACCEPT 1 packets, 36 bytes)
pkts bytes target     prot opt in     out     source               destination

Chain OUTPUT (policy ACCEPT 41 packets, 3572 bytes)
pkts bytes target     prot opt in     out     source               destination

Chain POSTROUTING (policy ACCEPT 41 packets, 3572 bytes)
pkts bytes target     prot opt in     out     source               destination
root@sonic:/home/admin#

To fix this issue, iptables need to update from 1.6.0 to 1.8.2 version and have to update the NAT docker from stretch to buster. 
Will raise a new PR with this.


Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>
