### PR TITLE
[warm-boot] Fix the issue as reported in https://github.com/Azure/sonic-buildimage/issues/5255

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -49,11 +49,7 @@ HWSKU=${HWSKU:-`sonic-cfggen -d -v "DEVICE_METADATA['localhost']['hwsku']"`}
 SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
 SWSS_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|swss" enable`
 if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; then
-  # We have to make sure db data has not been flushed.
-  RESTORE_COUNT=`sonic-db-cli STATE_DB hget "WARM_RESTART_TABLE|orchagent" restore_count`
-  if [[ -n "$RESTORE_COUNT" ]] && [[ "$RESTORE_COUNT" != "0" ]]; then
-    exit 0
-  fi
+  exit 0
 fi
 
 SWSSCONFIG_ARGS="00-copp.config.json ipinip.json ports.json switch.json "


### PR DESCRIPTION
Why I did:

Fixes the issue https://github.com/Azure/sonic-buildimage/issues/5255

Root Cause: Waiting on Restore count != 0 can lead to race condition
between orchagent process and swssconfig.sh.

Ideally check of  Restore count != 0 is not needed as the State DB
cannot be flushed as if it was flushed then Warm Restart or swss-restart
enable flag should not be true also.

How I verify:
After removing check did not hit race condition that resulted the error.
