### PR TITLE
[sonic-py-common] Add unit test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,12 +28,6 @@ platform/*/docker-*/Dockerfile
 # Installer-related files and directories
 installer/x86_64/platforms/
 
-src/sonic-py-common/**/*.pyc
-src/sonic-py-common/.eggs/
-src/sonic-py-common/build
-src/sonic-py-common/dist
-src/sonic-py-common/sonic_py_common.egg-info
-
 # Misc. files
 asic_config_checksum
 files/Aboot/boot0

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -351,6 +351,11 @@ RUN pip3 install pytest-runner==5.2
 RUN pip install mockredispy==2.9.3
 RUN pip3 install mockredispy==2.9.3
 
+# For Python 2 unit tests, we need 'mock'. The last version of 'mock'
+# which supports Python 2 is 3.0.5. In Python 3, 'mock' is part of 'unittest'
+# in the standard library
+RUN pip install mock==3.0.5
+
 # For p4 build
 RUN pip install \
         ctypesgen==1.0.2 \
@@ -375,7 +380,7 @@ RUN pip3 install "PyYAML>=5.1"
 RUN pip3 install redis
 
 # For supervisor build
-RUN pip install meld3 mock
+RUN pip install meld3
 
 # For vs image build
 RUN pip install pexpect==4.6.0

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -209,8 +209,10 @@ RUN apt-get update && apt-get install -y \
         clang \
         pylint \
         python-pytest \
+        python3-pytest \
         gcovr \
         python-pytest-cov \
+        python3-pytest-cov \
         python-parse \
 # For snmpd
         default-libmysqlclient-dev \
@@ -339,6 +341,16 @@ RUN export VERSION=1.14.2 \
  && echo 'export PATH=$PATH:$GOROOT/bin' >> /etc/bash.bashrc \
  && rm go$VERSION.linux-*.tar.gz
 
+# For building Python packages
+RUN pip install setuptools==40.8.0
+RUN pip3 install setuptools==49.6.00
+
+# For running Python unit tests
+RUN pip install pytest-runner==4.4
+RUN pip3 install pytest-runner==5.2
+RUN pip install mockredispy==2.9.3
+RUN pip3 install mockredispy==2.9.3
+
 # For p4 build
 RUN pip install \
         ctypesgen==1.0.2 \
@@ -357,9 +369,6 @@ RUN apt-get purge -y python-click
 # For sonic utilities testing
 RUN pip install click natsort tabulate netifaces==0.10.7 fastentrypoints
 
-# For sonic snmpagent mock testing
-RUN pip3 install mockredispy==2.9.3
-
 RUN pip3 install "PyYAML>=5.1"
 
 # For sonic-platform-common testing
@@ -370,11 +379,6 @@ RUN pip install meld3 mock
 
 # For vs image build
 RUN pip install pexpect==4.6.0
-
-# For sonic-utilities build
-RUN pip install mockredispy==2.9.3
-RUN pip install pytest-runner==4.4
-RUN pip install setuptools==40.8.0
 
 # For sonic-swss-common testing
 RUN pip install Pympler==0.8

