### PR TITLE
[caclmgrd] Provide empty list of destination ports for 'ANY' protocol

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -71,7 +71,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         },
         "ANY": {
             "ip_protocols": ["any"],
-            "dst_ports": ["0"]
+            "dst_ports": []
         }
     }
 
@@ -389,9 +389,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                             elif "SRC_IP" in rule_props and rule_props["SRC_IP"]:
                                 rule_cmd += " -s {}".format(rule_props["SRC_IP"])
 
-                            # Destination port 0 is reserved/unused port, so, using it to apply the rule to all ports.
-                            if dst_port != "0":
-                                rule_cmd += " --dport {}".format(dst_port)
+                            rule_cmd += " --dport {}".format(dst_port)
 
                             # If there are TCP flags present and ip protocol is TCP, append them
                             if ip_protocol == "tcp" and "TCP_FLAGS" in rule_props and rule_props["TCP_FLAGS"]:


### PR DESCRIPTION
**- Why I did it**

For the new "ANY" protocol, instead of using the reserved port "0" as a destination port, simply provide an empty list of destination ports. This way, no `--dport` arguments will be added to the command, effectively applying the rule to all ports without the need for a "magic number".

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
