### PR TITLE
[bash.bashrc] Add reverse SSH script to bash.bashrc

### DIFF
--- a/files/image_config/bash/bash.bashrc
+++ b/files/image_config/bash/bash.bashrc
@@ -58,9 +58,9 @@ fi
 tty | grep ttyS >/dev/null && TMOUT=900
 
 # if SSH_TARGET_CONSOLE_LINE was set, attach to console line interactive cli directly
-if [ ! -z "$SSH_TARGET_CONSOLE_LINE" ]; then
+if [ -n "$SSH_TARGET_CONSOLE_LINE" ]; then
     # enter the interactive cli
-    sudo connect $SSH_TARGET_CONSOLE_LINE
+    sudo connect line $SSH_TARGET_CONSOLE_LINE
 
     # exit after console session ended
     exit

--- a/files/image_config/bash/bash.bashrc
+++ b/files/image_config/bash/bash.bashrc
@@ -56,3 +56,12 @@ fi
 
 # Automatically log out console ttyS* sessions after 15 minutes of inactivity
 tty | grep ttyS >/dev/null && TMOUT=900
+
+# if SSH_TARGET_CONSOLE_LINE was set, attach to console line interactive cli directly
+if [ ! -z "$SSH_TARGET_CONSOLE_LINE" ]; then
+    # enter the interactive cli
+    sudo connect $SSH_TARGET_CONSOLE_LINE
+
+    # exit after console session ended
+    exit
+fi

--- a/files/image_config/bash/bash.bashrc
+++ b/files/image_config/bash/bash.bashrc
@@ -59,9 +59,17 @@ tty | grep ttyS >/dev/null && TMOUT=900
 
 # if SSH_TARGET_CONSOLE_LINE was set, attach to console line interactive cli directly
 if [ -n "$SSH_TARGET_CONSOLE_LINE" ]; then
-    # enter the interactive cli
-    sudo connect line $SSH_TARGET_CONSOLE_LINE
+    if [ $SSH_TARGET_CONSOLE_LINE -eq $SSH_TARGET_CONSOLE_LINE 2>/dev/null ]; then
+        # enter the interactive cli
+        connect line $SSH_TARGET_CONSOLE_LINE
 
-    # exit after console session ended
-    exit
+        # test exit code, 1 means the console switch feature not enabled
+        if [ $? -ne 1 ]; then
+            # exit after console session ended
+            exit
+        fi
+    else
+        # exit directly when target console line variable is invalid
+        exit
+    fi
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

To support reverse SSH for console connection, we need to add the script to attach to console line automatically after user login with reverse SSH.
(see HLD for more detail: https://github.com/Azure/SONiC/blob/master/doc/console/SONiC-Console-Switch-High-Level-Design.md#313-reverse-ssh)

The script will be executed only when this feature is available in SONiC: https://github.com/Blueve/openssh-portable/pull/1

**- How I did it**

Add script to `/etc/bash.bashrc` to support reverse ssh function.

**- How to verify it**

**Functional Test**
- [x] Test similar script on my WSL ubuntu (`sudo picocom` instead of `sudo connect`)
- [x] Test on Physical DUT with dummy environment variable
- [x] Build image with this change and test image on Physical DUT

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6898708/94265278-cda54c80-ff6a-11ea-9e39-ef6557677687.png)
_My first pet. My cutest boy. My favorite friend, My family. My cat, the cat I'll never to be seen again... R.I.P Cloud·Cake (2020-09-24)_