### PR TITLE
[Multi-Asic] Forward SNMP requests received on front panel interface to SNMP agent in host.

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -92,9 +92,9 @@ function postStartAction()
 {%- if docker_container_name == "database" %}
     if [ "$DEV" ]; then
         # Enable the forwarding on eth0 interface in namespace.
-        SYSCTL_CONF="/etc/sysctl.d/sysctl-net.conf"
+        SYSCTL_NET_CONFIG="/etc/sysctl.d/sysctl-net.conf"
         docker exec -i database$DEV sed -i -e "s/^net.ipv4.conf.eth0.forwarding=0/net.ipv4.conf.eth0.forwarding=1/;
-                                               s/^net.ipv6.conf.eth0.forwarding=0/net.ipv6.conf.eth0.forwarding=1/" $SYSCTL_CONF
+                                               s/^net.ipv6.conf.eth0.forwarding=0/net.ipv6.conf.eth0.forwarding=1/" $SYSCTL_NET_CONFIG
         docker exec -i database$DEV sysctl --system -e
         link_namespace $DEV
     fi

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -92,6 +92,8 @@ function postStartAction()
 {%- if docker_container_name == "database" %}
     if [ "$DEV" ]; then
         docker exec -i database$DEV sysctl --system -e
+        # Enable the forwarding on eth0 interface in namespace.
+        docker exec -i database$DEV sysctl net.ipv4.conf.eth0.forwarding=1 net.ipv6.conf.eth0.forwarding=1
         link_namespace $DEV
     fi
 

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -91,9 +91,11 @@ function postStartAction()
 {
 {%- if docker_container_name == "database" %}
     if [ "$DEV" ]; then
-        docker exec -i database$DEV sysctl --system -e
         # Enable the forwarding on eth0 interface in namespace.
-        docker exec -i database$DEV sysctl net.ipv4.conf.eth0.forwarding=1 net.ipv6.conf.eth0.forwarding=1
+        SYSCTL_CONF="/etc/sysctl.d/sysctl-net.conf"
+        docker exec -i database$DEV sed -i -e "s/^net.ipv4.conf.eth0.forwarding=0/net.ipv4.conf.eth0.forwarding=1/;
+                                               s/^net.ipv6.conf.eth0.forwarding=0/net.ipv6.conf.eth0.forwarding=1/" $SYSCTL_CONF
+        docker exec -i database$DEV sysctl --system -e
         link_namespace $DEV
     fi
 

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -81,7 +81,9 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         self.config_db_map[''].connect()
         self.iptables_cmd_ns_prefix[''] = ""
         self.namespace_mgmt_ip = self.get_namespace_mgmt_ip(self.iptables_cmd_ns_prefix[''], '')
+        self.namespace_mgmt_ipv6 = self.get_namespace_mgmt_ipv6(self.iptables_cmd_ns_prefix[''], '')
         self.namespace_docker_mgmt_ip = {}
+        self.namespace_docker_mgmt_ipv6 = {}
         namespaces = device_info.get_all_namespaces()
         for front_asic_namespace in namespaces['front_ns']:
             self.config_db_map[front_asic_namespace] = ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespace)
@@ -89,10 +91,14 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             self.iptables_cmd_ns_prefix[front_asic_namespace] = "ip netns exec " + front_asic_namespace + " "
             self.namespace_docker_mgmt_ip[front_asic_namespace] = self.get_namespace_mgmt_ip(self.iptables_cmd_ns_prefix[front_asic_namespace],
                                                                                               front_asic_namespace)
+            self.namespace_docker_mgmt_ipv6[front_asic_namespace] = self.get_namespace_mgmt_ipv6(self.iptables_cmd_ns_prefix[front_asic_namespace],
+                                                                                              front_asic_namespace)
 
         for back_asic_namespace in namespaces['back_ns']:
             self.iptables_cmd_ns_prefix[back_asic_namespace] = "ip netns exec " + back_asic_namespace + " "
             self.namespace_docker_mgmt_ip[back_asic_namespace] = self.get_namespace_mgmt_ip(self.iptables_cmd_ns_prefix[back_asic_namespace],
+                                                                                             back_asic_namespace)
+            self.namespace_docker_mgmt_ipv6[back_asic_namespace] = self.get_namespace_mgmt_ipv6(self.iptables_cmd_ns_prefix[back_asic_namespace],
                                                                                              back_asic_namespace)
 
     def get_namespace_mgmt_ip(self, iptable_ns_cmd_prefix, namespace):
