### PR TITLE
[hostcfgd] Enable/disable the container service only when the feature state was changed.

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -316,7 +316,7 @@ class HostConfigDaemon:
                 syslog.syslog(syslog.LOG_WARNING, "Eanble state of feature '{}' is None".format(feature_name))
                 continue
 
-            # Store the initial value of 'state' field in 'FEATURE' table of each container
+            # Store the initial value of 'state' field in 'FEATURE' table of a specific container
             self.cached_feature_states[feature_name] = state
 
             self.update_feature_state(feature_name, state, feature_table)
@@ -365,10 +365,10 @@ class HostConfigDaemon:
         # 'update_feature_state(...)' will be invoked to enable/disable the corresponding container service.
         # At the same time, the cached value will be updated with current value of 'state' field. The reason
         # to cache the previous value of 'state' field and do the comparison at here is that if we issue the 
-        # 'config' command to update the value of 'AutoRestart' field in 'FEATURE' table, the function 
+        # 'config' command to update the value of 'auto_restart' field in 'FEATURE' table, the function 
         # 'update_feature_state(...)' will also be invoked and this behavior is not expected.
         if self.cached_feature_states[feature_name] != state:
-            self.cached_feature_states = state
+            self.cached_feature_states[feature_name] = state
             self.update_feature_state(feature_name, state, feature_table)
 
     def start(self):

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -242,6 +242,8 @@ class HostConfigDaemon:
         self.iptables = Iptables()
         self.iptables.load(lpbk_table)
         self.is_multi_npu = device_info.is_multi_npu()
+        # Cache the values of 'state' field in 'FEATURE' table of each container
+        self.cached_feature_states = {}
 
     def update_feature_state(self, feature_name, state, feature_table):
         has_timer = ast.literal_eval(feature_table[feature_name].get('has_timer', 'False'))
@@ -314,6 +316,9 @@ class HostConfigDaemon:
                 syslog.syslog(syslog.LOG_WARNING, "Eanble state of feature '{}' is None".format(feature_name))
                 continue
 
+            # Store the initial value of 'state' field in 'FEATURE' table of each container
+            self.cached_feature_states[feature_name] = state
+
             self.update_feature_state(feature_name, state, feature_table)
 
     def aaa_handler(self, key, data):
@@ -356,7 +361,15 @@ class HostConfigDaemon:
             syslog.syslog(syslog.LOG_WARNING, "Enable state of feature '{}' is None".format(feature_name))
             return
 
-        self.update_feature_state(feature_name, state, feature_table)
+        # Compare the current value of 'state' field with cached value, if they are not equal, the function
+        # 'update_feature_state(...)' will be invoked to enable/disable the corresponding container service.
+        # At the same time, the cached value will be updated with current value of 'state' field. The reason
+        # to cache the previous value of 'state' field and do the comparison at here is that if we issue the 
+        # 'config' command to update the value of 'AutoRestart' field in 'FEATURE' table, the function 
+        # 'update_feature_state(...)' will also be invoked and this behavior is not expected.
+        if self.cached_feature_states[feature_name] != state:
+            self.cached_feature_states = state
+            self.update_feature_state(feature_name, state, feature_table)
 
     def start(self):
         # Update all feature states once upon starting

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -361,12 +361,7 @@ class HostConfigDaemon:
             syslog.syslog(syslog.LOG_WARNING, "Enable state of feature '{}' is None".format(feature_name))
             return
 
-        # Compare the current value of 'state' field with cached value, if they are not equal, the function
-        # 'update_feature_state(...)' will be invoked to enable/disable the corresponding container service.
-        # At the same time, the cached value will be updated with current value of 'state' field. The reason
-        # to cache the previous value of 'state' field and do the comparison at here is that if we issue the 
-        # 'config' command to update the value of 'auto_restart' field in 'FEATURE' table, the function 
-        # 'update_feature_state(...)' will also be invoked and this behavior is not expected.
+        # Enable/disable the container service if the feature state was changed from its previous state.
         if self.cached_feature_states[feature_name] != state:
             self.cached_feature_states[feature_name] = state
             self.update_feature_state(feature_name, state, feature_table)


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

**- Why I did it**
If we ran the CLI commands `sudo config feature autorestart snmp disabled/enabled` or `sudo config feature autorestart swss disabled/enabled`, then SNMP container will be stopped and started. This behavior was not expected since we updated the
`auto_restart` field not update `state` field in `FEATURE` table. The reason behind this issue is that either `state` field or `auto_restart` field was updated, the function `update_feature_state(...)` will be invoked which then starts snmp.timer service.
The snmp.timer service will first stop snmp.service and later start snmp.service. 

In order to solve this issue, the function `update_feature_state(...)` will be only invoked if `state` field in `FEATURE` table was
updated.

**- How I did it**
When the demon `hostcfgd` was activated, all the values of `state` field in `FEATURE` table of each container will be
cached. Each time the function `feature_state_handler(...)` is invoked, it will determine whether the `state` field of a
container was changed or not. If it was changed, function `update_feature_state(...)` will be invoked and the cached
value will also be updated. Otherwise, nothing will be done.

**- How to verify it**
We can run the CLI commands `sudo config feature autorestart snmp disabled/enabled` or `sudo config feature autorestart swss disabled/enabled` to check whether SNMP container is stopped and started. We also can run the CLI commands  `sudo config feature state snmp disabled/enabled` or `sudo config feature state swss disabled/enabled` to check whether the container is stopped and restarted.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
