### PR TITLE
[Arista] Add disable_pcie_firmware_check soc property

### DIFF
--- a/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-C64/th3-a7060px4-32-64x100G.config.bcm
+++ b/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-C64/th3-a7060px4-32-64x100G.config.bcm
@@ -5,6 +5,7 @@ bcm_num_cos.0=8
 bcm_stat_flags=1
 bcm_stat_jumbo.0=9236
 cdma_timeout_usec.0=15000000
+disable_pcie_firmware_check.0=1
 dma_desc_timeout_usec.0=15000000
 dpr_clock_frequency.0=1000
 higig2_hdr_mode.0=1

--- a/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-O32/th3-a7060px4-o32-32x400G.config.bcm
+++ b/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-O32/th3-a7060px4-o32-32x400G.config.bcm
@@ -5,6 +5,7 @@ bcm_num_cos.0=8
 bcm_stat_flags=1
 bcm_stat_jumbo.0=9236
 cdma_timeout_usec.0=15000000
+disable_pcie_firmware_check.0=1
 dma_desc_timeout_usec.0=15000000
 dpr_clock_frequency.0=1000
 higig2_hdr_mode.0=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -15,6 +15,7 @@ cdma_timeout_usec
 core_clock_frequency
 ctr_evict_enable
 device_clock_frequency
+disable_pcie_firmware_check
 dma_desc_timeout_usec
 dport_map_direct
 dport_map_enable


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
This is to fix pcie firmware check assert in Broadcom SDK once the SAI changes merges. This will be in the future but adding the soc property in the broadcom config now.

**- How I did it**

**- How to verify it**
Verified the image is fine with the additional soc property on the platform.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
