### PR TITLE
[devices]: Zero out 1st MB before repartitioning

### DIFF
--- a/files/initramfs-tools/arista-convertfs.j2
+++ b/files/initramfs-tools/arista-convertfs.j2
@@ -213,6 +213,9 @@ umount "$root_mnt"
 
 if [ $(echo -n "$root_dev" | tail -c 1) == "1" ]; then
     # Create a new partition table (content in flash_dev will be deleted)
+    err_msg="Error: Failed to zero out first MB"
+    cmd="dd if=/dev/zero of=$flash_dev bs=512 count=2048"
+    run_cmd "$cmd" "$err_msg"
     err_msg="Error: repartitioning $flash_dev failed"
     cmd="echo '2048' | sfdisk $flash_dev || (sleep 3; blockdev --rereadpt $flash_dev && fdisk -l $flash_dev | grep -q ${root_dev}.*Linux)"
     run_cmd "$cmd" "$err_msg"


### PR DESCRIPTION
The first partition starting point was changed to be 1M as part of this
commit: 6ba2f97. On systems that are misaligned before conversion
(partition start is the first sector), the relica partition that is
left in the first MB can cause problems in Aboot and result in corruption
of the filesystem on the new aligned partition.

Zeroing this old relica makes sure that there is nothing left of the old
partition lying around. There won't be any risk of having Aboot corrupt
the new filesystem because of the old relica.

**- How to verify it**

It is very easy to reproduce the corruption issue seen with 201811 on systems that are misaligned before conversion.
With a 201811 image that has this fix, I was not able to reproduce the corruption after many attempts.

**- Which release branch to backport (provide reason below if selected)**

- [ X] 201811
- [ X] 201911
- [X ] 202006