### PR TITLE
[docker-sonic-vs] Create /usr/share/sonic/platform symlink

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -136,7 +136,6 @@ COPY ["chassis_db.py", "/usr/bin/"]
 
 COPY ["platform.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/"]
 COPY ["hwsku.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/"]
-COPY ["platform.json", "/usr/share/sonic/platform/"]
 
 # Workaround the tcpdump issue
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -5,6 +5,7 @@
 export PLATFORM=x86_64-kvm_x86_64-r0
 export HWSKU=Force10-S6000
 
+ln -sf /usr/share/sonic/device/$PLATFORM /usr/share/sonic/platform
 ln -sf /usr/share/sonic/device/$PLATFORM/$HWSKU /usr/share/sonic/hwsku
 
 pushd /usr/share/sonic/hwsku


### PR DESCRIPTION
**- Why I did it**
Copying platform.json file into an empty /usr/share/sonic/platform directory does not mimic an actual device. A more correct approach is to create a /usr/share/sonic/platform symlink which links to the actual platform directory; this is more like what is done inside SONiC containers. Then, we only need to copy the platform.json file into the actual platform directory; the symlink takes care of the alternative path, and also exposes all the other files in the platform directory.

One question: Since the SONiC VS container mimics the host OS of a physical switch, do we even need to create the /usr/share/sonic/platform and /usr/share/sonic/hwsku symlinks? Maybe we can remove these in a future patch.

**- How I did it**
Create /usr/share/sonic/platform symlink in start.sh

**- How to verify it**
Start a SONiC VS container and ensure the symlink exists.

**- Which release branch to backport (provide reason below if selected)**
- [ ] 201811
- [ ] 201911
- [ ] 202006