### PR TITLE
Fix generate_l2_config: don't override hostname or device role (ToRRouter)

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -42,10 +42,6 @@ def generate_empty_config(data):
     return new_data
 
 def generate_l2_config(data):
-    if not data['DEVICE_METADATA']['localhost'].has_key('hostname'):
-        data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
-    if not data['DEVICE_METADATA']['localhost'].has_key('type'):
-        data['DEVICE_METADATA']['localhost']['type'] = 'ToRRouter'
     data['VLAN'] = {'Vlan1000': {'vlanid': '1000'}}
     vp = natsorted(data['PORT'].keys())
     data['VLAN']['Vlan1000'].setdefault('members', vp)

--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -43,8 +43,6 @@ def generate_empty_config(data):
 
 def generate_l2_config(data):
     data['VLAN'] = {'Vlan1000': {'vlanid': '1000'}}
-    vp = natsorted(data['PORT'].keys())
-    data['VLAN']['Vlan1000'].setdefault('members', vp)
     data['VLAN_MEMBER'] = {}
     for port in natsorted(data['PORT'].keys()):
         data['PORT'][port].setdefault('admin_status', 'up')

--- a/src/sonic-config-engine/tests/sample_output/l2switch.json
+++ b/src/sonic-config-engine/tests/sample_output/l2switch.json
@@ -1,304 +1,266 @@
 {
-    "DEVICE_METADATA": {
-        "localhost": {
-            "hwsku": "Mellanox-SN2700"
-        }
-    }, 
+    "DEVICE_METADATA": {"localhost": {"hwsku": "Mellanox-SN2700"}},
     "PORT": {
         "Ethernet0": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/0", 
-            "lanes": "29,30,31,32"
-        }, 
+            "alias": "fortyGigE0/0",
+            "lanes": "29,30,31,32",
+            "admin_status": "up"
+        },
         "Ethernet4": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/4", 
-            "lanes": "25,26,27,28"
-        }, 
+            "alias": "fortyGigE0/4",
+            "lanes": "25,26,27,28",
+            "admin_status": "up"
+        },
         "Ethernet8": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/8", 
-            "lanes": "37,38,39,40"
-        }, 
+            "alias": "fortyGigE0/8",
+            "lanes": "37,38,39,40",
+            "admin_status": "up"
+        },
         "Ethernet12": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/12", 
-            "lanes": "33,34,35,36"
-        }, 
+            "alias": "fortyGigE0/12",
+            "lanes": "33,34,35,36",
+            "admin_status": "up"
+        },
         "Ethernet16": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/16", 
-            "lanes": "41,42,43,44"
-        }, 
+            "alias": "fortyGigE0/16",
+            "lanes": "41,42,43,44",
+            "admin_status": "up"
+        },
         "Ethernet20": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/20", 
-            "lanes": "45,46,47,48"
-        }, 
+            "alias": "fortyGigE0/20",
+            "lanes": "45,46,47,48",
+            "admin_status": "up"
+        },
         "Ethernet24": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/24", 
-            "lanes": "5,6,7,8"
-        }, 
+            "alias": "fortyGigE0/24",
+            "lanes": "5,6,7,8",
+            "admin_status": "up"
+        },
         "Ethernet28": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/28", 
-            "lanes": "1,2,3,4"
-        }, 
+            "alias": "fortyGigE0/28",
+            "lanes": "1,2,3,4",
+            "admin_status": "up"
+        },
         "Ethernet32": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/32", 
-            "lanes": "9,10,11,12"
-        }, 
+            "alias": "fortyGigE0/32",
+            "lanes": "9,10,11,12",
+            "admin_status": "up"
+        },
         "Ethernet36": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/36", 
-            "lanes": "13,14,15,16"
-        }, 
+            "alias": "fortyGigE0/36",
+            "lanes": "13,14,15,16",
+            "admin_status": "up"
+        },
         "Ethernet40": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/40", 
-            "lanes": "21,22,23,24"
-        }, 
+            "alias": "fortyGigE0/40",
+            "lanes": "21,22,23,24",
+            "admin_status": "up"
+        },
         "Ethernet44": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/44", 
-            "lanes": "17,18,19,20"
-        }, 
+            "alias": "fortyGigE0/44",
+            "lanes": "17,18,19,20",
+            "admin_status": "up"
+        },
         "Ethernet48": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/48", 
