### PR TITLE
[redis] Use redis-server and redis-tools in blob storage to prevent upstream link broken

### DIFF
--- a/dockers/docker-base-buster/Dockerfile.j2
+++ b/dockers/docker-base-buster/Dockerfile.j2
@@ -53,6 +53,12 @@ RUN apt-get update &&        \
 # Install dependencies of supervisor
         python-pkg-resources \
         python-meld3         \
+# Install dependencies of redis-tools
+        libatomic1           \
+        libjemalloc2         \
+        liblua5.1-0          \
+        lua-bitop            \
+        lua-cjson            \
 # common dependencies
         libpython2.7         \
         libdaemon0           \
@@ -69,7 +75,7 @@ RUN apt-get update &&        \
 
 # Install redis-tools
 RUN curl -o redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
-RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_amd64.deb || apt-get install -f
+RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_amd64.deb || apt-get install -f -y
 RUN rm redis-tools_6.0.6-1~bpo10+1_amd64.deb
 
 # For templating

--- a/dockers/docker-base-buster/Dockerfile.j2
+++ b/dockers/docker-base-buster/Dockerfile.j2
@@ -52,8 +52,6 @@ RUN apt-get update &&        \
 # Install dependencies of supervisor
         python-pkg-resources \
         python-meld3         \
-# Install redis-tools
-        redis-tools=5:6.0.6-1~bpo10+1     \
 # common dependencies
         libpython2.7         \
         libdaemon0           \
@@ -67,6 +65,11 @@ RUN apt-get update &&        \
         python-wheel         \
 # for processing/handling json files in bash environment
         jq
+
+# Install redis-tools
+RUN wget -O redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
+RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_amd64.deb || apt-get install -f
+RUN rm redis-tools_6.0.6-1~bpo10+1_amd64.deb
 
 # For templating
 RUN pip install j2cli

--- a/dockers/docker-base-buster/Dockerfile.j2
+++ b/dockers/docker-base-buster/Dockerfile.j2
@@ -40,6 +40,7 @@ COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 # pre-install fundamental packages
 RUN apt-get update &&        \
     apt-get -y install       \
+        curl                 \
         less                 \
         perl                 \
         procps               \
@@ -67,7 +68,7 @@ RUN apt-get update &&        \
         jq
 
 # Install redis-tools
-RUN wget -O redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
+RUN curl -o redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
 RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_amd64.deb || apt-get install -f
 RUN rm redis-tools_6.0.6-1~bpo10+1_amd64.deb
 

--- a/dockers/docker-database/Dockerfile.j2
+++ b/dockers/docker-database/Dockerfile.j2
@@ -11,7 +11,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 
 # install redis-server
-RUN apt-get install -y redis-server=5:6.0.6-1~bpo10+1
+RUN wget -O redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
+RUN wget -O redis-server_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-server_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=2Ketg7BmkZEaTxR%2FgvAFVmhjn7ywdmkc7l2T2rsL57o%3D&se=2030-09-06T19%3A45%3A20Z&sp=r"
+RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_amd64.deb redis-server_6.0.6-1~bpo10+1_amd64.deb || apt-get install -f
+RUN rm redis-tools_6.0.6-1~bpo10+1_amd64.deb redis-server_6.0.6-1~bpo10+1_amd64.deb
 
 {% if docker_database_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/dockers/docker-database/Dockerfile.j2
+++ b/dockers/docker-database/Dockerfile.j2
@@ -11,8 +11,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 
 # install redis-server
-RUN wget -O redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
-RUN wget -O redis-server_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-server_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=2Ketg7BmkZEaTxR%2FgvAFVmhjn7ywdmkc7l2T2rsL57o%3D&se=2030-09-06T19%3A45%3A20Z&sp=r"
+RUN curl -o redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
+RUN curl -o redis-server_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-server_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=2Ketg7BmkZEaTxR%2FgvAFVmhjn7ywdmkc7l2T2rsL57o%3D&se=2030-09-06T19%3A45%3A20Z&sp=r"
 RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_amd64.deb redis-server_6.0.6-1~bpo10+1_amd64.deb || apt-get install -f
 RUN rm redis-tools_6.0.6-1~bpo10+1_amd64.deb redis-server_6.0.6-1~bpo10+1_amd64.deb
 

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -49,8 +49,8 @@ RUN apt-get install -y net-tools \
                        jq
 
 # install redis-server
-RUN wget -O redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
-RUN wget -O redis-server_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-server_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=2Ketg7BmkZEaTxR%2FgvAFVmhjn7ywdmkc7l2T2rsL57o%3D&se=2030-09-06T19%3A45%3A20Z&sp=r"
+RUN curl -o redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
+RUN curl -o redis-server_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-server_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=2Ketg7BmkZEaTxR%2FgvAFVmhjn7ywdmkc7l2T2rsL57o%3D&se=2030-09-06T19%3A45%3A20Z&sp=r"
 RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_amd64.deb redis-server_6.0.6-1~bpo10+1_amd64.deb || apt-get install -f
 RUN rm redis-tools_6.0.6-1~bpo10+1_amd64.deb redis-server_6.0.6-1~bpo10+1_amd64.deb
 

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -13,7 +13,6 @@ RUN echo "deb http://packages.microsoft.com/repos/sonic-dev/ jessie main" >> /et
 RUN apt-get update
 
 RUN apt-get install -y net-tools \
-                       redis-server=5:6.0.6-1~bpo10+1 \
                        arping \
                        ndisc6 \
                        ethtool \
@@ -48,6 +47,12 @@ RUN apt-get install -y net-tools \
                        iptables \
                        python3-pip \
                        jq
+
+# install redis-server
+RUN wget -O redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
+RUN wget -O redis-server_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-server_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=2Ketg7BmkZEaTxR%2FgvAFVmhjn7ywdmkc7l2T2rsL57o%3D&se=2030-09-06T19%3A45%3A20Z&sp=r"
+RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_amd64.deb redis-server_6.0.6-1~bpo10+1_amd64.deb || apt-get install -f
+RUN rm redis-tools_6.0.6-1~bpo10+1_amd64.deb redis-server_6.0.6-1~bpo10+1_amd64.deb
 
 RUN pip install setuptools
 RUN pip3 install setuptools


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Upstream link broken and the build is failed

**- How I did it**
Use redis-server and redis-tools in blob storage

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
