### PR TITLE
[201911][Monit] Unmonitor processes in disabled containers

### DIFF
--- a/dockers/docker-database/base_image_files/monit_database
+++ b/dockers/docker-database/base_image_files/monit_database
@@ -3,5 +3,5 @@
 ## process list:
 ##  redis_server
 ###############################################################################
-check program database|redis_server with path "/usr/bin/process_checker database redis-server /usr/bin/redis-server"
+check program database|redis_server with path "/usr/bin/process_checker database /usr/bin/redis-server"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-database/base_image_files/monit_database
+++ b/dockers/docker-database/base_image_files/monit_database
@@ -3,5 +3,5 @@
 ## process list:
 ##  redis_server
 ###############################################################################
-check process redis_server matching "/usr/bin/redis-server"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_redis_server with path "/usr/bin/process_checker database redis-server /usr/bin/redis-server"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-database/base_image_files/monit_database
+++ b/dockers/docker-database/base_image_files/monit_database
@@ -3,5 +3,5 @@
 ## process list:
 ##  redis_server
 ###############################################################################
-check program container_process_redis_server with path "/usr/bin/process_checker database redis-server /usr/bin/redis-server"
+check program database|redis_server with path "/usr/bin/process_checker database redis-server /usr/bin/redis-server"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-fpm-frr/base_image_files/monit_bgp
+++ b/dockers/docker-fpm-frr/base_image_files/monit_bgp
@@ -25,4 +25,3 @@ check program bgp|bgpcfgd with path "/usr/bin/process_checker bgp /usr/bin/pytho
 
 check program bgp|bgpmon with path "/usr/bin/process_checker bgp python /usr/local/bin/bgpmon"
     if status != 0 for 5 times within 5 cycles then alert
-=

--- a/dockers/docker-fpm-frr/base_image_files/monit_bgp
+++ b/dockers/docker-fpm-frr/base_image_files/monit_bgp
@@ -8,19 +8,19 @@
 ##  bgpcfgd
 ##  bgpmon
 ###############################################################################
-check program container_process_zebra with path "/usr/bin/process_checker bgp zebra /usr/lib/frr/zebra"
+check program bgp|zebra with path "/usr/bin/process_checker bgp zebra /usr/lib/frr/zebra"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_fpmsyncd with path "/usr/bin/process_checker bgp fpmsyncd fpmsyncd"
+check program bgp|fpmsyncd with path "/usr/bin/process_checker bgp fpmsyncd fpmsyncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_bgpd with path "/usr/bin/process_checker bgp bgpd /usr/lib/frr/bgpd"
+check program bgp|bgpd with path "/usr/bin/process_checker bgp bgpd /usr/lib/frr/bgpd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_staticd with path "/usr/bin/process_checker bgp staticd /usr/lib/frr/staticd"
+check program bgp|staticd with path "/usr/bin/process_checker bgp staticd /usr/lib/frr/staticd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_bgpcfgd with path "/usr/bin/process_checker bgp bgpcfgd python /usr/local/bin/bgpcfgd"
+check program bgp|bgpcfgd with path "/usr/bin/process_checker bgp bgpcfgd python /usr/local/bin/bgpcfgd"
     if status != 0 for 5 times within 5 cycles then alert
 
 check program bgp|bgpmon with path "/usr/bin/process_checker bgp python /usr/local/bin/bgpmon"

--- a/dockers/docker-fpm-frr/base_image_files/monit_bgp
+++ b/dockers/docker-fpm-frr/base_image_files/monit_bgp
@@ -8,20 +8,21 @@
 ##  bgpcfgd
 ##  bgpmon
 ###############################################################################
-check process zebra matching "/usr/lib/frr/zebra"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_zebra with path "/usr/bin/process_checker bgp zebra /usr/lib/frr/zebra"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process fpmsyncd matching "fpmsyncd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_fpmsyncd with path "/usr/bin/process_checker bgp fpmsyncd fpmsyncd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process bgpd matching "/usr/lib/frr/bgpd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_bgpd with path "/usr/bin/process_checker bgp bgpd /usr/lib/frr/bgpd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process staticd matching "/usr/lib/frr/staticd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_staticd with path "/usr/bin/process_checker bgp staticd /usr/lib/frr/staticd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process bgpcfgd matching "python /usr/local/bin/bgpcfgd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_bgpcfgd with path "/usr/bin/process_checker bgp bgpcfgd python /usr/local/bin/bgpcfgd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process bgpcfgd matching "python /usr/local/bin/bgpmon"
-    if does not exist for 5 times within 5 cycles then alert
+check program bgp|bgpmon with path "/usr/bin/process_checker bgp python /usr/local/bin/bgpmon"
+    if status != 0 for 5 times within 5 cycles then alert
+=

--- a/dockers/docker-fpm-frr/base_image_files/monit_bgp
+++ b/dockers/docker-fpm-frr/base_image_files/monit_bgp
@@ -8,19 +8,19 @@
 ##  bgpcfgd
 ##  bgpmon
 ###############################################################################
