### PR TITLE
[docker-ptf] add gnmi python client

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -139,7 +139,7 @@ RUN ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 
 RUN mkdir -p /var/log/supervisor
 
-# add dependencies to build gnmi pyclient
+# Install Python-based GNMI client
 RUN git clone https://github.com/lguohan/gnxi.git \
     && cd gnxi \
     && git checkout d01b36e \

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -139,6 +139,13 @@ RUN ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 
 RUN mkdir -p /var/log/supervisor
 
+# add dependencies to build gnmi pyclient
+RUN git clone https://github.com/lguohan/gnxi.git \
+    && cd gnxi \
+    && git checkout d01b36e \
+    && cd gnmi_cli_py \
+    && pip install -r requirements.txt
+
 EXPOSE 22 8009
 
 ENTRYPOINT ["/usr/local/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
For telemetry regression test we need gnmi client  to be present on ptfdocker. Gnmi-server will be present on SONiC DuT. Further, we can access gnmi_get from ptfdocker inside pytest to verify gnmi server streaming data successfully or not.

Link to previous closed PR: https://github.com/Azure/sonic-buildimage/pull/4720

**- How I did it**
Added changes to Dockerfile.j2 for ptfdocker
**- How to verify it**
**docker-ptf logs:**

```
Step 16/19 : RUN git clone https://github.com/lguohan/gnxi.git     && cd gnxi     && git checkout d01b36e     && cd gnmi_cli_py     && pip install -r requirements.txt
 ---> Running in 69381ec90596
^[[91mCloning into 'gnxi'...
^[[0m^[[91mNote: checking out 'd01b36e'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at d01b36e... add xpath_target option
^[[0m^[[91mDEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
^[[0mCollecting enum34==1.1.6
  Downloading enum34-1.1.6-py2-none-any.whl (12 kB)
Collecting futures==3.2.0
  Downloading futures-3.2.0-py2-none-any.whl (15 kB)
Collecting grpcio==1.18.0
  Downloading grpcio-1.18.0-cp27-cp27mu-manylinux1_x86_64.whl (10.4 MB)
Collecting grpcio-tools==1.15.0
  Downloading grpcio_tools-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl (22.8 MB)
Collecting protobuf==3.6.1
  Downloading protobuf-3.6.1.tar.gz (240 kB)
Collecting six==1.12.0
  Downloading six-1.12.0-py2.py3-none-any.whl (10 kB)
Requirement already satisfied: setuptools in /usr/local/lib/python2.7/dist-packages (from protobuf==3.6.1->-r requirements.txt (line 5)) (44.1.1)
Skipping wheel build for protobuf, due to binaries being disabled for it.
Installing collected packages: enum34, futures, six, grpcio, protobuf, grpcio-tools
  Attempting uninstall: enum34
    Found existing installation: enum34 1.1.10
    Uninstalling enum34-1.1.10:
      Successfully uninstalled enum34-1.1.10
  Attempting uninstall: six
    Found existing installation: six 1.10.0
    Uninstalling six-1.10.0:
      Successfully uninstalled six-1.10.0
    Running setup.py install for protobuf: started
    Running setup.py install for protobuf: finished with status 'done'
Successfully installed enum34-1.1.6 futures-3.2.0 grpcio-1.18.0 grpcio-tools-1.15.0 protobuf-3.6.1 six-1.12.0
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```

**- A picture of a cute animal (not mandatory but encouraged)**
