### PR TITLE
Skip vnet-vxlan interfaces from generating networks

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -14,14 +14,23 @@ ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERF
 ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | replace('/128', '/64') | ip_network }}/64
 {% endif %}
 !
+{# Get all interfaces that belong to vnet #}
+{% set vnet_intfs = [] %}
+{% if VLAN_INTERFACE is defined %}
+{% for (key, metadata) in VLAN_INTERFACE.iteritems() %}
+{%   if metadata.has_key("vnet_name") %}
+{%     set vnet_intfs = vnet_intfs.append(key) %}
+{%   endif %}
+{% endfor %}
+{% endif%}
 {% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
-{% if prefix | ipv4 %}
+{% if prefix | ipv4 and name not in vnet_intfs %}
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq {{ loop.index * 5 }} permit {{ prefix }}
 !
 {% endif %}
 {% endfor %}
 {% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
-{% if prefix | ipv6 %}
+{% if prefix | ipv6 and name not in vnet_intfs %}
 ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq {{ loop.index * 5 }} permit {{ prefix }}
 !
 {% endif %}
@@ -78,9 +87,9 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
 {% block vlan_advertisement %}
 {% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
-{% if prefix | ipv4 %}
+{% if prefix | ipv4 and name not in vnet_intfs %}
   network {{ prefix }}
-{% elif prefix | ipv6 %}
+{% elif prefix | ipv6 and name not in vnet_intfs %}
   address-family ipv6
    network {{ prefix }}
   exit-address-family

--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -1,4 +1,4 @@
-{% from "common/functions.conf.j2" import get_ipv4_loopback_address, get_ipv6_loopback_address %}
+{% from "common/functions.conf.j2" import get_ipv4_loopback_address, get_ipv6_loopback_address, get_vnet_interfaces %}
 !
 ! template: bgpd/bgpd.main.conf.j2
 !
@@ -14,15 +14,9 @@ ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERF
 ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | replace('/128', '/64') | ip_network }}/64
 {% endif %}
 !
-{# Get all interfaces that belong to vnet #}
-{% set vnet_intfs = [] %}
 {% if VLAN_INTERFACE is defined %}
-{% for (key, metadata) in VLAN_INTERFACE.iteritems() %}
-{%   if metadata.has_key("vnet_name") %}
-{%     set vnet_intfs = vnet_intfs.append(key) %}
-{%   endif %}
-{% endfor %}
-{% endif%}
+{% set vnet_intfs = get_vnet_interfaces(VLAN_INTERFACE) %}
+{% endif %}
 {% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 and name not in vnet_intfs %}
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq {{ loop.index * 5 }} permit {{ prefix }}

--- a/dockers/docker-fpm-frr/frr/common/functions.conf.j2
+++ b/dockers/docker-fpm-frr/frr/common/functions.conf.j2
@@ -21,3 +21,15 @@
 {% endfor %}
 {{ L.ip }}
 {%- endmacro %}
+
+{% macro get_vnet_interfaces(interfaces) -%}
+{% set L = namespace(intfs=[]) %}
+{% set vnet_intfs = [] %}
+{% for (key, metadata) in interfaces.iteritems() %}
+{%   if metadata.has_key("vnet_name") %}
+{%     set vnet_intfs = vnet_intfs.append(key) %}
+{%   endif %}
+{% endfor %}
+{% set L.intfs = vnet_intfs %}
+{{ L.intfs }}
+{%- endmacro %}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.json
@@ -11,7 +11,10 @@
     },
     "VLAN_INTERFACE": {
         "Vlan10|10.10.10.1/24": {},
-        "Vlan10|fc01::1/64": {}
+        "Vlan10|fc01::1/64": {},
+        "Vlan20": {"vnet_name": "Vnet1"},
+        "Vlan20|20.20.20.1/24": {},
+        "Vlan20|fd01::1/64": {}
     },
     "constants": {
         "bgp": {

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.json
@@ -11,7 +11,10 @@
     },
     "VLAN_INTERFACE": {
         "Vlan10|10.10.10.1/24": {},
-        "Vlan10|fc01::1/64": {}
+        "Vlan10|fc01::1/64": {},
+        "Vlan20": {"vnet_name": "Vnet1"},
+        "Vlan20|20.20.20.1/24": {},
+        "Vlan20|fd01::1/64": {}
     },
     "constants": {
         "bgp": {


### PR DESCRIPTION
**- Why I did it**
Vnet vlan interfaces should not be part of advertised networks by FRR

**- How I did it**

**- How to verify it**
Using vtysh

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
