### PR TITLE
[device/accton] Remove the use of python pickle package

### DIFF
--- a/device/accton/x86_64-accton_as5812_54t-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5812_54t-r0/plugins/sfputil.py
@@ -5,7 +5,6 @@
 try:
     import time
     import os
-    import pickle
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
@@ -83,16 +82,13 @@ class SfpUtil(SfpUtilBase):
 
     #Two i2c buses might get flipped order, check them both.
     def update_i2c_order(self):
-        if os.path.exists("/tmp/accton_util.p"):
-            self.I2C_BUS_ORDER = pickle.load(open("/tmp/accton_util.p", "rb"))
-        else:
-            if self.I2C_BUS_ORDER < 0:
-                eeprom_path = "/sys/bus/i2c/devices/1-0057/eeprom"
-                if os.path.exists(eeprom_path):
-                    self.I2C_BUS_ORDER = 0
-                eeprom_path = "/sys/bus/i2c/devices/0-0057/eeprom"
-                if os.path.exists(eeprom_path):
-                    self.I2C_BUS_ORDER = 1
+        if self.I2C_BUS_ORDER < 0:
+            eeprom_path = "/sys/bus/i2c/devices/1-0057/eeprom"
+            if os.path.exists(eeprom_path):
+                self.I2C_BUS_ORDER = 0
+            eeprom_path = "/sys/bus/i2c/devices/0-0057/eeprom"
+            if os.path.exists(eeprom_path):
+                self.I2C_BUS_ORDER = 1
         return self.I2C_BUS_ORDER 
 
     def get_presence(self, port_num):
@@ -285,4 +281,3 @@ class SfpUtil(SfpUtilBase):
         else:
             return True, {}
         return False, {}
-

--- a/device/accton/x86_64-accton_as5812_54x-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as5812_54x-r0/plugins/sfputil.py
@@ -5,7 +5,6 @@
 try:
     import time
     import os
-    import pickle
     from ctypes import create_string_buffer
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
@@ -132,16 +131,13 @@ class SfpUtil(SfpUtilBase):
 
     #Two i2c buses might get flipped order, check them both.
     def update_i2c_order(self):
-        if os.path.exists("/tmp/accton_util.p"):
-            self.I2C_BUS_ORDER = pickle.load(open("/tmp/accton_util.p", "rb"))
-        else:
-            if self.I2C_BUS_ORDER < 0:
-                eeprom_path = "/sys/bus/i2c/devices/1-0057/eeprom"
-                if os.path.exists(eeprom_path):
-                    self.I2C_BUS_ORDER = 0
-                eeprom_path = "/sys/bus/i2c/devices/0-0057/eeprom"
-                if os.path.exists(eeprom_path):
-                    self.I2C_BUS_ORDER = 1
+        if self.I2C_BUS_ORDER < 0:
+            eeprom_path = "/sys/bus/i2c/devices/1-0057/eeprom"
+            if os.path.exists(eeprom_path):
+                self.I2C_BUS_ORDER = 0
+            eeprom_path = "/sys/bus/i2c/devices/0-0057/eeprom"
+            if os.path.exists(eeprom_path):
+                self.I2C_BUS_ORDER = 1
         return self.I2C_BUS_ORDER 
 
     def get_presence(self, port_num):

--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_util.py
@@ -35,7 +35,6 @@ import sys, getopt
 import logging
 import re
 import time
-import pickle
 from collections import namedtuple
 
 PROJECT_NAME = 'as5712_54x'
@@ -295,30 +294,26 @@ def i2c_order_check():
     # i2c bus 0 and 1 might be installed in different order.
     # Here check if 0x70 is exist @ i2c-0
     tmp = "echo pca9548 0x70 > /sys/bus/i2c/devices/i2c-1/new_device"
-    status, output = log_os_system(tmp, 0)
+    log_os_system(tmp, 0)
     if not device_exist():
         order = 1
     else:
         order = 0
     tmp = "echo 0x70 > /sys/bus/i2c/devices/i2c-1/delete_device"
-    status, output = log_os_system(tmp, 0)
+    log_os_system(tmp, 0)
     return order
 
 def update_i2c_order():
     global I2C_BUS_ORDER
    
     order = i2c_order_check()
