### PR TITLE
[Dell S6100] Properly release memory upon ICH driver deinit

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/common/dell_ich.c
+++ b/platform/broadcom/sonic-platform-modules-dell/common/dell_ich.c
@@ -926,7 +926,7 @@ static int dell_ich_remove(struct platform_device *pdev)
 
     // Unmap and release PMC regions
     if(ich_data->pmc_base) iounmap(ich_data->pmc_base);
-    if(ich_data->pmc_alloc) release_region(pmc_res.start, PMC_REG_LEN);
+    if(ich_data->pmc_alloc) release_mem_region(pmc_res.start, PMC_REG_LEN);
 
     ret = acpi_remove_sci_handler(dell_ich_sci_handler);
     if(ret) {


### PR DESCRIPTION
**- Why I did it**
- xcvrd daemon crashes in Dell S6100 with the following errors.
   Oct  6 00:52:43.603633 CYS04-0101-0321-12T1 ERR pmon#xcvrd: System failed to recover in 120 secs. Exiting...
   Oct  6 00:52:43.603633 CYS04-0101-0321-12T1 INFO pmon#xcvrd: State transition from 0 to 2
   Oct  6 00:52:44.912121 CYS04-0101-0321-12T1 ERR pmon#xcvrd: Error: dom info update thread received stop event, 
   exiting...
   Oct  6 00:52:44.925275 CYS04-0101-0321-12T1 ERR pmon#xcvrd: Xcvrd main task stopped, exiting...


**- How I did it**
- During platform deinitialization, dell_ich is not removed properly and when we do initialize s6100 platform, ICH driver sysfs attributes are not attached. Because of this, get_transceiver_change_event returns error and this leads xcvrd to crash. 

**- How to verify it**
- Do s6100 platform re-init and verify OIR works properly. 
- Check journalctl -a | grep dell_ich output.
UT logs:
[S6100_mux_issue_UT.txt](https://github.com/Azure/sonic-buildimage/files/5345603/S6100_mux_issue_UT.txt)

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [x] 202006


**- A picture of a cute animal (not mandatory but encouraged)**
