### PR TITLE
[daemon_base] fix to not reregister signal handler

### DIFF
--- a/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
+++ b/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
@@ -90,6 +90,19 @@ class Logger(object):
 class DaemonBase(object):
     def __init__(self):
         # Register our signal handlers
+        '''all daemons inherit from daemon_base class, and for
+        signal handling functionality they register the signal_handler() by
+        overriding the siganl_handler() in daemon_base by their own
+        implmentation.
+        But some sonic_platform instances also can invoke the daemon_base
+        constructor while trying to instantiate the common utilities
+        for example
+        platform_chassis = sonic_platform.platform.Platform().get_chassis()
+        This will cause the re registration of signal_handler which will
+        cause base class signal_handler() to be invoked when the daemon
+        gets a signal, whereas the derived class signal_handler shoudl have
+        been invoked. The if checks will not allow the re registration
+        of signal handler '''
         if not signal.getsignal(signal.SIGHUP):
             signal.signal(signal.SIGHUP, self.signal_handler)
         if not signal.getsignal(signal.SIGINT):

--- a/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
+++ b/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
@@ -100,7 +100,7 @@ class DaemonBase(object):
         platform_chassis = sonic_platform.platform.Platform().get_chassis()
         This will cause the re registration of signal_handler which will
         cause base class signal_handler() to be invoked when the daemon
-        gets a signal, whereas the derived class signal_handler shoudl have
+        gets a signal, whereas the derived class signal_handler should have
         been invoked. The if checks will not allow the re registration
         of signal handler '''
         if not signal.getsignal(signal.SIGHUP):

--- a/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
+++ b/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
@@ -90,9 +90,12 @@ class Logger(object):
 class DaemonBase(object):
     def __init__(self):
         # Register our signal handlers
-        signal.signal(signal.SIGHUP, self.signal_handler)
-        signal.signal(signal.SIGINT, self.signal_handler)
-        signal.signal(signal.SIGTERM, self.signal_handler)
+        if not signal.getsignal(signal.SIGHUP):
+            signal.signal(signal.SIGHUP, self.signal_handler)
+        if not signal.getsignal(signal.SIGINT):
+            signal.signal(signal.SIGINT, self.signal_handler)
+        if not signal.getsignal(signal.SIGTERM):
+            signal.signal(signal.SIGTERM, self.signal_handler)
 
     # Signal handler
     def signal_handler(self, sig, frame):


### PR DESCRIPTION
- Why I did it
Currently all daemons inherit from daemon_base class, and for
signal handling functionality they register the signal_handler() by
overriding the siganl_handler() in daemon_base by their own
implmentation.
But some sonic_platform instances also can invoke the daemon_base
constructor while trying to instantiate the common utilities
for example
platform_chassis = sonic_platform.platform.Platform().get_chassis()
This will cause the re registration of signal_handler which will
cause base class signal_handler() to be invoked when the daemon
gets a signal, whereas their own signal_handler should have been
invoked.

- How I did it
We only register the siganl_handler once, and if signal_handler has
been registered, not re register it.

- How to verify it
Run any daemon and send a signal to it and ensure that the 
correct signal_handler is invoked. 

-src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
  added an if check for signal registration to not re register if 
  the signal is already registered. 
 
Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>