-check program bgp|zebra with path "/usr/bin/process_checker bgp zebra /usr/lib/frr/zebra"
+check program bgp|zebra with path "/usr/bin/process_checker bgp /usr/lib/frr/zebra"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program bgp|fpmsyncd with path "/usr/bin/process_checker bgp fpmsyncd fpmsyncd"
+check program bgp|fpmsyncd with path "/usr/bin/process_checker bgp fpmsyncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program bgp|bgpd with path "/usr/bin/process_checker bgp bgpd /usr/lib/frr/bgpd"
+check program bgp|bgpd with path "/usr/bin/process_checker bgp /usr/lib/frr/bgpd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program bgp|staticd with path "/usr/bin/process_checker bgp staticd /usr/lib/frr/staticd"
+check program bgp|staticd with path "/usr/bin/process_checker bgp /usr/lib/frr/staticd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program bgp|bgpcfgd with path "/usr/bin/process_checker bgp bgpcfgd python /usr/local/bin/bgpcfgd"
+check program bgp|bgpcfgd with path "/usr/bin/process_checker bgp python /usr/local/bin/bgpcfgd"
     if status != 0 for 5 times within 5 cycles then alert
 
 check program bgp|bgpmon with path "/usr/bin/process_checker bgp python /usr/local/bin/bgpmon"

--- a/dockers/docker-fpm-frr/base_image_files/monit_bgp
+++ b/dockers/docker-fpm-frr/base_image_files/monit_bgp
@@ -20,7 +20,7 @@ check program bgp|bgpd with path "/usr/bin/process_checker bgp /usr/lib/frr/bgpd
 check program bgp|staticd with path "/usr/bin/process_checker bgp /usr/lib/frr/staticd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program bgp|bgpcfgd with path "/usr/bin/process_checker bgp python /usr/local/bin/bgpcfgd"
+check program bgp|bgpcfgd with path "/usr/bin/process_checker bgp /usr/bin/python /usr/local/bin/bgpcfgd"
     if status != 0 for 5 times within 5 cycles then alert
 
 check program bgp|bgpmon with path "/usr/bin/process_checker bgp python /usr/local/bin/bgpmon"

--- a/dockers/docker-lldp-sv2/base_image_files/monit_lldp
+++ b/dockers/docker-lldp-sv2/base_image_files/monit_lldp
@@ -5,11 +5,11 @@
 ##  lldp-syncd
 ##  lldpmgrd
 ###############################################################################
-check process lldpd_monitor matching "lldpd: "
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_lldpd_monitor with path "/usr/bin/process_checker lldp lldpd lldpd:"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process lldp_syncd matching "python2 -m lldp_syncd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_lldp_syncd with path "/usr/bin/process_checker lldp lldp_syncd python2 -m lldp_syncd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process lldpmgrd matching "python /usr/bin/lldpmgrd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_lldpmgrd with path "/usr/bin/process_checker lldp lldpmgrd python /usr/bin/lldpmgrd"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-lldp-sv2/base_image_files/monit_lldp
+++ b/dockers/docker-lldp-sv2/base_image_files/monit_lldp
@@ -5,11 +5,11 @@
 ##  lldp-syncd
 ##  lldpmgrd
 ###############################################################################
-check program lldp|lldpd_monitor with path "/usr/bin/process_checker lldp lldpd lldpd:"
+check program lldp|lldpd_monitor with path "/usr/bin/process_checker lldp lldpd:"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program lldp|lldp_syncd with path "/usr/bin/process_checker lldp lldp_syncd python2 -m lldp_syncd"
+check program lldp|lldp_syncd with path "/usr/bin/process_checker lldp python2 -m lldp_syncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program lldp|lldpmgrd with path "/usr/bin/process_checker lldp lldpmgrd python /usr/bin/lldpmgrd"
+check program lldp|lldpmgrd with path "/usr/bin/process_checker lldp python /usr/bin/lldpmgrd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-lldp-sv2/base_image_files/monit_lldp
+++ b/dockers/docker-lldp-sv2/base_image_files/monit_lldp
@@ -5,11 +5,11 @@
 ##  lldp-syncd
 ##  lldpmgrd
 ###############################################################################
-check program container_process_lldpd_monitor with path "/usr/bin/process_checker lldp lldpd lldpd:"
+check program lldp|lldpd_monitor with path "/usr/bin/process_checker lldp lldpd lldpd:"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_lldp_syncd with path "/usr/bin/process_checker lldp lldp_syncd python2 -m lldp_syncd"
+check program lldp|lldp_syncd with path "/usr/bin/process_checker lldp lldp_syncd python2 -m lldp_syncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_lldpmgrd with path "/usr/bin/process_checker lldp lldpmgrd python /usr/bin/lldpmgrd"
+check program lldp|lldpmgrd with path "/usr/bin/process_checker lldp lldpmgrd python /usr/bin/lldpmgrd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-orchagent/base_image_files/monit_swss
+++ b/dockers/docker-orchagent/base_image_files/monit_swss
@@ -12,32 +12,32 @@
 ##  nbrmgrd
 ##  vxlanmgrd
 ##############################################################################
