### PR TITLE
[bgpcfgd]: Clarify error messages on reset Loopback0 ip address

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd
+++ b/src/sonic-bgpcfgd/bgpcfgd
@@ -787,16 +787,24 @@ class ZebraSetSrc(Manager):
             ip_addr_w_mask = key.replace("Loopback0|", "")
             slash_pos = ip_addr_w_mask.rfind("/")
             if slash_pos == -1:
-                log_err("Wrong Loopback0 ip address: '%s'" % ip_addr_w_mask)
+                log_err("Wrong Loopback0 ip prefix: '%s'" % ip_addr_w_mask)
                 return True
             ip_addr = ip_addr_w_mask[:slash_pos]
             try:
-                if TemplateFabric.is_ipv4(ip_addr) and self.lo_ipv4 is None:
-                    self.lo_ipv4 = ip_addr
-                    txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC", lo_ip=ip_addr, ip_proto="")
-                elif TemplateFabric.is_ipv6(ip_addr) and self.lo_ipv6 is None:
-                    self.lo_ipv6 = ip_addr
-                    txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC6", lo_ip=ip_addr, ip_proto="v6")
+                if TemplateFabric.is_ipv4(ip_addr):
+                    if self.lo_ipv4 is None:
+                        self.lo_ipv4 = ip_addr
+                        txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC", lo_ip=ip_addr, ip_proto="")
+                    else:
+                        log_warn("Update command is not supported for set src templates. lo_ip='%s'" % ip_addr_w_mask)
+                        return True
+                elif TemplateFabric.is_ipv6(ip_addr):
+                    if self.lo_ipv6 is None:
+                        self.lo_ipv6 = ip_addr
+                        txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC6", lo_ip=ip_addr, ip_proto="v6")
+                    else:
+                        log_warn("Update command is not supported for set src templates. lo_ip='%s'" % ip_addr_w_mask)
+                        return True
                 else:
                     log_err("Got ambiguous ip address '%s'" % ip_addr)
                     return True

--- a/src/sonic-bgpcfgd/bgpcfgd
+++ b/src/sonic-bgpcfgd/bgpcfgd
@@ -796,14 +796,14 @@ class ZebraSetSrc(Manager):
                         self.lo_ipv4 = ip_addr
                         txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC", lo_ip=ip_addr, ip_proto="")
                     else:
-                        log_warn("Update command is not supported for set src templates. lo_ip='%s'" % ip_addr_w_mask)
+                        log_warn("Update command is not supported for set src templates. current ip='%s'. new ip='%s'" % (self.lo_ipv4, ip_addr))
                         return True
                 elif TemplateFabric.is_ipv6(ip_addr):
                     if self.lo_ipv6 is None:
                         self.lo_ipv6 = ip_addr
                         txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC6", lo_ip=ip_addr, ip_proto="v6")
                     else:
-                        log_warn("Update command is not supported for set src templates. lo_ip='%s'" % ip_addr_w_mask)
+                        log_warn("Update command is not supported for set src templates. current ip='%s'. new ip='%s'" % (self.lo_ipv6, ip_addr))
                         return True
                 else:
                     log_err("Got ambiguous ip address '%s'" % ip_addr)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
To clarify error messages in case the ip address for Loopback is already set. It doesn't make sense to call correct ip address as ambiguous in this case

**- How I did it**
I split the check of constraints into two if clauses. One to check if the ip is correct or not. The second one to check if the ip address was already registered or not.

**- How to verify it**
```
admin@str-s6100-acs-1:~$ redis-cli 
127.0.0.1:6379> select 4
OK
127.0.0.1:6379[4]> keys LOOP*
1) "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32"
2) "LOOPBACK_INTERFACE|Loopback0"
3) "LOOPBACK_INTERFACE|Loopback0|FC00:1::32/128"
127.0.0.1:6379[4]> hset "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32" NULL NULL
(integer) 0
127.0.0.1:6379[4]> hset "LOOPBACK_INTERFACE|Loopback0|FC00:1::32/128" NULL NULL
(integer) 0
```
```
Jul 30 00:23:02.840009 str-s6100-acs-1 WARNING bgp#bgpcfgd: Update command is not supported for set src templates. current ip='10.1.0.32'. new ip='10.1.0.32'

Jul 30 00:23:28.543761 str-s6100-acs-1 WARNING bgp#bgpcfgd: Update command is not supported for set src templates. current ip='FC00:1::32'. new ip='FC00:1::32'
```

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
