### PR TITLE
[arista/7800r3_48cq(m)2_lc] remove platform_reboot

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/platform_reboot
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/platform_reboot
@@ -1,1 +1,0 @@
-../x86_64-arista_common/platform_reboot

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/platform_reboot
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/platform_reboot
@@ -1,1 +1,0 @@
-../x86_64-arista_common/platform_reboot


### PR DESCRIPTION
**- Why I did it**

We don't need a custom platform reboot on Clearwater2(Ms). They are expected to be rebooted via a normal linux soft reboot.

**- How I did it**

Remove symlink to the arista common platform reboot for those 2 platforms.

**- How to verify it**

Tested that reboot command on Clearwater2 works as expected and goes through normal linux reboot sequence.