### PR TITLE
[swss] Start Arp Update Process

### DIFF
--- a/dockers/docker-orchagent/docker-init.sh
+++ b/dockers/docker-orchagent/docker-init.sh
@@ -20,7 +20,7 @@ fi
 
 # Start arp_update when VLAN exists
 if [ "$VLAN" != "" ]; then
-    cp /usr/share/sonic/templates/arp_update.conf /etc/supervisord/conf.d/
+    cp /usr/share/sonic/templates/arp_update.conf /etc/supervisor/conf.d/
 fi
 
 exec /usr/bin/supervisord


### PR DESCRIPTION
Arp update process was not being started due to an issue with
the directory name having an extra 'd' in supervisor as in
'/etc/supervisord/conf.d/arp_update.conf'.

related to: #5217

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
arp_update script is not running

**- How I did it**
Fixed a bug with the dir name
`/etc/supervisord/conf.d/` --> `/etc/supervisor/conf.d/`

**- How to verify it**
After reboot, `arp_update` process should be running
```
admin@str-s6000-acs-14:~$ sudo zgrep arp_update /var/log/syslog*
Sep 17 01:32:29.345680 str-s6000-acs-14 INFO swss#supervisord 2020-09-17 01:32:25,607 INFO Included extra file "/etc/supervisor/conf.d/arp_update.conf" during parsing
Sep 17 01:33:09.656047 str-s6000-acs-14 INFO swss#supervisord 2020-09-17 01:33:02,318 INFO spawned: 'arp_update' with pid 90
Sep 17 01:33:09.656047 str-s6000-acs-14 INFO swss#supervisord 2020-09-17 01:33:03,411 INFO success: arp_update entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Sep 17 01:33:23.798435 str-s6000-acs-14 INFO swss#supervisord: arp_update ping6: Warning: source address might be selected on device other than Vlan1000.
admin@str-s6000-acs-14:~$ ps -ef | grep arp_update
root      3870  2435  0 01:33 pts/0    00:00:00 /bin/bash /usr/bin/arp_update
admin     5056  3409  0 01:34 pts/0    00:00:00 grep arp_update
```

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [x] 202006
