### PR TITLE
[sudoers] Add `sonic-installer list` to read-only commands

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -31,6 +31,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /sbin/brctl show, \
                                  /usr/bin/lldpshow, \
                                  /usr/bin/psuutil *, \
                                  /usr/bin/sensors, \
+                                 /usr/bin/sonic-installer list, \
                                  /usr/bin/sfputil show *, \
                                  /usr/bin/teamshow, \
                                  /usr/bin/vtysh -c show *, \


### PR DESCRIPTION
`sonic-installer list` is a read-only command. Specify it as such in the sudoers file.

This will also ensure the new `show boot` command, which calls `sudo sonic-installer list` under the hood doesn't fail due to permissions.