### PR TITLE
Enabling ipv6 support on docker container network.

### DIFF
--- a/files/docker/docker.service.conf
+++ b/files/docker/docker.service.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd -H unix:// --storage-driver=overlay2 --bip=240.127.1.1/24  --iptables=false
+ExecStart=/usr/bin/dockerd -H unix:// --storage-driver=overlay2 --bip=240.127.1.1/24  --iptables=false --ipv6=true --fixed-cidr-v6=fd00::/80


### PR DESCRIPTION
Why/What I did:-
Enabling ipv6 support on docker container network (Ref: https://docs.docker.com/config/daemon/ipv6/)
Needed for ipv6 communication between container and host in multi-asic
platforms. Address is assign is private subnet address space of fd::/80
with prefix len selected as 80 (Ref: Ref:https://medium.com/@skleeschulte/how-to-enable-ipv6-for-docker-containers-on-ubuntu-18-04-c68394a219a2) so that last 48 bits can be
container mac address and and  prevents NDP neighbor cache
invalidation issues in the Docker layer. 

How I test:

a) O/p of docker inspect bridge
        "Containers": {                                                                                                                                                                                    
            "1a313f25f4568e7f4ce379e6582768c0c29305f7739bffc34c2ffb1b14bdf937": {
                "Name": "database0",
                "EndpointID": "2c5ff23a377d8820ac12b1320fe2e99b175ee912c6fbde79d6bf6214eca00e47",
                "MacAddress": "02:42:f0:7f:01:04",
                "IPv4Address": "240.127.1.4/24",
                "IPv6Address": "fd00::242:f07f:104/80"
            },
            "1c00d6992db2f981bf59a33bf457e005f6f14aeeb2d1f205eeab7584244098b6": {
                "Name": "database1",
                "EndpointID": "28b7d157ed7fa62f031aac70fac37eebec9524543b1cf3f621a2af08d2867260",
                "MacAddress": "02:42:f0:7f:01:05",
                "IPv4Address": "240.127.1.5/24",
                "IPv6Address": "fd00::242:f07f:105/80"
            },
            "4856c962a672f541f40f943aa4f9722e81c724bab30f7a5b134d8998e9e736a0": {
                "Name": "database3",
                "EndpointID": "41e2ebbe2bed11358ff5a7f43c60c45a40f1bad8f362d6afaa432294786cc09c",
                "MacAddress": "02:42:f0:7f:01:07",
                "IPv4Address": "240.127.1.7/24",
                "IPv6Address": "fd00::242:f07f:107/80"
            },
            "7748de824fcb2bef7fe238bb6fecd0328c67efd79205b0872e7abcd802f79487": {
                "Name": "database2",
                "EndpointID": "9be9484c9dc69dbede99e19dff3bf6748c4014bb4ca3c43f4602240b377ee8b1",
                "MacAddress": "02:42:f0:7f:01:02",
                "IPv4Address": "240.127.1.2/24",
                "IPv6Address": "fd00::242:f07f:102/80"
            },
            "9d1bb9932cb59cc3896e2993a57efa234a701c3c73f69471bf3f8f3e82ab2cf2": {
                "Name": "database5",
                "EndpointID": "be2edffc8073fb5017b82967f2e4933fd9bfb1f5319b82001672cb22be0f0ae2",
                "MacAddress": "02:42:f0:7f:01:06",
                "IPv4Address": "240.127.1.6/24",
                "IPv6Address": "fd00::242:f07f:106/80"
            },
            "fcf39255790076b0c3bae4a572800b519c10b34311f8e0499cde3ba020b1ae9a": {
                "Name": "database4",
                "EndpointID": "f0a10c721a4fec020eb4c391a1d5b024c017e03e6e1e4b35abd3af47647efd5e",
                "MacAddress": "02:42:f0:7f:01:03",
                "IPv4Address": "240.127.1.3/24",
                "IPv6Address": "fd00::242:f07f:103/80"
            }

b) docker0 ifconfig
 sudo ifconfig docker0
docker0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 240.127.1.1  netmask 255.255.255.0  broadcast 240.127.1.255
        inet6 fe80::1  prefixlen 64  scopeid 0x20<link>
        inet6 fe80::42:6bff:fe8e:ac77  prefixlen 64  scopeid 0x20<link>
        inet6 fd00::1  prefixlen 80  scopeid 0x0<global>
        ether 02:42:6b:8e:ac:77  txqueuelen 0  (Ethernet)
        RX packets 38270  bytes 5800167 (5.5 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 34  bytes 2904 (2.8 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

c) Ping from Host to Conatiner
 ping6 fd00::242:f07f:103
PING fd00::242:f07f:103(fd00::242:f07f:103) 56 data bytes
64 bytes from fd00::242:f07f:103: icmp_seq=1 ttl=64 time=0.081 ms
64 bytes from fd00::242:f07f:103: icmp_seq=2 ttl=64 time=0.092 ms
64 bytes from fd00::242:f07f:103: icmp_seq=3 ttl=64 time=0.109 ms

d) Ping from container to host
ping6  fd00::1
PING fd00::1(fd00::1) 56 data bytes
64 bytes from fd00::1: icmp_seq=1 ttl=64 time=0.251 ms
64 bytes from fd00::1: icmp_seq=2 ttl=64 time=0.102 ms

