### PR TITLE
[dhcp-relay] Reduce Calls to SONiC Cfggen

### DIFF
--- a/dockers/docker-dhcp-relay/Dockerfile.j2
+++ b/dockers/docker-dhcp-relay/Dockerfile.j2
@@ -25,7 +25,7 @@ RUN apt-get clean -y         && \
     rm -rf /debs
 
 COPY ["docker_init.sh", "start.sh", "/usr/bin/"]
-COPY ["docker-dhcp-relay.supervisord.conf.j2", "wait_for_intf.sh.j2", "/usr/share/sonic/templates/"]
+COPY ["docker-dhcp-relay.supervisord.conf.j2", "port-name-alias-map.txt.j2", "wait_for_intf.sh.j2", "/usr/share/sonic/templates/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 

--- a/dockers/docker-dhcp-relay/docker_init.sh
+++ b/dockers/docker-dhcp-relay/docker_init.sh
@@ -3,10 +3,10 @@
 # Generate supervisord config file
 mkdir -p /etc/supervisor/conf.d/
 
-# Generate scripts that:
-# 1. dhcp-relay supervisord configuration, 
-# 2. waits for all interfaces to come up, and
-# 3. port alias map
+# Generate the following files from templates:
+# 1. supervisord configuration 
+# 2. wait_for_intf.sh, which waits for all interfaces to come up
+# 3. port-to-alias name map
 CFGGEN_PARAMS=" \
     -d \
     -t /usr/share/sonic/templates/docker-dhcp-relay.supervisord.conf.j2,/etc/supervisor/conf.d/docker-dhcp-relay.supervisord.conf \

--- a/dockers/docker-dhcp-relay/docker_init.sh
+++ b/dockers/docker-dhcp-relay/docker_init.sh
@@ -2,15 +2,21 @@
 
 # Generate supervisord config file
 mkdir -p /etc/supervisor/conf.d/
-sonic-cfggen -d -t /usr/share/sonic/templates/docker-dhcp-relay.supervisord.conf.j2 > /etc/supervisor/conf.d/docker-dhcp-relay.supervisord.conf
 
-# Generate the script that waits for all interfaces to come up and make it executable
-sonic-cfggen -d -t /usr/share/sonic/templates/wait_for_intf.sh.j2 > /usr/bin/wait_for_intf.sh
+# Generate scripts that:
+# 1. dhcp-relay supervisord configuration, 
+# 2. waits for all interfaces to come up, and
+# 3. port alias map
+CFGGEN_PARAMS=" \
+    -d \
+    -t /usr/share/sonic/templates/docker-dhcp-relay.supervisord.conf.j2,/etc/supervisor/conf.d/docker-dhcp-relay.supervisord.conf \
+    -t /usr/share/sonic/templates/wait_for_intf.sh.j2,/usr/bin/wait_for_intf.sh \
+    -t /usr/share/sonic/templates/port-name-alias-map.txt.j2,/tmp/port-name-alias-map.txt \
+"
+sonic-cfggen $CFGGEN_PARAMS
+
+# Make the script that waits for all interfaces to come up executable
 chmod +x /usr/bin/wait_for_intf.sh
-
-# Generate port name-alias map for isc-dhcp-relay to parse. Each line contains one
-# name-alias pair of the form "<name> <alias>"
-sonic-cfggen -d --var-json "PORT" | python -c "import sys, json, os; [sys.stdout.write('%s %s\n' % (k, v['alias'] if 'alias' in v else k)) for (k, v) in json.load(sys.stdin).iteritems()]" > /tmp/port-name-alias-map.txt
 
 # The docker container should start this script as PID 1, so now that supervisord is
 # properly configured, we exec supervisord so that it runs as PID 1 for the

--- a/dockers/docker-dhcp-relay/port-name-alias-map.txt.j2
+++ b/dockers/docker-dhcp-relay/port-name-alias-map.txt.j2
@@ -1,5 +1,5 @@
 {# Generate port name-alias map for isc-dhcp-relay to parse. Each line contains one #}
 {#  name-alias pair of the form "<name> <alias>" #}
 {% for port, config in PORT.items() %}
-    {{- port }} {% if "alias" in config %}{{ config["alias"] }}{% else %}{{ port }}{% endif %} {{ "\n" -}}
+    {{- port }} {% if "alias" in config %}{{ config["alias"] }}{% else %}{{ port }}{% endif %} {{- "\n" -}}
 {% endfor -%}

--- a/dockers/docker-dhcp-relay/port-name-alias-map.txt.j2
+++ b/dockers/docker-dhcp-relay/port-name-alias-map.txt.j2
@@ -1,0 +1,5 @@
+{# Generate port name-alias map for isc-dhcp-relay to parse. Each line contains one #}
+{#  name-alias pair of the form "<name> <alias>" #}
+{% for port, config in PORT.items() %}
+    {{- port }} {% if "alias" in config %}{{ config["alias"] }}{% else %}{{ port }}{% endif %} {{ "\n" -}}
+{% endfor -%}


### PR DESCRIPTION
Calls to sonic-cfggen is CPU expensive. This PR reduces calls to
sonic-cfggen to one call during startup when starting dhcp-relay
service.

singed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
Reduce time required when invoking dhcp-relay

**- How I did it**
Used template batch mode to batch together three calls into one call to sonic-cfggen

**- How to verify it**
```
root@str-s6000-acs-14:/# time ./docker_init_old.sh

real	0m5.548s
user	0m4.370s
sys	0m0.756s
root@str-s6000-acs-14:/# time ./docker_init_new.sh

real	0m1.611s
user	0m1.346s
sys	0m0.221s
root@str-s6000-acs-14:/# diff /etc/supervisor/conf.d/docker-dhcp-relay.supervisord.conf.old /etc/supervisor/conf.d/docker-dhcp-relay.supervisord.conf.new 
root@str-s6000-acs-14:/# diff /usr/bin/wait_for_intf.sh.old /usr/bin/wait_for_intf.sh.new 
root@str-s6000-acs-14:/# diff /tmp/port-name-alias-map.txt.old /tmp/port-name-alias-map.txt.new 
1,32c1,33
< Ethernet8 fortyGigE0/8
< Ethernet0 fortyGigE0/0
< Ethernet4 fortyGigE0/4
< Ethernet108 fortyGigE0/108
< Ethernet100 fortyGigE0/100
< Ethernet104 fortyGigE0/104
< Ethernet96 fortyGigE0/96
< Ethernet124 fortyGigE0/124
< Ethernet120 fortyGigE0/120
< Ethernet92 fortyGigE0/92
< Ethernet28 fortyGigE0/28
< Ethernet52 fortyGigE0/52
< Ethernet56 fortyGigE0/56
< Ethernet76 fortyGigE0/76
< Ethernet72 fortyGigE0/72
< Ethernet32 fortyGigE0/32
< Ethernet16 fortyGigE0/16
< Ethernet36 fortyGigE0/36
< Ethernet12 fortyGigE0/12
< Ethernet88 fortyGigE0/88
< Ethernet24 fortyGigE0/24
< Ethernet116 fortyGigE0/116
< Ethernet80 fortyGigE0/80
< Ethernet112 fortyGigE0/112
< Ethernet84 fortyGigE0/84
< Ethernet48 fortyGigE0/48
< Ethernet44 fortyGigE0/44
< Ethernet40 fortyGigE0/40
< Ethernet64 fortyGigE0/64
< Ethernet60 fortyGigE0/60
< Ethernet20 fortyGigE0/20
< Ethernet68 fortyGigE0/68
---
> Ethernet0 fortyGigE0/0 
> Ethernet4 fortyGigE0/4 
> Ethernet8 fortyGigE0/8 
> Ethernet12 fortyGigE0/12 
> Ethernet16 fortyGigE0/16 
> Ethernet20 fortyGigE0/20 
> Ethernet24 fortyGigE0/24 
> Ethernet28 fortyGigE0/28 
> Ethernet32 fortyGigE0/32 
> Ethernet36 fortyGigE0/36 
> Ethernet40 fortyGigE0/40 
> Ethernet44 fortyGigE0/44 
> Ethernet48 fortyGigE0/48 
> Ethernet52 fortyGigE0/52 
> Ethernet56 fortyGigE0/56 
> Ethernet60 fortyGigE0/60 
> Ethernet64 fortyGigE0/64 
> Ethernet68 fortyGigE0/68 
> Ethernet72 fortyGigE0/72 
> Ethernet76 fortyGigE0/76 
> Ethernet80 fortyGigE0/80 
> Ethernet84 fortyGigE0/84 
> Ethernet88 fortyGigE0/88 
> Ethernet92 fortyGigE0/92 
> Ethernet96 fortyGigE0/96 
> Ethernet100 fortyGigE0/100 
> Ethernet104 fortyGigE0/104 
> Ethernet108 fortyGigE0/108 
> Ethernet112 fortyGigE0/112 
> Ethernet116 fortyGigE0/116 
> Ethernet120 fortyGigE0/120 
> Ethernet124 fortyGigE0/124 
> 
root@str-s6000-acs-14:/# 
```

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [x] 202006
