### PR TITLE
[docker-orchagent]: start portsyncd before orchagent

### DIFF
--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -26,8 +26,8 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 
-[program:orchagent]
-command=/usr/bin/orchagent.sh
+[program:portsyncd]
+command=/usr/bin/portsyncd
 priority=3
 autostart=false
 autorestart=false
@@ -36,9 +36,19 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
+[program:orchagent]
+command=/usr/bin/orchagent.sh
+priority=4
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=portsyncd:running
+
 [program:restore_neighbors]
 command=/usr/bin/restore_neighbors.py
-priority=4
+priority=5
 autostart=false
 autorestart=false
 startsecs=0
@@ -60,19 +70,9 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=orchagent:running
 
-[program:portsyncd]
-command=/usr/bin/portsyncd
-priority=4
-autostart=false
-autorestart=false
-stdout_logfile=syslog
-stderr_logfile=syslog
-dependent_startup=true
-dependent_startup_wait_for=swssconfig:exited
-
 [program:neighsyncd]
 command=/usr/bin/neighsyncd
-priority=5
+priority=7
 autostart=false
 autorestart=false
 stdout_logfile=syslog


### PR DESCRIPTION
when portsyncd starts, it first enumerates all front panel ports
and marks them as old interfaces. Then, for new front panel ports
it checks if their indexes exist in previous sets. If yes, it will
treats them as old interfaces and ignore them.

The reason we have this check is because broadcom SAI only removes
front panel ports after sai switch init.

So, if portsyncd starts after orchagent, new interfaces could be
created before portsyncd and treated as old interface.

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
when portsyncd starts, it first enumerates all front panel ports
and marks them as old interfaces. Then, for new front panel ports
it checks if their indexes exist in previous sets. If yes, it will
treats them as old interfaces and ignore them.

The reason we have this check is because broadcom SAI only removes
front panel ports after sai switch init.

So, if portsyncd starts after orchagent, new interfaces could be
created before portsyncd and treated as old interface.

Signed-off-by: Guohan Lu <lguohan@gmail.com>

**- How I did it**
start portsyncd before orchagent

**- How to verify it**
run continuously config reload for 100 times

```
#!/bin/bash

# sysctl -w kernel.hung_task_panic=1
redis-cli -n 3 hmset portsyncd:portsyncd LOGLEVEL INFO

j=0
while [ True ]; do
        echo "iteration $j"
        config reload -y
        sleep 120
        i=0
        while [ $i -le 120 ]; do
                ip link show Ethernet24 | grep LOWER_UP
                if [ $? == 0 ]; then
                        break
                fi
                sleep 1
                i=$((i+1))
        done
        if [ $i -gt 120 ]; then
                break
        fi
        j=$((j+1))
done
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
