### PR TITLE
[Mellanox] Refactor SFP related platform API and plugins with new SDK API

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmget.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmget.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
+"""
+This utility get the power mode of a given module.
+"""
 
-import sys, errno
-import os
-from python_sdk_api.sxd_api import *
+import sys
+import errno
 from python_sdk_api.sx_api import *
-import python_sdk_api.sx_api as sx_api
 
 def mgmt_phy_mod_pwr_attr_get(handle, module_id, power_attr_type):
     sx_mgmt_phy_mod_pwr_attr_p = new_sx_mgmt_phy_mod_pwr_attr_t_p()
@@ -22,14 +23,14 @@ def mgmt_phy_mod_pwr_attr_get(handle, module_id, power_attr_type):
 
 # Check if SFP port number is provided
 if len(sys.argv) < 2:
-    print "SFP module number is missed."
-    print "Usage: sfplpmget.py <SFP module>"
+    print("SFP module number is missed.")
+    print("Usage: sfplpmget.py <SFP module>")
     sys.exit(errno.EINVAL)
 
 # Init SDK API
 rc, handle = sx_api_open(None)
 if (rc != SX_STATUS_SUCCESS):
-    print "Failed to open api handle.\nPlease check that SDK is running."
+    print("Failed to open api handle.\nPlease check that SDK is running.")
     sys.exit(errno.EACCES)
 
 # Get SFP module number
@@ -37,7 +38,6 @@ sfp_module = int(sys.argv[1]) - 1
 
 admin_pwr_mode, oper_pwr_mode = mgmt_phy_mod_pwr_attr_get(handle, sfp_module, SX_MGMT_PHY_MOD_PWR_ATTR_PWR_MODE_E)
 
-#pwr_mode_enum_dict = get_enum_string_dict('SX_MGMT_PHY_MOD_PWR_MODE')
 lpm_status = None
 if oper_pwr_mode == SX_MGMT_PHY_MOD_PWR_MODE_HIGH_E:
     lpm_status = False

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmget.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmget.py
@@ -4,6 +4,21 @@ import sys, errno
 import os
 from python_sdk_api.sxd_api import *
 from python_sdk_api.sx_api import *
+import python_sdk_api.sx_api as sx_api
+
+def mgmt_phy_mod_pwr_attr_get(handle, module_id, power_attr_type):
+    sx_mgmt_phy_mod_pwr_attr_p = new_sx_mgmt_phy_mod_pwr_attr_t_p()
+    sx_mgmt_phy_mod_pwr_attr = sx_mgmt_phy_mod_pwr_attr_t()
+    sx_mgmt_phy_mod_pwr_attr.power_attr_type = power_attr_type
+    sx_mgmt_phy_mod_pwr_attr_t_p_assign(sx_mgmt_phy_mod_pwr_attr_p, sx_mgmt_phy_mod_pwr_attr)
+    try:
+        rc = sx_mgmt_phy_mod_pwr_attr_get(handle, module_id, sx_mgmt_phy_mod_pwr_attr_p)
+        assert SX_STATUS_SUCCESS == rc, "sx_mgmt_phy_mod_pwr_attr_get failed"
+        sx_mgmt_phy_mod_pwr_attr = sx_mgmt_phy_mod_pwr_attr_t_p_value(sx_mgmt_phy_mod_pwr_attr_p)
+        pwr_mode_attr = sx_mgmt_phy_mod_pwr_attr.pwr_mode_attr
+        return pwr_mode_attr.admin_pwr_mode_e, pwr_mode_attr.oper_pwr_mode_e
+    finally:
+        delete_sx_mgmt_phy_mod_pwr_attr_t_p(sx_mgmt_phy_mod_pwr_attr_p)
 
 # Check if SFP port number is provided
 if len(sys.argv) < 2:
@@ -17,27 +32,20 @@ if (rc != SX_STATUS_SUCCESS):
     print "Failed to open api handle.\nPlease check that SDK is running."
     sys.exit(errno.EACCES)
 
-pid = os.getpid()
-rc = sxd_access_reg_init(pid, None, 0)
-if (rc != 0):
-    print "Failed to initializing register access.\nPlease check that SDK is running."
-    sys.exit(errno.EACCES)
-
 # Get SFP module number
 sfp_module = int(sys.argv[1]) - 1
 
-# Get MCION
-mcion = ku_mcion_reg()
-mcion.module = sfp_module
-meta = sxd_reg_meta_t()
-meta.dev_id = 1
-meta.swid = 0
-meta.access_cmd = SXD_ACCESS_CMD_GET
+admin_pwr_mode, oper_pwr_mode = mgmt_phy_mod_pwr_attr_get(handle, sfp_module, SX_MGMT_PHY_MOD_PWR_ATTR_PWR_MODE_E)
 
