### PR TITLE
[services] Fix Delay Start of SNMP And Telemetry

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -34,10 +34,11 @@
 {%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", false, "enabled")) %}{% endif %}
 {%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", true, "enabled")) %}{% endif %}
     "FEATURE": {
-{%- for feature, state, delay_start, autorestart in features %}
+{# has_timer field if set, will start the feature systemd .timer unit instead of .service unit #}
+{%- for feature, state, has_timer, autorestart in features %}
         "{{feature}}": {
             "state": "{{state}}",
-            "delay_start" : {{delay_start | lower()}},
+            "has_timer" : {{has_timer | lower()}},
             "auto_restart": "{{autorestart}}",
             "high_mem_alert": "disabled"
         }{% if not loop.last %},{% endif -%}

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -17,26 +17,27 @@
 {% endfor %}
         }
     },
-{%- set features = [("bgp", "enabled", "enabled"),
-                   ("database", "enabled", "disabled"),
-                   ("dhcp_relay", "enabled", "enabled"),
-                   ("lldp", "enabled", "enabled"),
-                   ("pmon", "enabled", "enabled"),
-                   ("radv", "enabled", "enabled"),
-                   ("snmp", "enabled", "enabled"),
-                   ("swss", "enabled", "enabled"),
-                   ("syncd", "enabled", "enabled"),
-                   ("teamd", "enabled", "enabled")] %}
-{%- if include_iccpd == "y" %}{% do features.append(("iccpd", "disabled", "enabled")) %}{% endif %}
-{%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", "enabled")) %}{% endif %}
-{%- if include_nat == "y" %}{% do features.append(("nat", "disabled", "enabled")) %}{% endif %}
-{%- if include_restapi == "y" %}{% do features.append(("restapi", "enabled", "enabled")) %}{% endif %}
-{%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", "enabled")) %}{% endif %}
-{%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", "enabled")) %}{% endif %}
+{%- set features = [("bgp", "enabled", false, "enabled"),
+                   ("database", "enabled", false, "disabled"),
+                   ("dhcp_relay", "enabled", false, "enabled"),
+                   ("lldp", "enabled", false, "enabled"),
+                   ("pmon", "enabled", false, "enabled"),
+                   ("radv", "enabled", false, "enabled"),
+                   ("snmp", "enabled", true, "enabled"),
+                   ("swss", "enabled", false, "enabled"),
+                   ("syncd", "enabled", false, "enabled"),
+                   ("teamd", "enabled", false, "enabled")] %}
+{%- if include_iccpd == "y" %}{% do features.append(("iccpd", "disabled", false, "enabled")) %}{% endif %}
+{%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", false, "enabled")) %}{% endif %}
+{%- if include_nat == "y" %}{% do features.append(("nat", "disabled", false, "enabled")) %}{% endif %}
+{%- if include_restapi == "y" %}{% do features.append(("restapi", "enabled", false, "enabled")) %}{% endif %}
+{%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", false, "enabled")) %}{% endif %}
+{%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", true, "enabled")) %}{% endif %}
     "FEATURE": {
-{%- for feature, state, autorestart in features %}
+{%- for feature, state, delay_start, autorestart in features %}
         "{{feature}}": {
             "state": "{{state}}",
+            "delay_start" : {{delay_start | lower()}},
             "auto_restart": "{{autorestart}}",
             "high_mem_alert": "disabled"
         }{% if not loop.last %},{% endif -%}

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -41,8 +41,8 @@ def obfuscate(data):
         return data
 
 
-def update_feature_state(feature_name, state, delay_start=False):
-    feature_suffix = "timer" if delay_start else "service"
+def update_feature_state(feature_name, state, has_timer=False):
+    feature_suffix = "timer" if has_timer else "service"
     if state == "enabled":
         start_cmds = []
         start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name, feature_suffix))
@@ -286,7 +286,7 @@ class HostConfigDaemon:
                 syslog.syslog(syslog.LOG_WARNING, "Eanble state of feature '{}' is None".format(feature_name))
                 continue
 
-            update_feature_state(feature_name, state, feature_table[feature_name]['delay_start'])
+            update_feature_state(feature_name, state, feature_table[feature_name]['has_timer'])
 
     def aaa_handler(self, key, data):
         self.aaacfg.aaa_update(key, data)
@@ -328,7 +328,7 @@ class HostConfigDaemon:
             syslog.syslog(syslog.LOG_WARNING, "Enable state of feature '{}' is None".format(feature_name))
             return
 
-        update_feature_state(feature_name, state, feature_table[feature_name]['delay_start'])
+        update_feature_state(feature_name, state, feature_table[feature_name]['has_timer'])
 
     def start(self):
         # Update all feature states once upon starting

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -42,11 +42,12 @@ def obfuscate(data):
 
 
 def update_feature_state(feature_name, state):
+    feature_suffix = "timer" if feature_name in ["snmp", "telemetry"] else "service"
     if state == "enabled":
         start_cmds = []
-        start_cmds.append("sudo systemctl unmask {}.service".format(feature_name))
-        start_cmds.append("sudo systemctl enable {}.service".format(feature_name))
-        start_cmds.append("sudo systemctl start {}.service".format(feature_name))
+        start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name, feature_suffix))
+        start_cmds.append("sudo systemctl enable {}.{}".format(feature_name, feature_suffix))
+        start_cmds.append("sudo systemctl start {}.{}".format(feature_name, feature_suffix))
         for cmd in start_cmds:
             syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
             try:
@@ -55,12 +56,12 @@ def update_feature_state(feature_name, state):
                 syslog.syslog(syslog.LOG_ERR, "'{}' failed. RC: {}, output: {}"
                               .format(err.cmd, err.returncode, err.output))
                 continue
-        syslog.syslog(syslog.LOG_INFO, "Feature '{}' is enabled and started".format(feature_name))
+        syslog.syslog(syslog.LOG_INFO, "Feature '{}.{}' is enabled and started".format(feature_name, feature_suffix))
     elif state == "disabled":
         stop_cmds = []
-        stop_cmds.append("sudo systemctl stop {}.service".format(feature_name))
-        stop_cmds.append("sudo systemctl disable {}.service".format(feature_name))
-        stop_cmds.append("sudo systemctl mask {}.service".format(feature_name))
+        stop_cmds.append("sudo systemctl stop {}.{}".format(feature_name, feature_suffix))
+        stop_cmds.append("sudo systemctl disable {}.{}".format(feature_name, feature_suffix))
+        stop_cmds.append("sudo systemctl mask {}.{}".format(feature_name, feature_suffix))
         for cmd in stop_cmds:
             syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
             try:
@@ -71,7 +72,8 @@ def update_feature_state(feature_name, state):
                 continue
         syslog.syslog(syslog.LOG_INFO, "Feature '{}' is stopped and disabled".format(feature_name))
     else:
-        syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}'".format(state, feature_name))
+        syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}.{}'"
+                      .format(state, feature_name, feature_suffix))
 
 
 class Iptables(object):

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -41,8 +41,8 @@ def obfuscate(data):
         return data
 
 
-def update_feature_state(feature_name, state):
-    feature_suffix = "timer" if feature_name in ["snmp", "telemetry"] else "service"
+def update_feature_state(feature_name, state, delay_start=False):
+    feature_suffix = "timer" if delay_start else "service"
     if state == "enabled":
         start_cmds = []
         start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name, feature_suffix))
