### PR TITLE
[Multi-Asic] Fix for multi-asic where we should allow namespace docker local communication on its docker/eth0 ip

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -200,6 +200,10 @@ class ControlPlaneAclManager(object):
         allow_internal_docker_ip_cmds = []
 
         if namespace:
+            # For namespace docker allow local communication on docker management ip for all proto
+            allow_internal_docker_ip_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -A INPUT -s {} -d {} -j ACCEPT".format
+                                                (self.namespace_docker_mgmt_ip[namespace], self.namespace_docker_mgmt_ip[namespace]))
+
             # For namespace docker allow all tcp/udp traffic from host docker bridge to its eth0 management ip
             allow_internal_docker_ip_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -A INPUT -p tcp -s {} -d {} -j ACCEPT".format
                                                  (self.namespace_mgmt_ip, self.namespace_docker_mgmt_ip[namespace]))


### PR DESCRIPTION
Why/What i did:
Fix for multi-asic where we should allow namespace docker local communication on its docker/eth0 ip
. Without this TCP Connection to Redis Server running on docker eth0 ip does not happen in namespace if there is Catch all DROP Rule.

Found this issue as part of debugging
a)  lldpmgrd was not able to start in namespace (uses Redis TCP Connection)
b) Feature auto restart not working for namespace docker (supervisor-proc-exit-listener also  uses Redis TCP Connection)

How I verify:

After fix both issue (a) and (b) are working fine.