### PR TITLE
Allow user to silence variable dump during make

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -89,11 +89,13 @@ endif
 -include $(PLATFORM_PATH)/rules.dep
 endif
 
+ifndef SONIC_BUILD_QUIETER
 $(info "SONIC_DPKG_CACHE_METHOD"         : "$(SONIC_DPKG_CACHE_METHOD)")
 ifneq ($(SONIC_DPKG_CACHE_METHOD),none)
 $(info "DPKG_CACHE_PATH"                 : "$(SONIC_DPKG_CACHE_SOURCE)")
 endif
 $(info )
+endif
 
 
 ###############################################################################

--- a/Makefile.work
+++ b/Makefile.work
@@ -116,12 +116,17 @@ DOCKER_RUN := docker run --rm=true --privileged --init \
     -w $(DOCKER_BUILDER_WORKDIR) \
     -e "http_proxy=$(http_proxy)" \
     -e "https_proxy=$(https_proxy)" \
-    -i$(if $(TERM),t,)
+    -i$(if $(TERM),t,) \
+    $(SONIC_BUILDER_EXTRA_CMDLINE)
 
 include rules/config
 
 ifneq ($(DOCKER_BUILDER_USER_MOUNT),)
 	DOCKER_RUN += $(foreach mount,$(subst $(comma), ,$(DOCKER_BUILDER_USER_MOUNT)), $(addprefix -v , $(mount)))
+endif
+
+ifdef SONIC_BUILD_QUIETER
+	DOCKER_RUN += -e "SONIC_BUILD_QUIETER=$(SONIC_BUILD_QUIETER)"
 endif
 
 ifneq ($(SONIC_DPKG_CACHE_SOURCE),)

--- a/slave.mk
+++ b/slave.mk
@@ -189,6 +189,7 @@ export FRR_USER_GID
 ## Dumping key config attributes associated to current building exercise
 ###############################################################################
 
+ifndef SONIC_BUILD_QUIETER
 $(info SONiC Build System)
 $(info )
 $(info Build Configuration)
@@ -232,6 +233,9 @@ $(info "INCLUDE_KUBERNETES"              : "$(INCLUDE_KUBERNETES)")
 $(info "TELEMETRY_WRITABLE"              : "$(TELEMETRY_WRITABLE)")
 $(info "ENABLE_SYNCHRONOUS_MODE"         : "$(ENABLE_SYNCHRONOUS_MODE)")
 $(info )
+else
+$(info SONiC Build System for $(CONFIGURED_PLATFORM):$(CONFIGURED_ARCH))
+endif
 
 include Makefile.cache
 


### PR DESCRIPTION
**- Why I did it**

Most of the devs know how they configured their build.
Instead of generating a huge header for every make operation, allow the
user to silence it via an environment variable.

Also add SONIC_BUILDER_EXTRA_ENV variable which allows the user to
inject arbitrary options to the docker run cmdline for the builder as part of tooling.

**- How I did it**

Just added a few ifdef in some Makefiles.

**- How to verify it**

Set the SONIC_BUILD_QUIETER environment variable with any value to prevent
make from displaying all the build options.
```
SONIC_BUILD_QUIETER=y make ...

bash% SONIC_BUILD_QUIETER=1 NOJESSIE=1 NOSTRETCH=1 make configure PLATFORM=broadcom
+++ Making configure +++
BLDENV=buster make -f Makefile.work configure
make[1]: Entering directory `/home/staphylo/sonic-buildimage'
SONiC Build System for broadcom:amd64
make[1]: Leaving directory `/home/staphylo/sonic-buildimage'
```

To export 2 environment variables with this mechanism, one can run the following.
```
SONIC_BUILDER_EXTRA_CMDLINE="-e test=var -e var='with spaces'" make ...
```
This is especially useful for tooling.

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**

Allow user to silence variable dump during make and to inject docker run variables