### PR TITLE
[dvs] Start portsyncd before orchagent for docker-sonic-vs container

### DIFF
--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -87,9 +87,9 @@ fi
 
 supervisorctl start syncd
 
-supervisorctl start orchagent
-
 supervisorctl start portsyncd
+
+supervisorctl start orchagent
 
 supervisorctl start neighsyncd
 

--- a/platform/vs/docker-sonic-vs/supervisord.conf
+++ b/platform/vs/docker-sonic-vs/supervisord.conf
@@ -45,7 +45,7 @@ stderr_logfile=syslog
 
 [program:portsyncd]
 command=/usr/bin/portsyncd
-priority=4
+priority=5
 autostart=false
 autorestart=false
 stdout_logfile=syslog
@@ -53,7 +53,7 @@ stderr_logfile=syslog
 
 [program:orchagent]
 command=/usr/bin/orchagent.sh
-priority=5
+priority=6
 autostart=false
 autorestart=false
 stdout_logfile=syslog

--- a/platform/vs/docker-sonic-vs/supervisord.conf
+++ b/platform/vs/docker-sonic-vs/supervisord.conf
@@ -43,17 +43,17 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
-[program:orchagent]
-command=/usr/bin/orchagent.sh
-priority=5
+[program:portsyncd]
+command=/usr/bin/portsyncd
+priority=4
 autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 
-[program:portsyncd]
-command=/usr/bin/portsyncd
-priority=6
+[program:orchagent]
+command=/usr/bin/orchagent.sh
+priority=5
 autostart=false
 autorestart=false
 stdout_logfile=syslog


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Many docker virtual switch tests are failing at the moment because orchagent never finishes initializing. After doing some searching I figured out that Ethernet24 is never published to State DB, which is reminiscent of #4821 

**- How I did it**
Re-ordered portsyncd and orchagent startup as done in the swss container in #4845 

**- How to verify it**
1. Build container
2. Re-run the tests several time and make sure `orchagent` doesn't get trapped in a deadlock.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[dvs] Start portsyncd before orchagent for docker-sonic-vs container

**- A picture of a cute animal (not mandatory but encouraged)**
