### PR TITLE
Change update_feature_state call to pass False as default if feature has no 'has_timer' field

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -291,7 +291,7 @@ class HostConfigDaemon:
                 syslog.syslog(syslog.LOG_WARNING, "Eanble state of feature '{}' is None".format(feature_name))
                 continue
 
-            update_feature_state(feature_name, state, feature_table[feature_name]['has_timer'])
+            update_feature_state(feature_name, state, feature_table[feature_name].get('has_timer', False))
 
     def aaa_handler(self, key, data):
         self.aaacfg.aaa_update(key, data)

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -291,7 +291,7 @@ class HostConfigDaemon:
                 syslog.syslog(syslog.LOG_WARNING, "Eanble state of feature '{}' is None".format(feature_name))
                 continue
 
-            update_feature_state(feature_name, state, feature_table[feature_name].get('has_timer', False))
+            update_feature_state(feature_name, state, feature_table[feature_name].get('has_timer', 'False'))
 
     def aaa_handler(self, key, data):
         self.aaacfg.aaa_update(key, data)
@@ -333,7 +333,7 @@ class HostConfigDaemon:
             syslog.syslog(syslog.LOG_WARNING, "Enable state of feature '{}' is None".format(feature_name))
             return
 
-        update_feature_state(feature_name, state, feature_table[feature_name]['has_timer'])
+        update_feature_state(feature_name, state, feature_table[feature_name].get('has_timer', 'False'))
 
     def start(self):
         # Update all feature states once upon starting


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
In order to make hostcfgd not to fail if feature has no 'has_timer' field
**- How I did it**
Change the update_feature_state call to pass False by default.
**- How to verify it**
Enable feature that has no 'has timer' field and make sure hostcfgd not failing. 
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
