### PR TITLE
[mgmt] Install dhclient in sonic-mgmt docker

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y build-essential \
                                          git \
                                          inetutils-ping \
                                          iproute2 \
+                                         isc-dhcp-client \
                                          libffi-dev \
                                          libssl-dev \
                                          libxml2 \


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fixes #5444. 

**- How I did it**
Install the [corresponding ubuntu package](http://manpages.ubuntu.com/manpages/bionic/man8/dhclient.8.html) for dhclient.

**- How to verify it**
Verify dhclient works inside the mgmt docker container.

**- A picture of a cute animal (not mandatory but encouraged)**

