### PR TITLE
[201911] Fix to remove the import of APIClient

### DIFF
--- a/files/image_config/misc/docker-wait-any
+++ b/files/image_config/misc/docker-wait-any
@@ -29,10 +29,9 @@
 import argparse
 import sys
 import threading
-from docker import Client
 import time
 
-from docker import APIClient
+from docker import Client
 from sonic_py_common import logger, device_info
 
 SYSLOG_IDENTIFIER = 'docker-wait-any'


### PR DESCRIPTION
**- Why I did it**

Getting the following error in 201911 branch 

Oct 27 00:30:20.120613 str-msn2700-02 INFO swss.sh[3928]: Traceback (most recent call last):
Oct 27 00:30:20.121455 str-msn2700-02 INFO swss.sh[3928]:   File "/usr/bin/docker-wait-any", line 35, in <module>
Oct 27 00:30:20.122256 str-msn2700-02 INFO swss.sh[3928]:     from docker import APIClient
Oct 27 00:30:20.123295 str-msn2700-02 INFO swss.sh[3928]: ImportError: cannot import name APIClient

There is a difference between the docker Python package in master and 201911 (via an earlier PR  (https://github.com/Azure/sonic-buildimage/commit/aec51c8aafbbb3d745a6a669ddc532245455148e)


**- How I did it**
Removed the import of APIClient.

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
