### PR TITLE
[mgmt] Fix Azure CLI install behind proxy

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -157,8 +157,10 @@ RUN chmod go= /var/$user/.ssh -R
 RUN echo "$user ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
 
 USER $user
-
 WORKDIR /var/$user
+
+# Add az symlink for backwards compatibility
+RUN mkdir bin && ln -s /usr/bin/az bin/az
 
 # Install Virtual Environments
 RUN python -m virtualenv --system-site-packages env-201811

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -97,6 +97,9 @@ RUN apt-get update                  \
     && apt-get update                                                                                              \
     && apt-get install -y docker-ce-cli
 
+# Install Azure CLI
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
 # Install Microsoft Azure Kusto Library for Python
 RUN pip install azure-kusto-data==0.0.13 \
                 azure-kusto-ingest==0.0.13
@@ -155,9 +158,7 @@ RUN echo "$user ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers
 
 USER $user
 
-# Install Azure CLI
 WORKDIR /var/$user
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
 # Install Virtual Environments
 RUN python -m virtualenv --system-site-packages env-201811


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
`sudo bash` doesn't work properly behind a proxy because the environment variables are lost, and `apt` is used in the installation script, so we can't run it in user mode.

**- How I did it**
Move the installation before we switch context to $user so that we have access to the proxy environment variables and can run the install script without sudo.

**- How to verify it**
Verified that `az` commands work inside the container. Ran w/ proxy configured and build succeeds.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
