### PR TITLE
[submodule update]: Use 201811 branch of sonic-quagga

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 [submodule "quagga"]
 	path = src/sonic-quagga
 	url = https://github.com/Azure/sonic-quagga
-	branch = debian/0.99.24.1
+	branch = 201811
 [submodule "sonic-dbsyncd"]
 	path = src/sonic-dbsyncd
 	url = https://github.com/Azure/sonic-dbsyncd


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
sonic-quagga using utility from master branch of sonic-buildimage. I had to create 201811 branch in sonic-quagga which could work with 201811 branch of sonic-buildimage.

**- How I did it**
1. Created new branch for quagga
2. Update submodule

**- How to verify it**
Build new image and run on your dut

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
