### PR TITLE
[build]: add user define mount for the build

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -46,6 +46,8 @@ SHELL = /bin/bash
 USER := $(shell id -un)
 PWD := $(shell pwd)
 
+comma := ,
+
 ifeq ($(USER), root)
 $(error Add your user account to docker group and use your user account to make. root or sudo are not supported!)
 endif
@@ -116,6 +118,10 @@ DOCKER_RUN := docker run --rm=true --privileged --init \
     -i$(if $(TERM),t,)
 
 include rules/config
+
+ifneq ($(DOCKER_BUILDER_USER_MOUNT),)
+	DOCKER_RUN += $(foreach mount,$(subst $(comma), ,$(DOCKER_BUILDER_USER_MOUNT)), $(addprefix -v , $(mount)))
+endif
 
 ifneq ($(SONIC_DPKG_CACHE_SOURCE),)
 	DOCKER_RUN += -v "$(SONIC_DPKG_CACHE_SOURCE):/dpkg_cache:rw"


### PR DESCRIPTION
follow command add additional mount in the sonic:

    DOCKER_BUILDER_USER_MOUNT=/data2:/data2,/data:/data make sonic-slave-bash

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

add developer to mount additional directory in the sonic-slave

**- How I did it**

follow command add additional mount in the sonic:

    DOCKER_BUILDER_USER_MOUNT=/data2:/data2,/data:/data make sonic-slave-bash

**- How to verify it**

run example command and validate the directory inside the docker

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