-rc = sxd_access_reg_mcion(mcion, meta, 1, None, None)
-assert rc == SXD_STATUS_SUCCESS, "sxd_access_reg_mcion failed, rc = %d" % rc
+#pwr_mode_enum_dict = get_enum_string_dict('SX_MGMT_PHY_MOD_PWR_MODE')
+lpm_status = None
+if oper_pwr_mode == SX_MGMT_PHY_MOD_PWR_MODE_HIGH_E:
+    lpm_status = False
+elif oper_pwr_mode == SX_MGMT_PHY_MOD_PWR_MODE_LOW_E:
+    lpm_status = True
+else:
+    print("LPM UNKNOWN")
 
-# Get low power mode status
-lpm_mask = 1 << 8
-lpm_status = (lpm_mask & mcion.module_status_bits) != 0
 print "LPM ON" if lpm_status else "LPM OFF"
+
+sx_api_close(handle)

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfplpmset.py
@@ -1,22 +1,19 @@
 #!/usr/bin/env python
-
-import sys, errno
-import os
-from python_sdk_api.sxd_api import *
+'''
+This utility set the power mode a given module.
+'''
+import sys
+import errno
 from python_sdk_api.sx_api import *
+import python_sdk_api.sx_api as sx_api
 
-REGISTER_NUM = 1
-SXD_LOG_VERBOSITY_LEVEL = 0
+######################################################
+#  power mode set utility functions.
+######################################################
+
 DEVICE_ID = 1
 SWITCH_ID = 0
 SX_PORT_ATTR_ARR_SIZE = 64
-
-PMAOS_ASE = 1
-PMAOS_EE = 1
-PMAOS_E = 2
-PMAOS_RST = 0
-PMAOS_ENABLE = 1
-PMAOS_DISABLE = 2
 
 PORT_TYPE_CPU = 4
 PORT_TYPE_NVE = 8
@@ -36,7 +33,7 @@ def is_port_admin_status_up(log_port):
     admin_state_p = new_sx_port_admin_state_t_p()
     module_state_p = new_sx_port_module_state_t_p()
     rc = sx_api_port_state_get(handle, log_port, oper_state_p, admin_state_p, module_state_p)
-    assert rc == SXD_STATUS_SUCCESS, "sx_api_port_state_get failed, rc = %d" % rc
+    assert rc == SX_STATUS_SUCCESS, "sx_api_port_state_get failed, rc = %d" % rc
 
     admin_state = sx_port_admin_state_t_p_value(admin_state_p)
     if admin_state == SX_PORT_ADMIN_STATUS_UP:
@@ -69,101 +66,91 @@ def get_log_ports(handle, sfp_module):
 
     return log_port_list
 
-def init_sx_meta_data():
-    meta = sxd_reg_meta_t()
-    meta.dev_id = DEVICE_ID
-    meta.swid = SWITCH_ID
-    return meta
+def mgmt_phy_mod_pwr_attr_set(handle, module_id, power_attr_type, admin_pwr_mode):
+    sx_mgmt_phy_mod_pwr_attr = sx_mgmt_phy_mod_pwr_attr_t()
+    sx_mgmt_phy_mod_pwr_mode_attr = sx_mgmt_phy_mod_pwr_mode_attr_t()
+    sx_mgmt_phy_mod_pwr_attr.power_attr_type = power_attr_type
+    sx_mgmt_phy_mod_pwr_mode_attr.admin_pwr_mode_e = admin_pwr_mode
+    sx_mgmt_phy_mod_pwr_attr.pwr_mode_attr = sx_mgmt_phy_mod_pwr_mode_attr
+    sx_mgmt_phy_mod_pwr_attr_p = new_sx_mgmt_phy_mod_pwr_attr_t_p()
+    sx_mgmt_phy_mod_pwr_attr_t_p_assign(sx_mgmt_phy_mod_pwr_attr_p, sx_mgmt_phy_mod_pwr_attr)
+    try:
+        rc = sx_mgmt_phy_mod_pwr_attr_set(handle, SX_ACCESS_CMD_SET, module_id, sx_mgmt_phy_mod_pwr_attr_p)
+        assert SX_STATUS_SUCCESS == rc, "sx_mgmt_phy_mod_pwr_attr_set failed"
+    finally:
+        delete_sx_mgmt_phy_mod_pwr_attr_t_p(sx_mgmt_phy_mod_pwr_attr_p)
 
