### PR TITLE
Fix test failure of  test_multinpu_cfggen.py when port2cable length is define in buffer_default_*.j2

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -34,7 +34,6 @@ def
 {%- else %}
     {%- set ports2cable = {
             'torrouter_server'       : '5m',
-            'internal'               : '5m',
             'leafrouter_torrouter'   : '40m',
             'spinerouter_leafrouter' : '300m'
             }
@@ -50,6 +49,9 @@ def
                 {%- set neighbor_role = neighbor.type %}
                 {%- if 'asic' == neighbor_role | lower %}
                          {%- set roles1 = 'internal' %}
+                         {%- if 'internal' not in ports2cable %}
+                             {%- set _ = ports2cable.update({'internal': '5m'}) %}
+                         {%- endif -%}
                 {%- else %}
                          {%- set roles1 = switch_role + '_' + neighbor_role %}
                          {%- set roles2 = neighbor_role + '_' + switch_role %}


### PR DESCRIPTION
Why I did:
Fix test failure of  test_multinpu_cfggen.py when port2cable length is define in buffer_default_*.j2
because of which internal cable length never gets
define and cause failure in test case test_multinpu_cfggen.py 

How I did:
Added 'internal' key always in port2cable dict if not previously define

How I verify:
Test case was passing after the change.