### PR TITLE
ssd firmware upgrade for S6100 3IE3 devices with cold-reboot/warm-reboot/fast-reboot.

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -8,6 +8,7 @@ s6100/scripts/platform_reboot_override usr/share/sonic/device/x86_64-dell_s6100_
 s6100/scripts/fast-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/track_reboot_reason.sh usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/warm-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
+s6100/scripts/ssd-fw-upgrade usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/override.conf /etc/systemd/system/systemd-reboot.service.d
 common/dell_lpc_mon.sh usr/local/bin
 s6100/scripts/platform_sensors.py usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_reboot_override
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_reboot_override
@@ -12,6 +12,11 @@ def log_software_reboot():
     res = subprocess.check_output(['/usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/fast-reboot_plugin'])
     return
 
+def ssd_hdparm_upgrade():
+    if os.path.exists('/tmp/SSD/SYS_S.bin'):
+        res = subprocess.check_output(['/usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/ssd-fw-upgrade', 'hdparm-upgrade'])
+    return
+
 def portio_reg_write(resource, offset, val):
     fd = os.open(resource, os.O_RDWR)
     if(fd < 0):
@@ -28,5 +33,6 @@ def portio_reg_write(resource, offset, val):
 
 if __name__ == "__main__":
     log_software_reboot()
+    ssd_hdparm_upgrade()
     portio_reg_write(PORT_RES, 0xcf9, 0xe)
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/ssd-fw-upgrade
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/ssd-fw-upgrade
@@ -55,40 +55,46 @@ mp_tool_reboot() {
         DEVICE=$(dmesg | grep "Attached SCSI disk" |  sed -n \$p | 
 	    grep -o -P '(sd[a-z])')
         cd /mnt/ramdisk/SSD
-        chmod +x mp_64
         ./mp_64 -d /dev/${DEVICE} -c 1 -u -k -r
     fi
 }
 
-reboot() {
-    cd /tmp
-    unzip -q SSD.zip
+hdparm-upgrade() {
     if [[ -x "$(command -v hdparm)" ]];then
         hdparm --fwdownload /tmp/SSD/SYS_S.bin --yes-i-know-what-i-am-doing \
 	    --please-destroy-my-drive /dev/sda
     fi
 }
 
-platform=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
-version_type=$(dmesg | grep "mSATA")
+platform_check() {
+    platform=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+    version_type=$(dmesg | grep "mSATA")
+    md5sum_value=$(md5sum /tmp/SSD.zip | cut -d ' ' -f1)
+    if [[ "$md5sum_value" != "$CHECKSUM_VALUE" || "$platform" != *"s6100"* || 
+        "$version_type" != *"3IE3"* || "$version_type" != *"S16425c1"*  ]];then
+        exit 1
+    fi
+}
 
 if [[ ! -f /tmp/SSD.zip ]];then
     exit 1
 fi
-md5sum_value=$(md5sum /tmp/SSD.zip | cut -d ' ' -f1)
-if [[ "$md5sum_value" != "$CHECKSUM_VALUE" || "$platform" != *"s6100"* || 
-    "$version_type" != *"3IE3"* || "$version_type" != *"S16425c1"*  ]];then
-    exit 1
-fi
+
 case "$1" in
     fast-reboot|warm-reboot)
+        platform_check
         mp_tool_reboot
         ;;
     reboot)
+        platform_check
+        cd /tmp
+        unzip -q SSD.zip
+        ;;
+    hdparm-upgrade)
         $1
         ;;
     *)
