### PR TITLE
Fix sonic-util command failure on Multi-asic platforms.

### DIFF
--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import subprocess
 
 from natsort import natsorted
 from swsssdk import ConfigDBConnector


### PR DESCRIPTION
Why I did:

After Recent PR https://github.com/Azure/sonic-buildimage/pull/5446  sonic-util command failure on Multi-asic platforms. 

How I verify:

After fix command were working fine.
