### PR TITLE
[hostcfgd] Fix Boolean String Evaluation

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -1,6 +1,7 @@
 #!/usr/bin/python -u
 # -*- coding: utf-8 -*-
 
+import ast
 import os
 import sys
 import subprocess
@@ -41,8 +42,8 @@ def obfuscate(data):
         return data
 
 
-def update_feature_state(feature_name, state, has_timer=False):
-    feature_suffixes = ["service"] + (["timer"] if has_timer else [])
+def update_feature_state(feature_name, state, has_timer):
+    feature_suffixes = ["service"] + (["timer"] if ast.literal_eval(has_timer) else [])
     if state == "enabled":
         start_cmds = []
         for suffix in feature_suffixes:

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -48,9 +48,9 @@ def update_feature_state(feature_name, state, has_timer):
         start_cmds = []
         for suffix in feature_suffixes:
             start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name, suffix))
-            start_cmds.append("sudo systemctl enable {}.{}".format(feature_name, suffix))
-        # If feature has timer associated with it, start corresponding systemd .timer unit
-        # otherwise, start corresponding systemd .service unit
+        # If feature has timer associated with it, start/enable corresponding systemd .timer unit
+        # otherwise, start/enable corresponding systemd .service unit
+        start_cmds.append("sudo systemctl enable {}.{}".format(feature_name, feature_suffixes[-1]))
         start_cmds.append("sudo systemctl start {}.{}".format(feature_name, feature_suffixes[-1]))
         for cmd in start_cmds:
             syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))


### PR DESCRIPTION
New attribute 'has_timer' introduced to init_cfg.json does not evaluate
as Bool, rather it evaluates as string. This PR fixes this issue. Also,
this PR fixes an issue when there is system config unit (snmp. telemetry) 
has no installation config (WantedBy=, RequiredBy=, Also=, Alias=) settings
in the [Install] section. In the latter case, the .service should not be enabled.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

The issue appears to be stemming from config_db as the new has_timer is stored as string in the config_db
```
    "FEATURE": {
        "bgp": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "database": {
            "auto_restart": "disabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "dhcp_relay": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "lldp": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "mgmt-framework": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "nat": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "disabled"
        }, 
        "pmon": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "radv": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "sflow": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "disabled"
        }, 
        "snmp": {
            "auto_restart": "enabled", 
            "has_timer": "True", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "swss": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "syncd": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "teamd": {
            "auto_restart": "enabled", 
            "has_timer": "False", 
            "high_mem_alert": "disabled", 
            "state": "enabled"
        }, 
        "telemetry": {
            "auto_restart": "enabled", 
            "has_timer": "True", 
            "high_mem_alert": "disabled", 
            "state": "enabled", 
            "status": "enabled"
        }
    }, 
```
**- Why I did it**
To fix service start noticed during test.

**- How I did it**
Add code to properly evaluate newly added field

**- How to verify it**
config load_minigraph does not shoe lldp.timer as started.

**- Which release branch to backport (provide reason below if selected)**
N/A

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
