### PR TITLE
Revert "Revert 'DPB Breakout Cli Test with proper setup (#3910)' "

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -46,7 +46,8 @@ RUN apt-get install -y net-tools \
                        python-scapy \
                        conntrack \
                        iptables \
-                       python3-pip
+                       python3-pip \
+                       jq
 
 RUN pip install setuptools
 RUN pip3 install setuptools
@@ -131,6 +132,10 @@ COPY ["database_config.json", "/etc/default/sonic-db/"]
 COPY ["hostname.j2", "/usr/share/sonic/templates/"]
 COPY ["default_chassis_cfg.json", "/etc/default/sonic-db/"]
 COPY ["chassis_db.py", "/usr/bin/"]
+
+COPY ["platform.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/"]
+COPY ["hwsku.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/"]
+COPY ["platform.json", "/usr/share/sonic/platform/"]
 
 # Workaround the tcpdump issue
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump

--- a/platform/vs/docker-sonic-vs/hwsku.json
+++ b/platform/vs/docker-sonic-vs/hwsku.json
@@ -1,100 +1,100 @@
 {
     "interfaces": {
         "Ethernet0": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet4": {
             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet8": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet12": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet16": {
             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet20": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet24": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet28": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet32": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet36": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet40": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet44": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet48": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet52": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet56": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet60": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet64": {
             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet68": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet72": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet76": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet80": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet84": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet88": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet92": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet96": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet100": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet104": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet108": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet112": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet116": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet120": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         },
         "Ethernet124": {
-	    "default_brkout_mode": "1x100G[40G]"
+             "default_brkout_mode": "1x100G[40G]"
         }
     }
 }

--- a/platform/vs/docker-sonic-vs/hwsku.json
+++ b/platform/vs/docker-sonic-vs/hwsku.json
@@ -1,0 +1,100 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet8": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet12": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet20": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet24": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet28": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet32": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet36": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet40": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet44": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet48": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet52": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet56": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet60": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet68": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet72": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet76": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet80": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet84": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet88": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet92": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet96": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet100": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet104": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet108": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet112": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet116": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet120": {
+	    "default_brkout_mode": "1x100G[40G]"
+        },
+        "Ethernet124": {
+	    "default_brkout_mode": "1x100G[40G]"
+        }
+    }
+}

