### PR TITLE
 Set sock rx Buf size to 3MB.

### DIFF
--- a/files/image_config/sysctl/sysctl-net.conf
+++ b/files/image_config/sysctl/sysctl-net.conf
@@ -35,5 +35,5 @@ net.ipv6.conf.eth0.keep_addr_on_down=1
 net.ipv4.tcp_l3mdev_accept=1
 net.ipv4.udp_l3mdev_accept=1
 net.core.rmem_max=3145728
-net.core.wmem_max=2097152
+net.core.wmem_max=3145728
 net.core.somaxconn=512

--- a/files/image_config/sysctl/sysctl-net.conf
+++ b/files/image_config/sysctl/sysctl-net.conf
@@ -34,6 +34,6 @@ net.ipv6.conf.all.keep_addr_on_down=1
 net.ipv6.conf.eth0.keep_addr_on_down=1
 net.ipv4.tcp_l3mdev_accept=1
 net.ipv4.udp_l3mdev_accept=1
-net.core.rmem_max=2097152
+net.core.rmem_max=3145728
 net.core.wmem_max=2097152
 net.core.somaxconn=512


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
netlink out of memory seen for 8K neighbor updates.
**- How I did it**

1) Config IP to 2 interfaces connected to ixia. Ethernet1 (21.0.0.1/16) and Ethernet4 (24.1.1.1/24)

2) DUT copp rules are as ARP CIR=2000 and IP2ME CIR=6000

3) Start Continuous Traffic (5G) is started from ixia connected to Ethernet4 with the DIP matching with the 8K ARP Host Range before learning ARP entries. These traffic will be software forwarded from linux kernel.

4) DUT is configured to learn ARP through ARP Reply packets
echo 1 > /proc/sys/net/ipv4/conf/Ethernet1/arp_accept

5) Start continuous ARP Reply Packet is sent from IXIA connected to Ethernet1 Port at 2K Packet/Secs with Host IP starting from 20.20.0.2 and Incrementing for 8K.

After step (5), expectation is all 5G traffic must be forwarded from ASIC but not all NEIGH entries are updated to APP_DB and ASIC_DB because of out of memory error.

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