@@ -100,6 +106,11 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                                  " | awk '{print $4}' | cut -d'/' -f1 | head -1"
 
         return self.run_commands([ip_address_get_command])
+
+    def get_namespace_mgmt_ipv6(self, iptable_ns_cmd_prefix, namespace):
+        ipv6_address_get_command = iptable_ns_cmd_prefix + "ip -6 -o addr show " + ("eth0" if namespace else "docker0") +\
+                                 " | awk '{print $4}' | cut -d'/' -f1 | head -1"
+        return self.run_commands([ipv6_address_get_command])
 
     def run_commands(self, commands):
         """
@@ -201,6 +212,36 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 allow_internal_docker_ip_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -A INPUT -p udp -s {} -d {} -j ACCEPT".format
                                                      (docker_mgmt_ip, self.namespace_mgmt_ip))
         return allow_internal_docker_ip_cmds
+
+    def generate_translate_front_panel_snmp_traffic_commands(self, namespace):
+        """
+        The below SNAT and DNAT rules are added in asic namespace in multi-ASIC platforms. It helps to forward the SNMP request coming
+        in through the front panel interfaces present in namespace to the SNMP Agent running in the linux host. The external IP address are
+        NATed to the internal docker IP address for the SNMP agent running in linux host to respond.
+        """
+        translate_front_panel_snmp_cmds = []
+
+        if namespace:
+            # IPv4 rules
+            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -t nat -X")
+            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -t nat -F")
+
+            # For namespace docker allow all tcp/udp traffic from host docker bridge to its eth0 management ip
+            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                 "iptables -t nat -A PREROUTING -p udp --dport 161  -j DNAT --to-destination {}".format(self.namespace_mgmt_ip))
+            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                 "iptables -t nat -A POSTROUTING -p udp --dport 161 -j SNAT --to-source {}".format(self.namespace_docker_mgmt_ip[namespace]))
+
+            # IPv6 rules
+            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -X")
+            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -F")
+
+            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                 "ip6tables -t nat -A PREROUTING -p udp --dport 161  -j DNAT --to-destination {}".format(self.namespace_mgmt_ipv6))
+            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                 "ip6tables -t nat -A POSTROUTING -p udp --dport 161 -j SNAT --to-source {}".format(self.namespace_docker_mgmt_ipv6[namespace]))
+
+        return translate_front_panel_snmp_cmds
 
     def is_rule_ipv4(self, rule_props):
         if (("SRC_IP" in rule_props and rule_props["SRC_IP"]) or
@@ -429,6 +470,19 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         self.run_commands(iptables_cmds)
 
+    def update_control_plane_nat_acls(self, namespace):
+        """
+        Convenience wrapper which programs the NAT rules for allowing the
+        snmp traffic coming on the front panel interface
+        """
+        # Add iptables commands to allow front panel snmp traffic
+        iptables_cmds = self.generate_translate_front_panel_snmp_traffic_commands(namespace)
+        log_info("Issuing the following iptables commands:")
+        for cmd in iptables_cmds:
+            log_info("  " + cmd)
+
+        self.run_commands(iptables_cmds)
+
     def run(self):
         # Select Time-out for 10 Seconds
         SELECT_TIMEOUT_MS = 1000 * 10
@@ -453,6 +507,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         for namespace in self.config_db_map.keys():
             # Unconditionally update control plane ACLs once at start on given namespace
             self.update_control_plane_acls(namespace)
+            self.update_control_plane_nat_acls(namespace)
             # Connect to Config DB of given namespace
             acl_db_connector = swsscommon.DBConnector("CONFIG_DB", 0, False, namespace)
             # Subscribe to notifications when ACL tables changes

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -108,7 +108,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         return self.run_commands([ip_address_get_command])
 
     def get_namespace_mgmt_ipv6(self, iptable_ns_cmd_prefix, namespace):
-        ipv6_address_get_command = iptable_ns_cmd_prefix + "ip -6 -o addr show " + ("eth0" if namespace else "docker0") +\
+        ipv6_address_get_command = iptable_ns_cmd_prefix + "ip -6 -o addr show scope global " + ("eth0" if namespace else "docker0") +\
                                  " | awk '{print $4}' | cut -d'/' -f1 | head -1"
         return self.run_commands([ipv6_address_get_command])
 
@@ -213,35 +213,35 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                                                      (docker_mgmt_ip, self.namespace_mgmt_ip))
         return allow_internal_docker_ip_cmds
 
-    def generate_translate_front_panel_snmp_traffic_commands(self, namespace):
+    def generate_fwd_snmp_traffic_from_namespace_to_host_commands(self, namespace):
         """
         The below SNAT and DNAT rules are added in asic namespace in multi-ASIC platforms. It helps to forward the SNMP request coming
         in through the front panel interfaces present in namespace to the SNMP Agent running in the linux host. The external IP address are
         NATed to the internal docker IP address for the SNMP agent running in linux host to respond.
         """
-        translate_front_panel_snmp_cmds = []
+        fwd_snmp_traffic_from_namespace_to_host_cmds = []
 
         if namespace:
             # IPv4 rules
-            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -t nat -X")
-            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -t nat -F")
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -t nat -X")
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -t nat -F")
 
             # For namespace docker allow all tcp/udp traffic from host docker bridge to its eth0 management ip
-            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
                  "iptables -t nat -A PREROUTING -p udp --dport 161  -j DNAT --to-destination {}".format(self.namespace_mgmt_ip))
-            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
                  "iptables -t nat -A POSTROUTING -p udp --dport 161 -j SNAT --to-source {}".format(self.namespace_docker_mgmt_ip[namespace]))
 
             # IPv6 rules
-            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -X")
-            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -F")
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -X")
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -F")
 
-            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
                  "ip6tables -t nat -A PREROUTING -p udp --dport 161  -j DNAT --to-destination {}".format(self.namespace_mgmt_ipv6))
-            translate_front_panel_snmp_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
                  "ip6tables -t nat -A POSTROUTING -p udp --dport 161 -j SNAT --to-source {}".format(self.namespace_docker_mgmt_ipv6[namespace]))
 
-        return translate_front_panel_snmp_cmds
+        return fwd_snmp_traffic_from_namespace_to_host_cmds
 
     def is_rule_ipv4(self, rule_props):
         if (("SRC_IP" in rule_props and rule_props["SRC_IP"]) or
@@ -476,7 +476,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         snmp traffic coming on the front panel interface
         """
         # Add iptables commands to allow front panel snmp traffic
