### PR TITLE
[calcmgrd] Allow all incoming traffic on http/https ports for restapi

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -259,6 +259,9 @@ class ControlPlaneAclManager(object):
         iptables_cmds.append("ip6tables -A INPUT -p tcp --dport 179 -j ACCEPT")
         iptables_cmds.append("ip6tables -A INPUT -p tcp --sport 179 -j ACCEPT")
 
+        # Add iptables/ip6tables commands to allow all restapi/http/https requests
+        iptables_cmds.append("iptables -A INPUT -p tcp --dport 8081 -j ACCEPT")
+        iptables_cmds.append("iptables -A INPUT -p tcp --dport 8090 -j ACCEPT")
 
         # Get current ACL tables and rules from Config DB
         self._tables_db_info = self.config_db.get_table(self.ACL_TABLE)


### PR DESCRIPTION
**- Why I did it**
Allow http/https ports for restapi ([Ref](https://github.com/Azure/sonic-buildimage/blob/master/rules/docker-restapi.mk#L23))

**- How I did it**
Install Iptable rules

**- How to verify it**
Check with curl commands

**- Which release branch to backport (provide reason below if seleted)**

<!--
- Note we only backport fixes to a release branch, not a feature!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