--- a/platform/vs/docker-sonic-vs/platform.json
+++ b/platform/vs/docker-sonic-vs/platform.json
@@ -1,0 +1,196 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "index": "0,0,0,0",
+            "lanes": "25,26,27,28",
+            "alias_at_lanes": "fortyGigE0/0,fortyGigE0/1,fortyGigE0/2,fortyGigE0/3",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+       "Ethernet4": {
+            "index": "1,1,1,1",
+            "lanes": "29,30,31,32",
+            "alias_at_lanes": "fortyGigE0/4,fortyGigE0/5,fortyGigE0/6,fortyGigE0/7",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G]"
+        },
+        "Ethernet8": {
+            "index": "2,2,2,2",
+            "lanes": "33,34,35,36",
+            "alias_at_lanes": "fortyGigE0/8,fortyGigE0/9,fortyGigE0/10,fortyGigE0/11",
+            "breakout_modes": "1x100G[40G],2x50G,2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet12": {
+            "index": "3,3,3,3",
+            "lanes": "37,38,39,40",
+            "alias_at_lanes": "fortyGigE0/12,fortyGigE0/13,fortyGigE0/14,fortyGigE0/15",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet16": {
+            "index": "4,4,4,4",
+            "lanes": "45,46,47,48",
+            "alias_at_lanes": "fortyGigE0/16,fortyGigE0/17,fortyGigE0/18,fortyGigE0/19",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet20": {
+            "index": "5,5,5,5",
+            "lanes": "41,42,43,44",
+            "alias_at_lanes": "fortyGigE0/20,fortyGigE0/21,fortyGigE0/22,fortyGigE0/23",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet24": {
+            "index": "6,6,6,6",
+            "lanes": "1,2,3,4",
+            "alias_at_lanes": "fortyGigE0/24,fortyGigE0/25,fortyGigE0/26,fortyGigE0/27",
+            "breakout_modes": "1x100G[40G],4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet28": {
+            "index": "7,7,7,7",
+            "lanes": "5,6,7,8",
+            "alias_at_lanes": "fortyGigE0/28,fortyGigE0/29,fortyGigE0/30,fortyGigE0/31",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet32": {
+            "index": "8,8,8,8",
+            "lanes": "13,14,15,16",
+            "alias_at_lanes": "fortyGigE0/32,fortyGigE0/33,fortyGigE0/34,fortyGigE0/35",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet36": {
+            "index": "9,9,9,9",
+            "lanes": "9,10,11,12",
+            "alias_at_lanes": "fortyGigE0/36,fortyGigE0/37,fortyGigE0/38,fortyGigE0/39",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet40": {
+            "index": "10,10,10,10",
+            "lanes": "17,18,19,20",
+            "alias_at_lanes": "fortyGigE0/40,fortyGigE0/41,fortyGigE0/42,fortyGigE0/43",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet44": {
+            "index": "11,11,11,11",
+            "lanes": "21,22,23,24",
+            "alias_at_lanes": "fortyGigE0/44,fortyGigE0/45,fortyGigE0/46,fortyGigE0/47",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet48": {
+            "index": "12,12,12,12",
+            "lanes": "53,54,55,56",
+            "alias_at_lanes": "fortyGigE0/48,fortyGigE0/49,fortyGigE0/50,fortyGigE0/51",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet52": {
+            "index": "13,13,13,13",
+            "lanes": "49,50,51,52",
+            "alias_at_lanes": "fortyGigE0/52,fortyGigE0/53,fortyGigE0/54,fortyGigE0/55",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet56": {
+            "index": "14,14,14,14",
+            "lanes": "57,58,59,60",
+            "alias_at_lanes": "fortyGigE0/56,fortyGigE0/57,fortyGigE0/58,fortyGigE0/59",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet60": {
+            "index": "15,15,15,15",
+            "lanes": "61,62,63,64",
+            "alias_at_lanes": "fortyGigE0/60,fortyGigE0/61,fortyGigE0/62,fortyGigE0/63",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet64": {
+            "index": "16,16,16,16",
+            "lanes": "69,70,71,72",
+            "alias_at_lanes": "fortyGigE0/64,fortyGigE0/65,fortyGigE0/66,fortyGigE0/67",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet68": {
+            "index": "17,17,17,17",
+            "lanes": "65,66,67,68",
+            "alias_at_lanes": "fortyGigE0/68,fortyGigE0/69,fortyGigE0/70,fortyGigE0/71",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet72": {
+            "index": "18,18,18,18",
+            "lanes": "73,74,75,76",
+            "alias_at_lanes": "fortyGigE0/72,fortyGigE0/73,fortyGigE0/74,fortyGigE0/75",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet76": {
+            "index": "19,19,19,19",
+            "lanes": "77,78,79,80",
+            "alias_at_lanes": "fortyGigE0/76,fortyGigE0/77,fortyGigE0/78,fortyGigE0/79",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet80": {
+            "index": "20,20,20,20",
+            "lanes": "109,110,111,112",
+            "alias_at_lanes": "fortyGigE0/80,fortyGigE0/81,fortyGigE0/82,fortyGigE0/83",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet84": {
+            "index": "21,21,21,21",
+            "lanes": "105,106,107,108",
+            "alias_at_lanes": "fortyGigE0/84,fortyGigE0/85,fortyGigE0/86,fortyGigE0/87",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet88": {
+            "index": "22,22,22,22",
+            "lanes": "113,114,115,116",
+            "alias_at_lanes": "fortyGigE0/88,fortyGigE0/89,fortyGigE0/90,fortyGigE0/91",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet92": {
+            "index": "23,23,23,23",
+            "lanes": "117,118,119,120",
+            "alias_at_lanes": "fortyGigE0/92,fortyGigE0/93,fortyGigE0/94,fortyGigE0/95",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet96": {
+            "index": "24,24,24,24",
+            "lanes": "125,126,127,128",
+            "alias_at_lanes": "fortyGigE0/96,fortyGigE0/97,fortyGigE0/98,fortyGigE0/99",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet100": {
+            "index": "25,25,25,25",
+            "lanes": "121,122,123,124",
+            "alias_at_lanes": "fortyGigE0/100,fortyGigE0/101,fortyGigE0/102,fortyGigE0/103",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet104": {
+            "index": "26,26,26,26",
+            "lanes": "81,82,83,84",
+            "alias_at_lanes": "fortyGigE0/104,fortyGigE0/105,fortyGigE0/106,fortyGigE0/107",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet108": {
+            "index": "27,27,27,27",
+            "lanes": "85,86,87,88",
+            "alias_at_lanes": "fortyGigE0/108,fortyGigE0/109,fortyGigE0/110,fortyGigE0/111",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet112": {
+            "index": "28,28,28,28",
+            "lanes": "93,94,95,96",
+            "alias_at_lanes": "fortyGigE0/112,fortyGigE0/113,fortyGigE0/114,fortyGigE0/115",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet116": {
+            "index": "29,29,29,29",
+            "lanes": "89,90,91,92",
+            "alias_at_lanes": "fortyGigE0/116,fortyGigE0/117,fortyGigE0/118,fortyGigE0/119",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet120": {
+            "index": "30,30,30,30",
+            "lanes": "101,102,103,104",
+            "alias_at_lanes": "fortyGigE0/120,fortyGigE0/121,fortyGigE0/122,fortyGigE0/123",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        },
+        "Ethernet124": {
+            "index": "31,31,31,31",
+            "lanes": "97,98,99,100",
+            "alias_at_lanes": "fortyGigE0/124,fortyGigE0/125,fortyGigE0/126,fortyGigE0/127",
+            "breakout_modes": "1x100G[40G],2x50G,4x25G[10G],2x25G(2)+1x50G(2),1x50G(2)+2x25G(2)"
+        }
+    }
+}

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -41,6 +41,8 @@ else
     sonic-cfggen -k $HWSKU -p /usr/share/sonic/device/$PLATFORM/platform.json -t /usr/share/sonic/hwsku/buffers.json.j2 > /tmp/buffers.json
     sonic-cfggen -j /etc/sonic/init_cfg.json -t /usr/share/sonic/hwsku/qos.json.j2 > /tmp/qos.json
     sonic-cfggen -p /usr/share/sonic/device/$PLATFORM/platform.json -k $HWSKU --print-data > /tmp/ports.json
