### PR TITLE
[BFN] Updated SDK packages to 20201023

### DIFF
--- a/platform/barefoot/bfn-platform.mk
+++ b/platform/barefoot/bfn-platform.mk
@@ -1,4 +1,4 @@
-BFN_PLATFORM = bfnplatform_20201009_deb9.deb
+BFN_PLATFORM = bfnplatform_20201023_deb9.deb
 $(BFN_PLATFORM)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/$(BFN_PLATFORM)"
 
 SONIC_ONLINE_DEBS += $(BFN_PLATFORM)

--- a/platform/barefoot/bfn-sai.mk
+++ b/platform/barefoot/bfn-sai.mk
@@ -1,4 +1,4 @@
-BFN_SAI = bfnsdk_20201009_deb9.deb
+BFN_SAI = bfnsdk_20201023_deb9.deb
 $(BFN_SAI)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/$(BFN_SAI)"
 
 $(BFN_SAI)_DEPENDS += $(LIBNL_GENL3_DEV)


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <akokhan@barefootnetworks.com>

**- Why I did it**
- BFN platform was affected by ACL changes that add IPV6_NEXT_HEADER support.
- Bugfixes

**- How I did it**
- Updated SDK packages to 20201023

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [x] 202006
