### PR TITLE
Enable NAT feature

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -29,7 +29,7 @@
                    ("teamd", "enabled", "enabled")] %}
 {%- if include_iccpd == "y" %}{% do features.append(("iccpd", "disabled", "enabled")) %}{% endif %}
 {%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", "enabled")) %}{% endif %}
-{%- if include_nat == "y" %}{% do features.append(("nat", "disabled", "enabled")) %}{% endif %}
+{%- if include_nat == "y" %}{% do features.append(("nat", "enabled", "enabled")) %}{% endif %}
 {%- if include_restapi == "y" %}{% do features.append(("restapi", "enabled", "enabled")) %}{% endif %}
 {%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", "enabled")) %}{% endif %}
 {%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", "enabled")) %}{% endif %}


### PR DESCRIPTION
NAT feature is not enabled in the latest Sonic image after the recent change 
https://github.com/Azure/sonic-buildimage/pull/5081/files

admin@sonic:~$ show feature status
Feature         State     AutoRestart
--------------  --------  -------------
bgp             enabled   enabled
database        enabled   disabled
dhcp_relay      enabled   enabled
lldp            enabled   enabled
mgmt-framework  enabled   enabled
nat             disabled  enabled
pmon            enabled   enabled

Verified by checking NAT docker on bootup and validated by configuring few static NAT entries.

Backport required to 201911
