### PR TITLE
[logrotate] ignore /etc/logrotate.d/alternatives

### DIFF
--- a/files/image_config/logrotate/logrotate.conf
+++ b/files/image_config/logrotate/logrotate.conf
@@ -12,6 +12,7 @@ create
 #compress
 
 # packages drop log rotation information into this directory
+taboopat alternatives
 include /etc/logrotate.d
 
 # no packages own wtmp, or btmp -- we'll rotate them here


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

**- Why I did it**
To fix the following error when running
`logrotate /etc/logrotate.conf` :
```
error: dpkg:10 duplicate log entry for /var/log/alternatives.log
error: found error in file dpkg, skipping
```
(<sonic-buildimage>/files/image_config/logrotate/logrotate.d/dpkg already contains rule for the /var/log/alternatives.log)

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
[logrotate] ignore /etc/logrotate.d/alternatives