### PR TITLE
[initramfs] Adding i2c-dev module in initramfs

### DIFF
--- a/files/initramfs-tools/modules
+++ b/files/initramfs-tools/modules
@@ -4,3 +4,4 @@ vfat
 nls_ascii
 nls_cp437
 nls_utf8
+i2c-dev

--- a/files/initramfs-tools/modules.arm
+++ b/files/initramfs-tools/modules.arm
@@ -5,3 +5,4 @@ m25p80
 ubi
 ubifs
 squashfs
+i2c-dev


### PR DESCRIPTION
Signed-off-by: Sabareesh Kumar A <sanandan@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
i2c-dev driver module is needed for accessing transceiver eeprom in some marvell devices. so, I have included i2c-dev module in initramfs
**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