-        iptables_cmds = self.generate_translate_front_panel_snmp_traffic_commands(namespace)
+        iptables_cmds = self.generate_fwd_snmp_traffic_from_namespace_to_host_commands(namespace)
         log_info("Issuing the following iptables commands:")
         for cmd in iptables_cmds:
             log_info("  " + cmd)

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -216,8 +216,8 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
     def generate_fwd_snmp_traffic_from_namespace_to_host_commands(self, namespace):
         """
         The below SNAT and DNAT rules are added in asic namespace in multi-ASIC platforms. It helps to forward the SNMP request coming
-        in through the front panel interfaces present in namespace to the SNMP Agent running in the linux host. The external IP address are
-        NATed to the internal docker IP address for the SNMP agent running in linux host to respond.
+        in through the front panel interfaces created/present in the asic namespace to the SNMP Agent running in SNMP container in
+        linux host network namespace. The external IP addresses are NATed to the internal docker IP addresses for the SNMP Agent to respond.
         """
         fwd_snmp_traffic_from_namespace_to_host_cmds = []
 

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -480,9 +480,9 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         """
         # Add iptables commands to allow front panel snmp traffic
         iptables_cmds = self.generate_fwd_snmp_traffic_from_namespace_to_host_commands(namespace)
-        log_info("Issuing the following iptables commands:")
+        self.log_info("Issuing the following iptables commands:")
         for cmd in iptables_cmds:
-            log_info("  " + cmd)
+            self.log_info("  " + cmd)
 
         self.run_commands(iptables_cmds)
 

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -221,27 +221,28 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         """
         fwd_snmp_traffic_from_namespace_to_host_cmds = []
 
