### PR TITLE
[sonic-py-common] Relocate some functions from sonic-utilities

### DIFF
--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -1,4 +1,8 @@
 """
+SONiC interface types and access functions.
+"""
+
+"""
  Dictionary of SONIC interface name prefixes. Each entry in the format
  "Human readable interface string":"Sonic interface prefix"
  Currently this is a static mapping, but in future could be stored as metadata in DB.
@@ -41,3 +45,39 @@ def loopback_prefix():
     Retrieves the SONIC Loopback interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["Loopback"]
+
+def get_interface_table_name(interface_name):
+    """Get table name by interface_name prefix
+    """
+    if interface_name.startswith(front_panel_prefix()):
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            return "VLAN_SUB_INTERFACE"
+        return "INTERFACE"
+    elif interface_name.startswith(portchannel_prefix()):
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            return "VLAN_SUB_INTERFACE"
+        return "PORTCHANNEL_INTERFACE"
+    elif interface_name.startswith(vlan_prefix()):
+        return "VLAN_INTERFACE"
+    elif interface_name.startswith(loopback_prefix()):
+        return "LOOPBACK_INTERFACE"
+    else:
+        return ""
+
+def get_port_table_name(interface_name):
+    """Get table name by port_name prefix
+    """
+    if interface_name.startswith(front_panel_prefix()):
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            return "VLAN_SUB_INTERFACE"
+        return "PORT"
+    elif interface_name.startswith(portchannel_prefix()):
+        if VLAN_SUB_INTERFACE_SEPARATOR in interface_name:
+            return "VLAN_SUB_INTERFACE"
+        return "PORTCHANNEL"
+    elif interface_name.startswith(vlan_prefix()):
+        return "VLAN_INTERFACE"
+    elif interface_name.startswith(loopback_prefix()):
+        return "LOOPBACK_INTERFACE"
+    else:
+        return ""

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -16,6 +16,8 @@ SONIC_INTERFACE_PREFIXES = {
     "Ethernet-Backplane": "Ethernet-BP"
 }
 
+VLAN_SUB_INTERFACE_SEPARATOR = '.'
+
 def front_panel_prefix():
     """
     Retrieves the SONIC front panel interface name prefix.

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -344,3 +344,15 @@ def get_asic_index_from_namespace(namespace):
         return int(get_asic_id_from_name(namespace))
 
     return 0
+
+# Validate whether a given namespace name is valid in the device.
+# This API is significant in multi-asic platforms.
+def validate_namespace(namespace):
+    if not multi_asic.is_multi_asic():
+        return True
+
+    namespaces = get_all_namespaces()
+    if namespace in namespaces['front_ns'] + namespaces['back_ns']:
+        return True
+    else:
+        return False

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -348,7 +348,7 @@ def get_asic_index_from_namespace(namespace):
 # Validate whether a given namespace name is valid in the device.
 # This API is significant in multi-asic platforms.
 def validate_namespace(namespace):
-    if not multi_asic.is_multi_asic():
+    if not is_multi_asic():
         return True
 
     namespaces = get_all_namespaces()

--- a/src/sonic-py-common/tests/interface_test.py
+++ b/src/sonic-py-common/tests/interface_test.py
@@ -1,22 +1,7 @@
 import os
 import sys
 
-# TODO: Remove this if/else block once we no longer support Python 2
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    # Expect the 'mock' package for python 2
-    # https://pypi.python.org/pypi/mock
-    import mock
-
 from sonic_py_common import interface
-
-
-# TODO: Remove this if/else block once we no longer support Python 2
-if sys.version_info.major == 3:
-    BUILTINS = "builtins"
-else:
-    BUILTINS = "__builtin__"
 
 class TestInterface(object):
     @classmethod

--- a/src/sonic-py-common/tests/interface_test.py
+++ b/src/sonic-py-common/tests/interface_test.py
@@ -1,0 +1,56 @@
+import os
+import sys
+
+# TODO: Remove this if/else block once we no longer support Python 2
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    # Expect the 'mock' package for python 2
+    # https://pypi.python.org/pypi/mock
+    import mock
+
+from sonic_py_common import interface
+
+
+# TODO: Remove this if/else block once we no longer support Python 2
+if sys.version_info.major == 3:
+    BUILTINS = "builtins"
+else:
+    BUILTINS = "__builtin__"
+
+class TestInterface(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    def test_get_interface_table_name(self):
+        result = interface.get_interface_table_name("Ethernet0")
+        assert result == "INTERFACE"
+        result = interface.get_interface_table_name("Ethernet0.100")
+        assert result == "VLAN_SUB_INTERFACE"
+        result = interface.get_interface_table_name("PortChannel0")
+        assert result == "PORTCHANNEL_INTERFACE"
+        result = interface.get_interface_table_name("PortChannel0.100")
+        assert result == "VLAN_SUB_INTERFACE"
+        result = interface.get_interface_table_name("Vlan100")
+        assert result == "VLAN_INTERFACE"
+        result = interface.get_interface_table_name("Loopback0")
+        assert result == "LOOPBACK_INTERFACE"
+
+    def test_get_port_table_name(self):
+        result = interface.get_port_table_name("Ethernet0")
+        assert result == "PORT"
+        result = interface.get_port_table_name("Ethernet0.100")
+        assert result == "VLAN_SUB_INTERFACE"
+        result = interface.get_port_table_name("PortChannel0")
+        assert result == "PORTCHANNEL"
+        result = interface.get_port_table_name("PortChannel0.100")
+        assert result == "VLAN_SUB_INTERFACE"
+        result = interface.get_port_table_name("Vlan100")
+        assert result == "VLAN_INTERFACE"
+        result = interface.get_port_table_name("Loopback0")
+        assert result == "LOOPBACK_INTERFACE"
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")


### PR DESCRIPTION
Move the common multi-asic/general functions from sonic-utilities to py-common 
validate_namespace()
get_port_table_name()
get_interface_table_name() 