### PR TITLE
[Multi-asic] Fixed IPv6 Default Route to be BGP Learned

### DIFF
--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -17,17 +17,19 @@ CFGGEN_PARAMS=" \
 "
 CONFIG_TYPE=$(sonic-cfggen $CFGGEN_PARAMS)
 
-if [[ ! -z "$NAMESPACE_ID" ]]; then
+update_default_gw()
+{
+   IP_VER=${1}
    # FRR is not running in host namespace so we need to delete
    # default gw kernel route added by docker network via eth0 and add it back
    # with higher administrative distance so that default route learnt
    # by FRR becomes best route if/when available
-   GATEWAY_IP=$(ip route show 0.0.0.0/0 dev eth0 | awk '{print $3}')
+   GATEWAY_IP=$(ip -${IP_VER} route show default dev eth0 | awk '{print $3}')
    #Check if docker default route is there
    if [[ ! -z "$GATEWAY_IP" ]]; then
-      ip route del 0.0.0.0/0 dev eth0
+      ip -${IP_VER} route del default dev eth0
       #Make sure route is deleted
-      CHECK_GATEWAY_IP=$(ip route show 0.0.0.0/0 dev eth0 | awk '{print $3}')
+      CHECK_GATEWAY_IP=$(ip -${IP_VER} route show default dev eth0 | awk '{print $3}')
       if [[ -z "$CHECK_GATEWAY_IP" ]]; then
          # Ref: http://docs.frrouting.org/en/latest/zebra.html#zebra-vrf
          # Zebra does treat Kernel routes as special case for the purposes of Admin Distance. \
@@ -35,9 +37,14 @@ if [[ ! -z "$NAMESPACE_ID" ]]; then
          # The top byte of the value is interpreted as the Administrative Distance and
          # the low three bytes are read in as the metric.
          # so here we are programming administrative distance of 210 (210 << 24) > 200 (for routes learnt via IBGP)
-         ip route add 0.0.0.0/0 via $GATEWAY_IP dev eth0 metric 3523215360
+         ip -${IP_VER} route add default via $GATEWAY_IP dev eth0 metric 3523215360
       fi
    fi
+}
+
+if [[ ! -z "$NAMESPACE_ID" ]]; then
+   update_default_gw 4
+   update_default_gw 6
 fi
 
 if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "separated" ]; then


### PR DESCRIPTION
Why I did:
After PR https://github.com/Azure/sonic-buildimage/pull/5418
Extending the changes done for v4 in https://github.com/Azure/sonic-buildimage/pull/4774 to v6 now.

How I verify

Before:
    sudo ip  -6 -n asic0 route show ::/0
    default via fd00::1 dev eth0 metric 1024  pref medium

After:
    sudo ip  -6 -n asic0 route show ::/0
    default via fc00::2 dev PortChannel0002 proto 186 src fc00:1::32 metric 20  pref medium
    default via fc00::6 dev PortChannel0005 proto 186 src fc00:1::32 metric 20  pref medium
    default via fd00::1 dev eth0 metric 3523215360  pref medium

