### PR TITLE
Add disabling HW watchdog during boot for fast-reboot and warm-reboot

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -237,6 +237,11 @@ sudo LANG=C cp $IMAGE_CONFIGS/warmboot-finalizer/finalize-warmboot.sh $FILESYSTE
 sudo LANG=C cp $IMAGE_CONFIGS/warmboot-finalizer/warmboot-finalizer.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 echo "warmboot-finalizer.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
+# Copy watchdog-control files
+sudo LANG=C cp $IMAGE_CONFIGS/watchdog-control/watchdog-control.sh $FILESYSTEM_ROOT/usr/local/bin/watchdog-control.sh
+sudo LANG=C cp $IMAGE_CONFIGS/watchdog-control/watchdog-control.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+echo "watchdog-control.service" | sudo tee -a $GENERATED_SERVICE_FILE
+
 # Copy rsyslog configuration files and templates
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog-config.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog-config.sh $FILESYSTEM_ROOT/usr/bin/

--- a/files/image_config/watchdog-control/watchdog-control.service
+++ b/files/image_config/watchdog-control/watchdog-control.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=watchdog control service
+After=swss.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/watchdog-control.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/files/image_config/watchdog-control/watchdog-control.sh
+++ b/files/image_config/watchdog-control/watchdog-control.sh
@@ -36,7 +36,7 @@ function disable_watchdog()
     # Obtain boot type from kernel arguments
     BOOT_TYPE=`getBootType`
     if [[ -x ${WATCHDOG_UTIL} ]]; then
-        debug "Disabling Watchdog during bootup after $getBootType"
+        debug "Disabling Watchdog during bootup after $BOOT_TYPE"
         ${WATCHDOG_UTIL} disarm
     fi
 }

--- a/files/image_config/watchdog-control/watchdog-control.sh
+++ b/files/image_config/watchdog-control/watchdog-control.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+
+VERBOSE=no
+WATCHDOG_UTIL="/usr/bin/watchdogutil"
+
+function debug()
+{
+    /usr/bin/logger "$0 : $1"
+    if [[ x"${VERBOSE}" == x"yes" ]]; then
+        echo "$(date) $0: $1"
+    fi
+}
+
+
+function getBootType()
+{
+    # same code snippet in files/scripts/syncd.sh
+    case "$(cat /proc/cmdline)" in
+    *SONIC_BOOT_TYPE=warm*)
+        TYPE='warm'
+        ;;
+    *SONIC_BOOT_TYPE=fastfast*)
+        TYPE='fastfast'
+        ;;
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
+        TYPE='fast'
+        ;;
+    *)
+        TYPE='cold'
+    esac
+    echo "${TYPE}"
+}
+
+function disable_watchdog()
+{
+    # Obtain boot type from kernel arguments
+    BOOT_TYPE=`getBootType`
+    if [[ -x ${WATCHDOG_UTIL} ]]; then
+        debug "Disabling Watchdog during bootup after $getBootType"
+        ${WATCHDOG_UTIL} disarm
+    fi
+}
+
+disable_watchdog


### PR DESCRIPTION
This change is to disable the hw watchdog during the boot after the fast-reboot and warm-reboot which is enabling the hw watchdog during its execution.