### PR TITLE
[frr] Reduce Calls to SONiC Cfggen

### DIFF
--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -3,13 +3,19 @@
 mkdir -p /etc/frr
 mkdir -p /etc/supervisor/conf.d
 
-CONFIG_TYPE=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["docker_routing_config_mode"]'`
-
 CFGGEN_PARAMS=" \
     -d \
     -y /etc/sonic/constants.yml \
+    -t /usr/share/sonic/templates/supervisord/frr_vars.j2 \
     -t /usr/share/sonic/templates/supervisord/supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf \
+    -t /usr/share/sonic/templates/bgpd/bgpd.conf.j2,/etc/frr/bgpd.conf \
+    -t /usr/share/sonic/templates/zebra/zebra.conf.j2,/etc/frr/zebra.conf \
+    -t /usr/share/sonic/templates/staticd/staticd.conf.j2,/etc/frr/staticd.conf \
+    -t /usr/share/sonic/templates/frr.conf.j2,/etc/frr/frr.conf \
+    -t /usr/share/sonic/templates/isolate.j2,/usr/sbin/bgp-isolate \
+    -t /usr/share/sonic/templates/unisolate.j2,/usr/sbin/bgp-unisolate \
 "
+CONFIG_TYPE=$(sonic-cfggen $CFGGEN_PARAMS)
 
 if [[ ! -z "$NAMESPACE_ID" ]]; then
    # FRR is not running in host namespace so we need to delete
@@ -35,26 +41,12 @@ if [[ ! -z "$NAMESPACE_ID" ]]; then
 fi
 
 if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "separated" ]; then
-    CFGGEN_PARAMS+=" \
-        -t /usr/share/sonic/templates/bgpd/bgpd.conf.j2,/etc/frr/bgpd.conf \
-        -t /usr/share/sonic/templates/zebra/zebra.conf.j2,/etc/frr/zebra.conf \
-        -t /usr/share/sonic/templates/staticd/staticd.conf.j2,/etc/frr/staticd.conf \
-    "
     echo "no service integrated-vtysh-config" > /etc/frr/vtysh.conf
     rm -f /etc/frr/frr.conf
 elif [ "$CONFIG_TYPE" == "unified" ]; then
-    CFGGEN_PARAMS+=" \
-        -t /usr/share/sonic/templates/frr.conf.j2,/etc/frr/frr.conf \
-    "
     echo "service integrated-vtysh-config" > /etc/frr/vtysh.conf
     rm -f /etc/frr/bgpd.conf /etc/frr/zebra.conf /etc/frr/staticd.conf
 fi
-
-CFGGEN_PARAMS+=" \
-    -t /usr/share/sonic/templates/isolate.j2,/usr/sbin/bgp-isolate \
-    -t /usr/share/sonic/templates/unisolate.j2,/usr/sbin/bgp-unisolate \
-"
-sonic-cfggen $CFGGEN_PARAMS
 
 chown -R frr:frr /etc/frr/
 

--- a/dockers/docker-fpm-frr/frr/frr_vars.j2
+++ b/dockers/docker-fpm-frr/frr/frr_vars.j2
@@ -1,0 +1,1 @@
+{{ DEVICE_METADATA["localhost"]["docker_routing_config_mode"] }}

--- a/dockers/docker-fpm-gobgp/start.sh
+++ b/dockers/docker-fpm-gobgp/start.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 
 mkdir -p /etc/quagga
-sonic-cfggen -d -t /usr/share/sonic/templates/gobgpd.conf.j2 > /etc/gobgp/gobgpd.conf
-sonic-cfggen -d -t /usr/share/sonic/templates/zebra.conf.j2 > /etc/quagga/zebra.conf
 
-sonic-cfggen -d -t /usr/share/sonic/templates/isolate.j2 > /usr/sbin/bgp-isolate
+CFGGEN_PARAMS=" \
+    -d \
+    -t /usr/share/sonic/templates/gobgpd.conf.j2,/etc/gobgp/gobgpd.conf \
+    -t /usr/share/sonic/templates/zebra.conf.j2,/etc/quagga/zebra.conf \
+    -t /usr/share/sonic/templates/isolate.j2,/usr/sbin/bgp-isolate \
+    -t /usr/share/sonic/templates/unisolate.j2,/usr/sbin/bgp-unisolate \
+"
+sonic-cfggen $CFGGEN_PARAMS
+
 chown root:root /usr/sbin/bgp-isolate
 chmod 0755 /usr/sbin/bgp-isolate
 
