### PR TITLE
Fix fast-reboot handling for swss script

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -37,6 +37,15 @@ function check_warm_boot()
     fi
 }
 
+function check_fast_boot()
+{
+    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+        FAST_BOOT="true"
+    else
+        FAST_BOOT="false"
+    fi
+}
+
 function validate_restore_count()
 {
     if [[ x"$WARM_BOOT" == x"true" ]]; then
@@ -99,8 +108,8 @@ start_peer_and_dependent_services() {
 }
 
 stop_peer_and_dependent_services() {
-    # if warm start enabled or peer lock exists, don't stop peer service docker
-    if [[ x"$WARM_BOOT" != x"true" ]]; then
+    # if warm/fast start enabled or peer lock exists, don't stop peer service docker
+    if [[ x"$WARM_BOOT" != x"true" ]] && [[ x"$FAST_BOOT" != x"true" ]]; then
         if [[ ! -z $DEV ]]; then
             /bin/systemctl stop ${PEER}@$DEV
         else
@@ -185,17 +194,23 @@ stop() {
     lock_service_state_change
     check_warm_boot
     debug "Warm boot flag: ${SERVICE}$DEV ${WARM_BOOT}."
+    check_fast_boot
+    debug "Fast boot flag: ${SERVICE}$DEV ${FAST_BOOT}."
 
-    /usr/bin/${SERVICE}.sh stop $DEV
-    debug "Stopped ${SERVICE}$DEV service..."
+    # For WARM/FAST boot do not perform service stop
+    if [[ x"$WARM_BOOT" != x"true" ]] && [[ x"$FAST_BOOT" != x"true" ]]; then
+        /usr/bin/${SERVICE}.sh stop $DEV
+        debug "Stopped ${SERVICE}$DEV service..."
+    fi
 
     # Flush FAST_REBOOT table when swss needs to stop. The only
     # time when this would take effect is when fast-reboot
     # encountered error, e.g. syncd crashed. And swss needs to
     # be restarted.
-    debug "Clearing FAST_REBOOT flag..."
-    clean_up_tables STATE_DB "'FAST_REBOOT*'"
-
+    if [[ x"$FAST_BOOT" != x"true" ]]; then
+        debug "Clearing FAST_REBOOT flag..."
+        clean_up_tables STATE_DB "'FAST_REBOOT*'"
+    fi
     # Unlock has to happen before reaching out to peer service
     unlock_service_state_change
 

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -201,6 +201,9 @@ stop() {
     if [[ x"$WARM_BOOT" != x"true" ]] && [[ x"$FAST_BOOT" != x"true" ]]; then
         /usr/bin/${SERVICE}.sh stop $DEV
         debug "Stopped ${SERVICE}$DEV service..."
+    else
+        debug "Killing Docker swss..."
+        /usr/bin/docker kill swss &> /dev/null || debug "Docker swss is not running ($?) ..."
     fi
 
     # Flush FAST_REBOOT table when swss needs to stop. The only


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Modified fast/warm reboot handling for swss script.

**- How I did it**
Changes added:
For Fast and warm reboot, do not stop peer and dependent services.
Do not perform service stop for fast/warm reboot.
Clear FAST_REBOOT flag only when it is NOT fast reboot mode.

**- How to verify it**
With and without this change, the fast-reboot and warm-reboot procedure continue as usual. So there is no immediate disruption to the existing procedure.

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
**- Warm disabled**
`sudo systemctl stop swss`
```
Jul 29 19:16:54.206439 str-s6100-acs-4 NOTICE root: Stopping swss service...
Jul 29 19:16:54.214536 str-s6100-acs-4 NOTICE root: Locking /tmp/swss-syncd-lock from swss service
Jul 29 19:16:54.226242 str-s6100-acs-4 NOTICE root: Locked /tmp/swss-syncd-lock (10) from swss service
Jul 29 19:16:54.682275 str-s6100-acs-4 NOTICE root: Warm boot flag: swss false.
Jul 29 19:16:54.909508 str-s6100-acs-4 NOTICE root: Fast boot flag: swss false.
Jul 29 19:16:58.202710 str-s6100-acs-4 INFO containerd[1187]: time="2020-07-29T19:16:58.202515714Z" level=info msg="shim reaped" id=6d4e9eaab90f34f37fe2830156f8b5707bbdbdaff6f480dd1658cee7b8109023
Jul 29 19:16:58.214503 str-s6100-acs-4 INFO dockerd[1188]: time="2020-07-29T19:16:58.213577510Z" level=info msg="ignoring event" module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
Jul 29 19:16:58.618211 str-s6100-acs-4 INFO swss.sh[3191]: 0
Jul 29 19:16:58.618893 str-s6100-acs-4 INFO swss.sh[7529]: swss
Jul 29 19:16:58.628091 str-s6100-acs-4 NOTICE root: Stopped swss service...
```

`sudo systemctl start swss`
```
Jul 29 19:25:04.566701 str-s6100-acs-4 NOTICE root: Starting swss service...
Jul 29 19:25:04.575282 str-s6100-acs-4 NOTICE root: Locking /tmp/swss-syncd-lock from swss service
Jul 29 19:25:04.585707 str-s6100-acs-4 NOTICE root: Locked /tmp/swss-syncd-lock (10) from swss service
Jul 29 19:25:05.489071 str-s6100-acs-4 NOTICE root: Warm boot flag: swss false.
Jul 29 19:25:05.496695 str-s6100-acs-4 NOTICE root: Flushing APP, ASIC, COUNTER, CONFIG, and partial STATE databases ...
Jul 29 19:25:05.689886 str-s6100-acs-4 INFO swss.sh[10035]: OK
Jul 29 19:25:06.619944 str-s6100-acs-4 INFO bgp#bgpcfgd: Delete command is not supported for set src templates
Jul 29 19:25:06.389959 str-s6100-acs-4 INFO swss.sh[10035]: message repeated 3 times: [ OK]
Jul 29 19:25:08.349384 str-s6100-acs-4 INFO swss.sh[10035]: Starting existing swss container with HWSKU Force10-S6100
Jul 29 19:25:08.621046 str-s6100-acs-4 INFO containerd[1187]: time="2020-07-29T19:25:08.620750843Z" level=info msg="shim containerd-shim started" address="/containerd-shim/moby/6d4e9eaab90f34f37fe2830156f8b5707bbdbdaff6f480dd1658cee7b8109023/shim.sock" debug=false pid=10365
Jul 29 19:25:08.791312 str-s6100-acs-4 INFO swss.sh[10035]: swss
Jul 29 19:25:09.232504 str-s6100-acs-4 NOTICE root: Started swss service...
```

**- Warm enabled**

`sudo systemctl stop swss`
```
Jul 29 19:30:51.797353 str-s6100-acs-4 NOTICE root: Stopping swss service...
Jul 29 19:30:51.804830 str-s6100-acs-4 NOTICE root: Locking /tmp/swss-syncd-lock from swss service
Jul 29 19:30:51.814063 str-s6100-acs-4 NOTICE root: Locked /tmp/swss-syncd-lock (10) from swss service
Jul 29 19:30:52.286197 str-s6100-acs-4 NOTICE root: Warm boot flag: swss true.
Jul 29 19:30:52.525833 str-s6100-acs-4 NOTICE root: Fast boot flag: swss false.
Jul 29 19:30:52.533910 str-s6100-acs-4 NOTICE root: Clearing FAST_REBOOT flag...
Jul 29 19:30:52.769908 str-s6100-acs-4 NOTICE root: Unlocking /tmp/swss-syncd-lock (10) from swss service
Jul 29 19:30:52.787214 str-s6100-acs-4 INFO systemd[1]: Stopped switch state service.
```
`sudo systemctl start swss`
```
Jul 29 19:31:13.709335 str-s6100-acs-4 INFO systemd[1]: Starting switch state service...
Jul 29 19:31:13.719837 str-s6100-acs-4 NOTICE root: Starting swss service...
Jul 29 19:31:13.727581 str-s6100-acs-4 NOTICE root: Locking /tmp/swss-syncd-lock from swss service
Jul 29 19:31:13.736647 str-s6100-acs-4 NOTICE root: Locked /tmp/swss-syncd-lock (10) from swss service
Jul 29 19:31:14.869476 str-s6100-acs-4 NOTICE root: Warm boot flag: swss true.
Jul 29 19:31:16.578414 str-s6100-acs-4 INFO swss.sh[15481]: Starting existing swss container with HWSKU Force10-S6100
Jul 29 19:31:16.653156 str-s6100-acs-4 INFO swss.sh[15481]: swss
Jul 29 19:31:17.127692 str-s6100-acs-4 NOTICE root: Started swss service...
```


**- A picture of a cute animal (not mandatory but encouraged)**
