### PR TITLE
[vstest]: remove kill exabgp command from the test

### DIFF
--- a/platform/vs/tests/bgp/test_gr_livelock.py
+++ b/platform/vs/tests/bgp/test_gr_livelock.py
@@ -81,7 +81,6 @@ def test_gr_livelock(dvs, testlog):
     dvs.servers[0].runcmd("pip install 'exabgp==4.0.10' --force-reinstall ")
     #
     dvs.copy_file("/etc/frr/", "bgp/files/gr_livelock/bgpd.conf")
-    dvs.servers[0].runcmd("pkill exabgp") # In case previous test didn't stop exa
     dvs.runcmd("supervisorctl stop bgpd")
     time.sleep(5)
     dvs.runcmd("supervisorctl start bgpd")

--- a/platform/vs/tests/bgp/test_no_export.py
+++ b/platform/vs/tests/bgp/test_no_export.py
@@ -5,10 +5,9 @@ import time
 import json
 
 def test_bounce(dvs, testlog):
-    dvs.servers[0].runcmd("pkill -f exabgp")
     dvs.copy_file("/etc/frr/", "bgp/files/no_export/bgpd.conf")
     dvs.runcmd("supervisorctl start bgpd")
-    dvs.runcmd("ip addr add 10.0.0.0/31 dev Ethernet0") 
+    dvs.runcmd("ip addr add 10.0.0.0/31 dev Ethernet0")
     dvs.runcmd("config interface startup Ethernet0")
 
     dvs.runcmd("ip addr add 10.0.0.2/31 dev Ethernet4")
@@ -30,7 +29,7 @@ def test_bounce(dvs, testlog):
     (exit_code, sum_res) =  dvs.runcmd(["vtysh", "-c", "show ip bgp sum"])
     (exit_code, all_route) = dvs.runcmd(["vtysh", "-c", "show ip bgp"])
     (exit_code, announce_route) = dvs.runcmd(["vtysh", "-c", "show ip bgp neighbors 10.0.0.3 advertised-routes"])
- 
+
     p1.terminate()
     p1 = p1.wait()
 


### PR DESCRIPTION
the command kills all exabgp processes on the host.
since the namespaces are newly added, there should
be no prior exabgp processes.

if it is existing namespace, it is also the dvs
framework job to clean up all prior processes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
the command kills all exabgp processes on the host.
since the namespaces are newly added, there should
be no prior exabgp processes.

if it is existing namespace, it is also the dvs
framework job to clean up all prior processes.

**- How I did it**
remove the kill line

**- How to verify it**
run vs test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
