### PR TITLE
Change the loopback interface netmask from /8 to /16

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -13,7 +13,7 @@ iface mgmt
 # The loopback network interface for mgmt VRF that is required for applications like NTP
     up ip link add lo-m type dummy
     up ip link set dev lo-m master mgmt
-    up ip addr add 127.0.0.1/8 dev lo-m
+    up ip addr add 127.0.0.1/16 dev lo-m
     up ip link set lo-m up
     down ip link delete dev lo-m
 {% endif %}
@@ -22,6 +22,9 @@ iface mgmt
 # The loopback network interface
 auto lo
 iface lo inet loopback
+   address 127.0.0.1
+   netmask 255.255.0.0
+   post-up ip addr del 127.0.0.1/8 dev lo
 {% endblock loopback %}
 {% block mgmt_interface %}
 

--- a/src/sonic-config-engine/tests/sample_output/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/interfaces
@@ -6,6 +6,9 @@
 # The loopback network interface
 auto lo
 iface lo inet loopback
+   address 127.0.0.1
+   netmask 255.255.0.0
+   post-up ip addr del 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0

--- a/src/sonic-config-engine/tests/sample_output/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/mvrf_interfaces
@@ -9,12 +9,15 @@ iface mgmt
 # The loopback network interface for mgmt VRF that is required for applications like NTP
     up ip link add lo-m type dummy
     up ip link set dev lo-m master mgmt
-    up ip addr add 127.0.0.1/8 dev lo-m
+    up ip addr add 127.0.0.1/16 dev lo-m
     up ip link set lo-m up
     down ip link delete dev lo-m
 # The loopback network interface
 auto lo
 iface lo inet loopback
+   address 127.0.0.1
+   netmask 255.255.0.0
+   post-up ip addr del 127.0.0.1/8 dev lo
 
 # The management network interface
 auto eth0


### PR DESCRIPTION
**- Why I did it**

As per the VOQ HLDs, internal networking between the linecards and supervisor is required within a chassis.
Allocating 127.X/16 subnets for private communication within a chassis is a good candidate.
It doesn't require any external IP allocation as well as ensure that the traffic will not leave the chassis.

References:
https://github.com/Azure/SONiC/pull/622
https://github.com/Azure/SONiC/pull/639

**- How I did it**

Changed the `interfaces.j2` file to add `127.0.0.1/16` as the `lo` ip address.
Then once the interface is up, the post-up command removes the `127.0.0.1/8` ip address.
The order in which the netmask change is made matters for `127.0.0.1` to be reachable at all times.

**- How to verify it**

```
root@sonic:~# ip address show dev lo
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/16 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
```

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**

Change the loopback interface netmask from /8 to /16