### PR TITLE
Update all references to new 'sonic-installer' file name

### DIFF
--- a/platform/mellanox/mlnx-ffb.sh
+++ b/platform/mellanox/mlnx-ffb.sh
@@ -23,8 +23,8 @@ check_sdk_upgrade()
 {
     CHECK_RESULT="${FFB_FAILURE}"
 
-    NEXT_SONIC_IMAGE="$(sonic_installer list | grep "Next: " | cut -f2 -d' ')"
-    CURRENT_SONIC_IMAGE="$(sonic_installer list | grep "Current: " | cut -f2 -d' ')"
+    NEXT_SONIC_IMAGE="$(sonic-installer list | grep "Next: " | cut -f2 -d' ')"
+    CURRENT_SONIC_IMAGE="$(sonic-installer list | grep "Current: " | cut -f2 -d' ')"
 
     FS_PATH="/host/image-${NEXT_SONIC_IMAGE#SONiC-OS-}/fs.squashfs"
     FS_MOUNTPOINT="/tmp/image-${NEXT_SONIC_IMAGE#SONiC-OS-}-fs"

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -217,8 +217,8 @@ function UpgradeFW() {
 }
 
 function UpgradeFWFromImage() {
-    local -r _NEXT_SONIC_IMAGE="$(sonic_installer list | grep "Next: " | cut -f2 -d' ')"
-    local -r _CURRENT_SONIC_IMAGE="$(sonic_installer list | grep "Current: " | cut -f2 -d' ')"
+    local -r _NEXT_SONIC_IMAGE="$(sonic-installer list | grep "Next: " | cut -f2 -d' ')"
+    local -r _CURRENT_SONIC_IMAGE="$(sonic-installer list | grep "Current: " | cut -f2 -d' ')"
 
     local -r _FS_PATH="/host/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}/fs.squashfs"
     local -r _FS_MOUNTPOINT="/tmp/image-${_NEXT_SONIC_IMAGE#SONiC-OS-}-fs"


### PR DESCRIPTION
**- Why I did it**
`sonic_installer` has been renamed `sonic-installer`

**- How I did it**
Update the file name everywhere it is used

**- How to verify it**

Test the affected applications. They should work and no longer output the sonic_installer deprecation warning.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006