### PR TITLE
Fix for ipv6 local-addr problem

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd
+++ b/src/sonic-bgpcfgd/bgpcfgd
@@ -542,6 +542,7 @@ class BGPPeerMgrBase(Manager):
         else:
             # The bgp session that belongs to a vnet cannot be advertised as the default BGP session.
             # So we need to check whether this bgp session belongs to a vnet.
+            data["local_addr"] = str(netaddr.IPNetwork(str(data["local_addr"])).ip)
             interface = self.get_local_interface(data["local_addr"])
             if not interface:
                 print_data = nbr, data["local_addr"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes: https://github.com/Azure/sonic-buildimage/issues/4572

**- Why I did it**
One ipv6 address could be represented in many ways. We must convert all incoming ipv6 addresses in one canonical way of the representation.

**- How I did it**
I convert ipv6 address to the canonical way before I saved it in the bgpcfgd.

**- How to verify it**
Build an image, run on your dut. create bgp_ipv6 neighbor which is not canonical, for example "fc02:0000:0000::1
And check that bgpcfgd created session "fc02::1"

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
