### PR TITLE
[bfn] Updated BFN SDK packages to 20200731 with SAI v1.5.2

### DIFF
--- a/platform/barefoot/bfn-platform.mk
+++ b/platform/barefoot/bfn-platform.mk
@@ -1,4 +1,4 @@
-BFN_PLATFORM = bfnplatform_20200507_deb9.deb
+BFN_PLATFORM = bfnplatform_20200731_sai_1.5.2_deb9.deb
 $(BFN_PLATFORM)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/$(BFN_PLATFORM)"
 
 SONIC_ONLINE_DEBS += $(BFN_PLATFORM)

--- a/platform/barefoot/bfn-sai.mk
+++ b/platform/barefoot/bfn-sai.mk
@@ -1,4 +1,4 @@
-BFN_SAI = bfnsdk_20200507_deb9.deb
+BFN_SAI = bfnsdk_20200731_sai_1.5.2_deb9.deb
 $(BFN_SAI)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/$(BFN_SAI)"
 
 $(BFN_SAI)_DEPENDS += $(LIBNL_GENL3_DEV)


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <akokhan@barefootnetworks.com>

**- Why I did it**
- Update  BFN SDK packages to 20200731 with SAI v1.5.2
- Fix BFN platform build
