### PR TITLE
[Mellanox] Fix issue: read data from eeprom should trim tail \0

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
@@ -82,18 +82,26 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         self._base_mac = self.mgmtaddrstr(eeprom)
         if self._base_mac is None:
             self._base_mac = "Undefined."
+        else:
+            self._base_mac = self._base_mac.strip('\0')
 
         self._serial_str = self.serial_number_str(eeprom)
         if self._serial_str is None:
             self._serial_str = "Undefined."
+        else:
+            self._serial_str = self._serial_str.strip('\0')
 
         self._product_name = self.modelstr(eeprom)
         if self._product_name is None:
             self._product_name = "Undefined."
+        else:
+            self._product_name = self._product_name.strip('\0')
 
         self._part_number = self.part_number_str(eeprom)
         if self._part_number is None:
             self._part_number = "Undefined."
+        else:
+            self._part_number = self._part_number.strip('\0')
 
         original_stdout = sys.stdout
         sys.stdout = StringIO()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Now we are reading base mac, product name from eeprom data, and the data read from eeprom contains multiple "\0" characters at the end, need trim them to make the string clean and display correct.

**- How I did it**

Strip all "\0" for the data read from eeprom

**- How to verify it**

Manual test

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