-check program swss|orchagent with path "/usr/bin/process_checker swss orchagent /usr/bin/orchagent -d /var/log/swss"
+check program swss|orchagent with path "/usr/bin/process_checker swss /usr/bin/orchagent -d /var/log/swss"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program swss|portsyncd with path "/usr/bin/process_checker swss portsyncd /usr/bin/portsyncd"
+check program swss|portsyncd with path "/usr/bin/process_checker swss /usr/bin/portsyncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program swss|neighsyncd with path "/usr/bin/process_checker swss neighsyncd /usr/bin/neighsyncd"
+check program swss|neighsyncd with path "/usr/bin/process_checker swss /usr/bin/neighsyncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program swss|vrfmgrd with path "/usr/bin/process_checker swss vrfmgrd /usr/bin/vrfmgrd"
+check program swss|vrfmgrd with path "/usr/bin/process_checker swss /usr/bin/vrfmgrd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program swss|vlanmgrd with path "/usr/bin/process_checker swss vlanmgrd /usr/bin/vlanmgrd"
+check program swss|vlanmgrd with path "/usr/bin/process_checker swss /usr/bin/vlanmgrd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program swss|intfmgrd with path "/usr/bin/process_checker swss intfmgrd /usr/bin/intfmgrd"
+check program swss|intfmgrd with path "/usr/bin/process_checker swss /usr/bin/intfmgrd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program swss|portmgrd with path "/usr/bin/process_checker swss portmgrd /usr/bin/portmgrd"
+check program swss|portmgrd with path "/usr/bin/process_checker swss /usr/bin/portmgrd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program swss|buffermgrd with path "/usr/bin/process_checker swss buffermgrd /usr/bin/buffermgrd -l"
+check program swss|buffermgrd with path "/usr/bin/process_checker swss /usr/bin/buffermgrd -l"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program swss|nbrmgrd with path "/usr/bin/process_checker swss nbrmgrd /usr/bin/nbrmgrd"
+check program swss|nbrmgrd with path "/usr/bin/process_checker swss /usr/bin/nbrmgrd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program swss|vxlanmgrd with path "/usr/bin/process_checker swss vxlanmgrd /usr/bin/vxlanmgrd"
+check program swss|vxlanmgrd with path "/usr/bin/process_checker swss /usr/bin/vxlanmgrd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-orchagent/base_image_files/monit_swss
+++ b/dockers/docker-orchagent/base_image_files/monit_swss
@@ -12,32 +12,32 @@
 ##  nbrmgrd
 ##  vxlanmgrd
 ###############################################################################
-check process orchagent matching "/usr/bin/orchagent -d /var/log/swss"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_orchagent with path "/usr/bin/process_checker swss orchagent /usr/bin/orchagent -d /var/log/swss"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process portsyncd matching "/usr/bin/portsyncd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_portsyncd with path "/usr/bin/process_checker swss portsyncd /usr/bin/portsyncd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process neighsyncd matching "/usr/bin/neighsyncd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_neighsyncd with path "/usr/bin/process_checker swss neighsyncd /usr/bin/neighsyncd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process vrfmgrd matching "/usr/bin/vrfmgrd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_vrfmgrd with path "/usr/bin/process_checker swss vrfmgrd /usr/bin/vrfmgrd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process vlanmgrd matching "/usr/bin/vlanmgrd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_vlanmgrd with path "/usr/bin/process_checker swss vlanmgrd /usr/bin/vlanmgrd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process intfmgrd matching "/usr/bin/intfmgrd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_intfmgrd with path "/usr/bin/process_checker swss intfmgrd /usr/bin/intfmgrd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process portmgrd matching "/usr/bin/portmgrd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_portmgrd with path "/usr/bin/process_checker swss portmgrd /usr/bin/portmgrd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process buffermgrd matching "/usr/bin/buffermgrd -l"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_buffermgrd with path "/usr/bin/process_checker swss buffermgrd /usr/bin/buffermgrd -l"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process nbrmgrd matching "/usr/bin/nbrmgrd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_nbrmgrd with path "/usr/bin/process_checker swss nbrmgrd /usr/bin/nbrmgrd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process vxlanmgrd matching "/usr/bin/vxlanmgrd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_vxlanmgrd with path "/usr/bin/process_checker swss vxlanmgrd /usr/bin/vxlanmgrd"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-orchagent/base_image_files/monit_swss
+++ b/dockers/docker-orchagent/base_image_files/monit_swss
@@ -11,33 +11,33 @@
 ##  buffermgrd
 ##  nbrmgrd
 ##  vxlanmgrd