-        echo "Usage: $0 {fast-reboot|warm-reboot|reboot}" >&2
+        echo "Usage: $0 {fast-reboot|warm-reboot|reboot|hdparm-upgrade}" >&2
         exit 2
         ;;
 esac

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/ssd-fw-upgrade
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/ssd-fw-upgrade
@@ -1,0 +1,94 @@
+#!/bin/bash
+# This script does the SSD firware upgrade
+# This has been integrated as part of reboot/warm-reboot/fast-reboot script.
+SKIP_UPGRADE=0
+CHECKSUM_VALUE="b9b6dbb362b7632837af9cd320c5d147"
+unmount () {
+    exist=$(mount | grep " $1 " | wc -l)
+    if [ $exist -ne 0 ]; then
+        umount $1
+        if [[ $? -ne 0 ]]; then
+            fuser -vm $1
+            SKIP_UPGRADE=1
+        fi
+    fi
+}
+
+mp_tool_reboot() {
+    if [ ! -d /mnt/ramdisk ]; then
+        mkdir -p /mnt/ramdisk;
+    fi
+    mount -t tmpfs -o size=16m swap /mnt/ramdisk
+    cp /tmp/SSD.zip /mnt/ramdisk/
+    cd /mnt/ramdisk
+    unzip -q SSD.zip
+    chmod +x SSD/mp_64
+    
+    #stopped journal and syslog services to unmount /host
+    systemctl stop systemd-journald.service
+    systemctl stop systemd-journald.socket
+    systemctl stop systemd-journald-audit.socket
+    systemctl stop systemd-journald-dev-log.socket
+    systemctl stop syslog.service
+    systemctl stop syslog.socket
+    systemctl stop docker.socket
+    sleep 2
+    unmount /var/log
+    loop_exist=$(losetup -a | grep loop1 | wc -l)
+    if [ $loop_exist -ne 0 ]; then
+        losetup -d /dev/loop1
+    fi
+    unmount /boot
+    unmount /var/lib/docker
+    unmount /host
+    #start the services whichever we stopped for succesful /host unmount
+    systemctl start systemd-journald.service
+    systemctl start systemd-journald.socket
+    systemctl start systemd-journald-audit.socket
+    systemctl start systemd-journald-dev-log.socket
+    systemctl start syslog.service
+    systemctl start syslog.socket
+    if [ $SKIP_UPGRADE == 0 ]; then
+        echo 1 > /sys/class/scsi_device/4\:0\:0\:0/device/delete
+        echo "0 0 0" > /sys/class/scsi_host/host4/scan
+        sleep 3
+        DEVICE=$(dmesg | grep "Attached SCSI disk" |  sed -n \$p | 
+	    grep -o -P '(sd[a-z])')
+        cd /mnt/ramdisk/SSD
+        chmod +x mp_64
+        ./mp_64 -d /dev/${DEVICE} -c 1 -u -k -r
+    fi
+}
+
+reboot() {
+    cd /tmp
+    unzip -q SSD.zip
+    if [[ -x "$(command -v hdparm)" ]];then
+        hdparm --fwdownload /tmp/SSD/SYS_S.bin --yes-i-know-what-i-am-doing \
+	    --please-destroy-my-drive /dev/sda
+    fi
+}
+
+platform=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+version_type=$(dmesg | grep "mSATA")
+
+if [[ ! -f /tmp/SSD.zip ]];then
+    exit 1
+fi
+md5sum_value=$(md5sum /tmp/SSD.zip | cut -d ' ' -f1)
+if [[ "$md5sum_value" != "$CHECKSUM_VALUE" || "$platform" != *"s6100"* || 
+    "$version_type" != *"3IE3"* || "$version_type" != *"S16425c1"*  ]];then
+    exit 1
+fi
+case "$1" in
+    fast-reboot|warm-reboot)
+        mp_tool_reboot
+        ;;
+    reboot)
+        $1
+        ;;
+    *)
+        echo "Usage: $0 {fast-reboot|warm-reboot|reboot}" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Implemented the routines for ssd firmware upgrade via normal-reboot, fast-reboot and warm-reboot
**- How I did it**
The SSD will be upgraded using ssd-fw-upgrade script which is being called by reboot scripts.
The files required for upgrade will be shared offline.
**- How to verify it**
The files has to be placed in /tmp and reboot(reboot/fast-reboot/warm-reboot) commands has to be issued.
Raised[https://github.com/Azure/sonic-utilities/pull/954] in sonic-utilities for the changes in fast-reboot/warm-reboot/reboot scripts.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->ssd firmware upgrade in S6100 3IE3


**- A picture of a cute animal (not mandatory but encouraged)**