-            "lanes": "49,50,51,52"
-        }, 
+            "alias": "fortyGigE0/48",
+            "lanes": "49,50,51,52",
+            "admin_status": "up"
+        },
         "Ethernet52": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/52", 
-            "lanes": "53,54,55,56"
-        }, 
+            "alias": "fortyGigE0/52",
+            "lanes": "53,54,55,56",
+            "admin_status": "up"
+        },
         "Ethernet56": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/56", 
-            "lanes": "61,62,63,64"
-        }, 
+            "alias": "fortyGigE0/56",
+            "lanes": "61,62,63,64",
+            "admin_status": "up"
+        },
         "Ethernet60": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/60", 
-            "lanes": "57,58,59,60"
-        }, 
+            "alias": "fortyGigE0/60",
+            "lanes": "57,58,59,60",
+            "admin_status": "up"
+        },
         "Ethernet64": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/64", 
-            "lanes": "65,66,67,68"
-        }, 
+            "alias": "fortyGigE0/64",
+            "lanes": "65,66,67,68",
+            "admin_status": "up"
+        },
         "Ethernet68": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/68", 
-            "lanes": "69,70,71,72"
-        }, 
+            "alias": "fortyGigE0/68",
+            "lanes": "69,70,71,72",
+            "admin_status": "up"
+        },
         "Ethernet72": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/72", 
-            "lanes": "77,78,79,80"
-        }, 
+            "alias": "fortyGigE0/72",
+            "lanes": "77,78,79,80",
+            "admin_status": "up"
+        },
         "Ethernet76": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/76", 
-            "lanes": "73,74,75,76"
-        }, 
+            "alias": "fortyGigE0/76",
+            "lanes": "73,74,75,76",
+            "admin_status": "up"
+        },
         "Ethernet80": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/80", 
-            "lanes": "105,106,107,108"
-        }, 
+            "alias": "fortyGigE0/80",
+            "lanes": "105,106,107,108",
+            "admin_status": "up"
+        },
         "Ethernet84": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/84", 
-            "lanes": "109,110,111,112"
-        }, 
+            "alias": "fortyGigE0/84",
+            "lanes": "109,110,111,112",
+            "admin_status": "up"
+        },
         "Ethernet88": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/88", 
-            "lanes": "117,118,119,120"
-        }, 
+            "alias": "fortyGigE0/88",
+            "lanes": "117,118,119,120",
+            "admin_status": "up"
+        },
         "Ethernet92": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/92", 
-            "lanes": "113,114,115,116"
-        }, 
+            "alias": "fortyGigE0/92",
+            "lanes": "113,114,115,116",
+            "admin_status": "up"
+        },
         "Ethernet96": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/96", 
-            "lanes": "121,122,123,124"
-        }, 
+            "alias": "fortyGigE0/96",
+            "lanes": "121,122,123,124",
+            "admin_status": "up"
+        },
         "Ethernet100": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/100", 
-            "lanes": "125,126,127,128"
-        }, 
+            "alias": "fortyGigE0/100",
+            "lanes": "125,126,127,128",
+            "admin_status": "up"
+        },
         "Ethernet104": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/104", 
-            "lanes": "85,86,87,88"
-        }, 
+            "alias": "fortyGigE0/104",
+            "lanes": "85,86,87,88",
+            "admin_status": "up"
+        },
         "Ethernet108": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/108", 
-            "lanes": "81,82,83,84"
-        }, 
+            "alias": "fortyGigE0/108",
+            "lanes": "81,82,83,84",
+            "admin_status": "up"
+        },
         "Ethernet112": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/112", 
-            "lanes": "89,90,91,92"
-        }, 
+            "alias": "fortyGigE0/112",
+            "lanes": "89,90,91,92",
+            "admin_status": "up"
+        },
         "Ethernet116": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/116", 
-            "lanes": "93,94,95,96"
-        }, 
+            "alias": "fortyGigE0/116",
+            "lanes": "93,94,95,96",
+            "admin_status": "up"
+        },
         "Ethernet120": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/120", 
