### PR TITLE
[multi-Asic] Add support for multi-asic to swssloglevel

### DIFF
--- a/dockers/docker-orchagent/base_image_files/swssloglevel
+++ b/dockers/docker-orchagent/base_image_files/swssloglevel
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# read SONiC immutable variables
+[ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
+
+function help()
+{
+    echo -e "Usage: $0 -n [0 to $(($NUM_ASIC-1))] [OPTION]... " 1>&2; exit 1;
+}
+
 DOCKER_EXEC_FLAGS="i"
 
 # Determine whether stdout is on a terminal
@@ -7,19 +15,12 @@ if [ -t 1 ] ; then
     DOCKER_EXEC_FLAGS+="t"
 fi
 
-function help()
-{
-    echo -e "Usage: $0 -n [0 to $(($NUM_ASIC-1))] [OPTION]... " 1>&2; exit 1;
-}
-
 DEV=""
-PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
 
 # Parse the device specific asic conf file, if it exists
 ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
-if [ -f "$ASIC_CONF" ]; then
-    source $ASIC_CONF
-fi
+[ -f $ASIC_CONF ] && . $ASIC_CONF
 
 if [[ ($NUM_ASIC -gt 1) ]]; then
     while getopts ":n:h:" opt; do

--- a/dockers/docker-orchagent/base_image_files/swssloglevel
+++ b/dockers/docker-orchagent/base_image_files/swssloglevel
@@ -22,23 +22,22 @@ if [ -f "$ASIC_CONF" ]; then
 fi
 
 if [[ ($NUM_ASIC -gt 1) ]]; then
-    OPTIND=1
-
     while getopts ":n:h:" opt; do
         case "${opt}" in
             h) help
-               exit 0
                ;;
             n) DEV=${OPTARG}
                [ $DEV -lt $NUM_ASIC -a  $DEV -ge 0 ] || help
                ;;
         esac
     done
-    shift "$((OPTIND-1))"
 
     if [ -z "${DEV}" ]; then
         help
     fi
+
+    # Skip the arguments -n <inst> while passing to docker command
+    shift 2
 fi
 
 docker exec -$DOCKER_EXEC_FLAGS swss$DEV swssloglevel "$@"

--- a/dockers/docker-orchagent/base_image_files/swssloglevel
+++ b/dockers/docker-orchagent/base_image_files/swssloglevel
@@ -9,7 +9,7 @@ fi
 
 function help()
 {
-    echo -e "\n Usage: $0 -n [0 to $(($NUM_ASIC-1))], where n is the namespace instance \n" 1>&2; exit 1;
+    echo -e "Usage: $0 -n [0 to $(($NUM_ASIC-1))], where n is the namespace instance" 1>&2; exit 1;
 }
 
 DEV=""

--- a/dockers/docker-orchagent/base_image_files/swssloglevel
+++ b/dockers/docker-orchagent/base_image_files/swssloglevel
@@ -9,7 +9,7 @@ fi
 
 function help()
 {
-    echo -e "Usage: $0 -n [0 to $(($NUM_ASIC-1))], where n is the namespace instance" 1>&2; exit 1;
+    echo -e "Usage: $0 -n [0 to $(($NUM_ASIC-1))] [OPTION]... " 1>&2; exit 1;
 }
 
 DEV=""

--- a/dockers/docker-orchagent/base_image_files/swssloglevel
+++ b/dockers/docker-orchagent/base_image_files/swssloglevel
@@ -7,4 +7,38 @@ if [ -t 1 ] ; then
     DOCKER_EXEC_FLAGS+="t"
 fi
 
-docker exec -$DOCKER_EXEC_FLAGS swss swssloglevel "$@"
+function help()
+{
+    echo -e "\n Usage: $0 -n [0 to $(($NUM_ASIC-1))], where n is the namespace instance \n" 1>&2; exit 1;
+}
+
+DEV=""
+PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+
+# Parse the device specific asic conf file, if it exists
+ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
+if [ -f "$ASIC_CONF" ]; then
+    source $ASIC_CONF
+fi
+
+if [[ ($NUM_ASIC -gt 1) ]]; then
+    OPTIND=1
+
+    while getopts ":n:h:" opt; do
+        case "${opt}" in
+            h) help
+               exit 0
+               ;;
+            n) DEV=${OPTARG}
+               [ $DEV -lt $NUM_ASIC -a  $DEV -ge 0 ] || help
+               ;;
+        esac
+    done
+    shift "$((OPTIND-1))"
+
+    if [ -z "${DEV}" ]; then
+        help
+    fi
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS swss$DEV swssloglevel "$@"


### PR DESCRIPTION
**- Why I did it**
Add the option -n to specify the swss docker instance running in a particular namespace to invoke swssloglevel. 
 
**- How I did it**
Update the script swssloglevel.

**- How to verify it**

The following options in multi-asic platform.
```
admin@str-acs-1:~$ swssloglevel 
Usage: /usr/bin/swssloglevel -n [0 to 3] [OPTION]... 
admin@str-acs-1:~$ swssloglevel -h
Usage: /usr/bin/swssloglevel -n [0 to 3] [OPTION]...
admin@str--acs-1:~$ swssloglevel -n 0 
Invalid loglevel value

Usage: swssloglevel [OPTIONS]
SONiC logging severity level setting.

Options:
	 -h	print this message
	 -l	loglevel value
	 -c	component name in DB for which loglevel is applied (provided with -l)
	 -a	apply loglevel to all components (provided with -l)
	 -s	apply loglevel for SAI api component (equivalent to adding prefix "SAI_API_" to component)
	 -p	print components registered in DB for which setting can be applied

Examples:
	swssloglevel -l NOTICE -c orchagent # set orchagent severity level to NOTICE
	swssloglevel -l SAI_LOG_LEVEL_ERROR -s -c SWITCH # set SAI_API_SWITCH severity to ERROR
	swssloglevel -l SAI_LOG_LEVEL_DEBUG -s -a # set all SAI_API_* severity to DEBUG
admin@str--acs-1:~$ swssloglevel -n 0 -l SAI_LOG_LEVEL_DEBUG -s -a
admin@str--acs-1:~$ 

```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x ] 201911
- [ x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
