### PR TITLE
[201911] Fix make command line option.

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -181,8 +181,8 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            KERNEL_PROCURE_METHOD=$(KERNEL_PROCURE_METHOD) \
                            HTTP_PROXY=$(http_proxy) \
                            HTTPS_PROXY=$(https_proxy) \
-                           SONIC_ENABLE_SYSTEM_TELEMETRY=$(INCLUDE_SYSTEM_TELEMETRY) \
-                           SONIC_ENABLE_RESTAPI=$(INCLUDE_RESTAPI) \
+                           SONIC_INCLUDE_SYSTEM_TELEMETRY=$(INCLUDE_SYSTEM_TELEMETRY) \
+                           SONIC_INCLUDE_RESTAPI=$(INCLUDE_RESTAPI) \
                            EXTRA_JESSIE_TARGETS=$(EXTRA_JESSIE_TARGETS) \
                            $(SONIC_OVERRIDE_BUILD_VARS)
 


### PR DESCRIPTION
Why I did:
INCLUDE_RESTAPI=y was not taking effect.
Fix the makefile to use include for restapi and telemetry.
As part of cherry-pick from master into 201911 conflict
was not handled correctly.

How I verify:
INLCUDE_RESTAPI is fine after change.
BLDENV=stretch make SONIC_BUILD_JOBS=8 INCLUDE_RESTAPI=y target/docker-syncd-brcm.gz-clean

Build Configuration
"CONFIGURED_PLATFORM"             : "broadcom"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "8"
"SONIC_CONFIG_MAKE_JOBS"          : "1"
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"ENABLE_DHCP_GRAPH_SERVICE"       : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"ENABLE_ZTP"                      : ""
"INCLUDE_ACMS"                    : "y"
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : "20200818.101223"
"BLDENV"                          : "stretch"
"VS_PREPARE_MEM"                  : "yes"
"INCLUDE_MGMT_FRAMEWORK"          : "n"
"INCLUDE_SYSTEM_TELEMETRY"        : "y"
"INCLUDE_RESTAPI"                 : "y"
"INCLUDE_SFLOW"                   : "n"
"INCLUDE_NAT"                     : "n"
"INCLUDE_KUBERNETES"              : "y"