-###############################################################################
-check program container_process_orchagent with path "/usr/bin/process_checker swss orchagent /usr/bin/orchagent -d /var/log/swss"
+##############################################################################
+check program swss|orchagent with path "/usr/bin/process_checker swss orchagent /usr/bin/orchagent -d /var/log/swss"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_portsyncd with path "/usr/bin/process_checker swss portsyncd /usr/bin/portsyncd"
+check program swss|portsyncd with path "/usr/bin/process_checker swss portsyncd /usr/bin/portsyncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_neighsyncd with path "/usr/bin/process_checker swss neighsyncd /usr/bin/neighsyncd"
+check program swss|neighsyncd with path "/usr/bin/process_checker swss neighsyncd /usr/bin/neighsyncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_vrfmgrd with path "/usr/bin/process_checker swss vrfmgrd /usr/bin/vrfmgrd"
+check program swss|vrfmgrd with path "/usr/bin/process_checker swss vrfmgrd /usr/bin/vrfmgrd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_vlanmgrd with path "/usr/bin/process_checker swss vlanmgrd /usr/bin/vlanmgrd"
+check program swss|vlanmgrd with path "/usr/bin/process_checker swss vlanmgrd /usr/bin/vlanmgrd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_intfmgrd with path "/usr/bin/process_checker swss intfmgrd /usr/bin/intfmgrd"
+check program swss|intfmgrd with path "/usr/bin/process_checker swss intfmgrd /usr/bin/intfmgrd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_portmgrd with path "/usr/bin/process_checker swss portmgrd /usr/bin/portmgrd"
+check program swss|portmgrd with path "/usr/bin/process_checker swss portmgrd /usr/bin/portmgrd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_buffermgrd with path "/usr/bin/process_checker swss buffermgrd /usr/bin/buffermgrd -l"
+check program swss|buffermgrd with path "/usr/bin/process_checker swss buffermgrd /usr/bin/buffermgrd -l"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_nbrmgrd with path "/usr/bin/process_checker swss nbrmgrd /usr/bin/nbrmgrd"
+check program swss|nbrmgrd with path "/usr/bin/process_checker swss nbrmgrd /usr/bin/nbrmgrd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_vxlanmgrd with path "/usr/bin/process_checker swss vxlanmgrd /usr/bin/vxlanmgrd"
+check program swss|vxlanmgrd with path "/usr/bin/process_checker swss vxlanmgrd /usr/bin/vxlanmgrd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-sflow/base_image_files/monit_sflow
+++ b/dockers/docker-sflow/base_image_files/monit_sflow
@@ -3,5 +3,5 @@
 ## process list:
 ##  sflowmgrd
 ###############################################################################
-check program container_process_sflowmgrd with path "/usr/bin/process_checker sflow sflowmgrd /usr/bin/sflowmgrd"
+check program sflow|sflowmgrd with path "/usr/bin/process_checker sflow sflowmgrd /usr/bin/sflowmgrd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-sflow/base_image_files/monit_sflow
+++ b/dockers/docker-sflow/base_image_files/monit_sflow
@@ -3,5 +3,5 @@
 ## process list:
 ##  sflowmgrd
 ###############################################################################
-check program sflow|sflowmgrd with path "/usr/bin/process_checker sflow sflowmgrd /usr/bin/sflowmgrd"
+check program sflow|sflowmgrd with path "/usr/bin/process_checker sflow /usr/bin/sflowmgrd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-sflow/base_image_files/monit_sflow
+++ b/dockers/docker-sflow/base_image_files/monit_sflow
@@ -3,5 +3,5 @@
 ## process list:
 ##  sflowmgrd
 ###############################################################################
-check process sflowmgrd matching "/usr/bin/sflowmgrd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_sflowmgrd with path "/usr/bin/process_checker sflow sflowmgrd /usr/bin/sflowmgrd"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-snmp-sv2/base_image_files/monit_snmp
+++ b/dockers/docker-snmp-sv2/base_image_files/monit_snmp
@@ -4,8 +4,8 @@
 ##  snmpd
 ##  snmpd_subagent
 ###############################################################################
-check program snmp|snmpd with path "/usr/bin/process_checker snmp snmpd /usr/sbin/snmpd"
+check program snmp|snmpd with path "/usr/bin/process_checker snmp /usr/sbin/snmpd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program snmp|snmp_subagent with path "/usr/bin/process_checker snmp snmp_subagent python3.6 -m sonic_ax_impl"
+check program snmp|snmp_subagent with path "/usr/bin/process_checker snmp python3.6 -m sonic_ax_impl"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-snmp-sv2/base_image_files/monit_snmp
+++ b/dockers/docker-snmp-sv2/base_image_files/monit_snmp
@@ -7,5 +7,5 @@
 check program container_process_snmpd with path "/usr/bin/process_checker snmp snmpd /usr/sbin/snmpd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_snmp_subagent with path "/usr/bin/process_checker snmp snmp_subagent python3 -m sonic_ax_impl"