--- a/src/sonic-py-common/.gitignore
+++ b/src/sonic-py-common/.gitignore
@@ -1,0 +1,13 @@
+**/*.pyc
+
+# Distribution / packaging 
+*.egg-info/
+.eggs/
+build/
+dist/
+
+# Unit test / coverage reports 
+.cache
+.coverage
+coverage.xml
+htmlcov/

--- a/src/sonic-py-common/pytest.ini
+++ b/src/sonic-py-common/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=sonic_py_common --cov-report html --cov-report term --cov-report xml

--- a/src/sonic-py-common/setup.cfg
+++ b/src/sonic-py-common/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup
 
 dependencies = [
     'natsort',
-    'pyyaml',
     'swsssdk>=2.0.1',
 ]
 
@@ -28,6 +27,10 @@ setup(
         'sonic_py_common',
     ],
     test_suite = 'setup.get_test_suite',
+    tests_require=[
+        'pytest',
+        'mock>=2.0.0'
+    ],
     classifiers=[
         'Intended Audience :: Developers',
         'Operating System :: Linux',

--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     tests_require=[
         'pytest',
-        'mock>=2.0.0'
+        'mock==3.0.5' # For python 2. Version >=4.0.0 drops support for py2
     ],
     classifiers=[
         'Intended Audience :: Developers',

--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -27,6 +27,7 @@ setup(
     packages=[
         'sonic_py_common',
     ],
+    test_suite = 'setup.get_test_suite',
     classifiers=[
         'Intended Audience :: Developers',
         'Operating System :: Linux',

--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -26,7 +26,9 @@ setup(
     packages=[
         'sonic_py_common',
     ],
-    test_suite = 'setup.get_test_suite',
+    setup_requires= [
+        'pytest-runner'
+    ],
     tests_require=[
         'pytest',
         'mock>=2.0.0'
@@ -39,5 +41,6 @@ setup(
         'Programming Language :: Python',
     ],
     keywords='SONiC sonic PYTHON python COMMON common',
+    test_suite = 'setup.get_test_suite'
 )
 

--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 
 dependencies = [
     'natsort',
+    'pyyaml',
     'swsssdk>=2.0.1',
 ]
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -6,7 +6,7 @@ import subprocess
 import yaml
 from natsort import natsorted
 
-# TODD: Replace with swsscommon
+# TODO: Replace with swsscommon
 from swsssdk import ConfigDBConnector, SonicDBConfig
 
 USR_SHARE_SONIC_PATH = "/usr/share/sonic"

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -1,7 +1,22 @@
 import os
+import sys
 
-import mock
+# TODO: Remove this if/else block once we no longer support Python 2
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    # Expect the 'mock' package for python 2
+    # https://pypi.python.org/pypi/mock
+    import mock
+
 from sonic_py_common import device_info
+
+
+# TODO: Remove this if/else block once we no longer support Python 2
+if sys.version_info.major == 3:
+    BUILTINS = "builtins"
+else:
+    BUILTINS = "__builtin__"
 
 MACHINE_CONF_CONTENTS = """\
 onie_version=2016.11-5.1.0008-9600
@@ -44,7 +59,7 @@ class TestDeviceInfo(object):
         with mock.patch('os.path.isfile') as mock_isfile:
             mock_isfile.return_value = True
             mocked_open = mock.mock_open(read_data=MACHINE_CONF_CONTENTS)
-            with mock.patch('__builtin__.open', mocked_open):
+            with mock.patch('{}.open'.format(BUILTINS), mocked_open):
                 result = device_info.get_machine_info()
                 assert result == EXPECTED_GET_MACHINE_INFO_RESULT
                 mocked_open.assert_called_once_with('/host/machine.conf')

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -58,19 +58,18 @@ class TestDeviceInfo(object):
     def test_get_machine_info(self):
         with mock.patch('os.path.isfile') as mock_isfile:
             mock_isfile.return_value = True
-            mocked_open = mock.mock_open(read_data=MACHINE_CONF_CONTENTS)
-            with mock.patch('{}.open'.format(BUILTINS), mocked_open):
+            open_mocked = mock.mock_open(read_data=MACHINE_CONF_CONTENTS)
+            with mock.patch('{}.open'.format(BUILTINS), open_mocked):
                 result = device_info.get_machine_info()
                 assert result == EXPECTED_GET_MACHINE_INFO_RESULT
-                mocked_open.assert_called_once_with('/host/machine.conf')
+                open_mocked.assert_called_once_with('/host/machine.conf')
 
     def test_get_platform(self):
-        with mock.patch('sonic_py_common.device_info.get_machine_info') as mock_get_machine_info:
-            mock_get_machine_info.return_value = EXPECTED_GET_MACHINE_INFO_RESULT
+        with mock.patch('sonic_py_common.device_info.get_machine_info') as get_machine_info_mocked:
+            get_machine_info_mocked.return_value = EXPECTED_GET_MACHINE_INFO_RESULT
             result = device_info.get_platform()
             assert result == 'x86_64-mlnx_msn2700-r0'
 
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
-        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -1,12 +1,6 @@
 import os
-import sys
 
 import mock
-
-test_path = os.path.dirname(os.path.abspath(__file__))
-modules_path = os.path.dirname(test_path)
-sys.path.insert(0, modules_path)
-
 from sonic_py_common import device_info
 
 MACHINE_CONF_CONTENTS = """\

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -1,0 +1,67 @@
+import os
+import sys
+
+import mock
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+sys.path.insert(0, modules_path)
+
+from sonic_py_common import device_info
+
+MACHINE_CONF_CONTENTS = """\
+onie_version=2016.11-5.1.0008-9600
+onie_vendor_id=33049
+onie_machine_rev=0
+onie_arch=x86_64
+onie_config_version=1
+onie_build_date="2017-04-26T11:01+0300"
+onie_partition_type=gpt
+onie_kernel_version=4.10.11
+onie_firmware=auto
+onie_switch_asic=mlnx
+onie_skip_ethmgmt_macs=yes
+onie_machine=mlnx_msn2700
+onie_platform=x86_64-mlnx_msn2700-r0"""
+
+EXPECTED_GET_MACHINE_INFO_RESULT = {
+    'onie_arch': 'x86_64',
+    'onie_skip_ethmgmt_macs': 'yes',
+    'onie_platform': 'x86_64-mlnx_msn2700-r0',
+    'onie_machine_rev': '0',
+    'onie_version': '2016.11-5.1.0008-9600',
+    'onie_machine': 'mlnx_msn2700',
+    'onie_config_version': '1',
+    'onie_partition_type': 'gpt',
+    'onie_build_date': '"2017-04-26T11:01+0300"',
+    'onie_switch_asic': 'mlnx',
+    'onie_vendor_id': '33049',
+    'onie_firmware': 'auto',
+    'onie_kernel_version': '4.10.11'
+}
+
+
+class TestDeviceInfo(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    def test_get_machine_info(self):
+        with mock.patch('os.path.isfile') as mock_isfile:
+            mock_isfile.return_value = True
+            mocked_open = mock.mock_open(read_data=MACHINE_CONF_CONTENTS)
+            with mock.patch('__builtin__.open', mocked_open):
+                result = device_info.get_machine_info()
+                assert result == EXPECTED_GET_MACHINE_INFO_RESULT
+                mocked_open.assert_called_once_with('/host/machine.conf')
+
+    def test_get_platform(self):
+        with mock.patch('sonic_py_common.device_info.get_machine_info') as mock_get_machine_info:
+            mock_get_machine_info.return_value = EXPECTED_GET_MACHINE_INFO_RESULT
+            result = device_info.get_platform()
+            assert result == 'x86_64-mlnx_msn2700-r0'
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -56,19 +56,19 @@ class TestDeviceInfo(object):
         print("SETUP")
 
     def test_get_machine_info(self):
-        with mock.patch('os.path.isfile') as mock_isfile:
+        with mock.patch("os.path.isfile") as mock_isfile:
             mock_isfile.return_value = True
             open_mocked = mock.mock_open(read_data=MACHINE_CONF_CONTENTS)
-            with mock.patch('{}.open'.format(BUILTINS), open_mocked):
+            with mock.patch("{}.open".format(BUILTINS), open_mocked):
                 result = device_info.get_machine_info()
                 assert result == EXPECTED_GET_MACHINE_INFO_RESULT
-                open_mocked.assert_called_once_with('/host/machine.conf')
+                open_mocked.assert_called_once_with("/host/machine.conf")
 
     def test_get_platform(self):
-        with mock.patch('sonic_py_common.device_info.get_machine_info') as get_machine_info_mocked:
+        with mock.patch("sonic_py_common.device_info.get_machine_info") as get_machine_info_mocked:
             get_machine_info_mocked.return_value = EXPECTED_GET_MACHINE_INFO_RESULT
             result = device_info.get_platform()
-            assert result == 'x86_64-mlnx_msn2700-r0'
+            assert result == "x86_64-mlnx_msn2700-r0"
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
**- Why I did it**

To install the framework for adding unit tests to the sonic-py-common package and report coverage.

** How I did it **

- Incorporate pytest and pytest-cov into sonic-py-common package build
- Updgrade version of 'mock' installed to version 3.0.5, the last version which supports Python 2. This fixes a bug where the file object returned from `mock_open()` was not iterable (see https://bugs.python.org/issue32933)
- Add support for Python 3 setuptools and pytest in sonic-slave-buster environment
- Add tests for `device_info.get_machine_info()` and `device_info.get_platform()` functions
- Also add a .gitignore in the root of the sonic-py-common directory, move all related ignores from main .gitignore file, and add ignores for files and dirs generated by pytest-cov.

**- How to verify it**

Build the Python 2 and 3 versions of the sonic-py-common package, ensure the unit tests run and coverage reports are displayed. Examples:

Python 2:
```
============================= test session starts ==============================
platform linux2 -- Python 2.7.16, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /sonic/src/sonic-py-common, inifile: pytest.ini
plugins: cov-2.6.0
collected 2 items

tests/device_info_test.py ..                                             [100%]

---------- coverage: platform linux2, python 2.7.16-final-0 ----------
Name                             Stmts   Miss  Cover
----------------------------------------------------
sonic_py_common/__init__.py          0      0   100%
sonic_py_common/daemon_base.py      48     48     0%
sonic_py_common/device_info.py     188    139    26%
sonic_py_common/interface.py        11     11     0%
sonic_py_common/logger.py           45     45     0%
sonic_py_common/multi_asic.py      171    171     0%
sonic_py_common/task_base.py        32     32     0%
----------------------------------------------------
TOTAL                              495    446    10%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml


=========================== 2 passed in 0.41 seconds ===========================
```

Python 3:
```
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /sonic/src/sonic-py-common, inifile: pytest.ini
plugins: cov-2.6.0
collected 2 items

tests/device_info_test.py ..                                             [100%]

----------- coverage: platform linux, python 3.7.3-final-0 -----------
Name                             Stmts   Miss  Cover
----------------------------------------------------
sonic_py_common/__init__.py          0      0   100%
sonic_py_common/daemon_base.py      48     48     0%
sonic_py_common/device_info.py     188    139    26%
sonic_py_common/interface.py        11     11     0%
sonic_py_common/logger.py           45     45     0%
sonic_py_common/multi_asic.py      171    171     0%
sonic_py_common/task_base.py        32     32     0%
----------------------------------------------------
TOTAL                              495    446    10%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml


=========================== 2 passed in 2.02 seconds ===========================
```


**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006