### PR TITLE
Add new DB for Restapi to database config

### DIFF
--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -52,6 +52,11 @@
             "id" : 7,
             "separator": "|",
             "instance" : "redis"
+        },
+        "RESTAPI_DB" : {
+            "id" : 8,
+            "separator": "|",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"


### PR DESCRIPTION
**- Why I did it**
Add new DB for Restapi.

This DB is used for storing RESTAPI docker's:

1. Reset info
2. Server Guid
3. Uptime

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
