### PR TITLE
[cfggen] Allow Write To Redis DB With Template/Batch Mode

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -266,10 +266,10 @@ def main():
     parser.add_argument("-T", "--template_dir", help="search base for the template files", action='store')
     group.add_argument("-v", "--var", help="print the value of a variable, support jinja2 expression")
     group.add_argument("--var-json", help="print the value of a variable, in json format")
-    group.add_argument("-w", "--write-to-db", help="write config into configdb", action='store_true')
     group.add_argument("--preset", help="generate sample configuration from a preset template", choices=get_available_config())
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--print-data", help="print all data", action='store_true')
+    group.add_argument("-w", "--write-to-db", help="write config into configdb", action='store_true')
     group.add_argument("-K", "--key", help="Lookup for a specific key")
     args = parser.parse_args()
 


### PR DESCRIPTION
Argument to write to config-db is not allowed when using template.
This PR allows cfggen to write to redis db when using template
mode.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
Reduce CPU util during bot

**- How I did it**
relocate write-to-db to new section such that it is not mutually exclusive with new batch mode

**- How to verify it**
I did load minigraph with and without this change and the resulting config_db is the same
```
admin@str-s6000-acs-14:~$ diff config_db.json.new config_db.json.old
admin@str-s6000-acs-14:~$ 
```

During boot profiling, there was about 1~1.5% CPU reduction when batching 4 cfggen calls into one call.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