@@ -286,7 +286,7 @@ class HostConfigDaemon:
                 syslog.syslog(syslog.LOG_WARNING, "Eanble state of feature '{}' is None".format(feature_name))
                 continue
 
-            update_feature_state(feature_name, state)
+            update_feature_state(feature_name, state, feature_table[feature_name]['delay_start'])
 
     def aaa_handler(self, key, data):
         self.aaacfg.aaa_update(key, data)
@@ -328,7 +328,7 @@ class HostConfigDaemon:
             syslog.syslog(syslog.LOG_WARNING, "Enable state of feature '{}' is None".format(feature_name))
             return
 
-        update_feature_state(feature_name, state)
+        update_feature_state(feature_name, state, feature_table[feature_name]['delay_start'])
 
     def start(self):
         # Update all feature states once upon starting


### PR DESCRIPTION
SNMP and Telemetry services are not critical to switch startup.
They also cause fast-reboot not to meet timing requirements.
In order to delay start those service are associated with systemd
timer units, however when hostcfgd initiate service start, it start
the service and not the timer. This PR fixes this issue by
starting the timer associated with systemd unit.

Fixes  Azure/sonic-buildimage#5172
closes Azure/sonic-buildimage#5172

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
Mellanox reports fast-reboot is failing due to anmp/telemetry services being started early

**- How I did it**
Enabled systemd timer unit instead of systemd service unit

**- How to verify it**
fast-reboot :
```
admin@str-s6000-acs-14:~$ docker ps -a
CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS              PORTS               NAMES
73a0ac3d8809        docker-snmp:latest                   "/usr/bin/supervisord"   11 seconds ago      Up 8 seconds                            snmp
e00c3b98073d        docker-sonic-telemetry:latest        "/usr/bin/supervisord"   11 seconds ago      Up 10 seconds                           telemetry
e9adb6db457d        docker-router-advertiser:latest      "/usr/bin/docker-ini…"   2 minutes ago       Up 2 minutes                            radv
307918645b4f        docker-sonic-mgmt-framework:latest   "/usr/bin/supervisord"   2 minutes ago       Up 2 minutes                            mgmt-framework
fedd5b3265a5        docker-lldp:latest                   "/usr/bin/docker-lld…"   2 minutes ago       Up 2 minutes                            lldp
585327cfb624        docker-dhcp-relay:latest             "/usr/bin/docker_ini…"   2 minutes ago       Up 2 minutes                            dhcp_relay
7af84c5ed228        docker-syncd-brcm:latest             "/usr/bin/supervisord"   2 minutes ago       Up 2 minutes                            syncd
3d20336c910c        docker-teamd:latest                  "/usr/bin/supervisord"   2 minutes ago       Up 2 minutes                            teamd
0e43c8188cd6        docker-orchagent:latest              "/usr/bin/docker-ini…"   2 minutes ago       Up 2 minutes                            swss
e4df6993ac97        docker-fpm-frr:latest                "/usr/bin/docker_ini…"   2 minutes ago       Up 2 minutes                            bgp
d16b86ef127d        docker-platform-monitor:latest       "/usr/bin/docker_ini…"   2 minutes ago       Up 2 minutes                            pmon
aefd87ac2fef        docker-database:latest               "/usr/local/bin/dock…"   3 minutes ago       Up 3 minutes                            database
admin@str-s6000-acs-14:~
```
syslog file shows delayed start succeeds:
```
Aug 18 18:40:43.594545 str-s6000-acs-14 INFO systemd[1]: Started Delays snmp container until SONiC has started.
Aug 18 18:41:46.093939 str-s6000-acs-14 INFO hostcfgd: Running cmd: 'sudo systemctl unmask snmp.timer'
Aug 18 18:41:47.866326 str-s6000-acs-14 INFO hostcfgd: Running cmd: 'sudo systemctl enable snmp.timer'
Aug 18 18:41:49.610696 str-s6000-acs-14 INFO hostcfgd: Running cmd: 'sudo systemctl start snmp.timer'
Aug 18 18:41:49.777290 str-s6000-acs-14 INFO hostcfgd: Feature 'snmp.timer' is enabled and started
Aug 18 18:44:04.788079 str-s6000-acs-14 INFO systemd[1]: snmp.timer: Succeeded.
Aug 18 18:44:04.788643 str-s6000-acs-14 INFO systemd[1]: Stopped Delays snmp container until SONiC has started.
Aug 18 18:44:05.128882 str-s6000-acs-14 INFO snmp.sh[4422]: Starting existing snmp container with HWSKU Force10-S6000
Aug 18 18:44:06.372863 str-s6000-acs-14 INFO snmp.sh[4422]: 1
Aug 18 18:44:07.068655 str-s6000-acs-14 INFO snmp.sh[4422]: snmp
Aug 18 18:44:10.422535 str-s6000-acs-14 INFO snmp#rsyslogd:  [origin software="rsyslogd" swVersion="8.1901.0" x-pid="19" x-info="https://www.rsyslog.com"] start

```

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [x] 202006

**- A picture of a cute animal (not mandatory but encouraged)**
