### PR TITLE
Enable restapi, update sonic-restapi

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -30,7 +30,7 @@
 {%- if include_iccpd == "y" %}{% do features.append(("iccpd", "disabled", "enabled")) %}{% endif %}
 {%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", "enabled")) %}{% endif %}
 {%- if include_nat == "y" %}{% do features.append(("nat", "disabled", "enabled")) %}{% endif %}
-{%- if include_restapi == "y" %}{% do features.append(("restapi", "disabled", "enabled")) %}{% endif %}
+{%- if include_restapi == "y" %}{% do features.append(("restapi", "enabled", "enabled")) %}{% endif %}
 {%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", "enabled")) %}{% endif %}
 {%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", "enabled")) %}{% endif %}
     "FEATURE": {


### PR DESCRIPTION
**- Why I did it**
Enable restapi if included in image.

Update sonic-restapi for:
d821e5a - 2020-08-12 : Accept subnet routes via tunnel, skip self loopback nexthop (#47) [Prince Sunny]
f8838c6 - 2020-06-30 : Config reset API (#46) [Sumukha Tumkur Vani]


**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x ] 201911
- [ ] 202006

**- Description for the changelog**
