### PR TITLE
[conf] append nos-config-part for s6100

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/installer.conf
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/installer.conf
@@ -1,3 +1,3 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=1
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich nos-config-part=/dev/sda12"

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -94,6 +94,9 @@ update_mgmt_interface_macaddr() {
 
 migrate_nos_configuration()
 {
+    rm -rf /host/migration
+    mkdir -p /host/migration
+
     # Extract the previous NOS's partition that contains the migration artifacts
     set -- $(cat /proc/cmdline)
     for x in "$@"; do
@@ -190,8 +193,6 @@ logger "SONiC version ${SONIC_VERSION} starting up..."
 # If the machine.conf is absent, it indicates that the unit booted
 # into SONiC from another NOS. Extract the machine.conf from ONIE.
 if [ ! -e /host/machine.conf ]; then
-    mkdir -p /host/migration
-
     onie_dev=$(blkid | grep ONIE-BOOT | head -n 1 | awk '{print $1}' |  sed -e 's/:.*$//')
     mkdir -p /mnt/onie-boot
     mount $onie_dev /mnt/onie-boot

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -148,6 +148,7 @@ if [ ! -e /host/machine.conf ]; then
     fi
 
     # Extract the previous NOS's partition that contains the migration artifacts
+    . /usr/share/sonic/device/$platform/installer.conf
     set -- $(cat /proc/cmdline)
     for x in "$@"; do
         case "$x" in

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -61,8 +61,8 @@ update_mgmt_interface_macaddr() {
     fi
 
     # Get the ethtool magic and offset for changing the mac address in the EEPROM
-    ethtool_magic=$(grep "ethtool_magic" $mgmt_config | awk -F'=' '{print $2}') 
-    ethtool_offset=$(grep "ethtool_offset" $mgmt_config | awk -F'=' '{print $2}') 
+    ethtool_magic=$(grep "ethtool_magic" $mgmt_config | awk -F'=' '{print $2}')
+    ethtool_offset=$(grep "ethtool_offset" $mgmt_config | awk -F'=' '{print $2}')
     if [ -z "$ethtool_magic" ] || [ -z "$ethtool_offset" ]; then
         log_migration "Unable to retrieve ethtool params ($ethtool_magic,$ethtool_offset)"
         return
@@ -90,6 +90,66 @@ update_mgmt_interface_macaddr() {
 
     log_migration "eth0 mac in EEPROM after update:"
     ethtool -e eth0 offset $ethtool_offset length 6 >> /host/migration/migration.log
+}
+
+migrate_nos_configuration()
+{
+    # Extract the previous NOS's partition that contains the migration artifacts
+    set -- $(cat /proc/cmdline)
+    for x in "$@"; do
+        case "$x" in
+            nos-config-part=*)
+                nos_dev="${x#nos-config-part=}"
+                ;;
+            SONIC_BOOT_TYPE=fast*)
+                sonic_fast_reboot=true
+                ;;
+        esac
+    done
+
+    if [ -n "$nos_dev" ]; then
+        # remove nos-config-part from cmdline
+        sed -r -i.bak "s/nos-config-part=[^[:space:]]+//" /host/grub/grub.cfg
+
+        # Mount the previous NOS's partition
+        NOS_DIR=/mnt/nos_migration
+        MG_GZFILE=$NOS_DIR/minigraph.xml.gz.base64.txt
+        MG_FILE=$NOS_DIR/minigraph.xml
+        ACL_GZFILE=$NOS_DIR/acl.json.gz.base64.txt
+        ACL_FILE=$NOS_DIR/acl.json
+        SNMP_FILE=$NOS_DIR/snmp.yml
+        mkdir -p $NOS_DIR
+
+        mount $nos_dev $NOS_DIR
+        if [ $? != 0 ]; then
+            log_migration "ERROR: cannot mount $nos_dev"
+        else
+
+            # decode & unzip minigraph.xml.gz.base64.txt
+            [ -f $MG_GZFILE ] && /usr/bin/base64 -d $MG_GZFILE | /bin/gunzip > $MG_FILE
+            [ -f $ACL_GZFILE ] && /usr/bin/base64 -d $ACL_GZFILE | /bin/gunzip > $ACL_FILE
+
+            # Copy relevant files
+            nos_migration_import $NOS_DIR/mgmt_interface.cfg /host/migration
+            nos_migration_import $MG_FILE /host/migration
+            nos_migration_import $ACL_FILE /host/migration
+            nos_migration_import $SNMP_FILE /host/migration
+
+            if [ "$sonic_fast_reboot" == true ]; then
+                mkdir -p /host/fast-reboot
+                nos_migration_import $NOS_DIR/arp.json /host/fast-reboot
+                nos_migration_import $NOS_DIR/fdb.json /host/fast-reboot
+                nos_migration_import $NOS_DIR/default_routes.json /host/fast-reboot
+            fi
+
+            umount $NOS_DIR
+            rmdir $NOS_DIR
+        fi
+
+        [ -f /host/migration/mgmt_interface.cfg ] && update_mgmt_interface_macaddr /host/migration/mgmt_interface.cfg
+
+        migration="TRUE"
+    fi
 }
 
 firsttime_exit() {
@@ -136,7 +196,7 @@ if [ ! -e /host/machine.conf ]; then
     mkdir -p /mnt/onie-boot
     mount $onie_dev /mnt/onie-boot
     onie_grub_cfg=/mnt/onie-boot/onie/grub/grub-machine.cfg
-    
+
     if [ ! -e $onie_grub_cfg ]; then
         log_migration "$onie_grub_cfg not found"
     else
@@ -147,60 +207,10 @@ if [ ! -e /host/machine.conf ]; then
         done
     fi
 
-    # Extract the previous NOS's partition that contains the migration artifacts
-    . /usr/share/sonic/device/$platform/installer.conf
-    set -- $(cat /proc/cmdline)
-    for x in "$@"; do
-        case "$x" in
-            nos-config-part=*)
-                nos_val="${x#nos-config-part=}"
-                ;;
-        esac
-    done
-
-    if [ -n "$nos_val" ]; then
-        nos_dev=$(findfs $nos_val)
-        if [ $? != 0 ]; then
-            log_migration "ERROR: nos_dev not found. Check grub parameters"
-        fi
-    else
-        log_migration "ERROR: nos_val not found. Check grub parameters"
-    fi
-
-    if [ -n "$nos_dev" ]; then
-        # Mount the previous NOS's partition
-        NOS_DIR=/mnt/nos_migration
-        MG_GZFILE=$NOS_DIR/minigraph.xml.gz.base64.txt
-        MG_FILE=$NOS_DIR/minigraph.xml
-        ACL_GZFILE=$NOS_DIR/acl.json.gz.base64.txt
-        ACL_FILE=$NOS_DIR/acl.json
-        SNMP_FILE=$NOS_DIR/snmp.yml
-        mkdir -p $NOS_DIR
-        mount $nos_dev $NOS_DIR
-        mkdir -p /host/fast-reboot
-
-        # decode & unzip minigraph.xml.gz.base64.txt
-        [ -f $MG_GZFILE ] && /usr/bin/base64 -d $MG_GZFILE | /bin/gunzip > $MG_FILE
-        [ -f $ACL_GZFILE ] && /usr/bin/base64 -d $ACL_GZFILE | /bin/gunzip > $ACL_FILE
-
-        # Copy relevant files
-        nos_migration_import $NOS_DIR/mgmt_interface.cfg /host/migration
-        nos_migration_import $MG_FILE /host/migration
-        nos_migration_import $ACL_FILE /host/migration
-        nos_migration_import $SNMP_FILE /host/migration
-        nos_migration_import $NOS_DIR/arp.json /host/fast-reboot
-        nos_migration_import $NOS_DIR/fdb.json /host/fast-reboot
-        nos_migration_import $NOS_DIR/default_routes.json /host/fast-reboot
-
-        umount $NOS_DIR
-        rmdir $NOS_DIR
-    fi
-
-    update_mgmt_interface_macaddr /host/migration/mgmt_interface.cfg
-
-    migration="TRUE"
     umount /mnt/onie-boot
 fi
+
+migrate_nos_configuration
 
 . /host/machine.conf
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

We want to support pick configuration from /dev/sda12 automatically after cold reboot for s6100

**- How I did it**

1. Append nos-config-part to ONIE_PLATFORM_EXTRA_CMDLINE_LINUX
1. Always mkdir before migrate nos configuration
1. Always migrate nos configuration

**- How to verify it**

1. Build image and install to a 6100 SONiC DUT
1. Copy configurations to ```/etc/sda12```
1. Clear /host/old_config
1. Reboot and verify if the configuration been picked

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[conf] support pick configuration from /dev/sda12 by configure installer.conf

**- A picture of a cute animal (not mandatory but encouraged)**
