### PR TITLE
[docker-platform-monitor] Fix copy of fancontrol config file

### DIFF
--- a/dockers/docker-platform-monitor/docker_init.sh
+++ b/dockers/docker-platform-monitor/docker_init.sh
@@ -3,15 +3,17 @@
 # Generate supervisord config file and the start.sh scripts
 mkdir -p /etc/supervisor/conf.d/
 
+SENSORS_CONF_FILE="/usr/share/sonic/platform/sensors.conf"
+FANCONTROL_CONF_FILE="/usr/share/sonic/platform/fancontrol"
 
 HAVE_SENSORS_CONF=0
 HAVE_FANCONTROL_CONF=0
 
-if [ -e /usr/share/sonic/platform/sensors.conf ]; then
+if [ -e $SENSORS_CONF_FILE ]; then
     HAVE_SENSORS_CONF=1
 fi
 
-if [ -e /usr/share/sonic/platform/fancontrol ]; then
+if [ -e $FANCONTROL_CONF_FILE ]; then
     HAVE_FANCONTROL_CONF=1
 fi
 
@@ -24,19 +26,18 @@ else
     sonic-cfggen -a "$confvar" -t /usr/share/sonic/templates/docker-pmon.supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
 fi
 
-# If this platform has an lm-sensors config file, copy it to it's proper place.
-if [ -e /usr/share/sonic/platform/sensors.conf ]; then
+# If this platform has an lm-sensors config file, copy it to its proper place
+if [ $HAVE_SENSORS_CONF -eq 1 ]; then
     mkdir -p /etc/sensors.d
-    /bin/cp -f /usr/share/sonic/platform/sensors.conf /etc/sensors.d/
+    /bin/cp -f $SENSORS_CONF_FILE /etc/sensors.d/
 fi
 
-# If this platform has a fancontrol config file, copy it to it's proper place
-# and start fancontrol
-if [ -e /usr/share/sonic/platform/fancontrol ]; then
+# If this platform has a fancontrol config file, copy it to its proper place
+if [ $HAVE_FANCONTROL_CONF -eq 1 ]; then
     # Remove stale pid file if it exists
     rm -f /var/run/fancontrol.pid
 
-    /bin/cp -f /usr/share/sonic/templates/fancontrol.conf /etc/supervisord/conf.d/
+    /bin/cp -f $FANCONTROL_CONF_FILE /etc/
 fi
 
 exec /usr/bin/supervisord


### PR DESCRIPTION
Copy proper fancontrol config file to the proper destination. Also some minor refactoring for code reuse to help prevent issues like this in the future.

Fixes a bug introduced by https://github.com/Azure/sonic-buildimage/pull/4599