### PR TITLE
[sonic-platform-common][sonic-platform-daemons] Update submodules

### DIFF
--- a/rules/sonic-platform-common.mk
+++ b/rules/sonic-platform-common.mk
@@ -10,8 +10,10 @@ SONIC_PYTHON_WHEELS += $(SONIC_PLATFORM_COMMON_PY2)
 SONIC_PLATFORM_COMMON_PY3 = sonic_platform_common-1.0-py3-none-any.whl
 $(SONIC_PLATFORM_COMMON_PY3)_SRC_PATH = $(SRC_PATH)/sonic-platform-common
 $(SONIC_PLATFORM_COMMON_PY3)_PYTHON_VERSION = 3
-$(SONIC_PLATFORM_COMMON_PY3)_DEPENDS += $(SONIC_PY_COMMON_PY3)
+$(SONIC_PLATFORM_COMMON_PY3)_DEPENDS += $(SONIC_PY_COMMON_PY3) $(SONIC_CONFIG_ENGINE)
 # Synthetic dependency just to avoid race condition
 $(SONIC_PLATFORM_COMMON_PY3)_DEPENDS += $(SONIC_PLATFORM_COMMON_PY2)
 $(SONIC_PLATFORM_COMMON_PY3)_TEST = n
-SONIC_PYTHON_WHEELS += $(SONIC_PLATFORM_COMMON_PY3)
+# Disable building Python 3 package for now, becuase it currently depends on sonic-config-engine,
+# and we're not yet building a Python 3 package for sonic-config-engine
+#SONIC_PYTHON_WHEELS += $(SONIC_PLATFORM_COMMON_PY3)

--- a/rules/sonic-platform-common.mk
+++ b/rules/sonic-platform-common.mk
@@ -10,10 +10,8 @@ SONIC_PYTHON_WHEELS += $(SONIC_PLATFORM_COMMON_PY2)
 SONIC_PLATFORM_COMMON_PY3 = sonic_platform_common-1.0-py3-none-any.whl
 $(SONIC_PLATFORM_COMMON_PY3)_SRC_PATH = $(SRC_PATH)/sonic-platform-common
 $(SONIC_PLATFORM_COMMON_PY3)_PYTHON_VERSION = 3
-$(SONIC_PLATFORM_COMMON_PY3)_DEPENDS += $(SONIC_PY_COMMON_PY3) $(SONIC_CONFIG_ENGINE)
+$(SONIC_PLATFORM_COMMON_PY3)_DEPENDS += $(SONIC_PY_COMMON_PY3)
 # Synthetic dependency just to avoid race condition
 $(SONIC_PLATFORM_COMMON_PY3)_DEPENDS += $(SONIC_PLATFORM_COMMON_PY2)
 $(SONIC_PLATFORM_COMMON_PY3)_TEST = n
-# Disable building Python 3 package for now, becuase it currently depends on sonic-config-engine,
-# and we're not yet building a Python 3 package for sonic-config-engine
-#SONIC_PYTHON_WHEELS += $(SONIC_PLATFORM_COMMON_PY3)
+SONIC_PYTHON_WHEELS += $(SONIC_PLATFORM_COMMON_PY3)


### PR DESCRIPTION
* src/sonic-platform-common be1cc24...f3f3573 (3):
  > Remove sonic-config-engine dependency from setup.py (#109)
  > Migrate from sonic-daemon-base package to sonic-py-common package (#103)
  > [Cables] Add support for 'Extended Specification Compliance' for QSFP cables (#108)
  > [sfputilbase.py] Add application_advertisement NA field to transceiver_info_dict for platform api 1.0 (#104)

* src/sonic-platform-daemons 49d145c...8e0704e (1):
  > Proper fix for thermalctld using sonic-py-common (#80)
  > Fix thermalctld tests which were broken by the transition to sonic-py-common (#79)
  > Migrate from sonic-daemon-base package to sonic-py-common package (#74)