### PR TITLE
[201911] increased memory usage in the pmon processes

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -3,9 +3,11 @@ import os
 import re
 import subprocess
 
-import yaml
-from natsort import natsorted
+# Move the yaml module import to the function where we use it. With python2.7 there
+# is a huge chunk of memory allocated in the process context with this module import.
+#import yaml
 
+from natsort import natsorted
 # TODD: Replace with swsscommon
 from swsssdk import ConfigDBConnector, SonicDBConfig
 
@@ -203,6 +205,7 @@ def get_path_to_port_config_file():
 
 
 def get_sonic_version_info():
+    import yaml
     if not os.path.isfile(SONIC_VERSION_YAML_PATH):
         return None
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
It was observed that the docker stats o/p of pmon docker showed up increased memory usage. Here we see it is 159 MB.
```
CONTAINER ID        NAME                CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
e1f547f0bea4        pmon                1.11%               159.5MiB / 7.785GiB   2.00%               0B / 0B             12.7MB / 119kB      12
```
It was found that each process running in the pmon docker was having an anonymous memory allocation of 35MB in the heap. On debugging it happens when we import of yaml module in sonic_py_common/device_info.py.

```
admin@str-s6000-acs-8:~$ sudo pmap 3183
3183:   /usr/bin/python /usr/bin/psud
00005602e6544000   3228K r-x-- python2.7
00005602e6a6a000      8K r---- python2.7
00005602e6a6c000    476K rw--- python2.7
00005602e6ae3000    140K rw---   [ anon ]
00005602e6e48000  35384K rw---   [ anon ]

admin@str-s6000-acs-8:~$ sudo pmap 3176
3176:   /usr/bin/python /usr/bin/xcvrd
0000561dfd329000   3228K r-x-- python2.7
0000561dfd84f000      8K r---- python2.7
0000561dfd851000    476K rw--- python2.7
0000561dfd8c8000    140K rw---   [ anon ]
0000561dfe2cc000  35924K rw---   [ anon ]
```
**- How I did it**
Since the pmon processes don't use the yaml module dependent files I have moved the "import yaml" to the functions which actually uses it.  Tried to debug a bit more of any other possible solution, I found that this happens only with import of yaml in python2.7. 

**With python3 - this import didn't result in the huge memory chuck allocation**. This fix is put only in 201911 where we still use python2.7. The master branch would migrate to python3 soon there.

**Note** : There are some platforms which uses yaml module in the specific platform library, those platforms will still see an increase in pmon docker memory.

**- How to verify it**

Verified that with this fix that the allocation don't happen in the pmon docker processes as we don't use that yaml dependent functions 
```
CONTAINER ID        NAME                CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
e1f547f0bea4        pmon                0.71%               62.18MiB / 7.785GiB   0.78%               0B / 0B             0B / 143kB          12
```

```
admin@str-s6000-acs-8:~$ sudo pmap 30199
30199:   /usr/bin/python /usr/bin/psud
000056083559f000   3228K r-x-- python2.7
0000560835ac5000      8K r---- python2.7
0000560835ac7000    476K rw--- python2.7
0000560835b3e000    140K rw---   [ anon ]
0000560836322000   3200K rw---   [ anon ]


admin@str-s6000-acs-8:~$ sudo pmap 30197
30197:   /usr/bin/python /usr/bin/xcvrd
000055aa1a4ef000   3228K r-x-- python2.7
000055aa1aa15000      8K r---- python2.7
000055aa1aa17000    476K rw--- python2.7
000055aa1aa8e000    140K rw---   [ anon ]
000055aa1c57b000   3860K rw---   [ anon ]

```



**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
