### PR TITLE
Added new pip packages, required by kube.py (kubernetes CLI).

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -53,6 +53,9 @@ RUN pip install py2_ipaddress
 RUN pip install six
 RUN pip install pyroute2==0.5.3 netifaces==0.10.7
 RUN pip install monotonic==1.5
+RUN pip install urllib3
+RUN pip install requests
+RUN pip install crontab
 
 {% if docker_sonic_vs_debs.strip() -%}
 # Copy locally-built Debian package dependencies


### PR DESCRIPTION
The new set of CLI commands that are required to support Kubernetes in SONiC requires these additional packages. W/o these, the PR tests fail.