-def set_sfp_admin_status(sfp_module, admin_status):
-    # Get PMAOS
-    pmaos = ku_pmaos_reg()
-    pmaos.module = sfp_module
-    meta = init_sx_meta_data()
-    meta.access_cmd = SXD_ACCESS_CMD_GET
-    rc = sxd_access_reg_pmaos(pmaos, meta, REGISTER_NUM, None, None)
-    assert rc == SXD_STATUS_SUCCESS, "sxd_access_reg_pmaos failed, rc = %d" % rc
+def mgmt_phy_mod_pwr_attr_get(handle, module_id, power_attr_type):
+    sx_mgmt_phy_mod_pwr_attr_p = new_sx_mgmt_phy_mod_pwr_attr_t_p()
+    sx_mgmt_phy_mod_pwr_attr = sx_mgmt_phy_mod_pwr_attr_t()
+    sx_mgmt_phy_mod_pwr_attr.power_attr_type = power_attr_type
+    sx_mgmt_phy_mod_pwr_attr_t_p_assign(sx_mgmt_phy_mod_pwr_attr_p, sx_mgmt_phy_mod_pwr_attr)
+    try:
+        rc = sx_mgmt_phy_mod_pwr_attr_get(handle, module_id, sx_mgmt_phy_mod_pwr_attr_p)
+        assert SX_STATUS_SUCCESS == rc, "sx_mgmt_phy_mod_pwr_attr_get failed"
+        sx_mgmt_phy_mod_pwr_attr = sx_mgmt_phy_mod_pwr_attr_t_p_value(sx_mgmt_phy_mod_pwr_attr_p)
+        pwr_mode_attr = sx_mgmt_phy_mod_pwr_attr.pwr_mode_attr
+        return pwr_mode_attr.admin_pwr_mode_e, pwr_mode_attr.oper_pwr_mode_e
+    finally:
+        delete_sx_mgmt_phy_mod_pwr_attr_t_p(sx_mgmt_phy_mod_pwr_attr_p)
 
-    # Set admin status to PMAOS
-    pmaos.ase = PMAOS_ASE
-    pmaos.ee = PMAOS_EE
-    pmaos.e = PMAOS_E
-    pmaos.rst = PMAOS_RST
-    if admin_status == SX_PORT_ADMIN_STATUS_DOWN:
-        pmaos.admin_status = PMAOS_DISABLE
+
+def pwr_attr_set(handle, module_id, ports, attr_type, power_mode):
+    # bring the port down
+    for port in ports:
+        set_port_admin_status_by_log_port(handle, port, SX_PORT_ADMIN_STATUS_DOWN)
+    # set the desired power mode
+    mgmt_phy_mod_pwr_attr_set(handle, module_id, attr_type, power_mode)
+    # get the current port power mode and make sure that it is as per the mode set.
+    admin_pwr_mode, oper_pwr_mode = mgmt_phy_mod_pwr_attr_get(handle, module_id, attr_type)
+    assert power_mode == admin_pwr_mode, "power mode mismatch"
+    # bring the port up
+    for port in ports:
+        set_port_admin_status_by_log_port(handle, port, SX_PORT_ADMIN_STATUS_UP)
+
+def set_lpmode(handle, cmd, module_id):
+    # construct the port module map.
+    log_port_list = get_log_ports(handle, module_id)
+
+    if cmd == "enable":
+        pwr_attr_set(handle, module_id, log_port_list, SX_MGMT_PHY_MOD_PWR_ATTR_PWR_MODE_E, SX_MGMT_PHY_MOD_PWR_MODE_LOW_E)
+        print "Enabled low power mode for module [%d]" % (module_id)
+    elif cmd == "disable":
+        pwr_attr_set(handle, module_id, log_port_list, SX_MGMT_PHY_MOD_PWR_ATTR_PWR_MODE_E, SX_MGMT_PHY_MOD_PWR_MODE_AUTO_E)
+        print "Disabled low power mode for module [%d]" % (module_id)
     else:
-        pmaos.admin_status = PMAOS_ENABLE
+        print("Error: Invalid command")
+        sys.exit(0)
 
