### PR TITLE
[Mellanox] Re-initialize SFP object when detecting a new SFP insertion

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -455,9 +455,28 @@ class Chassis(ChassisBase):
             status = self.sfp_event.check_sfp_status(port_dict, timeout)
 
         if status:
+            self.reinit_sfps(port_dict)
             return True, {'sfp':port_dict}
         else:
             return True, {'sfp':{}}
+
+    def reinit_sfps(self, port_dict):
+        """
+        Re-initialize SFP if there is any newly inserted SFPs
+        :param port_dict: SFP event data
+        :return:
+        """
+        # SFP not initialize yet, do nothing
+        if not self.sfp_module_initialized:
+            return
+
+        from . import sfp
+        for index, status in port_dict.items():
+            if status == sfp.SFP_STATUS_INSERTED:
+                try:
+                    self.get_sfp(index).reinit()
+                except Exception as e:
+                    logger.log_error("Fail to re-initialize SFP {} - {}".format(index, repr(e)))
 
     def get_thermal_manager(self):
         from .thermal_manager import ThermalManager

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -280,6 +280,9 @@ PORT_TYPE_MASK = 0xF0000000
 NVE_MASK = PORT_TYPE_MASK & (PORT_TYPE_NVE << PORT_TYPE_OFFSET)
 CPU_MASK = PORT_TYPE_MASK & (PORT_TYPE_CPU << PORT_TYPE_OFFSET)
 
+# parameters for SFP presence
+SFP_STATUS_INSERTED = '1'
+
 # Global logger class instance
 logger = Logger()
 
@@ -296,6 +299,13 @@ class SFP(SfpBase):
         self.sdk_handle = None
         self.sdk_index = sfp_index
 
+    def reinit(self):
+        """
+        Re-initialize this SFP object when a new SFP inserted
+        :return: 
+        """
+        self._detect_sfp_type(self.sfp_type)
+        self._dom_capability_detect()
 
     #SDK initializing stuff
     def _initialize_sdk_handle(self):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

SFP object will be initialized to a certain type even if no SFP present. A case could be:

1. A SFP object is initialized to QSFP type by default when there is no SFP present
2. User insert a SFP with an adapter to this QSFP port
3. The SFP object fail to read EEPROM because it still treats itself as QSFP.

This PR fixes this issue.

**- How I did it**

When detecting a new SFP insertion, read its SFP type and DOM capability from EEPROM again.

**- How to verify it**

Manual test

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
