### PR TITLE
[build] - Create system eeprom file

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -151,6 +151,10 @@ function postStartAction()
             docker cp $PSENSOR pmon:/usr/bin/
         fi
     fi
+
+    # Write contents of system EEPROM as JSON file
+    sudo /usr/bin/decode-syseeprom | /usr/bin/syseeprom-to-json | sudo tee /var/platform/syseeprom > /dev/null
+
 {%- else %}
     : # nothing
 {%- endif %}


### PR DESCRIPTION
* Create the system eeprom JSON file that is used in the sonic-mgmt-framework
  KLISH CLI.

Signed-off-by: Garrick He <garrick_he@dell.com>

**- Why I did it**
When you enter the sonic-mgmt-framework CLI with the command: 

`sonic-cli`

and execute: `show platform syseeprom`

You will get an error. This is due to the missing syseeprom.json.

**- How I did it**
Add the command to create the syseeprom.json file if the pmon container is present.

**- How to verify it**
Created the missing file using the command-line in this diff and verified the system eeprom information appears instead of a error message.
