### PR TITLE
TEST ONLY [services] Fix Delay Start of SNMP And Telemetry

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -42,12 +42,11 @@ def obfuscate(data):
 
 
 def update_feature_state(feature_name, state):
-    feature_suffix = "timer" if feature_name in ["snmp", "telemetry"] else "service"
     if state == "enabled":
         start_cmds = []
-        start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name, feature_suffix))
-        start_cmds.append("sudo systemctl enable {}.{}".format(feature_name, feature_suffix))
-        start_cmds.append("sudo systemctl start {}.{}".format(feature_name, feature_suffix))
+        start_cmds.append("sudo systemctl unmask {}".format(feature_name))
+        start_cmds.append("sudo systemctl enable {}".format(feature_name))
+        start_cmds.append("sudo systemctl start {}".format(feature_name))
         for cmd in start_cmds:
             syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
             try:
@@ -56,12 +55,12 @@ def update_feature_state(feature_name, state):
                 syslog.syslog(syslog.LOG_ERR, "'{}' failed. RC: {}, output: {}"
                               .format(err.cmd, err.returncode, err.output))
                 continue
-        syslog.syslog(syslog.LOG_INFO, "Feature '{}.{}' is enabled and started".format(feature_name, feature_suffix))
+        syslog.syslog(syslog.LOG_INFO, "Feature '{}' is enabled and started".format(feature_name))
     elif state == "disabled":
         stop_cmds = []
-        stop_cmds.append("sudo systemctl stop {}.{}".format(feature_name, feature_suffix))
-        stop_cmds.append("sudo systemctl disable {}.{}".format(feature_name, feature_suffix))
-        stop_cmds.append("sudo systemctl mask {}.{}".format(feature_name, feature_suffix))
+        stop_cmds.append("sudo systemctl stop {}".format(feature_name))
+        stop_cmds.append("sudo systemctl disable {}".format(feature_name))
+        stop_cmds.append("sudo systemctl mask {}".format(feature_name))
         for cmd in stop_cmds:
             syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
             try:
@@ -72,8 +71,8 @@ def update_feature_state(feature_name, state):
                 continue
         syslog.syslog(syslog.LOG_INFO, "Feature '{}' is stopped and disabled".format(feature_name))
     else:
-        syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}.{}'"
-                      .format(state, feature_name, feature_suffix))
+        syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}'"
+                      .format(state, feature_name))
 
 
 class Iptables(object):

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -42,11 +42,12 @@ def obfuscate(data):
 
 
 def update_feature_state(feature_name, state):
+    feature_suffix = "timer" if feature_name in ["snmp", "telemetry"] else "service"
     if state == "enabled":
         start_cmds = []
-        start_cmds.append("sudo systemctl unmask {}.service".format(feature_name))
-        start_cmds.append("sudo systemctl enable {}.service".format(feature_name))
-        start_cmds.append("sudo systemctl start {}.service".format(feature_name))
+        start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name, feature_suffix))
+        start_cmds.append("sudo systemctl enable {}.{}".format(feature_name, feature_suffix))
+        start_cmds.append("sudo systemctl start {}.{}".format(feature_name, feature_suffix))
         for cmd in start_cmds:
             syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
             try:
@@ -55,12 +56,12 @@ def update_feature_state(feature_name, state):
                 syslog.syslog(syslog.LOG_ERR, "'{}' failed. RC: {}, output: {}"
                               .format(err.cmd, err.returncode, err.output))
                 continue
-        syslog.syslog(syslog.LOG_INFO, "Feature '{}' is enabled and started".format(feature_name))
+        syslog.syslog(syslog.LOG_INFO, "Feature '{}.{}' is enabled and started".format(feature_name, feature_suffix))
     elif state == "disabled":
         stop_cmds = []
-        stop_cmds.append("sudo systemctl stop {}.service".format(feature_name))
-        stop_cmds.append("sudo systemctl disable {}.service".format(feature_name))
-        stop_cmds.append("sudo systemctl mask {}.service".format(feature_name))
+        stop_cmds.append("sudo systemctl stop {}.{}".format(feature_name, feature_suffix))
+        stop_cmds.append("sudo systemctl disable {}.{}".format(feature_name, feature_suffix))
+        stop_cmds.append("sudo systemctl mask {}.{}".format(feature_name, feature_suffix))
         for cmd in stop_cmds:
             syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
             try:
@@ -71,7 +72,8 @@ def update_feature_state(feature_name, state):
                 continue
         syslog.syslog(syslog.LOG_INFO, "Feature '{}' is stopped and disabled".format(feature_name))
     else:
-        syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}'".format(state, feature_name))
+        syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}.{}'"
+                      .format(state, feature_name, feature_suffix))
 
 
 class Iptables(object):


### PR DESCRIPTION
SNMP and Telemetry services are not critical to switch startup.
They also cause fast-reboot not to meet timing requirements.
In order to delay start those service are associated with systemd
timer units, however when hostcfgd initiate service start, it start
the service and not the timer. This PR fixes this issue by
starting the timer associated with systemd unit.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
