### PR TITLE
[docker-ptf] [cherry-pick] add gnmi python client (#4928)

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -130,6 +130,13 @@ RUN ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 
 RUN mkdir -p /var/log/supervisor
 
+# Install Python-based GNMI client
+RUN git clone https://github.com/lguohan/gnxi.git \
+    && cd gnxi \
+    && git checkout d01b36e \
+    && cd gnmi_cli_py \
+    && pip install -r requirements.txt
+
 EXPOSE 22 8009
 
 ENTRYPOINT ["/usr/local/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]


### PR DESCRIPTION
For telemetry regression test we need gnmi client to be present on ptfdocker. Gnmi-server will be present on SONiC DuT. Further, we can access gnmi_get from ptfdocker inside pytest to verify gnmi server streaming data successfully or not.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The 20191130.45 version introduces telemetry contanier, but there is no gnmi python client in ptf container. This PR cherry-pick corresponding commit from master branch.
**- How I did it**
N/A
**- How to verify it**
N/A
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This PR cherry-pick corresponding commit from master branch #4928.

**- A picture of a cute animal (not mandatory but encouraged)**
