### PR TITLE
[Mellanox] Add MFT DKMS build support

### DIFF
--- a/platform/mellanox/mft.mk
+++ b/platform/mellanox/mft.mk
@@ -10,7 +10,7 @@ $(MFT)_SRC_PATH = $(PLATFORM_PATH)/mft
 $(MFT)_DEPENDS += $(LINUX_HEADERS) $(LINUX_HEADERS_COMMON)
 SONIC_MAKE_DEBS += $(MFT)
 
-KERNEL_MFT = kernel-mft-dkms_$(MFT_VERSION)-$(KVERSION)_all.deb
+KERNEL_MFT = kernel-mft-dkms-modules-$(KVERSION)_$(MFT_VERSION)_amd64.deb
 $(eval $(call add_derived_package,$(MFT),$(KERNEL_MFT)))
 
 MFT_OEM = mft-oem_$(MFT_VERSION)-$(MFT_REVISION)_amd64.deb

--- a/platform/mellanox/mft/Makefile
+++ b/platform/mellanox/mft/Makefile
@@ -4,15 +4,21 @@ SHELL = /bin/bash
 
 MFT_NAME = mft-$(MFT_VERSION)-$(MFT_REVISION)-x86_64-deb
 MFT_TGZ = $(MFT_NAME).tgz
+
 SRC_DEB = kernel-mft-dkms_$(MFT_VERSION)-$(MFT_REVISION)_all.deb
+MOD_DEB = kernel-mft-dkms-modules-$(KVERSION)_$(MFT_VERSION)_amd64.deb
 
 MAIN_TARGET = mft_$(MFT_VERSION)-$(MFT_REVISION)_amd64.deb
-DERIVED_TARGETS = kernel-mft-dkms_$(MFT_VERSION)-$(KVERSION)_all.deb mft-oem_$(MFT_VERSION)-$(MFT_REVISION)_amd64.deb
+DERIVED_TARGETS = $(MOD_DEB) mft-oem_$(MFT_VERSION)-$(MFT_REVISION)_amd64.deb
+
+DKMS_BMDEB = /var/lib/dkms/kernel-mft-dkms/$(MFT_VERSION)/bmdeb
+DKMS_TMP := $(shell mktemp -u -d -t dkms.XXXXXXXXXX)
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf $(MFT_NAME)
 	wget -O $(MFT_TGZ) http://www.mellanox.com/downloads/MFT/$(MFT_TGZ)
 	tar xzf $(MFT_TGZ)
+
 	pushd $(MFT_NAME)/SDEBS
 
 	# put a lock here because dpkg does not allow installing packages in parallel
@@ -22,11 +28,27 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	fi
 	done
 
-	tar xvf `sudo dkms mkdriverdisk kernel-mft-dkms/$(MFT_VERSION) -a all -d ubuntu -k $(KVERSION) --media tar | grep "Disk image location" | cut -d':' -f2`
 	popd
 
+	sudo dkms build kernel-mft-dkms/$(MFT_VERSION) -k $(KVERSION) -a amd64
+	sudo dkms mkbmdeb kernel-mft-dkms/$(MFT_VERSION) -k $(KVERSION) -a amd64
+
+	# w/a: remove dependencies
+	mkdir -p $(DKMS_TMP)/DEBIAN
+
+	dpkg -e $(DKMS_BMDEB)/$(MOD_DEB) $(DKMS_TMP)/DEBIAN
+	dpkg -x $(DKMS_BMDEB)/$(MOD_DEB) $(DKMS_TMP)
+
+	sed -i '/^Depends:/c\Depends:' $(DKMS_TMP)/DEBIAN/control
+
+	pushd $(MFT_NAME)/DEBS
+	dpkg -b $(DKMS_TMP) .
+	popd
+
+	rm -rf $(DKMS_TMP)
+
 	# fix timestamp because we do not actually build tools, only kernel
