### PR TITLE
[dhcpmon] Monitor Mgmt Interface For DHCP Packets

### DIFF
--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -137,6 +137,11 @@ command=/usr/sbin/dhcpmon -id {{ vlan_name }}
 {% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
 {% endfor %}
+{% if MGMT_INTERFACE %}
+{% for (name, prefix) in MGMT_INTERFACE|pfx_filter %}
+{% if prefix | ipv4 %} -im {{ name }}{% endif %}
+{% endfor %}
+{% endif %}
 
 priority=4
 autostart=false

--- a/src/dhcpmon/src/dhcp_device.c
+++ b/src/dhcpmon/src/dhcp_device.c
@@ -24,7 +24,7 @@
 
 #include "dhcp_device.h"
 
-/** Counter printer width */
+/** Counter print width */
 #define DHCP_COUNTER_WIDTH  10
 
 /** Start of Ether header of a captured frame */
@@ -233,11 +233,11 @@ static void read_callback(int fd, short event, void *arg)
 static bool dhcp_device_is_dhcp_inactive(uint64_t counters[][DHCP_DIR_COUNT][DHCP_MESSAGE_TYPE_COUNT])
 {
     uint64_t *rx_counters = counters[DHCP_COUNTERS_CURRENT][DHCP_RX];
-    uint64_t *rx_coutner_snapshot = counters[DHCP_COUNTERS_SNAPSHOT][DHCP_RX];
+    uint64_t *rx_counter_snapshot = counters[DHCP_COUNTERS_SNAPSHOT][DHCP_RX];
 
     bool rv = true;
     for (uint8_t i = 0; (i < monitored_msg_sz) && rv; i++) {
-        rv = rx_counters[monitored_msgs[i]] == rx_coutner_snapshot[monitored_msgs[i]];
+        rv = rx_counters[monitored_msgs[i]] == rx_counter_snapshot[monitored_msgs[i]];
     }
 
     return rv;
@@ -302,11 +302,11 @@ static dhcp_mon_status_t dhcp_device_check_negative_health(uint64_t counters[][D
     dhcp_mon_status_t rv = DHCP_MON_STATUS_HEALTHY;
 
     uint64_t *tx_counters = counters[DHCP_COUNTERS_CURRENT][DHCP_TX];
-    uint64_t *tx_coutner_snapshot = counters[DHCP_COUNTERS_SNAPSHOT][DHCP_TX];
+    uint64_t *tx_counter_snapshot = counters[DHCP_COUNTERS_SNAPSHOT][DHCP_TX];
 
     bool is_dhcp_unhealthy = false;
     for (uint8_t i = 0; (i < monitored_msg_sz) && !is_dhcp_unhealthy; i++) {
-        is_dhcp_unhealthy = tx_counters[monitored_msgs[i]] > tx_coutner_snapshot[monitored_msgs[i]];
+        is_dhcp_unhealthy = tx_counters[monitored_msgs[i]] > tx_counter_snapshot[monitored_msgs[i]];
     }
 
     // for negative validation, return unhealthy if DHCP packet are being

--- a/src/dhcpmon/src/dhcp_device.c
+++ b/src/dhcpmon/src/dhcp_device.c
@@ -246,7 +246,8 @@ static bool dhcp_device_is_dhcp_inactive(uint64_t counters[][DHCP_DIR_COUNT][DHC
 /**
  * @code dhcp_device_is_dhcp_msg_unhealthy(type, counters);
  *
- * @brief Check if there were no DHCP activity
+ * @brief Check if DHCP relay is functioning properly for message of type 'type'.
+ *        For every rx of message 'type', there should be increment of the same message type.
  *
  * @param type      DHCP message type
  * @param counters  current/snapshot counter
@@ -264,7 +265,8 @@ static bool dhcp_device_is_dhcp_msg_unhealthy(dhcp_message_type_t type,
 /**
  * @code dhcp_device_check_positive_health(counters, counters_snapshot);
  *
- * @brief validate current interface counters by comparing aggregate counters with snapshot counters.
+ * @brief Check if DHCP relay is functioning properly for monitored messages (Discover, Offer, Request, ACK.)
+ *        For every rx of monitored messages, there should be increment of the same message type.
  *
  * @param counters  current/snapshot counter
  *
@@ -290,7 +292,9 @@ static dhcp_mon_status_t dhcp_device_check_positive_health(uint64_t counters[][D
 /**
  * @code dhcp_device_check_negative_health(counters);
  *
- * @brief validate current interface counters by comparing aggregate counters with snapshot counters.
+ * @brief Check that DHCP relayed messages are not being transmitted out of this interface/dev
+ *        using its counters. The interface is negatively healthy if there are not DHCP message
+ *        travelling through it.
  *
  * @param counters              recent interface counter
  * @param counters_snapshot     snapshot counters
@@ -321,7 +325,11 @@ static dhcp_mon_status_t dhcp_device_check_negative_health(uint64_t counters[][D
 /**
  * @code dhcp_device_check_health(check_type, counters, counters_snapshot);
  *
- * @brief validate current interface counters by comparing aggregate counter with snapshot counters.
+ * @brief Check that DHCP relay is functioning properly given a check type. Positive check
+ *        indicates for every rx of DHCP message of type 'type', there would increment of
+ *        the corresponding TX of the same message type. While negative check indicates the
+ *        device should not be actively transmitting any DHCP messages. If it does, it is
+ *        considered unhealthy.
  *
  * @param check_type    type of health check
  * @param counters      current/snapshot counter

--- a/src/dhcpmon/src/dhcp_device.h
+++ b/src/dhcpmon/src/dhcp_device.h
@@ -17,6 +17,23 @@
 #include <event2/buffer.h>
 
 
+/**
+ * DHCP message types
+ **/
+typedef enum
+{
+    DHCP_MESSAGE_TYPE_DISCOVER = 1,
+    DHCP_MESSAGE_TYPE_OFFER    = 2,
+    DHCP_MESSAGE_TYPE_REQUEST  = 3,
+    DHCP_MESSAGE_TYPE_DECLINE  = 4,
+    DHCP_MESSAGE_TYPE_ACK      = 5,
+    DHCP_MESSAGE_TYPE_NAK      = 6,
+    DHCP_MESSAGE_TYPE_RELEASE  = 7,
+    DHCP_MESSAGE_TYPE_INFORM   = 8,
+
+    DHCP_MESSAGE_TYPE_COUNT
+} dhcp_message_type_t;
+
 /** packet direction */
 typedef enum
 {
@@ -25,6 +42,15 @@ typedef enum
 
     DHCP_DIR_COUNT
 } dhcp_packet_direction_t;
+
+/** counters type */
+typedef enum
+{
+    DHCP_COUNTERS_CURRENT,      /** DHCP current counters */
+    DHCP_COUNTERS_SNAPSHOT,     /** DHCP snapshot counters */
+
+    DHCP_COUNTERS_COUNT
+} dhcp_counters_type_t;
 
 /** dhcp health status */
 typedef enum
@@ -41,15 +67,6 @@ typedef enum
     DHCP_MON_CHECK_POSITIVE,    /** Validate that received DORA packets are relayed */
 } dhcp_mon_check_t;
 
-/** DHCP device (interface) health counters */
-typedef struct
-{
-    uint64_t discover;      /** DHCP discover packets */
-    uint64_t offer;         /** DHCP offer packets */
-    uint64_t request;       /** DHCP request packets */
-    uint64_t ack;           /** DHCP ack packets */
-} dhcp_device_counters_t;
-
 /** DHCP device (interface) context */
 typedef struct
 {
@@ -61,10 +78,8 @@ typedef struct
     char intf[IF_NAMESIZE];         /** device (interface) name */
     uint8_t *buffer;                /** buffer used to read socket data */
     size_t snaplen;                 /** snap length or buffer size */
-    dhcp_device_counters_t counters[DHCP_DIR_COUNT];
-                                    /** current counters of DORA packets */
-    dhcp_device_counters_t counters_snapshot[DHCP_DIR_COUNT];
-                                    /** counter snapshot */
+    uint64_t counters[DHCP_COUNTERS_COUNT][DHCP_DIR_COUNT][DHCP_MESSAGE_TYPE_COUNT];
+                                    /** current/snapshot counters of DHCP packets */
 } dhcp_device_context_t;
 
 /**

--- a/src/dhcpmon/src/dhcp_device.h
+++ b/src/dhcpmon/src/dhcp_device.h
@@ -34,6 +34,13 @@ typedef enum
     DHCP_MON_STATUS_INDETERMINATE,  /** DHCP relay health could not be determined */
 } dhcp_mon_status_t;
 
+/** dhcp check type */
+typedef enum
+{
+    DHCP_MON_CHECK_NEGATIVE,    /** Presence of relayed DHCP packets activity is flagged as unhealthy state */
+    DHCP_MON_CHECK_POSITIVE,    /** Validate that received DORA packets are relayed */
+} dhcp_mon_check_t;
+
 /** DHCP device (interface) health counters */
 typedef struct
 {
@@ -55,7 +62,7 @@ typedef struct
     uint8_t *buffer;                /** buffer used to read socket data */
     size_t snaplen;                 /** snap length or buffer size */
     dhcp_device_counters_t counters[DHCP_DIR_COUNT];
-                                    /** current coutners of DORA packets */
+                                    /** current counters of DORA packets */
     dhcp_device_counters_t counters_snapshot[DHCP_DIR_COUNT];
                                     /** counter snapshot */
 } dhcp_device_context_t;
@@ -71,6 +78,15 @@ typedef struct
  * @return 0 on success, otherwise for failure
  */
 int dhcp_device_get_ip(dhcp_device_context_t *context, in_addr_t *ip);
+
+/**
+ * @code dhcp_device_get_aggregate_context();
+ *
+ * @brief Accessor method
+ *
+ * @return pointer to aggregate device (interface) context
+ */
+dhcp_device_context_t* dhcp_device_get_aggregate_context();
 
 /**
  * @code dhcp_device_init(context, intf, is_uplink);
@@ -116,21 +132,33 @@ int dhcp_device_start_capture(dhcp_device_context_t *context,
 void dhcp_device_shutdown(dhcp_device_context_t *context);
 
 /**
- * @code dhcp_device_get_status(context);
+ * @code dhcp_device_get_status(check_type, context);
  *
  * @brief collects DHCP relay status info for a given interface. If context is null, it will report aggregate
  *        status
  *
- * @param context   Device (interface) context
+ * @param check_type        Type of validation
+ * @param context           Device (interface) context
  *
  * @return DHCP_MON_STATUS_HEALTHY, DHCP_MON_STATUS_UNHEALTHY, or DHCP_MON_STATUS_INDETERMINATE
  */
-dhcp_mon_status_t dhcp_device_get_status(dhcp_device_context_t *context);
+dhcp_mon_status_t dhcp_device_get_status(dhcp_mon_check_t check_type, dhcp_device_context_t *context);
 
 /**
- * @code dhcp_device_print_status();
+ * @code dhcp_device_update_snapshot(context);
+ *
+ * @param context   Device (interface) context
+ *
+ * @brief Update device/interface counters snapshot
+ */
+void dhcp_device_update_snapshot(dhcp_device_context_t *context);
+
+/**
+ * @code dhcp_device_print_status(context);
  *
  * @brief prints status counters to syslog. If context is null, it will print aggregate status
+ *
+ * @param context   Device (interface) context
  *
  * @return none
  */

--- a/src/dhcpmon/src/dhcp_devman.c
+++ b/src/dhcpmon/src/dhcp_devman.c
@@ -27,22 +27,34 @@ static LIST_HEAD(intf_list, intf) intfs;
 static uint32_t dhcp_num_south_intf = 0;
 /** dhcp_num_north_intf number of north interfaces */
 static uint32_t dhcp_num_north_intf = 0;
+/** dhcp_num_mgmt_intf number of mgmt interfaces */
+static uint32_t dhcp_num_mgmt_intf = 0;
 
 /** On Device  vlan interface IP address corresponding vlan downlink IP
  *  This IP is used to filter Offer/Ack packet coming from DHCP server */
 static in_addr_t vlan_ip = 0;
 
-/** vlan interface name */
-static char vlan_intf[IF_NAMESIZE] = "Undefined";
+/** mgmt interface */
+static struct intf *mgmt_intf = NULL;
 
 /**
  * @code dhcp_devman_get_vlan_intf();
  *
  * Accessor method
  */
-const char* dhcp_devman_get_vlan_intf()
+dhcp_device_context_t* dhcp_devman_get_agg_dev()
 {
-    return vlan_intf;
+    return dhcp_device_get_aggregate_context();
+}
+
+/**
+ * @code dhcp_devman_get_mgmt_dev();
+ *
+ * Accessor method
+ */
+dhcp_device_context_t* dhcp_devman_get_mgmt_dev()
+{
+    return mgmt_intf ? mgmt_intf->dev_context : NULL;
 }
 
 /**
@@ -86,27 +98,41 @@ void dhcp_devman_shutdown()
  *
  * @brief adds interface to the device manager.
  */
-int dhcp_devman_add_intf(const char *name, uint8_t is_uplink)
+int dhcp_devman_add_intf(const char *name, char intf_type)
 {
     int rv = -1;
     struct intf *dev = malloc(sizeof(struct intf));
 
     if (dev != NULL) {
         dev->name = name;
-        dev->is_uplink = is_uplink;
-        if (is_uplink) {
+        dev->is_uplink = intf_type != 'd';
+
+        switch (intf_type)
+        {
+        case 'u':
             dhcp_num_north_intf++;
-        } else {
+            break;
+        case 'd':
             dhcp_num_south_intf++;
             assert(dhcp_num_south_intf <= 1);
+            break;
+        case 'm':
+            dhcp_num_mgmt_intf++;
+            assert(dhcp_num_mgmt_intf <= 1);
+            mgmt_intf = dev;
+            break;
+        default:
+            break;
         }
 
         rv = dhcp_device_init(&dev->dev_context, dev->name, dev->is_uplink);
-        if (rv == 0 && !is_uplink) {
+        if (rv == 0 && intf_type == 'd') {
             rv = dhcp_device_get_ip(dev->dev_context, &vlan_ip);
 
-            strncpy(vlan_intf, name, sizeof(vlan_intf) - 1);
-            vlan_intf[sizeof(vlan_intf) - 1] = '\0';
+            dhcp_device_context_t *agg_dev = dhcp_device_get_aggregate_context();
+
+            strncpy(agg_dev->intf, name, sizeof(agg_dev->intf) - 1);
+            agg_dev->intf[sizeof(agg_dev->intf) - 1] = '\0';
         }
 
         LIST_INSERT_HEAD(&intfs, dev, entry);
@@ -152,21 +178,31 @@ int dhcp_devman_start_capture(size_t snaplen, struct event_base *base)
 }
 
 /**
- * @code dhcp_devman_get_status();
+ * @code dhcp_devman_get_status(check_type, context);
  *
  * @brief collects DHCP relay status info.
  */
-dhcp_mon_status_t dhcp_devman_get_status()
+dhcp_mon_status_t dhcp_devman_get_status(dhcp_mon_check_t check_type, dhcp_device_context_t *context)
 {
-    return dhcp_device_get_status(NULL);
+    return dhcp_device_get_status(check_type, context);
 }
 
 /**
- * @code dhcp_devman_print_status();
+ * @code dhcp_devman_update_snapshot(context);
+ *
+ * @brief Update device/interface counters snapshot
+ */
+void dhcp_devman_update_snapshot(dhcp_device_context_t *context)
+{
+    dhcp_device_update_snapshot(context);
+}
+
+/**
+ * @code dhcp_devman_print_status(context);
  *
  * @brief prints status counters to syslog
  */
-void dhcp_devman_print_status()
+void dhcp_devman_print_status(dhcp_device_context_t *context)
 {
-    dhcp_device_print_status(NULL);
+    dhcp_device_print_status(context);
 }

--- a/src/dhcpmon/src/dhcp_devman.h
+++ b/src/dhcpmon/src/dhcp_devman.h
@@ -36,9 +36,18 @@ void dhcp_devman_shutdown();
  *
  * @brief Accessor method
  *
- * @return pointer to vlan ip interface name
+ * @return pointer to aggregate device (interface) context
  */
-const char* dhcp_devman_get_vlan_intf();
+dhcp_device_context_t* dhcp_devman_get_agg_dev();
+
+/**
+ * @code dhcp_devman_get_mgmt_intf_context();
+ *
+ * @brief Accessor method
+ *
+ * @return pointer to mgmt interface context
+ */
+dhcp_device_context_t* dhcp_devman_get_mgmt_dev();
 
 /**
  * @code dhcp_devman_add_intf(name, uplink);
@@ -46,11 +55,13 @@ const char* dhcp_devman_get_vlan_intf();
  * @brief adds interface to the device manager.
  *
  * @param name              interface name
- * @param is_uplink         true for uplink (north) interface
+ * @param intf_type         'u' for uplink (north) interface
+ *                          'd' for downlink (south) interface
+ *                          'm' for mgmt interface
  *
  * @return 0 on success, nonzero otherwise
  */
-int dhcp_devman_add_intf(const char *name, uint8_t is_uplink);
+int dhcp_devman_add_intf(const char *name, char intf_type);
 
 /**
  * @code dhcp_devman_start_capture(snaplen, base);
@@ -65,21 +76,35 @@ int dhcp_devman_add_intf(const char *name, uint8_t is_uplink);
 int dhcp_devman_start_capture(size_t snaplen, struct event_base *base);
 
 /**
- * @code dhcp_devman_get_status();
+ * @code dhcp_devman_get_status(check_type, context);
  *
  * @brief collects DHCP relay status info.
  *
+ * @param check_type        Type of validation
+ * @param context           pointer to device (interface) context
+ *
  * @return DHCP_MON_STATUS_HEALTHY, DHCP_MON_STATUS_UNHEALTHY, or DHCP_MON_STATUS_INDETERMINATE
  */
-dhcp_mon_status_t dhcp_devman_get_status();
+dhcp_mon_status_t dhcp_devman_get_status(dhcp_mon_check_t check_type, dhcp_device_context_t *context);
 
 /**
- * @code dhcp_devman_print_status();
+ * @code dhcp_devman_update_snapshot(context);
+ *
+ * @param context           Device (interface) context
+ *
+ * @brief Update device/interface counters snapshot
+ */
+void dhcp_devman_update_snapshot(dhcp_device_context_t *context);
+
+/**
+ * @code dhcp_devman_print_status(context);
  *
  * @brief prints status counters to syslog
  *
+ * @param context       pointer to device (interface) context
+ *
  * @return none
  */
-void dhcp_devman_print_status();
+void dhcp_devman_print_status(dhcp_device_context_t *context);
 
 #endif /* DHCP_DEVMAN_H_ */

--- a/src/dhcpmon/src/dhcp_mon.c
+++ b/src/dhcpmon/src/dhcp_mon.c
@@ -40,7 +40,7 @@ static struct event *ev_sigterm;
 /** libevent SIGUSR1 signal event struct */
 static struct event *ev_sigusr1;
 
-/** DHCP monintor state data for aggregate device for mgmt device */
+/** DHCP monitor state data for aggregate device for mgmt device */
 static dhcp_mon_state_t state_data[] = {
     [0] = {
         .check_type = DHCP_MON_CHECK_POSITIVE,
@@ -82,7 +82,7 @@ static void signal_callback(evutil_socket_t fd, short event, void *arg)
  *
  * @brief check DHCP relay overall health
  *
- * @param state_data        pointer to dhcp mon state data
+ * @param state_data        pointer to dhcpmon state data
  *
  * @return none
  */

--- a/src/dhcpmon/src/dhcp_mon.c
+++ b/src/dhcpmon/src/dhcp_mon.c
@@ -71,27 +71,10 @@ static dhcp_mon_state_t state_data[] = {
 static void signal_callback(evutil_socket_t fd, short event, void *arg)
 {
     syslog(LOG_ALERT, "Received signal: '%s'\n", strsignal(fd));
-    dhcp_devman_print_status(dhcp_devman_get_agg_dev());
-    dhcp_devman_print_status(dhcp_devman_get_mgmt_dev());
-    dhcp_mon_stop();
-}
-
-/**
- * @code sigusr1_callback(fd, event, arg);
- *
- * @brief signal handler for dhcpmon. It will print internal counters when signal is caught
- *
- * @param fd        libevent socket
- * @param event     event triggered
- * @param arg       pointer to user provided context (libevent base)
- *
- * @return none
- */
-static void sigusr1_callback(evutil_socket_t fd, short event, void *arg)
-{
-    syslog(LOG_ALERT, "Received signal: '%s'\n", strsignal(fd));
-    dhcp_devman_print_status(dhcp_devman_get_agg_dev());
-    dhcp_devman_print_status(dhcp_devman_get_mgmt_dev());
+    dhcp_devman_print_status(NULL);
+    if ((fd == SIGTERM) || (fd == SIGINT)) {
+        dhcp_mon_stop();
+    }
 }
 
 /**
@@ -185,7 +168,7 @@ int dhcp_mon_init(int window_sec, int max_count)
             break;
         }
 
-        ev_sigusr1 = evsignal_new(base, SIGUSR1, sigusr1_callback, base);
+        ev_sigusr1 = evsignal_new(base, SIGUSR1, signal_callback, base);
         if (ev_sigusr1 == NULL) {
             syslog(LOG_ERR, "Could not create SIGUSER1 libevent signal!\n");
             break;

--- a/src/dhcpmon/src/dhcp_mon.c
+++ b/src/dhcpmon/src/dhcp_mon.c
@@ -16,8 +16,17 @@
 #include "dhcp_mon.h"
 #include "dhcp_devman.h"
 
+/** DHCP device/interface state */
+typedef struct
+{
+    dhcp_mon_check_t check_type;                /** check type */
+    dhcp_device_context_t* (*get_context)();    /** functor to a device context accessor function */
+    int count;                                  /** count in the number of unhealthy checks */
+    const char *msg;                            /** message to be printed if unhealthy state is determined */
+} dhcp_mon_state_t;
+
 /** window_interval_sec monitoring window for dhcp relay health checks */
-static int window_interval_sec = 12;
+static int window_interval_sec = 18;
 /** dhcp_unhealthy_max_count max count of consecutive unhealthy statuses before reporting to syslog */
 static int dhcp_unhealthy_max_count = 10;
 /** libevent base struct */
@@ -28,6 +37,25 @@ static struct event *ev_timeout = NULL;
 static struct event *ev_sigint;
 /** libevent SIGTERM signal event struct */
 static struct event *ev_sigterm;
+/** libevent SIGUSR1 signal event struct */
+static struct event *ev_sigusr1;
+
+/** DHCP monintor state data for aggregate device for mgmt device */
+static dhcp_mon_state_t state_data[] = {
+    [0] = {
+        .check_type = DHCP_MON_CHECK_POSITIVE,
+        .get_context = dhcp_devman_get_agg_dev,
+        .count = 0,
+        .msg = "dhcpmon detected disparity in DHCP Relay behavior. Duration: %d (sec) for vlan: '%s'\n"
+    },
+    [1] = {
+        .check_type = DHCP_MON_CHECK_NEGATIVE,
+        .get_context = dhcp_devman_get_mgmt_dev,
+        .count = 0,
+        .msg = "dhcpmon detected DHCP packets traveling through mgmt interface (please check BGP routes.)"
+               " Duration: %d (sec) for intf: '%s'\n"
+    }
+};
 
 /**
  * @code signal_callback(fd, event, arg);
@@ -42,9 +70,64 @@ static struct event *ev_sigterm;
  */
 static void signal_callback(evutil_socket_t fd, short event, void *arg)
 {
-    syslog(LOG_ALERT, "Received signal %s\n", strsignal(fd));
-    dhcp_devman_print_status();
+    syslog(LOG_ALERT, "Received signal: '%s'\n", strsignal(fd));
+    dhcp_devman_print_status(dhcp_devman_get_agg_dev());
+    dhcp_devman_print_status(dhcp_devman_get_mgmt_dev());
     dhcp_mon_stop();
+}
+
+/**
+ * @code sigusr1_callback(fd, event, arg);
+ *
+ * @brief signal handler for dhcpmon. It will print internal counters when signal is caught
+ *
+ * @param fd        libevent socket
+ * @param event     event triggered
+ * @param arg       pointer to user provided context (libevent base)
+ *
+ * @return none
+ */
+static void sigusr1_callback(evutil_socket_t fd, short event, void *arg)
+{
+    syslog(LOG_ALERT, "Received signal: '%s'\n", strsignal(fd));
+    dhcp_devman_print_status(dhcp_devman_get_agg_dev());
+    dhcp_devman_print_status(dhcp_devman_get_mgmt_dev());
+}
+
+/**
+ * @code check_dhcp_relay_health(state_data);
+ *
+ * @brief check DHCP relay overall health
+ *
+ * @param state_data        pointer to dhcp mon state data
+ *
+ * @return none
+ */
+static void check_dhcp_relay_health(dhcp_mon_state_t *state_data)
+{
+    dhcp_device_context_t *context = state_data->get_context();
+    dhcp_mon_status_t dhcp_mon_status = dhcp_devman_get_status(state_data->check_type, context);
+
+    switch (dhcp_mon_status)
+    {
+    case DHCP_MON_STATUS_UNHEALTHY:
+        if (++state_data->count > dhcp_unhealthy_max_count) {
+            syslog(LOG_ALERT, state_data->msg, state_data->count * window_interval_sec, context->intf);
+            dhcp_devman_print_status(context);
+        }
+        break;
+    case DHCP_MON_STATUS_HEALTHY:
+        state_data->count = 0;
+        break;
+    case DHCP_MON_STATUS_INDETERMINATE:
+        if (state_data->count) {
+            state_data->count++;
+        }
+        break;
+    default:
+        syslog(LOG_ERR, "DHCP Relay returned unknown status %d\n", dhcp_mon_status);
+        break;
+    }
 }
 
 /**
@@ -60,28 +143,12 @@ static void signal_callback(evutil_socket_t fd, short event, void *arg)
  */
 static void timeout_callback(evutil_socket_t fd, short event, void *arg)
 {
-    static int count = 0;
-    dhcp_mon_status_t dhcp_mon_status = dhcp_devman_get_status();
+    for (uint8_t i = 0; i < sizeof(state_data) / sizeof(*state_data); i++) {
+        check_dhcp_relay_health(&state_data[i]);
+    }
 
-    switch (dhcp_mon_status)
-    {
-    case DHCP_MON_STATUS_UNHEALTHY:
-        if (++count > dhcp_unhealthy_max_count) {
-            syslog(LOG_ALERT, "dhcpmon detected disparity in DHCP Relay behavior. Failure count: %d for vlan: '%s'\n",
-                   count, dhcp_devman_get_vlan_intf());
-            dhcp_devman_print_status();
-        }
-        break;
-    case DHCP_MON_STATUS_HEALTHY:
-        if (count > 0) {
-            count = 0;
-        }
-        break;
-    case DHCP_MON_STATUS_INDETERMINATE:
-        break;
-    default:
-        syslog(LOG_ERR, "DHCP Relay returned unknown status %d\n", dhcp_mon_status);
-        break;
+    for (uint8_t i = 0; i < sizeof(state_data) / sizeof(*state_data); i++) {
+        dhcp_devman_update_snapshot(state_data[i].get_context());
     }
 }
 
@@ -118,6 +185,12 @@ int dhcp_mon_init(int window_sec, int max_count)
             break;
         }
 
+        ev_sigusr1 = evsignal_new(base, SIGUSR1, sigusr1_callback, base);
+        if (ev_sigusr1 == NULL) {
+            syslog(LOG_ERR, "Could not create SIGUSER1 libevent signal!\n");
+            break;
+        }
+
         ev_timeout = event_new(base, -1, EV_PERSIST, timeout_callback, base);
         if (ev_timeout == NULL) {
             syslog(LOG_ERR, "Could not create libevent timer!\n");
@@ -140,10 +213,12 @@ void dhcp_mon_shutdown()
     event_del(ev_timeout);
     event_del(ev_sigint);
     event_del(ev_sigterm);
+    event_del(ev_sigusr1);
 
     event_free(ev_timeout);
     event_free(ev_sigint);
     event_free(ev_sigterm);
+    event_free(ev_sigusr1);
 
     event_base_free(base);
 }
@@ -170,6 +245,11 @@ int dhcp_mon_start(size_t snaplen)
 
         if (evsignal_add(ev_sigterm, NULL) != 0) {
             syslog(LOG_ERR, "Could not add SIGTERM libevent signal!\n");
+            break;
+        }
+
+        if (evsignal_add(ev_sigusr1, NULL) != 0) {
+            syslog(LOG_ERR, "Could not add SIGUSR1 libevent signal!\n");
             break;
         }
 

--- a/src/dhcpmon/src/main.c
+++ b/src/dhcpmon/src/main.c
@@ -24,7 +24,7 @@
 static const size_t dhcpmon_default_snaplen = 65535;
 /** dhcpmon_default_health_check_window: default value for a time window, during which DHCP DORA packet counts are being
  *  collected */
-static const uint32_t dhcpmon_default_health_check_window = 12;
+static const uint32_t dhcpmon_default_health_check_window = 18;
 /** dhcpmon_default_unhealthy_max_count: default max consecutive unhealthy status reported before reporting an issue
  *  with DHCP relay */
 static const uint32_t dhcpmon_default_unhealthy_max_count = 10;
@@ -40,7 +40,7 @@ static const uint32_t dhcpmon_default_unhealthy_max_count = 10;
  */
 static void usage(const char *prog)
 {
-    printf("Usage: %s -id <south interface> {-iu <north interface>}+ [-w <snapshot window in sec>]"
+    printf("Usage: %s -id <south interface> {-iu <north interface>}+ -im <mgmt interface> [-w <snapshot window in sec>]"
             "[-c <unhealthy status count>] [-s <snap length>] [-d]\n", prog);
     printf("where\n");
     printf("\tsouth interface: is a vlan interface,\n");
@@ -50,7 +50,7 @@ static void usage(const char *prog)
     printf("\tunhealthy status count: count of consecutive unhealthy status before writing an alert to syslog "
            "(default %d),\n",
            dhcpmon_default_unhealthy_max_count);
-    printf("\tsnap length: snap length of packet capture (default %d),\n", dhcpmon_default_snaplen);
+    printf("\tsnap length: snap length of packet capture (default %ld),\n", dhcpmon_default_snaplen);
     printf("\t-d: daemonize %s.\n", prog);
 
     exit(EXIT_SUCCESS);
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
             usage(basename(argv[0]));
             break;
         case 'i':
-            if (dhcp_devman_add_intf(argv[i + 1], argv[i][2] == 'u') != 0) {
+            if (dhcp_devman_add_intf(argv[i + 1], argv[i][2]) != 0) {
                 usage(basename(argv[0]));
             }
             i += 2;

--- a/src/sonic-config-engine/tests/sample_output/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/docker-dhcp-relay.supervisord.conf
@@ -56,7 +56,7 @@ dependent_startup_wait_for=start:exited
 programs=dhcpmon-Vlan1000
 
 [program:dhcpmon-Vlan1000]
-command=/usr/sbin/dhcpmon -id Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04
+command=/usr/sbin/dhcpmon -id Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
 priority=4
 autostart=false
 autorestart=false


### PR DESCRIPTION
When BGP routes are missing, DHCP packets get relayed over mgmt
interface. This results in dhcpmon alerting that DHCP packets are
not being relayed. This is PR include mgmt interface as uplink
device, and so, if DHCP packet gets relayed over mgmt interface,
regular dhcpmon alert will not be issues. Instead, dhcpmon will
check the mgmt interface counts and issue a separate alert regarding
packets travelling through mgmt network.

In addition, this PR include the following enhancements:
1. Add SIGUSR1 handler that prints out current packet counts
2. Increase alert grace window to 3 minutes from current 2 min
3. Time is not computed more accurately
4. Print vlan name before counters

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
DHCP Monitor is alerting when DHCP packets got over mgmt network

**- How I did it**
1. Monitored mgmt interface
Also, Added
2. Add SIGUSR1 handler that prints out current packet counts
3. Increase alert grace window to 3 minutes from currently 2 minutes
4. Time is now computed more accurately
5. Print vlan name before counters

**- How to verify it**
Bring down BGP session, and noticed no dhcpmon alert get triggered. Instead the following trigger is observed:
```
Sep  6 07:21:35.928763 str-s6000-acs-14 ALERT dhcp_relay#dhcpmon[43]: dhcpmon detected DHCP packets traveling through mgmt interface (please check BGP routes.) Duration: 234 (sec) for intf: 'eth0'
Sep  6 07:21:35.928763 str-s6000-acs-14 NOTICE dhcp_relay#dhcpmon[43]: [            eth0] DHCP Discover rx/tx:          0/       288, Offer rx/tx:          0/         0, Request rx/tx:          0/         0, ACK rx/tx:          0/         0
Sep  6 07:22:29.927983 str-s6000-acs-14 ALERT dhcp_relay#dhcpmon[43]: dhcpmon detected DHCP packets traveling through mgmt interface (please check BGP routes.) Duration: 288 (sec) for intf: 'eth0'
Sep  6 07:22:29.927983 str-s6000-acs-14 NOTICE dhcp_relay#dhcpmon[43]: [            eth0] DHCP Discover rx/tx:          0/       336, Offer rx/tx:          0/         0, Request rx/tx:          0/         0, ACK rx/tx:          0/         0
```
New signal handler for SIGUSR1
```
Sep  6 07:21:48.670477 str-s6000-acs-14 ALERT dhcp_relay#dhcpmon[43]: Received signal: 'User defined signal 1'
Sep  6 07:21:48.670477 str-s6000-acs-14 NOTICE dhcp_relay#dhcpmon[43]: [            eth0] DHCP Discover rx/tx:          0/       288, Offer rx/tx:          0/         0, Request rx/tx:          0/         0, ACK rx/tx:          0/         0
Sep  6 07:21:48.670477 str-s6000-acs-14 NOTICE dhcp_relay#dhcpmon[43]: [ PortChannel0004] DHCP Discover rx/tx:          0/        55, Offer rx/tx:          0/         0, Request rx/tx:          0/        55, ACK rx/tx:          0/         0
Sep  6 07:21:48.670477 str-s6000-acs-14 NOTICE dhcp_relay#dhcpmon[43]: [ PortChannel0003] DHCP Discover rx/tx:          0/        40, Offer rx/tx:          0/         0, Request rx/tx:          0/        40, ACK rx/tx:          0/         0
Sep  6 07:21:48.670477 str-s6000-acs-14 NOTICE dhcp_relay#dhcpmon[43]: [ PortChannel0002] DHCP Discover rx/tx:          0/        70, Offer rx/tx:          5/         0, Request rx/tx:          0/        70, ACK rx/tx:          5/         0
Sep  6 07:21:48.670477 str-s6000-acs-14 NOTICE dhcp_relay#dhcpmon[43]: [ PortChannel0001] DHCP Discover rx/tx:          0/        75, Offer rx/tx:          0/         0, Request rx/tx:          0/        75, ACK rx/tx:          0/         0
Sep  6 07:21:48.670477 str-s6000-acs-14 NOTICE dhcp_relay#dhcpmon[43]: [        Vlan1000] DHCP Discover rx/tx:         11/         0, Offer rx/tx:          0/         5, Request rx/tx:          5/         0, ACK rx/tx:          0/         5
Sep  6 07:21:48.670477 str-s6000-acs-14 NOTICE dhcp_relay#dhcpmon[43]: [    Agg-Vlan1000] DHCP Discover rx/tx:         11/       528, Offer rx/tx:          5/         5, Request rx/tx:          5/       240, ACK rx/tx:          5/         5
```

**- Which release branch to backport (provide reason below if selected)**

- [x] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
