### PR TITLE
[LLDP] Fix for LLDP advertisement, PortID and Description

### DIFF
--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -103,15 +103,15 @@ class LldpManager(daemon_base.DaemonBase):
             if not port_alias:
                 self.log_info("Unable to retrieve port alias for port '{}'. Using port name instead.".format(port_name))
                 port_alias = port_name
-            
-            # Get the port description. If None or empty string, we'll skip this configuration 
-            port_desc = port_table_dict.get("description")
+            else:
+                # Set the port description to port alias, if it is available
+                port_desc = port_alias
 
         else:
             self.log_error("Port '{}' not found in {} table in Config DB. Using port name instead of port alias.".format(port_name, swsscommon.CFG_PORT_TABLE_NAME))
             port_alias = port_name
 
-        lldpcli_cmd = "lldpcli configure ports {0} lldp portidsubtype local {1}".format(port_name, port_alias)
+        lldpcli_cmd = "lldpcli configure ports {0} lldp portidsubtype local {1}".format(port_name, port_name)
 
         # if there is a description available, also configure that
         if port_desc:


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
PortID should reference to the interface name.
Port Description should reference to the interface alias.

**- How I did it**
Edit 'lldpmgrd' to configure 'lldpd' using 'lldpcli' with the correct values.

**- How to verify it**
Run tcpdump and observe LLDP packets.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
