### PR TITLE
[snmp]: Reduce Calls to SONiC Cfggen

### DIFF
--- a/dockers/docker-snmp/start.sh
+++ b/dockers/docker-snmp/start.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 
-mkdir -p /etc/ssw
-sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sysDescription.j2 > /etc/ssw/sysDescription
+mkdir -p /etc/ssw /etc/snmp
 
-mkdir -p /etc/snmp
-sonic-cfggen -d -y /etc/sonic/snmp.yml -t /usr/share/sonic/templates/snmpd.conf.j2 > /etc/snmp/snmpd.conf
+SONIC_CFGGEN_ARGS=" \
+    -d \
+    -y /etc/sonic/sonic_version.yml \
+    -t /usr/share/sonic/templates/sysDescription.j2,/etc/ssw/sysDescription \
+    -y /etc/sonic/snmp.yml \
+    -t /usr/share/sonic/templates/snmpd.conf.j2,/etc/snmp/snmpd.conf \
+"
+
+sonic-cfggen $SONIC_CFGGEN_ARGS
 
 mkdir -p /var/sonic
 echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status


### PR DESCRIPTION
Calls to sonic-cfggen is CPU expensive. This PR reduces calls to
sonic-cfggen to one call during snmp startup

singed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
Reduce time required to start snmp service

**- How I did it**
Used template batch mode to batch together two calls into one call sonic-cfggen 

**- How to verify it**
```
root@str-s6000-acs-14:/# time ./start-old.sh

real	0m3.912s
user	0m3.223s
sys	0m0.613s
root@str-s6000-acs-14:/# time ./start-new.sh

real	0m1.988s
user	0m1.621s
sys	0m0.266s
root@str-s6000-acs-14:/# diff /etc/ssw/sysDescription.old /etc/ssw/sysDescription.new 
root@str-s6000-acs-14:/# diff /etc/snmp/snmpd.conf.old /etc/snmp/snmpd.conf.new
```
**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [x] 202006
