### PR TITLE
[bgpcfgd] - Fix a key error during delete

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd
+++ b/src/sonic-bgpcfgd/bgpcfgd
@@ -647,7 +647,7 @@ class BGPPeerMgrBase(Manager):
         ret_code = self.apply_op(cmd, vrf)
         if ret_code:
             log_info("Peer '(%s|%s)' has been removed" % (vrf, nbr))
-            self.peers.remove(key)
+            self.peers.remove(peer_key)
         else:
             log_err("Peer '(%s|%s)' hasn't been removed" % (vrf, nbr))
 


### PR DESCRIPTION
**- Why I did it**
bgpcfgd crash while deleting peer entry

**- How I did it**

**- How to verify it**
```
self.del_handler(key)#012 File "/usr/bin/bgpcfgd", line 883, in del_handler#012   
self.peers.remove(key)#012KeyError: '10.0.0.1'

key -> '10.0.0.1'
peer_key -> ('default', '10.0.0.1')
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
