### PR TITLE
[device]support front port33 and port34

### DIFF
--- a/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/port_config.ini
+++ b/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/port_config.ini
@@ -31,3 +31,5 @@ Ethernet112     113,114,115,116       hundredGigE29     29     100000
 Ethernet116     117,118,119,120       hundredGigE30     30     100000
 Ethernet120     121,122,123,124       hundredGigE31     31     100000
 Ethernet124     125,126,127,128       hundredGigE32     32     100000
+Ethernet128     129       tenGigE31     33     10000
+Ethernet129     128       tenGigE32     34     10000

--- a/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/td3-as7726-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/td3-as7726-32x100G.config.bcm
@@ -102,8 +102,8 @@ portmap_115=113:100
 portmap_119=117:100
 portmap_123=121:100
 portmap_127=125:100
-#portmap_66=129:10:m
-#portmap_130=128:10:m
+portmap_66=129:10:m
+portmap_130=128:10:m
 #portmap_65=130:10
 #portmap_131=131:10
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
@@ -164,6 +164,7 @@ def main():
             logging.info('no option')
     for arg in args:
         if arg == 'install':
+           ds100_setting()
            do_install()
         elif arg == 'clean':
            do_uninstall()
@@ -254,6 +255,34 @@ def driver_inserted():
     logging.info('mods:'+lsmod)
     if len(lsmod) ==0:
         return False
+
+def ds100_setting():
+    ret, output = log_os_system("i2cset -y 0 0x77 0x0 0x1", 0)
+    ret, output = log_os_system("i2cset -y 0 0x76 0x0 0x20", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x06 0x18", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x0F 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x16 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x17 0xAA", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x18 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x1D 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x24 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x25 0xAA", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x26 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x2C 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x2D 0xAA", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x2E 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x34 0xAA", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x35 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x3A 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x3B 0xAA", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x3C 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x41 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x42 0xAA", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x43 0x00", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x5E 0x06", 0)
+    ret, output = log_os_system("i2cset -y 0 0x58 0x5F 0x00", 0)
+    return
+
 
 def cpld_reset_mac():
     ret, lsmod = log_os_system("i2cset -y 0 0x77 0x1", 0)


### PR DESCRIPTION
Signed-off-by:derek_sun <derek_sun@edge-core.com>

**- Why I did it**
- Support front port33(10G) and port34(10G).

**- How I did it**
- Modify platform configuration file.(td3-as7726-32x100G.config.bcm and port_config.ini)
- Modify accton_as7726_32x_util.py

**- How to verify it**
- Confirm this change items on as7726_32x device.
-- port32, port33 and port34 link-up status.
-- port32 and port34 traffic test.

**- Which release branch to backport (provide reason below if selected)**
- 202006 branch can support front port33 and port34 on as7726_32x. 

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
[Device] support front port33 and port34 on as7726_32x.


**- A picture of a cute animal (not mandatory but encouraged)**
