### PR TITLE
[201911] Dell S6100 fix mux issue

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
+++ b/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
@@ -174,6 +174,11 @@
 /* Mailbox PowerOn Reason */
 #define TRACK_POWERON_REASON    0x05FF
 
+/* CPU Set IO Modules */
+#define CPU_IOM1_CTRL_FLAG 0x04D9
+#define CPU_IOM2_CTRL_FLAG 0x04DA
+#define CPU_IOM3_CTRL_FLAG 0x04DB
+#define CPU_IOM4_CTRL_FLAG 0x04DC
 
 unsigned long  *mmio;
 static struct kobject *dell_kobj;
@@ -752,7 +757,24 @@ static ssize_t show_psu_fan(struct device *dev,
         return sprintf(buf, "%d\n", ret);  
 }
 
+static ssize_t show_cpu_iom_control(struct device *dev,
+                struct device_attribute *devattr, char *buf)
+{
+        int index = to_sensor_dev_attr(devattr)->index;
+        struct smf_data *data = dev_get_drvdata(dev);
+        int cpu_iom_status;
 
+        if(index == 0)
+            cpu_iom_status = smf_read_reg(data, CPU_IOM1_CTRL_FLAG);
+        else if (index == 1)
+            cpu_iom_status = smf_read_reg(data, CPU_IOM2_CTRL_FLAG);
+        else if (index == 2)
+            cpu_iom_status = smf_read_reg(data, CPU_IOM3_CTRL_FLAG);
+        else if (index == 3)
+            cpu_iom_status = smf_read_reg(data, CPU_IOM4_CTRL_FLAG);
+
+        return sprintf(buf, "%x\n", cpu_iom_status);
+}
 
 static umode_t smf_fanin_is_visible(struct kobject *kobj,
                 struct attribute *a, int n)
@@ -2023,6 +2045,11 @@ static SENSOR_DEVICE_ATTR(fan9_serialno, S_IRUGO, show_ppid, NULL, 4);
 static SENSOR_DEVICE_ATTR(iom_status, S_IRUGO, show_voltage, NULL, 44);
 static SENSOR_DEVICE_ATTR(iom_presence, S_IRUGO, show_voltage, NULL, 45);
 
+static SENSOR_DEVICE_ATTR(cpu_iom1_control, S_IRUGO, show_cpu_iom_control, NULL, 0);
+static SENSOR_DEVICE_ATTR(cpu_iom2_control, S_IRUGO, show_cpu_iom_control, NULL, 1);
+static SENSOR_DEVICE_ATTR(cpu_iom3_control, S_IRUGO, show_cpu_iom_control, NULL, 2);
+static SENSOR_DEVICE_ATTR(cpu_iom4_control, S_IRUGO, show_cpu_iom_control, NULL, 3);
+
 static SENSOR_DEVICE_ATTR(psu1_presence, S_IRUGO, show_psu, NULL, 1);
 static SENSOR_DEVICE_ATTR(psu2_presence, S_IRUGO, show_psu, NULL, 6);
 static SENSOR_DEVICE_ATTR(psu1_serialno, S_IRUGO, show_ppid, NULL, 10);
@@ -2070,6 +2097,10 @@ static struct attribute *smf_dell_attrs[] = {
         &sensor_dev_attr_fan7_serialno.dev_attr.attr,
         &sensor_dev_attr_fan9_serialno.dev_attr.attr,
         &sensor_dev_attr_current_total_power.dev_attr.attr,
+        &sensor_dev_attr_cpu_iom1_control.dev_attr.attr,
+        &sensor_dev_attr_cpu_iom2_control.dev_attr.attr,
+        &sensor_dev_attr_cpu_iom3_control.dev_attr.attr,
+        &sensor_dev_attr_cpu_iom4_control.dev_attr.attr,
         NULL
 };
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/iom_power_off.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/iom_power_off.sh
@@ -2,15 +2,15 @@
 #This script is used to power off IO modules
 # IOM can be controlled via SMF using mailbox registers 
 # write 0x2 to 0x04D9 to power off IOM 1
-./io_rd_wr.py --set --val 0x04 --offset 0x210
-./io_rd_wr.py --set --val 0xd9 --offset 0x211
-./io_rd_wr.py --set --val 0x2 --offset 0x213
+io_rd_wr.py --set --val 0x04 --offset 0x210
+io_rd_wr.py --set --val 0xd9 --offset 0x211
+io_rd_wr.py --set --val 0x2 --offset 0x213
 # write 0x2 to 0x04DA to power off IOM 2
-./io_rd_wr.py --set --val 0xda --offset 0x211
-./io_rd_wr.py --set --val 0x2 --offset 0x213
+io_rd_wr.py --set --val 0xda --offset 0x211
+io_rd_wr.py --set --val 0x2 --offset 0x213
 # write 0x2 to 0x04DB to power off IOM 3
