### PR TITLE
[dockers] Default container autorestart feature to "enabled" for all except database

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -28,7 +28,7 @@
 {%- for container in ["bgp", "database", "dhcp_relay", "lldp", "nat", "pmon", "radv", "restapi", "sflow",
                       "snmp", "swss", "syncd", "teamd", "telemetry"] %}
         "{{container}}": {
-            {% if container == "database" %}
+            {%- if container == "database" %}
             "auto_restart": "disabled",
             {% else %}
             "auto_restart": "enabled",

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -28,7 +28,7 @@
 {%- for container in ["bgp", "database", "dhcp_relay", "lldp", "nat", "pmon", "radv", "restapi", "sflow",
                       "snmp", "swss", "syncd", "teamd", "telemetry"] %}
         "{{container}}": {
-            "auto_restart": "disabled",
+            "auto_restart": "enabled",
             "high_mem_alert": "disabled"
         }{% if not loop.last %},{% endif -%}
 {% endfor %}

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -28,7 +28,11 @@
 {%- for container in ["bgp", "database", "dhcp_relay", "lldp", "nat", "pmon", "radv", "restapi", "sflow",
                       "snmp", "swss", "syncd", "teamd", "telemetry"] %}
         "{{container}}": {
-            "auto_restart": "enabled",
+            {% if container == "database" %}
+                "auto_restart": "disabled",
+            {% else %}
+                "auto_restart": "enabled",
+            {% endif -%}
             "high_mem_alert": "disabled"
         }{% if not loop.last %},{% endif -%}
 {% endfor %}

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -28,11 +28,7 @@
 {%- for container in ["bgp", "database", "dhcp_relay", "lldp", "nat", "pmon", "radv", "restapi", "sflow",
                       "snmp", "swss", "syncd", "teamd", "telemetry"] %}
         "{{container}}": {
-            {%- if container == "database" %}
-            "auto_restart": "disabled",
-            {% else %}
-            "auto_restart": "enabled",
-            {% endif -%}
+            "auto_restart": "{% if container == "database" %}disabled{% else %}enabled{% endif %}",
             "high_mem_alert": "disabled"
         }{% if not loop.last %},{% endif -%}
 {% endfor %}

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -29,9 +29,9 @@
                       "snmp", "swss", "syncd", "teamd", "telemetry"] %}
         "{{container}}": {
             {% if container == "database" %}
-                "auto_restart": "disabled",
+            "auto_restart": "disabled",
             {% else %}
-                "auto_restart": "enabled",
+            "auto_restart": "enabled",
             {% endif -%}
             "high_mem_alert": "disabled"
         }{% if not loop.last %},{% endif -%}


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

**- Why I did it**
Initially, the default state of autorestart feature is `disabled` for all containers. We change them to `enabled` except 
the database container such that we do not need
run extra `config` commands once this feature goes into production. If users do not want to adopt this feature,
they can disable it by running the `sudo config container feature autorestart <container_name> disabled`.

**- How I did it**

**- How to verify it**

