### PR TITLE
[bgpcfgd]: Clarify error message for update loopback address

### DIFF
--- a/dockers/docker-fpm-quagga/bgpcfgd
+++ b/dockers/docker-fpm-quagga/bgpcfgd
@@ -146,7 +146,7 @@ class BGPConfigManager(object):
             ip_addr_w_mask = key.replace("Loopback0|", "")
             slash_pos = ip_addr_w_mask.rfind("/")
             if slash_pos == -1:
-                syslog.syslog(syslog.LOG_ERR, "Wrong Loopback0 ip address'%s'" % ip_addr_w_mask)
+                syslog.syslog(syslog.LOG_ERR, "Wrong Loopback0 ip prefix '%s'" % ip_addr_w_mask)
                 return
             ip_addr = ip_addr_w_mask[:slash_pos]
             try:
@@ -155,14 +155,14 @@ class BGPConfigManager(object):
                         self.lo_ipv4 = ip_addr
                         txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC", lo_ip=ip_addr, ip_proto="")
                     else:
-                        syslog.syslog(syslog.LOG_INFO, "Update command is not supported for set src templates. lo_ip='%s'" % ip_addr)
+                        syslog.syslog(syslog.LOG_INFO, "Update command is not supported for set src templates. current ip='%s'. new ip='%s'" % (self.lo_ipv4, ip_addr))
                         return
                 elif TemplateFabric.is_ipv6(ip_addr):
                     if self.lo_ipv6 is None:
                         self.lo_ipv6 = ip_addr
                         txt = self.zebra_set_src_template.render(rm_name="RM_SET_SRC6", lo_ip=ip_addr, ip_proto="v6")
                     else:
-                        syslog.syslog(syslog.LOG_INFO, "Update command is not supported for set src templates. lo_ip='%s'" % ip_addr)
+                        syslog.syslog(syslog.LOG_INFO, "Update command is not supported for set src templates. current ip='%s'. new ip='%s'" % (self.lo_ipv6, ip_addr))
                         return
                 else:
                     syslog.syslog(syslog.LOG_ERR, "Got ambiguous ip address '%s'" % ip_addr)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
To make the syslog message more informative.

**- How I did it**
By adding current loopback ip address to the message

**- How to verify it**
Build new image, push into your DUT.
After that
```
redis-cli 
127.0.0.1:6379> select 4
OK
127.0.0.1:6379[4]> hset "LOOPBACK_INTERFACE|Loopback0|10.1.0.32/32" NULL NULL
(integer) 0
127.0.0.1:6379[4]> hset "LOOPBACK_INTERFACE|Loopback0|FC00:1::32/128" NULL NULL
(integer) 0
```

The syslog output would be
```
Last login: Thu Jul 30 16:24:17 2020 from 10.20.53.178
admin@str-s6100-acs-1:~$ sudo tail -F /var/log/syslog | grep 'bgpcfgd'
Jul 30 16:28:25.243134 str-s6100-acs-1 INFO bgp#bgpcfgd: Update command is not supported for set src templates. current ip='10.1.0.32'. new ip='10.1.0.32'
Jul 30 16:28:31.637956 str-s6100-acs-1 INFO bgp#bgpcfgd: Update command is not supported for set src templates. current ip='FC00:1::32'. new ip='FC00:1::32'
```

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
