### PR TITLE
Fix config qos reload on Multi-asic platforms.

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -2,7 +2,6 @@
 {%- for port in PORT %}
     {%- if PORT_ALL.append(port) %}{% endif %}
 {%- endfor %}
-{%- if PORT_ALL | sort_by_port_index %}{% endif %}
 
 {%- set port_names_list_all = [] %}
 {%- for port in PORT_ALL %}
@@ -19,7 +18,6 @@
         {%- if PORT_ACTIVE.append(port) %}{%- endif %}
     {%- endfor %}
 {%- endif %}
-{%- if PORT_ACTIVE | sort_by_port_index %}{% endif %}
 
 {%- set port_names_list_active = [] %}
 {%- for port in PORT_ACTIVE %}


### PR DESCRIPTION
Why I did:
config qos reload on Multi-asic platforms not working 
The sort Function on Portname is not able to understand
Backplane Interface name.

How I did:
Fix is to to remove sorting from j2 template as this is not needed
as all Ports are dervie from port_config.ini where ports are listed
in fixed static sort order.

Also we do not sort port in buffer_config.j2 so made logic similar to
that and keep it simple instead of enhancing sort function.

How I verified:
config load_minigraph -y is fine which internally invoke config qos reload.