### PR TITLE
Dell S6100 fix mux log issue

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_i2c_enumeration.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_i2c_enumeration.sh
@@ -253,7 +253,7 @@ check_iom_status()
             count=`expr $count + 1`
         done
 
-        if [ "$iom_sta" != "0" ];then
+        if [ "$iom_sta" != "1" ];then
             echo "All IOM's are UP"
         fi
     fi


### PR DESCRIPTION

**- Why I did it**
IOM completion log is not seen in syslog.

**- How I did it**
Modified the init script IOM condition
**- How to verify it**
Check "cat /var/log/syslog | grep -a IOM | grep S6100_"

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
Changed the if condition to log the mux state.

**- A picture of a cute animal (not m
[201811_muxlog_UT.txt](https://github.com/Azure/sonic-buildimage/files/5253870/201811_muxlog_UT.txt)
andatory but encouraged)**
