### PR TITLE
DellEMC S5232 Buffer profile changes

### DIFF
--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t0.j2
@@ -1,16 +1,15 @@
-
-{%- set default_cable = '40m' %}
+{%- set default_cable = '5m' %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "28550336",
+            "size": "26284032",
             "type": "ingress",
             "mode": "dynamic",
-            "xoff": "4194112"
+            "xoff": "6291456"
         },
-        "egress_pool": {
-            "size": "28550336",
+        "egress_lossless_pool": {
+            "size": "32575488",
             "type": "egress",
             "mode": "static"
         }
@@ -22,13 +21,13 @@
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
             "mode": "static",
-            "static_th":"32744448"
+            "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t1.j2
@@ -1,16 +1,15 @@
-
 {%- set default_cable = '40m' %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "28550336",
+            "size": "26284032",
             "type": "ingress",
             "mode": "dynamic",
-            "xoff": "4194112"
+            "xoff": "6291456"
         },
-        "egress_pool": {
-            "size": "28550336",
+        "egress_lossless_pool": {
+            "size": "32575488",
             "type": "egress",
             "mode": "static"
         }
@@ -22,13 +21,13 @@
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
             "mode": "static",
-            "static_th":"32744448"
+            "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/td3-s5232f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/td3-s5232f-32x100G.config.bcm
@@ -541,6 +541,6 @@ dport_map_port_129=126
 dport_map_port_66=127
 dport_map_port_130=128
 
-mmu_init_config="TD3-DEFAULT-LOSSLESS-P3P4"
+mmu_init_config="TD3-DELL-lossless"
 sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
 

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t0.j2
@@ -1,16 +1,15 @@
-
-{%- set default_cable = '40m' %}
+{%- set default_cable = '5m' %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "28550336",
+            "size": "26284032",
             "type": "ingress",
             "mode": "dynamic",
-            "xoff": "4194112"
+            "xoff": "6291456"
         },
-        "egress_pool": {
-            "size": "28550336",
+        "egress_lossless_pool": {
+            "size": "32575488",
             "type": "egress",
             "mode": "static"
         }
@@ -22,13 +21,13 @@
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
             "mode": "static",
-            "static_th":"32744448"
+            "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t1.j2
@@ -1,16 +1,15 @@
-
 {%- set default_cable = '40m' %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "28550336",
+            "size": "26284032",
             "type": "ingress",
             "mode": "dynamic",
-            "xoff": "4194112"
+            "xoff": "6291456"
         },
-        "egress_pool": {
-            "size": "28550336",
+        "egress_lossless_pool": {
+            "size": "32575488",
             "type": "egress",
             "mode": "static"
         }
@@ -22,16 +21,17 @@
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
             "mode": "static",
-            "static_th":"32744448"
+            "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"
         }
     },
 {%- endmacro %}
+

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/td3-s5232f-8x100G+48x50G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/td3-s5232f-8x100G+48x50G.config.bcm
@@ -567,6 +567,6 @@ dport_map_port_129=126
 dport_map_port_66=127
 dport_map_port_130=128
 
-mmu_init_config="TD3-DEFAULT-LOSSLESS-P3P4"
+mmu_init_config="TD3-DELL-lossless"
 sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
 

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t0.j2
@@ -1,46 +1,36 @@
-
-{%- set default_cable = '40m' %}
+{%- set default_cable = '5m' %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "32744448",
+            "size": "26284032",
             "type": "ingress",
-            "mode": "static"
+            "mode": "dynamic",
+            "xoff": "6291456"
         },
-        "egress_lossy_pool": {
-            "size": "32744448",
+        "egress_lossless_pool": {
+            "size": "32575488",
             "type": "egress",
-            "mode": "dynamic"
+            "mode": "static"
         }
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"32744448"
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "mode": "static",
+            "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
+            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },
 {%- endmacro %}
-
-{%- macro generate_pg_profils(port_names_active) %}
-    "BUFFER_PG": {
-        "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        }
-    },
-{%- endmacro %}
-
-{% macro generate_queue_buffers(port_names_active) %}
-    "BUFFER_QUEUE": {
-        "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        }
-    }
-{% endmacro %}
-

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t1.j2
@@ -1,46 +1,36 @@
-
 {%- set default_cable = '40m' %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "32744448",
+            "size": "26284032",
             "type": "ingress",
-            "mode": "static"
+            "mode": "dynamic",
+            "xoff": "6291456"
         },
-        "egress_lossy_pool": {
-            "size": "32744448",
+        "egress_lossless_pool": {
+            "size": "32575488",
             "type": "egress",
-            "mode": "dynamic"
+            "mode": "static"
         }
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"32744448"
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "mode": "static",
+            "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
+            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },
 {%- endmacro %}
-
-{%- macro generate_pg_profils(port_names_active) %}
-    "BUFFER_PG": {
-        "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        }
-    },
-{%- endmacro %}
-
-{% macro generate_queue_buffers(port_names_active) %}
-    "BUFFER_QUEUE": {
-        "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        }
-    }
-{% endmacro %}
-

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/td3-s5232f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/td3-s5232f-32x100G.config.bcm
@@ -541,5 +541,5 @@ dport_map_port_129=126
 dport_map_port_66=127
 dport_map_port_130=128
 
-mmu_init_config="TD3-DEFAULT"
+mmu_init_config="TD3-DELL-lossless"
 sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t0.j2
@@ -1,46 +1,36 @@
-
-{%- set default_cable = '40m' %}
+{%- set default_cable = '5m' %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "32744448",
+            "size": "26284032",
             "type": "ingress",
-            "mode": "static"
+            "mode": "dynamic",
+            "xoff": "6291456"
         },
-        "egress_lossy_pool": {
-            "size": "32744448",
+        "egress_lossless_pool": {
+            "size": "32575488",
             "type": "egress",
-            "mode": "dynamic"
+            "mode": "static"
         }
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"32744448"
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "mode": "static",
+            "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
+            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },
 {%- endmacro %}
-
-{%- macro generate_pg_profils(port_names_active) %}
-    "BUFFER_PG": {
-        "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        }
-    },
-{%- endmacro %}
-
-{% macro generate_queue_buffers(port_names_active) %}
-    "BUFFER_QUEUE": {
-        "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        }
-    }
-{% endmacro %}
-

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t1.j2
@@ -1,46 +1,36 @@
-
 {%- set default_cable = '40m' %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "32744448",
+            "size": "26284032",
             "type": "ingress",
-            "mode": "static"
+            "mode": "dynamic",
+            "xoff": "6291456"
         },
-        "egress_lossy_pool": {
-            "size": "32744448",
+        "egress_lossless_pool": {
+            "size": "32575488",
             "type": "egress",
-            "mode": "dynamic"
+            "mode": "static"
         }
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"32744448"
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "mode": "static",
+            "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
+            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },
 {%- endmacro %}
-
-{%- macro generate_pg_profils(port_names_active) %}
-    "BUFFER_PG": {
-        "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        }
-    },
-{%- endmacro %}
-
-{% macro generate_queue_buffers(port_names_active) %}
-    "BUFFER_QUEUE": {
-        "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        }
-    }
-{% endmacro %}
-

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/td3-s5232f-96x10G+8x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/td3-s5232f-96x10G+8x100G.config.bcm
@@ -614,5 +614,5 @@ dport_map_port_129=126
 dport_map_port_66=127
 dport_map_port_130=128
 
-mmu_init_config="TD3-DEFAULT"
+mmu_init_config="TD3-DELL-lossless"
 sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t0.j2
@@ -1,46 +1,36 @@
-
-{%- set default_cable = '40m' %}
+{%- set default_cable = '5m' %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "32744448",
+            "size": "26284032",
             "type": "ingress",
-            "mode": "static"
+            "mode": "dynamic",
+            "xoff": "6291456"
         },
-        "egress_lossy_pool": {
-            "size": "32744448",
+        "egress_lossless_pool": {
+            "size": "32575488",
             "type": "egress",
-            "mode": "dynamic"
+            "mode": "static"
         }
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"32744448"
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "mode": "static",
+            "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
+            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },
 {%- endmacro %}
-
-{%- macro generate_pg_profils(port_names_active) %}
-    "BUFFER_PG": {
-        "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        }
-    },
-{%- endmacro %}
-
-{% macro generate_queue_buffers(port_names_active) %}
-    "BUFFER_QUEUE": {
-        "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        }
-    }
-{% endmacro %}
-

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t1.j2
@@ -1,46 +1,36 @@
-
 {%- set default_cable = '40m' %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "32744448",
+            "size": "26284032",
             "type": "ingress",
-            "mode": "static"
+            "mode": "dynamic",
+            "xoff": "6291456"
         },
-        "egress_lossy_pool": {
-            "size": "32744448",
+        "egress_lossless_pool": {
+            "size": "32575488",
             "type": "egress",
-            "mode": "dynamic"
+            "mode": "static"
         }
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"32744448"
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "mode": "static",
+            "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
+            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },
 {%- endmacro %}
-
-{%- macro generate_pg_profils(port_names_active) %}
-    "BUFFER_PG": {
-        "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        }
-    },
-{%- endmacro %}
-
-{% macro generate_queue_buffers(port_names_active) %}
-    "BUFFER_QUEUE": {
-        "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        }
-    }
-{% endmacro %}
-

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/td3-s5232f-96x25G+8x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/td3-s5232f-96x25G+8x100G.config.bcm
@@ -614,5 +614,5 @@ dport_map_port_129=126
 dport_map_port_66=127
 dport_map_port_130=128
 
-mmu_init_config="TD3-DEFAULT"
+mmu_init_config="TD3-DELL-lossless"
 sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc


### PR DESCRIPTION
**- Why I did it**
Modified the correct settings for DellEMC S5232 buffer settings.
Increased Egress pool size from 28MB to 32 MB.

**- How I did it**
Edid buffer_defaults_t0.j2 and buffer_defaults_t1.j2 files 
**- How to verify it**
Verify ingress and egress register values in NPU shell. 
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

