### PR TITLE
[iccpd] Fix the bug of iccp cmd show.

### DIFF
--- a/src/iccpd/src/iccp_cmd_show.c
+++ b/src/iccpd/src/iccp_cmd_show.c
@@ -99,6 +99,7 @@ int iccp_mclag_config_dump(char * *buf,  int *num, int mclag_id)
         state_info.role = csm->role_type;
 
         str_size = MCLAGDCTL_PORT_MEMBER_BUF_LEN;
+        len = 0;
 
         LIST_FOREACH(lif_po, &(MLACP(csm).lif_list), mlacp_next)
         {


### PR DESCRIPTION
Signed-off-by: Sun Dandan <sundandan@asterfusion.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The cmd "mclagdctl dump state" would goes wrong when there are two or more mclag_groups configured. The field "MCLAG Interface" can not be displayed in some group.

**- How I did it**
Reset the len in each csm.

**- How to verify it**
When 4 mclag_groups were configured, running cmd "mclagdctl dump state" display all mclag_group correctly.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
