### PR TITLE
[DellEMC] S52xx fix SFP reset in 1.0 API 

### DIFF
--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
@@ -193,7 +193,7 @@ class SfpUtil(SfpUtilBase):
         if (reg_value == "" ):
             return False
 
-        # Mask off 4th bit for presence
+        # Mask off 6th bit for lpmode
         mask = (1 << 6)
 		
 	# LPMode is active high; set or clear the bit accordingly
@@ -224,7 +224,7 @@ class SfpUtil(SfpUtilBase):
             return False
 
         # Mask off 4th bit for presence
-        mask = (1 << 6)
+        mask = (1 << 4)
 
         # ResetL is active low
         reg_value = reg_value & ~mask

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/plugins/sfputil.py
@@ -252,7 +252,7 @@ class SfpUtil(SfpUtilBase):
         if (reg_value == "" ):
             return False
 
-        # Mask off 4th bit for presence
+        # Mask off 6th bit for lpmode
         mask = (1 << 6)
 		
 	# LPMode is active high; set or clear the bit accordingly
@@ -283,7 +283,7 @@ class SfpUtil(SfpUtilBase):
             return False
 
         # Mask off 4th bit for presence
-        mask = (1 << 6)
+        mask = (1 << 4)
 
         # ResetL is active low
         reg_value = reg_value & ~mask


### PR DESCRIPTION

**- Why I did it**
Port with AOC cable does not come up when "sfputil reset <port_name>" is executed.

**- How I did it**
Execute 1.0 API reset command.

**- Description for the changelog**
Modified the incorrect mask used in reset API to resolve the issue.