### PR TITLE
[brcm] Skip ledinit if there is no led_proc_init.soc file

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/start_led.sh
+++ b/platform/broadcom/docker-syncd-brcm/start_led.sh
@@ -2,6 +2,12 @@
 
 PLATFORM_DIR=/usr/share/sonic/platform
 SYNCD_SOCKET_FILE=/var/run/sswsyncd/sswsyncd.socket
+LED_PROC_INIT_SOC=${PLATFORM_DIR}/led_proc_init.soc
+
+if [ ! -f "$LED_PROC_INIT_SOC" ]; then
+   echo "No soc led configuration found under $LED_SOC_INIT_SOC"
+   exit 0
+fi
 
 # Function: wait until syncd has created the socket for bcmcmd to connect to
 wait_syncd() {
@@ -30,8 +36,8 @@ wait_syncd() {
 }
 
 # If this platform has an initialization file for the Broadcom LED microprocessor, load it
-if [[ -r ${PLATFORM_DIR}/led_proc_init.soc && ! -f /var/warmboot/warm-starting ]]; then
+if [[ -r "$LED_PROC_INIT_SOC" && ! -f /var/warmboot/warm-starting ]]; then
     wait_syncd
 fi
 
-/usr/bin/bcmcmd -t 60 "rcload /usr/share/sonic/platform/led_proc_init.soc"
+/usr/bin/bcmcmd -t 60 "rcload $LED_PROC_INIT_SOC"


### PR DESCRIPTION
**- Why I did it**

Some platforms don't leverage the brcm led coprocessor.
However ledinit will try to load a non existing file and exit with an
error code.
This change is a cosmetic fix mostly.

**- How I did it**

Check if the `led_proc_init.soc` exists or exit gracefully.

**- How to verify it**

Boot a platform without the configuration and verify in the syslog that the exit status of ledinit is 0
Boot a platform with the configuration and verify in the syslog that the exit status of ledinit is 0 and the leds are working.
Verified by adding a dumb `led_proc_init.soc` on an Arista platform which usually doesn't use it.

**- Which release branch to backport (provide reason below if selected)**

This is a cosmetic fix, but it's better to avoid an `unexpected exit status` in the syslog.

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**

Skip ledinit if there is no led_proc_init.soc file