### PR TITLE
[201911] Port #4845 from master to 201911

### DIFF
--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -25,16 +25,16 @@ autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
 
-[program:orchagent]
-command=/usr/bin/orchagent.sh
+[program:portsyncd]
+command=/usr/bin/portsyncd
 priority=3
 autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
-[program:portsyncd]
-command=/usr/bin/portsyncd
+[program:orchagent]
+command=/usr/bin/orchagent.sh
 priority=4
 autostart=false
 autorestart=false


### PR DESCRIPTION
Back port 
PR#https://github.com/Azure/sonic-buildimage/pull/4845 from master to 201911 as cherry-pick is not clean

