### PR TITLE
[redis] Add redis Group And Grant Read/Write Access to Members

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -246,7 +246,7 @@ sudo sed -i '/After=/s/$/ containerd.service/' $FILESYSTEM_ROOT/lib/systemd/syst
 sudo LANG=C chroot $FILESYSTEM_ROOT groupadd -f redis
 
 ## Create default user
-## Note: user should be in the group with the same name, and also in sudo/docker/redis group
+## Note: user should be in the group with the same name, and also in sudo/docker/redis groups
 sudo LANG=C chroot $FILESYSTEM_ROOT useradd -G sudo,docker,redis $USERNAME -c "$DEFAULT_USERINFO" -m -s /bin/bash
 ## Create password for the default user
 echo "$USERNAME:$PASSWORD" | sudo LANG=C chroot $FILESYSTEM_ROOT chpasswd

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -242,9 +242,12 @@ sudo cp files/docker/docker.service.conf $_
 ## Fix systemd race between docker and containerd
 sudo sed -i '/After=/s/$/ containerd.service/' $FILESYSTEM_ROOT/lib/systemd/system/docker.service
 
+## Create redis group
+sudo LANG=C chroot $FILESYSTEM_ROOT groupadd -f redis
+
 ## Create default user
-## Note: user should be in the group with the same name, and also in sudo/docker group
-sudo LANG=C chroot $FILESYSTEM_ROOT useradd -G sudo,docker $USERNAME -c "$DEFAULT_USERINFO" -m -s /bin/bash
+## Note: user should be in the group with the same name, and also in sudo/docker/redis group
+sudo LANG=C chroot $FILESYSTEM_ROOT useradd -G sudo,docker,redis $USERNAME -c "$DEFAULT_USERINFO" -m -s /bin/bash
 ## Create password for the default user
 echo "$USERNAME:$PASSWORD" | sudo LANG=C chroot $FILESYSTEM_ROOT chpasswd
 

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -131,6 +131,9 @@ function postStartAction()
             /usr/bin/db_migrator.py -o migrate
         fi
     fi
+    # Add redis UDS to the redis group and give read/write access to the group
+    REDIS_SOCK="/var/run/redis/redis.sock"
+    chgrp -f redis $REDIS_SOCK && chmod -f 0760 $REDIS_SOCK
 {%- elif docker_container_name == "swss" %}
     docker exec swss$DEV rm -f /ready   # remove cruft
     if [[ "$BOOT_TYPE" == "fast" ]] && [[ -d /host/fast-reboot ]]; then

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -132,7 +132,7 @@ function postStartAction()
         fi
     fi
     # Add redis UDS to the redis group and give read/write access to the group
-    REDIS_SOCK="/var/run/redis/redis.sock"
+    REDIS_SOCK="/var/run/redis${DEV}/redis.sock"
     chgrp -f redis $REDIS_SOCK && chmod -f 0760 $REDIS_SOCK
 {%- elif docker_container_name == "swss" %}
     docker exec swss$DEV rm -f /ready   # remove cruft
@@ -357,13 +357,8 @@ NAMESPACE_PREFIX="asic"
 if [ "$DEV" ]; then
     NET_NS="$NAMESPACE_PREFIX$DEV" #name of the network namespace
 
-    # While using -n (namespace) argument, sonic-cfggen/sonic-db-cli uses redis UNIX socket 
-    # for accessing redis DB in a namespace. This unix socket has permission restrictions since 
-    # it is created by systemd database.servce started with [User] as [root].
-    # sudo is needed here for services which are started by systemd with [User] as [admin]
-    # and needs to override this unix socket permission restrictions.
-    SONIC_CFGGEN="sudo sonic-cfggen -n $NET_NS"
-    SONIC_DB_CLI="sudo sonic-db-cli -n $NET_NS"
+    SONIC_CFGGEN="sonic-cfggen -n $NET_NS"
+    SONIC_DB_CLI="sonic-db-cli -n $NET_NS"
  else
     NET_NS=""
     SONIC_CFGGEN="sonic-cfggen"


### PR DESCRIPTION
sonic-cfggen is now using Unix Domain Socket for Redis DB. The socket
is created using root account. Subsequently, services that are started
as admin fail to start. This PR creates redis group and add admin
user to redis group. It also grants read/write access on redis.sock
for redis group members.

closes #5277 
resolves #5277 

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
Access to redis.sock fails when using admin account

**- How I did it**
Added `redis` group
Changed `redis.sock` group to the new group `redis`
Gave read/write access to `redis` group on `redis.sock`

**- How to verify it**
without this change
```
admin@str-s6000-acs-14:~$ groups
admin sudo docker

admin@str-s6000-acs-14:~$ ls -alrt /var/run/redis/redis.sock 
srwx------ 1 root root 0 Aug 31 18:48 /var/run/redis/redis.sock

admin@str-s6000-acs-14:~$ sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'
Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 420, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 347, in main
    configdb.connect()
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/configdb.py", line 74, in connect
    self.db_connect('CONFIG_DB', wait_for_init, retry_on)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/configdb.py", line 69, in db_connect
    SonicV2Connector.connect(self, self.db_name, retry_on)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/dbconnector.py", line 250, in connect
    self.dbintf.connect(db_id, retry_on)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/interface.py", line 171, in connect
    self._onetime_connect(db_id)
  File "/usr/local/lib/python2.7/dist-packages/swsssdk/interface.py", line 183, in _onetime_connect
    client.config_set('notify-keyspace-events', self.KEYSPACE_EVENTS)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 1243, in config_set
    return self.execute_command('CONFIG SET', name, value)
  File "/usr/local/lib/python2.7/dist-packages/redis/client.py", line 898, in execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 1192, in get_connection
    connection.connect()
  File "/usr/local/lib/python2.7/dist-packages/redis/connection.py", line 563, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 13 connecting to unix socket: /var/run/redis/redis.sock. Permission denied.
```
with this change
```
admin@str-s6000-acs-14:~$ groups
admin sudo docker redis

admin@str-s6000-acs-14:~$ ls -alrt /var/run/redis/redis.sock 
srwxrw---- 1 root redis 0 Aug 31 23:00 /var/run/redis/redis.sock

admin@str-s6000-acs-14:~$ sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'
Force10-S6000
```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
