### PR TITLE
Revert redis-tools version in docker-sonic-vs which is from debian:stretch

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -13,6 +13,7 @@ RUN echo "deb http://packages.microsoft.com/repos/sonic-dev/ jessie main" >> /et
 RUN apt-get update
 
 RUN apt-get install -y net-tools \
+                       redis-server=5:5.0.3-3~bpo9+2 \
                        arping \
                        ndisc6 \
                        ethtool \
@@ -46,12 +47,6 @@ RUN apt-get install -y net-tools \
                        conntrack \
                        iptables \
                        python3-pip
-
-# install redis-server
-RUN curl -o redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
-RUN curl -o redis-server_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-server_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=2Ketg7BmkZEaTxR%2FgvAFVmhjn7ywdmkc7l2T2rsL57o%3D&se=2030-09-06T19%3A45%3A20Z&sp=r"
-RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_amd64.deb redis-server_6.0.6-1~bpo10+1_amd64.deb || apt-get install -f
-RUN rm redis-tools_6.0.6-1~bpo10+1_amd64.deb redis-server_6.0.6-1~bpo10+1_amd64.deb
 
 RUN pip install setuptools
 RUN pip install py2_ipaddress


### PR DESCRIPTION
Fixed https://github.com/Azure/sonic-buildimage/issues/5404

Below commits are cherry-picked from master branch, and mistakenly applied to `platform/vs/docker-sonic-vs/Dockerfile.j2`.
```
65bd3857 2020-09-08 | [redis] Use redis-server and redis-tools in blob storage to prevent upstream link broken (#5340) [Qi Luo]
0a864966 2020-07-28 | [redis] Upgrade redis version (#5060) [Qi Luo]
```

On master, docker-sonic-vs is from debian:buster
on 202006, docker-sonic-vs is from debian:stretch

So we revert back the redis-tools version to the original one.

Signed-off-by: Qi Luo <qiluo-msft@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
