### PR TITLE
[Centec-ARM64] Update docker-syncd-centec critical_processes file to use new syntax

### DIFF
--- a/platform/centec-arm64/docker-syncd-centec/critical_processes
+++ b/platform/centec-arm64/docker-syncd-centec/critical_processes
@@ -1,1 +1,1 @@
-syncd
+program:syncd


### PR DESCRIPTION
This file was added recently, but was created using the old syntax. Update to the new syntax.