### PR TITLE
[201911] Syncd high CPU fix on Th/Th2 platforms

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_3.7.5.1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.5.1_amd64.deb?sv=2015-04-05&sr=b&sig=baLk8LLHxk9CN%2Fu0rOar5ELvojYxD00DEcFcbCnFD%2BA%3D&se=2034-02-12T01%3A20%3A05Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_3.7.5.1_amd64.deb
+BRCM_SAI = libsaibcm_3.7.5.1-1_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.5.1-1_amd64.deb?sv=2015-04-05&sr=b&sig=cxmXsJ%2BjcnR9ckFRbMigIbkzOncYkiV04weL%2FVPKBmk%3D&se=2034-03-06T00%3A30%3A30Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_3.7.5.1-1_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.5.1_amd64.deb?sv=2015-04-05&sr=b&sig=28n0jOPdv6r%2FhyQNXtufNdd9PEoA3WT5e1rCXs5cE58%3D&se=2034-02-12T01%3A20%3A56Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.5.1-1_amd64.deb?sv=2015-04-05&sr=b&sig=LVgghAv75VG4idW6xfpId%2FlrvPBja7uBQeTbjZsR3CA%3D&se=2034-03-06T00%3A31%3A30Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
**- Why I did it**
To fix syncd high cpu on TH/Th2 platforms as reported
https://github.com/Azure/sonic-buildimage/issues/4827

**- How I did it**
Updated libsaibcm Debian package
**- How to verify it**
Verified after loading on TH platforms cpu usage gone down:

Previous:
 PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                                                                                       
 2521 root      20   0 1512860 360452  63540 S 144.6   4.4   8:00.03 syncd  

After Fix:
 7500 root      20   0 1592420 350912  64184 S  45.4  4.3   3:50.99 syncd 
