### PR TITLE
Add support for bcmsh and bcmcmd utlitites in multi ASIC devices

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -299,6 +299,11 @@ start() {
         --tmpfs /tmp \
 {%- endif %}
 {%- endif %}
+{%- if sonic_asic_platform == "broadcom" %}
+{%- if docker_container_name == "syncd" %}
+        -v /var/run/docker-syncd$DEV:/var/run/sswsyncd \
+{%- endif %}
+{%- endif %}
 {%- if docker_container_name == "bgp" %}
         -v /etc/sonic/frr/$DEV:/etc/frr:rw \
 {%- endif %}

--- a/platform/broadcom/docker-syncd-brcm.mk
+++ b/platform/broadcom/docker-syncd-brcm.mk
@@ -15,8 +15,8 @@ SONIC_STRETCH_DOCKERS += $(DOCKER_SYNCD_BASE)
 SONIC_STRETCH_DBG_DOCKERS += $(DOCKER_SYNCD_BASE_DBG)
 
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/warmboot:/var/warmboot
-$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 
 $(DOCKER_SYNCD_BASE)_BASE_IMAGE_FILES += bcmcmd:/usr/bin/bcmcmd
 $(DOCKER_SYNCD_BASE)_BASE_IMAGE_FILES += bcmsh:/usr/bin/bcmsh
+$(DOCKER_SYNCD_BASE)_BASE_IMAGE_FILES += bcm_common:/usr/bin/bcm_common
 $(DOCKER_SYNCD_BASE)_BASE_IMAGE_FILES += monit_syncd:/etc/monit/conf.d

--- a/platform/broadcom/docker-syncd-brcm/base_image_files/bcm_common
+++ b/platform/broadcom/docker-syncd-brcm/base_image_files/bcm_common
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+function help()
+{
+    echo "Usage: $0 -n [0 to $(($NUM_ASIC-1))]" 1>&2; exit 1;
+
+}
+
+
+DEV=""
+
+PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+
+# Parse the device specific asic conf file, if it exists
+
+ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
+if [ -f "$ASIC_CONF" ]; then
+    source $ASIC_CONF
+fi
+
+
+if [[ ($NUM_ASIC -gt 1) ]]; then
+    OPTIND=1
+
+    while getopts ":n:h:" opt; do
+        case "${opt}" in
+            h) help
+               exit 0
+               ;;
+            n) DEV=${OPTARG}
+               [ $DEV -lt $NUM_ASIC -a  $DEV -ge 0 ] || help
+               ;;
+        esac
+    done
+    shift "$((OPTIND-1))"
+
+    if [ -z "${DEV}" ]; then
+        help
+    fi
+fi

--- a/platform/broadcom/docker-syncd-brcm/base_image_files/bcmcmd
+++ b/platform/broadcom/docker-syncd-brcm/base_image_files/bcmcmd
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-docker exec -i syncd bcmcmd "$@"
+BCM_COMMON=/usr/bin/bcm_common
+if [ -f "$BCM_COMMON" ]; then
+    source $BCM_COMMON
+fi
+docker exec -i syncd$DEV bcmcmd "$@"
+

--- a/platform/broadcom/docker-syncd-brcm/base_image_files/bcmsh
+++ b/platform/broadcom/docker-syncd-brcm/base_image_files/bcmsh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-docker exec -it syncd bcmsh "$@"
+BCM_COMMON=/usr/bin/bcm_common
+if [ -f "$BCM_COMMON" ]; then
+    source $BCM_COMMON
+fi
+
+docker exec -it syncd$DEV bcmsh "$@"


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
This PR has changes to support accessing the bcmsh and bcmcmd utilities on multi ASIC devices
**- How I did it**
Changes done
- move the link of /var/run/sswsyncd from docker-syncd-brcm.mk to docker_image_ctl.j2
- update the bcmsh and bcmcmd scripts to take **_-n [ASIC_ID]_** as an argument on multi ASIC platforms

**- How to verify it**
```
admin@sonic:~$ bcmcmd -n 5 "l3 intf show"
l3 intf show
Free L3INTF entries: 8186
Unit  Intf  VRF Group VLAN    Source Mac     MTU TTL Tunnel InnerVlan  NATRealm
------------------------------------------------------------------
0     1     0     0     1    02:42:f0:7f:01:03  9100 0    0     0     0
0     2     0     0     4095 02:42:f0:7f:01:03  9100 0    0     0     0
0     3     0     0     4095 02:42:f0:7f:01:03  9100 0    0     0     0
0     4     0     0     4095 02:42:f0:7f:01:03  9100 0    0     0     0
0     5     0     0     4095 02:42:f0:7f:01:03  9100 0    0     0     0
drivshell>
admin@sonic:~$ bcmcmd -n 1 "l3 intf show"
l3 intf show
Free L3INTF entries: 8186
Unit  Intf  VRF Group VLAN    Source Mac     MTU TTL Tunnel InnerVlan  NATRealm
------------------------------------------------------------------
0     1     0     0     1    00:be:75:3a:ef:50  9100 0    0     0     0
0     2     0     0     4095 00:be:75:3a:ef:50  9100 0    0     0     0
0     3     0     0     4095 00:be:75:3a:ef:50  9100 0    0     0     0
0     4     0     0     4095 00:be:75:3a:ef:50  9100 0    0     0     0
0     5     0     0     4095 00:be:75:3a:ef:50  9100 0    0     0     0
drivshell>

```


**- Description for thchangelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
