### PR TITLE
[barefoot][platform] increase init timeout in eeprom.py

### DIFF
--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/plugins/eeprom.py
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/plugins/eeprom.py
@@ -77,7 +77,7 @@ EEPROM_SYMLINK = "/var/run/platform/eeprom/syseeprom"
 EEPROM_STATUS = "/var/run/platform/eeprom/status"
 
 class board(eeprom_tlvinfo.TlvInfoDecoder):
-    RETRIES = 3
+    RETRIES = 35
 
     def __init__(self, name, path, cpld_root, ro):
 
@@ -101,7 +101,7 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
         super(board, self).__init__(self.eeprom_path, 0, EEPROM_STATUS, True)
 
         for attempt in range(self.RETRIES):
-            if self.eeprom_init() or (attempt + 1 >= self.RETRIES):
+            if self.eeprom_init():
                 break
             time.sleep(1)
 

--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/plugins/eeprom.py
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/plugins/eeprom.py
@@ -103,6 +103,8 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
         for attempt in range(self.RETRIES):
             if self.eeprom_init():
                 break
+            if attempt + 1 == self.RETRIES:
+                raise RuntimeError("eeprom.py: Initialization failed")
             time.sleep(1)
 
     def thrift_setup(self):


### PR DESCRIPTION
- Why I did it
Because of platform-specific reasons I have to increase init timeout in (platform-plugin)/eeprom.py
- Description for the changelog
[barefoot][platform] increase init timeout in eeprom.py