### PR TITLE
Add bgpmon to be started as a new daemon under BGP docker

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/monit_bgp
+++ b/dockers/docker-fpm-frr/base_image_files/monit_bgp
@@ -23,5 +23,5 @@ check process staticd matching "/usr/lib/frr/staticd"
 check process bgpcfgd matching "python /usr/local/bin/bgpcfgd"
     if does not exist for 5 times within 5 cycles then alert
 
-check process bgpmon matching "python /usr/local/bin/bgpmon.py"
+check process bgpmon matching "python /usr/local/bin/bgpmon"
     if does not exist for 5 times within 5 cycles then alert

--- a/dockers/docker-fpm-frr/base_image_files/monit_bgp
+++ b/dockers/docker-fpm-frr/base_image_files/monit_bgp
@@ -23,5 +23,5 @@ check process staticd matching "/usr/lib/frr/staticd"
 check process bgpcfgd matching "python /usr/local/bin/bgpcfgd"
     if does not exist for 5 times within 5 cycles then alert
 
-check process bgpmon matching "python2 /usr/bin/bgpmon.py"
+check process bgpmon matching "python /usr/local/bin/bgpmon.py"
     if does not exist for 5 times within 5 cycles then alert

--- a/dockers/docker-fpm-frr/base_image_files/monit_bgp
+++ b/dockers/docker-fpm-frr/base_image_files/monit_bgp
@@ -6,6 +6,7 @@
 ##  bgpd
 ##  staticd
 ##  bgpcfgd
+##  bgpmon
 ###############################################################################
 check process zebra matching "/usr/lib/frr/zebra"
     if does not exist for 5 times within 5 cycles then alert
@@ -20,4 +21,7 @@ check process staticd matching "/usr/lib/frr/staticd"
     if does not exist for 5 times within 5 cycles then alert
 
 check process bgpcfgd matching "python /usr/local/bin/bgpcfgd"
+    if does not exist for 5 times within 5 cycles then alert
+
+check process bgpmon matching "python2 /usr/bin/bgpmon.py"
     if does not exist for 5 times within 5 cycles then alert

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -85,7 +85,7 @@ dependent_startup=true
 dependent_startup_wait_for=bgpd:running
 
 [program:bgpmon]
-command=/usr/bin/bgpmon.py
+command=/usr/local/bin/bgpmon.py
 priority=6
 autostart=false
 autorestart=false

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -84,6 +84,17 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=bgpd:running
 
+[program:bgpmon]
+command=/usr/bin/bgpmon.py
+priority=6
+autostart=false
+autorestart=false
+startsecs=0
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=bgpd:running
+
 {% if DEVICE_METADATA.localhost.docker_routing_config_mode is defined and DEVICE_METADATA.localhost.docker_routing_config_mode == "unified" %}
 [program:vtysh_b]
 command=/usr/bin/vtysh -b

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -85,7 +85,7 @@ dependent_startup=true
 dependent_startup_wait_for=bgpd:running
 
 [program:bgpmon]
-command=/usr/local/bin/bgpmon.py
+command=/usr/local/bin/bgpmon
 priority=6
 autostart=false
 autorestart=false

