### PR TITLE
DellEMC Z9264f buffer changes

### DIFF
--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C64/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C64/buffers_defaults_t1.j2
@@ -11,18 +11,13 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "34859968",
+            "size": "35621248",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7847424"
         },
-        "egress_lossy_pool": {
-            "size": "29631680",
-            "type": "egress",
-            "mode": "dynamic"
-        },
         "egress_lossless_pool": {
-            "size": "43481152",
+            "size": "43468672",
             "type": "egress",
             "mode": "static"
         }
@@ -35,12 +30,13 @@
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"1518",
-            "static_th":"10870288"
+            "size":"0",
+            "static_th":"43468672"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"1518",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"1518",             
+            "mode":"dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C64/th2-z9264f-64x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C64/th2-z9264f-64x100G.config.bcm
@@ -1003,3 +1003,4 @@ dport_map_port_66=65
 dport_map_port_100=66
 
 module_64ports=1
+mmu_init_config="MSFT-TH2-Tier1"

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C8D112/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C8D112/buffers_defaults_t0.j2
@@ -18,18 +18,13 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "33096128",
+            "size": "34369920",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "9098752"
         },
-        "egress_lossy_pool": {
-            "size": "28132416",
-            "type": "egress",
-            "mode": "dynamic"
-        },
         "egress_lossless_pool": {
-            "size": "43108416",
+            "size": "43468672",
             "type": "egress",
             "mode": "static"
         }
@@ -42,12 +37,13 @@
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"1518",
-            "static_th":"10777104"
+            "size":"0",
+            "static_th":"43468672"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"1518",
+            "mode":"dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C8D112/th2-z9264f-8x100G-112x50G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C8D112/th2-z9264f-8x100G-112x50G.config.bcm
@@ -1115,5 +1115,5 @@ dport_map_port_66=121
 dport_map_port_100=122
 
 module_64ports=1
-mmu_init_config="MSFT-TH-Tier0"
+mmu_init_config="MSFT-TH2-Tier0"
 

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/buffers_defaults_t0.j2
@@ -11,18 +11,13 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "38738752",
+            "size": "35621248",
             "type": "ingress",
             "mode": "dynamic",
-            "xoff": "3855488"
-        },
-        "egress_lossy_pool": {
-            "size": "37057280",
-            "type": "egress",
-            "mode": "dynamic"
+            "xoff": "7847424"
         },
         "egress_lossless_pool": {
-            "size": "43507776",
+            "size": "43468672",
             "type": "egress",
             "mode": "static"
         }
@@ -35,12 +30,13 @@
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"1518",
-            "static_th":"10876944"
+            "size":"0",
+            "static_th":"43468672"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"1518",
+            "mode":"dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/buffers_defaults_t1.j2
@@ -11,18 +11,13 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "37968320",
+            "size": "35621248",
             "type": "ingress",
             "mode": "dynamic",
-            "xoff": "4625920"
-        },
-        "egress_lossy_pool": {
-            "size": "36402496",
-            "type": "egress",
-            "mode": "dynamic"
+            "xoff": "7847424"
         },
         "egress_lossless_pool": {
-            "size": "43507776",
+            "size": "43468672",
             "type": "egress",
             "mode": "static"
         }
@@ -35,11 +30,11 @@
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"1518",
-            "static_th":"10876944"
+            "size":"0",
+            "static_th":"43468672"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/th2-z9264f-64x40G-t0.config.bcm
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/th2-z9264f-64x40G-t0.config.bcm
@@ -1003,5 +1003,4 @@ dport_map_port_66=65
 dport_map_port_100=66
 
 module_64ports=1
-
-mmu_init_config="MSFT-TH-Tier0"
+mmu_init_config="MSFT-TH2-Tier0"

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/th2-z9264f-64x40G-t1.config.bcm
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/th2-z9264f-64x40G-t1.config.bcm
@@ -1004,4 +1004,4 @@ dport_map_port_100=66
 
 module_64ports=1
 
-mmu_init_config="MSFT-TH-Tier1"
+mmu_init_config="MSFT-TH2-Tier1"


### PR DESCRIPTION
**- Why I did it**
Converted two SP model to single pool model and modified the buffer size.
**- How I did it**
Changed buffer_default settings for all the DellEMC Z9264f HWSKU's.
**- How to verify it**
Check SP register values in NPU shell.
**- Which release branch to backport (provide reason below if selected)**
Need to be cherry picked for 201911 branch.
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

