### PR TITLE
[platform] Remove references to deprecated get_serial_number() method in Chassis class

### DIFF
--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/chassis.py
@@ -93,7 +93,7 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.get_mac()
 
-    def get_serial_number(self):
+    def get_serial(self):
         """
         Retrieves the hardware serial number for the chassis
         Returns:

--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/chassis.py
@@ -87,7 +87,7 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.get_mac()
 
-    def get_serial_number(self):
+    def get_serial(self):
         """
         Retrieves the hardware serial number for the chassis
         Returns:

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/chassis.py
@@ -91,14 +91,6 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.get_mac()
 
-    def get_serial_number(self):
-        """
-        Retrieves the hardware serial number for the chassis
-        Returns:
-            A string containing the hardware serial number for this chassis.
-        """
-        return self._eeprom.get_serial()
-
     def get_system_eeprom_info(self):
         """
         Retrieves the full content of system EEPROM information for the chassis
@@ -252,7 +244,7 @@ class Chassis(ChassisBase):
         Returns:
             string: Serial number of device
         """
-        return self.get_serial_number()
+        return self._eeprom.get_serial()
 
     def get_status(self):
         """

--- a/device/celestica/x86_64-cel_silverstone-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_silverstone-r0/sonic_platform/chassis.py
@@ -75,7 +75,7 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.get_mac()
 
-    def get_serial_number(self):
+    def get_serial(self):
         """
         Retrieves the hardware serial number for the chassis
         Returns:

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
@@ -101,15 +101,6 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.base_mac_addr()
 
-    def get_serial_number(self):
-        """
-        Retrieves the hardware serial number for the chassis
-
-        Returns:
-            A string containing the hardware serial number for this chassis.
-        """
-        return self._eeprom.serial_number_str()
-
     def get_system_eeprom_info(self):
         """
         Retrieves the full content of system EEPROM information for the chassis

--- a/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/chassis.py
@@ -126,14 +126,6 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.get_mac()
 
-    def get_serial_number(self):
-        """
-        Retrieves the hardware serial number for the chassis
-        Returns:
-            A string containing the hardware serial number for this chassis.
-        """
-        return self._eeprom.get_serial()
-
     def get_system_eeprom_info(self):
         """
         Retrieves the full content of system EEPROM information for the chassis

--- a/platform/broadcom/sonic-platform-modules-inventec/d6356/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-inventec/d6356/sonic_platform/chassis.py
@@ -116,15 +116,6 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.base_mac_address()
 
-    def get_serial_number(self):
-        """
-        Retrieves the hardware serial number for the chassis
-
-        Returns:
-            A string containing the hardware serial number for this chassis.
-        """
-        return self._eeprom.serial_number_str()
-
     def get_system_eeprom_info(self):
         """
         Retrieves the full content of system EEPROM information for the chassis

--- a/platform/broadcom/sonic-platform-modules-inventec/d7054q28b/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-inventec/d7054q28b/sonic_platform/chassis.py
@@ -119,15 +119,6 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.base_mac_addr()
 
-    def get_serial_number(self):
-        """
-        Retrieves the hardware serial number for the chassis
-
-        Returns:
-            A string containing the hardware serial number for this chassis.
-        """
-        return self._eeprom.serial_number_str()
-
     def get_system_eeprom_info(self):
         """
         Retrieves the full content of system EEPROM information for the chassis

--- a/platform/broadcom/sonic-platform-modules-juniper/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-juniper/sonic_platform/chassis.py
@@ -86,7 +86,7 @@ class Chassis(ChassisBase):
             return False
 
 
-    def get_serial_number(self):
+    def get_serial(self):
         serial_number_list = self.get_parameter_value('Serial Number')
         if serial_number_list:
             serial_number = ''.join(serial_number_list)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -287,7 +287,7 @@ class Chassis(ChassisBase):
         return self._eeprom.get_base_mac()
 
 
-    def get_serial_number(self):
+    def get_serial(self):
         """
         Retrieves the hardware serial number for the chassis
 


### PR DESCRIPTION
**- Why I did it**

The `get_serial_number()` method in the ChassisBase and ModuleBase classes was redundant, as the `get_serial()` method is inherited from the DeviceBase class. This method was removed from the base classes in sonic-platform-common and the submodule was updated in https://github.com/Azure/sonic-buildimage/pull/5625.

This PR aligns the existing vendor platform API implementations to remove the `get_serial_number()` methods and ensure the `get_serial()` methods are implemented, if they weren't previously.

Note that this PR does not modify the Dell platform API implementations, as this will be handled as part of https://github.com/Azure/sonic-buildimage/pull/5609

**- How I did it**

Remove `get_serial_number()` methods from existing platform API implementations (except Dell -- see above) and ensure the `get_serial()` method is implemented, if it wasn't previously.