### PR TITLE
[ssh limit] add infrastructure to set per user login limit

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -39,6 +39,8 @@
 #  * SONIC_DPKG_CACHE_SOURCE: Debian package cache location when cache enabled for debian packages
 #  * BUILD_LOG_TIMESTAMP: Set timestamp in the build log (simple/none)
 #  * ENABLE_SYNCHRONOUS_MODE: Enable synchronous mode between orchagent and syncd
+#  * USER_LOGIN_LIMIT: Specifying number of concurrent login allowed per user.
+#  *                 Default: unlimited
 #
 ###############################################################################
 
@@ -205,6 +207,7 @@ SONIC_BUILD_INSTRUCTION :=  make \
                            KERNEL_PROCURE_METHOD=$(KERNEL_PROCURE_METHOD) \
                            SONIC_DPKG_CACHE_METHOD=$(SONIC_DPKG_CACHE_METHOD) \
                            SONIC_DPKG_CACHE_SOURCE=$(SONIC_DPKG_CACHE_SOURCE) \
+                           USER_LOGIN_LIMIT=$(USER_LOGIN_LIMIT) \
                            HTTP_PROXY=$(http_proxy) \
                            HTTPS_PROXY=$(https_proxy) \
                            SONIC_INCLUDE_SYSTEM_TELEMETRY=$(INCLUDE_SYSTEM_TELEMETRY) \

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -413,6 +413,11 @@ done < files/image_config/sysctl/sysctl-net.conf
 
 sudo augtool --autosave "$sysctl_net_cmd_string" -r $FILESYSTEM_ROOT
 
+# Set per-user ssh login limit
+if [[ ${USER_LOGIN_LIMIT} -gt 0 ]]; then
+    sudo sed -i -e "$ i\# Limit per user ssh login\n*                -       maxlogins       ${USER_LOGIN_LIMIT}\n" ${FILESYSTEM_ROOT}/etc/security/limits.conf
+fi
+
 ## docker Python API package is needed by Ansible docker module
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'docker==4.1.0'
 ## Note: keep pip installed for maintainance purpose

--- a/rules/config
+++ b/rules/config
@@ -112,7 +112,6 @@ SONIC_DPKG_CACHE_SOURCE ?= /var/cache/sonic/artifacts
 # Default VS build memory preparation
 DEFAULT_VS_PREPARE_MEM = yes
 
-
 # INCLUDE_SYSTEM_TELEMETRY - build docker-sonic-telemetry for system telemetry support
 INCLUDE_SYSTEM_TELEMETRY = y
 
@@ -161,3 +160,6 @@ SONIC_ENABLE_IMAGE_SIGNATURE ?= n
 
 # ENABLE_SYNCHRONOUS_MODE - enable synchronous mode between orchagent and syncd
 ENABLE_SYNCHRONOUS_MODE = n
+
+# Default SSH per user login limit (unlimited)
+DEFAULT_USER_LOGIN_LIMIT = 0

--- a/slave.mk
+++ b/slave.mk
@@ -174,6 +174,10 @@ ifeq ($(BUILD_LOG_TIMESTAMP),)
 override BUILD_LOG_TIMESTAMP := $(DEFAULT_BUILD_LOG_TIMESTAMP)
 endif
 
+ifeq ($(USER_LOGIN_LIMIT),)
+override USER_LOGIN_LIMIT := $(DEFAULT_USER_LOGIN_LIMIT)
+endif
+
 MAKEFLAGS += -j $(SONIC_BUILD_JOBS)
 export SONIC_CONFIG_MAKE_JOBS
 
@@ -231,6 +235,7 @@ $(info "INCLUDE_NAT"                     : "$(INCLUDE_NAT)")
 $(info "INCLUDE_KUBERNETES"              : "$(INCLUDE_KUBERNETES)")
 $(info "TELEMETRY_WRITABLE"              : "$(TELEMETRY_WRITABLE)")
 $(info "ENABLE_SYNCHRONOUS_MODE"         : "$(ENABLE_SYNCHRONOUS_MODE)")
+$(info "USER_LOGIN_LIMIT"                : "$(USER_LOGIN_LIMIT)")
 $(info )
 
 include Makefile.cache
@@ -919,6 +924,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	DEBUG_SRC_ARCHIVE_FILE="$(DBG_SRC_ARCHIVE_FILE)" \
 	USERNAME="$(USERNAME)" \
 	PASSWORD="$(PASSWORD)" \
+	USER_LOGIN_LIMIT="$(USER_LOGIN_LIMIT)" \
 	IMAGE_TYPE=$($*_IMAGE_TYPE) \
 		./build_debian.sh $(LOG)
 


### PR DESCRIPTION
**- Why I did it**
We have an use case to limit max number of login per user.

**- How I did it**
Specifying per user login limit via USER_LOGIN_LIMIT build argument.

When not specified, the per user login is unlimited by default.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Verified in 2 aspects:
1. limit working on DUT: set the limit to 2 and validated that the 3rd login is rejected from ssh and/or console.
2. build test: without specifying the limit, /etc/security/limits.conf didn't change. Build with option SSH_USER_LOGIN_LIMIT=2, and verified that the configuration changed accordingly.

**- Which release branch to backport (provide reason below if selected)**

- [x] 201811
- [x] 201911
- [x] 202006
