### PR TITLE
[201911] Fix issues with sonic-py-common package

### DIFF
--- a/src/sonic-py-common/sonic_py_common/daemon_base.py
+++ b/src/sonic-py-common/sonic_py_common/daemon_base.py
@@ -8,7 +8,11 @@ from .logger import Logger
 #
 # Constants ====================================================================
 #
+# Redis DB information
+REDIS_HOSTNAME = 'localhost'
+REDIS_PORT = 6379
 REDIS_TIMEOUT_MSECS = 0
+
 
 EEPROM_MODULE_NAME = 'eeprom'
 EEPROM_CLASS_NAME = 'board'
@@ -17,9 +21,12 @@ EEPROM_CLASS_NAME = 'board'
 # Helper functions =============================================================
 #
 
-def db_connect(db_name):
+def db_connect(db):
     from swsscommon import swsscommon
-    return swsscommon.DBConnector(db_name, REDIS_TIMEOUT_MSECS, True)
+    return swsscommon.DBConnector(db,
+                                  REDIS_HOSTNAME,
+                                  REDIS_PORT,
+                                  REDIS_TIMEOUT_MSECS)
 
 #
 # DaemonBase ===================================================================

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -248,7 +248,7 @@ def get_npu_id_from_name(npu_name):
 
 
 def get_npu_device_id(npu_id):
-    platform = get_platform_info(get_machine_info())
+    platform = get_platform()
     if not platform:
         return None
 


### PR DESCRIPTION
What I did:
Two fixes/change were made with new sonic-py-common package:

a) we should use get_platform() with new sonic_py-common package
instead of get_platform_info()

b) In 201911 DB Connector is still using db id based constructor
as following PR#https://github.com/Azure/sonic-buildimage/pull/4549
is not cherry-picked yet. 
So revert the change to use db is instead of db_name for now. This will be updated when we move to db name 

How I verified:
Because of (b) PMON process were bailing out. After fix things are fine.