### PR TITLE
[Mellanox] Fix for system-health output for ACS-MSN2100 and ACS-MSN2010 platforms

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/system_health_monitoring_config.json
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/system_health_monitoring_config.json
@@ -1,1 +1,11 @@
-../x86_64-mlnx_msn2700-r0/system_health_monitoring_config.json
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": ["psu.voltage", "psu.temperature"],
+    "external_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+      "fault": "orange",
+      "normal": "green",
+      "booting": "orange_blink"
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/system_health_monitoring_config.json
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/system_health_monitoring_config.json
@@ -1,1 +1,1 @@
-../x86_64-mlnx_msn2700-r0/system_health_monitoring_config.json
+../x86_64-mlnx_msn2010-r0/system_health_monitoring_config.json


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
'x86_64-mlnx_msn2100-r0'  and 'x86_64-mlnx_msn2010-r0' platforms are not supporting PSU temperature sampling.
Ignore temperature check by default for these platforms.

**- How I did it**
Added "psu.temperature" to exclude devices check by system-health for these platforms.

**- How to verify it**
Run 'show system-health summary' command.

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