-            "lanes": "97,98,99,100"
-        }, 
+            "alias": "fortyGigE0/120",
+            "lanes": "97,98,99,100",
+            "admin_status": "up"
+        },
         "Ethernet124": {
-            "admin_status": "up", 
-            "alias": "fortyGigE0/124", 
-            "lanes": "101,102,103,104"
+            "alias": "fortyGigE0/124",
+            "lanes": "101,102,103,104",
+            "admin_status": "up"
         }
-    }, 
+    },
     "VLAN": {
         "Vlan1000": {
-            "members": [
-                "Ethernet0", 
-                "Ethernet4", 
-                "Ethernet8", 
-                "Ethernet12", 
-                "Ethernet16", 
-                "Ethernet20", 
-                "Ethernet24", 
-                "Ethernet28", 
-                "Ethernet32", 
-                "Ethernet36", 
-                "Ethernet40", 
-                "Ethernet44", 
-                "Ethernet48", 
-                "Ethernet52", 
-                "Ethernet56", 
-                "Ethernet60", 
-                "Ethernet64", 
-                "Ethernet68", 
-                "Ethernet72", 
-                "Ethernet76", 
-                "Ethernet80", 
-                "Ethernet84", 
-                "Ethernet88", 
-                "Ethernet92", 
-                "Ethernet96", 
-                "Ethernet100", 
-                "Ethernet104", 
-                "Ethernet108", 
-                "Ethernet112", 
-                "Ethernet116", 
-                "Ethernet120", 
-                "Ethernet124"
-            ], 
             "vlanid": "1000"
         }
-    }, 
+    },
     "VLAN_MEMBER": {
         "Vlan1000|Ethernet0": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet4": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet8": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet12": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet16": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet20": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet24": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet28": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet32": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet36": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet40": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet44": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet48": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet52": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet56": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet60": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet64": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet68": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet72": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet76": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet80": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet84": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet88": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet92": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet96": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet100": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet104": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet108": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet112": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet116": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet120": {
             "tagging_mode": "untagged"
-        }, 
+        },
         "Vlan1000|Ethernet124": {
             "tagging_mode": "untagged"
         }