-    meta.access_cmd = SXD_ACCESS_CMD_SET
-    rc = sxd_access_reg_pmaos(pmaos, meta, REGISTER_NUM, None, None)
-    assert rc == SXD_STATUS_SUCCESS, "sxd_access_reg_pmaos failed, rc = %d" % rc
-
-def set_sfp_lpmode(sfp_module, lpm_enable):
-    # Get PMMP
-    pmmp = ku_pmmp_reg()
-    pmmp.module = sfp_module
-    meta = init_sx_meta_data()
-    meta.access_cmd = SXD_ACCESS_CMD_GET
-    rc = sxd_access_reg_pmmp(pmmp, meta, REGISTER_NUM, None, None)
-    assert rc == SXD_STATUS_SUCCESS, "sxd_access_reg_pmmp failed, rc = %d" % rc
-
-    # Set low power mode status
-    lpm_mask = 1 << 8
-    if lpm_enable:
-        pmmp.eeprom_override = pmmp.eeprom_override | lpm_mask
-    else:
-        pmmp.eeprom_override = pmmp.eeprom_override & (~lpm_mask)
-
-    meta.access_cmd = SXD_ACCESS_CMD_SET
-    rc = sxd_access_reg_pmmp(pmmp, meta, REGISTER_NUM, None, None)
-    assert rc == SXD_STATUS_SUCCESS, "sxd_access_reg_pmmp failed, rc = %d" % rc
-
-# Check if SFP port number is provided
 if len(sys.argv) < 3:
     print "SFP module number or LPM is missed."
     print "Usage: sfplpmset.py <SFP module> <on|off>"
     sys.exit(errno.EINVAL)
 
+cmd = None
 lpm_enable = None
 if sys.argv[2] == 'on':
     lpm_enable = True
+    cmd = 'enable'
 elif sys.argv[2] == 'off':
     lpm_enable = False
+    cmd = 'disable'
 else:
     print "Unrecognized LPM parameter. Please use <on> or <off> values"
     sys.exit(errno.EINVAL)
 
-# Init SDK API
+# Get SFP module
+sfp_module = int(sys.argv[1]) - 1
+
+print "[+] opening sdk"
 rc, handle = sx_api_open(None)
+print ("sx_api_open handle:0x%x , rc %d " % (handle, rc))
+
 if (rc != SX_STATUS_SUCCESS):
     print "Failed to open api handle.\nPlease check that SDK is running."
     sys.exit(errno.EACCES)
 
-pid = os.getpid()
-rc = sxd_access_reg_init(pid, None, SXD_LOG_VERBOSITY_LEVEL)
-if (rc != SXD_STATUS_SUCCESS):
-    print "Failed to initializing register access.\nPlease check that SDK is running."
-    sys.exit(errno.EACCES);
+# Set low power mode 
+set_lpmode(handle, cmd, sfp_module)
 
-# Get SFP module
-sfp_module = int(sys.argv[1]) - 1
-
-# Get all ports at admin up status that related to the SFP module
-log_port_list = get_log_ports(handle, sfp_module)
-
-# SET SFP related ports to admin down status
-for log_port in log_port_list:
-    set_port_admin_status_by_log_port(handle, log_port, SX_PORT_ADMIN_STATUS_DOWN)
-
-# Disable admin status before LPM settings
-set_sfp_admin_status(sfp_module, SX_PORT_ADMIN_STATUS_DOWN)
-
-# Set low power mode status
-set_sfp_lpmode(sfp_module, lpm_enable)
-
-# Enable admin status after LPM settings
-set_sfp_admin_status(sfp_module, SX_PORT_ADMIN_STATUS_UP)
-
-# SET SFP related ports to admin up status
-for log_port in log_port_list:
-    set_port_admin_status_by_log_port(handle, log_port, SX_PORT_ADMIN_STATUS_UP)
+sx_api_close(handle)

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfpreset.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfpreset.py
@@ -1,22 +1,24 @@
 #!/usr/bin/env python
+"""
+This utility reset the given SFP module.
+"""
 
-import sys, errno
-#import os
-#from python_sdk_api.sxd_api import *
+import sys
+import errno
 from python_sdk_api.sx_api import *
 
 # Check if SFP port number is provided
 if len(sys.argv) < 2:
-    print "SFP module number or LPM is missed."
-    print "Usage: sfpreset.py <SFP module>"
+    print("SFP module number or LPM is missed.")
+    print("Usage: sfpreset.py <SFP module>")
     sys.exit(errno.EINVAL)
 
 # Init SDK API
 rc, handle = sx_api_open(None)
-if (rc != SX_STATUS_SUCCESS):
-    print "Failed to open api handle.\nPlease check that SDK is running."
+if rc != SX_STATUS_SUCCESS:
+    print("Failed to open api handle.\nPlease check that SDK is running.")
     sys.exit(errno.EACCES)
-    
+
 # Get SFP module number
 sfp_module = int(sys.argv[1]) - 1
 

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfpreset.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfpreset.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 import sys, errno
-import os
-from python_sdk_api.sxd_api import *
+#import os
+#from python_sdk_api.sxd_api import *
 from python_sdk_api.sx_api import *
 
 # Check if SFP port number is provided