-    pickle.dump(order, open("/tmp/accton_util.p", "wb"))  # save it
     I2C_BUS_ORDER = order
     print "[%s]Detected I2C_BUS_ORDER:%d" % (os.path.basename(__file__), I2C_BUS_ORDER)
 
 def get_i2c_order():
     global I2C_BUS_ORDER
     if I2C_BUS_ORDER < 0:
-        if os.path.exists("/tmp/accton_util.p"):
-            I2C_BUS_ORDER = pickle.load(open("/tmp/accton_util.p", "rb"))
-        else:
-            update_i2c_order()
+        update_i2c_order()
 
 def device_install():
     global FORCE
@@ -369,10 +364,7 @@ def device_install():
 
 def device_uninstall():
     global FORCE
-    global I2C_BUS_ORDER
 
-    get_i2c_order()
-    order = I2C_BUS_ORDER
     for i in range(0,len(sfp_map)):
         target = "/sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/delete_device"
         status, output =log_os_system("echo 0x50 > "+ target, 1)
@@ -380,7 +372,8 @@ def device_uninstall():
             print output
             if FORCE == 0:
                 return status
-
+    status, output = log_os_system("ls /sys/bus/i2c/devices/1-0070", 0)
+    order = 0 if (status == 0) else 1
     if order == 0:
         nodelist = mknod
     else:

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/utils/accton_as5812_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/utils/accton_as5812_util.py
@@ -35,7 +35,6 @@ import sys, getopt
 import logging
 import re
 import time
-import pickle
 from collections import namedtuple
 
 PROJECT_NAME = 'as5812_54x'
@@ -295,30 +294,26 @@ def i2c_order_check():
     # i2c bus 0 and 1 might be installed in different order.
     # Here check if 0x70 is exist @ i2c-0
     tmp = "echo pca9548 0x70 > /sys/bus/i2c/devices/i2c-1/new_device"
-    status, output = log_os_system(tmp, 0)
+    log_os_system(tmp, 0)
     if not device_exist():
         order = 1
     else:
         order = 0
     tmp = "echo 0x70 > /sys/bus/i2c/devices/i2c-1/delete_device"
-    status, output = log_os_system(tmp, 0)
+    log_os_system(tmp, 0)
     return order
 
 def update_i2c_order():
     global I2C_BUS_ORDER
    
     order = i2c_order_check()
-    pickle.dump(order, open("/tmp/accton_util.p", "wb"))  # save it
     I2C_BUS_ORDER = order
     print "[%s]Detected I2C_BUS_ORDER:%d" % (os.path.basename(__file__), I2C_BUS_ORDER)
 
 def get_i2c_order():
     global I2C_BUS_ORDER
     if I2C_BUS_ORDER < 0:
-        if os.path.exists("/tmp/accton_util.p"):
-            I2C_BUS_ORDER = pickle.load(open("/tmp/accton_util.p", "rb"))
-        else:
-            update_i2c_order()
+        update_i2c_order()
 
 def device_install():
     global FORCE
@@ -369,10 +364,7 @@ def device_install():
 
 def device_uninstall():
     global FORCE
-    global I2C_BUS_ORDER
 
-    get_i2c_order()
-    order = I2C_BUS_ORDER
     for i in range(0,len(sfp_map)):
         target = "/sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/delete_device"
         status, output =log_os_system("echo 0x50 > "+ target, 1)
@@ -380,7 +372,8 @@ def device_uninstall():
             print output
             if FORCE == 0:
                 return status
-
+    status, output = log_os_system("ls /sys/bus/i2c/devices/1-0070", 0)
+    order = 0 if (status == 0) else 1
     if order == 0:
         nodelist = mknod
     else:


### PR DESCRIPTION
Signed-off-by: roy_lee <roy_lee@edge-core.com>

**- Why I did it**
python pickle package is not secure. 

**- How I did it**
Remove pickle relative code, which are used as a cache.

**- How to verify it**
sfputil show eeprom


**- Which release branch to backport (provide reason below if selected)**
- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
Pickle is applied to save the order of i2c adapters at installation. 
With pickle removed, it just checks the order of i2c buses every time it needs.


