### PR TITLE
[sonic-utilities][sonic-py-common] Move logic to get port config file path to sonic-py-common and update sonic-utilities to comply

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -7,6 +7,7 @@ try:
     import re
     from collections import OrderedDict
     from swsssdk import ConfigDBConnector
+    from sonic_py_common import device_info
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
@@ -64,33 +65,6 @@ def db_connect_configdb():
         config_db = None
     return config_db
 
-def get_port_config_file_name(hwsku=None, platform=None, asic=None):
-
-    # check 'platform.json' file presence
-    port_config_candidates_Json = []
-    port_config_candidates_Json.append(os.path.join(PLATFORM_ROOT_PATH_DOCKER, PLATFORM_JSON))
-    if platform:
-        port_config_candidates_Json.append(os.path.join(PLATFORM_ROOT_PATH, platform, PLATFORM_JSON))
-
-    # check 'portconfig.ini' file presence
-    port_config_candidates = []
-    port_config_candidates.append(os.path.join(HWSKU_ROOT_PATH, PORT_CONFIG_INI))
-    if hwsku:
-        if platform:
-            if asic:
-                port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, hwsku, asic, PORT_CONFIG_INI))
-            port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, hwsku, PORT_CONFIG_INI))
-        port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH_DOCKER, hwsku, PORT_CONFIG_INI))
-        port_config_candidates.append(os.path.join(SONIC_ROOT_PATH, hwsku, PORT_CONFIG_INI))
-
-    elif platform and not hwsku:
-        port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, PORT_CONFIG_INI))
-
-    for candidate in port_config_candidates_Json + port_config_candidates:
-        if os.path.isfile(candidate):
-            return candidate
-    return None
-
 def get_hwsku_file_name(hwsku=None, platform=None):
     hwsku_candidates_Json = []
     hwsku_candidates_Json.append(os.path.join(HWSKU_ROOT_PATH, HWSKU_JSON))
@@ -119,7 +93,7 @@ def get_port_config(hwsku=None, platform=None, port_config_file=None, hwsku_conf
             return (ports, port_alias_map, port_alias_asic_map)
 
     if not port_config_file:
-        port_config_file = get_port_config_file_name(hwsku, platform, asic)
+        port_config_file = device_info.get_path_to_port_config_file(asic)
         if not port_config_file:
             return ({}, {}, {})
 
@@ -289,7 +263,7 @@ def parse_platform_json_file(hwsku_json_file, platform_json_file):
 
 def get_breakout_mode(hwsku=None, platform=None, port_config_file=None):
     if not port_config_file:
-        port_config_file = get_port_config_file_name(hwsku, platform)
+        port_config_file = device_info.get_path_to_port_config_file()
         if not port_config_file:
             return None
     if port_config_file.endswith('.json'):

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -93,7 +93,7 @@ def get_port_config(hwsku=None, platform=None, port_config_file=None, hwsku_conf
             return (ports, port_alias_map, port_alias_asic_map)
 
     if not port_config_file:
-        port_config_file = device_info.get_path_to_port_config_file(asic, hwsku)
+        port_config_file = device_info.get_path_to_port_config_file(hwsku, asic)
         if not port_config_file:
             return ({}, {}, {})
 

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -93,7 +93,7 @@ def get_port_config(hwsku=None, platform=None, port_config_file=None, hwsku_conf
             return (ports, port_alias_map, port_alias_asic_map)
 
     if not port_config_file:
-        port_config_file = device_info.get_path_to_port_config_file(asic)
+        port_config_file = device_info.get_path_to_port_config_file(asic, hwsku)
         if not port_config_file:
             return ({}, {}, {})
 
@@ -263,7 +263,7 @@ def parse_platform_json_file(hwsku_json_file, platform_json_file):
 
 def get_breakout_mode(hwsku=None, platform=None, port_config_file=None):
     if not port_config_file:
-        port_config_file = device_info.get_path_to_port_config_file()
+        port_config_file = device_info.get_path_to_port_config_file(hwsku)
         if not port_config_file:
             return None
     if port_config_file.endswith('.json'):

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -301,7 +301,7 @@ def main():
             }}}
         deep_update(data, hardware_data)
         if args.port_config is None:
-            args.port_config = device_info.get_path_to_port_config_file()
+            args.port_config = device_info.get_path_to_port_config_file(hwsku)
         (ports, _, _) = get_port_config(hwsku, platform, args.port_config, asic_id)
         if not ports:
             print('Failed to get port config', file=sys.stderr)

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -41,9 +41,10 @@ from minigraph import minigraph_encoder
 from minigraph import parse_xml
 from minigraph import parse_device_desc_xml
 from minigraph import parse_asic_sub_role
