### PR TITLE
[Mellanox] Change fan tolerance to 50%

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -288,8 +288,8 @@ class Fan(FanBase):
             An integer, the percentage of variance from target speed which is
                  considered tolerable
         """
-        # The tolerance value is fixed as 20% for all the Mellanox platform
-        return 20
+        # The tolerance value is fixed as 50% for all the Mellanox platform
+        return 50
 
     @classmethod
     def set_cooling_level(cls, level, cur_state):


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Mellanox platforms fan tolerance should change to 50%.

**- How I did it**
Changed fan tolerance to 50% on platform API.

**- How to verify it**
Check in the DB the tolerance value for fans.

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
