### PR TITLE
DellEMC S6100 disable pericom/xlinx chipset

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -26,6 +26,18 @@ if [[ "$1" == "init" ]]; then
     modprobe nvram
     systemctl start s6100-reboot-cause.service
 
+    # Disable Xilinx/pericom chipset
+    bios_version=$(dmidecode -s system-version | cut -d "-" -f2)
+
+    if [[ $bios_version -gt 5 ]] ; then
+        # Pericom is disabled in BIOS. Disable only Xilinx
+        echo 1 > /sys/bus/pci/devices/0000:02:00.0/remove
+    else
+        # Disable pericom/xilinx
+        echo 1 > /sys/bus/pci/devices/0000:02:00.0/remove
+        echo 1 > /sys/bus/pci/devices/0000:08:00.0/remove
+    fi
+
     # Disable Watchdog Timer
     if [[ -e /usr/local/bin/platform_watchdog_disable.sh ]]; then
         /usr/local/bin/platform_watchdog_disable.sh

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -19,7 +19,7 @@ remove_python_api_package() {
 
 if [[ "$1" == "init" ]]; then
 
-    pericom="/sys/bus/pci/devices/0000:08:00.0/"
+    pericom="/sys/bus/pci/devices/0000:08:00.0"
     modprobe i2c-dev
     modprobe i2c-mux-pca954x force_deselect_on_exit=1
     modprobe dell_ich
@@ -30,7 +30,7 @@ if [[ "$1" == "init" ]]; then
 
     # Disable pericom/xilinx
     echo 1 > /sys/bus/pci/devices/0000:02:00.0/remove
-    [ -d $pericom ] &&  echo 1 > /sys/bus/pci/devices/0000:08:00.0/remove
+    [ -d $pericom ] &&  echo 1 > $pericom/remove
 
     # Disable Watchdog Timer
     if [[ -e /usr/local/bin/platform_watchdog_disable.sh ]]; then

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -18,6 +18,8 @@ remove_python_api_package() {
 
 
 if [[ "$1" == "init" ]]; then
+
+    pericom="/sys/bus/pci/devices/0000:08:00.0/"
     modprobe i2c-dev
     modprobe i2c-mux-pca954x force_deselect_on_exit=1
     modprobe dell_ich
@@ -26,17 +28,9 @@ if [[ "$1" == "init" ]]; then
     modprobe nvram
     systemctl start s6100-reboot-cause.service
 
-    # Disable Xilinx/pericom chipset
-    bios_version=$(dmidecode -s system-version | cut -d "-" -f2)
-
-    if [[ $bios_version -gt 5 ]] ; then
-        # Pericom is disabled in BIOS. Disable only Xilinx
-        echo 1 > /sys/bus/pci/devices/0000:02:00.0/remove
-    else
-        # Disable pericom/xilinx
-        echo 1 > /sys/bus/pci/devices/0000:02:00.0/remove
-        echo 1 > /sys/bus/pci/devices/0000:08:00.0/remove
-    fi
+    # Disable pericom/xilinx
+    echo 1 > /sys/bus/pci/devices/0000:02:00.0/remove
+    [ -d $pericom ] &&  echo 1 > /sys/bus/pci/devices/0000:08:00.0/remove
 
     # Disable Watchdog Timer
     if [[ -e /usr/local/bin/platform_watchdog_disable.sh ]]; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
- Xilinx/pericom peripherals are not actively used in DellEMC S6100 switch.
- These peripherals are throwing PCIE corrected messages in some of the units and filling syslog.
- Since it is not usable disabling it at startup.

**- How I did it**
- Removing from PCIE sub-system

**- How to verify it**
```
root@sonic:/home/admin# lspci
00:00.0 Host bridge: Intel Corporation Atom processor C2000 SoC Transaction Router (rev 02)
00:01.0 PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 1 (rev 02)
00:02.0 PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 2 (rev 02)
00:03.0 PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 3 (rev 02)
00:04.0 PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 4 (rev 02)
00:0e.0 Host bridge: Intel Corporation Atom processor C2000 RAS (rev 02)
00:0f.0 IOMMU: Intel Corporation Atom processor C2000 RCEC (rev 02)
00:13.0 System peripheral: Intel Corporation Atom processor C2000 SMBus 2.0 (rev 02)
00:14.0 Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)
00:14.1 Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)
00:14.2 Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)
00:16.0 USB controller: Intel Corporation Atom processor C2000 USB Enhanced Host Controller (rev 02)
00:17.0 SATA controller: Intel Corporation Atom processor C2000 AHCI SATA2 Controller (rev 02)
00:18.0 SATA controller: Intel Corporation Atom processor C2000 AHCI SATA3 Controller (rev 02)
00:1f.0 ISA bridge: Intel Corporation Atom processor C2000 PCU (rev 02)
00:1f.3 SMBus: Intel Corporation Atom processor C2000 PCU SMBus (rev 02)
01:00.0 Ethernet controller: Broadcom Limited Broadcom BCM56960 Switch ASIC (rev 01)
01:00.1 Ethernet controller: Broadcom Limited Broadcom BCM56960 Switch ASIC (rev 01)
root@sonic:/home/admin#

```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