@@ -16,30 +16,11 @@ rc, handle = sx_api_open(None)
 if (rc != SX_STATUS_SUCCESS):
     print "Failed to open api handle.\nPlease check that SDK is running."
     sys.exit(errno.EACCES)
-
-pid = os.getpid()
-rc = sxd_access_reg_init(pid, None, 0)
-if (rc != 0):
-    print "Failed to initializing register access.\nPlease check that SDK is running."
-    sys.exit(errno.EACCES)
-
+    
 # Get SFP module number
 sfp_module = int(sys.argv[1]) - 1
 
-# Get PMAOS
-pmaos = ku_pmaos_reg()
-pmaos.module = sfp_module
-meta = sxd_reg_meta_t()
-meta.dev_id = 1
-meta.swid = 0
-meta.access_cmd = SXD_ACCESS_CMD_GET
+rc = sx_mgmt_phy_mod_reset(handle, sfp_module)
+assert rc == SX_STATUS_SUCCESS, "sx_mgmt_phy_mod_reset failed, rc = %d" % rc
 
-rc = sxd_access_reg_pmaos(pmaos, meta, 1, None, None)
-assert rc == SXD_STATUS_SUCCESS, "sxd_access_reg_pmaos failed, rc = %d" % rc
-
-# Reset SFP
-pmaos.rst = 1
-meta.access_cmd = SXD_ACCESS_CMD_SET
-rc = sxd_access_reg_pmaos(pmaos, meta, 1, None, None)
-assert rc == SXD_STATUS_SUCCESS, "sxd_access_reg_pmaos failed, rc = %d" % rc
-print "Reset flag is set"
+sx_api_close(handle)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -92,8 +92,8 @@ XCVR_SECOND_APPLICATION_LIST_WIDTH_QSFP_DD = 28
 # in function get_transceiver_info and get_transceiver_bulk_status
 # XCVR_INTERFACE_DATA_SIZE stands for the max size to be read
 # this variable is only used by get_transceiver_info.
-# please be noted that each time some new value added to the function 
-# we should make sure that it falls into the area 
+# please be noted that each time some new value added to the function
+# we should make sure that it falls into the area
 # [XCVR_INTERFACE_DATA_START, XCVR_INTERFACE_DATA_SIZE] or
 # adjust XCVR_INTERFACE_MAX_SIZE to contain the new data
 # It's same for [QSFP_DOM_BULK_DATA_START, QSFP_DOM_BULK_DATA_SIZE] and
@@ -197,12 +197,12 @@ QSFP_DD_CHANNL_STATUS_WIDTH = 1
 # identifier value of xSFP module which is in the first byte of the EEPROM
 # if the identifier value falls into SFP_TYPE_CODE_LIST the module is treated as a SFP module and parsed according to 8472
 # for QSFP_TYPE_CODE_LIST the module is treated as a QSFP module and parsed according to 8436/8636
-# Originally the type (SFP/QSFP) of each module is determined according to the SKU dictionary 
+# Originally the type (SFP/QSFP) of each module is determined according to the SKU dictionary
 # where the type of each FP port is defined. The content of EEPROM is parsed according to its type.
 # However, sometimes the SFP module can be fit in an adapter and then pluged into a QSFP port.
 # In this case the EEPROM content is in format of SFP but parsed as QSFP, causing failure.
-# To resolve that issue the type field of the xSFP module is also fetched so that we can know exectly what type the 
-# module is. Currently only the following types are recognized as SFP/QSFP module. 
+# To resolve that issue the type field of the xSFP module is also fetched so that we can know exectly what type the
+# module is. Currently only the following types are recognized as SFP/QSFP module.
 # Meanwhile, if the a module's identifier value can't be recognized, it will be parsed according to the SKU dictionary.
 # This is because in the future it's possible that some new identifier value which is not regonized but backward compatible
 # with the current format and by doing so it can be parsed as much as possible.
@@ -217,7 +217,7 @@ QSFP_DD_TYPE_CODE_LIST = [
     '18' # QSFP-DD Double Density 8X Pluggable Transceiver
 ]
 
