### PR TITLE
[Mellanox] Temporary rollback package extract logic

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -405,7 +405,18 @@ sudo chmod a+x $FILESYSTEM_ROOT/usr/sbin/policy-rc.d
 
 {% if installer_debs.strip() -%}
 {% for deb in installer_debs.strip().split(' ') -%}
+{% if sonic_asic_platform == "mellanox" %}
+if [ -e tmpdir ] ;
+then
+    rm -rf tmpdir;
+fi
+sudo mkdir tmpdir
+sudo dpkg --extract {{deb}} tmpdir
+for subdir in $(ls tmpdir) ; do sudo cp -R tmpdir/$subdir/* $FILESYSTEM_ROOT/$subdir; done
+sudo rm -rf tmpdir
+{% else %}
 sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
+{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

https://sonic-jenkins.westus2.cloudapp.azure.com/job/mellanox/job/buildimage-mlnx-all-pr/4259/artifact/target/sonic-mellanox.bin.log
```
+ sudo dpkg --root=./fsroot -i target/debs/buster/kernel-mft-dkms_4.15.0-4.19.0-9-2-amd64_all.deb
Selecting previously unselected package kernel-mft-dkms-modules-4.19.0-9-2-amd64.
(Reading database ... 33374 files and directories currently installed.)
Preparing to unpack .../kernel-mft-dkms_4.15.0-4.19.0-9-2-amd64_all.deb ...
dpkg: error processing archive target/debs/buster/kernel-mft-dkms_4.15.0-4.19.0-9-2-amd64_all.deb (--install):
 new kernel-mft-dkms-modules-4.19.0-9-2-amd64 package pre-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 target/debs/buster/kernel-mft-dkms_4.15.0-4.19.0-9-2-amd64_all.deb
```

**- Why I did it**
* Mellanox package extract logic should be added back until MFT DKMS build is updated

**- How I did it**
* N/A

**- How to verify it**
1. make target/sonic-mellanox.bin

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

**- A picture of a cute animal (not mandatory but encouraged)**
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```