-from portconfig import get_port_config, get_port_config_file_name, get_breakout_mode
+from portconfig import get_port_config, get_breakout_mode
 from sonic_py_common.device_info import get_platform, get_system_mac
 from sonic_py_common.multi_asic import get_asic_id_from_name, is_multi_asic
+from sonic_py_common import device_info
 from config_samples import generate_sample_config
 from config_samples import get_available_config
 from swsssdk import SonicV2Connector, ConfigDBConnector, SonicDBConfig, ConfigDBPipeConnector
@@ -301,7 +302,7 @@ def main():
             }}}
         deep_update(data, hardware_data)
         if args.port_config is None:
-            args.port_config = get_port_config_file_name(hwsku, platform)
+            args.port_config = device_info.get_path_to_port_config_file()
         (ports, _, _) = get_port_config(hwsku, platform, args.port_config, asic_id)
         if not ports:
             print('Failed to get port config', file=sys.stderr)

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -42,7 +42,6 @@ from minigraph import parse_xml
 from minigraph import parse_device_desc_xml
 from minigraph import parse_asic_sub_role
 from portconfig import get_port_config, get_breakout_mode
-from sonic_py_common.device_info import get_platform, get_system_mac
 from sonic_py_common.multi_asic import get_asic_id_from_name, is_multi_asic
 from sonic_py_common import device_info
 from config_samples import generate_sample_config
@@ -278,7 +277,7 @@ def main():
     group.add_argument("-K", "--key", help="Lookup for a specific key")
     args = parser.parse_args()
 
-    platform = get_platform()
+    platform = device_info.get_platform()
 
     db_kwargs = {}
     if args.redis_unix_sock_file != None:
@@ -357,11 +356,11 @@ def main():
                 asic_role = parse_asic_sub_role(args.minigraph, asic_name)
 
             if asic_role is not None and asic_role.lower() == "backend":
-                mac = get_system_mac(namespace=asic_name)
+                mac = device_info.get_system_mac(namespace=asic_name)
             else:
-                mac = get_system_mac()
+                mac = device_info.get_system_mac()
         else:
