### PR TITLE
[swss] Call sonic-cfggen Once

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
-# Export platform information. Required to be able to write
-# vendor specific code.
-SWSS_VARS=$(sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/swss.j2)
-export platform=$(echo $SWSS_VARS | jq -r '.asic_type')
+EXIT_SWSS_VARS_FILE_NOT_FOUND=1
+SWSS_VARS_FILE=/usr/share/sonic/templates/swss_vars.j2
+
+if [ ! -f "$SWSS_VARS_FILE" ]; then
+    echo "SWSS vars template file not found"
+    exit $EXIT_SWSS_VARS_FILE_NOT_FOUND
+fi
+
+# Retrieve SWSS vars from sonic-cfggen
+SWSS_VARS=$(sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t $SWSS_VARS_FILE)
+platform=$(echo $SWSS_VARS | jq -r '.asic_type')
 
 MAC_ADDRESS=$(echo $SWSS_VARS | jq -r '.mac')
 if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then

--- a/dockers/docker-orchagent/swss_vars.j2
+++ b/dockers/docker-orchagent/swss_vars.j2
@@ -1,0 +1,6 @@
+{
+    "asic_type": "{{ asic_type }}",
+    "asic_id": "{{ DEVICE_METADATA.localhost.asic_id }}",
+    "mac": "{{ DEVICE_METADATA.localhost.mac }}"
+}
+


### PR DESCRIPTION
Optimizing number of calls made to sonic-cfggen during service
start up as it adds to total system boot up time.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
sonic-cfggen call is slow and it adds to system start up time

**- How I did it**
places all required variable into single template and called into sonic-cfggen using this template

**- How to verify it**
***-Test 1***
there is an average saving of .5 to 1 sec between old script and new script
```
root@str-s6000-acs-14:/# time ./orchagent_old.sh
/usr/bin/orchagent -d /var/log/swss -b 8192 -m f4:8e:38:16:bc:8d

real	0m3.546s
user	0m2.365s
sys	0m0.585s

root@str-s6000-acs-14:/# time ./orchagent_new.sh
/usr/bin/orchagent -d /var/log/swss -b 8192 -m f4:8e:38:16:bc:8d

real	0m2.058s
user	0m1.650s
sys	0m0.363s
```
***-Test 2***
Built an image with this change and orchagent is running with intended params:
```
admin@str-s6000-acs-14:~$ ps -ef | grep orchagent
root      2988  1901  1 02:09 pts/0    00:00:02 /usr/bin/orchagent -d /var/log/swss -b 8192 -m f4:8e:38:16:bc:8d
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
