### PR TITLE
[Mellanox] Refactor platform API to remove dependency on database

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -18,7 +18,6 @@ try:
     import sys
     import io
     import re
-    import subprocess
     import syslog
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
@@ -26,8 +25,6 @@ except ImportError as e:
 MAX_SELECT_DELAY = 3600
 
 MLNX_NUM_PSU = 2
-
-GET_PLATFORM_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.platform"
 
 EEPROM_CACHE_ROOT = '/var/cache/sonic/decode-syseeprom'
 EEPROM_CACHE_FILE = 'syseeprom_cache'

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -27,7 +27,6 @@ MAX_SELECT_DELAY = 3600
 
 MLNX_NUM_PSU = 2
 
-GET_HWSKU_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku"
 GET_PLATFORM_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.platform"
 
 EEPROM_CACHE_ROOT = '/var/cache/sonic/decode-syseeprom'
@@ -61,18 +60,12 @@ class Chassis(ChassisBase):
     def __init__(self):
         super(Chassis, self).__init__()
 
-        # Initialize SKU name and Platform name
-        self.sku_name = self._get_sku_name()
-        self.platform_name = self._get_platform_name()
+        self.name = "Undefined"
+        self.model = "Undefined"
 
-        mi = device_info.get_machine_info()
-        if mi is not None:
-            self.name = mi['onie_platform']
-            self.platform_name = device_info.get_platform()
-        else:
-            self.name = self.sku_name
-            self.platform_name = self._get_platform_name()
-
+        # Initialize Platform name
+        self.platform_name = device_info.get_platform()
+        
         # move the initialization of each components to their dedicated initializer
         # which will be called from platform
         self.sfp_module_initialized = False
@@ -148,6 +141,9 @@ class Chassis(ChassisBase):
         from eeprom import Eeprom
         # Initialize EEPROM
         self._eeprom = Eeprom()
+        # Get chassis name and model from eeprom
+        self.name = self._eeprom.get_product_name()
+        self.model = self._eeprom.get_part_number()
 
 
     def initialize_components(self):
@@ -173,6 +169,15 @@ class Chassis(ChassisBase):
         return self.name
 
 
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+
+        Returns:
+            string: Model/part number of device
+        """
+        return self.model
+        
     ##############################################
     # SFP methods
     ##############################################
@@ -243,18 +248,6 @@ class Chassis(ChassisBase):
                         num_of_drawer = int(match_obj.group(1))
 
         return num_of_fan, num_of_drawer
-
-
-    def _get_sku_name(self):
-        p = subprocess.Popen(GET_HWSKU_CMD, shell=True, stdout=subprocess.PIPE)
-        out, err = p.communicate()
-        return out.rstrip('\n')
-
-
-    def _get_platform_name(self):
-        p = subprocess.Popen(GET_PLATFORM_CMD, shell=True, stdout=subprocess.PIPE)
-        out, err = p.communicate()
-        return out.rstrip('\n')
 
     def _get_port_position_tuple_by_platform_name(self):
         position_tuple = port_position_tuple_list[platform_dict_port[self.platform_name]]

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
@@ -80,12 +80,20 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
             pass
 
         self._base_mac = self.mgmtaddrstr(eeprom)
-        if self._base_mac == None:
+        if self._base_mac is None:
             self._base_mac = "Undefined."
 
         self._serial_str = self.serial_number_str(eeprom)
-        if self._serial_str == None:
+        if self._serial_str is None:
             self._serial_str = "Undefined."
+
+        self._product_name = self.modelstr(eeprom)
+        if self._product_name is None:
+            self._product_name = "Undefined."
+
+        self._part_number = self.part_number_str(eeprom)
+        if self._part_number is None:
+            self._part_number = "Undefined."
 
         original_stdout = sys.stdout
         sys.stdout = StringIO()
@@ -134,6 +142,28 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not self._eeprom_loaded:
             self._load_eeprom()
         return self._serial_str
+
+    def get_product_name(self):
+        """
+        Retrieves the hardware product name for the chassis
+
+        Returns:
+            A string containing the hardware product name for this chassis.
+        """
+        if not self._eeprom_loaded:
+            self._load_eeprom()
+        return self._product_name
+
+    def get_part_number(self):
+        """
+        Retrieves the hardware part number for the chassis
+
+        Returns:
+            A string containing the hardware part number for this chassis.
+        """
+        if not self._eeprom_loaded:
+            self._load_eeprom()
+        return self._part_number
 
     def get_system_eeprom_info(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -20,6 +20,7 @@ class Platform(PlatformBase):
             self._chassis = Chassis()
             self._chassis.initialize_components()
             self._chassis.initizalize_system_led()
+            self._chassis.initialize_eeprom()
         else:
             self._chassis = Chassis()
             self._chassis.initialize_psu()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

***This PR has a dependency on https://github.com/Azure/sonic-platform-common/pull/121***


**- Why I did it**
- Platform API implementation using sonic-cfggen to get platform name and SKU name, which will fail when the database is not available.
- Chassis name is not correctly assigned, it shall be assigned with EEPROM TLV "Product Name", instead of SKU name  
- Chassis model is not implemented, it shall be assigned with EEPROM TLV "Part Number"

**- How I did it**

1. Chassis

> - Get platform name from /host/machine.conf
> - Remove get SKU name with sonic-cfggen
> - Get Chassis name and model from EEPROM TLV "Product Name" and "Part Number" 
> - Add function to return model

2. EEPROM

> - Add function to return product name and part number

3. Platform

> - Init EEPROM on the host side, so also can get the Chassis name model from EEPROM on the host side.

**- How to verify it**

- Check whether platform API can still work when stop database service
- Check whether daemons calling platform API are still work well.
- Check whether Chassis name and model are as expected.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