+check program container_process_snmp_subagent with path "/usr/bin/process_checker snmp snmp_subagent python3.6 -m sonic_ax_impl"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-snmp-sv2/base_image_files/monit_snmp
+++ b/dockers/docker-snmp-sv2/base_image_files/monit_snmp
@@ -4,8 +4,8 @@
 ##  snmpd
 ##  snmpd_subagent
 ###############################################################################
-check process snmpd matching "/usr/sbin/snmpd -f"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_snmpd with path "/usr/bin/process_checker snmp snmpd /usr/sbin/snmpd"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process snmp_subagent matching "python3.6 -m sonic_ax_impl"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_snmp_subagent with path "/usr/bin/process_checker snmp snmp_subagent python3 -m sonic_ax_impl"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-sonic-restapi/base_image_files/monit_restapi
+++ b/dockers/docker-sonic-restapi/base_image_files/monit_restapi
@@ -3,5 +3,5 @@
 ## process list:
 ##  restapi
 ###############################################################################
-check program restapi|restapi with path "/usr/bin/process_checker restapi restapi /usr/sbin/go-server-server"
+check program restapi|restapi with path "/usr/bin/process_checker restapi /usr/sbin/go-server-server"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-sonic-restapi/base_image_files/monit_restapi
+++ b/dockers/docker-sonic-restapi/base_image_files/monit_restapi
@@ -3,5 +3,5 @@
 ## process list:
 ##  restapi
 ###############################################################################
-check program container_process_restapi with path "/usr/bin/process_checker restapi restapi /usr/sbin/go-server-server"
+check program restapi|restapi with path "/usr/bin/process_checker restapi restapi /usr/sbin/go-server-server"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-sonic-restapi/base_image_files/monit_restapi
+++ b/dockers/docker-sonic-restapi/base_image_files/monit_restapi
@@ -3,5 +3,5 @@
 ## process list:
 ##  restapi
 ###############################################################################
-check process restapi matching "/usr/sbin/go-server-server"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_restapi with path "/usr/bin/process_checker restapi restapi /usr/sbin/go-server-server"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
+++ b/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
@@ -4,8 +4,8 @@
 ##  telemetry
 ##  dialout_client
 ###############################################################################
-check process telemetry matching "/usr/sbin/telemetry"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_telemetry with path "/usr/bin/process_checker telemetry telemetry /usr/sbin/telemetry"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process dialout_client matching "/usr/sbin/dialout_client_cli"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_dialout_client with path "/usr/bin/process_checker telemetry dialout_client /usr/sbin/dialout_client_cli"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
+++ b/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
@@ -4,8 +4,8 @@
 ##  telemetry
 ##  dialout_client
 ###############################################################################
-check program container_process_telemetry with path "/usr/bin/process_checker telemetry telemetry /usr/sbin/telemetry"
+check program telemetry|telemetry with path "/usr/bin/process_checker telemetry telemetry /usr/sbin/telemetry"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_dialout_client with path "/usr/bin/process_checker telemetry dialout_client /usr/sbin/dialout_client_cli"
+check program telemetry|dialout_client with path "/usr/bin/process_checker telemetry dialout_client /usr/sbin/dialout_client_cli"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
+++ b/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
@@ -4,8 +4,8 @@
 ##  telemetry
 ##  dialout_client
 ###############################################################################
-check program telemetry|telemetry with path "/usr/bin/process_checker telemetry telemetry /usr/sbin/telemetry"
+check program telemetry|telemetry with path "/usr/bin/process_checker telemetry /usr/sbin/telemetry"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program telemetry|dialout_client with path "/usr/bin/process_checker telemetry dialout_client /usr/sbin/dialout_client_cli"
+check program telemetry|dialout_client with path "/usr/bin/process_checker telemetry /usr/sbin/dialout_client_cli"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-teamd/base_image_files/monit_teamd
+++ b/dockers/docker-teamd/base_image_files/monit_teamd
@@ -4,8 +4,8 @@
 ##  teamsyncd
 ##  teammgrd
 ###############################################################################
-check program teamd|teamsyncd with path "/usr/bin/process_checker teamd teamsyncd /usr/bin/teamsyncd"
+check program teamd|teamsyncd with path "/usr/bin/process_checker teamd /usr/bin/teamsyncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program teamd|teammgrd with path "/usr/bin/process_checker teamd teammgrd /usr/bin/teammgrd"
+check program teamd|teammgrd with path "/usr/bin/process_checker teamd /usr/bin/teammgrd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/dockers/docker-teamd/base_image_files/monit_teamd
+++ b/dockers/docker-teamd/base_image_files/monit_teamd
@@ -1,11 +1,11 @@
 ###############################################################################
-## Monit configuration for snmp container
+## Monit configuration for teamd container
 ## process list:
