### PR TITLE
[Mellanox] Add a configuration to delay start xcvrd for fast-reboot

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
@@ -1,5 +1,6 @@
 {
     "skip_ledd": true,
-    "skip_fancontrol": true
+    "skip_fancontrol": true,
+    "delay_xcvrd": true
 }
 

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -79,7 +79,11 @@ dependent_startup_wait_for=start:exited
 
 {% if not skip_xcvrd %}
 [program:xcvrd]
+{% if delay_xcvrd %}
+command=bash -c "sleep 30 && /usr/local/bin/xcvrd"
+{% else %}
 command=/usr/local/bin/xcvrd
+{% endif %}
 priority=6
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Delay start xcvrd on mellanox platform to save CPU cost during fast-reboot. With this change, fast-reboot saves about 8~9 seconds.

**- How I did it**

Add a sleep before xcvrd start in pmon supervisor.conf

**- How to verify it**

Manual test

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
