### PR TITLE
[201911][sudoers] Add `sonic_installer list` to read-only commands

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -32,6 +32,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /sbin/brctl show, \
                                  /usr/bin/psuutil *, \
                                  /usr/bin/sensors, \
                                  /usr/bin/sfputil show *, \
+                                 /usr/bin/sonic_installer list, \
                                  /usr/bin/teamshow, \
                                  /usr/bin/vtysh -c show *, \
                                  /bin/cat /var/log/syslog*, \


### PR DESCRIPTION
`sonic_installer list` is a read-only command. Specify it as such in the sudoers file.

This will also ensure the new `show boot` command, which calls `sudo sonic_installer list` under the hood doesn't fail due to permissions.