### PR TITLE
[Mellanox] Always restart thermalctld on Mellanox platform when it exits

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
@@ -1,5 +1,6 @@
 {
     "skip_ledd": true,
-    "skip_fancontrol": true
+    "skip_fancontrol": true,
+    "always_restart_thermalctld": true
 }
 

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -120,7 +120,11 @@ dependent_startup_wait_for=start:exited
 command=/usr/local/bin/thermalctld
 priority=9
 autostart=false
+{% if not always_restart_thermalctld %}
 autorestart=unexpected
+{% else %}
+autorestart=true
+{% endif %}
 stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

On mellanox paltform, part of thermalctld function is to handle user space thermal policies for events like fan/PSU removing, it works together with kernel thermal algorithm to make sure the switch won't be overheat.

Recently, we found that commit https://github.com/Azure/sonic-buildimage/commit/cbc75fe4c85fd01aded0bacb283c8bbf62adf2f8 changes its autorestart configuration in supervisord, and it won't be auto restarted after being killed. This PR is to make sure that thermalctld will be always restarted on mellanox platform when it is killed.

**- How I did it**

1. Add a variable "always_restart_thermalctld" in pmon_daemon_control.json
2. In docker-pmon.supervisord.conf.j2, it checks variable "always_restart_thermalctld" and set autorestart configuration for thermalctld accordingly.

**- How to verify it**

Manual test

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

Depends on where https://github.com/Azure/sonic-buildimage/commit/cbc75fe4c85fd01aded0bacb283c8bbf62adf2f8 is going to merge to. 

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
