### PR TITLE
[sonic mgmt docker] lock pycryptodome version to 3.9.7

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -49,7 +49,7 @@ RUN pip install cffi==1.10.0 \
                 prettytable \
                 psutil \
                 pyasn1==0.1.9 \
-                pycryptodome \
+                pycryptodome==3.9.7 \
                 pyfiglet \
                 pylint==1.8.1 \
                 pyro4 \


### PR DESCRIPTION
**- Why I did it**
While running ansible test in virtual environment, there is a failure related to crypto

**- How I did it**
Lock the pycryptodome version to 3.9.7

**- How to verify it**
on the docker exhibited problem remove pycryptodome version to 3.9.8 and install pycryptodome version to 3.9.7. Issue went away.