### PR TITLE
[process-reboot-cause] Use Logger class from sonic-py-common package

### DIFF
--- a/files/image_config/process-reboot-cause/process-reboot-cause
+++ b/files/image_config/process-reboot-cause/process-reboot-cause
@@ -9,11 +9,10 @@
 try:
     import os
     import pwd
-    import sys
-    import syslog
     import re
+    import sys
 
-    from sonic_py_common import device_info
+    from sonic_py_common import device_info, logger
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
 
@@ -39,24 +38,8 @@ REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
 REBOOT_CAUSE_UNKNOWN = "Unknown"
 
 
-# ========================== Syslog wrappers ==========================
-
-def log_info(msg):
-    syslog.openlog(SYSLOG_IDENTIFIER)
-    syslog.syslog(syslog.LOG_INFO, msg)
-    syslog.closelog()
-
-
-def log_warning(msg):
-    syslog.openlog(SYSLOG_IDENTIFIER)
-    syslog.syslog(syslog.LOG_WARNING, msg)
-    syslog.closelog()
-
-
-def log_error(msg):
-    syslog.openlog(SYSLOG_IDENTIFIER)
-    syslog.syslog(syslog.LOG_ERR, msg)
-    syslog.closelog()
+# Global logger class instance
+sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 
 # ============================= Functions =============================
@@ -79,9 +62,9 @@ def find_software_reboot_cause():
     if os.path.isfile(REBOOT_CAUSE_FILE):
         with open(REBOOT_CAUSE_FILE, "r") as cause_file:
             software_reboot_cause = cause_file.readline().rstrip('\n')
-            log_info("{} indicates the reboot cause: {}".format(REBOOT_CAUSE_FILE, software_reboot_cause))
+            sonic_logger.log_info("{} indicates the reboot cause: {}".format(REBOOT_CAUSE_FILE, software_reboot_cause))
     else:
-        log_info("Reboot cause file {} not found".format(REBOOT_CAUSE_FILE))
+        sonic_logger.log_info("Reboot cause file {} not found".format(REBOOT_CAUSE_FILE))
 
     if os.path.isfile(FIRST_BOOT_PLATFORM_FILE):
         if software_reboot_cause == REBOOT_CAUSE_UNKNOWN:
@@ -97,9 +80,9 @@ def find_proc_cmdline_reboot_cause():
     proc_cmdline_reboot_cause = parse_warmfast_reboot_from_proc_cmdline()
  
     if proc_cmdline_reboot_cause:
-        log_info("/proc/cmdline indicates reboot type: {}".format(proc_cmdline_reboot_cause))
+        sonic_logger.log_info("/proc/cmdline indicates reboot type: {}".format(proc_cmdline_reboot_cause))
     else:
-        log_info("No reboot cause found from /proc/cmdline")
+        sonic_logger.log_info("No reboot cause found from /proc/cmdline")
  
     return proc_cmdline_reboot_cause
  
@@ -128,21 +111,24 @@ def find_hardware_reboot_cause():
         else:
             hardware_reboot_cause = hardware_reboot_cause_major
     except ImportError as err:
-        log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
+        sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
 
     if hardware_reboot_cause:
-        log_info("Platform api indicates reboot cause {}".format(hardware_reboot_cause))
+        sonic_logger.log_info("Platform api indicates reboot cause {}".format(hardware_reboot_cause))
     else:
-        log_info("No reboot cause found from platform api")
+        sonic_logger.log_info("No reboot cause found from platform api")
 
     return hardware_reboot_cause
 
 
 def main():
-    log_info("Starting up...")
+    # Configure logger to log all messages INFO level and higher
+    sonic_logger.set_min_log_priority_info()
+
+    sonic_logger.log_info("Starting up...")
 
     if not os.geteuid() == 0:
-        log_error("User {} does not have permission to execute".format(pwd.getpwuid(os.getuid()).pw_name))
+        sonic_logger.log_error("User {} does not have permission to execute".format(pwd.getpwuid(os.getuid()).pw_name))
         sys.exit("This utility must be run as root")
 
     # Create REBOOT_CAUSE_DIR if it doesn't exist
@@ -186,7 +172,7 @@ def main():
         prev_cause_file.write(previous_reboot_cause)
 
     # Also log the previous reboot cause to the syslog
-    log_info("Previous reboot cause: {}".format(previous_reboot_cause))
+    sonic_logger.log_info("Previous reboot cause: {}".format(previous_reboot_cause))
 
     # Remove the old REBOOT_CAUSE_FILE
     if os.path.exists(REBOOT_CAUSE_FILE):


### PR DESCRIPTION
**- Why I did it**

Eliminate duplicate logging code by importing Logger class from sonic-py-common package.

**- How to verify it**

Ensure process-reboot-cause functionality is unchanged

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006