-        # The action set for iptables where D is DELETE, A is APPEND
-        rule_action_list = ['D', 'A']
-
         if namespace:
-            # Delete only the rules we created earlier before addiing them again, useful in case of caclmgrd restart.
-            for action in rule_action_list:
-                # IPv4 rules
-                fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                                   "iptables -t nat -{} PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
-                                                   (action, self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ip))
-                fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                                   "iptables -t nat -{} POSTROUTING -p udp --dport {} -j SNAT --to-source {}".format
-                                                   (action, self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ip[namespace]))
+            # IPv4 rules
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -t nat -X")
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -t nat -F")
 
-                # IPv6 rules
-                fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                                   "ip6tables -t nat -{} PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
-                                                   (action, self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ipv6))
-                fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                                   "ip6tables -t nat -{} POSTROUTING -p udp --dport {} -j SNAT --to-source {}".format
-                                                   (action, self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ipv6[namespace]))
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                               "iptables -t nat -A PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
+                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ip))
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                               "iptables -t nat -A POSTROUTING -p udp --dport {} -j SNAT --to-source {}".format
+                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ip[namespace]))
+
+            # IPv6 rules
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -X")
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -F")
+
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                               "ip6tables -t nat -A PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
+                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ipv6))
+            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                               "ip6tables -t nat -A POSTROUTING -p udp --dport {} -j SNAT --to-source {}".format
+                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ipv6[namespace]))
 
         return fwd_snmp_traffic_from_namespace_to_host_cmds
 

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -223,10 +223,6 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         if namespace:
             # IPv4 rules
-            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -t nat -X")
-            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -t nat -F")
-
-            # For namespace docker allow all tcp/udp traffic from host docker bridge to its eth0 management ip
             fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
                                                "iptables -t nat -A PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
                                                (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ip))
@@ -235,9 +231,6 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                                                (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ip[namespace]))
 
             # IPv6 rules
