### PR TITLE
[bgp]: Enable next-hop-tracking through default

### DIFF
--- a/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
@@ -10,6 +10,8 @@ vni {{ vnet_metadata['vni'] }}
 {% endblock vrf %}
 !
 {% block interfaces %}
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 {% for (name, prefix) in INTERFACE|pfx_filter %}
 interface {{ name }}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -18,6 +18,8 @@ agentx
 !
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet4
 link-detect

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/interfaces.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/interfaces.conf
@@ -1,5 +1,7 @@
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet4
 link-detect

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
@@ -22,6 +22,8 @@ vrf First
 vni 10
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet4
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -18,6 +18,8 @@ agentx
 !
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel03
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
@@ -19,6 +19,8 @@ vrf VnetFE
 vni 9000
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet8
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
@@ -19,6 +19,8 @@ vrf VnetFE
 vni 8000
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet8
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py2/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/zebra_frr.conf
@@ -16,6 +16,8 @@ log facility local4
 ! end of template: common/daemons.common.conf.j2!
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel03
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -18,6 +18,8 @@ agentx
 !
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel01
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
@@ -19,6 +19,8 @@ vrf VnetFE
 vni 9000
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet0
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
@@ -19,6 +19,8 @@ vrf VnetFE
 vni 8000
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet0
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
@@ -16,6 +16,8 @@ log facility local4
 ! end of template: common/daemons.common.conf.j2!
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel01
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/t2-chassis-fe-pc-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/t2-chassis-fe-pc-zebra.conf
@@ -12,6 +12,8 @@ vrf VnetFE
 vni 8000
 !
 !
+! Enable nht through default route
+ip nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel0
 link-detect


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
FRR introduced [next hop tracking](http://docs.frrouting.org/projects/dev-guide/en/latest/next-hop-tracking.html) functionality. 
That functionality requires resolving BGP neighbors before setting BGP connection (or explicit ebgp-multihop command). Sometimes (BGP MONITORS) our neighbors are not directly connected and sessions are IBGP. In this case current configuration prevents FRR to establish BGP connections.  Reason would be "waiting for NHT". To fix that we need either add static routes for each not-directly connected ibgp neighbor, or enable command `ip nht resolve-via-default`

**- How I did it**
Put `ip nht resolve-via-default` into the config

**- How to verify it**
Build an image. Enable BGP_MONITOR entry and check that entry is Established or Connecting in FRR

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
