### PR TITLE
[201911] Updated BRCM SAI Debian package to 3.7.5.1-2

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_3.7.5.1-1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.5.1-1_amd64.deb?sv=2015-04-05&sr=b&sig=cxmXsJ%2BjcnR9ckFRbMigIbkzOncYkiV04weL%2FVPKBmk%3D&se=2034-03-06T00%3A30%3A30Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_3.7.5.1-1_amd64.deb
+BRCM_SAI = libsaibcm_3.7.5.1-2_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.5.1-2_amd64.deb?sv=2015-04-05&sr=b&sig=NMXmDm7ME%2BDN9n4kw6wXgIVmIjRifu%2FWV0UbLU9qllw%3D&se=2034-03-17T05%3A53%3A29Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_3.7.5.1-2_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.5.1-1_amd64.deb?sv=2015-04-05&sr=b&sig=LVgghAv75VG4idW6xfpId%2FlrvPBja7uBQeTbjZsR3CA%3D&se=2034-03-06T00%3A31%3A30Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.5.1-2_amd64.deb?sv=2015-04-05&sr=b&sig=3Q8S5fwg7WV%2BCKVwMALrf8dpQWK2cSD4J4zxbVht%2BT8%3D&se=2034-03-17T05%3A54%3A05Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
Fix for Copp Rules not having Policer Rate-Limit applied.

Verified Copp PTF Test passing on Dell-6000 (TD2) based platforms

Ansible Command Run:

ansible-playbook test_sonic.yml -i str --limit str-s6000-on-2 --vault-password-file password.txt -e testcase_name=copp -e testbed_name=vms13-5-t1-lag -e testbed_type=ptf32 -e nn_target_port=3 -e nn_target_interface=Ethernet12

