### PR TITLE
Secure boot

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -147,6 +147,8 @@ sudo openssl req -new -x509 -newkey rsa:2048 -subj "/CN=db/" -keyout kernel_db.k
 sudo openssl x509 -in kernel_db.crt -outform der -out kernel_db.der
 sudo sbsign --key kernel_db.key --cert kernel_db.crt --output fsroot/boot/vmlinuz-4.19.0-9-2-amd64 fsroot/boot/vmlinuz-4.19.0-9-2-amd64
 
+sudo apt-get -y install mokutil
+
 ## Update initramfs for booting with squashfs+overlay
 cat files/initramfs-tools/modules | sudo tee -a $FILESYSTEM_ROOT/etc/initramfs-tools/modules > /dev/null
 

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -142,10 +142,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install dmidecode hdparm
 fi
-    sudo apt-get install efitools
-    sudo openssl req -new -x509 -newkey rsa:2048 -subj "/CN=db/" -keyout kernel_db.key -out kernel_db.crt -days 365 -nodes -sha256
-    sudo openssl x509 -in kernel_db.crt -outform der -out kernel_db.der
-    sudo sbsign --key kernel_db.key --cert kernel_db.crt --output fsroot/boot/vmlinuz-4.19.0-9-2-amd64 fsroot/boot/vmlinuz-4.19.0-9-2-amd64
+sudo apt-get -y install efitools
+sudo openssl req -new -x509 -newkey rsa:2048 -subj "/CN=db/" -keyout kernel_db.key -out kernel_db.crt -days 365 -nodes -sha256
+sudo openssl x509 -in kernel_db.crt -outform der -out kernel_db.der
+sudo sbsign --key kernel_db.key --cert kernel_db.crt --output fsroot/boot/vmlinuz-4.19.0-9-2-amd64 fsroot/boot/vmlinuz-4.19.0-9-2-amd64
 
 ## Update initramfs for booting with squashfs+overlay
 cat files/initramfs-tools/modules | sudo tee -a $FILESYSTEM_ROOT/etc/initramfs-tools/modules > /dev/null

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -320,6 +320,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     cron                    \
     haveged
 
+## Secure boot signed shim and grub
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \
+    grub-efi-amd64-signed           \
+    shim-signed
 
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -142,6 +142,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install dmidecode hdparm
 fi
+    sudo apt-get install efitools
+    sudo openssl req -new -x509 -newkey rsa:2048 -subj "/CN=db/" -keyout kernel_db.key -out kernel_db.crt -days 365 -nodes -sha256
+    sudo openssl x509 -in kernel_db.crt -outform der -out kernel_db.der
+    sudo sbsign --key kernel_db.key --cert kernel_db.crt --output fsroot/boot/vmlinuz-4.19.0-9-2-amd64 fsroot/boot/vmlinuz-4.19.0-9-2-amd64
 
 ## Update initramfs for booting with squashfs+overlay
 cat files/initramfs-tools/modules | sudo tee -a $FILESYSTEM_ROOT/etc/initramfs-tools/modules > /dev/null

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -412,7 +412,7 @@ demo_install_uefi_grub()
     efibootmgr --quiet --create \
         --label "$demo_volume_label" \
         --disk $blk_dev --part $uefi_part \
-        --loader "/EFI/$demo_volume_label/grubx64.efi" || {
+        --loader "/EFI/$demo_volume_label/shimx64.efi" || {
         echo "ERROR: efibootmgr failed to create new boot variable on: $blk_dev"
         exit 1
     }

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -310,7 +310,9 @@ RUN apt-get update && apt-get install -y \
 # For SWI Tools
         python-m2crypto \
 # For build dtb
-	device-tree-compiler
+	device-tree-compiler \
+# For secure boot signing
+	efitools
 
 ## Config dpkg
 ## install the configuration file if it’s currently missing


### PR DESCRIPTION
- Why I did it
To make SONiC boot with signed shim and grub when secure boot is enabled
Allow secure boot key signing and secure boot verification

- How I did it
Added signed grub and shim binary packages
Boot with shim instead of grub
Added efitools and mokutil 

- How to verify it
Use sbsign to sign binaries and mokutil to check secure boot state
Check if the following exists:
/usr/lib/shim/shimx64.efi.signed
/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed

