### PR TITLE
[201811 Monit] Enable monitoring of SWSS daemons

### DIFF
--- a/dockers/docker-orchagent/base_image_files/monit_swss
+++ b/dockers/docker-orchagent/base_image_files/monit_swss
@@ -10,7 +10,6 @@
 ##  portmgrd
 ##  buffermgrd
 ##  nbrmgrd
-##  vxlanmgrd
 ###############################################################################
 check process orchagent matching "/usr/bin/orchagent -d /var/log/swss"
     if does not exist for 5 times within 5 cycles then alert
@@ -39,5 +38,3 @@ check process buffermgrd matching "/usr/bin/buffermgrd -l"
 check process nbrmgrd matching "/usr/bin/nbrmgrd"
     if does not exist for 5 times within 5 cycles then alert
 
-check process vxlanmgrd matching "/usr/bin/vxlanmgrd"
-    if does not exist for 5 times within 5 cycles then alert

--- a/platform/template/docker-orchagent-base.mk
+++ b/platform/template/docker-orchagent-base.mk
@@ -32,4 +32,5 @@ $(DOCKER_ORCHAGENT_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_ORCHAGENT_BASE)_RUN_OPT += -v /var/log/swss:/var/log/swss:rw
 
 $(DOCKER_ORCHAGENT_BASE)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel
+$(DOCKER_ORCHAGENT_BASE)_BASE_IMAGE_FILES += monit_swss:/etc/monit/conf.d
 $(DOCKER_ORCHAGENT_BASE)_FILES += $(ARP_UPDATE_SCRIPT) $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
[201811 Monit] Enable monitoring of SWSS daemons

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

This fix is only applicable to 201811 branch.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Enable monitoring of SWSS daemons

**- How I did it**
See diff.

**- How to verify it**
**Before the fix**
```
sudo monit summary
Monit 5.20.0 uptime: 3d 12h 14m
┌─────────────────────────────────┬────────────────────────────┬───────────────┐
│ Service Name                    │ Status                     │ Type          │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ lnos-x1-a-csw04                 │ Running                    │ System        │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ rsyslog                         │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ telemetry                       │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ dialout_client                  │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ syncd                           │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ dsserve                         │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ snmpd                           │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ snmp_subagent                   │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ lldpd_monitor                   │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ lldp_syncd                      │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ lldpmgrd                        │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ redis_server                    │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ zebra                           │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ fpmsyncd                        │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ bgpd                            │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ root-overlay                    │ Accessible                 │ Filesystem    │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ var-log                         │ Accessible                 │ Filesystem    │
└─────────────────────────────────┴────────────────────────────┴───────────────┘
```

**After fix:**
```
 sudo monit summary
Monit 5.20.0 uptime: 3d 12h 13m
┌─────────────────────────────────┬────────────────────────────┬───────────────┐
│ Service Name                    │ Status                     │ Type          │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ lnos-x1-a-csw04                 │ Running                    │ System        │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ rsyslog                         │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ telemetry                       │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ dialout_client                  │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ syncd                           │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ dsserve                         │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ orchagent                       │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ portsyncd                       │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ neighsyncd                      │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ vrfmgrd                         │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ vlanmgrd                        │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ intfmgrd                        │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ portmgrd                        │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ buffermgrd                      │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ nbrmgrd                         │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ snmpd                           │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ snmp_subagent                   │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ lldpd_monitor                   │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ lldp_syncd                      │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ lldpmgrd                        │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ redis_server                    │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ zebra                           │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ fpmsyncd                        │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ bgpd                            │ Running                    │ Process       │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ root-overlay                    │ Accessible                 │ Filesystem    │
├─────────────────────────────────┼────────────────────────────┼───────────────┤
│ var-log                         │ Accessible                 │ Filesystem    │
└─────────────────────────────────┴────────────────────────────┴───────────────┘
```


**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [X] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
