### PR TITLE
[Multi Asic]: Fix to prevent classification all  portchannels is External

### DIFF
--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -265,7 +265,7 @@ def is_port_channel_internal(port_channel, namespace=None):
         port_channels = config_db.get_table(PORT_CHANNEL_CFG_DB_TABLE)
 
         if port_channel in port_channels:
-            if 'members' in port_channel:
+            if 'members' in port_channels[port_channel]:
                 members = port_channels[port_channel]['members']
                 if is_port_internal(members[0], namespace):
                     return True


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
the API `is_port_channel_internal(port_channel, namespace=None):` always returns False.
**- How I did it**
Fix the checks in the API `is_port_channel_internal`



**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
