### PR TITLE
FRR template change to add Vlan's prefix to prefix list

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -14,6 +14,18 @@ ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERF
 ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | replace('/128', '/64') | ip_network }}/64
 {% endif %}
 !
+{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
+{% if prefix | ipv4 %}
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq {{ loop.index * 5 }} permit {{ prefix }}
+!
+{% endif %}
+{% endfor %}
+{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
+{% if prefix | ipv6 %}
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq {{ loop.index * 5 }} permit {{ prefix }}
+!
+{% endif %}
+{% endfor %}
 !
 {% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' or DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
 route-map HIDE_INTERNAL permit 10

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -29,6 +29,11 @@ ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
 !
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.1/24
+!
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 10 permit fc01::1/64
+!
+!
 route-map HIDE_INTERNAL permit 10
   set community local-AS
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
@@ -11,6 +11,11 @@ ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
 !
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.1/24
+!
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 10 permit fc01::1/64
+!
+!
 route-map HIDE_INTERNAL permit 10
   set community local-AS
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
@@ -11,6 +11,11 @@ ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
 !
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.1/24
+!
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 10 permit fc01::1/64
+!
+!
 route-map HIDE_INTERNAL permit 10
   set community local-AS
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -46,6 +46,11 @@ ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
 !
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.1/24
+!
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 10 permit fc01::1/64
+!
+!
 route-map HIDE_INTERNAL permit 10
   set community local-AS
 !

--- a/src/sonic-config-engine/tests/sample_output/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/bgpd_frr.conf
@@ -33,6 +33,8 @@ ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.1/27
+!
 !
 !
 router bgp 65100

--- a/src/sonic-config-engine/tests/sample_output/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/frr.conf
@@ -49,6 +49,8 @@ ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.1/27
+!
 !
 !
 router bgp 65100


### PR DESCRIPTION
**- Why I did it**
To add the Vlan prefix list to the FRR templates

**- How I did it**
By updating bgpd.main.conf.j2

**- How to verify it**
Via unit tests in sonic-bgpcfgd and sonic-config-engine

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