--- a/src/sonic-bgpcfgd/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python2
+
+""""
+Description: bgpmon.py -- populating bgp related information in stateDB.
+    script is started by supervisord in bgp docker when the docker is started.
+
+    Initial creation of this daemon is to assist SNMP agent in obtaining the 
+    BGP related information for its MIB support. The MIB that this daemon is
+    assiting is for the CiscoBgp4MIB (Neighbor state only). If there are other
+    BGP related items that needs to be updated in a periodic manner in the 
+    future, then more can be added into this process.
+
+    The script check if there are any bgp activities by monitoring the bgp
+    frr.log file timestamp.  If activity is detected, then it will request bgp
+    neighbor state via vtysh cli interface. This bgp activity monitoring is 
+    done periodically (every 15 second). When triggered, it looks specifically
+    for the neighbor state in the json output of show ip bgp neighbors json
+    and update the state DB for each neighbor accordingly.
+    In order to not disturb and hold on to the State DB access too long and
+    removal of the stale neighbors (neighbors that was there previously on 
+    previous get request but no longer there in the current get request), a
+    "previous" neighbor dictionary will be kept and used to determine if there
+    is a need to perform update or the peer is stale to be removed from the
+    state DB
+"""
+import commands
+import json
+import os
+import syslog
+import swsssdk
+import time
+
+PIPE_BATCH_MAX_COUNT = 50
+
+class BgpStateGet():
+    def __init__(self):
+        # list peer_l stores the Neighbor peer Ip address
+        # dic peer_state stores the Neighbor peer state entries
+        # list new_peer_l stores the new snapshot of Neighbor peer ip address
+        # dic new_peer_state stores the new snapshot of Neighbor peer states
+        self.peer_l = []
+        self.peer_state = {}
+        self.new_peer_l = []
+        self.new_peer_state = {}
+        self.cached_timestamp = 0
+        self.db = swsssdk.SonicV2Connector()
+        self.db.connect(self.db.STATE_DB, False)
+        client = self.db.get_redis_client(self.db.STATE_DB)
+        self.pipe = client.pipeline()
+        self.db.delete_all_by_pattern(self.db.STATE_DB, "NEIGH_STATE_TABLE|*" )
+
+    # A quick way to check if there are anything happening within BGP is to
+    # check its log file has any activities. This is by checking its modified
+    # timestamp against the cached timestamp that we keep and if there is a
+    # difference, there is activity detected. In case the log file got wiped
+    # out, it will default back to constant pulling every 15 seconds
+    def bgp_activity_detected(self):
+        try:
+            timestamp = os.stat("/var/log/frr/frr.log").st_mtime
+            if timestamp != self.cached_timestamp:
+                self.cached_timestamp = timestamp
+                return True
+            else:
+                return False
+        except (IOError, OSError):
+            return True
+
+    def update_new_peer_states(self, peer_dict):
+        peer_l = peer_dict["peers"].keys()
+        self.new_peer_l.extend(peer_l)
+        for i in range (0, len(peer_l)):
+            self.new_peer_state[peer_l[i]] = peer_dict["peers"][peer_l[i]]["state"]
+
+    # Get a new snapshot of BGP neighbors and store them in the "new" location
+    def get_all_neigh_states(self):
+        cmd = "vtysh -c 'show bgp summary json'"
+        rc, output = commands.getstatusoutput(cmd)
+        if rc:
+            syslog.syslog(syslog.LOG_ERR, "*ERROR* Failed with rc:{} when execute: {}".format(rc, cmd))
+            return
+
+        peer_info = json.loads(output)
+        # cmd ran successfully, safe to Clean the "new" lists/dic for new sanpshot
+        del self.new_peer_l[:]
+        self.new_peer_state.clear()
+        for key, value in peer_info.items():
+            if key == "ipv4Unicast" or key == "ipv6Unicast":
+                self.update_new_peer_states(value)
+
+    # This method will take the caller's dictionary which contains the peer state operation
+    # That need to be updated in StateDB using Redis pipeline.
+    # The data{} will be cleared at the end of this method before returning to caller.
+    def flush_pipe(self, data):
+        """Dump each entry in data{} into State DB via redis pipeline.
+        Args:
+            data: Neighbor state in dictionary format
+            {
+                'NEIGH_STATE_TABLE|ip_address_a': {'state':state},
+                'NEIGH_STATE_TABLE|ip_address_b': {'state':state},
+                'NEIGH_STATE_TABLE|ip_address_c': {'state':state},
+                'NEIGH_STATE_TABLE|ip_address_x': None,
+                'NEIGH_STATE_TABLE|ip_address_z': None
+                ...
+            }
+        """
+        for key, value in data.items():
+            if value is None:
+                # delete case
+                self.pipe.delete(key)
+            else:
+                # Add or Modify case
+                self.pipe.hmset(key, value)
+        self.pipe.execute()
+        data.clear()
+
+    def update_neigh_states(self):
+        data = {}
+        for i in range (0, len(self.new_peer_l)):
+            peer = self.new_peer_l[i]
+            key = "NEIGH_STATE_TABLE|%s" % peer
+            if peer in self.peer_l:
+                # only update the entry if state changed
+                if self.peer_state[peer] != self.new_peer_state[peer]:
+                    # state changed. Update state DB for this entry
+                    state = self.new_peer_state[peer]
+                    data[key] = {'state':state}
+                    self.peer_state[peer] = state
+                # remove this neighbor from old list since it is accounted for
+                self.peer_l.remove(peer)
+            else:
+                # New neighbor found case. Add to dictionary and state DB
+                state = self.new_peer_state[peer]
+                data[key] = {'state':state}
+                self.peer_state[peer] = state
+            if len(data) > PIPE_BATCH_MAX_COUNT:
+                self.flush_pipe(data)
+        # Check for stale state entries to be cleaned up
+        while len(self.peer_l) > 0:
+            # remove this from the stateDB and the current nighbor state entry
+            peer = self.peer_l.pop(0)
+            del_key = "NEIGH_STATE_TABLE|%s" % peer
+            data[del_key] = None
+            del self.peer_state[peer]
+            if len(data) > PIPE_BATCH_MAX_COUNT:
+                self.flush_pipe(data)
+        # If anything in the pipeline not yet flushed, flush them now
+        if len(data) > 0:
+            self.flush_pipe(data)
+        # Save the new List
+        self.peer_l = self.new_peer_l[:]
+
+def main():
+
+    print "bgpmon service started"
+
+    try:
+        bgp_state_get = BgpStateGet()
+    except Exception as e:
+        syslog.syslog(syslog.LOG_ERR, "{}: error exit 1, reason {}".format(THIS_MODULE, str(e)))
+        exit(1)
+
+    # periodically obtain the new neighbor infomraton and update if necessary
+    while True:
+        time.sleep(15)
+        if bgp_state_get.bgp_activity_detected():
+            bgp_state_get.get_all_neigh_states()
+            bgp_state_get.update_neigh_states()
+
+if __name__ == '__main__':
+    main()

