### PR TITLE
[mgmt] Install ip command in mgmt docker

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y build-essential \
                                          gcc \
                                          git \
                                          inetutils-ping \
+                                         iproute2 \
                                          libffi-dev \
                                          libssl-dev \
                                          libxml2 \


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fixes #5425 

**- How I did it**
Explicitly installed the `ip` command in the mgmt container. This seems to be a new requirement in the 18.04 docker image.

**- How to verify it**
Log into the built container and run `ip`, `ip addr`, `ip route`, `ip -6 addr`, etc.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