-qsfp_cable_length_tup = ('Length(km)', 'Length OM3(2m)', 
+qsfp_cable_length_tup = ('Length(km)', 'Length OM3(2m)',
                          'Length OM2(m)', 'Length OM1(m)',
                          'Length Cable Assembly(m)')
 
@@ -225,7 +225,7 @@ sfp_cable_length_tup = ('LengthSMFkm-UnitsOfKm', 'LengthSMF(UnitsOf100m)',
                         'Length50um(UnitsOf10m)', 'Length62.5um(UnitsOfm)',
                         'LengthCable(UnitsOfm)', 'LengthOM3(UnitsOf10m)')
 
-sfp_compliance_code_tup = ('10GEthernetComplianceCode', 'InfinibandComplianceCode', 
+sfp_compliance_code_tup = ('10GEthernetComplianceCode', 'InfinibandComplianceCode',
                             'ESCONComplianceCodes', 'SONETComplianceCodes',
                             'EthernetComplianceCodes','FibreChannelLinkLength',
                             'FibreChannelTechnology', 'SFP+CableTechnology',
@@ -557,7 +557,7 @@ class SFP(SfpBase):
         Returns:
             A dict which contains following keys/values :
         ================================================================================
-        keys                       |Value Format   |Information	
+        keys                       |Value Format   |Information
         ---------------------------|---------------|----------------------------
         type                       |1*255VCHAR     |type of SFP
         hardware_rev               |1*255VCHAR     |hardware version of SFP
@@ -716,7 +716,7 @@ class SFP(SfpBase):
                 sfp_cable_len_data = sfpi_obj.parse_cable_len(sfp_cable_len_raw, 0)
             else:
                 return None
-            
+
             sfp_media_type_raw = self._read_eeprom_specific_bytes(XCVR_MEDIA_TYPE_OFFSET_QSFP_DD, XCVR_MEDIA_TYPE_WIDTH_QSFP_DD)
             if sfp_media_type_raw is not None:
                 sfp_media_type_dict = sfpi_obj.parse_media_type(sfp_media_type_raw, 0)
@@ -830,14 +830,14 @@ class SFP(SfpBase):
 
                 for key in qsfp_compliance_code_tup:
                     if key in sfp_interface_bulk_data['data']['Specification compliance']['value']:
-                        compliance_code_dict[key] = sfp_interface_bulk_data['data']['Specification compliance']['value'][key]['value']                
+                        compliance_code_dict[key] = sfp_interface_bulk_data['data']['Specification compliance']['value'][key]['value']
                 sfp_ext_specification_compliance_raw = self._read_eeprom_specific_bytes(offset + XCVR_EXT_SPECIFICATION_COMPLIANCE_OFFSET, XCVR_EXT_SPECIFICATION_COMPLIANCE_WIDTH)
                 if sfp_ext_specification_compliance_raw is not None:
                     sfp_ext_specification_compliance_data = sfpi_obj.parse_ext_specification_compliance(sfp_ext_specification_compliance_raw[0 : 1], 0)
                     if sfp_ext_specification_compliance_data['data']['Extended Specification compliance']['value'] != "Unspecified":
                         compliance_code_dict['Extended Specification compliance'] = sfp_ext_specification_compliance_data['data']['Extended Specification compliance']['value']
                 transceiver_info_dict['specification_compliance'] = str(compliance_code_dict)
-                
+
                 transceiver_info_dict['nominal_bit_rate'] = str(sfp_interface_bulk_data['data']['Nominal Bit Rate(100Mbs)']['value'])
             else:
                 for key in sfp_cable_length_tup:
@@ -851,7 +851,7 @@ class SFP(SfpBase):
                 transceiver_info_dict['specification_compliance'] = str(compliance_code_dict)
 
                 transceiver_info_dict['nominal_bit_rate'] = str(sfp_interface_bulk_data['data']['NominalSignallingRate(UnitsOf100Mbd)']['value'])
-    
+
         return transceiver_info_dict
 
 
@@ -862,7 +862,7 @@ class SFP(SfpBase):
         Returns:
             A dict which contains following keys/values :
         ========================================================================
-        keys                       |Value Format   |Information	
+        keys                       |Value Format   |Information
         ---------------------------|---------------|----------------------------
         RX LOS                     |BOOLEAN        |RX lost-of-signal status,
                                    |               |True if has RX los, False if not.
@@ -1239,12 +1239,12 @@ class SFP(SfpBase):
             A Boolean, True if reset enabled, False if disabled
 
         for QSFP, originally I would like to make use of Initialization complete flag bit
-        which is at Page a0 offset 6 bit 0 to test whether reset is complete. 
+        which is at Page a0 offset 6 bit 0 to test whether reset is complete.
         However as unit testing was carried out I find this approach may fail because:
             1. we make use of ethtool to read data on I2C bus rather than to read directly
             2. ethtool is unable to access I2C during QSFP module being reset
         In other words, whenever the flag is able to be retrived, the value is always be 1
-        As a result, it doesn't make sense to retrieve that flag. Just treat successfully 
+        As a result, it doesn't make sense to retrieve that flag. Just treat successfully
         retrieving data as "data ready".
         for SFP it seems that there is not flag indicating whether reset succeed. However,
         we can also do it in the way for QSFP.
@@ -1446,7 +1446,7 @@ class SFP(SfpBase):
         Returns:
             A hex of 4 bits (bit 0 to bit 3 as channel 0 to channel 3) to represent
             TX channels which have been disabled in this SFP.
-            As an example, a returned value of 0x5 indicates that channel 0 
+            As an example, a returned value of 0x5 indicates that channel 0
             and channel 2 have been disabled.
         """
         tx_disable_list = self.get_tx_disable()
@@ -1483,6 +1483,7 @@ class SFP(SfpBase):
         """
         handle = self._open_sdk()
         if handle is None:
+            logger.log_error("SDK handler is missing for sfp %d object" % self.index)
             return False
 
         admin_pwr_mode, oper_pwr_mode = self.mgmt_phy_mod_pwr_attr_get(SX_MGMT_PHY_MOD_PWR_ATTR_PWR_MODE_E)
@@ -1583,7 +1584,7 @@ class SFP(SfpBase):
         if self.sfp_type == QSFP_TYPE:
             offset = 0
             offset_xcvr = 128
-            
+
             sfpd_obj = sff8436Dom()
             if sfpd_obj is None:
                 return None
@@ -1599,7 +1600,7 @@ class SFP(SfpBase):
             return None
 
         if self.sfp_type == QSFP_DD_TYPE:
-            offset = 128        
+            offset = 128
 
             sfpd_obj = qsfp_dd_Dom()
             if sfpd_obj is None:
@@ -1644,7 +1645,7 @@ class SFP(SfpBase):
         if self.sfp_type == QSFP_TYPE:
             offset = 0
             offset_xcvr = 128
-            
+
             sfpd_obj = sff8436Dom()
             if sfpd_obj is None:
                 return None
@@ -1656,7 +1657,7 @@ class SFP(SfpBase):
                 tx_bias_list.append(self._convert_string_to_num(dom_channel_monitor_data['data']['TX2Bias']['value']))
                 tx_bias_list.append(self._convert_string_to_num(dom_channel_monitor_data['data']['TX3Bias']['value']))
                 tx_bias_list.append(self._convert_string_to_num(dom_channel_monitor_data['data']['TX4Bias']['value']))
-        
+
         elif self.sfp_type == QSFP_DD_TYPE:
             # page 11h
             if self.dom_rx_tx_power_bias_supported:
@@ -1716,7 +1717,7 @@ class SFP(SfpBase):
         elif self.sfp_type == QSFP_TYPE:
             offset = 0
             offset_xcvr = 128
-            
+
             sfpd_obj = sff8436Dom()
             if sfpd_obj is None:
                 return None
@@ -1864,8 +1865,9 @@ class SFP(SfpBase):
         """
         handle = self._open_sdk()
         if handle is None:
+            logger.log_error("SDK handler is missing for sfp %d object" % self.index)
             return False
-        
+
         rc = sx_mgmt_phy_mod_reset(self.sdk_handle, self.sdk_index)
         if rc != SX_STATUS_SUCCESS:
             logger.log_warning("sx_mgmt_phy_mod_reset failed, rc = %d" % rc)
@@ -1934,13 +1936,13 @@ class SFP(SfpBase):
     def set_port_admin_status_by_log_port(self, log_port, admin_status):
         rc = sx_api_port_state_set(self.sdk_handle, log_port, admin_status)
         if SX_STATUS_SUCCESS != rc:
-            logger.log_err("sx_api_port_state_set failed, rc = %d" % rc)
+            logger.log_error("sx_api_port_state_set failed, rc = %d" % rc)
 
         return SX_STATUS_SUCCESS == rc
 
 
-    # Get all the ports related to the sfp, if port admin status is up, put it to list
-    def get_log_ports(self):
+    def get_logical_ports(self):
+        # Get all the ports related to the sfp, if port admin status is up, put it to list
         port_attributes_list = new_sx_port_attributes_t_arr(SX_PORT_ATTR_ARR_SIZE)
         port_cnt_p = new_uint32_t_p()
         uint32_t_p_assign(port_cnt_p, SX_PORT_ATTR_ARR_SIZE)
@@ -1952,10 +1954,10 @@ class SFP(SfpBase):
         log_port_list = []
         for i in range(0, port_cnt):
             port_attributes = sx_port_attributes_t_arr_getitem(port_attributes_list, i)
-            if self.is_nve(int(port_attributes.log_port)) == False \
-            and self.is_cpu(int(port_attributes.log_port)) == False \
-            and port_attributes.port_mapping.module_port == self.sdk_index \
-            and self.is_port_admin_status_up(port_attributes.log_port):
+            if not self.is_nve(int(port_attributes.log_port)) \
+               and not self.is_cpu(int(port_attributes.log_port)) \
+               and port_attributes.port_mapping.module_port == self.sdk_index \
+               and self.is_port_admin_status_up(port_attributes.log_port):
                 log_port_list.append(port_attributes.log_port)
 
         return log_port_list
@@ -1973,8 +1975,8 @@ class SFP(SfpBase):
         try:
             rc = sx_mgmt_phy_mod_pwr_attr_set(self.sdk_handle, SX_ACCESS_CMD_SET, self.sdk_index, sx_mgmt_phy_mod_pwr_attr_p)
             if SX_STATUS_SUCCESS != rc:
-                logger.log_err("sx_mgmt_phy_mod_pwr_attr_set failed, rc = %d" % rc)
-                result  = False
+                logger.log_error("sx_mgmt_phy_mod_pwr_attr_set failed, rc = %d" % rc)
+                result = False
             else:
                 result = True
         finally:
@@ -1985,17 +1987,23 @@ class SFP(SfpBase):
 
     def _set_lpmode_raw(self, ports, attr_type, power_mode):
         result = False
-        # bring the port down
-        for port in ports:
-            self.set_port_admin_status_by_log_port(port, SX_PORT_ADMIN_STATUS_DOWN)
-        # set the desired power mode
-        result = self.mgmt_phy_mod_pwr_attr_set(attr_type, power_mode)
-        # get the current port power mode and make sure that it is as per the mode set.
+        # Check if the module already works in the same mode
         admin_pwr_mode, oper_pwr_mode = self.mgmt_phy_mod_pwr_attr_get(attr_type)
-        assert power_mode == admin_pwr_mode, "power mode mismatch"
-        # bring the port up
-        for port in ports:
-            self.set_port_admin_status_by_log_port(port, SX_PORT_ADMIN_STATUS_UP)
+        if (power_mode == SX_MGMT_PHY_MOD_PWR_MODE_LOW_E and oper_pwr_mode == SX_MGMT_PHY_MOD_PWR_MODE_LOW_E) \
+           or (power_mode == SX_MGMT_PHY_MOD_PWR_MODE_AUTO_E and admin_pwr_mode == SX_MGMT_PHY_MOD_PWR_MODE_AUTO_E):
+            return True
+        try:
+            # Bring the port down
+            for port in ports:
+                self.set_port_admin_status_by_log_port(port, SX_PORT_ADMIN_STATUS_DOWN)
+            # Set the desired power mode
+            result = self.mgmt_phy_mod_pwr_attr_set(attr_type, power_mode)
+        finally:
+            # Bring the port up
+            for port in ports:
+                self.set_port_admin_status_by_log_port(port, SX_PORT_ADMIN_STATUS_UP)
+
+        return result
 
 
     def set_lpmode(self, lpmode):
@@ -2011,9 +2019,10 @@ class SFP(SfpBase):
         """
         handle = self._open_sdk()
         if handle is None:
+            logger.log_error("SDK handler is missing for sfp %d object" % self.index)
             return False
 
-        log_port_list = self.get_log_ports()
+        log_port_list = self.get_logical_ports()
         if lpmode:
             self._set_lpmode_raw(log_port_list, SX_MGMT_PHY_MOD_PWR_ATTR_PWR_MODE_E, SX_MGMT_PHY_MOD_PWR_MODE_LOW_E)
             logger.log_info("Enabled low power mode for module [%d]" % (self.sdk_index))
@@ -2029,7 +2038,7 @@ class SFP(SfpBase):
         Sets SFP power level using power_override and power_set
 
         Args:
-            power_override : 
+            power_override :
                     A Boolean, True to override set_lpmode and use power_set
                     to control SFP power, False to disable SFP power control
                     through power_override/power_set and use set_lpmode


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Refactor SFP reset, low power get/set API, and plugins with new SDK SX APIs. Previously they were calling SDK SXD APIs which have glibc dependency because of shared memory usage.   

Remove implementation "set_power_override", "tx_disable_channel", "tx_disable" which using SXD APIs, once related SDK SX API available, will add them back based on new SDK SX APIs.

**- How I did it**
Refactor these API/Plugins with new set of SDK sx_mgmt_* APIs.

**- How to verify it**
Use sfputil command to test the plugin; load platform APIs and test changed APIs

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[Mellanox] Refactor SFP related platform API and plugins with new SDK API

**- A picture of a cute animal (not mandatory but encouraged)**