-./io_rd_wr.py --set --val 0xdb --offset 0x211
-./io_rd_wr.py --set --val 0x2 --offset 0x213
+io_rd_wr.py --set --val 0xdb --offset 0x211
+io_rd_wr.py --set --val 0x2 --offset 0x213
 # write 0x2 to 0x04DC to power off IOM 4
-./io_rd_wr.py --set --val 0xdc --offset 0x211
-./io_rd_wr.py --set --val 0x2 --offset 0x213
+io_rd_wr.py --set --val 0xdc --offset 0x211
+io_rd_wr.py --set --val 0x2 --offset 0x213

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/iom_power_on.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/iom_power_on.sh
@@ -15,3 +15,5 @@
 # write 0x1 to 0x04DC to power up IOM 4
 /usr/local/bin/io_rd_wr.py --set --val 0xdc --offset 0x211
 /usr/local/bin/io_rd_wr.py --set --val 0x1 --offset 0x213
+#Delay for SMF to power on IOMs
+sleep 3

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_i2c_enumeration.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_i2c_enumeration.sh
@@ -238,6 +238,46 @@ reset_muxes() {
 }
 
 init_devnum
+check_iom_status()
+{
+    SMF_DIR="/sys/devices/platform/SMF.512/hwmon/*"
+    count=0
+    iom_sta=0
+    MAX_IOM_STARTUP_DELAY=50
+
+    if [ -d $SMF_DIR ]; then
+        iom_status=$(cat $SMF_DIR/iom_status)
+        cpu_iom1_sta=$(cat $SMF_DIR/cpu_iom1_control)
+        cpu_iom2_sta=$(cat $SMF_DIR/cpu_iom2_control)
+        cpu_iom3_sta=$(cat $SMF_DIR/cpu_iom3_control)
+        cpu_iom4_sta=$(cat $SMF_DIR/cpu_iom4_control)
+        cpu_iom_sta=$(( cpu_iom1_sta|cpu_iom2_sta|cpu_iom3_sta|cpu_iom4_sta ))
+        echo "Started polling IOM status"
+        while [ "$iom_status" != "f0" -o "$cpu_iom_sta" != "0" ];
+        do
+            if [ "$count" -gt "$MAX_IOM_STARTUP_DELAY" ];then
+                echo "IOM is taking longer than expected to power up.Aborting.
+                      iom_status- $iom_status cpu_iom_sta1- $cpu_iom1_sta cpu_iom_sta2- $cpu_iom2_sta
+                      cpu_iom_sta3- $cpu_iom3_sta cpu_iom_sta4- $cpu_iom4_sta "
+                iom_sta=1
+                break
+            fi
+            cpu_iom1_sta=$(cat $SMF_DIR/cpu_iom1_control)
+            cpu_iom2_sta=$(cat $SMF_DIR/cpu_iom2_control)
+            cpu_iom3_sta=$(cat $SMF_DIR/cpu_iom3_control)
+            cpu_iom4_sta=$(cat $SMF_DIR/cpu_iom4_control)
+            cpu_iom_sta=$(( cpu_iom1_sta|cpu_iom2_sta|cpu_iom3_sta|cpu_iom4_sta ))
+            iom_status=$(cat $SMF_DIR/iom_status)
+            sleep .1
+            count=`expr $count + 1`
+        done
+
+        if [ "$iom_sta" != "1" ];then
+            echo "All IOM's are UP"
+        fi
+    fi
+}
+
 
 if [[ "$1" == "init" ]]; then
     cpu_board_mux "new_device"
@@ -245,11 +285,12 @@ if [[ "$1" == "init" ]]; then
     sys_eeprom "new_device"
     switch_board_eeprom "new_device"
     switch_board_cpld "new_device"
-    /usr/local/bin/s6100_bitbang_reset.sh
+    check_iom_status
     switch_board_qsfp_mux "new_device"
     switch_board_sfp "new_device"
     switch_board_qsfp "new_device"
     switch_board_qsfp_lpmode "disable"
+    /usr/local/bin/s6100_bitbang_reset.sh
     xcvr_presence_interrupts "enable"
 elif [[ "$1" == "deinit" ]]; then
     xcvr_presence_interrupts "disable"


### PR DESCRIPTION
- Why I did it
For fixing PCA MUX attachment issue in Dell S6100 platform.
- How I did it
Wait till IOM MUX powered up properly and start I2C enumeration.
- How to verify it
Check i2cdetect -l | wc -l and verify whether all the 82 I2C devices are attached.
Verified fast boot number is not affected by this change.
Ran power cycle script and the issue is not seen.

UT:
[201911_mux_UT.txt](https://github.com/Azure/sonic-buildimage/files/5254042/201911_mux_UT.txt)
