### PR TITLE
fix error: interface counters is mismatch after warm-reboot

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -76,6 +76,20 @@ function stop_control_plane_assistant()
     fi
 }
 
+function restore_counters_folder()
+{
+    debug "Restoring counters folder after warmboot..."
+
+    modules=("portstat-0" "dropstat" "pfcstat-0" "queuestat-0" "intfstat-0")
+    for module in ${modules[@]}
+    do
+        statfile="/host/$module"
+        if [[ -d $statfile ]]; then
+            mv $statfile /tmp/
+        fi
+    done
+}
+
 
 wait_for_database_service
 
@@ -85,6 +99,8 @@ if [[ x"${WARM_BOOT}" != x"true" ]]; then
     debug "warmboot is not enabled ..."
     exit 0
 fi
+
+restore_counters_folder
 
 list=${COMP_LIST}
 

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -83,7 +83,7 @@ function restore_counters_folder()
     modules=("portstat-0" "dropstat" "pfcstat-0" "queuestat-0" "intfstat-0")
     for module in ${modules[@]}
     do
-        statfile="/host/$module"
+        statfile="/host/counters/$module"
         if [[ -d $statfile ]]; then
             mv $statfile /tmp/
         fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
There is a issue for counters after warm-reboot:
If I clear counters by command "sonic-clear counters", then execute 'warm-reboot' and whenSONiC is restart, the counters showed with command "show interface counters" is still old counters before "sonic-clear".  It is not the right counters because the counters file in '/tmp' is lost in warm-reboot process.

**- How I did it**
I fixed it by saving '/tmp/portstat-0' folders in '/host/' before executing 'warm-reboot'  (in pull request Azure/sonic-utilities#1099 ), and restore the counters folders back to '/tmp/' after warm-reboot process is finished.

**- How to verify it**
1.  Clear counters by command 'sonic-clear'
        sonic-clear counters
	sonic-clear dropcounters
	sonic-clear pfccounters
	sonic-clear queuecounters
	sonic-clear rifcounters
2. Execute 'warm-reboot'
3.  Use command ‘show interface counters’ to see if the counters is right.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
