### PR TITLE
[systemd-generator]: Remove creation of NUM_ASIC environment variable

### DIFF
--- a/src/systemd-sonic-generator/systemd-sonic-generator.c
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.c
@@ -498,7 +498,6 @@ static int get_num_of_asic() {
     Determines if the current platform is single or multi-ASIC
     ***/
     FILE *fp;
-    FILE *env_fp;
     char *line = NULL;
     char* token;
     char* platform;
@@ -546,15 +545,6 @@ static int get_num_of_asic() {
             free(line);
         }
     }
-
-    /*set environment variable NUM_ASIC */
-    env_fp = fopen("/etc/environment", "a");
-    if (env_fp == NULL) {
-        fprintf(stderr, "Failed to open environment file\n");
-        exit(EXIT_FAILURE);
-    }
-    fprintf(env_fp, "NUM_ASIC=%d\n", num_asic);
-    fclose(env_fp);
     return num_asic;
 
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
NUM_ASIC environment variable was added so that it could be used by other utilities.
This is not being used by any other utility or docker, hence removing the addition of NUM_ASIC environment variable.
Also, the environment variable was added by adding the variable value to /etc/environ file.
Upon each reboot, this file gets updated with the NUM_ASIC value but the existing value was not removed.
This causes multiple lines getting appended in /etc/environ file upon each reboot.

**- How I did it**
Remove the addition of NUM_ASIC variable in /etc/environ file.

**- How to verify it**
Once image comes up, NUM_ASIC should not be present in environment variables in single asic and multi asic platforms.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X] 201911
- [X] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**