### PR TITLE
[make init] update submodule's remotes

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -283,7 +283,6 @@ showtag:
 
 init :
 	@git submodule update --init --recursive
-	@git submodule foreach --recursive git remote update &>/dev/null
 	@git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $$(realpath --relative-to=. $$(cut -d" " -f2 .git))" > .git'
 
 .ONESHELL : reset
@@ -302,6 +301,7 @@ reset :
 	        git reset --hard;
 	        git submodule foreach --recursive 'git clean -xfdf || true';
 	        git submodule foreach --recursive 'git reset --hard || true';
+	        git submodule foreach --recursive 'git remote update || true';
 	        git submodule update --init --recursive;
 	        echo "Reset complete!";
 	    else

--- a/Makefile.work
+++ b/Makefile.work
@@ -283,6 +283,7 @@ showtag:
 
 init :
 	@git submodule update --init --recursive
+	@git submodule foreach --recursive git remote update &>/dev/null
 	@git submodule foreach --recursive '[ -f .git ] && echo "gitdir: $$(realpath --relative-to=. $$(cut -d" " -f2 .git))" > .git'
 
 .ONESHELL : reset


### PR DESCRIPTION
**- Why I did it**
I am using a long standing checked out repo to build dev images. From time to time the repo is too out-sync'ed with remotes and some submodule stay behind even after make reset and make init call. This causes build to fail unexpectedly.

**- How I did it**
With further tests, I moved the recursive "git remote update' to make reset code block and placed in front of recursive --init. The original change has the ordering wrong but that was hidden by the fact that make init was executed multiple times in master branch and 201911 branch.

The summary is:
- for a newly cloned repo. existing 'make init' is enough.
- for long standing repo, when things are getting too out dated, or when we switching branch, we usually need to do a make reset before build again. Place the fix in make reset makes more sense.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Build a dev image. Tested it with a newly cloned repo as well.

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006

