### PR TITLE
[cfggen] Use Redis Pipeline

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -46,7 +46,7 @@ from sonic_py_common.device_info import get_platform, get_system_mac
 from sonic_py_common.multi_asic import get_asic_id_from_name, is_multi_asic
 from config_samples import generate_sample_config
 from config_samples import get_available_config
-from swsssdk import SonicV2Connector, ConfigDBConnector, SonicDBConfig 
+from swsssdk import SonicV2Connector, ConfigDBConnector, SonicDBConfig, ConfigDBPipeConnector
 from redis_bcc import RedisBytecodeCache
 from collections import OrderedDict
 from natsort import natsorted
@@ -340,9 +340,9 @@ def main():
 
     if args.from_db:
         if args.namespace is None:
-            configdb = ConfigDBConnector(use_unix_socket_path=True, **db_kwargs)
+            configdb = ConfigDBPipeConnector(use_unix_socket_path=True, **db_kwargs)
         else:
-            configdb = ConfigDBConnector(use_unix_socket_path=True, namespace=args.namespace, **db_kwargs)
+            configdb = ConfigDBPipeConnector(use_unix_socket_path=True, namespace=args.namespace, **db_kwargs)
 
         configdb.connect()
         deep_update(data, FormatConverter.db_to_output(configdb.get_config()))
@@ -401,9 +401,9 @@ def main():
 
     if args.write_to_db:
         if args.namespace is None:
-            configdb = ConfigDBConnector(use_unix_socket_path=True, **db_kwargs)
+            configdb = ConfigDBPipeConnector(use_unix_socket_path=True, **db_kwargs)
         else:
-            configdb = ConfigDBConnector(use_unix_socket_path=True, namespace=args.namespace, **db_kwargs)
+            configdb = ConfigDBPipeConnector(use_unix_socket_path=True, namespace=args.namespace, **db_kwargs)
 
         configdb.connect(False)
         configdb.mod_config(FormatConverter.output_to_db(data))


### PR DESCRIPTION
This PR enables cfggen to read/write from Redis DB using pipelines.
Pipelines enables batch read/write from/to Redis DB.

depends: Azure/sonic-buildimage#5249

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
cfggen uses extensive CPU plus read/write from/to Redis DB is slow

**- How I did it**
Update sonic cfggen to use Redis pipelines

**- How to verify it**
Current Connector
```
admin@str-s6000-acs-14:~$ time sudo sonic-cfggen -j /etc/sonic/config_db.json --write-to-db

real	0m2.286s
user	0m1.608s
sys	0m0.364s
admin@str-s6000-acs-14:~$ time sonic-cfggen -d --print-data > dump_old_debug.json 

real	0m2.219s
user	0m1.816s
sys	0m0.360s
```

Pipe Connector
```
admin@str-s6000-acs-14:~$ time sudo sonic-cfggen -j /etc/sonic/config_db.json --write-to-db

real	0m1.648s
user	0m1.316s
sys	0m0.304s
admin@str-s6000-acs-14:~$ time sonic-cfggen -d --print-data > dump_new_debug.json 

real	0m2.006s
user	0m1.732s
sys	0m0.260s
```

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
