### PR TITLE
/host unmount failed in VM during reboot.

### DIFF
--- a/files/image_config/syslog/override.conf
+++ b/files/image_config/syslog/override.conf
@@ -1,5 +1,5 @@
 [Unit]
-After=var-log.mount host.mount
+After=var-log.mount host.mount local-fs.target
 
 [Socket]
 ExecStopPre=/usr/bin/host_umount.sh journal_stop


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Raised https://github.com/Azure/sonic-buildimage/pull/4558 to fix the /host unmount issue during reboots and it got merged.
@lguohan  mentioned that the issue didnt resolve in VM due to timing issue. Fixed the same.

Fix #4651 

**- How I did it**
Added a check further to make the services to stop appropriately before unmount.

**- How to verify it**
Load the image in VM and execute reboot command.
**- Description for the changelog**
Fixes the /host unmount failed issue in VM.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
