### PR TITLE
[build]: add --init option in docker run for better signal handling

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -108,7 +108,7 @@ ifeq ($(DOCKER_BUILDER_WORKDIR),)
 override DOCKER_BUILDER_WORKDIR := "/sonic"
 endif
 
-DOCKER_RUN := docker run --rm=true --privileged \
+DOCKER_RUN := docker run --rm=true --privileged --init \
     -v $(DOCKER_BUILDER_MOUNT) \
     -w $(DOCKER_BUILDER_WORKDIR) \
     -e "http_proxy=$(http_proxy)" \


### PR DESCRIPTION


Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
--init: Run an init inside the container that forwards signals and
reaps processes

Before the change, process 1 is make, which does not do well to forward
signals and reaps process. We could see zombie process left if user
issues ctrl+c to interrupt the make process. with --init option,
a docker-init process will forwards the signals and reaps processes.
zombie process is no longer observed, and ctrl+c can reliably interrupt
the make process.

Before:
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
lgh            1  0.3  0.0  12604 11908 pts/0    S+   10:54   0:00 make ...

After:
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
lgh            1  0.0  0.0   1080     4 pts/0    Ss   10:54   0:00 /sbin/docker-init -- make ...
lgh            7  0.3  0.0  12604 11908 pts/0    S+   10:54   0:00 make ...

**- How I did it**
add --init option in docker run

**- How to verify it**
1. start the build process: make SONIC_BUILD_JOBS=1 target/sonic-broadcom.bin
2. type ctrl+c to interrupt the build process
3. verify the build process is reliably interrupted.

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
