### PR TITLE
[mgmt-framework] Call sonic-cfggen Once

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -29,6 +29,7 @@ debs/{{ deb }}{{' '}}
 {%- endfor %}
 
 COPY ["start.sh", "rest-server.sh", "/usr/bin/"]
+COPY ["mgmt_vars.j2", "/usr/share/sonic/templates/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 
 RUN apt-get remove -y g++ python-dev

--- a/dockers/docker-sonic-mgmt-framework/mgmt_vars.j2
+++ b/dockers/docker-sonic-mgmt-framework/mgmt_vars.j2
@@ -1,0 +1,4 @@
+{
+    "rest_server": {% if REST_SERVER is defined and "default" in RESET_SERVER.keys() %}{{ REST_SERVER['default'] }}{% else %}""{% endif %},
+    "x509" : {% if "x509" in DEVICE_METADATA.keys() %}{{ DEVICE_METADATA["x509"] }}{% else %}""{% endif %}
+}

--- a/dockers/docker-sonic-mgmt-framework/rest-server.sh
+++ b/dockers/docker-sonic-mgmt-framework/rest-server.sh
@@ -1,28 +1,39 @@
 #!/usr/bin/env bash
 
 # Startup script for SONiC Management REST Server
+EXIT_MGMT_VARS_FILE_NOT_FOUND=1
+MGMT_VARS_FILE=/usr/share/sonic/templates/mgmt_vars.j2
 
-# Read basic server settings from REST_SERVER|default entry
-HAS_REST_CONFIG=$(sonic-cfggen -d -v "1 if REST_SERVER and REST_SERVER['default']")
-if [ "$HAS_REST_CONFIG" == "1" ]; then
-    SERVER_PORT=$(sonic-cfggen -d -v "REST_SERVER['default']['port']")
-    CLIENT_AUTH=$(sonic-cfggen -d -v "REST_SERVER['default']['client_auth']")
-    LOG_LEVEL=$(sonic-cfggen -d -v "REST_SERVER['default']['log_level']")
+if [ ! -f "$MGMT_VARS_FILE" ]; then
+    echo "Mgmt vars template file not found"
+    exit $EXIT_MGMT_VARS_FILE_NOT_FOUND
+fi
 
-    SERVER_CRT=$(sonic-cfggen -d -v "REST_SERVER['default']['server_crt']")
-    SERVER_KEY=$(sonic-cfggen -d -v "REST_SERVER['default']['server_key']")
-    CA_CRT=$(sonic-cfggen -d -v "REST_SERVER['default']['ca_crt']")
+# Read basic server settings from mgmt vars entries
+MGMT_VARS=$(sonic-cfggen -d -t $MGMT_VARS_FILE)
+MGMT_VARS=${MGMT_VARS//[\']/\"}
+
+REST_SERVER=$(echo $MGMT_VARS | jq -r '.rest_server')
+
+if [ -n "$REST_SERVER" ]; then
+    SERVER_PORT=$(echo $REST_SERVER | jq -r '.port')
+    CLIENT_AUTH=$(echo $REST_SERVER | jq -r '.client_auth')
+    LOG_LEVEL=$(echo $REST_SERVER | jq -r '.log_level')
+
+    SERVER_CRT=$(echo $REST_SERVER | jq -r '.server_crt')
+    SERVER_KEY=$(echo $REST_SERVER | jq -r '.server_key')
+    CA_CRT=$(echo $REST_SERVER | jq -r '.ca_crt')
 fi
 
 if [[ -z $SERVER_CRT ]] && [[ -z $SERVER_KEY ]] && [[ -z $CA_CRT ]]; then
-    HAS_X509_CONFIG=$(sonic-cfggen -d -v "1 if DEVICE_METADATA and DEVICE_METADATA['x509']")
+    X509=$(echo $MGMT_VARS | jq -r '.x509')
 fi
 
 # Read certificate file paths from DEVICE_METADATA|x509 entry.
-if [ "$HAS_X509_CONFIG" == "1" ]; then
-    SERVER_CRT=$(sonic-cfggen -d -v "DEVICE_METADATA['x509']['server_crt']")
-    SERVER_KEY=$(sonic-cfggen -d -v "DEVICE_METADATA['x509']['server_key']")
-    CA_CRT=$(sonic-cfggen -d -v "DEVICE_METADATA['x509']['ca_crt']")
+if [ -n "$X509" ]; then
+    SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
+    SERVER_KEY=$(echo $X509 | jq -r '.server_key')
+    CA_CRT=$(echo $X509 | jq -r '.ca_crt')
 fi
 
 # Create temporary server certificate if they not configured in ConfigDB


### PR DESCRIPTION
Optimizing number of calls made to sonic-cfggen during service
start up as it adds to total system boot up time.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>


**- Why I did it**
sonic-cfggen call is slow and it adds to system start up time
**- How I did it**
placed all required variable into single template and called into sonic-cfggen using this template
**- How to verify it**

***-Test 1***
there is an average saving of 1 to 1.5 sec between old script and new script
```
root@str-s6000-acs-14:/# time /usr/bin/rest-server-old.sh
Generating temporary TLS server certificate ...
2020/07/09 19:03:33 wrote cert.pem
2020/07/09 19:03:33 wrote key.pem
REST_SERVER_ARGS = -ui /rest_ui -logtostderr -cert /tmp/cert.pem -key /tmp/key.pem
/usr/sbin/rest_server -ui /rest_ui -logtostderr -cert /tmp/cert.pem -key /tmp/key.pem

real	0m8.790s
user	0m7.993s
sys	0m0.584s
root@str-s6000-acs-14:/# time /usr/bin/rest-server-new.sh
Generating temporary TLS server certificate ...
2020/07/09 19:03:45 wrote cert.pem
2020/07/09 19:03:45 wrote key.pem
REST_SERVER_ARGS = -ui /rest_ui -logtostderr -cert /tmp/cert.pem -key /tmp/key.pem
/usr/sbin/rest_server -ui /rest_ui -logtostderr -cert /tmp/cert.pem -key /tmp/key.pem

real	0m6.940s
user	0m5.670s
sys	0m0.386s
```
***-Test 2***
Built an image with this change and rest server is running with params as described in test 1 above
```
admin@str-s6000-acs-14:~$ ps -ef | grep rest_server
root      3301  2866  2 02:09 pts/0    00:00:10 /usr/sbin/rest_server -ui /rest_ui -logtostderr -cert /tmp/cert.pem -key /tmp/key.pem

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
