### PR TITLE
[barefoot] Switch to Y profiles for Newport board

### DIFF
--- a/device/barefoot/x86_64-accton_as9516bf_32d-r0/syncd.conf
+++ b/device/barefoot/x86_64-accton_as9516bf_32d-r0/syncd.conf
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+
+y_profile_set() {
+    P4_PROFILE=$(sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["p4_profile"]')
+    if [[ -n "$P4_PROFILE" || ( ! -L /opt/bfn/install && -e /opt/bfn/install ) ]]; then
+        return
+    fi
+
+    Y_PROFILE=$(ls -d /opt/bfn/install_y*_profile 2> /dev/null | head -1)
+    if [[ -z $Y_PROFILE  ]]; then
+        echo "No P4 profile found for Newport"
+        return
+    fi
+
+    ln -srfn $Y_PROFILE /opt/bfn/install
+}
+
+(
+    unset PYTHONPATH
+    unset PYTHONHOME
+    y_profile_set
+)


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

**- Why I did it**
To make the newport platform choose the Y1 profile on startup.

**- How I did it**


**- Which release branch to backport (provide reason below if selected)**
- [ ] 201811
- [x] 201911
- [x] 202006
