### PR TITLE
[monit] Periodically monitor route consistency

### DIFF
--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -22,5 +22,5 @@ check process rsyslog with pidfile /var/run/rsyslogd.pid
     if totalmem > 800 MB for 10 times within 20 cycles then restart
 
 check program routeCheck with path "/usr/bin/route_check.py"
-    every "*/5 * * * *"
+    every 5 cycles
     if status != 0 then alert

--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -20,3 +20,7 @@ check process rsyslog with pidfile /var/run/rsyslogd.pid
     start program = "/bin/systemctl start rsyslog.service"
     stop program = "/bin/systemctl stop rsyslog.service"
     if totalmem > 800 MB for 10 times within 20 cycles then restart
+
+check program routeCheck with path "/usr/bin/route_check.py"
+    every "*/5 * * * *"
+    if status != 0 then alert

--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -21,6 +21,10 @@ check process rsyslog with pidfile /var/run/rsyslogd.pid
     stop program = "/bin/systemctl stop rsyslog.service"
     if totalmem > 800 MB for 10 times within 20 cycles then restart
 
+# route_check.py Verify routes between APPL-DB & ASIC-DB are in sync.
+# For any discrepancy, details are logged and a non-zero code is returned
+# which would trigger a monit alert.
+#
 check program routeCheck with path "/usr/bin/route_check.py"
     every 5 cycles
     if status != 0 then alert

--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -24,6 +24,8 @@ check process rsyslog with pidfile /var/run/rsyslogd.pid
 # route_check.py Verify routes between APPL-DB & ASIC-DB are in sync.
 # For any discrepancy, details are logged and a non-zero code is returned
 # which would trigger a monit alert.
+# Hence for any discrepancy, there will be log messages for "ERR" level
+# from both route_check.py & monit.
 #
 check program routeCheck with path "/usr/bin/route_check.py"
     every 5 cycles


### PR DESCRIPTION
route_check.py is a tool for "Verify routes between APPL-DB & ASIC-DB are in sync".
This tool is added to monit to run the check periodically.

For any failure, the monit will raise alert based on return code.
The tool will log required details.
