### PR TITLE
[201911][sonic-py-common]: Fix syslog implicit min priority override

### DIFF
--- a/src/sonic-py-common/sonic_py_common/daemon_base.py
+++ b/src/sonic-py-common/sonic_py_common/daemon_base.py
@@ -8,9 +8,8 @@ from .logger import Logger
 #
 # Constants ====================================================================
 #
-# Redis DB information
-REDIS_TIMEOUT_MSECS = 0
 
+REDIS_TIMEOUT_MSECS = 0
 
 EEPROM_MODULE_NAME = 'eeprom'
 EEPROM_CLASS_NAME = 'board'
@@ -32,7 +31,11 @@ def db_connect(db_name, namespace=EMPTY_NAMESPACE):
 
 class DaemonBase(Logger):
     def __init__(self, log_identifier):
-        super(DaemonBase, self).__init__(log_identifier, Logger.LOG_FACILITY_DAEMON)
+        super(DaemonBase, self).__init__(
+            log_identifier=log_identifier,
+            log_facility=Logger.LOG_FACILITY_DAEMON,
+            log_option=(Logger.LOG_OPTION_NDELAY | Logger.LOG_OPTION_PID)
+        )
 
         # Register our default signal handlers, unless the signal already has a
         # handler registered, most likely from a subclass implementation

--- a/src/sonic-py-common/sonic_py_common/logger.py
+++ b/src/sonic-py-common/sonic_py_common/logger.py
@@ -11,8 +11,11 @@ class Logger(object):
     """
     Logger class for SONiC Python applications
     """
-    LOG_FACILITY_USER = syslog.LOG_USER
     LOG_FACILITY_DAEMON = syslog.LOG_DAEMON
+    LOG_FACILITY_USER = syslog.LOG_USER
+
+    LOG_OPTION_NDELAY = syslog.LOG_NDELAY
+    LOG_OPTION_PID = syslog.LOG_PID
 
     LOG_PRIORITY_ERROR = syslog.LOG_ERR
     LOG_PRIORITY_WARNING = syslog.LOG_WARNING
@@ -20,21 +23,23 @@ class Logger(object):
     LOG_PRIORITY_INFO = syslog.LOG_INFO
     LOG_PRIORITY_DEBUG = syslog.LOG_DEBUG
 
-    def __init__(self, log_identifier=None, log_facility=LOG_FACILITY_USER):
-        self.syslog = syslog
+    DEFAULT_LOG_FACILITY = syslog.LOG_USER
+    DEFAULT_LOG_OPTION = syslog.LOG_NDELAY
 
-        if not log_identifier:
+    def __init__(self, log_identifier=None, log_facility=DEFAULT_LOG_FACILITY, log_option=DEFAULT_LOG_OPTION):
+        self._syslog = syslog
+
+        if log_identifier is None:
             log_identifier = os.path.basename(sys.argv[0])
 
-        self.syslog.openlog(ident=log_identifier,
-                            logoption=(syslog.LOG_PID | syslog.LOG_NDELAY),
-                            facility=log_facility)
+        # Initialize syslog
+        self._syslog.openlog(ident=log_identifier, logoption=log_option, facility=log_facility)
 
         # Set the default minimum log priority to LOG_PRIORITY_NOTICE
         self.set_min_log_priority(self.LOG_PRIORITY_NOTICE)
 
     def __del__(self):
-        self.syslog.closelog()
+        self._syslog.closelog()
 
     #
     # Methods for setting minimum log priority
@@ -48,7 +53,7 @@ class Logger(object):
         Args:
             priority: The minimum priority at which to log messages
         """
-        self.syslog.setlogmask(self.syslog.LOG_UPTO(priority))
+        self._min_log_priority = priority
 
     def set_min_log_priority_error(self):
         """
@@ -85,10 +90,13 @@ class Logger(object):
     #
 
     def log(self, priority, msg, also_print_to_console=False):
-        self.syslog.syslog(priority, msg)
+        if self._min_log_priority >= priority:
+            # Send message to syslog
+            self._syslog.syslog(priority, msg)
 
-        if also_print_to_console:
-            print(msg)
+            # Send message to console
+            if also_print_to_console:
+                print(msg)
 
     def log_error(self, msg, also_print_to_console=False):
         self.log(self.LOG_PRIORITY_ERROR, msg, also_print_to_console)

--- a/src/sonic-py-common/sonic_py_common/logger.py
+++ b/src/sonic-py-common/sonic_py_common/logger.py
@@ -23,8 +23,8 @@ class Logger(object):
     LOG_PRIORITY_INFO = syslog.LOG_INFO
     LOG_PRIORITY_DEBUG = syslog.LOG_DEBUG
 
-    DEFAULT_LOG_FACILITY = syslog.LOG_USER
-    DEFAULT_LOG_OPTION = syslog.LOG_NDELAY
+    DEFAULT_LOG_FACILITY = LOG_FACILITY_USER
+    DEFAULT_LOG_OPTION = LOG_OPTION_NDELAY
 
     def __init__(self, log_identifier=None, log_facility=DEFAULT_LOG_FACILITY, log_option=DEFAULT_LOG_OPTION):
         self._syslog = syslog


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

Current implementation of logger class is based on standard python syslog library.  
Thus, logger class can be instantiated in different places and share the same context across the entire process.  
This means that reducing log severity level will affect other modules which use logging facility.

**- Why I did it**
* To fix syslog implicit min priority override

**- How I did it**
* Added per instance log severity check

**- How to verify it**
1. Run code snippet
```
from sonic_py_common import logger

log1 = logger.Logger(log_identifier='myApp1')
log1.set_min_log_priority_debug()
log1.log_error("=> this is error")
log1.log_warning("=> this is warning")
log1.log_notice("=> this is notice")
log1.log_info("=> this is info")
log1.log_debug("=> this is debug")

log2 = logger.Logger(
    log_identifier='myApp2',
    log_facility=logger.Logger.LOG_FACILITY_DAEMON,
    log_option=(logger.Logger.LOG_OPTION_NDELAY | logger.Logger.LOG_OPTION_PID)
)
log2.log_error("=> this is error")
log2.log_warning("=> this is warning")
log2.log_notice("=> this is notice")
log2.log_info("=> this is info")
log2.log_debug("=> this is debug")
```
2. Sample output:
```
Oct 23 15:08:30.447301 sonic ERR myApp1: => this is error
Oct 23 15:08:30.447908 sonic WARNING myApp1: => this is warning
Oct 23 15:08:30.448305 sonic NOTICE myApp1: => this is notice
Oct 23 15:08:30.448696 sonic INFO myApp1: => this is info
Oct 23 15:08:30.449063 sonic DEBUG myApp1: => this is debug

Oct 23 15:08:30.449442 sonic ERR myApp2[19178]: => this is error
Oct 23 15:08:30.449819 sonic WARNING myApp2[19178]: => this is warning
Oct 23 15:08:30.450183 sonic NOTICE myApp2[19178]: => this is notice
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Closes #5684 

**- A picture of a cute animal (not mandatory but encouraged)**
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```