### PR TITLE
[201911] Multiasic cleanup of get_npu_device_id()

### DIFF
--- a/device/virtual/x86_64-kvm_x86_64-r0/pmon_daemon_control.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/pmon_daemon_control.json
@@ -2,5 +2,6 @@
     "skip_ledd": true,
     "skip_xcvrd": true,
     "skip_psud": true,
-    "skip_syseepromd": true
+    "skip_syseepromd": true,
+    "skip_thermalctld": true
 }

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -247,31 +247,6 @@ def get_npu_id_from_name(npu_name):
         return None
 
 
-def get_npu_device_id(npu_id):
-    platform = get_platform()
-    if not platform:
-        return None
-
-    asic_conf_file_path = os.path.join(SONIC_DEVICE_PATH, platform, ASIC_CONF_FILENAME)
-    if not os.path.isfile(asic_conf_file_path):
-        return None
-
-    # In a multi-npu device we need to have the file "asic.conf" updated with the asic instance
-    # and the corresponding device id which could be pci_id. Below is an eg: for a 2 ASIC platform/sku.
-    # DEV_ID_ASIC_0=03:00.0
-    # DEV_ID_ASIC_1=04:00.0
-    device_str = "DEV_ID_ASIC_{}".format(npu_id)
-
-    with open(asic_conf_file_path) as asic_conf_file:
-        for line in asic_conf_file:
-            tokens = line.split('=')
-            if len(tokens) < 2:
-               continue
-            if tokens[0] == device_str:
-                device_id = tokens[1].strip()
-                return device_id
-
-
 def get_namespaces():
     """
     In a multi NPU platform, each NPU is in a Linux Namespace.


### PR DESCRIPTION
[201911] After PR #https://github.com/Azure/sonic-buildimage/pull/5204
this function is no more needed so cleaning up.

