### PR TITLE
[Multi-ASIC]:Update the template to add ipinip entry for Loopback4096

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -2,12 +2,13 @@
 {% set ipv6_addresses = [] %}
 {% set ipv4_loopback_addresses = [] %}
 {% set ipv6_loopback_addresses = [] %}
+{% set loopback_intf_names = ['Loopback0', 'Loopback4096'] %}
 {% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
-    {%- if prefix | ipv4 and name == 'Loopback0' %}
+    {%- if prefix | ipv4 and name in loopback_intf_names %}
         {%- set ipv4_addresses = ipv4_addresses.append(prefix) %}
         {%- set ipv4_loopback_addresses = ipv4_loopback_addresses.append(prefix) %}
     {%- endif %}
-    {%- if prefix | ipv6 and name == 'Loopback0' %}
+    {%- if prefix | ipv6 and  name in loopback_intf_names   %}
         {%- set ipv6_addresses = ipv6_addresses.append(prefix) %}
         {%- set ipv6_loopback_addresses = ipv6_loopback_addresses.append(prefix) %}
     {%- endif %}

--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -2,13 +2,17 @@
 {% set ipv6_addresses = [] %}
 {% set ipv4_loopback_addresses = [] %}
 {% set ipv6_loopback_addresses = [] %}
+{% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' or  DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd'%}
 {% set loopback_intf_names = ['Loopback0', 'Loopback4096'] %}
+{% else %}
+{% set loopback_intf_names = ['Loopback0'] %}
+{% endif %}
 {% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
     {%- if prefix | ipv4 and name in loopback_intf_names %}
         {%- set ipv4_addresses = ipv4_addresses.append(prefix) %}
         {%- set ipv4_loopback_addresses = ipv4_loopback_addresses.append(prefix) %}
     {%- endif %}
-    {%- if prefix | ipv6 and  name in loopback_intf_names   %}
+    {%- if prefix | ipv6 and name in loopback_intf_names   %}
         {%- set ipv6_addresses = ipv6_addresses.append(prefix) %}
         {%- set ipv6_loopback_addresses = ipv6_loopback_addresses.append(prefix) %}
     {%- endif %}

--- a/src/sonic-config-engine/tests/multi_npu_data/ipinip.json
+++ b/src/sonic-config-engine/tests/multi_npu_data/ipinip.json
@@ -1,0 +1,23 @@
+[
+    {
+        "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
+            "tunnel_type":"IPINIP",
+            "dst_ip":"10.1.0.32,8.0.0.0,10.0.0.0,10.1.0.1,10.1.0.3",
+            "dscp_mode":"pipe",
+            "ecn_mode":"copy_from_outer",
+            "ttl_mode":"pipe"
+        },
+        "OP": "SET"
+    } 
+    ,
+    {
+        "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+            "tunnel_type":"IPINIP",
+            "dst_ip":"fc00:1::32,fd00:1::32,fc00::1",
+            "dscp_mode":"pipe",
+            "ecn_mode":"copy_from_outer",
+            "ttl_mode":"pipe"
+        },
+        "OP": "SET"
+    }
+]

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -19,6 +19,8 @@ class TestJ2Files(TestCase):
         self.mlnx_port_config = os.path.join(self.test_dir, 'sample-port-config-mlnx.ini')
         self.dell6100_t0_minigraph = os.path.join(self.test_dir, 'sample-dell-6100-t0-minigraph.xml')
         self.arista7050_t0_minigraph = os.path.join(self.test_dir, 'sample-arista-7050-t0-minigraph.xml')
+        self.multi_asic_minigraph = os.path.join(self.test_dir, 'multi_npu_data', 'sample-minigraph.xml')
+        self.multi_asic_port_config = os.path.join(self.test_dir, 'multi_npu_data', 'sample_port_config-0.ini')
         self.output_file = os.path.join(self.test_dir, 'output')
 
     def run_script(self, argument):
@@ -149,6 +151,14 @@ class TestJ2Files(TestCase):
         os.remove(buffers_config_file_new)
 
         sample_output_file = os.path.join(self.test_dir, 'sample_output', 'buffers-dell6100.json')
+        assert filecmp.cmp(sample_output_file, self.output_file)
+
+    def test_ipinip_multi_asic(self):
+        ipinip_file = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-orchagent', 'ipinip.json.j2')
+        argument = '-m ' + self.multi_asic_minigraph + ' -p ' + self.multi_asic_port_config + ' -t ' + ipinip_file  +  ' -n asic0 '  + ' > ' + self.output_file
+        print(argument)
+        self.run_script(argument) 
+        sample_output_file = os.path.join(self.test_dir, 'multi_npu_data',  'ipinip.json')
         assert filecmp.cmp(sample_output_file, self.output_file)
 
     def tearDown(self):


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Multi asic platform have 2 Loopback interfaces, Loopback0 and Loopback4096. IPinIP decap entries need to be added for both of them.

**- How I did it**
Update the ipinip.json.j2 template to add decap entries for Loopback4096.
Add corressponding unit test

**- How to verify it**
Verify the ipinip.json is generated properly.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
