### PR TITLE
Dell S6100 Port I2C changes to 201911 branch

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -1,5 +1,8 @@
 s6100/scripts/iom_power_*.sh usr/local/bin
 s6100/scripts/s6100_platform.sh usr/local/bin
+s6100/scripts/s6100_i2c_enumeration.sh usr/local/bin       
+s6100/scripts/s6100_bitbang_reset.sh usr/local/bin
+s6100/scripts/pcisysfs.py usr/bin  
 common/dell_i2c_utils.sh usr/local/bin
 common/io_rd_wr.py usr/local/bin
 common/nvram_rd_wr.py usr/local/bin
@@ -17,5 +20,6 @@ s6100/scripts/sensors usr/bin
 s6100/systemd/platform-modules-s6100.service etc/systemd/system
 s6100/systemd/s6100-lpc-monitor.service etc/systemd/system
 s6100/systemd/s6100-reboot-cause.service etc/systemd/system
+s6100/systemd/s6100-i2c-enumerate.service etc/systemd/system 
 tools/flashrom/flashrom usr/local/bin/
 common/fw-updater usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/fast-reboot_plugin
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/fast-reboot_plugin
@@ -4,3 +4,4 @@ if [[ -d /sys/devices/platform/SMF.512/hwmon/ ]]; then
     cd /sys/devices/platform/SMF.512/hwmon/*
     echo 0xcc > mb_poweron_reason
 fi
+/usr/local/bin/s6100_i2c_enumeration.sh deinit & > /dev/null

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/pcisysfs.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/pcisysfs.py
@@ -1,0 +1,91 @@
+#! /usr/bin/python
+
+import struct
+import sys
+import getopt
+from os import *
+from mmap import *
+
+def usage():
+   	''' This is the Usage Method '''
+
+   	print '\t\t pcisysfs.py  --get --offset <offset> --res <resource>'
+   	print '\t\t pcisysfs.py --set --val <val>  --offset <offset> --res <resource>'
+        sys.exit(1)
+
+def pci_mem_read(mm,offset):
+    mm.seek(offset)
+    read_data_stream=mm.read(4)
+    print ""
+    reg_val=struct.unpack('I',read_data_stream)
+    print "reg_val read:%x"%reg_val
+    return reg_val
+
+def pci_mem_write(mm,offset,data):
+    mm.seek(offset)
+    #print "data to write:%x"%data
+    mm.write(struct.pack('I',data))
+
+def pci_set_value(resource,val,offset):
+    fd=open(resource,O_RDWR)
+    mm=mmap(fd,0)
+    pci_mem_write(mm,offset,val)
+    close(fd)
+
+def pci_get_value(resource,offset):
+    fd=open(resource,O_RDWR)
+    mm=mmap(fd,0)
+    pci_mem_read(mm,offset)
+    close(fd)
+
+def main(argv):
+
+    ''' The main function will read the user input from the
+    command line argument and  process the request  '''
+
+    opts = ''
+    val = ''
+    choice = ''
+    resource = ''
+    offset = ''
+
+    try:
+        opts, args = getopt.getopt(argv, "hgsv:" , \
+        ["val=","res=","offset=","help", "get", "set"])
+	
+    except getopt.GetoptError:
+        usage()
+
+    for opt,arg in opts:
+
+        if opt in ('-h','--help'):
+            choice = 'help'
+
+        elif opt in ('-g', '--get'):
+            choice = 'get'
+
+        elif opt in ('-s', '--set'):
+            choice = 'set'
+
+        elif opt ==  '--res':
+            resource = arg
+
+        elif opt ==  '--val':
+            val = int(arg,16)
+
+        elif opt ==  '--offset':
+            offset = int(arg,16)
+
+    if choice == 'set' and val != '' and offset !='' and resource !='':
+        pci_set_value(resource,val,offset)
+
+    elif choice == 'get' and offset != '' and resource !='':
+        pci_get_value(resource,offset)
+
+    else:
+        usage()
+
+#Calling the main method
+if __name__ == "__main__":
+	main(sys.argv[1:])
+

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_bitbang_reset.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_bitbang_reset.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Script to unfreeze a stuck I2C controller, by bit-banging a STOP cycle on the bus
+
+bit_bang_recovery()
+{
+
+# Clear the ERRSTS
+pcisysfs.py --set --val 0xffffffff --offset 0x018 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+#Enable I2C bit-banging
+pcisysfs.py --set --val 0x80000000 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+count=1
+while [ $count -le 9 ];
+do
+    # Bit-bang an I2C STOP cycle
+
+    # SCL=0, SDA=0
+    pcisysfs.py --set --val 0x80000000 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+    sleep 0.01
+
+    # SCL=1, SDA=0
+    pcisysfs.py --set --val 0x80000002 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+    sleep 0.01
+
+    # SCL=1, SDA=1
+    pcisysfs.py --set --val 0x80000003 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+    sleep 1
+
+    # Check I2C DBSTS register
+    mctrl=$((`pcisysfs.py --get --offset 0x108 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+    msts=$((`pcisysfs.py --get --offset 0x10c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+    dbsts=$((`pcisysfs.py --get --offset 0x38c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+    msts_ip=$((msts&0x1))
+    
+    mctrl=$((10#$mctrl))
+    if [ $msts_ip = 0 ]; then
+	logger -p NOTICE "I2C_bitbang-Bit banging done on I2C bus"
+	logger -p NOTICE "After I2C_bitbang- MCTRL:$(printf "0x%x" $mctrl)","MSTS:$(printf "0x%x" $msts)","DBSTS:$(printf "0x%x" $dbsts)"
+	break
+    fi
+    count=$(( $count + 1 ))
+done
+
+#Disable I2C bit-banging
+pcisysfs.py --set --val 0x00000003 --offset 0x388 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0
+
+}
+
+mctrl=$((`pcisysfs.py --get --offset 0x108 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+msts=$((`pcisysfs.py --get --offset 0x10c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+dbsts=$((`pcisysfs.py --get --offset 0x38c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 | sed 's/^.*:/0x/'`))
+logger -p NOTICE "Before I2C_bitbang- MCTRL:$(printf "0x%x" $mctrl)","MSTS:$(printf "0x%x" $msts)","DBSTS:$(printf "0x%x" $dbsts)"
+sleep 2
+bit_bang_recovery

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_i2c_enumeration.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_i2c_enumeration.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+
+### DellEMC S6100 I2C MUX Enumeration script
+
+source dell_i2c_utils.sh
+
+init_devnum() {
+    found=0
+    for devnum in 0 1; do
+        devname=`cat /sys/bus/i2c/devices/i2c-${devnum}/name`
+        # iSMT adapter can be at either dffd0000 or dfff0000
+        if [[ $devname == 'SMBus iSMT adapter at '* ]]; then
+            found=1
+            break
+        fi
+    done
+
+    [[ $found -eq 0 ]] && echo "cannot find iSMT" && exit 1
+}
+
+# Attach/Detach CPU board mux @ 0x70
+cpu_board_mux() {
+    case $1 in
+        "new_device")    i2c_mux_create pca9547 0x70 $devnum 2
+                         ;;
+        "delete_device") i2c_mux_delete 0x70 $devnum
+                         ;;
+        *)               echo "s6100_platform: cpu_board_mux: invalid command !"
+                         ;;
+    esac
+}
+
+# Attach/Detach Switchboard MUX @ 0x71
+switch_board_mux() {
+    case $1 in
+        "new_device")    i2c_mux_create pca9548 0x71 4 10
+                         ;;
+        "delete_device") i2c_mux_delete 0x71 4
+                         ;;
+        *)               echo "s6100_platform: switch_board_mux : invalid command !"
+                         ;;
+    esac
+}
+
+# Attach/Detach syseeprom on CPU board
+sys_eeprom() {
+    case $1 in
+        "new_device")    i2c_config "echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-2/$1"
+                         ;;
+        "delete_device") i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-2/$1"
+                         ;;
+        *)               echo "s6100_platform: sys_eeprom : invalid command !"
+                         ;;
+    esac
+}
+
+#Attach/Detach eeprom on each IOM
+switch_board_eeprom() {
+    case $1 in
+        "new_device")
+                      for ((i=14;i<=17;i++));
+                      do
+                          i2c_config "echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
+                      done
+                      ;;
+        "delete_device")
+                      for ((i=14;i<=17;i++));
+                      do
+                          i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
+                      done
+                      ;;
+        *)            echo "s6100_platform: switch_board_eeprom : invalid command !"
+                      ;;
+    esac
+}
+
+#Attach/Detach CPLD devices to drivers for each IOM
+switch_board_cpld() {
+    case $1 in
+        "new_device")
+                      for ((i=14;i<=17;i++));
+                      do
+                          i2c_config "echo  dell_s6100_iom_cpld 0x3e > /sys/bus/i2c/devices/i2c-$i/$1"
+                      done
+                      ;;
+        "delete_device")
+                      for ((i=14;i<=17;i++));
+                      do
+                          i2c_config "echo  0x3e > /sys/bus/i2c/devices/i2c-$i/$1"
+                      done
+                      ;;
+        *)            echo "s6100_platform: switch_board_cpld : invalid command !"
+                      ;;
+    esac
+}
+
+#Attach/Detach the MUX connecting all QSFPs on each IOM @0x71 and 0x72
+switch_board_qsfp_mux() {
+    case $1 in
+        "new_device")
+                      # The mux for the QSFPs spawn {18..25}, {26..33}... {74..81}
+                      # starting at chennel 18 and 16 channels per IOM.
+                      channel_first=18
+                      for ((i=9;i>=6;i--));
+                      do
+                          # 0x71 mux on the IOM 1
+                          mux_index=$(expr $i - 5)
+                          echo "Attaching PCA9548 $mux_index"
+                          i2c_mux_create pca9548 0x71 $i $channel_first
+                          i2c_mux_create pca9548 0x72 $i $(expr $channel_first + 8)
+                          channel_first=$(expr $channel_first + 16)
+                      done
+                      ;;
+        "delete_device")
+                      for ((i=9;i>=6;i--));
+                      do
+                          # 0x71 mux on the IOM 1
+                          mux_index=$(expr $i - 5)
+                          echo "Detaching PCA9548 $mux_index"
+                          i2c_mux_delete 0x71 $i
+                          i2c_mux_delete 0x72 $i
+                      done
+                      ;;
+        *)            echo "s6100_platform: switch_board_qsfp_mux: invalid command !"
+                      ;;
+    esac
+}
+
+#Attach/Detach the SFP modules on PCA9548_2
+switch_board_sfp() {
+    case $1 in
+        "new_device")    i2c_config "echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
+                         i2c_config "echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
+                         ;;
+        "delete_device") i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
+                         i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
+                         ;;
+        *)               echo "s6100_platform: switch_board_sfp: invalid command !"
+                         ;;
+    esac
+}
+
+#Add/Delete ($1) a range ($2..$3) of QSFPs
+qsfp_device_mod() {
+    case $1 in
+        "new_device")    for ((i=$2;i<=$3;i++));
+                         do
+                             i2c_config "echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
+                         done
+                         ;;
+        "delete_device") for ((i=$2;i<=$3;i++));
+                         do
+                             i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
+                         done
+                         ;;
+        *)              echo "s6100_platform: qsfp_device_mod: invalid command $1:$2,$3!"
+                        ;;
+    esac
+}
+
+# Attach/Detach 16 instances of QSFP ports on each IO modules
+# eeprom can dump data using below command
+switch_board_qsfp() {
+    if  i2c_poll_bus_exists  "/sys/bus/i2c/devices/i2c-18"; then
+        qsfp_device_mod $1 18 33
+    fi
+
+    if  i2c_poll_bus_exists  "/sys/bus/i2c/devices/i2c-34"; then
+        qsfp_device_mod $1 34 49
+    fi
+
+    if  i2c_poll_bus_exists  "/sys/bus/i2c/devices/i2c-50"; then
+        qsfp_device_mod $1 50 65
+    fi
+
+    if  i2c_poll_bus_exists  "/sys/bus/i2c/devices/i2c-66"; then
+        qsfp_device_mod $1 66 81
+    fi
+}
+
+# Enable/Disable low power mode on all QSFP ports
+switch_board_qsfp_lpmode() {
+    case $1 in
+        "enable")   value=0xffff
+                    ;;
+        "disable")  value=0x0
+                    ;;
+        *)          echo "s6100_platform: switch_board_qsfp_lpmode: invalid command $1!"
+                    return
+                    ;;
+    esac
+    echo $value > /sys/class/i2c-adapter/i2c-14/14-003e/qsfp_lpmode
+    echo $value > /sys/class/i2c-adapter/i2c-15/15-003e/qsfp_lpmode
+    echo $value > /sys/class/i2c-adapter/i2c-16/16-003e/qsfp_lpmode
+    echo $value > /sys/class/i2c-adapter/i2c-17/17-003e/qsfp_lpmode
+}
+
+# Enable/Disable xcvr presence interrupts
+xcvr_presence_interrupts() {
+    case $1 in
+        "enable")
+                      for ((i=14;i<=17;i++));
+                      do
+                          echo 0x0 > /sys/class/i2c-adapter/i2c-$i/$i-003e/qsfp_abs_mask
+                      done
+                      ;;
+        "disable")
+                      for ((i=14;i<=17;i++));
+                      do
+                          echo 0xffff > /sys/class/i2c-adapter/i2c-$i/$i-003e/qsfp_abs_mask
+                      done
+                      ;;
+        *)            echo "s6100_platform: xcvr_presence_interrupts: invalid command !"
+                      ;;
+    esac
+}
+
+# Reset the mux tree
+reset_muxes() {
+    local i
+
+    # Reset the IOM muxes (if they have been already instantiated)
+    for ((i=14;i<=17;i++));
+    do
+        if [[ -e /sys/class/i2c-adapter/i2c-$i/$i-003e ]]; then
+            echo 0xfc > /sys/class/i2c-adapter/i2c-$i/$i-003e/sep_reset
+            echo 0xff > /sys/class/i2c-adapter/i2c-$i/$i-003e/sep_reset
+        fi
+    done
+
+    # Reset the switch card PCA9548A
+    io_rd_wr.py --set --val 0xef --offset 0x110
+    io_rd_wr.py --set --val 0xff --offset 0x110
+
+    # Reset the CPU Card PCA9547
+    io_rd_wr.py --set --val 0xfd --offset 0x20b
+    io_rd_wr.py --set --val 0xff --offset 0x20b
+}
+
+init_devnum
+
+if [[ "$1" == "init" ]]; then
+    cpu_board_mux "new_device"
+    switch_board_mux "new_device"
+    sys_eeprom "new_device"
+    switch_board_eeprom "new_device"
+    switch_board_cpld "new_device"
+    /usr/local/bin/s6100_bitbang_reset.sh
+    switch_board_qsfp_mux "new_device"
+    switch_board_sfp "new_device"
+    switch_board_qsfp "new_device"
+    switch_board_qsfp_lpmode "disable"
+    xcvr_presence_interrupts "enable"
+elif [[ "$1" == "deinit" ]]; then
+    xcvr_presence_interrupts "disable"
+    switch_board_sfp "delete_device"
+    switch_board_cpld "delete_device"
+    switch_board_eeprom "delete_device"
+    switch_board_mux "delete_device"
+    sys_eeprom "delete_device"
+    switch_board_qsfp "delete_device"
+    switch_board_qsfp_mux "delete_device"
+    cpu_board_mux "delete_device"
+fi

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -2,241 +2,6 @@
 
 #platform init script for Dell S6100
 
-source dell_i2c_utils.sh
-
-init_devnum() {
-    found=0
-    for devnum in 0 1; do
-        devname=`cat /sys/bus/i2c/devices/i2c-${devnum}/name`
-        # iSMT adapter can be at either dffd0000 or dfff0000
-        if [[ $devname == 'SMBus iSMT adapter at '* ]]; then
-            found=1
-            break
-        fi
-    done
-
-    [[ $found -eq 0 ]] && echo "cannot find iSMT" && exit 1
-}
-
-# Attach/Detach CPU board mux @ 0x70
-cpu_board_mux() {
-    case $1 in
-        "new_device")    i2c_mux_create pca9547 0x70 $devnum 2 
-                         ;;
-        "delete_device") i2c_mux_delete 0x70 $devnum
-                         ;;
-        *)               echo "s6100_platform: cpu_board_mux: invalid command !"
-                         ;;
-    esac
-}
-
-# Attach/Detach Switchboard MUX @ 0x71
-switch_board_mux() {
-    case $1 in
-        "new_device")    i2c_mux_create pca9548 0x71 4 10
-                         ;;
-        "delete_device") i2c_mux_delete 0x71 4
-                         ;;
-        *)               echo "s6100_platform: switch_board_mux : invalid command !"
-                         ;;
-    esac
-}
-
-# Attach/Detach syseeprom on CPU board
-sys_eeprom() {
-    case $1 in
-        "new_device")    i2c_config "echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-2/$1"
-                         ;;
-        "delete_device") i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-2/$1"
-                         ;;
-        *)               echo "s6100_platform: sys_eeprom : invalid command !"
-                         ;;
-    esac
-}
-
-#Attach/Detach eeprom on each IOM
-switch_board_eeprom() {
-    case $1 in
-        "new_device")
-                      for ((i=14;i<=17;i++));
-                      do
-                          i2c_config "echo 24c02 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
-                      done
-                      ;;
-        "delete_device")
-                      for ((i=14;i<=17;i++));
-                      do
-                          i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
-                      done
-                      ;;
-        *)            echo "s6100_platform: switch_board_eeprom : invalid command !"
-                      ;;
-    esac
-}
-
-#Attach/Detach CPLD devices to drivers for each IOM
-switch_board_cpld() {
-    case $1 in
-        "new_device")    
-                      for ((i=14;i<=17;i++));
-                      do
-                          i2c_config "echo  dell_s6100_iom_cpld 0x3e > /sys/bus/i2c/devices/i2c-$i/$1"
-                      done
-                      ;;
-        "delete_device")
-                      for ((i=14;i<=17;i++));
-                      do
-                          i2c_config "echo  0x3e > /sys/bus/i2c/devices/i2c-$i/$1"
-                      done
-                      ;;
-        *)            echo "s6100_platform: switch_board_cpld : invalid command !"
-                      ;;
-    esac
-}
-
-#Attach/Detach the MUX connecting all QSFPs on each IOM @0x71 and 0x72
-switch_board_qsfp_mux() {
-    case $1 in
-        "new_device")
-                      # The mux for the QSFPs spawn {18..25}, {26..33}... {74..81}
-                      # starting at chennel 18 and 16 channels per IOM.
-                      channel_first=18
-                      for ((i=9;i>=6;i--));
-                      do
-                          # 0x71 mux on the IOM 1
-                          mux_index=$(expr $i - 5)
-                          echo "Attaching PCA9548 $mux_index"
-                          i2c_mux_create pca9548 0x71 $i $channel_first
-                          i2c_mux_create pca9548 0x72 $i $(expr $channel_first + 8)
-                          channel_first=$(expr $channel_first + 16)
-                      done
-                      ;;
-        "delete_device")
-                      for ((i=9;i>=6;i--));
-                      do
-                          # 0x71 mux on the IOM 1
-                          mux_index=$(expr $i - 5)
-                          echo "Detaching PCA9548 $mux_index"
-                          i2c_mux_delete 0x71 $i
-                          i2c_mux_delete 0x72 $i
-                      done
-                      ;;
-        *)            echo "s6100_platform: switch_board_qsfp_mux: invalid command !"
-                      ;;
-    esac
-}
-
-#Attach/Detach the SFP modules on PCA9548_2
-switch_board_sfp() {
-    case $1 in
-        "new_device")    i2c_config "echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
-                         i2c_config "echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
-                         ;;
-        "delete_device") i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-11/$1"
-                         i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-12/$1"
-                         ;;
-        *)               echo "s6100_platform: switch_board_sfp: invalid command !"
-                         ;;
-    esac
-}
-
-#Add/Delete ($1) a range ($2..$3) of QSFPs
-qsfp_device_mod() {
-    case $1 in
-        "new_device")    for ((i=$2;i<=$3;i++));
-                         do
-                             i2c_config "echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
-                         done
-                         ;;
-        "delete_device") for ((i=$2;i<=$3;i++));
-                         do
-                             i2c_config "echo 0x50 > /sys/bus/i2c/devices/i2c-$i/$1"
-                         done
-                         ;;
-        *)              echo "s6100_platform: qsfp_device_mod: invalid command $1:$2,$3!"
-                        ;;
-    esac
-}
-
-# Attach/Detach 16 instances of QSFP ports on each IO modules
-# eeprom can dump data using below command
-switch_board_qsfp() {
-    if  i2c_poll_bus_exists  "/sys/bus/i2c/devices/i2c-18"; then
-        qsfp_device_mod $1 18 33
-    fi
-
-    if  i2c_poll_bus_exists  "/sys/bus/i2c/devices/i2c-34"; then
-        qsfp_device_mod $1 34 49
-    fi
-
-    if  i2c_poll_bus_exists  "/sys/bus/i2c/devices/i2c-50"; then
-        qsfp_device_mod $1 50 65
-    fi
-
-    if  i2c_poll_bus_exists  "/sys/bus/i2c/devices/i2c-66"; then
-        qsfp_device_mod $1 66 81
-    fi
-}
-
-# Enable/Disable low power mode on all QSFP ports
-switch_board_qsfp_lpmode() {
-    case $1 in
-        "enable")   value=0xffff
-                    ;;
-        "disable")  value=0x0
-                    ;;
-        *)          echo "s6100_platform: switch_board_qsfp_lpmode: invalid command $1!"
-                    return
-                    ;;
-    esac
-    echo $value > /sys/class/i2c-adapter/i2c-14/14-003e/qsfp_lpmode
-    echo $value > /sys/class/i2c-adapter/i2c-15/15-003e/qsfp_lpmode
-    echo $value > /sys/class/i2c-adapter/i2c-16/16-003e/qsfp_lpmode
-    echo $value > /sys/class/i2c-adapter/i2c-17/17-003e/qsfp_lpmode
-}
-
-# Enable/Disable xcvr presence interrupts
-xcvr_presence_interrupts() {
-    case $1 in
-        "enable")
-                      for ((i=14;i<=17;i++));
-                      do
-                          echo 0x0 > /sys/class/i2c-adapter/i2c-$i/$i-003e/qsfp_abs_mask
-                      done
-                      ;;
-        "disable")
-                      for ((i=14;i<=17;i++));
-                      do
-                          echo 0xffff > /sys/class/i2c-adapter/i2c-$i/$i-003e/qsfp_abs_mask
-                      done
-                      ;;
-        *)            echo "s6100_platform: xcvr_presence_interrupts: invalid command !"
-                      ;;
-    esac
-}
-
-# Reset the mux tree
-reset_muxes() {
-    local i
-
-    # Reset the IOM muxes (if they have been already instantiated)
-    for ((i=14;i<=17;i++));
-    do
-        if [[ -e /sys/class/i2c-adapter/i2c-$i/$i-003e ]]; then
-            echo 0xfc > /sys/class/i2c-adapter/i2c-$i/$i-003e/sep_reset
-            echo 0xff > /sys/class/i2c-adapter/i2c-$i/$i-003e/sep_reset
-        fi
-    done
-
-    # Reset the switch card PCA9548A
-    io_rd_wr.py --set --val 0xef --offset 0x110
-    io_rd_wr.py --set --val 0xff --offset 0x110
-
-    # Reset the CPU Card PCA9547
-    io_rd_wr.py --set --val 0xfd --offset 0x20b
-    io_rd_wr.py --set --val 0xff --offset 0x20b
-}
-
 install_python_api_package() {
     device="/usr/share/sonic/device"
     platform=$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
@@ -251,7 +16,6 @@ remove_python_api_package() {
     fi
 }
 
-init_devnum
 
 if [[ "$1" == "init" ]]; then
 
@@ -273,29 +37,18 @@ if [[ "$1" == "init" ]]; then
         /usr/local/bin/platform_watchdog_disable.sh
     fi
 
-    cpu_board_mux "new_device"
-    switch_board_mux "new_device"
-    sys_eeprom "new_device"
-    switch_board_eeprom "new_device"
-    switch_board_cpld "new_device"
-    switch_board_qsfp_mux "new_device"
-    switch_board_sfp "new_device"
-    switch_board_qsfp "new_device"
-    switch_board_qsfp_lpmode "disable"
-    xcvr_presence_interrupts "enable"
+    is_fast_warm=$(cat /proc/cmdline | grep SONIC_BOOT_TYPE | wc -l)
+
+    if [[ "$is_fast_warm" == "1" ]]; then
+        systemctl start --no-block s6100-i2c-enumerate.service
+    else
+        systemctl start s6100-i2c-enumerate.service
+    fi
 
     install_python_api_package
 
 elif [[ "$1" == "deinit" ]]; then
-    xcvr_presence_interrupts "disable"
-    switch_board_sfp "delete_device"
-    switch_board_cpld "delete_device"
-    switch_board_eeprom "delete_device"
-    switch_board_mux "delete_device"
-    sys_eeprom "delete_device"
-    switch_board_qsfp "delete_device"
-    switch_board_qsfp_mux "delete_device"
-    cpu_board_mux "delete_device"
+    /usr/local/bin/s6100_i2c_enumeration.sh deinit
 
     modprobe -r dell_s6100_lpc
     modprobe -r dell_s6100_iom_cpld

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/systemd/s6100-i2c-enumerate.service
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/systemd/s6100-i2c-enumerate.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Dell S6100 I2C MUX Enumeration
+Before=pmon.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/s6100_i2c_enumeration.sh init
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION

**- Why I did it**
To resolve ISMT timeout issue, I2C changes has to be ported from master branch.

**- How to verify it**
Verify bit bang  reset logs in the syslog, check whether all the I2C components are coming up and verify show interfaces transceiver commands.
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
Added I2C enumeration as a service in PMON.
Added Bit bang reset mechanisms.

**- A picture of a cute animal (not mandatory but encouraged)**
[201911_i2c.txt](https://github.com/Azure/sonic-buildimage/files/5056301/201911_i2c.txt)
