### PR TITLE
[syncd]: install libzmq5 in syncd docker

### DIFF
--- a/dockers/docker-base-buster/Dockerfile.j2
+++ b/dockers/docker-base-buster/Dockerfile.j2
@@ -71,7 +71,9 @@ RUN apt-get update &&        \
         python-setuptools    \
         python-wheel         \
 # for processing/handling json files in bash environment
-        jq
+        jq                   \
+# for sairedis zmq rpc channel
+        libzmq5
 
 # Install redis-tools
 RUN curl -o redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"

--- a/dockers/docker-base-stretch/Dockerfile.j2
+++ b/dockers/docker-base-stretch/Dockerfile.j2
@@ -63,7 +63,9 @@ RUN apt-get update &&        \
         python-setuptools    \
         python-wheel         \
 # for processing json files in bash environment
-        jq
+        jq                   \
+# for sairedis zmq rpc channel
+        libzmq5
 
 # Install a newer version of rsyslog from stretch-backports to support -iNONE
 RUN apt-get -y -t stretch-backports install rsyslog


### PR DESCRIPTION
syncd support use zmq as rpc channel

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
syncd support use zmq as rpc channel

**- How I did it**
install libzmq5 in syncd docker

**- How to verify it**
install libzmq5 in vs syncd docker

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
