### PR TITLE
[docker-vs] Install dependencies for testing DPB

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -57,7 +57,7 @@ RUN pip install urllib3
 RUN pip install requests
 RUN pip install crontab
 
-# Get package to support Dynamic Port Breakout
+# Install dependencies for Dynamic Port Breakout
 RUN pip install xmltodict==0.12.0
 RUN pip install jsondiff==1.2.0
 

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -57,6 +57,10 @@ RUN pip install urllib3
 RUN pip install requests
 RUN pip install crontab
 
+# Get package to support Dynamic Port Breakout
+RUN pip install xmltodict==0.12.0
+RUN pip install jsondiff==1.2.0
+
 {% if docker_sonic_vs_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {%- for deb in docker_sonic_vs_debs.split(' ') %}


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**- Why I did it**
Added **xmltodict** and **jsondiff** packages needed to run vs test cases successfully for DPB.

[sonic-utilities PR #766](https://github.com/Azure/sonic-utilities/pull/766) has a dependency on it.
Getting   [error](https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/sonic-utilities-build-pr/1753/testReport/junit/test_crm/TestCrm/test_CrmIpv6Route/) without this fix

**- How I did it**
Added necessary packages into Dockerfile for vs docker.

**- How to verify it**

