### PR TITLE
[201911] Fix the error message for Tx Drop happening when netdev link is down

### DIFF
--- a/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+++ b/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
@@ -5279,7 +5279,7 @@ bkn_tx(struct sk_buff *skb, struct net_device *dev)
     }
 
     if (!netif_carrier_ok(dev)) {
-        DBG_WARN(("Tx drop: Invalid RCPU encapsulation\n"));
+        DBG_WARN(("Tx drop: Netif link is down.\n"));
         priv->stats.tx_dropped++;
         sinfo->tx.pkts_d_no_link++;
         dev_kfree_skb_any(skb);


### PR DESCRIPTION
Why/How I did:
The error message is updated to provide correct information
of Netdevice link being down for Tx Drop
Taken the change from BRCM SAI 4.2.1.3 (6.5.19 hsdk) (https://github.com/Azure/sonic-buildimage/pull/5532/files#diff-9787d8debde44bb0dd3ce502443bf25cR5362)

