### PR TITLE
[logrotate] create separate logrotate.d config for update-alternatives

### DIFF
--- a/files/image_config/logrotate/logrotate.d/alternatives
+++ b/files/image_config/logrotate/logrotate.d/alternatives
@@ -1,4 +1,4 @@
-/var/log/dpkg.log {
+/var/log/alternatives.log {
         size 100k
         rotate 1
         compress


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

**- Why I did it**
To fix the following error when running
`logrotate /etc/logrotate.conf` :
```
error: dpkg:10 duplicate log entry for /var/log/alternatives.log
error: found error in file dpkg, skipping
```
update-alternatives is provided with dedicated logrotate config in newer dpkg package versions (probably starting from buster)

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
[logrotate] create separate logrotate.d config for update-alternatives