### PR TITLE
[enable counters] enable port buffer drops by default

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -18,6 +18,7 @@ def enable_counters():
     enable_counter_group(db, 'PG_WATERMARK')
     enable_counter_group(db, 'QUEUE_WATERMARK')
     enable_counter_group(db, 'BUFFER_POOL_WATERMARK')
+    enable_counter_group(db, 'PORT_BUFFER_DROP')
 
 def get_uptime():
     with open('/proc/uptime') as fp:


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
**Do not merge yet**,
Should go on top of https://github.com/Azure/sonic-swss/pull/1368

Submodule update:
    SAI_Implementation
     - reenable port in/oit dropped pkts stats

**- Why I did it**
Introduce separate FC group for port level buffer drop counters as discussed in [#1308](https://github.com/Azure/sonic-swss/pull/1308)
**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
