### PR TITLE
[201911] skip_thermalctld for VS platform 

### DIFF
--- a/device/virtual/x86_64-kvm_x86_64-r0/pmon_daemon_control.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/pmon_daemon_control.json
@@ -2,5 +2,6 @@
     "skip_ledd": true,
     "skip_xcvrd": true,
     "skip_psud": true,
-    "skip_syseepromd": true
+    "skip_syseepromd": true,
+    "skip_thermalctld": true
 }


### PR DESCRIPTION
Why I did:
skip_thermalctld for VS platform  as it is not supported. 
Otherwise syslog gets flooded with error messages.

How I verify:
root@vlab-01:/# supervisorctl status
dependent-startup                EXITED    Aug 18 06:22 AM
rsyslogd                         RUNNING   pid 18, uptime 0:12:26
start                            EXITED    Aug 18 06:22 AM
supervisor-proc-exit-listener    RUNNING   pid 13, uptime 0:12:27
