### PR TITLE
Fixes the DPKG cache break because of SAI package content changes wit…

### DIFF
--- a/platform/broadcom/sai.dep
+++ b/platform/broadcom/sai.dep
@@ -3,12 +3,16 @@
 SPATH       := $($(BRCM_SAI)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/broadcom/sai.mk platform/broadcom/sai.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+# Get the Latest HTTP Header and calculate the SHA value as it is a softlink that always points to LATEST_INT_OCP_SAI_X.X.X
+SAI_FLAGS   := $(shell wget --spider --server-response $($(BRCM_SAI)_URL) $($(BRCM_SAI_DEV)_URL)  2>&1 \
+			   | grep -Ev -- '--|Date:'|sha256sum|awk '{print $$1}' )
 
 $(BRCM_SAI)_CACHE_MODE  := GIT_CONTENT_SHA 
-$(BRCM_SAI)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(BRCM_SAI)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST) $(SAI_FLAGS)
 $(BRCM_SAI)_DEP_FILES   := $(DEP_FILES)
 
+
 $(BRCM_SAI_DEV)_CACHE_MODE  := GIT_CONTENT_SHA 
-$(BRCM_SAI_DEV)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(BRCM_SAI_DEV)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST) $(SAI_FLAGS)
 $(BRCM_SAI_DEV)_DEP_FILES   := $(DEP_FILES)
 


### PR DESCRIPTION
…the docker rebuild

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->
- The issue is that the SAI package content is changed without changing its version. The DPKG caches the wrong version of SAI package. 
- The fix is to include the SAI package content header for SHA calcaulation. This will detect if there is any change in the SAI package.

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
