### PR TITLE
Vtysh support for multi asic

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/vtysh
+++ b/dockers/docker-fpm-frr/base_image_files/vtysh
@@ -1,4 +1,37 @@
 #!/bin/bash
+# read SONiC immutable variables
+[ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
+
+function help()
+{
+    echo -e "Usage: $0 -n [0 to $(($NUM_ASIC-1))] [OPTION]... " 1>&2; exit 1;
+}
+
+DEV=""
+PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
+
+# Parse the device specific asic conf file, if it exists
+ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
+[ -f $ASIC_CONF ] && . $ASIC_CONF
+
+if [[ ($NUM_ASIC -gt 1) ]]; then
+    while getopts ":n:h:" opt; do
+        case "${opt}" in
+            h) help
+               ;;
+            n) DEV=${OPTARG}
+               [ $DEV -lt $NUM_ASIC -a  $DEV -ge 0 ] || help
+               ;;
+        esac
+    done
+
+    if [ -z "${DEV}" ]; then
+        help
+    fi
+
+    # Skip the arguments -n <inst> while passing to docker command
+    shift 2
+fi
 
 # Determine whether stdout is on a terminal
 if [ -t 1 ] ; then
@@ -7,10 +40,10 @@ if [ -t 1 ] ; then
   TTY=$(tty)
   function cleanup
   {
-    docker exec -i bgp pkill -HUP -f "vtysh $TTY"
+    docker exec -i bgp$DEV pkill -HUP -f "vtysh $TTY"
   }
   trap cleanup HUP
-  docker exec -ti bgp vtysh "$TTY" "$@"
+  docker exec -ti bgp$DEV vtysh "$TTY" "$@"
 else
-  docker exec -i bgp vtysh "$@"
+  docker exec -i bgp$DEV vtysh "$@"
 fi


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Add the option -n to specify the bgp container running in a namespace.

**- How I did it**
Update the vtysh script with new option `-n <namespace_id>`
This option is no applicable for single asic.
 
**- How to verify it**
```
admin@str-acs-2:~/arlakshm$ vtysh
Usage: /usr/bin/vtysh -n [0 to 5] [OPTION]... 
admin@str-acs-2:~/arlakshm$ vtysh -n 0 -c "show ip bgp summary"

IPv4 Unicast Summary:
BGP router identifier 8.0.0.0, local AS number 65100 vrf-id 0
BGP table version 12826
RIB entries 12833, using 2306 KiB of memory
Peers 4, using 82 KiB of memory
Peer groups 4, using 256 bytes of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
10.0.0.1        4      65200   81661   82715        0    0    0 2d17h22m         6402
10.0.0.5        4      65200   81664   82714        0    0    0 2d17h22m         6402
10.1.0.0        4      65100    6414    3325        0    0    0 2d17h22m         6417
10.1.0.2        4      65100    4056    3211        0    0    0 2d17h22m         6417

Total number of neighbors 4
admin@str-acs-2:~/arlakshm$ 

```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X ] 201911
- [ X] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