-            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -X")
-            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -F")
-
             fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
                                                "ip6tables -t nat -A PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
                                                (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ipv6))

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -221,22 +221,27 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         """
         fwd_snmp_traffic_from_namespace_to_host_cmds = []
 
-        if namespace:
-            # IPv4 rules
-            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                               "iptables -t nat -A PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
-                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ip))
-            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                               "iptables -t nat -A POSTROUTING -p udp --dport {} -j SNAT --to-source {}".format
-                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ip[namespace]))
+        # The action set for iptables where D is DELETE, A is APPEND
+        rule_action_list = ['D', 'A']
 
-            # IPv6 rules
-            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                               "ip6tables -t nat -A PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
-                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ipv6))
-            fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                               "ip6tables -t nat -A POSTROUTING -p udp --dport {} -j SNAT --to-source {}".format
-                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ipv6[namespace]))
+        if namespace:
+            # Delete only the rules we created earlier before addiing them again, useful in case of caclmgrd restart.
+            for action in rule_action_list:
+                # IPv4 rules
+                fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                                   "iptables -t nat -{} PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
+                                                   (action, self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ip))
+                fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                                   "iptables -t nat -{} POSTROUTING -p udp --dport {} -j SNAT --to-source {}".format
+                                                   (action, self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ip[namespace]))
+
+                # IPv6 rules
+                fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                                   "ip6tables -t nat -{} PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
+                                                   (action, self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ipv6))
+                fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                                   "ip6tables -t nat -{} POSTROUTING -p udp --dport {} -j SNAT --to-source {}".format
+                                                   (action, self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ipv6[namespace]))
 
         return fwd_snmp_traffic_from_namespace_to_host_cmds
 

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -228,18 +228,22 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
             # For namespace docker allow all tcp/udp traffic from host docker bridge to its eth0 management ip
             fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                 "iptables -t nat -A PREROUTING -p udp --dport 161  -j DNAT --to-destination {}".format(self.namespace_mgmt_ip))
+                                               "iptables -t nat -A PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
+                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ip))
             fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                 "iptables -t nat -A POSTROUTING -p udp --dport 161 -j SNAT --to-source {}".format(self.namespace_docker_mgmt_ip[namespace]))
+                                               "iptables -t nat -A POSTROUTING -p udp --dport {} -j SNAT --to-source {}".format
+                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ip[namespace]))
 
             # IPv6 rules
             fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -X")
             fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -t nat -F")
 
             fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                 "ip6tables -t nat -A PREROUTING -p udp --dport 161  -j DNAT --to-destination {}".format(self.namespace_mgmt_ipv6))
+                                               "ip6tables -t nat -A PREROUTING -p udp --dport {}  -j DNAT --to-destination {}".format
+                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_mgmt_ipv6))
             fwd_snmp_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                 "ip6tables -t nat -A POSTROUTING -p udp --dport 161 -j SNAT --to-source {}".format(self.namespace_docker_mgmt_ipv6[namespace]))
+                                               "ip6tables -t nat -A POSTROUTING -p udp --dport {} -j SNAT --to-source {}".format
+                                               (self.ACL_SERVICES['SNMP']['dst_ports'][0], self.namespace_docker_mgmt_ipv6[namespace]))
 
         return fwd_snmp_traffic_from_namespace_to_host_cmds
 


### PR DESCRIPTION
**- Why I did it**

The SNMP loopback health check and other SNMP requests coming through the front panel interfaces where not getting serviced by the SNMP agent running in the SNMP container in the linux host network namespace. This change is to create translation rules so that the SNMP packets coming in would be translated and forwarded to the agent running in linux host.

**- How I did it**

Create NAT rules for trapping the SNMP packets coming in the front panel interface in the linux network namespace and sent to the docker0 subnet 240.12.1.x. The NAT rules added will be for  SNMP packets, which are UDP + dest port 161

* change the destination IP to that of the docker0 eth0 IP address in the host which is 240.127.1.1. This is DNAT rule 

* change the Source IP to that of the docker0 eth0 IP address in the namespace which could be any of 240.127.1.x. This is SNAT rule 

 With these rules, the SNMP packets coming from front panel interface destined to the Loopback IP in the namespace gets translated to 240.127.1.x subnet, reaches the SNMP agents running in HOST. The agent's response is in 240.127.1.x subnet, reaches the respective network namespace. The NAT module finds entries in connection tracking table and changes it back to the external IP address, which is then routed out through front panel interface. 

When the NAT translation happens with SNAT/DNAT rules, it creates connection tracking entry. For eg: the connection tracking entry created is here, where the values 171,164 is the entry timeout value for which it will exists,  Original 5 tuple value incoming SNMP packet, the invert tuple is stored to be matched in the reverse direction.  
```
admin@str--acs-1:~$ sudo ip netns exec asic0 cat /proc/net/nf_conntrack   | grep 161 
ipv4     2 udp      17 171 src=10.0.0.1 dst=8.0.0.0 sport=55785 dport=161 src=240.127.1.1 dst=240.127.1.6 sport=161 dport=55785 [ASSURED] mark=0 zone=0 use=2
ipv6     10 udp      17 164 src=fc00:0000:0000:0000:0000:0000:0000:0002 dst=fc00:0000:0000:0000:0000:0000:0000:0001 sport=48303 dport=161 src=fd00:0000:0000:0000:0000:0000:0000:0001 dst=fd00:0000:0000:0000:0000:0242:f07f:0106 sport=161 dport=48303 [ASSURED] mark=0 zone=0 use=2

```

**- How to verify it**
Verified with SNMP requests through the front panel interface working correctly for both IPv4 and IPv6.

```
admin@str--acs-1:~$ docker exec -i database0 sysctl net.ipv4.conf.eth0.forwarding net.ipv6.conf.eth0.forwarding
net.ipv4.conf.eth0.forwarding = 1
net.ipv6.conf.eth0.forwarding = 1

admin@str--acs-1:~$ sudo ip netns exec asic0 iptables -L -n -v -t nat --line-numbers
Chain PREROUTING (policy ACCEPT 21 packets, 1260 bytes)
num   pkts bytes target     prot opt in     out     source               destination         
1        2   136 DNAT       udp  --  *      *       0.0.0.0/0            0.0.0.0/0            udp dpt:161 to:240.127.1.1

Chain INPUT (policy ACCEPT 21 packets, 1260 bytes)
num   pkts bytes target     prot opt in     out     source               destination         

Chain OUTPUT (policy ACCEPT 593 packets, 36495 bytes)
num   pkts bytes target     prot opt in     out     source               destination         

Chain POSTROUTING (policy ACCEPT 593 packets, 36495 bytes)
num   pkts bytes target     prot opt in     out     source               destination         
1        2   136 SNAT       udp  --  *      *       0.0.0.0/0            0.0.0.0/0            udp dpt:161 to:240.127.1.6

admin@str--acs-1:~$ sudo ip netns exec asic0 ip6tables -L -n -v -t nat --line-numbers
Chain PREROUTING (policy ACCEPT 2 packets, 184 bytes)
num   pkts bytes target     prot opt in     out     source               destination         
1        3   264 DNAT       udp      *      *       ::/0                 ::/0                 udp dpt:161 to:fd00::1

Chain INPUT (policy ACCEPT 2 packets, 184 bytes)
num   pkts bytes target     prot opt in     out     source               destination         

Chain OUTPUT (policy ACCEPT 1 packets, 80 bytes)
num   pkts bytes target     prot opt in     out     source               destination         

Chain POSTROUTING (policy ACCEPT 1 packets, 80 bytes)
num   pkts bytes target     prot opt in     out     source               destination         
1        3   264 SNAT       udp      *      *       ::/0                 ::/0                 udp dpt:161 to:fd00::242:f07f:106

[admin@ARISTA01T2 ~]$ snmpwalk -v2c -c public 8.0.0.0
SNMPv2-MIB::sysDescr.0 = STRING: SONiC Software Version: SONiC.20191130.47-dirty-20200902.083657 - HwSku: Nexus-3164 - Distribution: Debian 9.13 - Kernel: 4.9.0-11-2-amd64
SNMPv2-MIB::sysObjectID.0 = OID: NET-SNMP-MIB::netSnmpAgentOIDs.200
DISMAN-EVENT-MIB::sysUpTimeInstance = Timeticks: (588089) 1:38:00.89
SNMPv2-MIB::sysContact.0 = STRING: Azure Cloud Switch vteam <linuxnetdev@microsoft.com>
SNMPv2-MIB::sysName.0 = STRING: str-n3164-acs-1
SNMPv2-MIB::sysLocation.0 = STRING: public
SNMPv2-MIB::sysServices.0 = INTEGER: 72
SNMPv2-MIB::sysORLastChange.0 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORID.1 = OID: SNMP-MPD-MIB::snmpMPDCompliance
SNMPv2-MIB::sysORID.2 = OID: SNMP-USER-BASED-SM-MIB::usmMIBCompliance
SNMPv2-MIB::sysORID.3 = OID: SNMP-FRAMEWORK-MIB::snmpFrameworkMIBCompliance
SNMPv2-MIB::sysORID.4 = OID: SNMPv2-MIB::snmpMIB
SNMPv2-MIB::sysORID.5 = OID: SNMP-VIEW-BASED-ACM-MIB::vacmBasicGroup
SNMPv2-MIB::sysORID.6 = OID: TCP-MIB::tcpMIB
SNMPv2-MIB::sysORID.7 = OID: UDP-MIB::udpMIB
SNMPv2-MIB::sysORID.8 = OID: SNMP-NOTIFICATION-MIB::snmpNotifyFullCompliance
SNMPv2-MIB::sysORID.9 = OID: NOTIFICATION-LOG-MIB::notificationLogMIB
SNMPv2-MIB::sysORDescr.1 = STRING: The MIB for Message Processing and Dispatching.
SNMPv2-MIB::sysORDescr.2 = STRING: The management information definitions for the SNMP User-based Security Model.
SNMPv2-MIB::sysORDescr.3 = STRING: The SNMP Management Architecture MIB.
SNMPv2-MIB::sysORDescr.4 = STRING: The MIB module for SNMPv2 entities
SNMPv2-MIB::sysORDescr.5 = STRING: View-based Access Control Model for SNMP.
SNMPv2-MIB::sysORDescr.6 = STRING: The MIB module for managing TCP implementations
SNMPv2-MIB::sysORDescr.7 = STRING: The MIB module for managing UDP implementations
SNMPv2-MIB::sysORDescr.8 = STRING: The MIB modules for managing SNMP Notification, plus filtering.
SNMPv2-MIB::sysORDescr.9 = STRING: The MIB module for logging SNMP Notifications.
SNMPv2-MIB::sysORUpTime.1 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.2 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.3 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.4 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.5 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.6 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.7 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.8 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.9 = Timeticks: (1) 0:00:00.01


[admin@ARISTA01T2 ~]$ snmpwalk -v2c -c public fc00::1
SNMPv2-MIB::sysDescr.0 = STRING: SONiC Software Version: SONiC.20191130.47-dirty-20200902.083657 - HwSku: Nexus-3164 - Distribution: Debian 9.13 - Kernel: 4.9.0-11-2-amd64
^C
[admin@ARISTA01T2 ~]$ snmpwalk -v2c -c public fc00::1
SNMPv2-MIB::sysDescr.0 = STRING: SONiC Software Version: SONiC.20191130.47-dirty-20200902.083657 - HwSku: Nexus-3164 - Distribution: Debian 9.13 - Kernel: 4.9.0-11-2-amd64
SNMPv2-MIB::sysObjectID.0 = OID: NET-SNMP-MIB::netSnmpAgentOIDs.200
DISMAN-EVENT-MIB::sysUpTimeInstance = Timeticks: (615250) 1:42:32.50
SNMPv2-MIB::sysContact.0 = STRING: Azure Cloud Switch vteam <linuxnetdev@microsoft.com>
SNMPv2-MIB::sysName.0 = STRING: str-n3164-acs-1
SNMPv2-MIB::sysLocation.0 = STRING: public
SNMPv2-MIB::sysServices.0 = INTEGER: 72
SNMPv2-MIB::sysORLastChange.0 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORID.1 = OID: SNMP-MPD-MIB::snmpMPDCompliance
SNMPv2-MIB::sysORID.2 = OID: SNMP-USER-BASED-SM-MIB::usmMIBCompliance
SNMPv2-MIB::sysORID.3 = OID: SNMP-FRAMEWORK-MIB::snmpFrameworkMIBCompliance
SNMPv2-MIB::sysORID.4 = OID: SNMPv2-MIB::snmpMIB
SNMPv2-MIB::sysORID.5 = OID: SNMP-VIEW-BASED-ACM-MIB::vacmBasicGroup
SNMPv2-MIB::sysORID.6 = OID: TCP-MIB::tcpMIB
SNMPv2-MIB::sysORID.7 = OID: UDP-MIB::udpMIB
SNMPv2-MIB::sysORID.8 = OID: SNMP-NOTIFICATION-MIB::snmpNotifyFullCompliance
SNMPv2-MIB::sysORID.9 = OID: NOTIFICATION-LOG-MIB::notificationLogMIB
SNMPv2-MIB::sysORDescr.1 = STRING: The MIB for Message Processing and Dispatching.
SNMPv2-MIB::sysORDescr.2 = STRING: The management information definitions for the SNMP User-based Security Model.
SNMPv2-MIB::sysORDescr.3 = STRING: The SNMP Management Architecture MIB.
SNMPv2-MIB::sysORDescr.4 = STRING: The MIB module for SNMPv2 entities
SNMPv2-MIB::sysORDescr.5 = STRING: View-based Access Control Model for SNMP.
SNMPv2-MIB::sysORDescr.6 = STRING: The MIB module for managing TCP implementations
SNMPv2-MIB::sysORDescr.7 = STRING: The MIB module for managing UDP implementations
SNMPv2-MIB::sysORDescr.8 = STRING: The MIB modules for managing SNMP Notification, plus filtering.
SNMPv2-MIB::sysORDescr.9 = STRING: The MIB module for logging SNMP Notifications.
SNMPv2-MIB::sysORUpTime.1 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.2 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.3 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.4 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.5 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.6 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.7 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.8 = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysORUpTime.9 = Timeticks: (1) 0:00:00.01


```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
