### PR TITLE
DellEMC: PCIe config files for S6000, S6100

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/pcie.yaml
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/pcie.yaml
@@ -2,72 +2,62 @@
   dev: '01'
   fn: '0'
   id: 0c46
-  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port
-    1 (rev 01)'
+  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port 1'
 - bus: '00'
   dev: '02'
   fn: '0'
   id: 0c47
-  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port
-    2 (rev 01)'
+  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port 2'
 - bus: '00'
   dev: '03'
   fn: '0'
   id: 0c48
-  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port
-    3 (rev 01)'
+  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port 3'
 - bus: '00'
   dev: '04'
   fn: '0'
   id: 0c49
-  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port
-    4 (rev 01)'
+  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port 4'
 - bus: '00'
   dev: 0e
   fn: '0'
   id: 0c54
-  name: 'IOMMU: Intel Corporation Atom Processor S1200 Internal (rev 01)'
+  name: 'IOMMU: Intel Corporation Atom Processor S1200 Internal'
 - bus: '00'
   dev: '13'
   fn: '0'
   id: 0c59
-  name: 'System peripheral: Intel Corporation Atom Processor S1200 SMBus 2.0 Controller
-    0 (rev 01)'
+  name: 'System peripheral: Intel Corporation Atom Processor S1200 SMBus 2.0 Controller 0'
 - bus: '00'
   dev: '13'
   fn: '1'
   id: 0c5a
-  name: 'System peripheral: Intel Corporation Atom Processor S1200 SMBus 2.0 Controller
-    1 (rev 01)'
+  name: 'System peripheral: Intel Corporation Atom Processor S1200 SMBus 2.0 Controller 1'
 - bus: '01'
   dev: '00'
   fn: '0'
   id: b850
-  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56850 Switch ASIC (rev
-    02)'
+  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56850 Switch ASIC'
 - bus: '02'
   dev: '00'
   fn: '0'
   id: '9170'
-  name: 'SATA controller: Marvell Technology Group Ltd. Device 9170 (rev 12)'
+  name: 'SATA controller: Marvell Technology Group Ltd. Device 9170'
 - bus: '03'
   dev: '00'
   fn: '0'
   id: 400a
-  name: 'PCI bridge: Pericom Semiconductor PI7C9X442SL PCI Express Bridge Port (rev
-    02)'
+  name: 'PCI bridge: Pericom Semiconductor PI7C9X442SL PCI Express Bridge Port'
 - bus: '04'
   dev: '01'
   fn: '0'
   id: 400a
-  name: 'PCI bridge: Pericom Semiconductor PI7C9X442SL PCI Express Bridge Port (rev
-    02)'
+  name: 'PCI bridge: Pericom Semiconductor PI7C9X442SL PCI Express Bridge Port'
 - bus: '04'
   dev: '02'
   fn: '0'
   id: 400a
-  name: 'PCI bridge: Pericom Semiconductor PI7C9X442SL PCI Express Bridge Port (rev
-    02)'
+  name: 'PCI bridge: Pericom Semiconductor PI7C9X442SL PCI Express Bridge Port'
 - bus: 08
   dev: '00'
   fn: '0'

--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/pcie.yaml
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/pcie.yaml
@@ -1,0 +1,75 @@
+- bus: '00'
+  dev: '01'
+  fn: '0'
+  id: 0c46
+  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port
+    1 (rev 01)'
+- bus: '00'
+  dev: '02'
+  fn: '0'
+  id: 0c47
+  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port
+    2 (rev 01)'
+- bus: '00'
+  dev: '03'
+  fn: '0'
+  id: 0c48
+  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port
+    3 (rev 01)'
+- bus: '00'
+  dev: '04'
+  fn: '0'
+  id: 0c49
+  name: 'PCI bridge: Intel Corporation Atom Processor S1200 PCI Express Root Port
+    4 (rev 01)'
+- bus: '00'
+  dev: 0e
+  fn: '0'
+  id: 0c54
+  name: 'IOMMU: Intel Corporation Atom Processor S1200 Internal (rev 01)'
+- bus: '00'
+  dev: '13'
+  fn: '0'
+  id: 0c59
+  name: 'System peripheral: Intel Corporation Atom Processor S1200 SMBus 2.0 Controller
+    0 (rev 01)'
+- bus: '00'
+  dev: '13'
+  fn: '1'
+  id: 0c5a
+  name: 'System peripheral: Intel Corporation Atom Processor S1200 SMBus 2.0 Controller
+    1 (rev 01)'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: b850
+  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56850 Switch ASIC (rev
+    02)'
+- bus: '02'
+  dev: '00'
+  fn: '0'
+  id: '9170'
+  name: 'SATA controller: Marvell Technology Group Ltd. Device 9170 (rev 12)'
+- bus: '03'
+  dev: '00'
+  fn: '0'
+  id: 400a
+  name: 'PCI bridge: Pericom Semiconductor PI7C9X442SL PCI Express Bridge Port (rev
+    02)'
+- bus: '04'
+  dev: '01'
+  fn: '0'
+  id: 400a
+  name: 'PCI bridge: Pericom Semiconductor PI7C9X442SL PCI Express Bridge Port (rev
+    02)'
+- bus: '04'
+  dev: '02'
+  fn: '0'
+  id: 400a
+  name: 'PCI bridge: Pericom Semiconductor PI7C9X442SL PCI Express Bridge Port (rev
+    02)'
+- bus: 08
+  dev: '00'
+  fn: '0'
+  id: 10d3
+  name: 'Ethernet controller: Intel Corporation 82574L Gigabit Network Connection'

