### PR TITLE
[procdockerstatsd & redis] Fix exception when attempting to write a datetime object to db

### DIFF
--- a/files/image_config/procdockerstatsd/procdockerstatsd
+++ b/files/image_config/procdockerstatsd/procdockerstatsd
@@ -184,9 +184,9 @@ class ProcDockerStats(daemon_base.DaemonBase):
             self.update_dockerstats_command()
             datetimeobj = datetime.now()
             # Adding key to store latest update time.
-            self.update_state_db('DOCKER_STATS|LastUpdateTime', 'lastupdate', datetimeobj)
+            self.update_state_db('DOCKER_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
             self.update_processstats_command()
-            self.update_state_db('PROCESS_STATS|LastUpdateTime', 'lastupdate', datetimeobj)
+            self.update_state_db('PROCESS_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
 
             # Data need to be updated every 2 mins. hence adding delay of 120 seconds
             time.sleep(120)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The redis-py 3.0 used in master branch only accepts user data as bytes,
strings or numbers (ints, longs and floats). Attempting to specify a key
or a value as any other type will raise a DataError exception.
The procdockerstatsd script write a datatime object as value to redis, and will get stuck. 

**- How I did it**
This PR address the issue bt converting datetime to str

**- How to verify it**
Verified on Celestica-DX010-C32, running a master image.
```
Before the update, the **DOCKER_STATS|LastUpdateTime** will never be updated successfully.
After Update:
root@str-dx010-acs-4:~# redis-cli -n 6 hgetall 'DOCKER_STATS|LastUpdateTime'
1) "lastupdate"
2) "2020-09-25 07:27:00.417102"
```

**- Which release branch to backport (provide reason below if selected)**
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