--- a/src/sonic-config-engine/tests/sample_output/l2switch.json
+++ b/src/sonic-config-engine/tests/sample_output/l2switch.json
@@ -1,266 +1,304 @@
 {
-    "DEVICE_METADATA": {"localhost": {"hwsku": "Mellanox-SN2700"}},
+    "DEVICE_METADATA": {
+        "localhost": {
+            "hwsku": "Mellanox-SN2700"
+        }
+    }, 
     "PORT": {
         "Ethernet0": {
-            "alias": "fortyGigE0/0",
-            "lanes": "29,30,31,32",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/0", 
+            "lanes": "29,30,31,32"
+        }, 
         "Ethernet4": {
-            "alias": "fortyGigE0/4",
-            "lanes": "25,26,27,28",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/4", 
+            "lanes": "25,26,27,28"
+        }, 
         "Ethernet8": {
-            "alias": "fortyGigE0/8",
-            "lanes": "37,38,39,40",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/8", 
+            "lanes": "37,38,39,40"
+        }, 
         "Ethernet12": {
-            "alias": "fortyGigE0/12",
-            "lanes": "33,34,35,36",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/12", 
+            "lanes": "33,34,35,36"
+        }, 
         "Ethernet16": {
-            "alias": "fortyGigE0/16",
-            "lanes": "41,42,43,44",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/16", 
+            "lanes": "41,42,43,44"
+        }, 
         "Ethernet20": {
-            "alias": "fortyGigE0/20",
-            "lanes": "45,46,47,48",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/20", 
+            "lanes": "45,46,47,48"
+        }, 
         "Ethernet24": {
-            "alias": "fortyGigE0/24",
-            "lanes": "5,6,7,8",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/24", 
+            "lanes": "5,6,7,8"
+        }, 
         "Ethernet28": {
-            "alias": "fortyGigE0/28",
-            "lanes": "1,2,3,4",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/28", 
+            "lanes": "1,2,3,4"
+        }, 
         "Ethernet32": {
-            "alias": "fortyGigE0/32",
-            "lanes": "9,10,11,12",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/32", 
+            "lanes": "9,10,11,12"
+        }, 
         "Ethernet36": {
-            "alias": "fortyGigE0/36",
-            "lanes": "13,14,15,16",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/36", 
+            "lanes": "13,14,15,16"
+        }, 
         "Ethernet40": {
-            "alias": "fortyGigE0/40",
-            "lanes": "21,22,23,24",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/40", 
+            "lanes": "21,22,23,24"
+        }, 
         "Ethernet44": {
-            "alias": "fortyGigE0/44",
-            "lanes": "17,18,19,20",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/44", 
+            "lanes": "17,18,19,20"
+        }, 
         "Ethernet48": {
-            "alias": "fortyGigE0/48",
-            "lanes": "49,50,51,52",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/48", 
+            "lanes": "49,50,51,52"
+        }, 
         "Ethernet52": {
-            "alias": "fortyGigE0/52",
-            "lanes": "53,54,55,56",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/52", 
+            "lanes": "53,54,55,56"
+        }, 
         "Ethernet56": {
-            "alias": "fortyGigE0/56",
-            "lanes": "61,62,63,64",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/56", 
+            "lanes": "61,62,63,64"
+        }, 
         "Ethernet60": {
-            "alias": "fortyGigE0/60",
-            "lanes": "57,58,59,60",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/60", 
+            "lanes": "57,58,59,60"
+        }, 
         "Ethernet64": {
-            "alias": "fortyGigE0/64",
-            "lanes": "65,66,67,68",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/64", 
+            "lanes": "65,66,67,68"
+        }, 
         "Ethernet68": {
-            "alias": "fortyGigE0/68",
-            "lanes": "69,70,71,72",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/68", 
+            "lanes": "69,70,71,72"
+        }, 
         "Ethernet72": {
-            "alias": "fortyGigE0/72",
-            "lanes": "77,78,79,80",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/72", 
+            "lanes": "77,78,79,80"
+        }, 
         "Ethernet76": {
-            "alias": "fortyGigE0/76",
-            "lanes": "73,74,75,76",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/76", 
+            "lanes": "73,74,75,76"
+        }, 
         "Ethernet80": {
-            "alias": "fortyGigE0/80",
-            "lanes": "105,106,107,108",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/80", 
+            "lanes": "105,106,107,108"
+        }, 
         "Ethernet84": {
-            "alias": "fortyGigE0/84",
-            "lanes": "109,110,111,112",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/84", 
+            "lanes": "109,110,111,112"
+        }, 
         "Ethernet88": {
-            "alias": "fortyGigE0/88",
-            "lanes": "117,118,119,120",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/88", 
+            "lanes": "117,118,119,120"
+        }, 
         "Ethernet92": {
-            "alias": "fortyGigE0/92",
-            "lanes": "113,114,115,116",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/92", 
+            "lanes": "113,114,115,116"
+        }, 
         "Ethernet96": {
-            "alias": "fortyGigE0/96",
-            "lanes": "121,122,123,124",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/96", 
+            "lanes": "121,122,123,124"
+        }, 
         "Ethernet100": {
-            "alias": "fortyGigE0/100",
-            "lanes": "125,126,127,128",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/100", 
+            "lanes": "125,126,127,128"
+        }, 
         "Ethernet104": {
-            "alias": "fortyGigE0/104",
-            "lanes": "85,86,87,88",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/104", 
+            "lanes": "85,86,87,88"
+        }, 
         "Ethernet108": {
-            "alias": "fortyGigE0/108",
-            "lanes": "81,82,83,84",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/108", 
+            "lanes": "81,82,83,84"
+        }, 
         "Ethernet112": {
-            "alias": "fortyGigE0/112",
-            "lanes": "89,90,91,92",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/112", 
+            "lanes": "89,90,91,92"
+        }, 
         "Ethernet116": {
-            "alias": "fortyGigE0/116",
-            "lanes": "93,94,95,96",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/116", 
+            "lanes": "93,94,95,96"
+        }, 
         "Ethernet120": {
-            "alias": "fortyGigE0/120",
-            "lanes": "97,98,99,100",
-            "admin_status": "up"
-        },
+            "admin_status": "up", 
+            "alias": "fortyGigE0/120", 
+            "lanes": "97,98,99,100"
+        }, 
         "Ethernet124": {
-            "alias": "fortyGigE0/124",
-            "lanes": "101,102,103,104",
-            "admin_status": "up"
+            "admin_status": "up", 
+            "alias": "fortyGigE0/124", 
+            "lanes": "101,102,103,104"
         }
-    },
+    }, 
     "VLAN": {
         "Vlan1000": {
+            "members": [
+                "Ethernet0", 
+                "Ethernet4", 
+                "Ethernet8", 
+                "Ethernet12", 
+                "Ethernet16", 
+                "Ethernet20", 
+                "Ethernet24", 
+                "Ethernet28", 
+                "Ethernet32", 
+                "Ethernet36", 
+                "Ethernet40", 
+                "Ethernet44", 
+                "Ethernet48", 
+                "Ethernet52", 
+                "Ethernet56", 
+                "Ethernet60", 
+                "Ethernet64", 
+                "Ethernet68", 
+                "Ethernet72", 
+                "Ethernet76", 
+                "Ethernet80", 
+                "Ethernet84", 
+                "Ethernet88", 
+                "Ethernet92", 
+                "Ethernet96", 
+                "Ethernet100", 
+                "Ethernet104", 
+                "Ethernet108", 
+                "Ethernet112", 
+                "Ethernet116", 
+                "Ethernet120", 
+                "Ethernet124"
+            ], 
             "vlanid": "1000"
         }
-    },
+    }, 
     "VLAN_MEMBER": {
         "Vlan1000|Ethernet0": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet4": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet8": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet12": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet16": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet20": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet24": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet28": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet32": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet36": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet40": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet44": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet48": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet52": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet56": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet60": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet64": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet68": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet72": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet76": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet80": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet84": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet88": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet92": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet96": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet100": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet104": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet108": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet112": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet116": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet120": {
             "tagging_mode": "untagged"
-        },
+        }, 
         "Vlan1000|Ethernet124": {
             "tagging_mode": "untagged"
         }

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -89,7 +89,7 @@ class TestJ2Files(TestCase):
         assert filecmp.cmp(sample_output_file, self.output_file)
 
     def test_l2switch_template(self):
