### PR TITLE
[sonic-py-common][multi ASIC] API to get a list of frontend ports

### DIFF
--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -135,9 +135,8 @@ def get_namespaces_from_linux():
     In a multi asic platform, each ASIC is in a Linux Namespace.
     This method returns list of all the Namespace present on the device
 
-    Note: It is preferable to use this function can be used only
-    when the config_db is not available.
-    When configdb is available use get_all_namespaces()
+    Note: It is preferable to use this function only when config_db is not
+    available. When configdb is available use get_all_namespaces()
 
     Returns:
         List of the namespaces present in the system

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -135,8 +135,8 @@ def get_namespaces_from_linux():
     In a multi asic platform, each ASIC is in a Linux Namespace.
     This method returns list of all the Namespace present on the device
 
-    Note: It is preferable to use this function can be used only 
-    when the config_db is not available. 
+    Note: It is preferable to use this function can be used only
+    when the config_db is not available.
     When configdb is available use get_all_namespaces()
 
     Returns:
@@ -251,6 +251,17 @@ def is_port_internal(port_name, namespace=None):
         return True
 
     return False
+
+
+def get_external_ports(port_names, namespace=None):
+    external_ports = set()
+    ports_config = get_port_table(namespace)
+    for port in port_names:
+        if port in ports_config:
+            if (PORT_ROLE not in ports_config[port] or
+                ports_config[port][PORT_ROLE] == EXTERNAL_PORT):
+                external_ports.add(port)
+    return external_ports
 
 
 def is_port_channel_internal(port_channel, namespace=None):

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -259,7 +259,7 @@ def get_external_ports(port_names, namespace=None):
     for port in port_names:
         if port in ports_config:
             if (PORT_ROLE not in ports_config[port] or
-                ports_config[port][PORT_ROLE] == EXTERNAL_PORT):
+                    ports_config[port][PORT_ROLE] == EXTERNAL_PORT):
                 external_ports.add(port)
     return external_ports
 


### PR DESCRIPTION
**- Why I did it**
API to get a list of frontend ports from a given list of ports. There are APIs to find the port role but it can only be used one a time resulting in getting the list of ports from config DB for each query.

**- How I did it**
Get the list of ports only once and check ports that is passed as a port list or set. 

**- How to verify it**
verified using the show command.

```
Before:
admin@str-n3164-acs-2:/usr/bin$ pfcstat -n asic0

      Port Rx    PFC0    PFC1    PFC2    PFC3    PFC4    PFC5    PFC6    PFC7                                                                                                         
-------------  ------  ------  ------  ------  ------  ------  ------  ------                                                                                                         
    Ethernet0       0       0       0       0       0       0       0       0                                                                                                         
    Ethernet4       0       0       0       0       0       0       0       0                                                                                                         
    Ethernet8       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet12       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet16       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet20       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet24       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet28       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet32       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet36       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet40       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet44       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet48       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet52       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet56       0       0       0       0       0       0       0       0                                                                                                         
   Ethernet60       0       0       0       0       0       0       0       0                                                                                                         
 Ethernet-BP0       0       0       0       0       0       0       0       0                                                                                                         
 Ethernet-BP4       0       0       0       0       0       0       0       0                                                                                                         
 Ethernet-BP8       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP12       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP16       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP20       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP24       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP28       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP32       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP36       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP40       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP44       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP48       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP52       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP56       0       0       0       0       0       0       0       0                                                                                                         
Ethernet-BP60       0       0       0       0       0       0       0       0     
```

```
After:

admin@str-n3164-acs-2:/usr/bin$ pfcstat -n asic0
   Port Rx    PFC0    PFC1    PFC2    PFC3    PFC4    PFC5    PFC6    PFC7
----------  ------  ------  ------  ------  ------  ------  ------  ------
 Ethernet0       0       0       0       0       0       0       0       0
 Ethernet4       0       0       0       0       0       0       0       0
 Ethernet8       0       0       0       0       0       0       0       0
Ethernet12       0       0       0       0       0       0       0       0
Ethernet16       0       0       0       0       0       0       0       0
Ethernet20       0       0       0       0       0       0       0       0
Ethernet24       0       0       0       0       0       0       0       0
Ethernet28       0       0       0       0       0       0       0       0
Ethernet32       0       0       0       0       0       0       0       0
Ethernet36       0       0       0       0       0       0       0       0
Ethernet40       0       0       0       0       0       0       0       0
Ethernet44       0       0       0       0       0       0       0       0
Ethernet48       0       0       0       0       0       0       0       0
Ethernet52       0       0       0       0       0       0       0       0
Ethernet56       0       0       0       0       0       0       0       0
Ethernet60       0       0       0       0       0       0       0       0
```


**- Description for the changelog**

Added an API in sonic-py-common/multi_asic.py 

**- A picture of a cute animal (not mandatory but encouraged)**
