### PR TITLE
[201911][docker-lldp] Correct lldp-syncd program name in critical_processes file

### DIFF
--- a/dockers/docker-lldp-sv2/critical_processes
+++ b/dockers/docker-lldp-sv2/critical_processes
@@ -1,3 +1,3 @@
 program:lldpd
-program:lldp_syncd
+program:lldp-syncd
 program:lldpmgrd


### PR DESCRIPTION
Signed-off-by: Yong Zhao yozhao@microsoft.com

- Why I did it
The program name in critical_processes file must match the program name defined in supervisord.conf file.
It is not related to the process name in the command in supervisord.file. I made a mistake. I should test it
after doing this change.

- How I did it

- How to verify it
