### PR TITLE
[201911] Fix the frr start.sh jinja2 exception during docker start:

### DIFF
--- a/dockers/docker-fpm-frr/start.sh
+++ b/dockers/docker-fpm-frr/start.sh
@@ -57,7 +57,7 @@ rm -f /var/run/rsyslogd.pid
 supervisorctl start rsyslogd
 
 # start eoiu pulling, only if configured so
-if [[ $(sonic-cfggen -d -v 'WARM_RESTART.bgp.bgp_eoiu') == 'true' ]]; then
+if [[ $(sonic-cfggen -d -v 'WARM_RESTART.bgp.bgp_eoiu if WARM_RESTART and WARM_RESTART.bgp and WARM_RESTART.bgp.bgp_eoiu') == 'true' ]]; then
     supervisorctl start bgp_eoiu_marker
 fi
 


### PR DESCRIPTION
Fix the below frr start.sh jinja2 exception in 201911 image syslog during docker start:
   
File "/usr/local/bin/sonic-cfggen", line 380, in <module>
     main()
   File "/usr/local/bin/sonic-cfggen", line 354, in main
     print(template.render(data))
   File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 1090, in render
     self.environment.handle_exception()
   File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 832, in handle_exception
     reraise(*rewrite_traceback_stack(source=source))
   File "<template>", line 1, in top-level template code
   File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 471, in getattr
     return getattr(obj, attribute)
 jinja2.exceptions.UndefinedError: 'WARM_RESTART' is undefined

**- How to verify it**
a) Made sure when WARM_RESTART is not there the exception is not generated.
b) If WARM_RESTART.bgp.bgp_eoiu is define it is processed correctly.

root@str-s6000-on-2:/# sonic-cfggen -d -v 'WARM_RESTART.bgp.bgp_eoiu if WARM_RESTART and WARM_RESTART.bgp and WARM_RESTART.bgp.bgp_eoiu'
true