### PR TITLE
[DellEMC]: FanDrawer and get_high_critical_threshold Platform API implementation for S6000, S6100, Z9100 and Z9264F

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
+++ b/platform/broadcom/sonic-platform-modules-dell/common/dell_pmc.c
@@ -718,18 +718,13 @@ static ssize_t show_fan_airflow(struct device *dev,
 {
         int index = to_sensor_dev_attr(devattr)->index;
         struct smf_data *data = dev_get_drvdata(dev);
-        int ret=1, fan_airflow;
+        int ret, fan_airflow;
 
         if (data->kind == s6100smf && index == FAN_TRAY_5)
                 return 0;
 
         fan_airflow = smf_read_reg(data, FAN_TRAY_AIRFLOW);
-
-        if (fan_airflow & (1 << (index)))
-                ret=1;
-
-        if (ret < 0)
-                return ret;
+        ret = (fan_airflow >> index) & 1;
 
         return sprintf(buf, "%d\n", ret);  
 }

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/__init__.py
@@ -1,2 +1,2 @@
-__all__ = ["platform", "chassis", "sfp", "psu", "thermal"]
+__all__ = ["platform", "chassis", "fan", "fan_drawer", "sfp", "psu", "thermal"]
 from sonic_platform import *

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
@@ -16,7 +16,7 @@ try:
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_platform.sfp import Sfp
     from sonic_platform.eeprom import Eeprom, EepromS6000
-    from sonic_platform.fan import Fan
+    from sonic_platform.fan_drawer import FanDrawer
     from sonic_platform.psu import Psu
     from sonic_platform.thermal import Thermal
     from sonic_platform.component import Component
@@ -24,7 +24,7 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 
-MAX_S6000_FAN = 3
+MAX_S6000_FANTRAY = 3
 MAX_S6000_PSU = 2
 MAX_S6000_THERMAL = 10
 MAX_S6000_COMPONENT = 4
@@ -76,9 +76,10 @@ class Chassis(ChassisBase):
         else:
             self._eeprom = EepromS6000()
 
-        for i in range(MAX_S6000_FAN):
-            fan = Fan(i)
-            self._fan_list.append(fan)
+        for i in range(MAX_S6000_FANTRAY):
+            fandrawer = FanDrawer(i)
+            self._fan_drawer_list.append(fandrawer)
+            self._fan_list.extend(fandrawer._fan_list)
 
         for i in range(MAX_S6000_PSU):
             psu = Psu(i)

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/fan_drawer.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+########################################################################
+# DellEMC S6000
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the Fan-Drawers' information available in the platform.
+#
+########################################################################
+
+try:
+    from sonic_platform_base.fan_drawer_base import FanDrawerBase
+    from sonic_platform.fan import Fan
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class FanDrawer(FanDrawerBase):
+    """DellEMC Platform-specific Fan class"""
+
+    def __init__(self, fantray_index):
+
+        FanDrawerBase.__init__(self)
+        # FanTray is 1-based in DellEMC platforms
+        self.fantrayindex = fantray_index + 1
+        self._fan_list.append(Fan(fantray_index))
+
+    def get_name(self):
+        """
+        Retrieves the fan drawer name
+        Returns:
+            string: The name of the device
+        """
+        return "FanTray{}".format(self.fantrayindex)

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ["platform", "chassis", "module", "fan", "psu", "sfp", "thermal"]
+__all__ = ["platform", "chassis", "module", "fan", "fan_drawer", "psu", "sfp", "thermal"]
 from sonic_platform import *
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -14,7 +14,7 @@ try:
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_platform.sfp import Sfp
     from sonic_platform.psu import Psu
-    from sonic_platform.fan import Fan
+    from sonic_platform.fan_drawer import FanDrawer
     from sonic_platform.module import Module
     from sonic_platform.thermal import Thermal
     from sonic_platform.component import Component
@@ -25,7 +25,7 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 MAX_S6100_MODULE = 4
-MAX_S6100_FAN = 4
+MAX_S6100_FANTRAY = 4
 MAX_S6100_PSU = 2
 MAX_S6100_THERMAL = 10
 MAX_S6100_COMPONENT = 3
@@ -65,9 +65,10 @@ class Chassis(ChassisBase):
             self._module_list.append(module)
             self._sfp_list.extend(module._sfp_list)
 
-        for i in range(MAX_S6100_FAN):
-            fan = Fan(i)
-            self._fan_list.append(fan)
+        for i in range(MAX_S6100_FANTRAY):
+            fandrawer = FanDrawer(i)
+            self._fan_drawer_list.append(fandrawer)
+            self._fan_list.extend(fandrawer._fan_list)
 
         for i in range(MAX_S6100_PSU):
             psu = Psu(i)

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan_drawer.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+########################################################################
+# DellEMC S6100
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the Fan-Drawers' information available in the platform.
+#
+########################################################################
+
+try:
+    from sonic_platform_base.fan_drawer_base import FanDrawerBase
+    from sonic_platform.fan import Fan
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class FanDrawer(FanDrawerBase):
+    """DellEMC Platform-specific Fan class"""
+
+    def __init__(self, fantray_index):
+
+        FanDrawerBase.__init__(self)
+        # FanTray is 1-based in DellEMC platforms
+        self.fantrayindex = fantray_index + 1
+        self._fan_list.append(Fan(fantray_index))
+
+    def get_name(self):
+        """
+        Retrieves the fan drawer name
+        Returns:
+            string: The name of the device
+        """
+        return "FanTray{}".format(self.fantrayindex)

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/thermal.py
@@ -49,9 +49,13 @@ class Thermal(ThermalBase):
         self.thermal_temperature_file = self.HWMON_DIR \
             + "temp{}_input".format(hwmon_temp_index)
         self.thermal_high_threshold_file = self.HWMON_DIR \
-            + "temp{}_crit".format(hwmon_temp_index)
+            + "temp{}_max".format(hwmon_temp_index)
         self.thermal_low_threshold_file = self.HWMON_DIR \
             + "temp{}_min".format(hwmon_temp_index)
+
+        if not self.is_cpu_thermal:
+            self.thermal_high_crit_threshold_file = self.HWMON_DIR \
+                + "temp{}_crit".format(hwmon_temp_index)
 
     def _read_sysfs_file(self, sysfs_file):
         # On successful read, returns the value read from given
@@ -179,6 +183,27 @@ class Thermal(ThermalBase):
             thermal_low_threshold = 0
 
         return thermal_low_threshold / 1000.0
+
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold temperature of thermal
+
+        Returns:
+            A float number, the high critical threshold temperature of
+            thermal in Celsius up to nearest thousandth of one degree
+            Celsius, e.g. 30.125
+        """
+        if self.is_cpu_thermal:
+            return super(Thermal, self).get_high_critical_threshold()
+
+        thermal_high_crit_threshold = self._read_sysfs_file(
+            self.thermal_high_crit_threshold_file)
+        if (thermal_high_crit_threshold != 'ERR'):
+            thermal_high_crit_threshold = float(thermal_high_crit_threshold)
+        else:
+            thermal_high_crit_threshold = 0
+
+        return thermal_high_crit_threshold / 1000.0
 
     def set_high_threshold(self, temperature):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ["platform", "chassis", "fan", "psu", "sfp", "thermal"]
+__all__ = ["platform", "chassis", "fan", "fan_drawer", "psu", "sfp", "thermal"]
 from sonic_platform import *
 

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/chassis.py
@@ -14,7 +14,7 @@ try:
     import sys
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_platform.sfp import Sfp
-    from sonic_platform.fan import Fan
+    from sonic_platform.fan_drawer import FanDrawer
     from sonic_platform.psu import Psu
     from sonic_platform.thermal import Thermal
     from sonic_platform.component import Component
@@ -24,7 +24,6 @@ except ImportError as e:
 
 
 MAX_Z9100_FANTRAY = 5
-MAX_Z9100_FAN = 2
 MAX_Z9100_PSU = 2
 MAX_Z9100_THERMAL = 8
 MAX_Z9100_COMPONENT = 6
@@ -100,9 +99,9 @@ class Chassis(ChassisBase):
         # Initialize EEPROM
         self._eeprom = Eeprom()
         for i in range(MAX_Z9100_FANTRAY):
-            for j in range(MAX_Z9100_FAN):
-                fan = Fan(i, j)
-                self._fan_list.append(fan)
+            fandrawer = FanDrawer(i)
+            self._fan_drawer_list.append(fandrawer)
+            self._fan_list.extend(fandrawer._fan_list)
 
         for i in range(MAX_Z9100_PSU):
             psu = Psu(i)

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/fan_drawer.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+########################################################################
+# DellEMC Z9100
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the Fan-Drawers' information available in the platform.
+#
+########################################################################
+
+try:
+    from sonic_platform_base.fan_drawer_base import FanDrawerBase
+    from sonic_platform.fan import Fan
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+Z9100_FANS_PER_FANTRAY = 2
+
+
+class FanDrawer(FanDrawerBase):
+    """DellEMC Platform-specific Fan class"""
+
+    def __init__(self, fantray_index):
+
+        FanDrawerBase.__init__(self)
+        # FanTray is 1-based in DellEMC platforms
+        self.fantrayindex = fantray_index + 1
+        for i in range(Z9100_FANS_PER_FANTRAY):
+            self._fan_list.append(Fan(fantray_index, i))
+
+    def get_name(self):
+        """
+        Retrieves the fan drawer name
+        Returns:
+            string: The name of the device
+        """
+        return "FanTray{}".format(self.fantrayindex)

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/thermal.py
@@ -45,9 +45,13 @@ class Thermal(ThermalBase):
         self.thermal_temperature_file = self.HWMON_DIR \
             + "temp{}_input".format(hwmon_temp_index)
         self.thermal_high_threshold_file = self.HWMON_DIR \
-            + "temp{}_crit".format(hwmon_temp_index)
+            + "temp{}_max".format(hwmon_temp_index)
         self.thermal_low_threshold_file = self.HWMON_DIR \
             + "temp{}_min".format(hwmon_temp_index)
+
+        if not self.is_cpu_thermal:
+            self.thermal_high_crit_threshold_file = self.HWMON_DIR \
+                + "temp{}_crit".format(hwmon_temp_index)
 
     def _read_sysfs_file(self, sysfs_file):
         # On successful read, returns the value read from given
@@ -175,6 +179,27 @@ class Thermal(ThermalBase):
             thermal_low_threshold = 0
 
         return thermal_low_threshold / 1000.0
+
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold temperature of thermal
+
+        Returns:
+            A float number, the high critical threshold temperature of
+            thermal in Celsius up to nearest thousandth of one degree
+            Celsius, e.g. 30.125
+        """
+        if self.is_cpu_thermal:
+            return super(Thermal, self).get_high_critical_threshold()
+
+        thermal_high_crit_threshold = self._read_sysfs_file(
+            self.thermal_high_crit_threshold_file)
+        if (thermal_high_crit_threshold != 'ERR'):
+            thermal_high_crit_threshold = float(thermal_high_crit_threshold)
+        else:
+            thermal_high_crit_threshold = 0
+
+        return thermal_high_crit_threshold / 1000.0
 
     def set_high_threshold(self, temperature):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/__init__.py
@@ -1,2 +1,2 @@
-__all__ = ["platform", "chassis", "sfp", "eeprom", "component", "psu", "thermal", "fan"]
+__all__ = ["platform", "chassis", "sfp", "eeprom", "component", "psu", "thermal", "fan", "fan_drawer"]
 from sonic_platform import *

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/chassis.py
@@ -17,13 +17,12 @@ try:
     from sonic_platform.component import Component
     from sonic_platform.psu import Psu
     from sonic_platform.watchdog import Watchdog
-    from sonic_platform.fan import Fan
+    from sonic_platform.fan_drawer import FanDrawer
     from sonic_platform.thermal import Thermal
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 MAX_Z9264F_FANTRAY =4
-MAX_Z9264F_FAN = 2
 MAX_Z9264F_COMPONENT = 8 # BIOS,BMC,FPGA,SYSTEM CPLD,4 SLAVE CPLDs
 MAX_Z9264F_PSU = 2
 MAX_Z9264F_THERMAL = 8
@@ -64,24 +63,24 @@ class Chassis(ChassisBase):
         self._eeprom = Eeprom()
 
         self._watchdog = Watchdog()
-        
+
         for i in range(MAX_Z9264F_COMPONENT):
             component = Component(i)
             self._component_list.append(component)
-            
+
         for i in range(MAX_Z9264F_PSU):
             psu = Psu(i)
             self._psu_list.append(psu)
 
         for i in range(MAX_Z9264F_FANTRAY):
-            for j in range(MAX_Z9264F_FAN):
-                fan = Fan(i,j)
-                self._fan_list.append(fan)
+            fandrawer = FanDrawer(i)
+            self._fan_drawer_list.append(fandrawer)
+            self._fan_list.extend(fandrawer._fan_list)
 
         for i in range(MAX_Z9264F_THERMAL):
             thermal = Thermal(i)
             self._thermal_list.append(thermal)
-        
+
         for port_num in range(self.PORT_START, (self.PORT_END + 1)):
             presence = self.get_sfp(port_num).get_presence()
             if presence:

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/fan_drawer.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+########################################################################
+# DellEMC Z9264F
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the Fan-Drawers' information available in the platform.
+#
+########################################################################
+
+try:
+    from sonic_platform_base.fan_drawer_base import FanDrawerBase
+    from sonic_platform.fan import Fan
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+Z9264F_FANS_PER_FANTRAY = 2
+
+
+class FanDrawer(FanDrawerBase):
+    """DellEMC Platform-specific Fan class"""
+
+    def __init__(self, fantray_index):
+
+        FanDrawerBase.__init__(self)
+        # FanTray is 1-based in DellEMC platforms
+        self.fantrayindex = fantray_index + 1
+        for i in range(Z9264F_FANS_PER_FANTRAY):
+            self._fan_list.append(Fan(fantray_index, i))
+
+    def get_name(self):
+        """
+        Retrieves the fan drawer name
+        Returns:
+            string: The name of the device
+        """
+        return "FanTray{}".format(self.fantrayindex)

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/thermal.py
@@ -105,7 +105,7 @@ class Thermal(ThermalBase):
             Celsius up to nearest thousandth of one degree Celsius,
             e.g. 30.125
         """
-        is_valid, high_threshold = self.sensor.get_threshold("UpperNonRecoverable")
+        is_valid, high_threshold = self.sensor.get_threshold("UpperCritical")
         if not is_valid:
             high_threshold = 0
 
@@ -125,6 +125,21 @@ class Thermal(ThermalBase):
             low_threshold = 0
 
         return float(low_threshold)
+
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold temperature of thermal
+
+        Returns:
+            A float number, the high critical threshold temperature of
+            thermal in Celsius up to nearest thousandth of one degree
+            Celsius, e.g. 30.125
+        """
+        is_valid, high_crit_threshold = self.sensor.get_threshold("UpperNonRecoverable")
+        if not is_valid:
+            high_crit_threshold = 0
+
+        return float(high_crit_threshold)
 
     def set_high_threshold(self, temperature):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

- Implement FanDrawer and get_high_critical_threshold Platform API for S6000, S6100, Z9100 and Z9264F.
- Fix incorrect fan direction values in S6100, Z9100

**- How I did it**

-  Added a new file fan_drawer.py for FanDrawer implementation.
-  Modified chassis.py to use FanDrawer for updating _fan_drawer_list and _fan_list.
-  Added ‘get_high_critical_threshold’ method in thermal.py for supported sensors in S6100, Z9100, Z9264.

**- How to verify it**

Wrote a python script to load chassis class and call the appropriate methods.
Logs: [UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/5407692/UT_logs.txt)

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[DellEMC]: FanDrawer and get_high_critical_threshold Platform API implementation for S6000, S6100, Z9100 and Z9264F

**- A picture of a cute animal (not mandatory but encouraged)**
