### PR TITLE
[orchagent]: Fix platform string export

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -10,7 +10,7 @@ fi
 
 # Retrieve SWSS vars from sonic-cfggen
 SWSS_VARS=$(sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t $SWSS_VARS_FILE)
-platform=$(echo $SWSS_VARS | jq -r '.asic_type')
+export platform=$(echo $SWSS_VARS | jq -r '.asic_type')
 
 MAC_ADDRESS=$(echo $SWSS_VARS | jq -r '.mac')
 if [ "$MAC_ADDRESS" == "None" ] || [ -z "$MAC_ADDRESS" ]; then


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
This PR fixes ACL capability issue:
```
Jul 17 14:31:52.566955 sonic ERR swss#orchagent: :- processAclTableType: Mirror table type MIRRORV6 is not supported
Jul 17 14:31:52.567052 sonic ERR swss#orchagent: :- doAclTableTask: Failed to process ACL table EVERFLOWV6 type
Jul 17 14:31:52.567052 sonic ERR swss#orchagent: :- doAclTableTask: Failed to create ACL table EVERFLOWV6, invalid configuration
```

**- Why I did it**
* Fixed platform string export

**- How I did it**
* N/A

**- How to verify it**
1. config reload -y

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

**- A picture of a cute animal (not mandatory but encouraged)**
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```