### PR TITLE
Secure boot 

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -314,7 +314,11 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     cron                    \
     haveged
 
-
+## Secure boot signed shim and grub
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \
+    grub-efi-amd64-signed           \
+    shim-signed
+    
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -312,12 +312,13 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     python-pip              \
     python3-pip             \
     cron                    \
-    haveged
+    haveged                 
 
-## Secure boot signed shim and grub
+## Secure boot signed shim grub and signing tool    
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \
     grub-efi-amd64-signed           \
-    shim-signed
+    shim-signed         \
+    efitools
     
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -314,11 +314,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     cron                    \
     haveged                 
 
-## Secure boot signed shim grub and signing tool    
+## Secure boot signed shim grub 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \
     grub-efi-amd64-signed           \
-    shim-signed         \
-    efitools
+    shim-signed         
     
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -310,7 +310,10 @@ RUN apt-get update && apt-get install -y \
 # For SWI Tools
         python-m2crypto \
 # For build dtb
-	device-tree-compiler
+	device-tree-compiler \
+# For secure boot key signing and import
+	efitools \
+	mokutil
 
 ## Config dpkg
 ## install the configuration file if it’s currently missing


### PR DESCRIPTION
- Why I did it
Add signed shim and grub, secure boot key signing and importing tools

- How I did it
Add corresponding packages

- How to verify it
Verify secure boot state and import keys with mokutil
Sign binaries with sbsign
Check if the following exist:
/usr/lib/shim/shimx64.efi.signed
/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed
