### PR TITLE
Support to convert certificate from pfx to pem format

### DIFF
--- a/scripts/convert-pfx-cert-format.sh
+++ b/scripts/convert-pfx-cert-format.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -ex
+
+usage()
+{
+    echo "Usage:  $0 -p <pfx_cert> -k <signing_key> -c <signing_cert> -a <ca_cert>"
+    exit 1
+}
+
+while getopts "p:k:c:a:" opt; do
+    case $opt in
+        p)
+            PFX_FILE=$OPTARG
+            ;;
+        k)
+            SIGNING_KEY=$OPTARG
+            ;;
+        c)
+            SIGNING_CERT=$OPTARG
+            ;;
+        a)
+            CA_CERT=$OPTARG
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+
+[ -z $PFX_FILE ] || [ -z $SIGNING_KEY ] || [ -z $SIGNING_CERT ] || [ -z $CA_CERT ] && exit 1
+
+openssl pkcs12 -in "${PFX_FILE}" -clcerts -nokeys -nodes -passin pass: | sed -z -e "s/.*\(-----BEGIN CERTIFICATE\)/\1/" > ${SIGNING_CERT}
+openssl pkcs12 -in "${PFX_FILE}" -nocerts -nodes -passin pass: | sed -z -e "s/.*\(-----BEGIN PRIVATE KEY\)/\1/" > ${SIGNING_KEY}
+openssl pkcs12 -in "${PFX_FILE}" -cacerts -nokeys -nodes -passin pass: | sed -z -e "s/.*\(-----BEGIN CERTIFICATE\)/\1/" > ${CA_CERT}
+

--- a/scripts/convert-pfx-cert-format.sh
+++ b/scripts/convert-pfx-cert-format.sh
@@ -27,9 +27,8 @@ while getopts "p:k:c:a:" opt; do
 done
 
 
-[ -z $PFX_FILE ] || [ -z $SIGNING_KEY ] || [ -z $SIGNING_CERT ] || [ -z $CA_CERT ] && exit 1
+( [ -z $PFX_FILE ] || [ -z $SIGNING_KEY ] || [ -z $SIGNING_CERT ] || [ -z $CA_CERT ] ) && exit 1
 
 openssl pkcs12 -in "${PFX_FILE}" -clcerts -nokeys -nodes -passin pass: | sed -z -e "s/.*\(-----BEGIN CERTIFICATE\)/\1/" > ${SIGNING_CERT}
 openssl pkcs12 -in "${PFX_FILE}" -nocerts -nodes -passin pass: | sed -z -e "s/.*\(-----BEGIN PRIVATE KEY\)/\1/" > ${SIGNING_KEY}
 openssl pkcs12 -in "${PFX_FILE}" -cacerts -nokeys -nodes -passin pass: | sed -z -e "s/.*\(-----BEGIN CERTIFICATE\)/\1/" > ${CA_CERT}
-


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
It provides a small script for Jinkins build pipeline to convert pfx format certificate to pem format. It will export the ca certificate, signing certificate and signing key from the pfx certificate.

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
