### PR TITLE
[hostcfgd] Handle Both Service And Timer Units

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -42,12 +42,13 @@ def obfuscate(data):
 
 
 def update_feature_state(feature_name, state, has_timer=False):
-    feature_suffix = "timer" if has_timer else "service"
+    feature_suffixes = ["service"] + (["timer"] if has_timer else [])
     if state == "enabled":
         start_cmds = []
-        start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name, feature_suffix))
-        start_cmds.append("sudo systemctl enable {}.{}".format(feature_name, feature_suffix))
-        start_cmds.append("sudo systemctl start {}.{}".format(feature_name, feature_suffix))
+        for suffix in feature_suffixes:
+            start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name, suffix))
+            start_cmds.append("sudo systemctl enable {}.{}".format(feature_name, suffix))
+        start_cmds.append("sudo systemctl start {}.{}".format(feature_name, feature_suffixes[-1]))
         for cmd in start_cmds:
             syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
             try:
@@ -56,12 +57,14 @@ def update_feature_state(feature_name, state, has_timer=False):
                 syslog.syslog(syslog.LOG_ERR, "'{}' failed. RC: {}, output: {}"
                               .format(err.cmd, err.returncode, err.output))
                 continue
-        syslog.syslog(syslog.LOG_INFO, "Feature '{}.{}' is enabled and started".format(feature_name, feature_suffix))
+        syslog.syslog(syslog.LOG_INFO, "Feature '{}.{}' is enabled and started"
+                      .format(feature_name, feature_suffixes[-1]))
     elif state == "disabled":
         stop_cmds = []
-        stop_cmds.append("sudo systemctl stop {}.{}".format(feature_name, feature_suffix))
-        stop_cmds.append("sudo systemctl disable {}.{}".format(feature_name, feature_suffix))
-        stop_cmds.append("sudo systemctl mask {}.{}".format(feature_name, feature_suffix))
+        for suffix in reversed(feature_suffixes):
+            stop_cmds.append("sudo systemctl stop {}.{}".format(feature_name, suffix))
+            stop_cmds.append("sudo systemctl disable {}.{}".format(feature_name, suffix))
+            stop_cmds.append("sudo systemctl mask {}.{}".format(feature_name, suffix))
         for cmd in stop_cmds:
             syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
             try:
@@ -72,8 +75,8 @@ def update_feature_state(feature_name, state, has_timer=False):
                 continue
         syslog.syslog(syslog.LOG_INFO, "Feature '{}' is stopped and disabled".format(feature_name))
     else:
-        syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}.{}'"
-                      .format(state, feature_name, feature_suffix))
+        syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}'"
+                      .format(state, feature_name))
 
 
 class Iptables(object):


### PR DESCRIPTION
Commit e484ae9dd introduced systemd .timer unit to hostcfgd.
However, when stopping service that has timer, there is possibility that
timer is not running and the service would not be stopped. This PR
address this situation by handling both .timer and .service units.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>


**- Why I did it**
Feature may remain active after it is disabled in configdb

**- How I did it**
Add code to hand both .service and .timer units

**- How to verify it**
```
admin@str-s6000-acs-14:~$ sudo systemctl stop snmp
Warning: Stopping snmp.service, but it can still be activated by:
  snmp.timer
admin@str-s6000-acs-14:~$ sudo systemctl stop snmp.timer
admin@str-s6000-acs-14:~$ sudo systemctl disable snmp
admin@str-s6000-acs-14:~$ sudo systemctl disable snmp.timer
Removed /etc/systemd/system/timers.target.wants/snmp.timer.
Removed /etc/systemd/system/swss.service.wants/snmp.timer.
^[[Aadmin@str-s6000-acs-14:~$ sudo systemctl mask snmp
Created symlink /etc/systemd/system/snmp.service → /dev/null.
admin@str-s6000-acs-14:~$ sudo systemctl mask snmp.timer
Created symlink /etc/systemd/system/snmp.timer → /dev/null.
admin@str-s6000-acs-14:~$ docker ps -a
CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS                     PORTS               NAMES
4879e4cb9426        docker-snmp:latest                   "/usr/bin/supervisord"   About an hour ago   Exited (0) 2 minutes ago                       snmp
f9234eeca249        docker-sonic-telemetry:latest        "/usr/bin/supervisord"   About an hour ago   Exited (0) 9 minutes ago                       telemetry
e0a47c004de5        docker-router-advertiser:latest      "/usr/bin/docker-ini…"   2 hours ago         Up 58 seconds                                  radv
df7c69048854        docker-dhcp-relay:latest             "/usr/bin/docker_ini…"   2 hours ago         Up About a minute                              dhcp_relay
17e61ab8053a        docker-sonic-mgmt-framework:latest   "/usr/bin/supervisord"   2 hours ago         Up 59 seconds                                  mgmt-framework
d2225a95b4cf        docker-lldp:latest                   "/usr/bin/docker-lld…"   2 hours ago         Up About a minute                              lldp
67d5528e6479        docker-syncd-brcm:latest             "/usr/bin/supervisord"   2 hours ago         Up About a minute                              syncd
fabf0f7d464f        docker-teamd:latest                  "/usr/bin/supervisord"   2 hours ago         Up About a minute                              teamd
b9d112dd63b5        docker-orchagent:latest              "/usr/bin/docker-ini…"   2 hours ago         Up About a minute                              swss
acc6724f66b1        docker-fpm-frr:latest                "/usr/bin/docker_ini…"   2 hours ago         Up About a minute                              bgp
4cb2c968b5ea        docker-platform-monitor:latest       "/usr/bin/docker_ini…"   2 hours ago         Up About a minute                              pmon
81a6c484cf42        docker-database:latest               "/usr/local/bin/dock…"   2 hours ago         Up About a minute                              database
admin@str-s6000-acs-14:~$ sudo systemctl status snmp
● snmp.service
   Loaded: masked (Reason: Unit snmp.service is masked.)
   Active: inactive (dead)
admin@str-s6000-acs-14:~$ 
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