-	touch $(MFT_NAME)/DEBS/*
-	mv $(MFT_NAME)/SDEBS/ubuntu-drivers/4.19.0/kernel-mft-dkms_$(MFT_VERSION)-$(KVERSION)_all.deb $(MFT_NAME)/DEBS/* $(DEST)
+	touch $(MFT_NAME)/DEBS/*.deb
+	mv $(MFT_NAME)/DEBS/*.deb $(DEST)
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
This PR adds MFT DKMS build support and overcomes module deb installation issue:
`Package generated with mkbmdeb fails to be installed when using kernel mainline build`
https://bugs.launchpad.net/ubuntu/+source/dkms/+bug/1835429

**Sample DPKG output with original dependencies:**
```
root@sonic:/home/admin# dpkg -i kernel-mft-dkms-modules-4.19.0-9-2-amd64_4.15.0_amd64.deb
(Reading database ... 29799 files and directories currently installed.)
Preparing to unpack kernel-mft-dkms-modules-4.19.0-9-2-amd64_4.15.0_amd64.deb ...
Unpacking kernel-mft-dkms-modules-4.19.0-9-2-amd64 (4.15.0) over (4.15.0) ...
dpkg: dependency problems prevent configuration of kernel-mft-dkms-modules-4.19.0-9-2-amd64:
 kernel-mft-dkms-modules-4.19.0-9-2-amd64 depends on linux-image-4.19.0-9-2-amd64; however:
  Package linux-image-4.19.0-9-2-amd64 is not installed.

dpkg: error processing package kernel-mft-dkms-modules-4.19.0-9-2-amd64 (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 kernel-mft-dkms-modules-4.19.0-9-2-amd64

root@sonic:/home/admin# dpkg -l | grep linux-image
iU  kernel-mft-dkms-modules-4.19.0-9-2-amd64 4.15.0                       amd64        kernel-mft-dkms binary drivers for linux-image-4.19.0-9-2-amd64
ii  linux-image-4.19.0-9-2-amd64-unsigned    4.19.118-2+deb10u1           amd64        Linux 4.19 for 64-bit PCs
```

**DKMS templates:**
https://github.com/dell/dkms/blob/master/template-dkms-mkbmdeb/debian/control
`Depends: ${misc:Depends}, linux-image-KERNEL_VERSION`

https://github.com/dell/dkms/blob/master/template-dkms-mkdeb/debian/control
`Depends: dkms (>= 1.95), ${misc:Depends}`

https://github.com/dell/dkms/blob/master/dkms#L2526
`Depends:`

`mkdriverdisk` vs `mkbmdeb`:
```
root@sonic:/home/admin# dpkg --info kernel-mft-dkms_4.15.0-4.19.0-9-2-amd64_all.deb
 new debian package, version 2.0.
 size 7684 bytes: control archive=439 bytes.
     346 bytes,    11 lines      control
      66 bytes,     3 lines   *  preinst              #!/bin/bash
 Package: kernel-mft-dkms-modules-4.19.0-9-2-amd64
 Version: 4.15.0-1
 Section: misc
 Priority: optional
 Architecture: all
 Depends:
 Maintainer: DKMS <dkms-devel@dell.com>
 Description: DKMS packaged binary driver update
  DKMS automagically generated debian package for
  driver update disks, used with Ubuntu installation
  programs (such as Ubiquity).

root@sonic:/home/admin# dpkg --info kernel-mft-dkms-modules-4.19.0-9-2-amd64_4.15.0_amd64.deb
 new debian package, version 2.0.
 size 8508 bytes: control archive=868 bytes.
     527 bytes,    13 lines      control
     479 bytes,     5 lines      md5sums
     366 bytes,     9 lines   *  postinst             #!/bin/sh
     234 bytes,     7 lines   *  postrm               #!/bin/sh
 Package: kernel-mft-dkms-modules-4.19.0-9-2-amd64
 Source: kernel-mft-dkms-dkms-bin
 Version: 4.15.0
 Architecture: amd64
 Maintainer: Dynamic Kernel Modules Support Team <pkg-dkms-maint@lists.alioth.debian.org>
 Installed-Size: 44
 Depends: linux-image-4.19.0-9-2-amd64
 Provides: kernel-mft-dkms-modules
 Section: misc
 Priority: optional
 Description: kernel-mft-dkms binary drivers for linux-image-4.19.0-9-2-amd64
  This package contains kernel-mft-dkms drivers for the 4.19.0-9-2-amd64 Linux kernel,
  built from kernel-mft-dkms-dkms for the amd64 architecture.

root@sonic:/home/admin# tree kernel-mft-dkms_4.15.0-4.19.0-9-2-amd64_all
kernel-mft-dkms_4.15.0-4.19.0-9-2-amd64_all
├── DEBIAN
│   ├── control
│   └── preinst
└── lib
    └── modules
        └── 4.19.0-9-2-amd64
            └── updates
                └── dkms
                    ├── mst_pciconf.ko
                    └── mst_pci.ko

6 directories, 4 files

root@sonic:/home/admin# tree kernel-mft-dkms-modules-4.19.0-9-2-amd64_4.15.0_amd64
kernel-mft-dkms-modules-4.19.0-9-2-amd64_4.15.0_amd64
├── DEBIAN
│   ├── control
│   ├── md5sums
│   ├── postinst
│   └── postrm
├── lib
│   └── modules
│       └── 4.19.0-9-2-amd64
│           └── updates
│               └── dkms
│                   ├── mst_pciconf.ko
│                   └── mst_pci.ko
└── usr
    └── share
        └── doc
            └── kernel-mft-dkms-modules-4.19.0-9-2-amd64
                ├── changelog
                ├── copyright
                └── README.Debian

10 directories, 9 files

root@sonic:/home/admin# cat kernel-mft-dkms_4.15.0-4.19.0-9-2-amd64_all/DEBIAN/control
Package: kernel-mft-dkms-modules-4.19.0-9-2-amd64
Version: 4.15.0-1
Section: misc
Priority: optional
Architecture: all
Depends:
Maintainer: DKMS <dkms-devel@dell.com>
Description: DKMS packaged binary driver update
 DKMS automagically generated debian package for
 driver update disks, used with Ubuntu installation
 programs (such as Ubiquity).

root@sonic:/home/admin# cat kernel-mft-dkms_4.15.0-4.19.0-9-2-amd64_all/DEBIAN/preinst
#!/bin/bash
[[ $(uname -r) = 4.19.0-9-2-amd64 ]] || exit 1
exit 0

root@sonic:/home/admin# cat kernel-mft-dkms-modules-4.19.0-9-2-amd64_4.15.0_amd64/DEBIAN/control
Package: kernel-mft-dkms-modules-4.19.0-9-2-amd64
Source: kernel-mft-dkms-dkms-bin
Version: 4.15.0
Architecture: amd64
Maintainer: Dynamic Kernel Modules Support Team <pkg-dkms-maint@lists.alioth.debian.org>
Installed-Size: 44
Depends: linux-image-4.19.0-9-2-amd64
Provides: kernel-mft-dkms-modules
Section: misc
Priority: optional
Description: kernel-mft-dkms binary drivers for linux-image-4.19.0-9-2-amd64
 This package contains kernel-mft-dkms drivers for the 4.19.0-9-2-amd64 Linux kernel,
 built from kernel-mft-dkms-dkms for the amd64 architecture.

root@sonic:/home/admin# cat kernel-mft-dkms-modules-4.19.0-9-2-amd64_4.15.0_amd64/DEBIAN/postrm
#!/bin/sh
set -e
# Automatically added by dh_installmodules/12.1.1~bpo9+1
if [ -e /boot/System.map-4.19.0-9-2-amd64 ]; then
        depmod -a -F /boot/System.map-4.19.0-9-2-amd64 4.19.0-9-2-amd64 || true
fi
# End automatically added section

root@sonic:/home/admin# cat kernel-mft-dkms-modules-4.19.0-9-2-amd64_4.15.0_amd64/DEBIAN/postinst
#!/bin/sh
set -e
# Automatically added by dh_installmodules/12.1.1~bpo9+1
if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
        if [ -e /boot/System.map-4.19.0-9-2-amd64 ]; then
                depmod -a -F /boot/System.map-4.19.0-9-2-amd64 4.19.0-9-2-amd64 || true
        fi
fi
# End automatically added section
```

Either `preinst` should be removed or `Depends:` updated, which causes debian repack in any case

**- Why I did it**
* To add MFT DKMS build support
* To fix deb installation in chroot mode

**- How I did it**
* Repacked deb package and removed linux image dependencies: the same behaviour as for mkdriverdisk

**- How to verify it**
1. BLDENV=buster make target/debs/buster/mft_4.15.0-104_amd64.deb

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```