### PR TITLE
[sonic-py-common] Add interface utilities

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -15,7 +15,7 @@ from lxml.etree import QName
 
 from portconfig import get_port_config
 from sonic_py_common.multi_asic import get_asic_id_from_name
-from sonic_py_common import sonic_interface
+from sonic_py_common import interface
 
 """minigraph.py
 version_added: "1.9"
@@ -729,7 +729,7 @@ def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
     # architecture
     for port_channel_intf in port_channels:
         backend_port_channel = any(lag_member in port_alias_asic_map \
-                                   and lag_member.startswith(sonic_interface.sonic_bp_interface_prefix()) \
+                                   and lag_member.startswith(interface.bp_interface_prefix()) \
                                    for lag_member in port_channels[port_channel_intf]['members'])
         if not backend_port_channel:
             front_port_channel_intf.append(port_channel_intf)
@@ -751,7 +751,7 @@ def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
         # This will be applicable in Multi-NPU Platforms.
         front_panel_ports = []
         for port in group_params.get('ports', []):
-            if port in port_alias_asic_map and port.startswith(sonic_interface.sonic_bp_interface_prefix()):
+            if port in port_alias_asic_map and port.startswith(interface.bp_interface_prefix()):
                 continue
             if port in port_channels and port not in front_port_channel_intf:
                 continue

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -15,6 +15,7 @@ from lxml.etree import QName
 
 from portconfig import get_port_config
 from sonic_py_common.multi_asic import get_asic_id_from_name
+from sonic_py_common import sonic_interface
 
 """minigraph.py
 version_added: "1.9"
@@ -37,7 +38,6 @@ VLAN_SUB_INTERFACE_VLAN_ID = '10'
 
 FRONTEND_ASIC_SUB_ROLE = 'FrontEnd'
 BACKEND_ASIC_SUB_ROLE = 'BackEnd'
-BACKEND_ASIC_INTERFACE_NAME_PREFIX = 'Ethernet-BP'
 
 # Default Virtual Network Index (VNI) 
 vni_default = 8000
@@ -729,7 +729,7 @@ def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
     # architecture
     for port_channel_intf in port_channels:
         backend_port_channel = any(lag_member in port_alias_asic_map \
-                                   and lag_member.startswith(BACKEND_ASIC_INTERFACE_NAME_PREFIX) \
+                                   and lag_member.startswith(sonic_interface.sonic_bp_interface_prefix()) \
                                    for lag_member in port_channels[port_channel_intf]['members'])
         if not backend_port_channel:
             front_port_channel_intf.append(port_channel_intf)
@@ -751,7 +751,7 @@ def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
         # This will be applicable in Multi-NPU Platforms.
         front_panel_ports = []
         for port in group_params.get('ports', []):
-            if port in port_alias_asic_map and port.startswith(BACKEND_ASIC_INTERFACE_NAME_PREFIX):
+            if port in port_alias_asic_map and port.startswith(sonic_interface.sonic_bp_interface_prefix()):
                 continue
             if port in port_channels and port not in front_port_channel_intf:
                 continue

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -15,7 +15,7 @@ from lxml.etree import QName
 
 from portconfig import get_port_config
 from sonic_py_common.multi_asic import get_asic_id_from_name
-from sonic_py_common import interface
+from sonic_py_common.interface import backplane_prefix
 
 """minigraph.py
 version_added: "1.9"
@@ -729,7 +729,7 @@ def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
     # architecture
     for port_channel_intf in port_channels:
         backend_port_channel = any(lag_member in port_alias_asic_map \
-                                   and lag_member.startswith(interface.bp_interface_prefix()) \
+                                   and lag_member.startswith(backplane_prefix()) \
                                    for lag_member in port_channels[port_channel_intf]['members'])
         if not backend_port_channel:
             front_port_channel_intf.append(port_channel_intf)
@@ -751,7 +751,7 @@ def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
         # This will be applicable in Multi-NPU Platforms.
         front_panel_ports = []
         for port in group_params.get('ports', []):
-            if port in port_alias_asic_map and port.startswith(interface.bp_interface_prefix()):
+            if port in port_alias_asic_map and port.startswith(backplane_prefix()):
                 continue
             if port in port_channels and port not in front_port_channel_intf:
                 continue

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -12,31 +12,31 @@ SONIC_INTERFACE_PREFIXES = {
   "Ethernet-Backplane":"Ethernet-BP"
 }
 
-def fp_interface_prefix():
+def front_panel_prefix():
     """
     Retrieves the SONIC front panel interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["Ethernet-FrontPanel"]
 
