### PR TITLE
[as5835-54x] Modify qsfp port reset to normal state

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/modules/accton_as5835_54t_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/modules/accton_as5835_54t_cpld.c
@@ -225,7 +225,7 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
     struct i2c_client *client = to_i2c_client(dev);
     struct as5835_54t_cpld_data *data = i2c_get_clientdata(client);
 	int status = 0;
-	u8 reg = 0, mask = 0, revert = 0;
+	u8 reg = 0, mask = 0, invert  = 0;
 
 	switch (attr->index) {  
 	case MODULE_PRESENT_49 ... MODULE_PRESENT_54:
@@ -239,13 +239,14 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
 	case MODULE_RESET_49 ... MODULE_RESET_54:
 		reg  = 0x15;
 		mask = 0x1 << (attr->index - MODULE_RESET_49);
+		invert = 1;
 		break;
 	default:
 		return 0;
 	}
 
     if (attr->index >= MODULE_PRESENT_49 && attr->index <= MODULE_PRESENT_54) {
-        revert = 1;
+        invert = 1;
     }
 
     mutex_lock(&data->update_lock);
@@ -255,7 +256,7 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
 	}
 	mutex_unlock(&data->update_lock);
 
-	return sprintf(buf, "%d\n", revert ? !(status & mask) : !!(status & mask));
+	return sprintf(buf, "%d\n", invert ? !(status & mask) : !!(status & mask));
 
 exit:
 	mutex_unlock(&data->update_lock);
@@ -298,6 +299,9 @@ static ssize_t set_control(struct device *dev, struct device_attribute *da,
 	}
 
 	/* Update tx_disable/lpmode/reset status */
+    if (attr->index >= MODULE_RESET_49 && attr->index <= MODULE_RESET_54) {
+        value = !value;
+    }
 	if (value) {
 		status |= mask;
 	}

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_util.py
@@ -291,6 +291,9 @@ def device_install():
                 print output
                 if FORCE == 0:                
                     return status  
+    for i in range(49, 55): #Set qsfp port to normal state
+        log_os_system("echo 0 > /sys/bus/i2c/devices/3-0062/module_reset_" + str(i), 1)   
+    
     for i in range(0,len(sfp_map)):
         status, output =log_os_system("echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/new_device", 1)
         if status:

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/accton_as5835_54x_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/accton_as5835_54x_cpld.c
@@ -678,7 +678,7 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
     struct i2c_client *client = to_i2c_client(dev);
     struct as5835_54x_cpld_data *data = i2c_get_clientdata(client);
 	int status = 0;
-	u8 reg = 0, mask = 0, revert = 0;
+	u8 reg = 0, mask = 0, invert = 0;
 
 	switch (attr->index) {
 	case MODULE_PRESENT_1 ... MODULE_PRESENT_8:
@@ -804,13 +804,14 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
 	case MODULE_RESET_49 ... MODULE_RESET_54:
 		reg  = 0x15;
 		mask = 0x1 << (attr->index - MODULE_RESET_49);
+		invert = 1;
 		break;
 	default:
 		return 0;
 	}
 
     if (attr->index >= MODULE_PRESENT_1 && attr->index <= MODULE_PRESENT_54) {
-        revert = 1;
+        invert = 1;
     }
 
     mutex_lock(&data->update_lock);
@@ -820,7 +821,7 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
 	}
 	mutex_unlock(&data->update_lock);
 
-	return sprintf(buf, "%d\n", revert ? !(status & mask) : !!(status & mask));
+	return sprintf(buf, "%d\n", invert ? !(status & mask) : !!(status & mask));
 
 exit:
 	mutex_unlock(&data->update_lock);
@@ -891,6 +892,9 @@ static ssize_t set_control(struct device *dev, struct device_attribute *da,
 	}
 
 	/* Update tx_disable/lpmode/reset status */
+    if (attr->index >= MODULE_RESET_49 && attr->index <= MODULE_RESET_54) {
+        value = !value;
+    }
 	if (value) {
 		status |= mask;
 	}

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_util.py
@@ -314,6 +314,10 @@ def device_install():
                 print output
                 if FORCE == 0:                
                     return status  
+    
+    for i in range(49, 55): #Set qsfp port to normal state
+        log_os_system("echo 0 > /sys/bus/i2c/devices/3-0062/module_reset_" + str(i), 1)    
+         
     for i in range(0,len(sfp_map)):
         if i < qsfp_start:
             status, output =log_os_system("echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/new_device", 1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
HW set qsfp port to reset at default. so need SW to set to normal when boot.
**- How I did it**
1. Modify cpld driver to invert reset offset value
2. Set to normal when boot.
**- How to verify it**
Make sure all qsfp port reset sysfs=0 
 cat /sys/bus/i2c/devices/3-0062/module_reset_49
0

 cat /sys/bus/i2c/devices/3-0062/module_reset_50
0

cat /sys/bus/i2c/devices/3-0062/module_reset_51
0

 cat /sys/bus/i2c/devices/3-0062/module_reset_52
0

 cat /sys/bus/i2c/devices/3-0062/module_reset_53
0

 cat /sys/bus/i2c/devices/3-0062/module_reset_54
0

Make sure CPLD offset val=0x3f 
 i2cget -y -f 3 0x62 0x15
0x3f

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
