### PR TITLE
[swss] Reduce Calls to SONiC Cfggen

### DIFF
--- a/dockers/docker-orchagent/docker-init.sh
+++ b/dockers/docker-orchagent/docker-init.sh
@@ -2,10 +2,16 @@
 
 mkdir -p /etc/swss/config.d/
 
-sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/switch.json.j2 > /etc/swss/config.d/switch.json
-sonic-cfggen -d -t /usr/share/sonic/templates/ipinip.json.j2 > /etc/swss/config.d/ipinip.json
-sonic-cfggen -d -t /usr/share/sonic/templates/ports.json.j2 > /etc/swss/config.d/ports.json
-sonic-cfggen -d -t /usr/share/sonic/templates/copp.json.j2 > /etc/swss/config.d/00-copp.config.json
+CFGGEN_PARAMS=" \
+    -d \
+    -y /etc/sonic/constants.yml \
+    -t /usr/share/sonic/templates/switch.json.j2,/etc/swss/config.d/switch.json \
+    -t /usr/share/sonic/templates/ipinip.json.j2,/etc/swss/config.d/ipinip.json \
+    -t /usr/share/sonic/templates/ports.json.j2,/etc/swss/config.d/ports.json \
+    -t /usr/share/sonic/templates/copp.json.j2,/etc/swss/config.d/00-copp.config.json \
+    -t /usr/share/sonic/templates/vlan_vars.j2 \
+"
+VLAN=$(sonic-cfggen $CFGGEN_PARAMS)
 
 # Executed HWSKU specific initialization tasks.
 if [ -x /usr/share/sonic/hwsku/hwsku-init ]; then
@@ -13,7 +19,6 @@ if [ -x /usr/share/sonic/hwsku/hwsku-init ]; then
 fi
 
 # Start arp_update when VLAN exists
-VLAN=`sonic-cfggen -d -v 'VLAN.keys() | join(" ") if VLAN'`
 if [ "$VLAN" != "" ]; then
     cp /usr/share/sonic/templates/arp_update.conf /etc/supervisord/conf.d/
 fi

--- a/dockers/docker-orchagent/vlan_vars.j2
+++ b/dockers/docker-orchagent/vlan_vars.j2
@@ -1,0 +1,1 @@
+{%- if VLAN -%}{{- VLAN.keys() | join(' ') -}}{%- endif -%}


### PR DESCRIPTION
Calls to sonic-cfggen is CPU expensive. This PR reduces calls to
sonic-cfggen to one call during startup when starting swss service.

singed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
Reduce time required when invoking swss

**- How I did it**
Used template batch mode to batch together three calls into one call to sonic-cfggen

**- How to verify it**
```
root@str-s6000-acs-14:/# time ./docker-init-old.sh
VLAN=Vlan1000

real	0m8.323s
user	0m6.820s
sys	0m1.036s
root@str-s6000-acs-14:/# time ./docker-init-new.sh
VLAN=Vlan1000

real	0m1.931s
user	0m1.617s
sys	0m0.282s
root@str-s6000-acs-14:/# diff /etc/swss/config.d/switch.json.old /etc/swss/config.d/switch.json.new 
root@str-s6000-acs-14:/# diff /etc/swss/config.d/ipinip.json.old /etc/swss/config.d/ipinip.json.new
root@str-s6000-acs-14:/# diff /etc/swss/config.d/ports.json.old /etc/swss/config.d/ports.json.new
root@str-s6000-acs-14:/# diff /etc/swss/config.d/00-copp.config.json.old /etc/swss/config.d/00-copp.config.json.new 
root@str-s6000-acs-14:/# 
```

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [x] 202006
