### PR TITLE
Add a user defined rules/config file not tracked by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .arch
 .platform
 .screen
+rules/config.user
 
 # Build artifacts
 fsroot/

--- a/slave.mk
+++ b/slave.mk
@@ -94,6 +94,7 @@ list :
 ###############################################################################
 
 include $(RULES_PATH)/config
+-include $(RULES_PATH)/config.user
 
 ifeq ($(SONIC_ENABLE_PFCWD_ON_START),y)
 ENABLE_PFCWD_ON_START = y


### PR DESCRIPTION
**- Why I did it**

This change introduces the `rules/config.user` file.
Since this path is tracked by `.gitignore`, it provides a mean to change 
the configuration of a sonic build without dirtying the git tree.

**- How I did it**

This configuration gets loaded after `rules/config` as a mean to override default values.
Thus it allows the default configuration to grow with new default values without having
to track each and single one of them when one generates a configuration.
If the `rules/config.user` configuration file does not exists this step is ignored.

**- How to verify it**

Here is an example of the use of `rules/config.user`
```
echo DEFAULT_PASSWORD=password > rules/config.user
```
You should now see the new password being displayed when running a `make` operation.
Running `git status` should not show any files in the `dirty` section nor in the `not staged` section.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add a user defined rules/config.user file not tracked by git
