### PR TITLE
[Mellanox] Fix truncated manufacture date returned from platform API

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
@@ -109,7 +109,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
 
         for line in lines:
             try:
-                match = re.search('(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                match = re.search('(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+[\s]*[\S]*)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

The manufacture date returned from platform API was truncated, time is not included.
        
   05/11/2017 17:20:17  ------>   05/11/2017

**- How I did it**

Revise the regular expression used for matching.

**- How to verify it**

Call the platform API and check whether the manufacture date is correctly returned.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
