### PR TITLE
[Juniper][QFX5210] Fixing a few platform issues

### DIFF
--- a/platform/broadcom/sonic-platform-modules-juniper/debian/sonic-platform-juniper-qfx5210.postinst
+++ b/platform/broadcom/sonic-platform-modules-juniper/debian/sonic-platform-juniper-qfx5210.postinst
@@ -28,4 +28,5 @@ if [ -f $FIRST_BOOT_FILE ]; then
         # Creating the UEFI entry for the first time.
         efibootmgr -c -L "SONiC" -l "\EFI\BOOT\BOOTX64.EFI" > /var/tmp/efi_log 2>&1
     fi
+    rm -rf /sys/fs/pstore/*
 fi

--- a/platform/broadcom/sonic-platform-modules-juniper/qfx5210/utils/juniper_qfx5210_util.py
+++ b/platform/broadcom/sonic-platform-modules-juniper/qfx5210/utils/juniper_qfx5210_util.py
@@ -338,14 +338,12 @@ def system_ready():
                
 def do_install():
     logging.info('Checking system....')
-    if driver_check() == False:
-        logging.info('No driver, installing....')
-        status = driver_install()
-        if status:
-            if FORCE == 0:        
-                return  status
-    else:
-        print PROJECT_NAME.upper()+" drivers detected...."                      
+
+    status = driver_install()
+    if status:
+        if FORCE == 0:        
+            return  status
+
     if not device_exist():
         logging.info('No device, installing....')     
         status = device_install() 
@@ -353,7 +351,8 @@ def do_install():
             if FORCE == 0:        
                 return  status        
     else:
-        print PROJECT_NAME.upper()+" devices detected...."           
+        print PROJECT_NAME.upper()+" devices detected...."
+
     return
     
 def do_uninstall():


### PR DESCRIPTION
**- Description**

This patch addresses the following issues:

 1) Platform drivers were not loading in the latest images. Fixed
    the intialization script to make sure that all the drivers are
    loaded.

 2) Getting rid of "pstore: crypto_comp_decompress failed, ret = -22!"
    messages during the kernel boot, after moving to 4.19 kernel. The
    solution is to remove the files under '/sys/fs/pstore' directory.

Signed-off-by: Ciju Rajan K <crajank@juniper.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- How to verify it**
1) No kernel boot messages regarding pstore decompression failures
2) Make sure that drivers are loaded
```
admin@sonic:~$ sudo lsmod | grep juniper
x86_64_juniper_qfx5210_64x_psu    16384  0
x86_64_juniper_qfx5210_64x_leds    16384  0
x86_64_juniper_qfx5210_64x_fan    16384  0
juniper_i2c_cpld       16384  2 x86_64_juniper_qfx5210_64x_leds,x86_64_juniper_qfx5210_64x_psu
```