--- a/device/dell/x86_64-dell_s6100_c2538-r0/plugins/pcie.yaml
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/plugins/pcie.yaml
@@ -2,61 +2,54 @@
   dev: '01'
   fn: '0'
   id: 1f10
-  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 1 (rev
-    03)'
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 1'
 - bus: '00'
   dev: '02'
   fn: '0'
   id: 1f11
-  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 2 (rev
-    03)'
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 2'
 - bus: '00'
   dev: '03'
   fn: '0'
   id: 1f12
-  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 3 (rev
-    03)'
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 3'
 - bus: '00'
   dev: '04'
   fn: '0'
   id: 1f13
-  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 4 (rev
-    03)'
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 4'
 - bus: '00'
   dev: 0f
   fn: '0'
   id: 1f16
-  name: 'IOMMU: Intel Corporation Atom processor C2000 RCEC (rev 03)'
+  name: 'IOMMU: Intel Corporation Atom processor C2000 RCEC'
 - bus: '00'
   dev: '13'
   fn: '0'
   id: 1f15
-  name: 'System peripheral: Intel Corporation Atom processor C2000 SMBus 2.0 (rev
-    03)'
+  name: 'System peripheral: Intel Corporation Atom processor C2000 SMBus 2.0'
 - bus: '00'
   dev: '14'
   fn: '0'
   id: 1f41
-  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)'
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354'
 - bus: '00'
   dev: '14'
   fn: '1'
   id: 1f41
-  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)'
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354'
 - bus: '00'
   dev: '14'
   fn: '2'
   id: 1f41
-  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)'
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354'
 - bus: '01'
   dev: '00'
   fn: '0'
   id: b960
-  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56960 Switch ASIC (rev
-    12)'
+  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56960 Switch ASIC'
 - bus: '01'
   dev: '00'
   fn: '1'
   id: b960
-  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56960 Switch ASIC (rev
-    12)'
+  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56960 Switch ASIC'

--- a/device/dell/x86_64-dell_s6100_c2538-r0/plugins/pcie.yaml
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/plugins/pcie.yaml
@@ -1,0 +1,62 @@
+- bus: '00'
+  dev: '01'
+  fn: '0'
+  id: 1f10
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 1 (rev
+    03)'
+- bus: '00'
+  dev: '02'
+  fn: '0'
+  id: 1f11
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 2 (rev
+    03)'
+- bus: '00'
+  dev: '03'
+  fn: '0'
+  id: 1f12
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 3 (rev
+    03)'
+- bus: '00'
+  dev: '04'
+  fn: '0'
+  id: 1f13
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 4 (rev
+    03)'
+- bus: '00'
+  dev: 0f
+  fn: '0'
+  id: 1f16
+  name: 'IOMMU: Intel Corporation Atom processor C2000 RCEC (rev 03)'
+- bus: '00'
+  dev: '13'
+  fn: '0'
+  id: 1f15
+  name: 'System peripheral: Intel Corporation Atom processor C2000 SMBus 2.0 (rev
+    03)'
+- bus: '00'
+  dev: '14'
+  fn: '0'
+  id: 1f41
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)'
+- bus: '00'
+  dev: '14'
+  fn: '1'
+  id: 1f41
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)'
+- bus: '00'
+  dev: '14'
+  fn: '2'
+  id: 1f41
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: b960
+  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56960 Switch ASIC (rev
+    12)'
+- bus: '01'
+  dev: '00'
+  fn: '1'
+  id: b960
+  name: 'Ethernet controller: Broadcom Limited Broadcom BCM56960 Switch ASIC (rev
+    12)'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

To support "pcieutil pcie-check" command in DellEMC S6000, S6100.

**- How I did it**

Add 'pcie.yaml' consisting of the PCIe devices, in device/dell/[PLATFORM]/plugins/ directory.

**- How to verify it**

Execute "pcieutil pcie-check" command.
Logs: [S6000_pcie_check_logs.txt](https://github.com/Azure/sonic-buildimage/files/5193662/S6000_pcie_check_logs.txt), [S6100_pcie_check_logs.txt](https://github.com/Azure/sonic-buildimage/files/5193667/S6100_pcie_check_logs.txt)


**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC: PCIe config files for S6000, S6100

**- A picture of a cute animal (not mandatory but encouraged)**
