### PR TITLE
[swss] Start Restore Neighbor After SWSS Config

### DIFF
--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -47,21 +47,9 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=portsyncd:running
 
-[program:restore_neighbors]
-command=/usr/bin/restore_neighbors.py
-priority=5
-autostart=false
-autorestart=false
-startsecs=0
-startretries=0
-stdout_logfile=syslog
-stderr_logfile=syslog
-dependent_startup=true
-dependent_startup_wait_for=orchagent:running
-
 [program:swssconfig]
 command=/usr/bin/swssconfig.sh
-priority=6
+priority=5
 autostart=false
 autorestart=unexpected
 startretries=0
@@ -70,6 +58,18 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=orchagent:running
+
+[program:restore_neighbors]
+command=/usr/bin/restore_neighbors.py
+priority=6
+autostart=false
+autorestart=false
+startsecs=0
+startretries=0
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=swssconfig:exited
 
 [program:neighsyncd]
 command=/usr/bin/neighsyncd


### PR DESCRIPTION
SWSS config script restore ARP/FDB/Routes. Restore neighbor script
uses config DB ARP information to restore ARP entries and so needs
to be started after swssconfig exits.

Fixes: #5217
Closes: #5217

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
Fixes start dependencies that causes ARP entries to not be restored during fast-reboot

**- How I did it**
Change supervisord config on order to ensure restore_neigh runs after swssconfig.sh

**- How to verify it**
fast-reboot succeeds

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [x] 202006
