### PR TITLE
Pass pid of process as seen  in host to coredump_compress script

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -393,7 +393,7 @@ sudo mkdir -p $FILESYSTEM_ROOT/var/core
 
 # Config sysctl
 sudo augtool --autosave "
-set /files/etc/sysctl.conf/kernel.core_pattern '|/usr/bin/coredump-compress %e %t %p'
+set /files/etc/sysctl.conf/kernel.core_pattern '|/usr/bin/coredump-compress %e %t %p %P'
 set /files/etc/sysctl.conf/kernel.softlockup_panic 1
 set /files/etc/sysctl.conf/kernel.panic 10
 set /files/etc/sysctl.conf/vm.panic_on_oom 2


### PR DESCRIPTION
This would enable the coredump_compress script to retrieve additional info regarding the crashing process.
  
**- Why I did it**
To facilitate coredump_compress script. Currently there is a need to identify the namespace of a crashing  process.

**- How I did it**
By passing %P as part of core-pattern, which translates to "` %P  PID of dumped process, as seen in the initial PID namespace`"

**- How to verify it**
You can use the last parameter to be able look  into /proc/<pid>/ folder for crashing process from the coredump_compress script.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] 201911
- [x] 202006

Backport to all branches that support multi-asic.

