### PR TITLE
Revert "[sonic mgmt docker] lock pycryptodome version to 3.9.7"

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -49,7 +49,7 @@ RUN pip install cffi==1.10.0 \
                 prettytable \
                 psutil \
                 pyasn1==0.1.9 \
-                pycryptodome==3.9.7 \
+                pycryptodome \
                 pyfiglet \
                 pylint==1.8.1 \
                 pyro4 \


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#4913

removal and reinstall fixed it. not fixing version (maybe version still needs to be fixed). More investigation is needed. simply fixing the version to 3.9.7 wasn't the right solution.