-sonic-cfggen -d -t /usr/share/sonic/templates/unisolate.j2 > /usr/sbin/bgp-unisolate
 chown root:root /usr/sbin/bgp-unisolate
 chmod 0755 /usr/sbin/bgp-unisolate
 

--- a/dockers/docker-fpm-quagga/start.sh
+++ b/dockers/docker-fpm-quagga/start.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 
 mkdir -p /etc/quagga
-sonic-cfggen -d -y /etc/sonic/constants.yml -t /usr/share/sonic/templates/bgpd.conf.j2 > /etc/quagga/bgpd.conf
 
-sonic-cfggen -d -t /usr/share/sonic/templates/zebra.conf.j2 > /etc/quagga/zebra.conf
+CFGGEN_PARAMS=" \
+    -d \
+    -y /etc/sonic/constants.yml \
+    -t /usr/share/sonic/templates/bgpd.conf.j2,/etc/quagga/bgpd.conf \
+    -t /usr/share/sonic/templates/zebra.conf.j2,/etc/quagga/zebra.conf \
+    -t /usr/share/sonic/templates/isolate.j2,/usr/sbin/bgp-isolate \
+    -t /usr/share/sonic/templates/unisolate.j2,/usr/sbin/bgp-unisolate \
+"
+sonic-cfggen $CFGGEN_PARAMS
 
-sonic-cfggen -d -t /usr/share/sonic/templates/isolate.j2 > /usr/sbin/bgp-isolate
 chown root:root /usr/sbin/bgp-isolate
 chmod 0755 /usr/sbin/bgp-isolate
 
-sonic-cfggen -d -t /usr/share/sonic/templates/unisolate.j2 > /usr/sbin/bgp-unisolate
 chown root:root /usr/sbin/bgp-unisolate
 chmod 0755 /usr/sbin/bgp-unisolate
 


### PR DESCRIPTION
Calls to sonic-cfggen is CPU expensive. This PR reduces calls to
sonic-cfggen to two calls during startup when starting frr service.

singed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
Reduce time required when invoking frr

**- How I did it**
Used template batch mode to batch together three calls into one call to sonic-cfggen

**- How to verify it**
```
root@str-s6000-acs-14:/# time ./docker_init_old.sh

real	0m12.873s
user	0m10.486s
sys	0m1.624s
root@str-s6000-acs-14:/# time ./docker_init_new.sh

real	0m3.572s
user	0m2.927s
sys	0m0.499s
root@str-s6000-acs-14:/# diff /etc/supervisor/conf.d/supervisord.conf.old /etc/supervisor/conf.d/supervisord.conf.new 
root@str-s6000-acs-14:/# diff /etc/frr/bgpd.conf.old /etc/frr/bgpd.conf.new 
root@str-s6000-acs-14:/# diff /etc/frr/zebra.conf.old /etc/frr/zebra.conf.new 
root@str-s6000-acs-14:/# diff /etc/frr/staticd.conf.old /etc/frr/staticd.conf.new 
root@str-s6000-acs-14:/# diff /usr/sbin/bgp-isolate.old /usr/sbin/bgp-isolate.new 
root@str-s6000-acs-14:/# diff /usr/sbin/bgp-unisolate.old /usr/sbin/bgp-unisolate.new 
root@str-s6000-acs-14:/# 

```

Update for the case when just once call is placed t sonic-cfggen:
```
root@str-s6000-acs-14:/# time ./docker_init_old.sh
CONFIG_TYPE=separated

real	0m12.117s
user	0m9.803s
sys	0m1.523s
root@str-s6000-acs-14:/# time ./docker_init_new.sh
CONFIG_TYPE=separated

real	0m2.598s
user	0m1.986s
sys	0m0.383s
root@str-s6000-acs-14:/# diff /etc/supervisor/conf.d/supervisord.conf.old /etc/supervisor/conf.d/supervisord.conf.new 
root@str-s6000-acs-14:/# diff /etc/frr/bgpd.conf.old /etc/frr/bgpd.conf.new 
root@str-s6000-acs-14:/# diff /etc/frr/zebra.conf.old /etc/frr/zebra.conf.new
root@str-s6000-acs-14:/# diff /etc/frr/staticd.conf.old /etc/frr/staticd.conf.new
root@str-s6000-acs-14:/# diff /usr/sbin/bgp-isolate.old /usr/sbin/bgp-isolate.new
root@str-s6000-acs-14:/# diff /usr/sbin/bgp-unisolate.old /usr/sbin/bgp-unisolate.new
root@str-s6000-acs-14:/# 
```

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [x] 202006
