### PR TITLE
[sonic-py-common] Add platform.json to port_config files candidates only if interfaces are present within platform.json

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -1,4 +1,5 @@
 import glob
+import json
 import os
 import re
 import subprocess
@@ -256,7 +257,11 @@ def get_path_to_port_config_file(hwsku=None, asic=None):
     # if 'hwsku.json' file is available, Check for 'platform.json' file presence,
     # if 'platform.json' is available, APPEND it. Otherwise, SKIP it.
     if os.path.isfile(hwsku_json_file):
-        port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
+        if os.path.isfile(os.path.join(platform_path, PLATFORM_JSON_FILE)):
+            json_file = os.path.join(platform_path, PLATFORM_JSON_FILE)
+            platform_data = json.loads(open(json_file).read())
+            if len(platform_data.get("interfaces")) > 0:
+                port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
 
     # Check for 'port_config.ini' file presence in a few locations
     if asic:

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -256,6 +256,14 @@ def get_path_to_port_config_file(hwsku=None, asic=None):
 
     # if 'hwsku.json' file is available, Check for 'platform.json' file presence,
     # if 'platform.json' is available, APPEND it. Otherwise, SKIP it.
+
+    """
+    This length check for interfaces in platform.json is performed to make sure
+    the cfggen does not fail if port configuration information is not present
+    TODO: once platform.json has all the necessary port config information
+          remove this check
+    """
+
     if os.path.isfile(hwsku_json_file):
         if os.path.isfile(os.path.join(platform_path, PLATFORM_JSON_FILE)):
             json_file = os.path.join(platform_path, PLATFORM_JSON_FILE)

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -269,9 +269,8 @@ def get_path_to_port_config_file(hwsku=None, asic=None):
             json_file = os.path.join(platform_path, PLATFORM_JSON_FILE)
             platform_data = json.loads(open(json_file).read())
             interfaces = platform_data.get('interfaces', None)
-            if interfaces:
-                if len(interfaces) > 0:
-                    port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
+            if interfaces is not None and len(interfaces) > 0:
+                port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
 
     # Check for 'port_config.ini' file presence in a few locations
     if asic:

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -268,8 +268,7 @@ def get_path_to_port_config_file(hwsku=None, asic=None):
         if os.path.isfile(os.path.join(platform_path, PLATFORM_JSON_FILE)):
             json_file = os.path.join(platform_path, PLATFORM_JSON_FILE)
             platform_data = json.loads(open(json_file).read())
-            interfaces = platform_data.get('interfaces', None)
-            if interfaces and len(interfaces) > 0:
+            if len(platform_data.get("interfaces")) > 0:
                 port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
 
     # Check for 'port_config.ini' file presence in a few locations

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -268,7 +268,8 @@ def get_path_to_port_config_file(hwsku=None, asic=None):
         if os.path.isfile(os.path.join(platform_path, PLATFORM_JSON_FILE)):
             json_file = os.path.join(platform_path, PLATFORM_JSON_FILE)
             platform_data = json.loads(open(json_file).read())
-            if len(platform_data.get("interfaces")) > 0:
+            interfaces = platform_data.get('interfaces', None)
+            if interfaces and len(interfaces) > 0:
                 port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
 
     # Check for 'port_config.ini' file presence in a few locations

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -269,8 +269,9 @@ def get_path_to_port_config_file(hwsku=None, asic=None):
             json_file = os.path.join(platform_path, PLATFORM_JSON_FILE)
             platform_data = json.loads(open(json_file).read())
             interfaces = platform_data.get('interfaces', None)
-            if interfaces and len(interfaces) > 0:
-                port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
+            if interfaces:
+                if len(interfaces) > 0:
+                    port_config_candidates.append(os.path.join(platform_path, PLATFORM_JSON_FILE))
 
     # Check for 'port_config.ini' file presence in a few locations
     if asic:


### PR DESCRIPTION
Summary:

For this PR the motivation is to add logic so that platform.json is considered for port configuration candidates only if platform.json has an interfaces key 
and the length of the key is greater than zero. This happened with new platform.json file utilized to test platform_api's infrastructure which in turn had interfaces key without any port configs. 

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

To make sure platform.json is not used for sonic-cfggen if it does not have "interfaces" key populated

#### How did you do it?
added logic to check if platform.json is present, check if "interfaces" key size is greater than zero


#### How did you verify/test it?

Run it on a mellanox-acs2700 platform and verify cfggen does not cause errors

#### Any platform specific information?

platform.json should be present without "interfaces" key populated


Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>