+    # change admin_status from up to down; Test cases dependent
+    sed -i "s/up/down/g" /tmp/ports.json
     sonic-cfggen -j /etc/sonic/init_cfg.json -j /tmp/buffers.json -j /tmp/qos.json -j /tmp/ports.json --print-data > /etc/sonic/config_db.json
 fi
 

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -38,9 +38,9 @@ if [ -f /etc/sonic/config_db.json ]; then
     mv /tmp/config_db.json /etc/sonic/config_db.json
 else
     # generate and merge buffers configuration into config file
-    sonic-cfggen -k $HWSKU -p /usr/share/sonic/hwsku/port_config.ini -t /usr/share/sonic/hwsku/buffers.json.j2 > /tmp/buffers.json
+    sonic-cfggen -k $HWSKU -p /usr/share/sonic/device/$PLATFORM/platform.json -t /usr/share/sonic/hwsku/buffers.json.j2 > /tmp/buffers.json
     sonic-cfggen -j /etc/sonic/init_cfg.json -t /usr/share/sonic/hwsku/qos.json.j2 > /tmp/qos.json
-    sonic-cfggen -p /usr/share/sonic/hwsku/port_config.ini -k $HWSKU --print-data > /tmp/ports.json
+    sonic-cfggen -p /usr/share/sonic/device/$PLATFORM/platform.json -k $HWSKU --print-data > /tmp/ports.json
     sonic-cfggen -j /etc/sonic/init_cfg.json -j /tmp/buffers.json -j /tmp/qos.json -j /tmp/ports.json --print-data > /etc/sonic/config_db.json
 fi
 

