### PR TITLE
Load config after subscribe

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -239,6 +239,8 @@ class HostConfigDaemon:
         # Cache the values of 'state' field in 'FEATURE' table of each container
         self.cached_feature_states = {}
 
+        self.is_multi_npu = device_info.is_multi_npu()
+
 
     def load(self):
         aaa = self.config_db.get_table('AAA')
@@ -249,7 +251,6 @@ class HostConfigDaemon:
         lpbk_table = self.config_db.get_table('LOOPBACK_INTERFACE')
         self.iptables.load(lpbk_table)
 
-        self.is_multi_npu = device_info.is_multi_npu()
 
     def update_feature_state(self, feature_name, state, feature_table):
         has_timer = ast.literal_eval(feature_table[feature_name].get('has_timer', 'False'))

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -233,17 +233,23 @@ class HostConfigDaemon:
         self.config_db = ConfigDBConnector()
         self.config_db.connect(wait_for_init=True, retry_on=True)
         syslog.syslog(syslog.LOG_INFO, 'ConfigDB connect success')
+
+        self.aaacfg = AaaCfg()
+        self.iptables = Iptables()
+        # Cache the values of 'state' field in 'FEATURE' table of each container
+        self.cached_feature_states = {}
+
+
+    def load(self):
         aaa = self.config_db.get_table('AAA')
         tacacs_global = self.config_db.get_table('TACPLUS')
         tacacs_server = self.config_db.get_table('TACPLUS_SERVER')
-        self.aaacfg = AaaCfg()
         self.aaacfg.load(aaa, tacacs_global, tacacs_server)
+
         lpbk_table = self.config_db.get_table('LOOPBACK_INTERFACE')
-        self.iptables = Iptables()
         self.iptables.load(lpbk_table)
+
         self.is_multi_npu = device_info.is_multi_npu()
-        # Cache the values of 'state' field in 'FEATURE' table of each container
-        self.cached_feature_states = {}
 
     def update_feature_state(self, feature_name, state, feature_table):
         has_timer = ast.literal_eval(feature_table[feature_name].get('has_timer', 'False'))
@@ -367,14 +373,19 @@ class HostConfigDaemon:
             self.update_feature_state(feature_name, state, feature_table)
 
     def start(self):
-        # Update all feature states once upon starting
-        self.update_all_feature_states()
 
         self.config_db.subscribe('AAA', lambda table, key, data: self.aaa_handler(key, data))
         self.config_db.subscribe('TACPLUS_SERVER', lambda table, key, data: self.tacacs_server_handler(key, data))
         self.config_db.subscribe('TACPLUS', lambda table, key, data: self.tacacs_global_handler(key, data))
         self.config_db.subscribe('LOOPBACK_INTERFACE', lambda table, key, data: self.lpbk_handler(key, data))
         self.config_db.subscribe('FEATURE', lambda table, key, data: self.feature_state_handler(key, data))
+
+        # Defer load until subscribe
+        self.load()
+
+        # Update all feature states once upon starting
+        self.update_all_feature_states()
+
         self.config_db.listen()
 
 

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -380,11 +380,11 @@ class HostConfigDaemon:
         self.config_db.subscribe('LOOPBACK_INTERFACE', lambda table, key, data: self.lpbk_handler(key, data))
         self.config_db.subscribe('FEATURE', lambda table, key, data: self.feature_state_handler(key, data))
 
-        # Defer load until subscribe
-        self.load()
-
         # Update all feature states once upon starting
         self.update_all_feature_states()
+
+        # Defer load until subscribe
+        self.load()
 
         self.config_db.listen()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The update_all_feature_states can run in the range of 20+ seconds to one minute. With load of AAA & Tacacs preceding it, any DB updates in AAA/TACACS during the long running feature updates would get missed. To avoid, switch the order.

**- How I did it**
Do a load after after updating all feature states. 

**- How to verify it**
Not a easy one
Have a script that 
   restart hostcfgd
   sleep 2s
   run redis-cli/config command to update AAA/TACACS table

Run the script above and watch the file /etc/pam.d/common-auth-sonic for a minute.

***_When it repro:
The updates will not reflect in /etc/pam.d/common-auth-sonic 

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
