### PR TITLE
[sonic_py_common] Fix exception in daemon_base.py

### DIFF
--- a/src/sonic-py-common/sonic_py_common/daemon_base.py
+++ b/src/sonic-py-common/sonic_py_common/daemon_base.py
@@ -44,15 +44,15 @@ class DaemonBase(Logger):
     # Default signal handler; can be overridden by subclass
     def signal_handler(self, sig, frame):
         if sig == signal.SIGHUP:
-            log_info("DaemonBase: Caught SIGHUP - ignoring...")
+            self.log_info("DaemonBase: Caught SIGHUP - ignoring...")
         elif sig == signal.SIGINT:
-            log_info("DaemonBase: Caught SIGINT - exiting...")
+            self.log_info("DaemonBase: Caught SIGINT - exiting...")
             sys.exit(128 + sig)
         elif sig == signal.SIGTERM:
-            log_info("DaemonBase: Caught SIGTERM - exiting...")
+            self.log_info("DaemonBase: Caught SIGTERM - exiting...")
             sys.exit(128 + sig)
         else:
-            log_warning("DaemonBase: Caught unhandled signal '{}'".format(sig))
+            self.log_warning("DaemonBase: Caught unhandled signal '{}'".format(sig))
 
     # Loads platform specific platform module from source
     def load_platform_util(self, module_name, class_name):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
There is a syntax error (self is missing for log_info and log_warning) in signal_handler in daemon_base.py, which causes an exception
```
INFO lldp#supervisord: lldpmgrd Traceback (most recent call last):
INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 224, in <module>
INFO lldp#supervisord: lldpmgrd     main()
INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 220, in main
INFO lldp#supervisord: lldpmgrd     lldpmgr.run()
INFO lldp#supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 181, in run
INFO lldp#supervisord: lldpmgrd     (state, c) = sel.select(SELECT_TIMEOUT_MS)
INFO lldp#supervisord: lldpmgrd   File "/usr/lib/python2.7/dist-packages/swsscommon/swsscommon.py", line 965, in select
INFO lldp#supervisord: lldpmgrd     return _swsscommon.Select_select(self, timeout)
INFO lldp#supervisord: lldpmgrd   File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/daemon_base.py", line 52, in signal_handler
INFO lldp#supervisord: lldpmgrd     log_info("DaemonBase: Caught SIGTERM - exiting...")
INFO lldp#supervisord: lldpmgrd NameError: global name 'log_info' is not defined
```
**- How I did it**
Fix the syntax error.
**- How to verify it**
Verified by static syntax analysis.
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
No.

**- A picture of a cute animal (not mandatory but encouraged)**
No.