--- a/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
+++ b/platform/vs/tests/breakout/sample_output/sample_new_port_config.json
@@ -1,0 +1,252 @@
+{
+    "Ethernet0_2x50G": {
+	    "Ethernet2": {
+	        "alias": "fortyGigE0/2",
+	        "admin_status": "up",
+	        "lanes": "27,28",
+	        "speed": "50000",
+	        "index": "0"
+	    },
+	    "Ethernet0": {
+	        "alias": "fortyGigE0/0",
+	        "admin_status": "up",
+	        "lanes": "25,26",
+	        "speed": "50000",
+	        "index": "0"
+	    }
+    },
+    "Ethernet12_1x50G_2x25G": {
+            "Ethernet12": {
+                "alias": "fortyGigE0/12",
+                "admin_status": "up",
+                "lanes": "37,38",
+                "speed": "50000",
+                "index": "3"
+            },
+            "Ethernet14": {
+                "alias": "fortyGigE0/14",
+                "admin_status": "up",
+                "lanes": "39",
+                "speed": "25000",
+                "index": "3"
+            },
+	    "Ethernet15": {
+                "alias": "fortyGigE0/15",
+                "admin_status": "up",
+                "lanes": "40",
+                "speed": "25000",
+                "index": "3"
+            }
+    },
+    "Ethernet0_2x50G": {
+            "Ethernet2": {
+                "alias": "fortyGigE0/2",
+                "admin_status": "up",
+                "lanes": "27,28",
+                "speed": "50000",
+                "index": "0"
+            },
+            "Ethernet0": {
+                "alias": "fortyGigE0/0",
+                "admin_status": "up",
+                "lanes": "25,26",
+                "speed": "50000",
+                "index": "0"
+            }
+    },
+    "Ethernet0_1x100G": {
+	    "Ethernet0": {
+	        "alias": "fortyGigE0/0",
+	        "admin_status": "up",
+	        "lanes": "25,26,27,28",
+	        "speed": "100000",
+	        "index": "0"
+	    }
+    },
+    "Ethernet0_4x25G":	{
+	    "Ethernet2": {
+	        "alias": "fortyGigE0/2",
+	        "admin_status": "up",
+	        "lanes": "27",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet3": {
+	        "alias": "fortyGigE0/3",
+	        "admin_status": "up",
+	        "lanes": "28",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet0": {
+	        "alias": "fortyGigE0/0",
+	        "admin_status": "up",
+	        "lanes": "25",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet1": {
+	        "alias": "fortyGigE0/1",
+	        "admin_status": "up",
+	        "lanes": "26",
+	        "speed": "25000",
+	        "index": "0"
+	    }
+    },
+    "Ethernet0_2x25G_1x50G": {
+	    "Ethernet2": {
+	        "alias": "fortyGigE0/2",
+	        "admin_status": "up",
+	        "lanes": "27,28",
+	        "speed": "50000",
+	        "index": "0"
+	    },
+	    "Ethernet0": {
+	        "alias": "fortyGigE0/0",
+	        "admin_status": "up",
+	        "lanes": "25",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet1": {
+	        "alias": "fortyGigE0/1",
+	        "admin_status": "up",
+	        "lanes": "26",
+	        "speed": "25000",
+	        "index": "0"
+	    }
+    },
+    "Ethernet0_1x50G_2x25G": {
+	    "Ethernet2": {
+	        "alias": "fortyGigE0/2",
+	        "admin_status": "up",
+	        "lanes": "27",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet3": {
+	        "alias": "fortyGigE0/3",
+	        "admin_status": "up",
+	        "lanes": "28",
+	        "speed": "25000",
+	        "index": "0"
+	    },
+	    "Ethernet0": {
+	        "alias": "fortyGigE0/0",
+	        "admin_status": "up",
+	        "lanes": "25,26",
+	        "speed": "50000",
+	        "index": "0"
+		}
+    },
+    "Ethernet4_4x25G": {
+	"Ethernet6": {
+		"alias": "fortyGigE0/6",
+		"admin_status": "up",
+		"lanes": "31",
+		"speed": "25000",
+		"index": "1"
+	},
+	"Ethernet7": {
+		"alias": "fortyGigE0/7",
+		"admin_status": "up",
+		"lanes": "32",
+		"speed": "25000",
+		"index": "1"
+	},
+	"Ethernet4": {
+		"alias": "fortyGigE0/4",
+		"admin_status": "up",
+		"lanes": "29",
+		"speed": "25000",
+		"index": "1"
+	},
+	"Ethernet5": {
+		"alias": "fortyGigE0/5",
+		"admin_status": "up",
+		"lanes": "30",
+		"speed": "25000",
+		"index": "1"
+	}
+    },
+    "Ethernet4_2x50G": {
+        "Ethernet6": {
+		"alias": "fortyGigE0/6",
+		"admin_status": "up",
+		"lanes": "31,32",
+		"speed": "50000",
+		"index": "1"
+	},
+	"Ethernet4": {
+		"alias": "fortyGigE0/4",
+		"admin_status": "up",
+		"lanes": "29,30",
+		"speed": "50000",
+		"index": "1"
+	}
+    },
+    "Ethernet8_2x50G": {
+	    "Ethernet8": {
+	        "alias": "fortyGigE0/8",
+	        "admin_status": "up",
+	        "lanes": "33,34",
+	        "speed": "50000",
+	        "index": "2"
+	    },
+	    "Ethernet10": {
+	        "alias": "fortyGigE0/10",
+	        "admin_status": "up",
+	        "lanes": "35,36",
+	        "speed": "50000",
+	        "index": "2"
+	    }
+    },
+    "Ethernet8_1x50G_2x25G": {
+	    "Ethernet10": {
+	        "alias": "fortyGigE0/10",
+	        "admin_status": "up",
+	        "lanes": "35",
+	        "speed": "25000",
+	        "index": "2"
+	    },
+	    "Ethernet11": {
+	        "alias": "fortyGigE0/11",
+	        "admin_status": "up",
+	        "lanes": "36",
+	        "speed": "25000",
+	        "index": "2"
+	    }
+    },
+    "Ethernet8_2x25G_1x50G": {
+	    "Ethernet8": {
+	        "alias": "fortyGigE0/8",
+	        "admin_status": "up",
+	        "lanes": "33",
+	        "speed": "25000",
+	        "index": "2"
+	    },
+	    "Ethernet9": {
+	        "alias": "fortyGigE0/9",
+	        "admin_status": "up",
+	        "lanes": "34",
+	        "speed": "25000",
+	        "index": "2"
+	    },
+	    "Ethernet10": {
+	        "alias": "fortyGigE0/10",
+	        "admin_status": "up",
+	        "lanes": "35,36",
+	        "speed": "50000",
+	        "index": "2"
+	    }
+    },
+    "Ethernet8_1x100G": {
+	    "Ethernet8": {
+	        "alias": "fortyGigE0/8",
+	        "admin_status": "up",
+	        "lanes": "33,34,35,36",
+	        "speed": "100000",
+	        "index": "2"
+	    }
+    }
+}

