### PR TITLE
[201811][bcm SAI] ugprade Broadcom SAI to 3.5.3.5-2

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.5.3.5-1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm_3.5.3.5-1_amd64.deb?sv=2015-04-05&sr=b&sig=eZe9zHqIQPE9iC9qqfKo1mtEUN8t21Knk3rTJiBCBNk%3D&se=2034-02-16T17%3A02%3A25Z&sp=r"
+BRCM_SAI = libsaibcm_3.5.3.5-2_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm_3.5.3.5-2_amd64.deb?sv=2015-04-05&sr=b&sig=MbN7UziViFCHGemjYicnN9NBitcgiasBZFwTDEAaxkk%3D&se=2034-05-18T22%3A40%3A56Z&sp=r"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.5.3.5-1_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.5.3.5-2_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm-dev_3.5.3.5-1_amd64.deb?sv=2015-04-05&sr=b&sig=uGQ9jcEbi7oyowp7YkCkBjFmR0pYuYeeAdPcWa8Z7zo%3D&se=2034-02-16T17%3A02%3A03Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm-dev_3.5.3.5-2_amd64.deb?sv=2015-04-05&sr=b&sig=JICIoChs68GfIgWDmrrcMvrTlrZaXEkMzc0hkan0NUM%3D&se=2034-05-18T22%3A40%3A30Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
**- How I did it**
ugprade Broadcom SAI to 3.5.3.5-2

Including following Broadcom patches:
- CS00010869953, CS00010914668(KB29456), CS00010503275(KB0029315), CS00010914673(KB0029442)

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


**- How to verify it**
Nightly test.