-def bp_interface_prefix():
+def backplane_prefix():
     """
     Retrieves the SONIC backplane interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["Ethernet-Backplane"]
 
-def portchannel_interface_prefix():
+def portchannel_prefix():
     """
     Retrieves the SONIC PortChannel interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["PortChannel"]
 
-def vlan_interface_prefix():
+def vlan_prefix():
     """
     Retrieves the SONIC Vlan interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["Vlan"]
 
-def lo_interface_prefix():
+def loopback_prefix():
     """
     Retrieves the SONIC Loopback interface name prefix.
     """

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -1,5 +1,3 @@
-import sys
-
 """
  Dictionary of SONIC interface name prefixes. Each entry in the format
  "Human readable interface string":"Sonic interface prefix"

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -12,31 +12,31 @@ SONIC_INTERFACE_PREFIXES = {
   "Ethernet-Backplane":"Ethernet-BP"
 }
 
-def sonic_fp_interface_prefix():
+def fp_interface_prefix():
     """
     Retrieves the SONIC front panel interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["Ethernet-FrontPanel"]
 
-def sonic_bp_interface_prefix():
+def bp_interface_prefix():
     """
     Retrieves the SONIC backplane interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["Ethernet-Backplane"]
 
-def sonic_portchannel_interface_prefix():
+def portchannel_interface_prefix():
     """
     Retrieves the SONIC PortChannel interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["PortChannel"]
 
-def sonic_vlan_interface_prefix():
+def vlan_interface_prefix():
     """
     Retrieves the SONIC Vlan interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["Vlan"]
 
-def sonic_lo_interface_prefix():
+def lo_interface_prefix():
     """
     Retrieves the SONIC Loopback interface name prefix.
     """

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -5,11 +5,11 @@
 """
 
 SONIC_INTERFACE_PREFIXES = {
-  "Ethernet-FrontPanel":"Ethernet",
-  "PortChannel":"PortChannel",
-  "Vlan":"Vlan",
-  "Loopback":"Loopback",
-  "Ethernet-Backplane":"Ethernet-BP"
+    "Ethernet-FrontPanel": "Ethernet",
+    "PortChannel": "PortChannel",
+    "Vlan": "Vlan",
+    "Loopback": "Loopback",
+    "Ethernet-Backplane": "Ethernet-BP"
 }
 
 def front_panel_prefix():

--- a/src/sonic-py-common/sonic_py_common/sonic_interface.py
+++ b/src/sonic-py-common/sonic_py_common/sonic_interface.py
@@ -1,0 +1,45 @@
+import sys
+
+"""
+ Dictionary of SONIC interface name prefixes. Each entry in the format
+ "Human readable interface string":"Sonic interface prefix"
+ Currently this is a static mapping, but in future could be stored as metadata in DB.
+"""
+
+SONIC_INTERFACE_PREFIXES = {
+  "Ethernet-FrontPanel":"Ethernet",
+  "PortChannel":"PortChannel",
+  "Vlan":"Vlan",
+  "Loopback":"Loopback",
+  "Ethernet-Backplane":"Ethernet-BP"
+}
+
+def sonic_fp_interface_prefix():
+    """
+    Retrieves the SONIC front panel interface name prefix.
+    """
+    return SONIC_INTERFACE_PREFIXES["Ethernet-FrontPanel"]
+
+def sonic_bp_interface_prefix():
+    """
+    Retrieves the SONIC backplane interface name prefix.
+    """
+    return SONIC_INTERFACE_PREFIXES["Ethernet-Backplane"]
+
+def sonic_portchannel_interface_prefix():
+    """
+    Retrieves the SONIC PortChannel interface name prefix.
+    """
+    return SONIC_INTERFACE_PREFIXES["PortChannel"]
+
+def sonic_vlan_interface_prefix():
+    """
+    Retrieves the SONIC Vlan interface name prefix.
+    """
+    return SONIC_INTERFACE_PREFIXES["Vlan"]
+
+def sonic_lo_interface_prefix():
+    """
+    Retrieves the SONIC Loopback interface name prefix.
+    """
+    return SONIC_INTERFACE_PREFIXES["Loopback"]


### PR DESCRIPTION
**- Why I did it**
There are many places in the code where there is hardcoding to the way we refer to the Sonic front-panel/backplane interface prefixes.  The idea with this PR is to keep this SONIC PREFIX naming convention in one place in py-common and all modules/applications use the functions defined here. 


**- How I did it**
To start with I have add a file sonic_interface.py in sonic-py-common with API's to get the sonic interface prefix string. Can add more sonic interface specific utilities here. This is useful especially in the sonic-utilities show/config modules. 

**- How to verify it**
Newly added  functions were verified with CLI commands.
