### PR TITLE
Added new method get_back_end_interface_set() to speed up back-end in…

### DIFF
--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -333,16 +333,17 @@ def get_back_end_interface_set(namespace=None):
         if PORT_ROLE in info and info[PORT_ROLE] == INTERNAL_PORT:
             bk_end_intf_list.append(port)
 
-    ns_list = get_namespace_list(namespace)
-    for ns in ns_list:
-        config_db = connect_config_db_for_ns(ns)
-        port_channels = config_db.get_table(PORT_CHANNEL_CFG_DB_TABLE)
-        # a back-end LAG must be configured with all of its member from back-end interfaces.
-        # mixing back-end and front-end interfaces is miss configuration and not allowed.
-        # To determine if a LAG is back-end LAG, just need to check its first member is back-end or not
-        # is sufficient. Note that a user defined LAG may have empty members so the list expansion logic
-        # need to ensure there are members before inspecting member[0].
-        bk_end_intf_list.extend([port_channel for port_channel, lag_info in port_channels.items()\
+    if len(bk_end_intf_list):
+        ns_list = get_namespace_list(namespace)
+        for ns in ns_list:
+            config_db = connect_config_db_for_ns(ns)
+            port_channels = config_db.get_table(PORT_CHANNEL_CFG_DB_TABLE)
+            # a back-end LAG must be configured with all of its member from back-end interfaces.
+            # mixing back-end and front-end interfaces is miss configuration and not allowed.
+            # To determine if a LAG is back-end LAG, just need to check its first member is back-end or not
+            # is sufficient. Note that a user defined LAG may have empty members so the list expansion logic
+            # need to ensure there are members before inspecting member[0].
+            bk_end_intf_list.extend([port_channel for port_channel, lag_info in port_channels.items()\
                                 if 'members' in lag_info and lag_info['members'][0] in bk_end_intf_list])
     a = set()
     a.update(bk_end_intf_list)

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -333,15 +333,16 @@ def get_back_end_interface_set(namespace=None):
         if PORT_ROLE in info and info[PORT_ROLE] == INTERNAL_PORT:
             bk_end_intf_list.append(port)
 
-        ns_list = get_namespace_list(namespace)
-        for ns in ns_list:
-            config_db = connect_config_db_for_ns(ns)
-            port_channels = config_db.get_table(PORT_CHANNEL_CFG_DB_TABLE)
-            for port_channel, lag_info in port_channels.items():
-                if 'members' in lag_info:
-                    members = lag_info['members']
-                    if members[0] in bk_end_intf_list:
-                        bk_end_intf_list.append(port_channel)
+    ns_list = get_namespace_list(namespace)
+    for ns in ns_list:
+        config_db = connect_config_db_for_ns(ns)
+        port_channels = config_db.get_table(PORT_CHANNEL_CFG_DB_TABLE)
+        for port_channel, lag_info in port_channels.items():
+            if 'members' in lag_info:
+                members = lag_info['members']
+                if members[0] in bk_end_intf_list:
+                    bk_end_intf_list.append(port_channel)
+
     a = set()
     a.update(bk_end_intf_list)
     return a

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -321,6 +321,30 @@ def is_port_channel_internal(port_channel, namespace=None):
 
     return False
 
+# Allow user to get a set() of back-end interface and back-end LAG per namespace
+# default is getting it for all name spaces if no namespace is specified
+def get_back_end_interface_set(namespace=None):
+    bk_end_intf_list =[]
+    if not is_multi_asic():
+        return None
+
+    port_table = get_port_table(namespace)
+    for port, info in port_table.items():
+        if PORT_ROLE in info and info[PORT_ROLE] == INTERNAL_PORT:
+            bk_end_intf_list.append(port)
+
+        ns_list = get_namespace_list(namespace)
+        for ns in ns_list:
+            config_db = connect_config_db_for_ns(ns)
+            port_channels = config_db.get_table(PORT_CHANNEL_CFG_DB_TABLE)
+            for port_channel, lag_info in port_channels.items():
+                if 'members' in lag_info:
+                    members = lag_info['members']
+                    if members[0] in bk_end_intf_list:
+                        bk_end_intf_list.append(port_channel)
+    a = set()
+    a.update(bk_end_intf_list)
+    return a
 
 def is_bgp_session_internal(bgp_neigh_ip, namespace=None):
 

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -337,12 +337,13 @@ def get_back_end_interface_set(namespace=None):
     for ns in ns_list:
         config_db = connect_config_db_for_ns(ns)
         port_channels = config_db.get_table(PORT_CHANNEL_CFG_DB_TABLE)
-        for port_channel, lag_info in port_channels.items():
-            if 'members' in lag_info:
-                members = lag_info['members']
-                if members[0] in bk_end_intf_list:
-                    bk_end_intf_list.append(port_channel)
-
+        # a back-end LAG must be configured with all of its member from back-end interfaces.
+        # mixing back-end and front-end interfaces is miss configuration and not allowed.
+        # To determine if a LAG is back-end LAG, just need to check its first member is back-end or not
+        # is sufficient. Note that a user defined LAG may have empty members so the list expansion logic
+        # need to ensure there are members before inspecting member[0].
+        bk_end_intf_list.extend([port_channel for port_channel, lag_info in port_channels.items()\
+                                if 'members' in lag_info and lag_info['members'][0] in bk_end_intf_list])
     a = set()
     a.update(bk_end_intf_list)
     return a


### PR DESCRIPTION
…terface check by cache the back-end intf set instead of each time need to read from redis DB

**- Why I did it**
For Multi-Asic if the caller needs to determine whether  an interface (port or LAG) involved is one of the back-end ASIC interface, it calls "skip_display()" which access the config DB in order to determine the interface's role.  This can not scale if the caller is repeatedly doing this in a scale environment such as handling "show ip route" that needs to filter out all back-end interfaces for each name spaces that contains many thousands of routes.  This new method was implemented to cache the output of interface's role into a set so that the user can refer to the set to do its filtering operation thus able to handle scale cases efficiently.

**- How I did it**
The new method read out from configDB based on the namespace given (default is all name spaces) and cache all backe-end interfaces into a set.  It also walk through all the LAGs of the given namespace and add to the same set if any of its member port is a back-end interface.

**- How to verify it**
Manual testing was done to dumpout the set content to validate that all members of the set are back-end interfaces and back-end LAGs.

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
Added new method to get the back-end interfaces to support multi-asic functionalities. This method will be used by "show ip(ipv6) route" multi-asic support

