### PR TITLE
Everflow and Dataacl should not get binded to Backplane port-channels.

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -727,13 +727,13 @@ def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
         return filter_acls
 
     front_port_channel_intf = []
+
+    # List of Backplane ports
+    backplane_port_list = [v for k,v in port_alias_map.items() if v.startswith(backplane_prefix())]
    
-    # Get the front panel port channel. It will use port_alias_asic_map
-    # which will get populated from port_config.ini for Multi-NPU 
-    # architecture
+    # Get the front panel port channel.
     for port_channel_intf in port_channels:
-        backend_port_channel = any(lag_member in port_alias_asic_map \
-                                   and lag_member.startswith(backplane_prefix()) \
+        backend_port_channel = any(lag_member in backplane_port_list \
                                    for lag_member in port_channels[port_channel_intf]['members'])
         if not backend_port_channel:
             front_port_channel_intf.append(port_channel_intf)
@@ -755,8 +755,10 @@ def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
         # This will be applicable in Multi-NPU Platforms.
         front_panel_ports = []
         for port in group_params.get('ports', []):
-            if port in port_alias_asic_map and port.startswith(backplane_prefix()):
+            # Filter out backplane ports
+            if port in backplane_port_list:
                 continue
+            # Filter out backplane port channels
             if port in port_channels and port not in front_port_channel_intf:
                 continue
             front_panel_ports.append(port)

--- a/src/sonic-config-engine/tests/multi_npu_data/sample_port_config-0.ini
+++ b/src/sonic-config-engine/tests/multi_npu_data/sample_port_config-0.ini
@@ -3,7 +3,7 @@ Ethernet0     33,34,35,36      Ethernet1/1        0       Eth0-ASIC0         Ext
 Ethernet4     29,30,31,32      Ethernet1/2        1       Eth1-ASIC0         Ext  
 Ethernet8     41,42,43,44      Ethernet1/3        2       Eth2-ASIC0         Ext 
 Ethernet12    37,38,39,40      Ethernet1/4        3       Eth3-ASIC0         Ext 
-Ethernet-BP0  13,14,15,16      Ethernet-BP0       0       Eth4-ASIC0         Int 
-Ethernet-BP4  17,18,19,20      Ethernet-BP4       1       Eth5-ASIC0         Int 
-Ethernet-BP8  21,22,23,24      Ethernet-BP8       2       Eth6-ASIC0         Int 
-Ethernet-BP12 25,26,27,28      Ethernet-BP12      3       Eth7-ASIC0         Int 
+Ethernet-BP0  13,14,15,16      Eth4-ASIC0         0       Eth4-ASIC0         Int 
+Ethernet-BP4  17,18,19,20      Eth5-ASIC0         1       Eth5-ASIC0         Int 
+Ethernet-BP8  21,22,23,24      Eth6-ASIC0         2       Eth6-ASIC0         Int 
+Ethernet-BP12 25,26,27,28      Eth7-ASIC0         3       Eth7-ASIC0         Int 

--- a/src/sonic-config-engine/tests/multi_npu_data/sample_port_config-1.ini
+++ b/src/sonic-config-engine/tests/multi_npu_data/sample_port_config-1.ini
@@ -1,9 +1,9 @@
-# name          lanes               alias        index    asic_port_name    role
+# name          lanes               alias        index      asic_port_name     role
 Ethernet16      33,34,35,36      Ethernet1/5        4        Eth0-ASIC1        Ext
 Ethernet20      29,30,31,32      Ethernet1/6        5        Eth1-ASIC1        Ext
 Ethernet24      41,42,43,44      Ethernet1/7        6        Eth2-ASIC1        Ext
 Ethernet28      37,38,39,40      Ethernet1/8        7        Eth3-ASIC1        Ext
-Ethernet-BP16   13,14,15,16      Ethernet-BP16      4        Eth4-ASIC1        Int
-Ethernet-BP20   17,18,19,20      Ethernet-BP20      5        Eth5-ASIC1        Int
-Ethernet-BP24   21,22,23,24      Ethernet-BP24      6        Eth6-ASIC1        Int
-Ethernet-BP28   25,26,27,28      Ethernet-BP28      7        Eth7-ASIC1        Int
+Ethernet-BP16   13,14,15,16      Eth4-ASIC1         4        Eth4-ASIC1        Int
+Ethernet-BP20   17,18,19,20      Eth5-ASIC1         5        Eth5-ASIC1        Int
+Ethernet-BP24   21,22,23,24      Eth6-ASIC1         6        Eth6-ASIC1        Int
+Ethernet-BP28   25,26,27,28      Eth7-ASIC1         7        Eth7-ASIC1        Int

--- a/src/sonic-config-engine/tests/multi_npu_data/sample_port_config-2.ini
+++ b/src/sonic-config-engine/tests/multi_npu_data/sample_port_config-2.ini
@@ -1,9 +1,9 @@
-# name              lanes               alias         index    asic_port_name    role
-Ethernet-BP256     61,62,63,64      Ethernet-BP256     8        Eth0-ASIC2          Int
-Ethernet-BP260     57,58,59,60      Ethernet-BP260     9        Eth1-ASIC2          Int
-Ethernet-BP264     53,54,55,56      Ethernet-BP264     10       Eth2-ASIC2          Int
-Ethernet-BP268     49,50,51,52      Ethernet-BP268     11       Eth3-ASIC2          Int
-Ethernet-BP272     45,46,47,48      Ethernet-BP272     12       Eth4-ASIC2          Int
-Ethernet-BP276     41,42,43,44      Ethernet-BP276     13       Eth5-ASIC2          Int
-Ethernet-BP280     37,38,39,40      Ethernet-BP280     14       Eth6-ASIC2          Int
-Ethernet-BP284     33,34,35,36      Ethernet-BP284     15       Eth7-ASIC2          Int
+# name              lanes        alias        index    asic_port_name    role
+Ethernet-BP256     61,62,63,64   Eth0-ASIC2      8        Eth0-ASIC2      Int
+Ethernet-BP260     57,58,59,60   Eth1-ASIC2      9        Eth1-ASIC2      Int
+Ethernet-BP264     53,54,55,56   Eth2-ASIC2      10       Eth2-ASIC2      Int
+Ethernet-BP268     49,50,51,52   Eth3-ASIC2      11       Eth3-ASIC2      Int
+Ethernet-BP272     45,46,47,48   Eth4-ASIC2      12       Eth4-ASIC2      Int
+Ethernet-BP276     41,42,43,44   Eth5-ASIC2      13       Eth5-ASIC2      Int
+Ethernet-BP280     37,38,39,40   Eth6-ASIC2      14       Eth6-ASIC2      Int
+Ethernet-BP284     33,34,35,36   Eth7-ASIC2      15       Eth7-ASIC2      Int

--- a/src/sonic-config-engine/tests/multi_npu_data/sample_port_config-3.ini
+++ b/src/sonic-config-engine/tests/multi_npu_data/sample_port_config-3.ini
@@ -1,9 +1,9 @@
-# name              lanes               alias             index    asic_port_name    role
-Ethernet-BP384     29,30,31,32      Ethernet-BP384         16         Eth0-ASIC3        Int
-Ethernet-BP388     25,26,27,28      Ethernet-BP388         17         Eth1-ASIC3        Int
-Ethernet-BP392     21,22,23,24      Ethernet-BP392         18         Eth2-ASIC3        Int
-Ethernet-BP396     17,18,19,20      Ethernet-BP396         19         Eth3-ASIC3        Int
-Ethernet-BP400     13,14,15,16      Ethernet-BP400         20         Eth4-ASIC3        Int
-Ethernet-BP404     9,10,11,12       Ethernet-BP404         21         Eth5-ASIC3        Int
-Ethernet-BP408     5,6,7,8          Ethernet-BP408         22         Eth6-ASIC3        Int
-Ethernet-BP412     1,2,3,4          Ethernet-BP412         23         Eth7-ASIC3        Int
+# name              lanes               alias          index      asic_port_name    role
+Ethernet-BP384     29,30,31,32      Eth0-ASIC3         16         Eth0-ASIC3        Int
+Ethernet-BP388     25,26,27,28      Eth1-ASIC3         17         Eth1-ASIC3        Int
+Ethernet-BP392     21,22,23,24      Eth2-ASIC3         18         Eth2-ASIC3        Int
+Ethernet-BP396     17,18,19,20      Eth3-ASIC3         19         Eth3-ASIC3        Int
+Ethernet-BP400     13,14,15,16      Eth4-ASIC3         20         Eth4-ASIC3        Int
+Ethernet-BP404     9,10,11,12       Eth5-ASIC3         21         Eth5-ASIC3        Int
+Ethernet-BP408     5,6,7,8          Eth6-ASIC3         22         Eth6-ASIC3        Int
+Ethernet-BP412     1,2,3,4          Eth7-ASIC3         23         Eth7-ASIC3        Int

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -181,11 +181,11 @@ class TestMultiNpuCfgGen(TestCase):
             "Ethernet4": { "admin_status": "up",  "alias": "Ethernet1/2",  "asic_port_name": "Eth1-ASIC0",  "description": "01T2:Ethernet2",  "index": "1",  "lanes": "29,30,31,32",  "mtu": "9100",  "pfc_asym": "off",  "role": "Ext",  "speed": "40000" }, 
             "Ethernet8": { "alias": "Ethernet1/3",  "asic_port_name": "Eth2-ASIC0",  "description": "Ethernet1/3",  "index": "2",  "lanes": "41,42,43,44",  "mtu": "9100",  "pfc_asym": "off",  "role": "Ext",  "speed": "40000" }, 
             "Ethernet12": { "alias": "Ethernet1/4",  "asic_port_name": "Eth3-ASIC0",  "description": "Ethernet1/4",  "index": "3",  "lanes": "37,38,39,40",  "mtu": "9100",  "pfc_asym": "off",  "role": "Ext",  "speed": "40000" }, 
-            "Ethernet-BP0": { "admin_status": "up",  "alias": "Ethernet-BP0",  "asic_port_name": "Eth4-ASIC0",  "description": "ASIC2:Eth0-ASIC2",  "index": "0",  "lanes": "13,14,15,16",  "mtu": "9100",  "pfc_asym": "off",  "role": "Int",  "speed": "40000" }, 
-            "Ethernet-BP4": { "admin_status": "up",  "alias": "Ethernet-BP4",  "asic_port_name": "Eth5-ASIC0",  "description": "ASIC2:Eth1-ASIC2",  "index": "1",  "lanes": "17,18,19,20",  "mtu": "9100",  "pfc_asym": "off",  "role": "Int",  "speed": "40000" }, 
-            "Ethernet-BP8": { "admin_status": "up",  "alias": "Ethernet-BP8",  "asic_port_name": "Eth6-ASIC0",  "description": "ASIC3:Eth0-ASIC3",  "index": "2",  "lanes": "21,22,23,24",  "mtu": "9100",  "pfc_asym": "off",  "role": "Int",  "speed": "40000" }, 
-            "Ethernet-BP12": { "admin_status": "up",  "alias": "Ethernet-BP12",  "asic_port_name": "Eth7-ASIC0",  "description": "ASIC3:Eth1-ASIC3",  "index": "3",  "lanes": "25,26,27,28",  "mtu": "9100",  "pfc_asym": "off",  "role": "Int",  "speed": "40000" }})
-    
+            "Ethernet-BP0": { "admin_status": "up",  "alias": "Eth4-ASIC0",  "asic_port_name": "Eth4-ASIC0",  "description": "ASIC2:Eth0-ASIC2",  "index": "0",  "lanes": "13,14,15,16",  "mtu": "9100",  "pfc_asym": "off",  "role": "Int",  "speed": "40000" },
+            "Ethernet-BP4": { "admin_status": "up",  "alias": "Eth5-ASIC0",  "asic_port_name": "Eth5-ASIC0",  "description": "ASIC2:Eth1-ASIC2",  "index": "1",  "lanes": "17,18,19,20",  "mtu": "9100",  "pfc_asym": "off",  "role": "Int",  "speed": "40000" },
+            "Ethernet-BP8": { "admin_status": "up",  "alias": "Eth6-ASIC0",  "asic_port_name": "Eth6-ASIC0",  "description": "ASIC3:Eth0-ASIC3",  "index": "2",  "lanes": "21,22,23,24",  "mtu": "9100",  "pfc_asym": "off",  "role": "Int",  "speed": "40000" },
+            "Ethernet-BP12": { "admin_status": "up",  "alias": "Eth7-ASIC0",  "asic_port_name": "Eth7-ASIC0",  "description": "ASIC3:Eth1-ASIC3",  "index": "3",  "lanes": "25,26,27,28",  "mtu": "9100",  "pfc_asym": "off",  "role": "Int",  "speed": "40000" }})
+
     def test_frontend_asic_device_neigh(self):
         argument = "-m {} -p {} -n asic0 --var-json \"DEVICE_NEIGHBOR\"".format(self.sample_graph, self.port_config[0])
         output = json.loads(self.run_script(argument))


### PR DESCRIPTION
Why I did:
Everflow and Dataacl should not get binded to Backplane port-channels.
However with updated port alias mapping it was getting binded.
Reason is because we were relying on port_alias_asic_map dictionary
but that dictionary can't be used as alias name format has changed.

How I verify:

After updating alias name in *.ini  uni-test were failing.
With updating logic in minigraph.py test are passing.
Also verified on Multi-asic platforms.