### PR TITLE
[radv] Reduce Calls to SONiC Cfggen

### DIFF
--- a/dockers/docker-router-advertiser/docker-init.sh
+++ b/dockers/docker-router-advertiser/docker-init.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 
 mkdir -p /etc/supervisor/conf.d
-sonic-cfggen -d -t /usr/share/sonic/templates/docker-router-advertiser.supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
 
-# Generate /etc/radvd.conf config file
-sonic-cfggen -d -t /usr/share/sonic/templates/radvd.conf.j2 > /etc/radvd.conf
+# Generate supervisord router advertiser config, /etc/radvd.conf config file, and
+# the script that waits for pertinent interfaces to come up and make it executable
+CFGGEN_PARAMS=" \
+    -d \
+    -t /usr/share/sonic/templates/docker-router-advertiser.supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf \
+    -t /usr/share/sonic/templates/radvd.conf.j2,/etc/radvd.conf \
+    -t /usr/share/sonic/templates/wait_for_intf.sh.j2,/usr/bin/wait_for_intf.sh \
+"
+sonic-cfggen $CFGGEN_PARAMS
 
-# Generate the script that waits for pertinent interfaces to come up and make it executable
-sonic-cfggen -d -t /usr/share/sonic/templates/wait_for_intf.sh.j2 > /usr/bin/wait_for_intf.sh
 chmod +x /usr/bin/wait_for_intf.sh
 
 exec /usr/bin/supervisord


### PR DESCRIPTION
Calls to sonic-cfggen is CPU expensive. This PR reduces calls to
sonic-cfggen to one call during startup when starting radv service.

singed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
Reduce time required when invoking swss

**- How I did it**
Used template batch mode to batch together three calls into one call to sonic-cfggen

**- How to verify it**
```
root@str-s6000-acs-14:/# time ./docker-init-old.sh 

real	0m5.099s
user	0m4.180s
sys	0m0.585s
root@str-s6000-acs-14:/# time ./docker-init-new.sh 

real	0m1.583s
user	0m1.335s
sys	0m0.200s
root@str-s6000-acs-14:/# diff /etc/supervisor/conf.d/supervisord.conf.old /etc/supervisor/conf.d/supervisord.conf.new 
root@str-s6000-acs-14:/# diff /etc/radvd.conf.old /etc/radvd.conf.new 
root@str-s6000-acs-14:/# diff /usr/bin/wait_for_intf.sh.old /usr/bin/wait_for_intf.sh.new 
root@str-s6000-acs-14:/# 
```

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [x] 202006