-            mac = get_system_mac()
+            mac = device_info.get_system_mac()
 
         hardware_data = {'DEVICE_METADATA': {'localhost': {
             'platform': platform,

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -188,31 +188,24 @@ def get_path_to_port_config_file(asic=None):
     Returns:
         A string containing the path the the device's port configuration file
     """
-    (platform, hwsku) = get_platform_and_hwsku()
+    (platform_path, hwsku_path) = get_paths_to_platform_and_hwsku_dirs()
 
-    # check 'platform.json' file presence
-    port_config_candidates_json = []
-    port_config_candidates_json.append(os.path.join(PLATFORM_ROOT_PATH_DOCKER, PLATFORM_JSON))
-    if platform:
-        port_config_candidates_Json.append(os.path.join(PLATFORM_ROOT_PATH, platform, PLATFORM_JSON))
-
-    # check 'portconfig.ini' file presence
     port_config_candidates = []
-    port_config_candidates.append(os.path.join(HWSKU_ROOT_PATH, PORT_CONFIG_INI))
-    if hwsku:
-        if platform:
-            if asic:
-                port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, hwsku, asic, PORT_CONFIG_INI))
-            port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, hwsku, PORT_CONFIG_INI))
-        port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH_DOCKER, hwsku, PORT_CONFIG_INI))
-        port_config_candidates.append(os.path.join(SONIC_ROOT_PATH, hwsku, PORT_CONFIG_INI))
 
-    elif platform and not hwsku:
-        port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, PORT_CONFIG_INI))
+    # Check for 'platform.json' file presence first
+    port_config_candidates_json.append(os.path.join(platform_path, PLATFORM_JSON))
 
-    for candidate in port_config_candidates_json + port_config_candidates:
+    # Check for 'portconfig.ini' file presence in a few locations
+    port_config_candidates.append(os.path.join(hwsku_path, PORT_CONFIG_INI))
+    if asic:
+        port_config_candidates.append(os.path.join(hwsku_path, asic, PORT_CONFIG_INI))
+    port_config_candidates.append(os.path.join(hwsku_path, PORT_CONFIG_INI))
+    port_config_candidates.append(os.path.join(platform_path, PORT_CONFIG_INI))
+
+    for candidate in port_config_candidates:
         if os.path.isfile(candidate):
             return candidate
+
     return None
 
 def get_sonic_version_info():

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -167,17 +167,21 @@ def get_paths_to_platform_and_hwsku_dirs():
     # Get platform and hwsku
     (platform, hwsku) = get_platform_and_hwsku()
 
+    platform_path = None
+    hwsku_path = None
     # Determine whether we're running in a container or on the host
-    platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
+    if platform:
+        platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
 
-    if os.path.isdir(CONTAINER_PLATFORM_PATH):
+    if  os.path.isdir(CONTAINER_PLATFORM_PATH):
         platform_path = CONTAINER_PLATFORM_PATH
-    elif os.path.isdir(platform_path_host):
+    elif platform_path_host and os.path.isdir(platform_path_host):
         platform_path = platform_path_host
     else:
         raise OSError("Failed to locate platform directory")
 
-    hwsku_path = os.path.join(platform_path, hwsku)
+    if hwsku:
+        hwsku_path = os.path.join(platform_path, hwsku)
 
     return (platform_path, hwsku_path)
 
@@ -195,11 +199,10 @@ def get_path_to_port_config_file(asic=None):
     # Check for 'platform.json' file presence first
     port_config_candidates_json.append(os.path.join(platform_path, PLATFORM_JSON))
 
-    # Check for 'portconfig.ini' file presence in a few locations
+    # Check for 'port_config.ini' file presence in a few locations
     port_config_candidates.append(os.path.join(hwsku_path, PORT_CONFIG_INI))
     if asic:
         port_config_candidates.append(os.path.join(hwsku_path, asic, PORT_CONFIG_INI))
-    port_config_candidates.append(os.path.join(hwsku_path, PORT_CONFIG_INI))
     port_config_candidates.append(os.path.join(platform_path, PORT_CONFIG_INI))
 
     for candidate in port_config_candidates:

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -188,6 +188,19 @@ def get_path_to_port_config_file(asic=None):
     Returns:
         A string containing the path the the device's port configuration file
     """
+
+    '''
+    This platform check is performed to make sure we return a None
+    in case of unit-tests within sonic-cfggen where platform is not expected to be
+    present because tests are not run on actual Hardware/Container.
+    This check should however be ommitted once Sonic-cfggen does not use
+    port_config file for unit-tests.
+    '''
+
+    platform = get_platform()
+    if not platform:
+        return None
+
     (platform_path, hwsku_path) = get_paths_to_platform_and_hwsku_dirs()
 
     port_config_candidates = []

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -227,7 +227,7 @@ def get_paths_to_platform_and_hwsku_dirs():
 
     return (platform_path, hwsku_path)
 
-def get_path_to_port_config_file(asic=None, hwsku=None):
+def get_path_to_port_config_file(hwsku=None, asic=None):
     """
     Retrieves the path to the device's port configuration file
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -246,11 +246,9 @@ def get_path_to_port_config_file(hwsku=None, asic=None):
     if not platform:
         return None
 
-    if hwsku:
-        platform_path = get_path_to_platform_dir()
-        hwsku_path = hwsku
-    else:
-        (platform_path, hwsku_path) = get_paths_to_platform_and_hwsku_dirs()
+    platform_path = get_path_to_platform_dir()
+
+    hwsku_path = os.path.join(platform_path, hwsku) if hwsku else get_path_to_hwsku_dir()
 
     port_config_candidates = []
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -154,6 +154,52 @@ def get_asic_conf_file_path():
     return None
 
 
+def get_path_to_platform_dir():
+    """
+    Retreives the paths to the device's platform directory
+
+    Returns:
+        A string containing the path to the platform directory of the device
+    """
+    # Get platform
+    platform = get_platform()
+
+    # Determine whether we're running in a container or on the host
+    platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
+
+    if os.path.isdir(CONTAINER_PLATFORM_PATH):
+        platform_path = CONTAINER_PLATFORM_PATH
+    elif os.path.isdir(platform_path_host):
+        platform_path = platform_path_host
+    else:
+        raise OSError("Failed to locate platform directory")
+
+    return platform_path
+
+def get_path_to_hwsku_dir():
+    """
+    Retreives the path to the device's hardware SKU data directory
+
+    Returns:
+        A string, containing the path to the hardware SKU directory of the device
+    """
+    # Get hwsku
+    hwsku = get_hwsku()
+
+    # Determine whether we're running in a container or on the host
+    platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
+
+    if os.path.isdir(CONTAINER_PLATFORM_PATH):
+        platform_path = CONTAINER_PLATFORM_PATH
+    elif os.path.isdir(platform_path_host):
+        platform_path = platform_path_host
+    else:
+        raise OSError("Failed to locate platform directory")
+
+    hwsku_path = os.path.join(platform_path, hwsku)
+
+    return hwsku_path
+
 def get_paths_to_platform_and_hwsku_dirs():
     """
     Retreives the paths to the device's platform and hardware SKU data
@@ -181,7 +227,7 @@ def get_paths_to_platform_and_hwsku_dirs():
 
     return (platform_path, hwsku_path)
 
-def get_path_to_port_config_file(asic=None):
+def get_path_to_port_config_file(asic=None, hwsku=None):
     """
     Retrieves the path to the device's port configuration file
 
@@ -200,7 +246,11 @@ def get_path_to_port_config_file(asic=None):
     if not platform:
         return None
 
-    (platform_path, hwsku_path) = get_paths_to_platform_and_hwsku_dirs()
+    if hwsku:
+        platform_path = get_path_to_platform_dir()
+        hwsku_path = hwsku
+    else:
+        (platform_path, hwsku_path) = get_paths_to_platform_and_hwsku_dirs()
 
     port_config_candidates = []
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -219,10 +219,11 @@ def get_path_to_port_config_file(hwsku=None, asic=None):
     """
     Retrieves the path to the device's port configuration file
 
-    the hwsku argument is allowed to be passed in args because when loading the
-    initial configuration on the device, the HwSKU is not yet present in ConfigDB.
-    asic argument should be passed on multi-ASIC devices only,
-    it should be omitted on single-ASIC platforms.
+    Args:
+        hwsku: a string, it is allowed to be passed in args because when loading the
+              initial configuration on the device, the HwSKU is not yet present in ConfigDB.
+        asic: a string , asic argument should be passed on multi-ASIC devices only,
+              it should be omitted on single-ASIC platforms.
 
     Returns:
         A string containing the path the the device's port configuration file

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -176,30 +176,6 @@ def get_path_to_platform_dir():
 
     return platform_path
 
-def get_path_to_hwsku_dir():
-    """
-    Retreives the path to the device's hardware SKU data directory
-
-    Returns:
-        A string, containing the path to the hardware SKU directory of the device
-    """
-    # Get hwsku
-    hwsku = get_hwsku()
-
-    # Determine whether we're running in a container or on the host
-    platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
-
-    if os.path.isdir(CONTAINER_PLATFORM_PATH):
-        platform_path = CONTAINER_PLATFORM_PATH
-    elif os.path.isdir(platform_path_host):
-        platform_path = platform_path_host
-    else:
-        raise OSError("Failed to locate platform directory")
-
-    hwsku_path = os.path.join(platform_path, hwsku)
-
-    return hwsku_path
-
 def get_paths_to_platform_and_hwsku_dirs():
     """
     Retreives the paths to the device's platform and hardware SKU data

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -193,18 +193,21 @@ def get_path_to_port_config_file(asic=None):
     # check 'platform.json' file presence
     port_config_candidates_json = []
     port_config_candidates_json.append(os.path.join(PLATFORM_ROOT_PATH_DOCKER, PLATFORM_JSON))
-    port_config_candidates_json.append(os.path.join(PLATFORM_ROOT_PATH, platform, PLATFORM_JSON))
+    if platform:
+        port_config_candidates_Json.append(os.path.join(PLATFORM_ROOT_PATH, platform, PLATFORM_JSON))
 
     # check 'portconfig.ini' file presence
     port_config_candidates = []
     port_config_candidates.append(os.path.join(HWSKU_ROOT_PATH, PORT_CONFIG_INI))
-    if asic:
-        port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, hwsku, asic, PORT_CONFIG_INI))
-    port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, hwsku, PORT_CONFIG_INI))
-    port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH_DOCKER, hwsku, PORT_CONFIG_INI))
-    port_config_candidates.append(os.path.join(SONIC_ROOT_PATH, hwsku, PORT_CONFIG_INI))
+    if hwsku:
+        if platform:
+            if asic:
+                port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, hwsku, asic, PORT_CONFIG_INI))
+            port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, hwsku, PORT_CONFIG_INI))
+        port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH_DOCKER, hwsku, PORT_CONFIG_INI))
+        port_config_candidates.append(os.path.join(SONIC_ROOT_PATH, hwsku, PORT_CONFIG_INI))
 
-    if platform and not hwsku:
+    elif platform and not hwsku:
         port_config_candidates.append(os.path.join(PLATFORM_ROOT_PATH, platform, PORT_CONFIG_INI))
 
     for candidate in port_config_candidates_json + port_config_candidates:

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -189,13 +189,12 @@ def get_path_to_port_config_file(asic=None):
         A string containing the path the the device's port configuration file
     """
 
-    '''
+    """
     This platform check is performed to make sure we return a None
     in case of unit-tests within sonic-cfggen where platform is not expected to be
     present because tests are not run on actual Hardware/Container.
-    This check should however be ommitted once Sonic-cfggen does not use
-    port_config file for unit-tests.
-    '''
+    TODO: refactor sonic-cfggen such that we can remove this check
+    """
 
     platform = get_platform()
     if not platform:

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -176,6 +176,30 @@ def get_path_to_platform_dir():
 
     return platform_path
 
+def get_path_to_hwsku_dir():
+    """
+    Retreives the path to the device's hardware SKU data directory
+
+    Returns:
+        A string, containing the path to the hardware SKU directory of the device
+    """
+    # Get platform and hwsku
+    (platform, hwsku) = get_platform_and_hwsku()
+
+    # Determine whether we're running in a container or on the host
+    platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
+
+    if os.path.isdir(CONTAINER_PLATFORM_PATH):
+        platform_path = CONTAINER_PLATFORM_PATH
+    elif os.path.isdir(platform_path_host):
+        platform_path = platform_path_host
+    else:
+        raise OSError("Failed to locate platform directory")
+
+    hwsku_path = os.path.join(platform_path, hwsku)
+
+    return hwsku_path
+
 def get_paths_to_platform_and_hwsku_dirs():
     """
     Retreives the paths to the device's platform and hardware SKU data

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -206,13 +206,13 @@ def get_path_to_port_config_file(asic=None):
     port_config_candidates = []
 
     # Check for 'platform.json' file presence first
-    port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON))
+    port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
 
     # Check for 'port_config.ini' file presence in a few locations
-    port_config_candidates.append(os.path.join(hwsku_path, PORT_CONFIG_INI))
+    port_config_candidates.append(os.path.join(hwsku_path, PORT_CONFIG_FILE))
     if asic:
-        port_config_candidates.append(os.path.join(hwsku_path, asic, PORT_CONFIG_INI))
-    port_config_candidates.append(os.path.join(platform_path, PORT_CONFIG_INI))
+        port_config_candidates.append(os.path.join(hwsku_path, asic, PORT_CONFIG_FILE))
+    port_config_candidates.append(os.path.join(platform_path, PORT_CONFIG_FILE))
 
     for candidate in port_config_candidates:
         if os.path.isfile(candidate):

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -209,10 +209,10 @@ def get_path_to_port_config_file(asic=None):
     port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
 
     # Check for 'port_config.ini' file presence in a few locations
-    port_config_candidates.append(os.path.join(hwsku_path, PORT_CONFIG_FILE))
     if asic:
         port_config_candidates.append(os.path.join(hwsku_path, asic, PORT_CONFIG_FILE))
-    port_config_candidates.append(os.path.join(platform_path, PORT_CONFIG_FILE))
+    else:
+        port_config_candidates.append(os.path.join(hwsku_path, PORT_CONFIG_FILE))
 
     for candidate in port_config_candidates:
         if os.path.isfile(candidate):

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -183,18 +183,12 @@ def get_path_to_hwsku_dir():
     Returns:
         A string, containing the path to the hardware SKU directory of the device
     """
-    # Get platform and hwsku
-    (platform, hwsku) = get_platform_and_hwsku()
 
-    # Determine whether we're running in a container or on the host
-    platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
+    # Get Platform path first
+    platform_path = get_path_to_platform_dir()
 
-    if os.path.isdir(CONTAINER_PLATFORM_PATH):
-        platform_path = CONTAINER_PLATFORM_PATH
-    elif os.path.isdir(platform_path_host):
-        platform_path = platform_path_host
-    else:
-        raise OSError("Failed to locate platform directory")
+    # Get hwsku
+    hwsku = get_hwsku()
 
     hwsku_path = os.path.join(platform_path, hwsku)
 
@@ -210,18 +204,12 @@ def get_paths_to_platform_and_hwsku_dirs():
         directory of the device, the second containing the path to the hardware
         SKU directory of the device
     """
-    # Get platform and hwsku
-    (platform, hwsku) = get_platform_and_hwsku()
 
-    # Determine whether we're running in a container or on the host
-    platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
+    # Get Platform path first
+    platform_path = get_path_to_platform_dir()
 
-    if os.path.isdir(CONTAINER_PLATFORM_PATH):
-        platform_path = CONTAINER_PLATFORM_PATH
-    elif os.path.isdir(platform_path_host):
-        platform_path = platform_path_host
-    else:
-        raise OSError("Failed to locate platform directory")
+    # Get hwsku
+    hwsku = get_hwsku()
 
     hwsku_path = os.path.join(platform_path, hwsku)
 
@@ -230,6 +218,11 @@ def get_paths_to_platform_and_hwsku_dirs():
 def get_path_to_port_config_file(hwsku=None, asic=None):
     """
     Retrieves the path to the device's port configuration file
+
+    the hwsku argument is allowed to be passed in args because when loading the
+    initial configuration on the device, the HwSKU is not yet present in ConfigDB.
+    asic argument should be passed on multi-ASIC devices only,
+    it should be omitted on single-ASIC platforms.
 
     Returns:
         A string containing the path the the device's port configuration file

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -246,9 +246,11 @@ def get_path_to_port_config_file(hwsku=None, asic=None):
     if not platform:
         return None
 
-    platform_path = get_path_to_platform_dir()
-
-    hwsku_path = os.path.join(platform_path, hwsku) if hwsku else get_path_to_hwsku_dir()
+    if hwsku:
+        platform_path = get_path_to_platform_dir()
+        hwsku_path = os.path.join(platform_path, hwsku)
+    else:
+        (platform_path, hwsku_path) = get_paths_to_platform_and_hwsku_dirs()
 
     port_config_candidates = []
 

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -167,21 +167,17 @@ def get_paths_to_platform_and_hwsku_dirs():
     # Get platform and hwsku
     (platform, hwsku) = get_platform_and_hwsku()
 
-    platform_path = None
-    hwsku_path = None
     # Determine whether we're running in a container or on the host
-    if platform:
-        platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
+    platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
 
-    if  os.path.isdir(CONTAINER_PLATFORM_PATH):
+    if os.path.isdir(CONTAINER_PLATFORM_PATH):
         platform_path = CONTAINER_PLATFORM_PATH
-    elif platform_path_host and os.path.isdir(platform_path_host):
+    elif os.path.isdir(platform_path_host):
         platform_path = platform_path_host
     else:
         raise OSError("Failed to locate platform directory")
 
-    if hwsku:
-        hwsku_path = os.path.join(platform_path, hwsku)
+    hwsku_path = os.path.join(platform_path, hwsku)
 
     return (platform_path, hwsku_path)
 
@@ -197,7 +193,7 @@ def get_path_to_port_config_file(asic=None):
     port_config_candidates = []
 
     # Check for 'platform.json' file presence first
-    port_config_candidates_json.append(os.path.join(platform_path, PLATFORM_JSON))
+    port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON))
 
     # Check for 'port_config.ini' file presence in a few locations
     port_config_candidates.append(os.path.join(hwsku_path, PORT_CONFIG_INI))


### PR DESCRIPTION
This PR addresses fixes in sonic-py-common to imitate the behavior inside 
sonic-cfggen. Essentially this is a fix for accessing the port-config file. 
First check if there is a platform.json file for config generation 
and then for legacy port_config.ini. 
Also updating the sub-module sonic-utilities. 

sonic-utilities update submodule includes all these PR's 

Fix pfcwd stats crash with invalid queue name (#1077)
[show][bgp]Display the Total number of neighbors in the show ip bgp(v6) summary. (#1079)
[config] Update SONiC Environment Vars When Loading Minigraph (#1073)
Multi asic platform changes for interface, portchannel commands (#878)
Update Command-Reference.md (#1075)
[filter-fdb] Fix Filter FDB With IPv6 Present in Config DB (#1059)
[config] Remove _get_breakout_cfg_file_name helper function (#1069)
[SHOW][BGP] support show ip(v6) bgp summary for multi asic platform (#1064)
[fanshow] Display other fan status, such as Updating (#1014)
Add ip_prefix len based on proxy_arp status (#1046)
Enable the platform specific ssd firmware upgrade during reboot (#954)
[show][cli[show interface portchannel support for Multi ASIC (#1005)
support show interface commands for multi ASIC platforms (#1006)

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>


