### PR TITLE
[telemetry] Fix telemetry vars template path

### DIFF
--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -22,7 +22,8 @@ RUN apt-get clean -y      && \
     apt-get autoremove -y && \
     rm -rf /debs
 
-COPY ["start.sh", "telemetry.sh", "dialout.sh", "telemetry_vars.j2", "/usr/bin/"]
+COPY ["start.sh", "telemetry.sh", "dialout.sh", "/usr/bin/"]
+COPY ["telemetry_vars.j2", "/usr/share/sonic/templates/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -2,7 +2,7 @@
 
 # Try to read telemetry and certs config from ConfigDB.
 # Use default value if no valid config exists
-TELEMETRY_VARS=$(sonic-cfggen -d -t telemetry_vars.j2)
+TELEMETRY_VARS=$(sonic-cfggen -d -t /usr/bin/telemetry_vars.j2)
 TELEMETRY_VARS=${TELEMETRY_VARS//[\']/\"}
 X509=$(echo $TELEMETRY_VARS | jq -r '.x509')
 GNMI=$(echo $TELEMETRY_VARS | jq -r '.gnmi')

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 
+EXIT_TELEMETRY_VARS_FILE_NOT_FOUND=1
+TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
+
+if [ ! -f "$TELEMETRY_VARS_FILE" ]; then
+    echo "Telemetry vars template file not found"
+    exit $EXIT_TELEMETRY_VARS_FILE_NOT_FOUND
+fi
+
 # Try to read telemetry and certs config from ConfigDB.
 # Use default value if no valid config exists
-TELEMETRY_VARS=$(sonic-cfggen -d -t /usr/bin/telemetry_vars.j2)
+TELEMETRY_VARS=$(sonic-cfggen -d -t $TELEMETRY_VARS_FILE)
 TELEMETRY_VARS=${TELEMETRY_VARS//[\']/\"}
 X509=$(echo $TELEMETRY_VARS | jq -r '.x509')
 GNMI=$(echo $TELEMETRY_VARS | jq -r '.gnmi')

--- a/dockers/docker-sonic-telemetry/telemetry_vars.j2
+++ b/dockers/docker-sonic-telemetry/telemetry_vars.j2
@@ -1,5 +1,5 @@
 {
-    "certs": "{% if "certs" in TELEMETRY.keys() %}{{ TELEMETRY["certs"] }}{% endif %}",
-    "gnmi" : "{% if "gnmi" in TELEMETRY.keys() %}{{ TELEMETRY["gnmi"] }}{% endif %}",
-    "x509" : "{% if "x509" in DEVICE_METADATA.keys() %}{{ DEVICE_METADATA["x509"] }}{% endif %}"
+    "certs": {% if "certs" in TELEMETRY.keys() %}{{ TELEMETRY["certs"] }}{% else %}""{% endif %},
+    "gnmi" : {% if "gnmi" in TELEMETRY.keys() %}{{ TELEMETRY["gnmi"] }}{% else %}""{% endif %},
+    "x509" : {% if "x509" in DEVICE_METADATA.keys() %}{{ DEVICE_METADATA["x509"] }}{% else %}""{% endif %}
 }


### PR DESCRIPTION
The template is reference relative to the script path and this could
results in errors in case script is run from root. Add explicit
path to the template file name.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
recent test shows that script is run from root dir and template could not be located

**- How I did it**
Added explicit template path

**- How to verify it**
Build new telemetry docker, load and make sure there is not error message in the syslog
```
telemetry.log:317:Jul  8 17:28:45.194596 str-s6000-acs-14 INFO telemetry#supervisord: telemetry Traceback (most recent call last):
telemetry.log:318:Jul  8 17:28:45.194596 str-s6000-acs-14 INFO telemetry#supervisord: telemetry   File "/usr/local/bin/sonic-cfggen", line 394, in <module>
telemetry.log:319:Jul  8 17:28:45.194596 str-s6000-acs-14 INFO telemetry#supervisord: telemetry     main()
telemetry.log:320:Jul  8 17:28:45.194596 str-s6000-acs-14 INFO telemetry#supervisord: telemetry   File "/usr/local/bin/sonic-cfggen", line 363, in main
telemetry.log:321:Jul  8 17:28:45.194710 str-s6000-acs-14 INFO telemetry#supervisord: telemetry     template = env.get_template(template_file)
telemetry.log:322:Jul  8 17:28:45.194790 str-s6000-acs-14 INFO telemetry#supervisord: telemetry   File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 883, in get_template
telemetry.log:323:Jul  8 17:28:45.206910 str-s6000-acs-14 INFO telemetry#supervisord: telemetry     return self._load_template(name, self.make_globals(globals))
telemetry.log:324:Jul  8 17:28:45.206910 str-s6000-acs-14 INFO telemetry#supervisord: telemetry   File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 857, in _load_template
telemetry.log:325:Jul  8 17:28:45.206910 str-s6000-acs-14 INFO telemetry#supervisord: telemetry     template = self.loader.load(self, name, globals)
telemetry.log:326:Jul  8 17:28:45.206910 str-s6000-acs-14 INFO telemetry#supervisord: telemetry   File "/usr/local/lib/python2.7/dist-packages/jinja2/loaders.py", line 115, in load
telemetry.log:327:Jul  8 17:28:45.226630 str-s6000-acs-14 INFO telemetry#supervisord: telemetry     source, filename, uptodate = self.get_source(environment, name)
telemetry.log:328:Jul  8 17:28:45.226630 str-s6000-acs-14 INFO telemetry#supervisord: telemetry   File "/usr/local/lib/python2.7/dist-packages/jinja2/loaders.py", line 197, in get_source
telemetry.log:329:Jul  8 17:28:45.226630 str-s6000-acs-14 INFO telemetry#supervisord: telemetry     raise TemplateNotFound(template)
```
**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**
