### PR TITLE
[sonic-config-engine] Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,11 +28,6 @@ platform/*/docker-*/Dockerfile
 # Installer-related files and directories
 installer/x86_64/platforms/
 
-# Config engine
-src/sonic-config-engine/**/*.pyc
-src/sonic-config-engine/build
-src/sonic-config-engine/sonic_config_engine.egg-info
-
 src/sonic-py-common/**/*.pyc
 src/sonic-py-common/.eggs/
 src/sonic-py-common/build

--- a/src/sonic-config-engine/.gitignore
+++ b/src/sonic-config-engine/.gitignore
@@ -1,3 +1,5 @@
+*.egg-info/
+.eggs/
 dist/
 tests/output
 tests/output2

--- a/src/sonic-config-engine/.gitignore
+++ b/src/sonic-config-engine/.gitignore
@@ -1,5 +1,7 @@
+**/*.pyc
 *.egg-info/
 .eggs/
+build/
 dist/
 tests/output
 tests/output2


### PR DESCRIPTION
- Ignore directories generated by building Python wheel package
- Move all sonic-config-engine ignores from the root .gitignore to src/sonic-config-engine/.gitignore