### PR TITLE
[201811][Build] pin down setuptools for build issues

### DIFF
--- a/dockers/docker-snmp-sv2/Dockerfile.j2
+++ b/dockers/docker-snmp-sv2/Dockerfile.j2
@@ -33,6 +33,11 @@ RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return
 
 # Install up-to-date version of pip
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6
+
+# pin down setuptools version for issues to install sonic_ax_impl
+# see https://github.com/Azure/sonic-buildimage/issues/5279
+RUN python3.6 -m pip install setuptools==49.6.0
+
 RUN python3.6 -m pip install --no-cache-dir hiredis
 
 # Install pyyaml dependency for use by some plugins


### PR DESCRIPTION
[Build] pin down setuptools for build issues

See: https://github.com/Azure/sonic-buildimage/issues/5279

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Build failed

**- How I did it**
pin down the setuptools version

**- How to verify it**
Build successfully after the fix

**- Which release branch to backport (provide reason below if selected)**
It should go to 201811 and 201911

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
