### PR TITLE
Putting on hold: Don't merge yet; CoreUploader to get credentials path from CONFIG-DB

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -285,10 +285,10 @@ sudo cp $IMAGE_CONFIGS/hostcfgd/*.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 
 # copy core file uploader files
 sudo cp $IMAGE_CONFIGS/corefile_uploader/core_uploader.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
-sudo LANG=C chroot $FILESYSTEM_ROOT systemctl disable core_uploader.service
 sudo cp $IMAGE_CONFIGS/corefile_uploader/core_uploader.py $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/corefile_uploader/core_analyzer.rc.json $FILESYSTEM_ROOT_ETC_SONIC/
 sudo chmod og-rw $FILESYSTEM_ROOT_ETC_SONIC/core_analyzer.rc.json
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable core_uploader.service
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install libffi-dev libssl-dev
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install azure-storage==0.36.0

--- a/files/image_config/corefile_uploader/core_analyzer.rc.json
+++ b/files/image_config/corefile_uploader/core_analyzer.rc.json
@@ -3,8 +3,6 @@
         "core_upload": "/tmp/core_upload/"
     },
     "azure_sonic_core_storage": {
-        "account_name": "corefilecollection",
-        "account_key": "",
         "share_name": "corefiles-root"
     },
     "metadata_files_in_archive": {

--- a/files/image_config/corefile_uploader/core_uploader.py
+++ b/files/image_config/corefile_uploader/core_uploader.py
@@ -78,10 +78,10 @@ def get_db_credential_files():
     db = ConfigDBConnector()
     db.connect()
 
-    acms = db.get_entry("ACMS", "credentials")
-    if 'path' not in acms or not acms['path']:
-        raise Exception("ACMS|credentials path field is missing or empty")
-    path = acms['path']
+    cred_store = db.get_entry("CREDENTIALS", "STORE")
+    if 'path' not in cred_store or not cred_store['path']:
+        raise Exception("CREDENTIALS|STORE path field is missing or empty")
+    path = cred_store['path']
 
     val = db.get_entry('CORE_UPLOADER', 'credentials')
     if (not 'acct_name_file' in val or

--- a/files/image_config/corefile_uploader/core_uploader.py
+++ b/files/image_config/corefile_uploader/core_uploader.py
@@ -34,6 +34,7 @@ sharename = ""
 cwd = []
 
 HOURS_4 = (4 * 60 * 60)
+PAUSE_UPLOAD = (5 * 60)
 PAUSE_ON_FAIL = (60 * 60)
 WAIT_FILE_WRITE1 = (10 * 60)
 WAIT_FILE_WRITE2= (5 * 60)
@@ -300,7 +301,7 @@ Expect a min of two elements in path")
                 if (i >= 3):
                     # Retry 3 times, before failing
                     raise
-                time.sleep(PAUSE_ON_FAIL)
+                time.sleep(PAUSE_UPLOAD)
 
 
     @staticmethod

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1137,8 +1137,8 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             'client_crt_cname': 'client.restapi.sonic'
         }
     }
-    results['ACMS'] = {
-        'credentials': {
+    results['CREDENTIALS'] = {
+        'STORE': {
             'path': '/etc/sonic/credentials'
         }
     }

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1137,6 +1137,19 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             'client_crt_cname': 'client.restapi.sonic'
         }
     }
+    results['ACMS'] = {
+        'credentials': {
+            'path': '/etc/sonic/credentials'
+        }
+    }
+    results['CORE_UPLOADER'] = {
+        'credentials': {
+            'acct_name_file': 'corestorage_acctname',
+            'acct_key_file': 'corestorage_acctkey'
+        }
+    }
+
+
     # Do not configure the minigraph's mirror session, which is currently unused
     # mirror_sessions = {}
     # if erspan_dst:


### PR DESCRIPTION
1) Get storage account credentials file path from DB
2) Enable core uploader by default.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
