### PR TITLE
Fix bug with pcie-check.service

### DIFF
--- a/files/image_config/pcie-check/pcie-check.service
+++ b/files/image_config/pcie-check/pcie-check.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Check the PCIe device presence and status
-After=rc.local.service
+After=rc.local.service database.service
 
 [Service]
 Type=simple

--- a/files/image_config/pcie-check/pcie-check.sh
+++ b/files/image_config/pcie-check/pcie-check.sh
@@ -16,7 +16,7 @@ function debug()
 
 function check_and_rescan_pcie_devices()
 {
-    PCIE_CHK_CMD=$(sudo pcieutil pcie-check |grep "$RESULTS")
+    PCIE_CHK_CMD='sudo pcieutil pcie-check |grep "$RESULTS"'
     PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 
     if [ ! -f /usr/share/sonic/device/$PLATFORM/plugins/pcie.yaml ]; then
@@ -36,8 +36,8 @@ function check_and_rescan_pcie_devices()
             break
         fi
 
-        if [ "$PCIE_CHK_CMD" = "$EXPECTED" ]; then
-            redis-cli -n 6 SET "PCIE_STATUS|PCIE_DEVICES" "PASSED"
+        if [ "$(eval $PCIE_CHK_CMD)" = "$EXPECTED" ]; then
+            redis-cli -n 6 HSET "PCIE_DEVICES" "status" "PASSED"
             debug "PCIe check passed"
             exit
         else
@@ -53,7 +53,7 @@ function check_and_rescan_pcie_devices()
 
      done
      debug "PCIe check failed"
-     redis-cli -n 6 SET "PCIE_STATUS|PCIE_DEVICES" "FAILED"
+     redis-cli -n 6 HSET "PCIE_DEVICES" "status" "FAILED"
 }
 
 check_and_rescan_pcie_devices


### PR DESCRIPTION
Signed-off-by: Petro Bratash <petrox.bratash@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
pci-check.service and pcied daemon set different variables in STATE_DB.

- _pci-check.service_ set `"PCIE_STATUS|PCIE_DEVICES"` variable with type _**string**_, 

- _pcied daemon_ set  `"PCIE_STATUS|" -> "PCIE_DEVICES"`  variable with type _**hash**_.  

**- How I did it**
Change type for variable with PCI device status from `string` to `hash` ("PCIE_STATUS|PCIE_DEVICES" --> "PCIE_DEVICES" "status"), because haven't got [API ](https://github.com/Azure/sonic-py-swsssdk/blob/91cc6c651e903b65b95838dc3b2cd1d2751c63b6/src/swsssdk/dbconnector.py#L305) for work with string variable from Python.
**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Also, in this PR fixed the issues:

- `PCIE_CHK_CMD` the variable contains the result of the command work's, and this result cyclically compares with `EXPECTED` without rescanning devices.

- Added dependency to `database.service`,  because when `pcie-check.service` start before `database.service` will be next error:

> pcie-check.sh[912]: Traceback (most recent call last):
> pcie-check.sh[912]:   File "/usr/bin/pcieutil", line 12, in <module>
> pcie-check.sh[912]:     sys.exit(cli())
> pcie-check.sh[912]:   File "/usr/lib/python2.7/dist-packages/click/core.py", line 764, in __call__
> pcie-check.sh[912]:     return self.main(*args, **kwargs)
> pcie-check.sh[912]:   File "/usr/lib/python2.7/dist-packages/click/core.py", line 717, in main
> pcie-check.sh[912]:     rv = self.invoke(ctx)
> pcie-check.sh[912]:   File "/usr/lib/python2.7/dist-packages/click/core.py", line 1134, in invoke
> pcie-check.sh[912]:     Command.invoke(self, ctx)
> pcie-check.sh[912]:   File "/usr/lib/python2.7/dist-packages/click/core.py", line 956, in invoke
> pcie-check.sh[912]:     return ctx.invoke(self.callback, **ctx.params)
> pcie-check.sh[912]:   File "/usr/lib/python2.7/dist-packages/click/core.py", line 555, in invoke
> pcie-check.sh[912]:     return callback(*args, **kwargs)
> pcie-check.sh[912]:   File "/usr/lib/python2.7/dist-packages/pcieutil/main.py", line 75, in cli
> pcie-check.sh[912]:     load_platform_pcieutil()
> pcie-check.sh[912]:   File "/usr/lib/python2.7/dist-packages/pcieutil/main.py", line 49, in load_platform_pcieutil
> pcie-check.sh[912]:     platform_path, _ = device_info.get_paths_to_platform_and_hwsku_dirs()
> pcie-check.sh[912]:   File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/device_info.py", line 213, in get_paths_to_platform_and_hwsku_dirs
> pcie-check.sh[912]:     hwsku_path = os.path.join(platform_path, hwsku)
> pcie-check.sh[912]:   File "/usr/lib/python2.7/posixpath.py", line 68, in join
> pcie-check.sh[912]:     if b.startswith('/'):
> pcie-check.sh[912]: AttributeError: 'NoneType' object has no attribute 'startswith'

Related PR: https://github.com/Azure/sonic-platform-daemons/pull/93
Fix for: https://github.com/Azure/sonic-buildimage/issues/5349

**- A picture of a cute animal (not mandatory but encouraged)**
