### PR TITLE
Optimze ACL Table/Rule notification handling

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -563,7 +563,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                     # Check ACL Rule notification and make sure Rule point to ACL Table which is Controlplane
                     else:
                         acl_table = key.split(acl_rule_table_seprator)[0]
-                        if self.config_db_map[namespace].get_table(self.ACL_TABLE)[acl_table]["type"]  == self.ACL_TABLE_TYPE_CTRLPLANE:
+                        if self.config_db_map[namespace].get_table(self.ACL_TABLE)[acl_table]["type"] == self.ACL_TABLE_TYPE_CTRLPLANE:
                             ctrl_plane_acl_notification.add(namespace)
 
             # Update the Control Plane ACL of the namespace that got config db acl table event

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -539,7 +539,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         # Loop on select to see if any event happen on config db of any namespace
         while True:
-            ctrl_plane_acl_notification = False
+            ctrl_plane_acl_notification = set()
             (state, selectableObj) = sel.select(SELECT_TIMEOUT_MS)
             # Continue if select is timeout or selectable object is not return
             if state != swsscommon.Select.OBJECT:
@@ -550,23 +550,24 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             namespace = redisSelectObj.getDbConnector().getNamespace()
             # Pop data of both Subscriber Table object of namespace that got config db acl table event
             for table in config_db_subscriber_table_map[namespace]:
-                (key, op, fvp) = table.pop()
-                # Pop of table that does not have data
-                if key == '':
-                    continue
-                # ACL Table notification. We will take Control Plane ACTION for any ACL Table Event
-                # This can be optimize further but we should not have many acl table set/del events in normal
-                # scenario
-                elif acl_rule_table_seprator not in key:
-                    ctrl_plane_acl_notification = True
-                # Check ACL Rule notification and make sure Rule point to ACL Table which is Controlplane
-                else:
-                    acl_table = key.split(acl_rule_table_seprator)[0]
-                    if self.config_db_map[namespace].get_table(self.ACL_TABLE)[acl_table]["type"] == self.ACL_TABLE_TYPE_CTRLPLANE:
-                        ctrl_plane_acl_notification = True
+                while True:
+                    (key, op, fvp) = table.pop()
+                    # Pop of table that does not have data so break
+                    if key == '':
+                        break
+                    # ACL Table notification. We will take Control Plane ACTION for any ACL Table Event
+                    # This can be optimize further but we should not have many acl table set/del events in normal
+                    # scenario
+                    if acl_rule_table_seprator not in key:
+                        ctrl_plane_acl_notification.add(namespace)
+                    # Check ACL Rule notification and make sure Rule point to ACL Table which is Controlplane
+                    else:
+                        acl_table = key.split(acl_rule_table_seprator)[0]
+                        if self.config_db_map[namespace].get_table(self.ACL_TABLE)[acl_table]["type"]  == self.ACL_TABLE_TYPE_CTRLPLANE:
+                            ctrl_plane_acl_notification.add(namespace)
 
-            # Update the Control Plane ACL of the namespace that got config db acl table/rule event
-            if ctrl_plane_acl_notification:
+            # Update the Control Plane ACL of the namespace that got config db acl table event
+            for namespace in ctrl_plane_acl_notification:
                 self.update_control_plane_acls(namespace)
 
 # ============================= Functions =============================


### PR DESCRIPTION
What I did:
Optimize ACL Table/Rule notification handling
to loop pop() until empty to consume all the data in a batch
This way we prevent multiple call to iptable updates

**- How to verify it**

Loaded (sudo acl-loader update full acl.json) with 100 rules and verified all the set notification are batch together in one update to iptables .

Similarly (sudo acl-loader delete) batch all del operation in one update.
