### PR TITLE
[as9716-32d] Add to support lpmode for sfputil

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as9716_32d-r0/plugins/sfputil.py
@@ -7,6 +7,7 @@ try:
     import time
     import os
     import sys, getopt
+    from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
@@ -115,10 +116,65 @@ class SfpUtil(SfpUtilBase):
         return False
 
     def get_low_power_mode(self, port_num): 
-      raise NotImplementedError
+        # Check for invalid port_num
+        if port_num < self.port_start or port_num > self.port_end:
+            return False
+
+        try:
+            eeprom = None
+
+            if not self.get_presence(port_num):
+                return False
+
+            eeprom = open(self.port_to_eeprom_mapping[port_num], "rb")
+            eeprom.seek(93)
+            lpmode = ord(eeprom.read(1))
+
+            if ((lpmode & 0x3) == 0x3):
+                return True # Low Power Mode if "Power override" bit is 1 and "Power set" bit is 1
+            else:
+                return False # High Power Mode if one of the following conditions is matched:
+                             # 1. "Power override" bit is 0
+                             # 2. "Power override" bit is 1 and "Power set" bit is 0 
+        except IOError as e:
+            print "Error: unable to open file: %s" % str(e)
+            return False
+        finally:
+            if eeprom is not None:
+                eeprom.close()
+                time.sleep(0.01)
         
     def set_low_power_mode(self, port_num, lpmode):
-        raise NotImplementedError
+        # Check for invalid port_num
+        if port_num < self.port_start or port_num > self.port_end:
+            return False
+
+        try:
+            eeprom = None
+
+            if not self.get_presence(port_num):
+                return False # Port is not present, unable to set the eeprom
+
+            # Fill in write buffer
+            # 0x3:Low Power Mode. "Power override" bit is 1 and "Power set" bit is 1 
+            # 0x9:High Power Mode. "Power override" bit is 1 ,"Power set" bit is 0 and "High Power Class Enable" bit is 1 
+            regval = 0x3 if lpmode else 0x9 
+            
+            buffer = create_string_buffer(1)
+            buffer[0] = chr(regval)
+
+            # Write to eeprom
+            eeprom = open(self.port_to_eeprom_mapping[port_num], "r+b")
+            eeprom.seek(93)
+            eeprom.write(buffer[0])
+            return True
+        except IOError as e:
+            print "Error: unable to open file: %s" % str(e)
+            return False
+        finally:
+            if eeprom is not None:
+                eeprom.close()
+                time.sleep(0.01)
 
     def reset(self, port_num):
         if port_num < self.port_start or port_num > self.port_end:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Add to support lpmode.
**- How I did it**
Implement code to set/get lpmode.
**- How to verify it**
root@sonic:/home/admin# sfputil show lpmode
Port         Low-power Mode
-----------  ----------------
Ethernet0    Off
Ethernet8    Off
Ethernet16   Off
Ethernet24   Off
Ethernet32   Off
Ethernet40   Off.....

root@sonic:/home/admin# sfputil  lpmode on Ethernet0
Enabling low-power mode for port Ethernet0...  OK
root@sonic:/home/admin# sfputil show lpmode
Port         Low-power Mode
-----------  ----------------
Ethernet0    On
Ethernet8    Off
Ethernet16   Off
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
