### PR TITLE
[frr/ruijie] fix #4733 Add support for BGP_ROUTEMAPS & BGP_PEER_RANGE

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -97,5 +97,53 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endblock maximum_paths %}
 {% endif %}
 !
+{% if BGP_ROUTEMAPS %}
+{% for name, routemap in BGP_ROUTEMAPS.iteritems() %}
+route-map {{ name[0] }} {{ routemap['opttype'] }} {{ routemap['seqnumber'] }}
+{% if routemap.has_key('matchcommunity') %}
+ match community {{ routemap['matchcommunity'] }}
+{% endif %}
+{% if routemap.has_key('prefix_name') %}
+ match ip address prefix-list {{ routemap['prefix_name'] }}
+{% endif %}
+{% if routemap.has_key('comm_range') %}
+ set community {{ routemap['comm_range'] }}
+{% endif %}
+{% if routemap.has_key('applycost') %}
+ set metric {{ routemap['applycost'] }}
+{% endif %}
+!
+{% endfor %}
+{% endif %}
+!
+{% block bgp_peers_with_range %}
+{% if BGP_PEER_RANGE %}
+{% for bgp_peer in BGP_PEER_RANGE.values() %}
+ neighbor {{ bgp_peer['name'] }} peer-group
+{% if bgp_peer.has_key('remote_as') %}
+ neighbor {{ bgp_peer['name'] }} remote-as {{ bgp_peer['remote_as'] }}
+{% endif %}
+{% if bgp_peer.has_key('password') %}
+ neighbor {{ bgp_peer['name'] }} password simple {{ bgp_peer['password'] }}
+{% endif %}
+{% if bgp_peer.has_key('description') %}
+ neighbor {{ bgp_peer['name'] }} description {{ bgp_peer['description'] }}
+{% endif %}
+{% if bgp_peer.has_key('source') %}
+ neighbor {{ bgp_peer['name'] }} update-source {{ bgp_peer['source'] }}
+{% endif %}
+{% endfor %}
+{% for bgp_peer in BGP_PEER_RANGE.values() %}
+{% if bgp_peer.has_key('ip_range') %}
+{% for iplist in bgp_peer['ip_range'] %}
+{% if iplist %}
+ neighbor {{ iplist }} peer-group {{ bgp_peer['name'] }}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endblock bgp_peers_with_range %}
+!
 ! end of template: bgpd/bgpd.main.conf.j2
 !


### PR DESCRIPTION
Signed-off-by: tim-rj <sonic_rd@ruijie.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
BGP_ROUTEMAPS is not translated into FRR configuration
**- How I did it**
Add support for BGP_ROUTEMAPS & BGP_PEER_RANGE
**- How to verify it**
Check BGP_ROUTEMAPS configuration via show route-map
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
root@switch2:/home/admin# show route-map
ZEBRA:
...
route-map: From-LC Invoked: 0
 permit, sequence 5 Invoked 0
  Match clauses:
    community 20
  Set clauses:
  Call clause:
  Action:
    Exit routemap
route-map: SetComm-1/1 Invoked: 0
 permit, sequence 5 Invoked 0
  Match clauses:
  Set clauses:
    community 1:1
    metric 1000
  Call clause:
  Action:
    Exit routemap
route-map: SetComm-1/2 Invoked: 0
 permit, sequence 5 Invoked 0
  Match clauses:
  Set clauses:
    community 1:2
    metric 1000
  Call clause:
  Action:
    Exit routemap
route-map: SetComm-1/4 Invoked: 0
 permit, sequence 5 Invoked 0
  Match clauses:
  Set clauses:
    community 1:4
    metric 1000
  Call clause:
  Action:
    Exit routemap
route-map: SetComm-HostRoute Invoked: 0
 permit, sequence 5 Invoked 0
  Match clauses:
  Set clauses:
    community 1:8005
    metric 1000
  Call clause:
  Action:
    Exit routemap
route-map: To-LC Invoked: 0
 permit, sequence 5 Invoked 0
  Match clauses:
    community 10
  Set clauses:
  Call clause:
  Action:
    Exit routemap
```

**- A picture of a cute animal (not mandatory but encouraged)**
