### PR TITLE
[portconfig] Fallback to port_config.ini if  hwsku.json is not available

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -20,6 +20,9 @@ SONIC_VERSION_YAML_PATH = "/etc/sonic/sonic_version.yml"
 PORT_CONFIG_FILE = "port_config.ini"
 PLATFORM_JSON_FILE = "platform.json"
 
+# HwSKU configuration file name
+HWSKU_JSON_FILE = 'hwsku.json'
+
 # Multi-NPU constants
 # TODO: Move Multi-ASIC-related functions and constants to a "multi_asic.py" module
 NPU_NAME_PREFIX = "asic"
@@ -247,8 +250,13 @@ def get_path_to_port_config_file(hwsku=None, asic=None):
 
     port_config_candidates = []
 
-    # Check for 'platform.json' file presence first
-    port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
+    # Check for 'hwsku.json' file presence first
+    hwsku_json_file = os.path.join(hwsku_path, HWSKU_JSON_FILE)
+
+    # if 'hwsku.json' file is available, Check for 'platform.json' file presence,
+    # if 'platform.json' is available, APPEND it. Otherwise, SKIP it.
+    if os.path.isfile(hwsku_json_file):
+        port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
 
     # Check for 'port_config.ini' file presence in a few locations
     if asic:


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**- Why I did it**
As discussed, This PR covers the below points.
1. Give precedence to platform.json only if both platform.json and  hwsku.json file exist.  In case only platform.json exists, we don’t allow breakout for that HWSKU and fallback to port_config.ini.
 
**- How I did it**
check for `hwsku.json` file presence under get_path_to_port_config_file function.

