### PR TITLE
[docker-sonic-vs] Set PLATFORM and HWSKU env vars in Dockerfile

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -151,4 +151,8 @@ RUN rm /etc/frr/frr.conf
 # Create /var/warmboot/teamd folder for teammgrd
 RUN mkdir -p /var/warmboot/teamd
 
+# Set PLATFORM and HWSKU environment variables
+ENV PLATFORM=x86_64-kvm_x86_64-r0
+ENV HWSKU=Force10-S6000
+
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -e
 
-# generate configuration
+# Generate configuration
 
-export PLATFORM=x86_64-kvm_x86_64-r0
-export HWSKU=Force10-S6000
+# NOTE: 'PLATFORM' and 'HWSKU' environment variables are set
+# in the Dockerfile so that they persist for the life of the container
 
 ln -sf /usr/share/sonic/device/$PLATFORM/$HWSKU /usr/share/sonic/hwsku
 


### PR DESCRIPTION
**- Why I did it**
sonic-py-common package relies on the `PLATFORM` environment variable to be set at runtime in the SONiC VS container. Exporting the variables in the start.sh script causes the variables to only be available to the shell running start.sh and any subshells it spawns. However, once the script exits, the variable is lost. This is resulting in the failure of tests which are run in the VS container, as they call applications which in turn call sonic-py-common functions which rely on `PLATFORM` to be set (e.g., https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/buildimage-vs-all-pr/4805/console)

Setting the environment variables in the Dockerfile allows them to persist through the entire runtime of the container.

**- How I did it**
Set the `PLATFORM` and `HWSKU` environment variables in the docker-sonic-vs Dockerfile rather than the start.sh script.

**- How to verify it**
Enter the SONiC VS container and ensure the following output is correct:
```bash
echo $PLATFORM
echo $HWSKU
```
**- Which release branch to backport (provide reason below if selected)**
- [ ] 201811
- [ ] 201911
- [ ] 202006