### PR TITLE
[Mellanox] Fix issue: there should be 2 cpu core temperature sensors in ACS-MSN3420 (201911)

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -267,7 +267,7 @@ thermal_profile_list = [
     },
     # 3420
     {
-        THERMAL_DEV_CATEGORY_CPU_CORE:(0, 4),
+        THERMAL_DEV_CATEGORY_CPU_CORE:(0, 2),
         THERMAL_DEV_CATEGORY_MODULE:(1, 60),
         THERMAL_DEV_CATEGORY_PSU:(1, 2),
         THERMAL_DEV_CATEGORY_CPU_PACK:(0,1),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

ACS-MSN3420 has 2 physical CPU and 2 CPU temperature sensors, but it initialize 4 thermals in platform API implementation.

**- How I did it**

Change CPU core number from 4 to 2

**- How to verify it**

Manual test

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