--- a/src/sonic-bgpcfgd/setup.py
+++ b/src/sonic-bgpcfgd/setup.py
@@ -9,7 +9,12 @@ setuptools.setup(name='sonic-bgpcfgd',
       author_email='pavelsh@microsoft.com',
       url='https://github.com/Azure/sonic-buildimage',
       packages=setuptools.find_packages(),
-      scripts=['bgpcfgd','bgpmon.py'],
+      scripts=['bgpcfgd'],
+      entry_points={
+          'console_scripts': [
+              'bgpmon = bgpmon:main',
+          ]
+      },
       install_requires=['jinja2>=2.10', 'netaddr', 'pyyaml'],
       setup_requires=['pytest-runner', 'pytest'],
 )

--- a/src/sonic-bgpcfgd/setup.py
+++ b/src/sonic-bgpcfgd/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(name='sonic-bgpcfgd',
       author_email='pavelsh@microsoft.com',
       url='https://github.com/Azure/sonic-buildimage',
       packages=setuptools.find_packages(),
-      scripts=['bgpcfgd'],
+      scripts=['bgpcfgd','bgpmon.py'],
       install_requires=['jinja2>=2.10', 'netaddr', 'pyyaml'],
       setup_requires=['pytest-runner', 'pytest'],
 )


### PR DESCRIPTION
This PR is to auto start the bgpmon (BGP Monitor) Daemon under the BGP docker.

