### PR TITLE
Fix unwanted python exception in syslog during database container startup

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -95,8 +95,13 @@ function postStartAction()
         link_namespace $DEV
     fi
 
-    # Wait until redis starts
-    until [[ $($SONIC_DB_CLI PING | grep -c PONG) -gt 0 ]]; do
+    # Wait until supervisord and redis starts. This change is needed
+    # because now database_config.json is jinja2 templated based
+    # and by the time file gets generated if we do redis ping
+    # then we catch python exception of file not valid
+    # that comes to syslog which is unwanted so wait till database
+    # config is ready and then ping
+    until [[ ($(docker exec -i database$DEV pgrep -x -c supervisord) -gt 0) && ($($SONIC_DB_CLI PING | grep -c PONG) -gt 0) ]]; do
       sleep 1;
     done
 


### PR DESCRIPTION
**- Why I did it**
Fix unwanted python exception in syslog during database container startup
when doing redis PING since database_config.json getting
generated from jinja2 template is still not ready. 

**- How I did it**

Added check to see if supervisord process is running and then do redis ping.
supervisord  is 1st process to start after dtabase_config.json is generated by
docker-database-init.sh

**- How to verify it**

Before
====
Aug 20 22:13:59.134966 str-s6000-on-2 INFO database.sh[876]: database
Aug 20 22:13:59.431225 str-s6000-on-2 INFO database.sh[876]: Traceback (most recent call last):
Aug 20 22:13:59.432663 str-s6000-on-2 INFO database.sh[876]:   File "/usr/local/bin/sonic-db-cli", line 124, in <module>
Aug 20 22:13:59.434240 str-s6000-on-2 INFO database.sh[876]:     main()
Aug 20 22:13:59.435658 str-s6000-on-2 INFO database.sh[876]:   File "/usr/local/bin/sonic-db-cli", line 114, in main
Aug 20 22:13:59.436988 str-s6000-on-2 INFO database.sh[876]:     ping_all_instances(args.namespace, args.unixsocket)
Aug 20 22:13:59.438441 str-s6000-on-2 INFO database.sh[876]:   File "/usr/local/bin/sonic-db-cli", line 40, in ping_all_instances
Aug 20 22:13:59.440025 str-s6000-on-2 INFO database.sh[876]:     db_insts = swsssdk.SonicDBConfig.get_instancelist(namespace)
Aug 20 22:13:59.441710 str-s6000-on-2 INFO database.sh[876]:   File "/usr/local/lib/python2.7/dist-packages/swsssdk/dbconnector.py", line 185, in get_instancelist
Aug 20 22:13:59.443497 str-s6000-on-2 INFO database.sh[876]:     SonicDBConfig.load_sonic_db_config()
Aug 20 22:13:59.445366 str-s6000-on-2 INFO database.sh[876]:   File "/usr/local/lib/python2.7/dist-packages/swsssdk/dbconnector.py", line 97, in load_sonic_db_config
Aug 20 22:13:59.447233 str-s6000-on-2 INFO database.sh[876]:     SonicDBConfig._sonic_db_config[''] = json.load(read_file)
Aug 20 22:13:59.449024 str-s6000-on-2 INFO database.sh[876]:   File "/usr/lib/python2.7/json/__init__.py", line 291, in load
Aug 20 22:13:59.450962 str-s6000-on-2 INFO database.sh[876]:     **kw)
Aug 20 22:13:59.452697 str-s6000-on-2 INFO database.sh[876]:   File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
Aug 20 22:13:59.454598 str-s6000-on-2 INFO database.sh[876]:     return _default_decoder.decode(s)
Aug 20 22:13:59.456488 str-s6000-on-2 INFO database.sh[876]:   File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
Aug 20 22:13:59.458447 str-s6000-on-2 INFO database.sh[876]:     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
Aug 20 22:13:59.460197 str-s6000-on-2 INFO database.sh[876]:   File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
Aug 20 22:13:59.462050 str-s6000-on-2 INFO database.sh[876]:     raise ValueError("No JSON object could be decoded")
Aug 20 22:13:59.463829 str-s6000-on-2 INFO database.sh[876]: ValueError: No JSON object could be decoded

After
====
Syslog is clean