### PR TITLE
Changes to add template support for copp.json.

### DIFF
--- a/dockers/docker-orchagent/copp.json.j2
+++ b/dockers/docker-orchagent/copp.json.j2
@@ -33,7 +33,7 @@
         },
         "OP": "SET"
     },
-{% if DEVICE_METADATA['localhost']['type'] == "ToRRouter" %}
+{% if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] == "ToRRouter" %}
     {
         "COPP_TABLE:trap.group.lldp.dhcp.dhcpv6.udld": {
             "trap_ids": "lldp,dhcp,dhcpv6,udld",
@@ -43,10 +43,20 @@
         },
         "OP": "SET"
     },
-{% else %}
+{% elif DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined %}
     {
         "COPP_TABLE:trap.group.lldp.udld": {
             "trap_ids": "lldp,udld",
+            "trap_action":"trap",
+            "trap_priority":"4",
+            "queue": "4"
+        },
+        "OP": "SET"
+    },
+{% else %}
+    {
+        "COPP_TABLE:trap.group.lldp.dhcp.dhcpv6.udld": {
+            "trap_ids": "lldp,dhcp,dhcpv6,udld",
             "trap_action":"trap",
             "trap_priority":"4",
             "queue": "4"

--- a/dockers/docker-orchagent/copp.json.j2
+++ b/dockers/docker-orchagent/copp.json.j2
@@ -1,0 +1,85 @@
+[
+    {
+        "COPP_TABLE:default": {
+            "queue": "0",
+            "meter_type":"packets",
+            "mode":"sr_tcm",
+            "cir":"600",
+            "cbs":"600",
+            "red_action":"drop"
+        },
+        "OP": "SET"
+    },
+    {
+        "COPP_TABLE:trap.group.bgp.lacp": {
+            "trap_ids": "bgp,bgpv6,lacp",
+            "trap_action":"trap",
+            "trap_priority":"4",
+            "queue": "4"
+        },
+        "OP": "SET"
+    },
+    {
+        "COPP_TABLE:trap.group.arp": {
+            "trap_ids": "arp_req,arp_resp,neigh_discovery",
+            "trap_action":"copy",
+            "trap_priority":"4",
+            "queue": "4",
+            "meter_type":"packets",
+            "mode":"sr_tcm",
+            "cir":"600",
+            "cbs":"600",
+            "red_action":"drop"
+        },
+        "OP": "SET"
+    },
+{% if DEVICE_METADATA['localhost']['type'] == "ToRRouter" %}
+    {
+        "COPP_TABLE:trap.group.lldp.dhcp.dhcpv6.udld": {
+            "trap_ids": "lldp,dhcp,dhcpv6,udld",
+            "trap_action":"trap",
+            "trap_priority":"4",
+            "queue": "4"
+        },
+        "OP": "SET"
+    },
+{% else %}
+    {
+        "COPP_TABLE:trap.group.lldp.udld": {
+            "trap_ids": "lldp,udld",
+            "trap_action":"trap",
+            "trap_priority":"4",
+            "queue": "4"
+        },
+        "OP": "SET"
+    },
+{% endif %}
+    {
+        "COPP_TABLE:trap.group.ip2me": {
+            "trap_ids": "ip2me",
+            "trap_action":"trap",
+            "trap_priority":"1",
+            "queue": "1",
+            "meter_type":"packets",
+            "mode":"sr_tcm",
+            "cir":"6000",
+            "cbs":"6000",
+            "red_action":"drop"
+        },
+        "OP": "SET"
+    },
+    {
+        "COPP_TABLE:trap.group.nat": {
+            "trap_ids": "src_nat_miss,dest_nat_miss",
+            "trap_action":"trap",
+            "trap_priority":"1",
+            "queue": "1",
+            "meter_type":"packets",
+            "mode":"sr_tcm",
+            "cir":"600",
+            "cbs":"600",
+            "red_action":"drop"
+        },
+        "OP": "SET"
+    }
+]

--- a/dockers/docker-orchagent/copp.json.j2
+++ b/dockers/docker-orchagent/copp.json.j2
@@ -33,17 +33,7 @@
         },
         "OP": "SET"
     },
-{% if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] == "ToRRouter" %}
-    {
-        "COPP_TABLE:trap.group.lldp.dhcp.dhcpv6.udld": {
-            "trap_ids": "lldp,dhcp,dhcpv6,udld",
-            "trap_action":"trap",
-            "trap_priority":"4",
-            "queue": "4"
-        },
-        "OP": "SET"
-    },
-{% elif DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined %}
+{% if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != "ToRRouter" %}
     {
         "COPP_TABLE:trap.group.lldp.udld": {
             "trap_ids": "lldp,udld",

--- a/dockers/docker-orchagent/docker-init.sh
+++ b/dockers/docker-orchagent/docker-init.sh
@@ -5,6 +5,7 @@ mkdir -p /etc/swss/config.d/
 sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/switch.json.j2 > /etc/swss/config.d/switch.json
 sonic-cfggen -d -t /usr/share/sonic/templates/ipinip.json.j2 > /etc/swss/config.d/ipinip.json
 sonic-cfggen -d -t /usr/share/sonic/templates/ports.json.j2 > /etc/swss/config.d/ports.json
+sonic-cfggen -d -t /usr/share/sonic/templates/copp.json.j2 > /etc/swss/config.d/00-copp.config.json
 
 # Executed HWSKU specific initialization tasks.
 if [ -x /usr/share/sonic/hwsku/hwsku-init ]; then

--- a/files/build_scripts/generate_asic_config_checksum.py
+++ b/files/build_scripts/generate_asic_config_checksum.py
@@ -9,7 +9,7 @@ SYSLOG_IDENTIFIER = 'asic_config_checksum'
 CHUNK_SIZE = 8192
 
 CONFIG_FILES = {
-    os.path.abspath('./src/sonic-swss/swssconfig/sample/'): ['netbouncer.json', '00-copp.config.json']
+    os.path.abspath('./src/sonic-swss/swssconfig/sample/'): ['netbouncer.json']
 }
 
 OUTPUT_FILE = os.path.abspath('./asic_config_checksum')


### PR DESCRIPTION
Changes:=

Changes to add template support for copp.json.
This is needed so that we can install different type of
Traps based on Device Role (Tor/Leaf/Mgmt/etc...).

Initial use case is to install DHCP/DHCPv6 trap only
for Tor router.

This PR is dependent on https://github.com/Azure/sonic-swss/pull/1366.

Currently this change is not compatible with warm-reboot from previous image version. 
Need to handle warm-reboot case with this change. This will done in separate PR

Testing:
Manually Verified based on Device Role json file getting generated. Also verfied if Device_Metadata or it's sub-param are not present then no exception is generated and correct template is formed.
Dump APP DB to have correct traps based on generated json file.
