### PR TITLE
[docker-base]: Rate limit priority INFO and lower in syslog

### DIFF
--- a/dockers/docker-base-buster/etc/rsyslog.conf
+++ b/dockers/docker-base-buster/etc/rsyslog.conf
@@ -12,7 +12,7 @@
 $ModLoad imuxsock # provides support for local system logging
 
 #
-# Set a rate limit on messages from the container
+# Set a rate limit on messages from the container of priority INFO or lower (level 6 and above)
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000

--- a/dockers/docker-base-buster/etc/rsyslog.conf
+++ b/dockers/docker-base-buster/etc/rsyslog.conf
@@ -16,6 +16,7 @@ $ModLoad imuxsock # provides support for local system logging
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000
+$SystemLogRateLimitSeverity 6
 
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability

--- a/dockers/docker-base-stretch/etc/rsyslog.conf
+++ b/dockers/docker-base-stretch/etc/rsyslog.conf
@@ -12,7 +12,7 @@
 $ModLoad imuxsock # provides support for local system logging
 
 #
-# Set a rate limit on messages from the container
+# Set a rate limit on messages from the container of priority INFO or lower (level 6 and above)
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000

--- a/dockers/docker-base-stretch/etc/rsyslog.conf
+++ b/dockers/docker-base-stretch/etc/rsyslog.conf
@@ -16,6 +16,7 @@ $ModLoad imuxsock # provides support for local system logging
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000
+$SystemLogRateLimitSeverity 6
 
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability

--- a/dockers/docker-base/etc/rsyslog.conf
+++ b/dockers/docker-base/etc/rsyslog.conf
@@ -16,7 +16,7 @@
 $ModLoad imuxsock # provides support for local system logging
 
 #
-# Set a rate limit on messages from the container
+# Set a rate limit on messages from the container of priority INFO or lower (level 6 and above)
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000

--- a/dockers/docker-base/etc/rsyslog.conf
+++ b/dockers/docker-base/etc/rsyslog.conf
@@ -20,6 +20,7 @@ $ModLoad imuxsock # provides support for local system logging
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000
+$SystemLogRateLimitSeverity 6
 
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability

--- a/files/image_config/rsyslog/rsyslog-container.conf.j2
+++ b/files/image_config/rsyslog/rsyslog-container.conf.j2
@@ -12,10 +12,11 @@
 $ModLoad imuxsock # provides support for local system logging
 
 #
-# Set a rate limit on messages from the container
+# Set a rate limit on messages from the container of priority INFO or lower (level 6 and above)
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000
+$SystemLogRateLimitSeverity 6
 
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"



Please provide the following information:
-->
Temporary fix for #5570 

**- Why I did it**
There is currently a bug where messages from swss with priority lower than the current log level are still being counted against the syslog rate limiting threshhold. This leads to rate-limiting in syslog when the rate-limiting conditions have not been met, which causes several sonic-mgmt tests to fail since they are dependent on LogAnalyzer. It also omits potentially useful information from the syslog. Only rate-limiting messages of level INFO and lower allows these tests to pass successfully.

**- How I did it**
Add `$SystemLogRateLimitSeverity` option to `rsyslog.conf` in the base Dockerfiles

**- How to verify it**
Build a new orchagent image and install it. Run the ACL tests, which should now pass. No rate limiting should occur in the syslogs.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