--- a/platform/vs/tests/breakout/test_breakout_cli.py
+++ b/platform/vs/tests/breakout/test_breakout_cli.py
@@ -1,0 +1,166 @@
+from swsscommon import swsscommon
+import time
+import os
+import json
+import ast
+import pytest
+import collections
+
+@pytest.mark.usefixtures('dpb_setup_fixture')
+class TestBreakoutCli(object):
+    def setup_db(self, dvs):
+        self.cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+
+    def read_Json(self, dvs):
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        sample_output_file = os.path.join(test_dir, 'sample_output', 'sample_new_port_config.json')
+        fh = open(sample_output_file, 'rb')
+        fh_data = json.load(fh)
+        fh.close()
+
+        if not fh_data:
+            return False
+        expected = ast.literal_eval(json.dumps(fh_data))
+        return expected
+
+    def breakout(self, dvs, interface, brkout_mode):
+        (exitcode, result) = dvs.runcmd("config interface breakout {} {} -y".format(interface, brkout_mode))
+
+        if result.strip("\n")[0] == "[ERROR] Breakout feature is not available without platform.json file" :
+            pytest.skip("**** This test is not needed ****")
+        root_dir = os.path.dirname('/')
+        (exitcode, output_dict) = dvs.runcmd("jq '.' new_port_config.json")
+        if output_dict is None:
+            raise Exception("Breakout output cant be None")
+
+        output_dict = ast.literal_eval(output_dict.strip())
+        return output_dict
+
+    # Check Initial Brakout Mode
+    def test_InitialBreakoutMode(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        output_dict = {}
+        brkoutTbl = swsscommon.Table(self.cdb, "BREAKOUT_CFG")
+        brkout_entries = brkoutTbl.getKeys()
+        assert len(brkout_entries) == 32
+
+        for key in brkout_entries:
+            (status, fvs) = brkoutTbl.get(key)
+            assert(status == True)
+
+            brkout_mode = fvs[0][1]
+            output_dict[key] = brkout_mode
+        output = collections.OrderedDict(sorted(output_dict.items(), key=lambda t: t[0]))
+        expected_dict = \
+                {'Ethernet8': '1x100G[40G]', 'Ethernet0': '1x100G[40G]', 'Ethernet4': '1x100G[40G]', \
+                'Ethernet108': '1x100G[40G]', 'Ethernet100': '1x100G[40G]', 'Ethernet104': '1x100G[40G]', \
+                'Ethernet68': '1x100G[40G]', 'Ethernet96': '1x100G[40G]', 'Ethernet124': '1x100G[40G]', \
+                'Ethernet92': '1x100G[40G]', 'Ethernet120': '1x100G[40G]', 'Ethernet52': '1x100G[40G]', \
+                'Ethernet56': '1x100G[40G]', 'Ethernet76': '1x100G[40G]', 'Ethernet72': '1x100G[40G]', \
+                'Ethernet32': '1x100G[40G]', 'Ethernet16': '1x100G[40G]', 'Ethernet36': '1x100G[40G]', \
+                'Ethernet12': '1x100G[40G]', 'Ethernet28': '1x100G[40G]', 'Ethernet88': '1x100G[40G]', \
+                'Ethernet116': '1x100G[40G]', 'Ethernet80': '1x100G[40G]', 'Ethernet112': '1x100G[40G]', \
+                'Ethernet84': '1x100G[40G]', 'Ethernet48': '1x100G[40G]', 'Ethernet44': '1x100G[40G]', \
+                'Ethernet40': '1x100G[40G]', 'Ethernet64': '1x100G[40G]', 'Ethernet60': '1x100G[40G]', \
+                'Ethernet20': '1x100G[40G]', 'Ethernet24': '1x100G[40G]'}
+        expected = collections.OrderedDict(sorted(expected_dict.items(), key=lambda t: t[0]))
+        assert output == expected
+
+    # Breakout Cli Test Mode
+    def test_breakout_modes(self, dvs):
+        expected = self.read_Json(dvs)
+        assert expected
+
+        print("**** Breakout Cli test Starts ****")
+        output_dict = self.breakout(dvs, 'Ethernet0', '2x50G')
+        expected_dict = expected["Ethernet0_2x50G"]
+        assert output_dict == expected_dict
+        print("**** 1X100G --> 2x50G passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet4', '4x25G[10G]')
+        expected_dict = expected["Ethernet4_4x25G"]
+        assert output_dict == expected_dict
+        print("**** 1X100G --> 4x25G[10G] passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet8', '2x25G(2)+1x50G(2)')
+        expected_dict = expected["Ethernet8_2x25G_1x50G"]
+        assert output_dict == expected_dict
+        print("**** 1X100G --> 2x25G(2)+1x50G(2) passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet12', '1x50G(2)+2x25G(2)')
+        expected_dict = expected["Ethernet12_1x50G_2x25G"]
+        assert output_dict == expected_dict
+        print("**** 1X100G --> 1x50G(2)+2x25G(2) passed ****")
+
+        #TODOFIX: remove comments once #4442 PR got merged.
+        """
+        output_dict = self.breakout(dvs, 'Ethernet0', '1x100G[40G]')
+        expected_dict = expected["Ethernet0_1x100G"]
+        assert output_dict == expected_dict
+        print("**** 2x50G --> 1x100G[40G] passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '4x25G[10G]')
+        expected_dict = expected["Ethernet0_4x25G"]
+        assert output_dict == expected_dict
+        print("**** 1X100G --> 4x25G[10G] passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '1x100G[40G]')
+        expected_dict = expected["Ethernet0_1x100G"]
+        assert output_dict == expected_dict
+        print("**** 4x25G[10G] --> 1x100G[40G] passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet4', '2x50G')
+        print("**** 1X100G --> 2x50G mode change ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet4', '4x25G[10G]')
+        expected_dict = expected["Ethernet4_4x25G"]
+        assert output_dict == expected_dict
+        print("**** 2X50G --> 4x25G[10G] passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet4', '2x50G')
+        expected_dict = expected["Ethernet4_2x50G"]
+        assert output_dict == expected_dict
+        print("**** 4x25G[10G] --> 2X50G passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet4', '1x100G[40G]')
+        print("**** 2x50G  -- > 1X100G mode change ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '2x25G(2)+1x50G(2)')
+        expected_dict = expected["Ethernet0_2x25G_1x50G"]
+        assert output_dict == expected_dict
+        print("**** 1x100G[40G] --> 2x25G(2)+1x50G(2) passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '1x100G[40G]')
+        expected_dict = expected["Ethernet0_1x100G"]
+        assert output_dict == expected_dict
+        print("**** 2x25G(2)+1x50G(2) --> 1x100G[40G] passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '1x50G(2)+2x25G(2)')
+        expected_dict = expected["Ethernet0_1x50G_2x25G"]
+        assert output_dict == expected_dict
+        print("**** 1x100G[40G] --> 1x50G(2)+2x25G(2)  passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet0', '1x100G[40G]')
+        expected_dict = expected["Ethernet0_1x100G"]
+        assert output_dict == expected_dict
+        print("**** 1x50G(2)+2x25G(2) --> 1x100G[40G] passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet8', '2x50G')
+        print("**** 1x100G[40G] --> 2x50G  mode change ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet8', '1x50G(2)+2x25G(2)')
+        expected_dict = expected["Ethernet8_1x50G_2x25G"]
+        assert output_dict == expected_dict
+        print("**** 2x50G --> 2x25G(2)+1x50G(2)  passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet8', '2x25G(2)+1x50G(2)')
+        expected_dict = expected["Ethernet8_2x25G_1x50G"]
+        assert output_dict == expected_dict
+        print("**** 1x50G(2)+2x25G(2) --> 2x25G(2)+1x50G(2)  passed ****")
+
+        output_dict = self.breakout(dvs, 'Ethernet8', '1x100G[40G]')
+        expected_dict = expected["Ethernet8_1x100G"]
+        assert output_dict == expected_dict
+        print("**** 2x25G(2)+1x50G(2)  --> 1x100G[40G]  passed ****")
+        """

--- a/platform/vs/tests/breakout/test_breakout_cli.py
+++ b/platform/vs/tests/breakout/test_breakout_cli.py
@@ -14,9 +14,8 @@ class TestBreakoutCli(object):
     def read_Json(self, dvs):
         test_dir = os.path.dirname(os.path.realpath(__file__))
         sample_output_file = os.path.join(test_dir, 'sample_output', 'sample_new_port_config.json')
-        fh = open(sample_output_file, 'rb')
-        fh_data = json.load(fh)
-        fh.close()
+        with open(sample_output_file, 'rb') as fh:
+            fh_data = json.load(fh)
 
         if not fh_data:
             return False
@@ -47,7 +46,7 @@ class TestBreakoutCli(object):
 
         for key in brkout_entries:
             (status, fvs) = brkoutTbl.get(key)
-            assert(status == True)
+            assert status
 
             brkout_mode = fvs[0][1]
             output_dict[key] = brkout_mode
@@ -93,7 +92,10 @@ class TestBreakoutCli(object):
         assert output_dict == expected_dict
         print("**** 1X100G --> 1x50G(2)+2x25G(2) passed ****")
 
-        #TODOFIX: remove comments once #4442 PR got merged.
+        # TODOFIX: remove comments once #4442 PR got merged and
+        # yang model for DEVICE_METADATA becomes available.
+        # As below test cases are dependent on DEVICE_METADATA to go
+        # from a non-default breakout mode to a different breakout mode.
         """
         output_dict = self.breakout(dvs, 'Ethernet0', '1x100G[40G]')
         expected_dict = expected["Ethernet0_1x100G"]


### PR DESCRIPTION
1. This reverts commit 457674ce00adf2b03d33db24399e5d05b2b7478e. -- **first commit**

2. Also, made a small change in terms of  admin status of all the interfaces from up to down to be compatible with swss vs test cases specially both vnet tests, sflow tests. ->  **second commit**

Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**- What I did**
Created the VS setup to test DPB functionality.
1. Created "platform.json" for vs docker.
2. Added Test case for Breakout Cli


> we also need to update swss submodule once this PR gets merged so that test_speed.py doesn't have any hard-coded speed dependency. otherwise, this test case will fail.


**- How to verify it**
```

samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/platform/vs/tests$ sudo pytest -s -vv --dvsname=vs-sa breakout/test_breakout_cli.py
[sudo] password for samaity:
============================================================================================================ test session starts ============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/platform/vs/tests
plugins: repeat-0.8.0
collected 2 items

breakout/test_breakout_cli.py::TestBreakoutCli::test_InitialBreakoutMode remove extra link dummy
PASSED
breakout/test_breakout_cli.py::TestBreakoutCli::test_breakout_modes **** Breakout Cli test Starts ****
**** 1X100G --> 2x50G passed ****
**** 1X100G --> 4x25G[10G] passed ****
**** 1X100G --> 2x25G(2)+1x50G(2) passed ****
**** 1X100G --> 1x50G(2)+2x25G(2) passed ****
PASSED
```




**- Which release branch to backport (provide reason below if selected)**
202006