### PR TITLE
[devices] Update SFP keys to align with new standard

### DIFF
--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/sfp.py
@@ -195,7 +195,7 @@ class Sfp(SfpBase):
             self.port_to_eeprom_mapping[p_num] = eeprom_path.format(
                 self.port_to_i2c_mapping[p_num])
 
-        self.info_dict_keys = ['type', 'hardwarerev', 'serialnum', 'manufacturename', 'modelname', 'Connector', 'encoding', 'ext_identifier',
+        self.info_dict_keys = ['type', 'hardware_rev', 'serial', 'manufacturer', 'model', 'connector', 'encoding', 'ext_identifier',
                                'ext_rateselect_compliance', 'cable_type', 'cable_length', 'nominal_bit_rate', 'specification_compliance', 'vendor_date', 'vendor_oui']
 
         self.dom_dict_keys = ['rx_los', 'tx_fault', 'reset_status', 'power_lpmode', 'tx_disable', 'tx_disable_channel', 'temperature', 'voltage',
@@ -308,11 +308,11 @@ class Sfp(SfpBase):
         keys                       |Value Format   |Information
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
-        hardwarerev                |1*255VCHAR     |hardware version of SFP
-        serialnum                  |1*255VCHAR     |serial number of the SFP
-        manufacturename            |1*255VCHAR     |SFP vendor name
-        modelname                  |1*255VCHAR     |SFP model name
-        Connector                  |1*255VCHAR     |connector information
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
         encoding                   |1*255VCHAR     |encoding information
         ext_identifier             |1*255VCHAR     |extend identifier
         ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance
@@ -371,17 +371,17 @@ class Sfp(SfpBase):
 
         if sfp_interface_bulk_data:
             transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['Connector'] = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['connector'] = sfp_interface_bulk_data['data']['Connector']['value']
             transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
             transceiver_info_dict['type_abbrv_name'] = sfp_interface_bulk_data['data']['type_abbrv_name']['value']
 
-        transceiver_info_dict['manufacturename'] = sfp_vendor_name_data[
+        transceiver_info_dict['manufacturer'] = sfp_vendor_name_data[
             'data']['Vendor Name']['value'] if sfp_vendor_name_data else 'N/A'
-        transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value'] if sfp_vendor_pn_data else 'N/A'
-        transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value'] if sfp_vendor_rev_data else 'N/A'
-        transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value'] if sfp_vendor_sn_data else 'N/A'
+        transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value'] if sfp_vendor_pn_data else 'N/A'
+        transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value'] if sfp_vendor_rev_data else 'N/A'
+        transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value'] if sfp_vendor_sn_data else 'N/A'
         transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value'] if sfp_vendor_oui_data else 'N/A'
         transceiver_info_dict['vendor_date'] = sfp_vendor_date_data[
             'data']['VendorDataCode(YYYY-MM-DD Lot)']['value'] if sfp_vendor_date_data else 'N/A'
@@ -562,11 +562,11 @@ class Sfp(SfpBase):
         keys                       |Value Format   |Information
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
-        hardwarerev                |1*255VCHAR     |hardware version of SFP
-        serialnum                  |1*255VCHAR     |serial number of the SFP
-        manufacturename            |1*255VCHAR     |SFP vendor name
-        modelname                  |1*255VCHAR     |SFP model name
-        Connector                  |1*255VCHAR     |connector information
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
         encoding                   |1*255VCHAR     |encoding information
         ext_identifier             |1*255VCHAR     |extend identifier
         ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance
@@ -625,17 +625,17 @@ class Sfp(SfpBase):
 
         if sfp_interface_bulk_data:
             transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['Connector'] = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['connector'] = sfp_interface_bulk_data['data']['Connector']['value']
             transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
             transceiver_info_dict['type_abbrv_name'] = sfp_interface_bulk_data['data']['type_abbrv_name']['value']
 
-        transceiver_info_dict['manufacturename'] = sfp_vendor_name_data[
+        transceiver_info_dict['manufacturer'] = sfp_vendor_name_data[
             'data']['Vendor Name']['value'] if sfp_vendor_name_data else 'N/A'
-        transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value'] if sfp_vendor_pn_data else 'N/A'
-        transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value'] if sfp_vendor_rev_data else 'N/A'
-        transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value'] if sfp_vendor_sn_data else 'N/A'
+        transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value'] if sfp_vendor_pn_data else 'N/A'
+        transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value'] if sfp_vendor_rev_data else 'N/A'
+        transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value'] if sfp_vendor_sn_data else 'N/A'
         transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value'] if sfp_vendor_oui_data else 'N/A'
         transceiver_info_dict['vendor_date'] = sfp_vendor_date_data[
             'data']['VendorDataCode(YYYY-MM-DD Lot)']['value'] if sfp_vendor_date_data else 'N/A'
@@ -1121,7 +1121,7 @@ class Sfp(SfpBase):
             string: Model/part number of device
         """
         transceiver_dom_info_dict = self.get_transceiver_info()
-        return transceiver_dom_info_dict.get("modelname", "N/A")
+        return transceiver_dom_info_dict.get("model", "N/A")
 
     def get_serial(self):
         """
@@ -1130,4 +1130,4 @@ class Sfp(SfpBase):
             string: Serial number of device
         """
         transceiver_dom_info_dict = self.get_transceiver_info()
-        return transceiver_dom_info_dict.get("serialnum", "N/A")
+        return transceiver_dom_info_dict.get("serial", "N/A")

--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/sfp.py
@@ -105,7 +105,7 @@ class Sfp(SfpBase):
             self.port_to_eeprom_mapping[x] = eeprom_path.format(
                 self.port_to_i2c_mapping[x])
 
-        self.info_dict_keys = ['type', 'hardwarerev', 'serialnum', 'manufacturename', 'modelname', 'Connector', 'encoding', 'ext_identifier',
+        self.info_dict_keys = ['type', 'hardware_rev', 'serial', 'manufacturer', 'model', 'connector', 'encoding', 'ext_identifier',
                                'ext_rateselect_compliance', 'cable_type', 'cable_length', 'nominal_bit_rate', 'specification_compliance', 'vendor_date', 'vendor_oui']
 
         self.dom_dict_keys = ['rx_los', 'tx_fault', 'reset_status', 'power_lpmode', 'tx_disable', 'tx_disable_channel', 'temperature', 'voltage',
@@ -185,11 +185,11 @@ class Sfp(SfpBase):
         keys                       |Value Format   |Information
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
-        hardwarerev                |1*255VCHAR     |hardware version of SFP
-        serialnum                  |1*255VCHAR     |serial number of the SFP
-        manufacturename            |1*255VCHAR     |SFP vendor name
-        modelname                  |1*255VCHAR     |SFP model name
-        Connector                  |1*255VCHAR     |connector information
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
         encoding                   |1*255VCHAR     |encoding information
         ext_identifier             |1*255VCHAR     |extend identifier
         ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance
@@ -248,17 +248,17 @@ class Sfp(SfpBase):
 
         if sfp_interface_bulk_data:
             transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['Connector'] = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['connector'] = sfp_interface_bulk_data['data']['Connector']['value']
             transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
             transceiver_info_dict['type_abbrv_name'] = sfp_interface_bulk_data['data']['type_abbrv_name']['value']
 
-        transceiver_info_dict['manufacturename'] = sfp_vendor_name_data[
+        transceiver_info_dict['manufacturer'] = sfp_vendor_name_data[
             'data']['Vendor Name']['value'] if sfp_vendor_name_data else 'N/A'
-        transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value'] if sfp_vendor_pn_data else 'N/A'
-        transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value'] if sfp_vendor_rev_data else 'N/A'
-        transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value'] if sfp_vendor_sn_data else 'N/A'
+        transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value'] if sfp_vendor_pn_data else 'N/A'
+        transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value'] if sfp_vendor_rev_data else 'N/A'
+        transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value'] if sfp_vendor_sn_data else 'N/A'
         transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value'] if sfp_vendor_oui_data else 'N/A'
         transceiver_info_dict['vendor_date'] = sfp_vendor_date_data[
             'data']['VendorDataCode(YYYY-MM-DD Lot)']['value'] if sfp_vendor_date_data else 'N/A'
@@ -705,7 +705,7 @@ class Sfp(SfpBase):
             string: Model/part number of device
         """
         transceiver_dom_info_dict = self.get_transceiver_info()
-        return transceiver_dom_info_dict.get("modelname", "N/A")
+        return transceiver_dom_info_dict.get("model", "N/A")
 
     def get_serial(self):
         """
@@ -714,4 +714,4 @@ class Sfp(SfpBase):
             string: Serial number of device
         """
         transceiver_dom_info_dict = self.get_transceiver_info()
-        return transceiver_dom_info_dict.get("serialnum", "N/A")
+        return transceiver_dom_info_dict.get("serial", "N/A")

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
@@ -193,7 +193,7 @@ class Sfp(SfpBase):
             port_eeprom_path = eeprom_path.format(self.port_to_i2c_mapping[x])
             self.port_to_eeprom_mapping[x] = port_eeprom_path
 
-        self.info_dict_keys = ['type', 'hardwarerev', 'serialnum', 'manufacturename', 'modelname', 'Connector', 'encoding', 'ext_identifier',
+        self.info_dict_keys = ['type', 'hardware_rev', 'serial', 'manufacturer', 'model', 'connector', 'encoding', 'ext_identifier',
                                'ext_rateselect_compliance', 'cable_type', 'cable_length', 'nominal_bit_rate', 'specification_compliance', 'vendor_date', 'vendor_oui']
 
         self.dom_dict_keys = ['rx_los', 'tx_fault', 'reset_status', 'power_lpmode', 'tx_disable', 'tx_disable_channel', 'temperature', 'voltage',
@@ -373,11 +373,11 @@ class Sfp(SfpBase):
         keys                       |Value Format   |Information
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
-        hardwarerev                |1*255VCHAR     |hardware version of SFP
-        serialnum                  |1*255VCHAR     |serial number of the SFP
-        manufacturename            |1*255VCHAR     |SFP vendor name
-        modelname                  |1*255VCHAR     |SFP model name
-        Connector                  |1*255VCHAR     |connector information
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
         encoding                   |1*255VCHAR     |encoding information
         ext_identifier             |1*255VCHAR     |extend identifier
         ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance
@@ -444,13 +444,13 @@ class Sfp(SfpBase):
                 return None
 
             transceiver_info_dict['type'] = sfp_type_data['data']['type']['value']
-            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
             transceiver_info_dict['vendor_oui'] = 'N/A'
             transceiver_info_dict['vendor_date'] = 'N/A'
-            transceiver_info_dict['Connector'] = 'N/A'
+            transceiver_info_dict['connector'] = 'N/A'
             transceiver_info_dict['encoding'] = 'N/A'
             transceiver_info_dict['ext_identifier'] = 'N/A'
             transceiver_info_dict['ext_rateselect_compliance'] = 'N/A'
@@ -521,14 +521,14 @@ class Sfp(SfpBase):
             sfp_vendor_date_data = sfpi_obj.parse_vendor_date(
                 sfp_interface_bulk_raw[start: end], 0)
             transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
             transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value']
             transceiver_info_dict['vendor_date'] = sfp_vendor_date_data[
                 'data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
-            transceiver_info_dict['Connector'] = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['connector'] = sfp_interface_bulk_data['data']['Connector']['value']
             transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
@@ -1359,7 +1359,7 @@ class Sfp(SfpBase):
             string: Model/part number of device
         """
         transceiver_dom_info_dict = self.get_transceiver_info()
-        return transceiver_dom_info_dict.get("modelname", "N/A")
+        return transceiver_dom_info_dict.get("model", "N/A")
 
     def get_serial(self):
         """
@@ -1368,7 +1368,7 @@ class Sfp(SfpBase):
             string: Serial number of device
         """
         transceiver_dom_info_dict = self.get_transceiver_info()
-        return transceiver_dom_info_dict.get("serialnum", "N/A")
+        return transceiver_dom_info_dict.get("serial", "N/A")
 
     def get_status(self):
         """

--- a/device/celestica/x86_64-cel_silverstone-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_silverstone-r0/sonic_platform/sfp.py
@@ -228,7 +228,7 @@ class Sfp(SfpBase):
             port_eeprom_path = eeprom_path.format(self.port_to_i2c_mapping[x])
             self.port_to_eeprom_mapping[x] = port_eeprom_path
 
-        self.info_dict_keys = ['type', 'hardwarerev', 'serialnum', 'manufacturename', 'modelname', 'Connector', 'encoding', 'ext_identifier',
+        self.info_dict_keys = ['type', 'hardware_rev', 'serial', 'manufacturer', 'model', 'connector', 'encoding', 'ext_identifier',
                                'ext_rateselect_compliance', 'cable_type', 'cable_length', 'nominal_bit_rate', 'specification_compliance', 'vendor_date', 'vendor_oui']
 
         self.dom_dict_keys = ['rx_los', 'tx_fault', 'reset_status', 'power_lpmode', 'tx_disable', 'tx_disable_channel', 'temperature', 'voltage',
@@ -412,11 +412,11 @@ class Sfp(SfpBase):
         keys                       |Value Format   |Information
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
-        hardwarerev                |1*255VCHAR     |hardware version of SFP
-        serialnum                  |1*255VCHAR     |serial number of the SFP
-        manufacturename            |1*255VCHAR     |SFP vendor name
-        modelname                  |1*255VCHAR     |SFP model name
-        Connector                  |1*255VCHAR     |connector information
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
         encoding                   |1*255VCHAR     |encoding information
         ext_identifier             |1*255VCHAR     |extend identifier
         ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance
@@ -483,13 +483,13 @@ class Sfp(SfpBase):
                 return None
 
             transceiver_info_dict['type'] = sfp_type_data['data']['type']['value']
-            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
             transceiver_info_dict['vendor_oui'] = 'N/A'
             transceiver_info_dict['vendor_date'] = 'N/A'
-            transceiver_info_dict['Connector'] = 'N/A'
+            transceiver_info_dict['connector'] = 'N/A'
             transceiver_info_dict['encoding'] = 'N/A'
             transceiver_info_dict['ext_identifier'] = 'N/A'
             transceiver_info_dict['ext_rateselect_compliance'] = 'N/A'
@@ -562,14 +562,14 @@ class Sfp(SfpBase):
             sfp_vendor_date_data = sfpi_obj.parse_vendor_date(
                 sfp_interface_bulk_raw[start: end], 0)
             transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
             transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value']
             transceiver_info_dict['vendor_date'] = sfp_vendor_date_data[
                 'data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
-            transceiver_info_dict['Connector'] = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['connector'] = sfp_interface_bulk_data['data']['Connector']['value']
             transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
@@ -1447,7 +1447,7 @@ class Sfp(SfpBase):
             string: Model/part number of device
         """
         transceiver_dom_info_dict = self.get_transceiver_info()
-        return transceiver_dom_info_dict.get("modelname", "N/A")
+        return transceiver_dom_info_dict.get("model", "N/A")
 
     def get_serial(self):
         """
@@ -1456,7 +1456,7 @@ class Sfp(SfpBase):
             string: Serial number of device
         """
         transceiver_dom_info_dict = self.get_transceiver_info()
-        return transceiver_dom_info_dict.get("serialnum", "N/A")
+        return transceiver_dom_info_dict.get("serial", "N/A")
 
     def get_status(self):
         """

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -320,14 +320,14 @@ class SfpUtil(SfpUtilBase):
                 return None
 
             transceiver_info_dict['type'] = sfp_type_data['data']['type']['value']
-            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
             # Below part is added to avoid fail the xcvrd, shall be implemented later
             transceiver_info_dict['vendor_oui'] = 'N/A'
             transceiver_info_dict['vendor_date'] = 'N/A'
-            transceiver_info_dict['Connector'] = 'N/A'
+            transceiver_info_dict['connector'] = 'N/A'
             transceiver_info_dict['encoding'] = 'N/A'
             transceiver_info_dict['ext_identifier'] = 'N/A'
             transceiver_info_dict['ext_rateselect_compliance'] = 'N/A'
@@ -404,13 +404,13 @@ class SfpUtil(SfpUtilBase):
                 return None
 
             transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
             transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value']
             transceiver_info_dict['vendor_date'] = sfp_vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
-            transceiver_info_dict['Connector'] = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['connector'] = sfp_interface_bulk_data['data']['Connector']['value']
             transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/sfp.py
@@ -62,8 +62,8 @@ sfp_compliance_code_tup = ('10GEthernetComplianceCode', 'InfinibandComplianceCod
                            'FibreChannelTechnology', 'SFP+CableTechnology',
                            'FibreChannelTransmissionMedia', 'FibreChannelSpeed')
 
-info_dict_keys = ['type', 'hardwarerev', 'serialnum',
-                  'manufacturename', 'modelname', 'Connector',
+info_dict_keys = ['type', 'hardware_rev', 'serial',
+                  'manufacturer', 'model', 'connector',
                   'encoding', 'ext_identifier', 'ext_rateselect_compliance',
                   'cable_type', 'cable_length', 'nominal_bit_rate',
                   'specification_compliance', 'type_abbrv_name','vendor_date', 'vendor_oui']
@@ -102,7 +102,7 @@ sff8436_parser = {
 
        'cable_type': [QSFP_INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
      'cable_length': [QSFP_INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
-        'Connector': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
+        'connector': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
              'type': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
          'encoding': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
    'ext_identifier': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
@@ -112,11 +112,11 @@ sff8436_parser = {
  'specification_compliance':
                      [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
   'type_abbrv_name': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
-  'manufacturename': [QSFP_INFO_OFFSET, 20, 16, 'parse_vendor_name'],
+     'manufacturer': [QSFP_INFO_OFFSET, 20, 16, 'parse_vendor_name'],
        'vendor_oui': [QSFP_INFO_OFFSET, 37,  3, 'parse_vendor_oui'],
-        'modelname': [QSFP_INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
-      'hardwarerev': [QSFP_INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
-        'serialnum': [QSFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
+            'model': [QSFP_INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
+     'hardware_rev': [QSFP_INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
+           'serial': [QSFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
       'vendor_date': [QSFP_INFO_OFFSET, 84,  8, 'parse_vendor_date'],
    'dom_capability': [QSFP_INFO_OFFSET, 92,  1, 'parse_qsfp_dom_capability'],
           'dom_rev': [QSFP_DOM_OFFSET,   1,  1, 'parse_sfp_dom_rev'],
@@ -131,7 +131,7 @@ sff8472_parser = {
 
        'cable_type': [SFP_INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
      'cable_length': [SFP_INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
-        'Connector': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
+        'connector': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
              'type': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
          'encoding': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
    'ext_identifier': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
@@ -141,11 +141,11 @@ sff8472_parser = {
  'specification_compliance':
                      [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
   'type_abbrv_name': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
-  'manufacturename': [SFP_INFO_OFFSET, 20, 16, 'parse_vendor_name'],
+     'manufacturer': [SFP_INFO_OFFSET, 20, 16, 'parse_vendor_name'],
        'vendor_oui': [SFP_INFO_OFFSET,  37, 3, 'parse_vendor_oui'],
-        'modelname': [SFP_INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
-      'hardwarerev': [SFP_INFO_OFFSET, 56,  4, 'parse_vendor_rev'],
-        'serialnum': [SFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
+            'model': [SFP_INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
+     'hardware_rev': [SFP_INFO_OFFSET, 56,  4, 'parse_vendor_rev'],
+           'serial': [SFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
       'vendor_date': [SFP_INFO_OFFSET, 84,  8, 'parse_vendor_date'],
   'ModuleThreshold': [SFP_DOM_OFFSET,   0, 56, 'parse_alarm_warning_threshold'],
 }
@@ -321,7 +321,7 @@ class Sfp(SfpBase):
             return transceiver_info_dict
 
         # Vendor Name
-        vendor_name_data = self._get_eeprom_data('manufacturename')
+        vendor_name_data = self._get_eeprom_data('manufacturer')
         if (vendor_name_data is not None):
             vendor_name = vendor_name_data['data']['Vendor Name']['value']
         else:
@@ -335,21 +335,21 @@ class Sfp(SfpBase):
             return transceiver_info_dict
 
         # Vendor PN
-        vendor_pn_data = self._get_eeprom_data('modelname')
+        vendor_pn_data = self._get_eeprom_data('model')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
             return transceiver_info_dict
 
         # Vendor Revision
-        vendor_rev_data = self._get_eeprom_data('hardwarerev')
+        vendor_rev_data = self._get_eeprom_data('hardware_rev')
         if (vendor_rev_data is not None):
             vendor_rev = vendor_rev_data['data']['Vendor Rev']['value']
         else:
             return transceiver_info_dict
 
         # Vendor Serial Number
-        vendor_sn_data = self._get_eeprom_data('serialnum')
+        vendor_sn_data = self._get_eeprom_data('serial')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:
@@ -357,11 +357,11 @@ class Sfp(SfpBase):
 
         # Fill The Dictionary and return
         transceiver_info_dict['type'] = identifier
-        transceiver_info_dict['hardwarerev'] = vendor_rev
-        transceiver_info_dict['serialnum'] = vendor_sn
-        transceiver_info_dict['manufacturename'] = vendor_name
-        transceiver_info_dict['modelname'] = vendor_pn
-        transceiver_info_dict['Connector'] = connector
+        transceiver_info_dict['hardware_rev'] = vendor_rev
+        transceiver_info_dict['serial'] = vendor_sn
+        transceiver_info_dict['manufacturer'] = vendor_name
+        transceiver_info_dict['model'] = vendor_pn
+        transceiver_info_dict['connector'] = connector
         transceiver_info_dict['encoding'] = encoding
         transceiver_info_dict['ext_identifier'] = ext_id
         transceiver_info_dict['ext_rateselect_compliance'] = rate_identifier
@@ -557,7 +557,7 @@ class Sfp(SfpBase):
         """
         Retrieves the model number (or part number) of the sfp
         """
-        vendor_pn_data = self._get_eeprom_data('modelname')
+        vendor_pn_data = self._get_eeprom_data('model')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
@@ -569,7 +569,7 @@ class Sfp(SfpBase):
         """
         Retrieves the serial number of the sfp
         """
-        vendor_sn_data = self._get_eeprom_data('serialnum')
+        vendor_sn_data = self._get_eeprom_data('serial')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py
@@ -40,8 +40,8 @@ compliance_code_tup = (
     'Fibre Channel transmission media',
     'Fibre Channel Speed')
 
-info_dict_keys = ['type', 'hardwarerev', 'serialnum',
-                  'manufacturename', 'modelname', 'Connector',
+info_dict_keys = ['type', 'hardware_rev', 'serial',
+                  'manufacturer', 'model', 'connector',
                   'encoding', 'ext_identifier', 'ext_rateselect_compliance',
                   'cable_type', 'cable_length', 'nominal_bit_rate',
                   'specification_compliance', 'type_abbrv_name','vendor_date', 'vendor_oui']
@@ -78,7 +78,7 @@ sff8436_parser = {
 
        'cable_type': [INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
      'cable_length': [INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
-        'Connector': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
+        'connector': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
              'type': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
          'encoding': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
    'ext_identifier': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
@@ -87,12 +87,12 @@ sff8436_parser = {
  'nominal_bit_rate': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
  'specification_compliance':
                      [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
- 'type_abbrv_name' : [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
-  'manufacturename': [INFO_OFFSET, 20, 16, 'parse_vendor_name'],
+  'type_abbrv_name': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
+     'manufacturer': [INFO_OFFSET, 20, 16, 'parse_vendor_name'],
        'vendor_oui': [INFO_OFFSET,  37, 3, 'parse_vendor_oui'],
-        'modelname': [INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
-      'hardwarerev': [INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
-        'serialnum': [INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
+            'model': [INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
+     'hardware_rev': [INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
+           'serial': [INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
       'vendor_date': [INFO_OFFSET, 84,  8, 'parse_vendor_date'],
   'ModuleThreshold': [DOM_OFFSET1, 128, 24, 'parse_module_threshold_values'],
  'ChannelThreshold': [DOM_OFFSET1, 176, 16, 'parse_channel_threshold_values'],
@@ -208,7 +208,7 @@ class Sfp(SfpBase):
             return None
 
         # Vendor Name
-        vendor_name_data = self._get_eeprom_data('manufacturename')
+        vendor_name_data = self._get_eeprom_data('manufacturer')
         if (vendor_name_data is not None):
             vendor_name = vendor_name_data['data']['Vendor Name']['value']
         else:
@@ -222,21 +222,21 @@ class Sfp(SfpBase):
             return transceiver_info_dict
 
         # Vendor PN
-        vendor_pn_data = self._get_eeprom_data('modelname')
+        vendor_pn_data = self._get_eeprom_data('model')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
             return transceiver_info_dict
 
         # Vendor Revision
-        vendor_rev_data = self._get_eeprom_data('hardwarerev')
+        vendor_rev_data = self._get_eeprom_data('hardware_rev')
         if (vendor_rev_data is not None):
             vendor_rev = vendor_rev_data['data']['Vendor Rev']['value']
         else:
             return transceiver_info_dict
 
         # Vendor Serial Number
-        vendor_sn_data = self._get_eeprom_data('serialnum')
+        vendor_sn_data = self._get_eeprom_data('serial')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:
@@ -244,11 +244,11 @@ class Sfp(SfpBase):
 	
         # Fill The Dictionary and return
         transceiver_info_dict['type'] = identifier
-        transceiver_info_dict['hardwarerev'] = vendor_rev
-        transceiver_info_dict['serialnum'] = vendor_sn
-        transceiver_info_dict['manufacturename'] = vendor_name
-        transceiver_info_dict['modelname'] = vendor_pn
-        transceiver_info_dict['Connector'] = connector
+        transceiver_info_dict['hardware_rev'] = vendor_rev
+        transceiver_info_dict['serial'] = vendor_sn
+        transceiver_info_dict['manufacturer'] = vendor_name
+        transceiver_info_dict['model'] = vendor_pn
+        transceiver_info_dict['connector'] = connector
         transceiver_info_dict['encoding'] = encoding
         transceiver_info_dict['ext_identifier'] = ext_id
         transceiver_info_dict['ext_rateselect_compliance'] = rate_identifier
@@ -434,7 +434,7 @@ class Sfp(SfpBase):
         """
         Retrieves the model number (or part number) of the sfp
         """
-        vendor_pn_data = self._get_eeprom_data('modelname')
+        vendor_pn_data = self._get_eeprom_data('model')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
@@ -446,7 +446,7 @@ class Sfp(SfpBase):
         """
         Retrieves the serial number of the sfp
         """
-        vendor_sn_data = self._get_eeprom_data('serialnum')
+        vendor_sn_data = self._get_eeprom_data('serial')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/sfp.py
@@ -40,8 +40,8 @@ compliance_code_tup = (
     'Fibre Channel transmission media',
     'Fibre Channel Speed')
 
-info_dict_keys = ['type', 'hardwarerev', 'serialnum',
-                  'manufacturename', 'modelname', 'Connector',
+info_dict_keys = ['type', 'hardware_rev', 'serial',
+                  'manufacturer', 'model', 'connector',
                   'encoding', 'ext_identifier', 'ext_rateselect_compliance',
                   'cable_type', 'cable_length', 'nominal_bit_rate',
                   'specification_compliance', 'vendor_date', 'vendor_oui']
@@ -78,7 +78,7 @@ sff8436_parser = {
 
        'cable_type': [INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
      'cable_length': [INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
-        'Connector': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
+        'connector': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
              'type': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
          'encoding': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
    'ext_identifier': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
@@ -87,11 +87,11 @@ sff8436_parser = {
  'nominal_bit_rate': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
  'specification_compliance':
                      [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
-  'manufacturename': [INFO_OFFSET, 20, 16, 'parse_vendor_name'],
+     'manufacturer': [INFO_OFFSET, 20, 16, 'parse_vendor_name'],
        'vendor_oui': [INFO_OFFSET,  37, 3, 'parse_vendor_oui'],
-        'modelname': [INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
-      'hardwarerev': [INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
-        'serialnum': [INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
+            'model': [INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
+     'hardware_rev': [INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
+           'serial': [INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
       'vendor_date': [INFO_OFFSET, 84,  8, 'parse_vendor_date'],
   'ModuleThreshold': [DOM_OFFSET1, 128, 24, 'parse_module_threshold_values'],
  'ChannelThreshold': [DOM_OFFSET1, 176, 16, 'parse_channel_threshold_values'],
@@ -205,7 +205,7 @@ class Sfp(SfpBase):
             return transceiver_info_dict
 
         # Vendor Name
-        vendor_name_data = self._get_eeprom_data('manufacturename')
+        vendor_name_data = self._get_eeprom_data('manufacturer')
         if (vendor_name_data is not None):
             vendor_name = vendor_name_data['data']['Vendor Name']['value']
         else:
@@ -219,21 +219,21 @@ class Sfp(SfpBase):
             return transceiver_info_dict
 
         # Vendor PN
-        vendor_pn_data = self._get_eeprom_data('modelname')
+        vendor_pn_data = self._get_eeprom_data('model')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
             return transceiver_info_dict
 
         # Vendor Revision
-        vendor_rev_data = self._get_eeprom_data('hardwarerev')
+        vendor_rev_data = self._get_eeprom_data('hardware_rev')
         if (vendor_rev_data is not None):
             vendor_rev = vendor_rev_data['data']['Vendor Rev']['value']
         else:
             return transceiver_info_dict
 
         # Vendor Serial Number
-        vendor_sn_data = self._get_eeprom_data('serialnum')
+        vendor_sn_data = self._get_eeprom_data('serial')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:
@@ -241,11 +241,11 @@ class Sfp(SfpBase):
 
         # Fill The Dictionary and return
         transceiver_info_dict['type'] = identifier
-        transceiver_info_dict['hardwarerev'] = vendor_rev
-        transceiver_info_dict['serialnum'] = vendor_sn
-        transceiver_info_dict['manufacturename'] = vendor_name
-        transceiver_info_dict['modelname'] = vendor_pn
-        transceiver_info_dict['Connector'] = connector
+        transceiver_info_dict['hardware_rev'] = vendor_rev
+        transceiver_info_dict['serial'] = vendor_sn
+        transceiver_info_dict['manufacturer'] = vendor_name
+        transceiver_info_dict['model'] = vendor_pn
+        transceiver_info_dict['connector'] = connector
         transceiver_info_dict['encoding'] = encoding
         transceiver_info_dict['ext_identifier'] = ext_id
         transceiver_info_dict['ext_rateselect_compliance'] = rate_identifier
@@ -436,7 +436,7 @@ class Sfp(SfpBase):
         """
         Retrieves the model number (or part number) of the sfp
         """
-        vendor_pn_data = self._get_eeprom_data('modelname')
+        vendor_pn_data = self._get_eeprom_data('model')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
@@ -448,7 +448,7 @@ class Sfp(SfpBase):
         """
         Retrieves the serial number of the sfp
         """
-        vendor_sn_data = self._get_eeprom_data('serialnum')
+        vendor_sn_data = self._get_eeprom_data('serial')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/sfp.py
@@ -40,8 +40,8 @@ compliance_code_tup = (
     'Fibre Channel transmission media',
     'Fibre Channel Speed')
 
-info_dict_keys = ['type', 'hardwarerev', 'serialnum',
-                  'manufacturename', 'modelname', 'Connector',
+info_dict_keys = ['type', 'hardware_rev', 'serial',
+                  'manufacturer', 'model', 'connector',
                   'encoding', 'ext_identifier', 'ext_rateselect_compliance',
                   'cable_type', 'cable_length', 'nominal_bit_rate',
                   'specification_compliance','type_abbrv_name','vendor_date', 'vendor_oui']
@@ -78,7 +78,7 @@ sff8436_parser = {
 
        'cable_type': [INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
      'cable_length': [INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
-        'Connector': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
+        'connector': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
              'type': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
          'encoding': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
    'ext_identifier': [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
@@ -88,11 +88,11 @@ sff8436_parser = {
  'specification_compliance':
                      [INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
  'type_abbrv_name': [INFO_OFFSET,  0,  20, 'parse_sfp_info_bulk'],
-  'manufacturename': [INFO_OFFSET, 20, 16, 'parse_vendor_name'],
+     'manufacturer': [INFO_OFFSET, 20, 16, 'parse_vendor_name'],
        'vendor_oui': [INFO_OFFSET,  37, 3, 'parse_vendor_oui'],
-        'modelname': [INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
-      'hardwarerev': [INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
-        'serialnum': [INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
+            'model': [INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
+     'hardware_rev': [INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
+           'serial': [INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
       'vendor_date': [INFO_OFFSET, 84,  8, 'parse_vendor_date'],
   'ModuleThreshold': [DOM_OFFSET1, 128, 24, 'parse_module_threshold_values'],
  'ChannelThreshold': [DOM_OFFSET1, 176, 16, 'parse_channel_threshold_values'],
@@ -207,7 +207,7 @@ class Sfp(SfpBase):
             return transceiver_info_dict
 
         # Vendor Name
-        vendor_name_data = self._get_eeprom_data('manufacturename')
+        vendor_name_data = self._get_eeprom_data('manufacturer')
         if (vendor_name_data is not None):
             vendor_name = vendor_name_data['data']['Vendor Name']['value']
         else:
@@ -221,21 +221,21 @@ class Sfp(SfpBase):
             return transceiver_info_dict
 
         # Vendor PN
-        vendor_pn_data = self._get_eeprom_data('modelname')
+        vendor_pn_data = self._get_eeprom_data('model')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
             return transceiver_info_dict
 
         # Vendor Revision
-        vendor_rev_data = self._get_eeprom_data('hardwarerev')
+        vendor_rev_data = self._get_eeprom_data('hardware_rev')
         if (vendor_rev_data is not None):
             vendor_rev = vendor_rev_data['data']['Vendor Rev']['value']
         else:
             return transceiver_info_dict
 
         # Vendor Serial Number
-        vendor_sn_data = self._get_eeprom_data('serialnum')
+        vendor_sn_data = self._get_eeprom_data('serial')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:
@@ -243,11 +243,11 @@ class Sfp(SfpBase):
 
         # Fill The Dictionary and return
         transceiver_info_dict['type'] = identifier
-        transceiver_info_dict['hardwarerev'] = vendor_rev
-        transceiver_info_dict['serialnum'] = vendor_sn
-        transceiver_info_dict['manufacturename'] = vendor_name
-        transceiver_info_dict['modelname'] = vendor_pn
-        transceiver_info_dict['Connector'] = connector
+        transceiver_info_dict['hardware_rev'] = vendor_rev
+        transceiver_info_dict['serial'] = vendor_sn
+        transceiver_info_dict['manufacturer'] = vendor_name
+        transceiver_info_dict['model'] = vendor_pn
+        transceiver_info_dict['connector'] = connector
         transceiver_info_dict['encoding'] = encoding
         transceiver_info_dict['ext_identifier'] = ext_id
         transceiver_info_dict['ext_rateselect_compliance'] = rate_identifier
@@ -436,7 +436,7 @@ class Sfp(SfpBase):
         """
         Retrieves the model number (or part number) of the sfp
         """
-        vendor_pn_data = self._get_eeprom_data('modelname')
+        vendor_pn_data = self._get_eeprom_data('model')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
@@ -448,7 +448,7 @@ class Sfp(SfpBase):
         """
         Retrieves the serial number of the sfp
         """
-        vendor_sn_data = self._get_eeprom_data('serialnum')
+        vendor_sn_data = self._get_eeprom_data('serial')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/sfp.py
@@ -66,8 +66,8 @@ sfp_compliance_code_tup = ('10GEthernetComplianceCode', 'InfinibandComplianceCod
                            'FibreChannelTechnology', 'SFP+CableTechnology',
                            'FibreChannelTransmissionMedia', 'FibreChannelSpeed')
 
-info_dict_keys = ['type', 'hardwarerev', 'serialnum',
-                  'manufacturename', 'modelname', 'Connector',
+info_dict_keys = ['type', 'hardware_rev', 'serial',
+                  'manufacturer', 'model', 'connector',
                   'encoding', 'ext_identifier', 'ext_rateselect_compliance',
                   'cable_type', 'cable_length', 'nominal_bit_rate',
                   'specification_compliance', 'type_abbrv_name','vendor_date', 'vendor_oui']
@@ -106,7 +106,7 @@ sff8436_parser = {
 
        'cable_type': [QSFP_INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
      'cable_length': [QSFP_INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
-        'Connector': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
+        'connector': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
              'type': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
          'encoding': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
    'ext_identifier': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
@@ -116,11 +116,11 @@ sff8436_parser = {
  'specification_compliance':
                      [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
   'type_abbrv_name': [QSFP_INFO_OFFSET,  0, 20, 'parse_sfp_info_bulk'],
-  'manufacturename': [QSFP_INFO_OFFSET, 20, 16, 'parse_vendor_name'],
+     'manufacturer': [QSFP_INFO_OFFSET, 20, 16, 'parse_vendor_name'],
        'vendor_oui': [QSFP_INFO_OFFSET, 37,  3, 'parse_vendor_oui'],
-        'modelname': [QSFP_INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
-      'hardwarerev': [QSFP_INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
-        'serialnum': [QSFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
+            'model': [QSFP_INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
+     'hardware_rev': [QSFP_INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
+           'serial': [QSFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
       'vendor_date': [QSFP_INFO_OFFSET, 84,  8, 'parse_vendor_date'],
    'dom_capability': [QSFP_INFO_OFFSET, 92,  1, 'parse_qsfp_dom_capability'],
           'dom_rev': [QSFP_DOM_OFFSET,   1,  1, 'parse_sfp_dom_rev'],
@@ -135,7 +135,7 @@ sff8472_parser = {
 
        'cable_type': [SFP_INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
      'cable_length': [SFP_INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
-        'Connector': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
+        'connector': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
              'type': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
          'encoding': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
    'ext_identifier': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
@@ -145,11 +145,11 @@ sff8472_parser = {
  'specification_compliance':
                      [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
   'type_abbrv_name': [SFP_INFO_OFFSET,  0, 21, 'parse_sfp_info_bulk'],
-  'manufacturename': [SFP_INFO_OFFSET, 20, 16, 'parse_vendor_name'],
+     'manufacturer': [SFP_INFO_OFFSET, 20, 16, 'parse_vendor_name'],
        'vendor_oui': [SFP_INFO_OFFSET,  37, 3, 'parse_vendor_oui'],
-        'modelname': [SFP_INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
-      'hardwarerev': [SFP_INFO_OFFSET, 56,  4, 'parse_vendor_rev'],
-        'serialnum': [SFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
+            'model': [SFP_INFO_OFFSET, 40, 16, 'parse_vendor_pn'],
+     'hardware_rev': [SFP_INFO_OFFSET, 56,  4, 'parse_vendor_rev'],
+           'serial': [SFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
       'vendor_date': [SFP_INFO_OFFSET, 84,  8, 'parse_vendor_date'],
   'ModuleThreshold': [SFP_DOM_OFFSET,   0, 56, 'parse_alarm_warning_threshold'],
 }
@@ -326,7 +326,7 @@ class Sfp(SfpBase):
             return transceiver_info_dict
 
         # Vendor Name
-        vendor_name_data = self._get_eeprom_data('manufacturename')
+        vendor_name_data = self._get_eeprom_data('manufacturer')
         if (vendor_name_data is not None):
             vendor_name = vendor_name_data['data']['Vendor Name']['value']
         else:
@@ -340,21 +340,21 @@ class Sfp(SfpBase):
             return transceiver_info_dict
 
         # Vendor PN
-        vendor_pn_data = self._get_eeprom_data('modelname')
+        vendor_pn_data = self._get_eeprom_data('model')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
             return transceiver_info_dict
 
         # Vendor Revision
-        vendor_rev_data = self._get_eeprom_data('hardwarerev')
+        vendor_rev_data = self._get_eeprom_data('hardware_rev')
         if (vendor_rev_data is not None):
             vendor_rev = vendor_rev_data['data']['Vendor Rev']['value']
         else:
             return transceiver_info_dict
 
         # Vendor Serial Number
-        vendor_sn_data = self._get_eeprom_data('serialnum')
+        vendor_sn_data = self._get_eeprom_data('serial')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:
@@ -362,11 +362,11 @@ class Sfp(SfpBase):
 
         # Fill The Dictionary and return
         transceiver_info_dict['type'] = identifier
-        transceiver_info_dict['hardwarerev'] = vendor_rev
-        transceiver_info_dict['serialnum'] = vendor_sn
-        transceiver_info_dict['manufacturename'] = vendor_name
-        transceiver_info_dict['modelname'] = vendor_pn
-        transceiver_info_dict['Connector'] = connector
+        transceiver_info_dict['hardware_rev'] = vendor_rev
+        transceiver_info_dict['serial'] = vendor_sn
+        transceiver_info_dict['manufacturer'] = vendor_name
+        transceiver_info_dict['model'] = vendor_pn
+        transceiver_info_dict['connector'] = connector
         transceiver_info_dict['encoding'] = encoding
         transceiver_info_dict['ext_identifier'] = ext_id
         transceiver_info_dict['ext_rateselect_compliance'] = rate_identifier
@@ -562,7 +562,7 @@ class Sfp(SfpBase):
         """
         Retrieves the model number (or part number) of the sfp
         """
-        vendor_pn_data = self._get_eeprom_data('modelname')
+        vendor_pn_data = self._get_eeprom_data('model')
         if (vendor_pn_data is not None):
             vendor_pn = vendor_pn_data['data']['Vendor PN']['value']
         else:
@@ -574,7 +574,7 @@ class Sfp(SfpBase):
         """
         Retrieves the serial number of the sfp
         """
-        vendor_sn_data = self._get_eeprom_data('serialnum')
+        vendor_sn_data = self._get_eeprom_data('serial')
         if (vendor_sn_data is not None):
             vendor_sn = vendor_sn_data['data']['Vendor SN']['value']
         else:

--- a/platform/broadcom/sonic-platform-modules-inventec/d6356/sonic_platform/qsfp.py
+++ b/platform/broadcom/sonic-platform-modules-inventec/d6356/sonic_platform/qsfp.py
@@ -205,7 +205,7 @@ class QSfp(SfpBase):
             string: Model/part number of device
         """
         transceiver_info_dict = self.get_transceiver_info()
-        return transceiver_info_dict.get("modelname", "N/A")
+        return transceiver_info_dict.get("model", "N/A")
 
     def get_serial(self):
         """
@@ -215,7 +215,7 @@ class QSfp(SfpBase):
             string: Serial number of device
         """
         transceiver_info_dict = self.get_transceiver_info()
-        return transceiver_info_dict.get("serialnum", "N/A")
+        return transceiver_info_dict.get("serial", "N/A")
 
     def get_status(self):
         """
@@ -240,11 +240,11 @@ class QSfp(SfpBase):
         keys                       |Value Format   |Information	
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
-        hardwarerev                |1*255VCHAR     |hardware version of SFP
-        serialnum                  |1*255VCHAR     |serial number of the SFP
-        manufacturename            |1*255VCHAR     |SFP vendor name
-        modelname                  |1*255VCHAR     |SFP model name
-        Connector                  |1*255VCHAR     |connector information
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
         encoding                   |1*255VCHAR     |encoding information
         ext_identifier             |1*255VCHAR     |extend identifier
         ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance
@@ -256,9 +256,9 @@ class QSfp(SfpBase):
         ========================================================================
         """
 
-        transceiver_info_dict_keys = ['type',                      'hardwarerev',
-                                      'serialnum',                 'manufacturename',
-                                      'modelname',                 'Connector',
+        transceiver_info_dict_keys = ['type',                      'hardware_rev',
+                                      'serial',                    'manufacturer',
+                                      'model',                     'connector',
                                       'encoding',                  'ext_identifier',
                                       'ext_rateselect_compliance', 'cable_type',
                                       'cable_length',              'nominal_bit_rate',
@@ -305,22 +305,22 @@ class QSfp(SfpBase):
 
         if sfp_interface_bulk_data:
             transceiver_info_dict['type']                      = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['Connector']                 = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['connector']                 = sfp_interface_bulk_data['data']['Connector']['value']
             transceiver_info_dict['encoding']                  = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier']            = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
             transceiver_info_dict['type_abbrv_name']           = sfp_interface_bulk_data['data']['type_abbrv_name']['value']
             transceiver_info_dict['nominal_bit_rate']          = str(sfp_interface_bulk_data['data']['Nominal Bit Rate(100Mbs)']['value'])
 
-        transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value'] if sfp_vendor_name_data else 'N/A'
-        transceiver_info_dict['modelname']       = sfp_vendor_pn_data['data']['Vendor PN']['value'] if sfp_vendor_pn_data else 'N/A'
-        transceiver_info_dict['hardwarerev']     = sfp_vendor_rev_data['data']['Vendor Rev']['value'] if sfp_vendor_rev_data else 'N/A'
-        transceiver_info_dict['serialnum']       = sfp_vendor_sn_data['data']['Vendor SN']['value'] if sfp_vendor_sn_data else 'N/A'
-        transceiver_info_dict['vendor_oui']      = sfp_vendor_oui_data['data']['Vendor OUI']['value'] if sfp_vendor_oui_data else 'N/A'
-        transceiver_info_dict['vendor_date']     = sfp_vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value'] if sfp_vendor_date_data else 'N/A'
+        transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value'] if sfp_vendor_name_data else 'N/A'
+        transceiver_info_dict['model']        = sfp_vendor_pn_data['data']['Vendor PN']['value'] if sfp_vendor_pn_data else 'N/A'
+        transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value'] if sfp_vendor_rev_data else 'N/A'
+        transceiver_info_dict['serial']       = sfp_vendor_sn_data['data']['Vendor SN']['value'] if sfp_vendor_sn_data else 'N/A'
+        transceiver_info_dict['vendor_oui']   = sfp_vendor_oui_data['data']['Vendor OUI']['value'] if sfp_vendor_oui_data else 'N/A'
+        transceiver_info_dict['vendor_date']  = sfp_vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value'] if sfp_vendor_date_data else 'N/A'
 
-        transceiver_info_dict['cable_type']      = "Unknown"
-        transceiver_info_dict['cable_length']    = "Unknown"
+        transceiver_info_dict['cable_type']   = "Unknown"
+        transceiver_info_dict['cable_length'] = "Unknown"
         for key in qsfp_cable_length_tup:
             if key in sfp_interface_bulk_data['data']:
                 transceiver_info_dict['cable_type']   = key

--- a/platform/broadcom/sonic-platform-modules-inventec/d6356/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-inventec/d6356/sonic_platform/sfp.py
@@ -192,7 +192,7 @@ class Sfp(SfpBase):
             string: Model/part number of device
         """
         transceiver_info_dict = self.get_transceiver_info()
-        return transceiver_info_dict.get("modelname", "N/A")
+        return transceiver_info_dict.get("model", "N/A")
 
     def get_serial(self):
         """
@@ -202,7 +202,7 @@ class Sfp(SfpBase):
             string: Serial number of device
         """
         transceiver_info_dict = self.get_transceiver_info()
-        return transceiver_info_dict.get("serialnum", "N/A")
+        return transceiver_info_dict.get("serial", "N/A")
 
     def get_status(self):
         """
@@ -227,11 +227,11 @@ class Sfp(SfpBase):
         keys                       |Value Format   |Information	
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
-        hardwarerev                |1*255VCHAR     |hardware version of SFP
-        serialnum                  |1*255VCHAR     |serial number of the SFP
-        manufacturename            |1*255VCHAR     |SFP vendor name
-        modelname                  |1*255VCHAR     |SFP model name
-        Connector                  |1*255VCHAR     |connector information
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
         encoding                   |1*255VCHAR     |encoding information
         ext_identifier             |1*255VCHAR     |extend identifier
         ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance
@@ -243,9 +243,9 @@ class Sfp(SfpBase):
         ========================================================================
         """
 
-        transceiver_info_dict_keys = ['type',                      'hardwarerev',
-                                      'serialnum',                 'manufacturename',
-                                      'modelname',                 'Connector',
+        transceiver_info_dict_keys = ['type',                      'hardware_rev',
+                                      'serial',                    'manufacturer',
+                                      'model',                     'connector',
                                       'encoding',                  'ext_identifier',
                                       'ext_rateselect_compliance', 'cable_type',
                                       'cable_length',              'nominal_bit_rate',
@@ -294,22 +294,22 @@ class Sfp(SfpBase):
 
         if sfp_interface_bulk_data:
             transceiver_info_dict['type']                      = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['Connector']                 = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['connector']                 = sfp_interface_bulk_data['data']['Connector']['value']
             transceiver_info_dict['encoding']                  = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier']            = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
             transceiver_info_dict['type_abbrv_name']           = sfp_interface_bulk_data['data']['type_abbrv_name']['value']
             transceiver_info_dict['nominal_bit_rate']          = str(sfp_interface_bulk_data['data']['NominalSignallingRate(UnitsOf100Mbd)']['value'])
 
-        transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value'] if sfp_vendor_name_data else 'N/A'
-        transceiver_info_dict['modelname']       = sfp_vendor_pn_data['data']['Vendor PN']['value'] if sfp_vendor_pn_data else 'N/A'
-        transceiver_info_dict['hardwarerev']     = sfp_vendor_rev_data['data']['Vendor Rev']['value'] if sfp_vendor_rev_data else 'N/A'
-        transceiver_info_dict['serialnum']       = sfp_vendor_sn_data['data']['Vendor SN']['value'] if sfp_vendor_sn_data else 'N/A'
-        transceiver_info_dict['vendor_oui']      = sfp_vendor_oui_data['data']['Vendor OUI']['value'] if sfp_vendor_oui_data else 'N/A'
-        transceiver_info_dict['vendor_date']     = sfp_vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value'] if sfp_vendor_date_data else 'N/A'
+        transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value'] if sfp_vendor_name_data else 'N/A'
+        transceiver_info_dict['model']        = sfp_vendor_pn_data['data']['Vendor PN']['value'] if sfp_vendor_pn_data else 'N/A'
+        transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value'] if sfp_vendor_rev_data else 'N/A'
+        transceiver_info_dict['serial']       = sfp_vendor_sn_data['data']['Vendor SN']['value'] if sfp_vendor_sn_data else 'N/A'
+        transceiver_info_dict['vendor_oui']   = sfp_vendor_oui_data['data']['Vendor OUI']['value'] if sfp_vendor_oui_data else 'N/A'
+        transceiver_info_dict['vendor_date']  = sfp_vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value'] if sfp_vendor_date_data else 'N/A'
 
-        transceiver_info_dict['cable_type']      = "Unknown"
-        transceiver_info_dict['cable_length']    = "Unknown"
+        transceiver_info_dict['cable_type']   = "Unknown"
+        transceiver_info_dict['cable_length'] = "Unknown"
         for key in sfp_cable_length_tup:
             if key in sfp_interface_bulk_data['data']:
                 transceiver_info_dict['cable_type']   = key

--- a/platform/broadcom/sonic-platform-modules-inventec/d7054q28b/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-inventec/d7054q28b/sonic_platform/sfp.py
@@ -557,7 +557,7 @@ class Sfp(SfpBase):
             end = start + XCVR_VENDOR_DATE_WIDTH
             sfp_vendor_date_data = sfpi_obj.parse_vendor_date(sfp_interface_bulk_raw[start : end], 0)
             transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['manufacture'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
             transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
             transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
             transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']

--- a/platform/broadcom/sonic-platform-modules-inventec/d7054q28b/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-inventec/d7054q28b/sonic_platform/sfp.py
@@ -232,7 +232,7 @@ class Sfp(SfpBase):
             port_eeprom_path = eeprom_path.format(self.port_to_i2c_mapping[x])
             self.port_to_eeprom_mapping[x] = port_eeprom_path
 
-        self.info_dict_keys = ['type', 'hardwarerev', 'serialnum', 'manufacturename', 'modelname', 'Connector', 'encoding', 'ext_identifier',
+        self.info_dict_keys = ['type', 'hardware_rev', 'serial', 'manufacturer', 'model', 'connector', 'encoding', 'ext_identifier',
                                'ext_rateselect_compliance', 'cable_type', 'cable_length', 'nominal_bit_rate', 'specification_compliance', 'vendor_date', 'vendor_oui']
 
         self.dom_dict_keys = ['rx_los', 'tx_fault', 'reset_status', 'power_lpmode', 'tx_disable', 'tx_disable_channel', 'temperature', 'voltage',
@@ -426,11 +426,11 @@ class Sfp(SfpBase):
         keys                       |Value Format   |Information
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
-        hardwarerev                |1*255VCHAR     |hardware version of SFP
-        serialnum                  |1*255VCHAR     |serial number of the SFP
-        manufacturename            |1*255VCHAR     |SFP vendor name
-        modelname                  |1*255VCHAR     |SFP model name
-        Connector                  |1*255VCHAR     |connector information
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
         encoding                   |1*255VCHAR     |encoding information
         ext_identifier             |1*255VCHAR     |extend identifier
         ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance
@@ -486,13 +486,13 @@ class Sfp(SfpBase):
                 return None
 
             transceiver_info_dict['type'] = sfp_type_data['data']['type']['value']
-            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
             transceiver_info_dict['vendor_oui'] = 'N/A'
             transceiver_info_dict['vendor_date'] = 'N/A'
-            transceiver_info_dict['Connector'] = 'N/A'
+            transceiver_info_dict['connector'] = 'N/A'
             transceiver_info_dict['encoding'] = 'N/A'
             transceiver_info_dict['ext_identifier'] = 'N/A'
             transceiver_info_dict['ext_rateselect_compliance'] = 'N/A'
@@ -557,13 +557,13 @@ class Sfp(SfpBase):
             end = start + XCVR_VENDOR_DATE_WIDTH
             sfp_vendor_date_data = sfpi_obj.parse_vendor_date(sfp_interface_bulk_raw[start : end], 0)
             transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['manufacture'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
             transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value']
             transceiver_info_dict['vendor_date'] = sfp_vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
-            transceiver_info_dict['Connector'] = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['connector'] = sfp_interface_bulk_data['data']['Connector']['value']
             transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
             transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
             transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -556,11 +556,11 @@ class SFP(SfpBase):
         keys                       |Value Format   |Information	
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
-        hardwarerev                |1*255VCHAR     |hardware version of SFP
-        serialnum                  |1*255VCHAR     |serial number of the SFP
-        manufacturename            |1*255VCHAR     |SFP vendor name
-        modelname                  |1*255VCHAR     |SFP model name
-        Connector                  |1*255VCHAR     |connector information
+        hardware_rev               |1*255VCHAR     |hardware version of SFP
+        serial                     |1*255VCHAR     |serial number of the SFP
+        manufacturer               |1*255VCHAR     |SFP vendor name
+        model                      |1*255VCHAR     |SFP model name
+        connector                  |1*255VCHAR     |connector information
         encoding                   |1*255VCHAR     |encoding information
         ext_identifier             |1*255VCHAR     |extend identifier
         ext_rateselect_compliance  |1*255VCHAR     |extended rateSelect compliance


### PR DESCRIPTION
Align SFP key names with new standard defined in https://github.com/Azure/sonic-platform-common/pull/97

- hardwarerev -> hardware_rev
- serialnum -> serial
- manufacturename -> manufacturer
- modelname -> model
- Connector -> connector