### PR TITLE
[build]: Added support for cache status on the build output

### DIFF
--- a/rules/functions
+++ b/rules/functions
@@ -64,12 +64,12 @@ define HEADER
 @
 $(PRINT_DEPENDENCIES)
 $(FLUSH_LOG)
-./update_screen.sh -a $@
+./update_screen.sh -a $@ $*
 endef
 
 # footer for each rule
 define FOOTER
-./update_screen.sh -d $@
+./update_screen.sh -d $@ $($*_CACHE_LOADED)
 endef
 
 ###############################################################################

--- a/update_screen.sh
+++ b/update_screen.sh
@@ -28,7 +28,9 @@ done
 
 function remove_target {
 # Check if TERM is available
-[[ "${TERM}" == "dumb" ]] && echo "[ finished ] [ $1 ] " && return
+local status="finished"
+[[ ! -z "${2}" ]] &&  status="cached"
+[[ "${TERM}" == "dumb" ]] && echo "[ ${status} ] [ $1 ] " && return
 
 old_list=$(cat ${target_list_file})
 rm ${target_list_file}
@@ -52,6 +54,17 @@ sleep 2 && print_targets  && rm -f .screen &
 exit 0
 }
 
+# $3 takes the DPKG caching argument, if the target is loaded from cache,
+# it adds the log as 'cached' else it is logged as 'finished'
+#
+# Without DPKG cache support :
+#   [ building ] [ target/docker-base.gz ]
+#   [ finished ] [ target/docker-base.gz ]
+#
+# With DPKG cache support :
+#   [ building ] [ target/docker-base.gz ]
+#   [ cached   ] [ target/docker-base.gz ]
+
 while getopts ":a:d:e:" opt; do
     case $opt in
         a)
@@ -61,12 +74,12 @@ while getopts ":a:d:e:" opt; do
             ;;
         d)
             scroll_up
-            remove_target ${OPTARG}
+            remove_target ${OPTARG} $3
             print_targets
             ;;
         e)
             scroll_up
-            remove_target ${OPTARG}
+            remove_target ${OPTARG} $3
             echo "[ FAIL LOG START ] [ ${OPTARG} ]"
             cat ${OPTARG}.log
             echo "[  FAIL LOG END  ] [ ${OPTARG} ]"


### PR DESCRIPTION
print cache status when use cached file in the build process

Without DPKG cache support :
  [ building ] [ target/docker-base.gz ]
  [ finished ] [ target/docker-base.gz ]

With DPKG cache support :
  [ building ] [ target/docker-base.gz ]
  [ cached   ] [ target/docker-base.gz ]

extracted from PR 4595 by Kalimuthu Velappan

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
print cache status when use cached file in the build process

Without DPKG cache support :
  [ building ] [ target/docker-base.gz ]
  [ finished ] [ target/docker-base.gz ]

With DPKG cache support :
  [ building ] [ target/docker-base.gz ]
  [ cached   ] [ target/docker-base.gz ]

**- How I did it**
modify update_screen.sh

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
