### PR TITLE
[Cables] Add support for 'Extended Specification Compliance' for QSFP cables

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -30,7 +30,7 @@ except ImportError as e:
 
 # definitions of the offset and width for values in XCVR info eeprom
 XCVR_INTFACE_BULK_OFFSET = 0
-XCVR_INTFACE_BULK_WIDTH_QSFP = 20
+XCVR_INTFACE_BULK_WIDTH_QSFP = 65
 XCVR_INTFACE_BULK_WIDTH_SFP = 21
 XCVR_TYPE_OFFSET = 0
 XCVR_TYPE_WIDTH = 1
@@ -827,6 +827,8 @@ class SFP(SfpBase):
                 for key in qsfp_compliance_code_tup:
                     if key in sfp_interface_bulk_data['data']['Specification compliance']['value']:
                         compliance_code_dict[key] = sfp_interface_bulk_data['data']['Specification compliance']['value'][key]['value']
+                if sfp_interface_bulk_data['data']['Extended Specification compliance']['value'] != "Unspecified":
+                    compliance_code_dict['Extended Specification compliance'] = sfp_interface_bulk_data['data']['Extended Specification compliance']['value']
                 transceiver_info_dict['specification_compliance'] = str(compliance_code_dict)
                 
                 transceiver_info_dict['nominal_bit_rate'] = str(sfp_interface_bulk_data['data']['Nominal Bit Rate(100Mbs)']['value'])


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
To have this field in DB along with other cable information.

**- How I did it**
Parse 'Extended Specification Compliance' field from EEPROM and add it to DB, if exist.

**- How to verify it**
Run 'show interface transceiver eeprom Ethernet#'.

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