-        argument = '-k Mellanox-SN2700 -t ' + os.path.join(self.test_dir, '../data/l2switch.j2') + ' -p ' + self.t0_port_config + ' > ' + self.output_file
+        argument = '-k Mellanox-SN2700 --preset l2 -p ' + self.t0_port_config + ' > ' + self.output_file
         self.run_script(argument)
 
         sample_output_file = os.path.join(self.test_dir, 'sample_output', 'l2switch.json')

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -89,12 +89,15 @@ class TestJ2Files(TestCase):
         assert filecmp.cmp(sample_output_file, self.output_file)
 
     def test_l2switch_template(self):
-        argument = '-k Mellanox-SN2700 --preset l2 -p ' + self.t0_port_config + ' > ' + self.output_file
-        self.run_script(argument)
+        argument = '-k Mellanox-SN2700 --preset l2 -p ' + self.t0_port_config
+        output = self.run_script(argument)
+        output_json = json.loads(output)
 
         sample_output_file = os.path.join(self.test_dir, 'sample_output', 'l2switch.json')
+        with open(sample_output_file) as sample_output_fd:
+            sample_output_json = json.load(sample_output_fd)
 
-        self.assertTrue(filecmp.cmp(sample_output_file, self.output_file))
+        self.assertTrue(json.dumps(sample_output_json, sort_keys=True), json.dumps(output_json, sort_keys=True))
 
     def test_qos_arista7050_render_template(self):
         arista_dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', 'arista', 'x86_64-arista_7050_qx32s', 'Arista-7050-QX-32S')

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -97,7 +97,7 @@ class TestJ2Files(TestCase):
         with open(sample_output_file) as sample_output_fd:
             sample_output_json = json.load(sample_output_fd)
 
-        self.assertTrue(json.dumps(sample_output_json, sort_keys=True), json.dumps(output_json, sort_keys=True))
+        self.assertTrue(json.dumps(sample_output_json, sort_keys=True) == json.dumps(output_json, sort_keys=True))
 
     def test_qos_arista7050_render_template(self):
         arista_dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', 'arista', 'x86_64-arista_7050_qx32s', 'Arista-7050-QX-32S')


### PR DESCRIPTION
sonic-cfggen may not read from Redis, so override hostname will impact existing ConfigDB. Fix test_l2switch_template test case to test preset l2 feature.

This is same as https://github.com/Azure/sonic-buildimage/pull/5510 but targeting 201911 branch.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