**- How to verify it**
```

admin@lnos-x1-a-csw07:~$ sudo sonic-cfggen -H -k Celestica-DX010-D48C8  --preset=t1
('Celestica-DX010-D48C8', 'x86_64-cel_seastone-r0', '/usr/share/sonic/device/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/port_config.ini', None, None)
{
    "BGP_NEIGHBOR": {
        "10.0.0.1": {
            "asn": "65200",
            "holdtime": "180",
            "keepalive": "60",
            "local_addr": "10.0.0.0",
            "name": "ARISTA01T2",
            "nhopself": 0,
            "rrclient": 0
        },
       .......continue
        }
    },
    "DEVICE_METADATA": {
        "localhost": {
            "bgp_asn": "65100",
            "hostname": "sonic",
            "hwsku": "Celestica-DX010-D48C8",
            "mac": "00:e0:ec:3b:d6:ac",
            "platform": "x86_64-cel_seastone-r0",
            "type": "LeafRouter"
        }
    },
    "DEVICE_NEIGHBOR": {},
    "INTERFACE": {
        "Ethernet0|10.0.0.0/31": {},
        "Ethernet2|10.0.0.2/31": {},
        "Ethernet4|10.0.0.4/31": {},
        "Ethernet6|10.0.0.6/31": {},
        "Ethernet8|10.0.0.8/31": {},
        ......continue
    },
    "LOOPBACK_INTERFACE": {
        "Loopback0|10.1.0.1/32": {}
    },
    "PORT": {
        "Ethernet0": {
            "admin_status": "up",
            "alias": "etp1a",
            "index": "1",
            "lanes": "65,66",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet2": {
            "admin_status": "up",
            "alias": "etp1b",
            "index": "1",
            "lanes": "67,68",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet4": {
            "admin_status": "up",
            "alias": "etp2a",
            "index": "2",
            "lanes": "69,70",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet6": {
            "admin_status": "up",
            "alias": "etp2b",
            "index": "2",
            "lanes": "71,72",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet8": {
            "admin_status": "up",
            "alias": "etp3a",
            "index": "3",
            "lanes": "73,74",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet10": {
            "admin_status": "up",
            "alias": "etp3b",
            "index": "3",
            "lanes": "75,76",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet12": {
            "admin_status": "up",
            "alias": "etp4a",
            "index": "4",
            "lanes": "77,78",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet14": {
            "admin_status": "up",
            "alias": "etp4b",
            "index": "4",
            "lanes": "79,80",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet16": {
            "admin_status": "up",
            "alias": "etp5a",
            "index": "5",
            "lanes": "33,34",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet18": {
            "admin_status": "up",
            "alias": "etp5b",
            "index": "5",
            "lanes": "35,36",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet20": {
            "admin_status": "up",
            "alias": "etp6a",
            "index": "6",
            "lanes": "37,38",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet22": {
            "admin_status": "up",
            "alias": "etp6b",
            "index": "6",
            "lanes": "39,40",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet24": {
            "admin_status": "up",
            "alias": "etp7a",
            "index": "7",
            "lanes": "41,42",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet26": {
            "admin_status": "up",
            "alias": "etp7b",
            "index": "7",
            "lanes": "43,44",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet28": {
            "admin_status": "up",
            "alias": "etp8a",
            "index": "8",
            "lanes": "45,46",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet30": {
            "admin_status": "up",
            "alias": "etp8b",
            "index": "8",
            "lanes": "47,48",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet32": {
            "admin_status": "up",
            "alias": "etp9a",
            "index": "9",
            "lanes": "49,50",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet34": {
            "admin_status": "up",
            "alias": "etp9b",
            "index": "9",
            "lanes": "51,52",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet36": {
            "admin_status": "up",
            "alias": "etp10a",
            "index": "10",
            "lanes": "53,54",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet38": {
            "admin_status": "up",
            "alias": "etp10b",
            "index": "10",
            "lanes": "55,56",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet40": {
            "admin_status": "up",
            "alias": "etp11",
            "index": "11",
            "lanes": "57,58,59,60",
            "mtu": "9100",
            "speed": "100000"
        },
        "Ethernet44": {
            "admin_status": "up",
            "alias": "etp12",
            "index": "12",
            "lanes": "61,62,63,64",
            "mtu": "9100",
            "speed": "100000"
        },
        "Ethernet48": {
            "admin_status": "up",
            "alias": "etp13",
            "index": "13",
            "lanes": "81,82,83,84",
            "mtu": "9100",
            "speed": "100000"
        },
        "Ethernet52": {
            "admin_status": "up",
            "alias": "etp14",
            "index": "14",
            "lanes": "85,86,87,88",
            "mtu": "9100",
            "speed": "100000"
        },
        "Ethernet56": {
            "admin_status": "up",
            "alias": "etp15a",
            "index": "15",
            "lanes": "89,90",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet58": {
            "admin_status": "up",
            "alias": "etp15b",
            "index": "15",
            "lanes": "91,92",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet60": {
            "admin_status": "up",
            "alias": "etp16a",
            "index": "16",
            "lanes": "93,94",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet62": {
            "admin_status": "up",
            "alias": "etp16b",
            "index": "16",
            "lanes": "95,96",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet64": {
            "admin_status": "up",
            "alias": "etp17a",
            "index": "17",
            "lanes": "97,98",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet66": {
            "admin_status": "up",
            "alias": "etp17b",
            "index": "17",
            "lanes": "99,100",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet68": {
            "admin_status": "up",
            "alias": "etp18a",
            "index": "18",
            "lanes": "101,102",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet70": {
            "admin_status": "up",
            "alias": "etp18b",
            "index": "18",
            "lanes": "103,104",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet72": {
            "admin_status": "up",
            "alias": "etp19",
            "index": "19",
            "lanes": "105,106,107,108",
            "mtu": "9100",
            "speed": "100000"
        },
        "Ethernet76": {
            "admin_status": "up",
            "alias": "etp20",
            "index": "20",
            "lanes": "109,110,111,112",
            "mtu": "9100",
            "speed": "100000"
        },
        "Ethernet80": {
            "admin_status": "up",
            "alias": "etp21",
            "index": "21",
            "lanes": "1,2,3,4",
            "mtu": "9100",
            "speed": "100000"
        },
        "Ethernet84": {
            "admin_status": "up",
            "alias": "etp22",
            "index": "22",
            "lanes": "5,6,7,8",
            "mtu": "9100",
            "speed": "100000"
        },
        "Ethernet88": {
            "admin_status": "up",
            "alias": "etp23a",
            "index": "23",
            "lanes": "9,10",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet90": {
            "admin_status": "up",
            "alias": "etp23b",
            "index": "23",
            "lanes": "11,12",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet92": {
            "admin_status": "up",
            "alias": "etp24a",
            "index": "24",
            "lanes": "13,14",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet94": {
            "admin_status": "up",
            "alias": "etp24b",
            "index": "24",
            "lanes": "15,16",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet96": {
            "admin_status": "up",
            "alias": "etp25a",
            "index": "25",
            "lanes": "17,18",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet98": {
            "admin_status": "up",
            "alias": "etp25b",
            "index": "25",
            "lanes": "19,20",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet100": {
            "admin_status": "up",
            "alias": "etp26a",
            "index": "26",
            "lanes": "21,22",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet102": {
            "admin_status": "up",
            "alias": "etp26b",
            "index": "26",
            "lanes": "23,24",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet104": {
            "admin_status": "up",
            "alias": "etp27a",
            "index": "27",
            "lanes": "25,26",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet106": {
            "admin_status": "up",
            "alias": "etp27b",
            "index": "27",
            "lanes": "27,28",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet108": {
            "admin_status": "up",
            "alias": "etp28a",
            "index": "28",
            "lanes": "29,30",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet110": {
            "admin_status": "up",
            "alias": "etp28b",
            "index": "28",
            "lanes": "31,32",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet112": {
            "admin_status": "up",
            "alias": "etp29a",
            "index": "29",
            "lanes": "113,114",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet114": {
            "admin_status": "up",
            "alias": "etp29b",
            "index": "29",
            "lanes": "115,116",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet116": {
            "admin_status": "up",
            "alias": "etp30a",
            "index": "30",
            "lanes": "117,118",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet118": {
            "admin_status": "up",
            "alias": "etp30b",
            "index": "30",
            "lanes": "119,120",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet120": {
            "admin_status": "up",
            "alias": "etp31a",
            "index": "31",
            "lanes": "121,122",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet122": {
            "admin_status": "up",
            "alias": "etp31b",
            "index": "31",
            "lanes": "123,124",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet124": {
            "admin_status": "up",
            "alias": "etp32a",
            "index": "32",
            "lanes": "125,126",
            "mtu": "9100",
            "speed": "50000"
        },
        "Ethernet126": {
            "admin_status": "up",
            "alias": "etp32b",
            "index": "32",
            "lanes": "127,128",
            "mtu": "9100",
            "speed": "50000"
        }
    }
}
admin@lnos-x1-a-csw07:~$
```
```
admin@lnos-x1-a-csw07:~$ sudo sonic-cfggen -H -k Seastone-DX010 --preset=t1
('Seastone-DX010', 'x86_64-cel_seastone-r0', '/usr/share/sonic/device/x86_64-cel_seastone-r0/platform.json', None, None)
{
    "BGP_NEIGHBOR": {
        "10.0.0.1": {
            "asn": "65200",
            "holdtime": "180",
            "keepalive": "60",
            "local_addr": "10.0.0.0",
            "name": "ARISTA01T2",
            "nhopself": 0,
            "rrclient": 0............

```
**- Which release branch to backport (provide reason below if selected)**

- [x] 202006
