### PR TITLE
[Mellanox] Add sensors labels for human readable output for MSN2740

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2740-r0/sensors.conf
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/sensors.conf
@@ -1,1 +1,76 @@
-../x86_64-mlnx_msn2700-r0/sensors.conf
+################################################################################
+# Copyright (c) 2020 Mellanox Technologies
+#
+# Platform specific sensors config for SN2740
+################################################################################
+
+# Temperature sensors
+bus "i2c-2" "i2c-1-mux (chan_id 1)"
+    chip "mlxsw-i2c-*-48"
+        label temp1 "Ambient ASIC Temp"
+
+bus "i2c-7" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-*-48"
+        label temp1 "Ambient Port Temp"
+
+bus "i2c-6" "i2c-1-mux (chan_id 5)"
+    chip "tmp102-i2c-*-49"
+        label temp1 "Ambient Fan Temp"
+
+# Power controllers
+bus "i2c-5" "i2c-1-mux (chan_id 4)"
+    chip "pmbus-i2c-*-41"
+        label in1 "PMB-1 PSU 12V Rail (in)"
+        label in2 "PMB-1 0.9V VCORE Rail (out)"
+        label in3 "PMB-1 1.8V VCORE Rail (out)"
+        label temp1 "PMB-1 Temp 1"
+        label temp2 "PMB-1 Temp 2"
+        ignore power1
+        label power2 "PMB-1 0.9V VCORE Rail Pwr (out)"
+        label power3 "PMB-1 1.8V Rail Pwr (out)"
+        ignore curr1
+        label curr2 "PMB-1 0.9V VCORE Rail Curr (out)"
+        label curr3 "PMB-1 1.8V Rail Curr (out)"
+    chip "pmbus-i2c-*-27"
+        label in1 "PMB-2 PSU 12V Rail (in)"
+        label in2 "PMB-2 3.3V Rail (out)"
+        label in3 "PMB-2 1.2V Rail (out)"
+        label temp1 "PMB-2 Temp 1"
+        label temp2 "PMB-2 Temp 2"
+        ignore power1
+        label power2 "PMB-2 3.3V Rail Pwr (out)"
+        label power3 "PMB-2 1.2V Rail Pwr (out)"
+        ignore curr1
+        label curr2 "PMB-2 3.3V Rail Curr (out)"
+        label curr3 "PMB-2 1.2V Rail Curr (out)"
+
+# Power supplies
+bus "i2c-4" "i2c-1-mux (chan_id 3)"
+    chip "dps460-i2c-*-58"
+        label in1 "PSU-2(R) 220V Rail (in)"
+        label in2 "PSU-2(R) 12V Rail (out)"
+        label fan1 "PSU-2(R) Fan 1"
+        label temp1 "PSU-2(R) Temp 1"
+        label temp2 "PSU-2(R) Temp 2"
+        label power1 "PSU-2(R) 220V Rail Pwr (in)"
+        label power2 "PSU-2(R) 12V Rail Pwr (out)"
+        label curr1 "PSU-2(R) 220V Rail Curr (in)"
+        label curr2 "PSU-2(R) 12V Rail Curr (out)"
+    chip "dps460-i2c-*-59"
+        label in1 "PSU-1(L) 220V Rail (in)"
+        label in2 "PSU-1(L) 12V Rail (out)"
+        label fan1 "PSU-1(L) Fan 1"
+        label temp1 "PSU-1(L) Temp 1"
+        label temp2 "PSU-1(L) Temp 2"
+        label power1 "PSU-1(L) 220V Rail Pwr (in)"
+        label power2 "PSU-1(L) 12V Rail Pwr (out)"
+        label curr1 "PSU-1(L) 220V Rail Curr (in)"
+        label curr2 "PSU-1(L) 12V Rail Curr (out)"
+
+# Chassis fans
+bus "i2c-2" "i2c-1-mux (chan_id 1)"
+    chip "mlxsw-i2c-*-48"
+        label fan1 "Chassis Fan Drawer-1"
+        label fan2 "Chassis Fan Drawer-2"
+        label fan3 "Chassis Fan Drawer-3"
+        label fan4 "Chassis Fan Drawer-4"


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Add sensors labels for human readable output for MSN2740

**- How I did it**
Configured the correct labels on 'sensors.conf' file

**- How to verify it**
run 'sensors' command

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**