### PR TITLE
Enable DPB dependency check using YANG model in VS container (#45)

### DIFF
--- a/platform/vs/docker-sonic-vs.mk
+++ b/platform/vs/docker-sonic-vs.mk
@@ -7,7 +7,10 @@ $(DOCKER_SONIC_VS)_DEPENDS += $(SWSS) \
                               $(PYTHON_SWSSCOMMON) \
                               $(LIBTEAMDCTL) \
                               $(LIBTEAM_UTILS) \
-                              $(SONIC_DEVICE_DATA)
+                              $(SONIC_DEVICE_DATA) \
+                              $(LIBYANG) \
+                              $(LIBYANG_CPP) \
+                              $(LIBYANG_PY2)
 
 $(DOCKER_SONIC_VS)_PYTHON_DEBS += $(SONIC_UTILS)
 

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -60,6 +60,8 @@ RUN pip install crontab
 # Install dependencies for Dynamic Port Breakout
 RUN pip install xmltodict==0.12.0
 RUN pip install jsondiff==1.2.0
+RUN pip install click==7.0.0
+RUN pip install ijson
 
 {% if docker_sonic_vs_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -60,7 +60,7 @@ RUN pip install crontab
 # Install dependencies for Dynamic Port Breakout
 RUN pip install xmltodict==0.12.0
 RUN pip install jsondiff==1.2.0
-RUN pip install ijson
+RUN pip install ijson==2.6.1
 
 {% if docker_sonic_vs_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -60,7 +60,6 @@ RUN pip install crontab
 # Install dependencies for Dynamic Port Breakout
 RUN pip install xmltodict==0.12.0
 RUN pip install jsondiff==1.2.0
-RUN pip install click==7.0.0
 RUN pip install ijson
 
 {% if docker_sonic_vs_debs.strip() -%}


### PR DESCRIPTION
Signed-off-by: Sangita Maity sangitamaity0211@gmail.com

**- What I did**
Added required packages to enabled YANG dependency check for Dynamic Port Breakout in VS container.

[sonic-utilities PR #766](https://github.com/Azure/sonic-utilities/pull/766) has a dependency on it.
Getting [error](https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/sonic-utilities-build-pr/1773/testReport/junit/test_crm/TestCrm/test_CrmIpv6Route/) like below without this fix
```
ImportError: No module named yang - required module not found
```



**- How I did it**
Modified Make and Docker jinja template files

**- How to verify it**
Built VS container and ensured that port breakout command executed successfully