### PR TITLE
[barefoot][platform] Remove PLATFORM variable from debian/rules

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/debian/rules
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/debian/rules
@@ -1,6 +1,5 @@
 #!/usr/bin/make -f
 
-PLATFORM := x86_64-accton_wedge100bf_32x-r0
 PACKAGE_NAME := sonic-platform-modules-bfn-montara
 SCRIPT_SRC := $(shell pwd)/scripts
 CONFIGS_SRC := $(shell pwd)/configs
@@ -22,10 +21,10 @@ override_dh_auto_install:
 	cp -r $(SCRIPT_SRC)/* debian/$(PACKAGE_NAME)/usr/local/bin
 	dh_installdirs -p$(PACKAGE_NAME) etc/network/interfaces.d/
 	cp -r $(CONFIGS_SRC)/network/interfaces.d/* debian/$(PACKAGE_NAME)/etc/network/interfaces.d/
-	dh_installdirs -p$(PACKAGE_NAME) usr/share/sonic/device/$(PLATFORM)/
-	cp -r $(WHEEL_BUILD_DIR)/*  debian/$(PACKAGE_NAME)/usr/share/sonic/device/$(PLATFORM)/
-	dh_installdirs -p$(PACKAGE_NAME) usr/share/sonic/device/$(PLATFORM)/plugins
-	cp -r $(PLUGINS_DIR)/*  debian/$(PACKAGE_NAME)/usr/share/sonic/device/$(PLATFORM)/plugins/
+	dh_installdirs -p$(PACKAGE_NAME) usr/share/sonic/device/x86_64-accton_wedge100bf_32x-r0
+	cp -r $(WHEEL_BUILD_DIR)/*  debian/$(PACKAGE_NAME)/usr/share/sonic/device/x86_64-accton_wedge100bf_32x-r0/
+	dh_installdirs -p$(PACKAGE_NAME) usr/share/sonic/device/x86_64-accton_wedge100bf_32x-r0/plugins
+	cp -r $(PLUGINS_DIR)/*  debian/$(PACKAGE_NAME)/usr/share/sonic/device/x86_64-accton_wedge100bf_32x-r0/plugins/
 
 override_dh_usrlocal:
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
when building the platform package with `deb-buildpackage -us -c` the whl packages are located under  
`/usr/share/sonic/device/<platform>/` inside the built deb package but gets unpacked on device under `/usr/share/sonic/device/`

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
