### PR TITLE
[mgmt] Upgrade sonic-mgmt container to stretch

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -20,6 +20,9 @@ RUN apt-get update && apt-get install -y build-essential \
                                          python-dev \
                                          python-scapy \
                                          python-setuptools \
+                                         python-pip \
+                                         python3-pip \
+                                         python3-venv \
                                          rsyslog \
                                          snmp \
                                          sshpass \
@@ -27,8 +30,6 @@ RUN apt-get update && apt-get install -y build-essential \
                                          tcpdump \
                                          telnet \
                                          vim
-
-RUN easy_install pip==20.1.1
 
 RUN pip install cffi==1.10.0 \
                 "cryptography>=2.5" \
@@ -156,18 +157,14 @@ USER $user
 
 # Install Azure CLI
 WORKDIR /var/$user
-RUN curl -L https://aka.ms/InstallAzureCliBundled -o azure-cli_bundle.tar.gz
-RUN tar -xvzf azure-cli_bundle.tar.gz
-RUN azure-cli_bundle_*/installer
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
-# Known bug: azure keyvault cannot work behind a proxy
-# Temporary fix: upgrade the azure-keyvault package within az cli
-# TODO: if azure-cli contains newer version azure-keyvault, remove this
-RUN ~/lib/azure-cli/bin/python -m pip install azure-keyvault==0.3.7 -U
-
-# Install Virtual Environment
+# Install Virtual Environments
 RUN python -m virtualenv --system-site-packages env-201811
 RUN env-201811/bin/pip install ansible==2.0.0.2
+
+RUN python3 -m venv test-reporting-env0
+RUN test-reporting-env/bin/pip3 install azure-kusto-data azure-kusto-ingest defusedxml pytest
 
 # NOTE: There is an ordering dependency for pycryptodome. Leaving this at
 #       the end until we figure that out.

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -163,8 +163,8 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 RUN python -m virtualenv --system-site-packages env-201811
 RUN env-201811/bin/pip install ansible==2.0.0.2
 
-RUN python3 -m venv test-reporting-env0
-RUN test-reporting-env/bin/pip3 install azure-kusto-data azure-kusto-ingest defusedxml pytest
+RUN python3 -m venv env-python3
+RUN env-python3/bin/pip3 install azure-kusto-data azure-kusto-ingest defusedxml pytest
 
 # NOTE: There is an ordering dependency for pycryptodome. Leaving this at
 #       the end until we figure that out.


### PR DESCRIPTION
- Bump sonic-mgmt version to 18.04
- Update installation methods
- Add virtualenv for python3

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->
**- Why I did it**
1. We need (at least) python3.6 for the test reporting features.
2. We will eventually need python3.6+ support in the mgmt container to start migrating to python3

**- How I did it**
1. Bumped the version to 18.04
2. Moved from easy_install to apt to fix the pip installation
3. Used the "all in one" az-cli install to fix the az-cli install (which also fixed the az keyvault bug)
4. Added a python3 venv for test reporting

**- How to verify it**
Ran it on our test server and verified that:
1. 201811 virtualenv still works
2. test-reporting-env works
3. pytest still works
4. ansible still works (config-based-on-testbed, add-topo, remove-topo)

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
