### PR TITLE
[docker-base-stretch]: install rsyslog from stretch-backports

### DIFF
--- a/dockers/docker-base-stretch/Dockerfile.j2
+++ b/dockers/docker-base-stretch/Dockerfile.j2
@@ -45,7 +45,6 @@ RUN apt-get update &&        \
         procps               \
         python               \
         python-pip           \
-        rsyslog              \
         vim-tiny             \
 # Install dependencies of supervisor
         python-pkg-resources \
@@ -65,6 +64,9 @@ RUN apt-get update &&        \
         python-wheel         \
 # for processing json files in bash environment
         jq
+
+# Install a newer version of rsyslog from stretch-backports to support -iNONE
+RUN apt-get -y -t stretch-backports install rsyslog
 
 # For templating
 RUN pip install j2cli


### PR DESCRIPTION
Install a newer version of rsyslog from stretch-backports to support -iNONE

Previous backport from master use -iNONE option which is only
available after v8.32.0

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Previous backport from master use -iNONE option which is only
available after v8.32.0

**- How I did it**
Install a newer version of rsyslog from stretch-backports to support -iNONE

**- How to verify it**
test the build image

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
