### PR TITLE
[Mellanox] Add sensors labels for human readable output for MSN2010

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/sensors.conf
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/sensors.conf
@@ -1,92 +1,49 @@
+################################################################################
+# Copyright (c) 2020 Mellanox Technologies
+#
+# Platform specific sensors config for SN2010
+################################################################################
+
+# Temperature sensors
 bus "i2c-2" "i2c-1-mux (chan_id 1)"
-chip "mlxsw-i2c-2-48"
-    label temp1 "ASIC Temp"
+    chip "mlxsw-i2c-*-48"
+        label temp1 "Ambient ASIC Temp"
 
 bus "i2c-7" "i2c-1-mux (chan_id 6)"
-chip "lm75-*"
-    label temp1 "Ambient Port Temp"
+    chip "lm75-i2c-*-4a"
+        label temp1 "Ambient Port Side Temp (air exhaust)"
+    chip "lm75-i2c-*-4b"
+        label temp1 "Ambient Fan Side Temp (air intake)"
 
+# Power supplies
 bus "i2c-5" "i2c-1-mux (chan_id 4)"
-chip "tps53679-*"
-    label vin "TPS vin"
-    label vout1 "TPS vout1"
-    label vout2 "TPS vout2"
-    label temp1 "TPS Temp1"
-    label temp2 "TPS Temp2"
-    label pout1 "TPS pouti1"
-    label pout2 "TPS pout2"
-    label iout1 "TPS iout1"
-    label iout2 "TPS iout2"
+    chip "tps53679-i2c-*-70"
+        label in1 "PMIC-1 PSU 12V Rail (in1)"
+        label in2 "PMIC-1 PSU 12V Rail (in2)"
+        label in3 "PMIC-1 0.9V VCORE (out)"
+        label in4 "PMIC-1 1.2V Rail (out)"
+        label temp1 "PMIC-1 Temp 1"
+        label temp2 "PMIC-1 Temp 2"
+        label power1 "PMIC-1 0.9V VCORE Pwr (out)"
+        label power2 "PMIC-1 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-1 0.9V VCORE Curr (out)"
+        label curr2 "PMIC-1 1.2V Rail Curr (out)"
+    chip "tps53679-i2c-*-71"
+        label in1 "PMIC-2 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-2 2.2V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-2 Temp 1"
+        label temp2 "PMIC-2 Temp 2"
+        label power1 "PMIC-2 2.2V Rail Pwr (out)"
+        ignore power2
+        label curr1 "PMIC-2 2.2V Rail Curr (out)"
+        ignore curr2
 
-chip "mlxsw-*"
-    ignore temp2
-    ignore temp3
-    ignore temp4
-    ignore temp5
-    ignore temp6
-    ignore temp7
-    ignore temp8
-    ignore temp9
-    ignore temp10
-    ignore temp11
-    ignore temp12
-    ignore temp13
-    ignore temp14
-    ignore temp15
-    ignore temp16
-    ignore temp17
-    ignore temp18
-    ignore temp19
-    ignore temp20
-    ignore temp21
-    ignore temp22
-    ignore temp23
-    ignore temp24
-    ignore temp25
-    ignore temp26
-    ignore temp27
-    ignore temp28
-    ignore temp29
-    ignore temp30
-    ignore temp31
-    ignore temp32
-    ignore temp33
-    ignore temp34
-    ignore temp35
-    ignore temp36
-    ignore temp37
-    ignore temp38
-    ignore temp39
-    ignore temp40
-    ignore temp41
-    ignore temp42
-    ignore temp43
-    ignore temp44
-    ignore temp45
-    ignore temp46
-    ignore temp47
-    ignore temp48
-    ignore temp49
-    ignore temp50
-    ignore temp51
-    ignore temp52
-    ignore temp53
-    ignore temp54
-    ignore temp55
-    ignore temp56
-    ignore temp57
-    ignore temp58
-    ignore temp59
-    ignore temp60
-    ignore temp61
-    ignore temp62
-    ignore temp63
-    ignore temp64
-
-chip "*-virtual-*"
-    ignore temp1
-    ignore temp2
-
-chip "dps460-*"
-    ignore fan2
-    ignore fan3
+# Chassis fans
+bus "i2c-2" "i2c-1-mux (chan_id 1)"
+    chip "mlxsw-i2c-*-48"
+        label fan1 "Chassis Fan 1"
+        label fan2 "Chassis Fan 2"
+        label fan3 "Chassis Fan 3"
+        label fan4 "Chassis Fan 4"


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Add sensors labels for human readable output for MSN2010

**- How I did it**
Configured the correct labels on 'sensors.conf' file

**- How to verify it**
run 'sensors' command

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**