### PR TITLE
[Mellanox] Configure SAI to log to syslog instead of stdout.

### DIFF
--- a/platform/mellanox/mlnx-sai/Makefile
+++ b/platform/mellanox/mlnx-sai/Makefile
@@ -10,7 +10,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	pushd mlnx_sai
 
 	chmod a+x autogen.sh
-	debuild -e 'make_extra_flags="DEFS=-DACS_OS"' -us -uc -d -b
+	debuild -e 'make_extra_flags="DEFS=-DACS_OS -DCONFIG_SYSLOG"' -us -uc -d -b
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/


### PR DESCRIPTION
Example of syslog message from Mellanox SAI:

"Oct  7 15:39:11.482315 arc-switch1025 INFO syncd#supervisord: syncd Oct 07 15:39:11 NOTICE  SAI_BUFFER: mlnx_sai_buffer.c[3893]- mlnx_clear_buffer_pool_stats: Clear pool stats pool id:1"

There is a log INFO from supervisord which actually printed NOTICE and
date again. This confusion happens becuase if SAI is not built to log
to syslog it will log everything to stdout with format "[date] [level]
[message]" so supervisord sends it to syslog with level INFO.

New logs look like:

"Oct  7 15:40:21.488055 arc-switch1025 NOTICE syncd#SDK  [SAI_BUFFER]: mlnx_sai_buffer.c[3893]- mlnx_clear_buffer_pool_stats: Clear pool stats pool id:17"

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Misleading log messages from SAI with INFO level when it should not be an INFO and also two timestampts in the log.

**- How I did it**

Config SAI to log directly to syslog.

**- How to verify it**

Look at SAI logs.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
