### PR TITLE
[device/accton]as4630-54pe, two i2c adaptors might be installed not in presumed order.

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_util.py
@@ -277,13 +277,13 @@ def i2c_order_check():
     # i2c bus 0 and 1 might be installed in different order.
     # Here check if 0x77 is exist @ i2c-1
     tmp = "echo pca9548 0x77 > /sys/bus/i2c/devices/i2c-1/new_device"
-    status, output = log_os_system(tmp, 0)
+    log_os_system(tmp, 0)
     if not device_exist():
         order = 1
     else:
         order = 0
     tmp = "echo 0x77 > /sys/bus/i2c/devices/i2c-1/delete_device"
-    status, output = log_os_system(tmp, 0)
+    log_os_system(tmp, 0)
     return order
 
 def device_install():


### PR DESCRIPTION
Add a check on i2c bus topology and follow up.
Signed-off-by: roy_lee <roy_lee@accton.com>


**- Why I did it**
Sometimes, DUT boot-up with i2c dev error message.

**- How I did it**
Check i2c buses and use the correct one to install devices.

**- How to verify it**
No error at a long time reboot test. 

**- Which release branch to backport (provide reason below if selected)**
- [x] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
As the code diff. 