-##  snmpd
-##  snmpd_subagent
+##  teamsyncd
+##  teammgrd
 ###############################################################################
-check program snmp|snmpd with path "/usr/bin/process_checker snmp snmpd /usr/sbin/snmpd"
+check program teamd|teamsyncd with path "/usr/bin/process_checker teamd teamsyncd /usr/bin/teamsyncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program snmp|snmp_subagent with path "/usr/bin/process_checker snmp snmp_subagent python3.6 -m sonic_ax_impl"
+check program teamd|teammgrd with path "/usr/bin/process_checker teamd teammgrd /usr/bin/teammgrd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -203,7 +203,6 @@ sudo chmod 600 $FILESYSTEM_ROOT/etc/monit/conf.d/*
 sudo cp $IMAGE_CONFIGS/monit/process_checker $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/process_checker
 
-
 # Copy crontabs
 sudo cp -f $IMAGE_CONFIGS/cron.d/* $FILESYSTEM_ROOT/etc/cron.d/
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -197,6 +197,9 @@ sudo cp $IMAGE_CONFIGS/monit/monitrc $FILESYSTEM_ROOT/etc/monit/
 sudo chmod 600 $FILESYSTEM_ROOT/etc/monit/monitrc
 sudo cp $IMAGE_CONFIGS/monit/conf.d/* $FILESYSTEM_ROOT/etc/monit/conf.d/
 sudo chmod 600 $FILESYSTEM_ROOT/etc/monit/conf.d/*
+sudo cp $IMAGE_CONFIGS/monit/process_checker $FILESYSTEM_ROOT/usr/bin/
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/process_checker
+
 
 # Copy crontabs
 sudo cp -f $IMAGE_CONFIGS/cron.d/* $FILESYSTEM_ROOT/etc/cron.d/

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -109,6 +109,9 @@ sudo rm -rf $FILESYSTEM_ROOT/$REDIS_DUMP_LOAD_PY2_WHEEL_NAME
 # Install Python module for ipaddress
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install ipaddress
 
+# Install Python module for psutil
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install psutil
+
 # Install SwSS SDK Python 2 package
 SWSSSDK_PY2_WHEEL_NAME=$(basename {{swsssdk_py2_wheel_path}})
 sudo cp {{swsssdk_py2_wheel_path}} $FILESYSTEM_ROOT/$SWSSSDK_PY2_WHEEL_NAME

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -33,6 +33,8 @@ def check_process_existence(container_name, process_cmdline):
                     break
 
             if not is_running:
+                # If this script is run by Monit, then the following output will be appneded to
+                # Monit's syslog message.
                 print("'{}' is not running.".format(process_cmdline))
                 sys.exit(1)
     else:

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -1,0 +1,64 @@
+#!/usr/bin/python
+import argparse
+import sys
+import syslog
+
+import psutil
+import swsssdk
+
+
+def check_process_existence(container_name, process_name, process_cmdline):
+    """
+    @summary: Check whether the process in the specified container is running or not and
+              an alerting message will written into syslog if it failed to run.
+    """
+    config_db = swsssdk.ConfigDBConnector()
+    config_db.connect()
+    feature_table = config_db.get_table("FEATURE")
+
+    if container_name in feature_table.keys():
+        # We look into the 'FEATURE' table to verify whether the container is disabled or not.
+        # If the container is diabled, we exit.
+        if ("state" in feature_table[container_name].keys()
+                and feature_table[container_name]["state"] == "disabled"):
+            sys.exit(0)
+        else:
+            # We leveraged the psutil library to help us check whether the process is running or not.
+            # If the process entity is found in process tree and it is also in the 'running' or 'sleeping'
+            # state, then it will be marked as 'running'.
+            is_running = False
+            for process in psutil.process_iter(["name", "cmdline", "status"]):
+                # The script process_checker has the command line format '/usr/bin/process_checker <container_name>
+                # <process_name> <process_cmdline>' such as '/usr/bin/process_checker bgp fpmsyncd fpmsyncd'. So
+                # when using psutil to search process 'fpmsyncd', we should skip the process which ran process_checker
+                # since it is not 'fpmsyncd' process although 'fpmsyncd' is a sustring of its cmdline.
+                if process.name() == "process_checker":
+                    continue
+
+                if ((process_name == process.name() or process_cmdline in ' '.join(process.cmdline()))
+                        and process.status() in ["running", "sleeping"]):
+                    is_running = True
+                    break
+
+            if not is_running:
+                print("'{}' is not running.".format(process_name))
+                sys.exit(1)
+    else:
+        syslog.syslog(syslog.LOG_ERR, "contianer '{}' is not included in SONiC image or the given container name is invalid!"
+                      .format(container_name))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check whether the process in the specified \
+             container is running and an alerting message will be written into syslog if it \
+             failed to run.", usage="/usr/bin/process_checker <container_name> <process_name> <process_cmdline>")
+    parser.add_argument("container_name", help="container name")
+    parser.add_argument("process_name", help="process name")
+    parser.add_argument("process_cmdline", nargs=argparse.REMAINDER, help="process name")
+    args = parser.parse_args()
+
+    check_process_existence(args.container_name, args.process_name, ' '.join(args.process_cmdline))
+
+
+if __name__ == '__main__':
+    main()

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -33,7 +33,7 @@ def check_process_existence(container_name, process_cmdline):
                     break
 
             if not is_running:
-                # If this script is run by Monit, then the following output will be appneded to
+                # If this script is run by Monit, then the following output will be appended to
                 # Monit's syslog message.
                 print("'{}' is not running.".format(process_cmdline))
                 sys.exit(1)

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -44,7 +44,7 @@ def check_process_existence(container_name, process_name, process_cmdline):
                 print("'{}' is not running.".format(process_name))
                 sys.exit(1)
     else:
-        syslog.syslog(syslog.LOG_ERR, "contianer '{}' is not included in SONiC image or the given container name is invalid!"
+        syslog.syslog(syslog.LOG_ERR, "container '{}' is not included in SONiC image or the given container name is invalid!"
                       .format(container_name))
 
 

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -35,7 +35,7 @@ def check_process_existence(container_name, process_name, process_cmdline):
                 if process.name() == "process_checker":
                     continue
 
-                if ((process_name == process.name() or process_cmdline in ' '.join(process.cmdline()))
+                if ((process_name == process.name() or (' '.join(process.cmdline())).startswith(process_cmdline))
                         and process.status() in ["running", "sleeping"]):
                     is_running = True
                     break

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -28,15 +28,7 @@ def check_process_existence(container_name, process_name, process_cmdline):
             # state, then it will be marked as 'running'.
             is_running = False
             for process in psutil.process_iter(["name", "cmdline", "status"]):
-                # The script process_checker has the command line format '/usr/bin/process_checker <container_name>
-                # <process_name> <process_cmdline>' such as '/usr/bin/process_checker bgp fpmsyncd fpmsyncd'. So
-                # when using psutil to search process 'fpmsyncd', we should skip the process which ran process_checker
-                # since it is not 'fpmsyncd' process although 'fpmsyncd' is a sustring of its cmdline.
-                if process.name() == "process_checker":
-                    continue
-
-                if ((process_name == process.name() or (' '.join(process.cmdline())).startswith(process_cmdline))
-                        and process.status() in ["running", "sleeping"]):
+                if ((' '.join(process.cmdline())).startswith(process_cmdline) and process.status() in ["running", "sleeping"]):
                     is_running = True
                     break
 
@@ -51,13 +43,12 @@ def check_process_existence(container_name, process_name, process_cmdline):
 def main():
     parser = argparse.ArgumentParser(description="Check whether the process in the specified \
              container is running and an alerting message will be written into syslog if it \
-             failed to run.", usage="/usr/bin/process_checker <container_name> <process_name> <process_cmdline>")
+             failed to run.", usage="/usr/bin/process_checker <container_name> <process_cmdline>")
     parser.add_argument("container_name", help="container name")
-    parser.add_argument("process_name", help="process name")
     parser.add_argument("process_cmdline", nargs=argparse.REMAINDER, help="process name")
     args = parser.parse_args()
 
-    check_process_existence(args.container_name, args.process_name, ' '.join(args.process_cmdline))
+    check_process_existence(args.container_name, ' '.join(args.process_cmdline))
 
 
 if __name__ == '__main__':

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -7,7 +7,7 @@ import psutil
 import swsssdk
 
 
-def check_process_existence(container_name, process_name, process_cmdline):
+def check_process_existence(container_name, process_cmdline):
     """
     @summary: Check whether the process in the specified container is running or not and
               an alerting message will written into syslog if it failed to run.
@@ -27,13 +27,13 @@ def check_process_existence(container_name, process_name, process_cmdline):
             # If the process entity is found in process tree and it is also in the 'running' or 'sleeping'
             # state, then it will be marked as 'running'.
             is_running = False
-            for process in psutil.process_iter(["name", "cmdline", "status"]):
+            for process in psutil.process_iter(["cmdline", "status"]):
                 if ((' '.join(process.cmdline())).startswith(process_cmdline) and process.status() in ["running", "sleeping"]):
                     is_running = True
                     break
 
             if not is_running:
-                print("'{}' is not running.".format(process_name))
+                print("'{}' is not running.".format(process_cmdline))
                 sys.exit(1)
     else:
         syslog.syslog(syslog.LOG_ERR, "container '{}' is not included in SONiC image or the given container name is invalid!"
@@ -45,7 +45,7 @@ def main():
              container is running and an alerting message will be written into syslog if it \
              failed to run.", usage="/usr/bin/process_checker <container_name> <process_cmdline>")
     parser.add_argument("container_name", help="container name")
-    parser.add_argument("process_cmdline", nargs=argparse.REMAINDER, help="process name")
+    parser.add_argument("process_cmdline", nargs=argparse.REMAINDER, help="process command line")
     args = parser.parse_args()
 
     check_process_existence(args.container_name, ' '.join(args.process_cmdline))

--- a/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
+++ b/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
+check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
+++ b/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
+++ b/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd\s"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
+++ b/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
+++ b/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
@@ -4,8 +4,8 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_dsserve with path "/usr/bin/process_checker syncd dsserve /usr/bin/dsserve /usr/bin/syncd"
+check program syncd|dsserve with path "/usr/bin/process_checker syncd dsserve /usr/bin/dsserve /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
+++ b/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
@@ -4,8 +4,8 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
+check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program syncd|dsserve with path "/usr/bin/process_checker syncd dsserve /usr/bin/dsserve /usr/bin/syncd"
+check program syncd|dsserve with path "/usr/bin/process_checker syncd /usr/bin/dsserve /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
+++ b/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
@@ -4,7 +4,7 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert
 
 check program syncd|dsserve with path "/usr/bin/process_checker syncd dsserve /usr/bin/dsserve /usr/bin/syncd"

--- a/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
+++ b/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
@@ -4,8 +4,8 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check process syncd matching "/usr/bin/syncd\s"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process dsserve matching "/usr/bin/dsserve /usr/bin/syncd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_dsserve with path "/usr/bin/process_checker syncd dsserve /usr/bin/dsserve /usr/bin/syncd"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
+++ b/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
+check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
+++ b/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
+++ b/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd\s"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
+++ b/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
+++ b/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
+check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
+++ b/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
+++ b/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd\s"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
+++ b/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
+check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd\s"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
+check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd\s"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
+check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd\s"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
+++ b/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
+check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
+++ b/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
+++ b/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check process syncd matching "/usr/bin/syncd\s"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
+++ b/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
@@ -3,5 +3,5 @@
 ## process list:
 ##  syncd
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
+++ b/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
@@ -4,8 +4,8 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program container_process_dsserve with path "/usr/bin/process_checker syncd dsserve /usr/bin/dsserve /usr/bin/syncd"
+check program syncd|dsserve with path "/usr/bin/process_checker syncd dsserve /usr/bin/dsserve /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
+++ b/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
@@ -4,8 +4,8 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
+check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program syncd|dsserve with path "/usr/bin/process_checker syncd dsserve /usr/bin/dsserve /usr/bin/syncd"
+check program syncd|dsserve with path "/usr/bin/process_checker syncd /usr/bin/dsserve /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert

--- a/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
+++ b/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
@@ -4,7 +4,7 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+check program syncd|syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert
 
 check program syncd|dsserve with path "/usr/bin/process_checker syncd dsserve /usr/bin/dsserve /usr/bin/syncd"

--- a/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
+++ b/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
@@ -4,8 +4,8 @@
 ##  syncd
 ##  dsserve
 ###############################################################################
-check process syncd matching "/usr/bin/syncd\s"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_syncd with path "/usr/bin/process_checker syncd syncd /usr/bin/syncd --diag"
+    if status != 0 for 5 times within 5 cycles then alert
 
-check process dsserve matching "/usr/bin/dsserve /usr/bin/syncd"
-    if does not exist for 5 times within 5 cycles then alert
+check program container_process_dsserve with path "/usr/bin/process_checker syncd dsserve /usr/bin/dsserve /usr/bin/syncd"
+    if status != 0 for 5 times within 5 cycles then alert

--- a/rules/docker-teamd.mk
+++ b/rules/docker-teamd.mk
@@ -29,4 +29,5 @@ $(DOCKER_TEAMD)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_TEAMD)_RUN_OPT += -v /host/warmboot:/var/warmboot
 
 $(DOCKER_TEAMD)_BASE_IMAGE_FILES += teamdctl:/usr/bin/teamdctl
+$(DOCKER_TEAMD)_BASE_IMAGE_FILES += monit_teamd:/etc/monit/conf.d
 $(DOCKER_TEAMD)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)


### PR DESCRIPTION
**- Why I did it**
We want to let Monit to unmonitor the processes in containers which are disabled in FEATURE table such that
Monit will not generate false alerting messages into the syslog.

**- How I did it**
Monit will periodically run a script which accepts three parameters: <container_name>, <process_name> and
<process_cmdline>. This script will first check whether the container is disabled in the FEATURE table or not.
If it is disabled, Monit will skip monitoring the processes. Otherwise, this script will leverage psutil library to inspect
the process tree in host to look for the processes. If the process is not found, then an alerting message will be written
into syslog.

**- How to verify it**
We can change the state field of a container in FEATURE table from enabled to disabled and then kill a critical
process in it to see whether Monit can generate the alerting message in syslog or not. The message format in syslog is:
<process_name> is not running.

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
