### PR TITLE
rsyslogd starting inside container fails

### DIFF
--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -19,7 +19,7 @@ autostart=true
 autorestart=unexpected
 
 [program:rsyslogd]
-command=/usr/sbin/rsyslogd -n -iNONE
+command=/usr/sbin/rsyslogd -n -i/tmp/NONE
 priority=1
 autostart=false
 autorestart=unexpected

--- a/platform/marvell-arm64/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell-arm64/docker-syncd-mrvl/supervisord.conf
@@ -19,7 +19,7 @@ autostart=true
 autorestart=unexpected
 
 [program:rsyslogd]
-command=/usr/sbin/rsyslogd -n -iNONE
+command=/usr/sbin/rsyslogd -n -i/tmp/NONE
 priority=1
 autostart=false
 autorestart=false

--- a/platform/marvell-armhf/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell-armhf/docker-syncd-mrvl/supervisord.conf
@@ -19,7 +19,7 @@ autostart=true
 autorestart=unexpected
 
 [program:rsyslogd]
-command=/usr/sbin/rsyslogd -n -iNONE
+command=/usr/sbin/rsyslogd -n -i/tmp/NONE
 priority=1
 autostart=false
 autorestart=false

--- a/platform/marvell/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell/docker-syncd-mrvl/supervisord.conf
@@ -19,7 +19,7 @@ autostart=true
 autorestart=unexpected
 
 [program:rsyslogd]
-command=/usr/sbin/rsyslogd -n -iNONE
+command=/usr/sbin/rsyslogd -n -i/tmp/NONE
 priority=1
 autostart=false
 autorestart=unexpected


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
spawning of rsyslogd inside the frr and syncd containers fails with error
rsyslogd: error reading pid file, cannot start up
rsyslogd: run failed with error -3000 (see rsyslog.h or try http://www.rsyslog.com/e/3000 to learn what that number means)
**- How I did it**
modified option to pass the pid file
**- How to verify it**
config load_minigraph
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

**LOGS**
supervisord logs:

2019-02-14 10:36:21,353 ERRO pool dependent-startup event buffer overflowed, discarding event 58133
2019-02-14 10:36:21,354 INFO exited: rsyslogd (exit status 1; not expected)
2019-02-14 10:36:21,355 ERRO pool dependent-startup event buffer overflowed, discarding event 58134
2019-02-14 10:36:21,358 INFO spawned: 'rsyslogd' with pid 19491
2019-02-14 10:36:21,362 ERRO pool dependent-startup event buffer overflowed, discarding event 58135
2019-02-14 10:36:21,363 INFO success: rsyslogd entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2019-02-14 10:36:21,391 INFO exited: rsyslogd (exit status 1; not expected)
2019-02-14 10:36:21,392 ERRO pool dependent-startup event buffer overflowed, discarding event 58137
2019-02-14 10:36:21,396 INFO spawned: 'rsyslogd' with pid 19492
2019-02-14 10:36:21,401 ERRO pool dependent-startup event buffer overflowed, discarding event 58138
2019-02-14 10:36:21,401 INFO success: rsyslogd entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2019-02-14 10:36:21,434 ERRO pool dependent-startup event buffer overflowed, discarding event 58139
2019-02-14 10:36:21,434 INFO exited: rsyslogd (exit status 1; not expected)

