### PR TITLE
[bgpcfgd]: Fix bgpcfgd crash on reset Loopback0 ip addresses

### DIFF
--- a/dockers/docker-fpm-quagga/bgpcfgd
+++ b/dockers/docker-fpm-quagga/bgpcfgd
@@ -157,7 +157,8 @@ class BGPConfigManager(object):
                     self.lo_ipv6 = ip_addr
                     txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC6", lo_ip=ip_addr, ip_proto="v6")
                 else:
-                    syslog.syslog(syslog.LOG_ERR, "Got ambigous ip addres '%s'" % ip_addr)
+                    syslog.syslog(syslog.LOG_ERR, "Got ambiguous ip address '%s'" % ip_addr)
+                    return
             except:
                 syslog.syslog(syslog.LOG_ERR, "Error while rendering set src template '%s'" % ip_addr)
             else:

--- a/dockers/docker-fpm-quagga/bgpcfgd
+++ b/dockers/docker-fpm-quagga/bgpcfgd
@@ -150,12 +150,20 @@ class BGPConfigManager(object):
                 return
             ip_addr = ip_addr_w_mask[:slash_pos]
             try:
-                if TemplateFabric.is_ipv4(ip_addr) and self.lo_ipv4 is None:
-                    self.lo_ipv4 = ip_addr
-                    txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC", lo_ip=ip_addr, ip_proto="")
-                elif TemplateFabric.is_ipv6(ip_addr) and self.lo_ipv6 is None:
-                    self.lo_ipv6 = ip_addr
-                    txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC6", lo_ip=ip_addr, ip_proto="v6")
+                if TemplateFabric.is_ipv4(ip_addr):
+                    if self.lo_ipv4 is None:
+                        self.lo_ipv4 = ip_addr
+                        txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC", lo_ip=ip_addr, ip_proto="")
+                    else:
+                        syslog.syslog(syslog.LOG_INFO, "Update command is not supported for set src templates. lo_ip='%s'" % ip_addr)
+                        return
+                elif TemplateFabric.is_ipv6(ip_addr):
+                    if self.lo_ipv6 is None:
+                        self.lo_ipv6 = ip_addr
+                        txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC6", lo_ip=ip_addr, ip_proto="v6")
+                    else:
+                        syslog.syslog(syslog.LOG_INFO, "Update command is not supported for set src templates. lo_ip='%s'" % ip_addr)
+                        return
                 else:
                     syslog.syslog(syslog.LOG_ERR, "Got ambiguous ip address '%s'" % ip_addr)
                     return


### PR DESCRIPTION
Also some typos were fixed

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
1. Fix an error which causes bgpcfgd crash on invalid ip address. Before the fix we had an issue here. When either loopback ipv4 or ipv6 addresses were already set and bgpcfgd received another "SET" message for already set ip loopback address, bgpcfgd will send syslog message about ambiguous ip address (despite the fact that the address is good) and crash of bgpcfgd. With this change this behavior is changed: if we receive ip address and this ip address is already set, bgpcfgd will send this message to the syslog and return from the handler.
 
2. Fix typos

**- How I did it**
Return from the handler on invalid ip address

**- How to verify it**
Build an image, run on your dut. Add an interface entry with invalid ip address. bgpcfgd should not crash.

```
admin@str-s6100-acs-1:~$ redis-cli 
127.0.0.1:6379> select 4
OK
127.0.0.1:6379[4]> keys L*
1) "LOOPBACK_INTERFACE|Loopback0|FC00:1::32/128"
2) "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32"
127.0.0.1:6379[4]> hgetall "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32"
1) "NULL"
2) "NULL"
127.0.0.1:6379[4]> hset "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32" NULL NULL
(integer) 0
127.0.0.1:6379[4]> hset "LOOPBACK_INTERFACE|Loopback0|FC00:1::32/128" NULL NULL
(integer) 0
```

```
admin@str-s6100-acs-1:~$ sudo tail -F /var/log/syslog | grep bgpcfgd


Jul 27 18:54:32.241152 str-s6100-acs-1 INFO bgp#bgpcfgd: Update command is not supported for set src templates. lo_ip='10.1.0.32'

Jul 27 18:54:57.701735 str-s6100-acs-1 INFO bgp#bgpcfgd: Update command is not supported for set src templates. lo_ip='FC00:1::32'

```

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