The purpose of bgpmon (BGP Monitor daemon) is to assist gathering BGP related information periodically based on BGP activity detection to store BGP Neighbor information into State DB.  For components such as SNMP agent that uses this new BGP related DB in  state DB to support the MIB operation.
This PR is to auto start the bgpmon daemon under the BGP docker. There is another PR which I originally used to implements the bgpmon processing code (https://github.com/Azure/sonic-swss/pull/1429) that was later decided to be moved into this PR instead of under the sonic-swss repo.  Many valuable comments are still in that PR so reader should refer to that PR for review comments history purpose only.

Note: This new daemon is also added to be monitored by Monit so that in case it stops running it will be reported.

The HLD doc PR can be found here:
- [Azure-SONiC] (https://github.com/Azure/SONiC/pull/667)

The following PR (SNMP Agent Changes to use State DB for BGP MIB )has a dependency on this PR:
- [Azure-sonic-snmpagent] (https://github.com/Azure/sonic-snmpagent/pull/158)

The following PR contains the Pytest code that validate this feature functionality whenever VS Image test is run as part of all PRs as well as used in DUT pytest:
-[Azure-sonic-mgmt] (https://github.com/Azure/sonic-mgmt/pull/2241)

Signed-off-by: Gen-Hwa Chiang <gechiang@microsoft.com>

**- What I did**

Added a new daemon to be run under BGP docker periodically to gather the BGP peer state information and update them in 
the state DB.  In order not to continuously running even when there are no BGP peer activities, this new daemon will use the BGP frr.log file timestamp as an indicator whether there are any activities in BGP that warrants it to inspect the peer state info for possible updates.

**- How I did it**

- Start a periodic timer to get triggered every 15 second.
- Check if there is a change in the timestamp of the frr.log file against a cached timestamp from the previous update.
- Request the back-end handler (FRR/Zebra) to dump out the "show bgp summary json"
- For each peer state that it just received, check it against the previous state that was cached and if there is a change or this is new peer, update/add the corresponding state DB table entry.  
- At the end of processing all the peer info, check if there are any stale peer entry present and delete the corresponding state DB entry accordingly.

**- How to verify it**

once the BGP docker is up and running, you can perform "show services" to see that this new daemon "bgpmon.py" is running under the BGP docker service similar to the following output:
```
admin@SONic:~$ show services
...
bgp     docker
---------------------------
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.2  0.2  28576 22632 pts/0    Ss+  19:10   0:08 /usr/bin/python2 /usr/bin/supervisord
root        21  0.0  0.2  22664 16716 pts/0    S    19:11   0:00 python /usr/bin/supervisor-proc-exit-listener --container-name bgp
root        25  0.0  0.0 225856  3512 pts/0    Sl   19:11   0:00 /usr/sbin/rsyslogd -n -iNONE
frr         29  1.0  0.4 525176 36580 pts/0    Sl   19:11   0:40 /usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M fpm -M snmp
frr         30  0.0  0.0  43304  6080 pts/0    S    19:11   0:00 /usr/lib/frr/staticd -A 127.0.0.1
frr         31  2.5  1.0 356196 84108 pts/0    Sl   19:11   1:36 /usr/lib/frr/bgpd -A 127.0.0.1 -M snmp
root        40  0.1  0.6  69172 55876 pts/0    S    19:11   0:05 /usr/bin/python /usr/local/bin/bgpcfgd
root        41  0.0  0.1  20988 15508 pts/0    S    19:11   0:00 /usr/bin/python /usr/local/bin/bgpmon
root        42  0.2  0.0  82108  6136 pts/0    Sl   19:11   0:10 fpmsyncd
...
```
For IPV4 You can perform "show ip bgp summary" and use that output to check against the state DB for each peer.
The state DB key would be something like "NEIGH_STATE_TABLE|10.0.0.33"  where 10.0.0.33 is the peer ip address.
you can then read out the state information by issuing the redis cmd hgetall "NEIGH_STATE_TABLE|10.0.0.33". Compare that with the corresponding output of "show ip bgp summary".
Here is a sample output from the State DB:
admin@str-s6000-acs-8:~$ redis-cli -n 6
127.0.0.1:6379[6]> keys "NEIGH*"
 1) "NEIGH_STATE_TABLE|fc00::1a"
 2) "NEIGH_STATE_TABLE|fc00::32"
 3) "NEIGH_STATE_TABLE|10.0.0.33"
 4) "NEIGH_STATE_TABLE|fc00::66"
 5) "NEIGH_STATE_TABLE|fc00::62"
 6) "NEIGH_STATE_TABLE|fc00::46"
 7) "NEIGH_STATE_TABLE|10.0.0.35"
 8) "NEIGH_STATE_TABLE|10.0.0.53"
 9) "NEIGH_STATE_TABLE|10.0.0.47"
10) "NEIGH_STATE_TABLE|10.0.0.9"
11) "NEIGH_STATE_TABLE|fc00::6e"
12) "NEIGH_STATE_TABLE|10.0.0.41"
13) "NEIGH_STATE_TABLE|10.0.0.63"
14) "NEIGH_STATE_TABLE|10.0.0.17"
15) "NEIGH_STATE_TABLE|fc00::4a"
16) "NEIGH_STATE_TABLE|fc00::52"
17) "NEIGH_STATE_TABLE|fc00::5e"
18) "NEIGH_STATE_TABLE|10.0.0.29"
19) "NEIGH_STATE_TABLE|10.0.0.45"
20) "NEIGH_STATE_TABLE|fc00::2a"
21) "NEIGH_STATE_TABLE|fc00::42"
22) "NEIGH_STATE_TABLE|10.0.0.1"
23) "NEIGH_STATE_TABLE|10.0.0.59"
127.0.0.1:6379[6]> hgetall "NEIGH_STATE_TABLE|10.0.0.1"
1) "state"
2) "Established"
127.0.0.1:6379[6]>

you can do the same for ipv6 by performing "show ipv6 bgp summary" and follow the same steps  above to validate with the corresponding peer states stored in state DB.