### PR TITLE
+ Modified buffer config template to include internal ASIC with 5m ca…

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -34,6 +34,7 @@ def
 {%- else %}
     {%- set ports2cable = {
             'torrouter_server'       : '5m',
+            'internal'               : '5m',
             'leafrouter_torrouter'   : '40m',
             'spinerouter_leafrouter' : '300m'
             }
@@ -47,10 +48,14 @@ def
             {%- if DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[local_port].name] %}
                 {%- set neighbor = DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[local_port].name] %}
                 {%- set neighbor_role = neighbor.type %}
-                {%- set roles1 = switch_role + '_' + neighbor_role %}
-                {%- set roles2 = neighbor_role + '_' + switch_role %}
-                {%- set roles1 = roles1 | lower %}
-                {%- set roles2 = roles2 | lower %}
+                {%- 'asic' == neighbor_role | lower %}
+                         {%- set roles1 = 'internal' %}
+                {%- else %}
+                         {%- set roles1 = switch_role + '_' + neighbor_role %}
+                         {%- set roles2 = neighbor_role + '_' + switch_role %}
+                         {%- set roles1 = roles1 | lower %}
+                         {%- set roles2 = roles2 | lower %}
+                {%- endif %}
                 {%- if roles1 in ports2cable %}
                     {%- if cable_len.append(ports2cable[roles1]) %}{% endif %}
                 {%- elif roles2 in ports2cable %}

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -48,7 +48,7 @@ def
             {%- if DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[local_port].name] %}
                 {%- set neighbor = DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[local_port].name] %}
                 {%- set neighbor_role = neighbor.type %}
-                {%- 'asic' == neighbor_role | lower %}
+                {%- if 'asic' == neighbor_role | lower %}
                          {%- set roles1 = 'internal' %}
                 {%- else %}
                          {%- set roles1 = switch_role + '_' + neighbor_role %}

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -57,6 +57,8 @@ def sort_by_port_index(value):
     if not value:
         return
     if isinstance(value, list):
+        # In multi-ASIC platforms backend ethernet ports are identified as 
+        # 'Ethernet-BPxy'. Add 1024 to sort backend ports to the end.
         value.sort(
             key = lambda k: int(k[8:]) if "BP" not in k else int(k[11:]) + 1024
         )

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -57,7 +57,9 @@ def sort_by_port_index(value):
     if not value:
         return
     if isinstance(value, list):
-        value.sort(key = lambda k: int(k[8:]))
+        value.sort(
+            key = lambda k: int(k[8:]) if "BP" not in k else int(k[11:]) + 1024
+        )
 
 def is_ipv4(value):
     if not value:

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -4,6 +4,7 @@ import subprocess
 import os
 import json
 import yaml
+import shutil
 
 SKU = 'multi-npu-01'
 ASIC_SKU = 'multi-npu-asic'
@@ -274,3 +275,47 @@ class TestMultiNpuCfgGen(TestCase):
                                       "Loopback0|FC00:1::32/128": {},
                                       "Loopback4096|8.0.0.5/32": {},
                                       "Loopback4096|FD00:4::32/128": {}})
+
+    def test_buffers_multi_asic_template(self):
+        build_root_dir = os.path.join(
+            self.test_dir, "..", "..", ".."
+        )
+        # using Trident2 buffer configuration
+        device_config_dir = os.path.join(
+            build_root_dir,
+            "device",
+            "arista",
+            "x86_64-arista_7050_qx32",
+            "Arista-7050-QX32"
+        )
+        device_buffer_template = os.path.join(
+            device_config_dir, "buffers.json.j2"
+        )
+        buffer_template = os.path.join(
+            build_root_dir, "files", "build_templates", "buffers_config.j2"
+        )
+        port_config_ini_asic0 = os.path.join(
+            self.test_data_dir, "sample_port_config-0.ini"
+        )
+        # asic0 - mix of front end and back end ports
+        shutil.copy2(buffer_template, device_config_dir)
+        argument = "-m {} -p {} -n asic0 -t {}".format(
+            self.sample_graph, port_config_ini_asic0, device_buffer_template
+        )
+        output = json.loads(self.run_script(argument))
+        os.remove(os.path.join(device_config_dir, "buffers_config.j2"))
+        self.assertDictEqual(
+            output['CABLE_LENGTH'],
+            {
+                'AZURE': {
+                    'Ethernet8': '300m',
+                    'Ethernet0': '300m',
+                    'Ethernet4': '300m',
+                    'Ethernet-BP4': '5m',
+                    'Ethernet-BP0': '5m',
+                    'Ethernet-BP12': '5m',
+                    'Ethernet-BP8': '5m',
+                    'Ethernet12': '300m'
+                }
+            }
+        )


### PR DESCRIPTION
**- Why I did it**

To support buffer config generation for multi ASIC platform. The cable length used to select buffer profile is determined by the role of local and peer switch. In case of multi ASIC platforms cable length needs to determined between ASICs.

**- How I did it**

Added a new role called "internal" with a cable length of "5m". The role becomes "internal" if one of the ASICs in the pair is defined as 'internal' in minigraph.

**- How to verify it**

Verified config generation on multi-ASIC and single ASIC platforms. Sent traffic with different priorities, verified the queue counters. Visual confirmation of buffer configuration values. 

```

admin@str-nSonic-acs-2:/etc/sonic$ grep "Ethernet-BP..|3-4" config_db0.json -A2
        "Ethernet-BP12|3-4": {
            "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
        },
--
        "Ethernet-BP16|3-4": {
            "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
        },
--
        "Ethernet-BP20|3-4": {
            "profile": "[BUFFER_PROFILE|pg_lossless_40000_5m_profile]"
        },
--
.
.


admin@str-nSonic-acs-2:~$ sudo ip netns exec asic0 show mmu
Pool: ingress_lossless_pool
----  --------
type  ingress
mode  dynamic
size  12766208
----  --------

Pool: egress_lossless_pool
----  --------
type  egress
mode  static
size  12766208
----  --------

Pool: egress_lossy_pool
----  -------
type  egress
mode  dynamic
size  7326924
----  -------

Profile: pg_lossless_40000_300m_profile
----------  -----------------------------------
xon_offset  2496
dynamic_th  -3
xon         18432
xoff        55120
pool        [BUFFER_POOL|ingress_lossless_pool]
size        56368
----------  -----------------------------------

Profile: pg_lossless_40000_5m_profile
----------  -----------------------------------
xon_offset  2496
dynamic_th  -3
xon         18432
xoff        55120
pool        [BUFFER_POOL|ingress_lossless_pool]
size        56368
----------  -----------------------------------

Profile: egress_lossy_profile
----------  -------------------------------
dynamic_th  3
pool        [BUFFER_POOL|egress_lossy_pool]
size        1518
----------  -------------------------------

Profile: ingress_lossy_profile
----------  -----------------------------------
dynamic_th  3
pool        [BUFFER_POOL|ingress_lossless_pool]
size        0
----------  -----------------------------------

Profile: egress_lossless_profile
---------  ----------------------------------
static_th  12766208
pool       [BUFFER_POOL|egress_lossless_pool]
size       0
---------  ----------------------------------

```

**- Description for the changelog**

Modified the 'buffers_config' template to generate cable length between internal ASICs.

Modified sort API to account for internal interfaces that are named as "Ethernet-BPx".


**- A picture of a cute animal (not mandatory but encouraged)**
