### PR TITLE
[caclmgrd] Only add a default DROP rule on the INPUT chain

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -378,9 +378,7 @@ class ControlPlaneAclManager(object):
         # add iptables/ip6tables commands to drop all other incoming packets
         if num_ctrl_plane_acl_rules > 0:
             iptables_cmds.append("iptables -A INPUT -j DROP")
-            iptables_cmds.append("iptables -A FORWARD -j DROP")
             iptables_cmds.append("ip6tables -A INPUT -j DROP")
-            iptables_cmds.append("ip6tables -A FORWARD -j DROP")
 
         return iptables_cmds
 


### PR DESCRIPTION
No longer add a default DROP rule on the FORWARD chain