### PR TITLE
[201911] Monit snmp fix

### DIFF
--- a/dockers/docker-snmp-sv2/base_image_files/monit_snmp
+++ b/dockers/docker-snmp-sv2/base_image_files/monit_snmp
@@ -7,5 +7,5 @@
 check program snmp|snmpd with path "/usr/bin/process_checker snmp /usr/sbin/snmpd"
     if status != 0 for 5 times within 5 cycles then alert
 
-check program snmp|snmp_subagent with path "/usr/bin/process_checker snmp python3 -m sonic_ax_impl"
+check program snmp|snmp_subagent with path "/usr/bin/process_checker snmp python3.6 -m sonic_ax_impl"
     if status != 0 for 5 times within 5 cycles then alert


### PR DESCRIPTION
Why I did:

Fix https://github.com/Azure/sonic-buildimage/issues/5529 of monit complaining about SNMP.
In 201911 branch we start the process "python3.6 -m sonic_ax_impl"
Updated the semantics in monit file also.