### PR TITLE
[minigraph.py]: Parse IP-in-IP tunnels from minigraph

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import calendar
-from ipaddress import IPv4Address, ip_address
+from ipaddress import IPv4Address, IPv4Network, ip_address, ip_network
 import math
 import os
 import sys
@@ -1227,8 +1227,9 @@ def get_tunnel_entries(tunnel_intfs, lo_intfs, hostname):
     lo_addr = ''
     # Use the first IPv4 loopback as the tunnel destination IP
     for addr in lo_intfs.keys():
-        if "." in addr[1]:
-            lo_addr = addr[1]
+        ip_addr = ip_network(UNICODE_TYPE(addr[1]))
+        if isinstance(ip_addr, IPv4Network):
+            lo_addr = str(ip_addr.network_address)
             break
 
     tunnels = {}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1146,14 +1146,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     results['VLAN'] = vlans
     results['VLAN_MEMBER'] = vlan_members
 
-    tunnels = {}
-    for type, tunnel_dict in tunnel_intfs.items():
-        if type == "IPInIP":
-            for tunnel_key, tunnel_attr in tunnel_dict.items():
-                tunnel_attr['dst_ip'] = devices[hostname]['lo_addr']
-                tunnels[tunnel_key] = tunnel_attr
-
-    results['TUNNEL_TABLE'] = tunnels
+    results['TUNNEL_TABLE'] = get_ipinip_tunnels(tunnel_intfs, devices, hostname)
 
     for nghbr in list(neighbors.keys()):
         # remove port not in port_config.ini
@@ -1221,6 +1214,15 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_members, devices)
 
     return results
+
+def get_ipinip_tunnels(tunnel_intfs, devices, hostname):
+    tunnels = {}
+    for type, tunnel_dict in tunnel_intfs.items():
+        if type == "IPInIP":
+            for tunnel_key, tunnel_attr in tunnel_dict.items():
+                tunnel_attr['dst_ip'] = devices[hostname]['lo_addr']
+                tunnels[tunnel_key] = tunnel_attr
+    return tunnels
 
 
 def parse_device_desc_xml(filename):

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -481,7 +481,7 @@ def parse_dpg(dpg, hname):
                 tunnelintfs[mg_tunnel.attrib["Type"]]["MUX_TUNNEL_{}".format(tunnel_num)] = {
                     "tunnel_type": mg_tunnel.attrib["Type"].upper(),
                     "encap_ecn_mode": mg_tunnel.attrib["EcnEncapsulationMode"],
-                    "decap_ecn_mode": mg_tunnel.attrib["EcnDecapsulationMode"],
+                    "ecn_mode": mg_tunnel.attrib["EcnDecapsulationMode"],
                     "dscp_mode": mg_tunnel.attrib["DifferentiatedServicesCodePointMode"],
                     "ttl_mode": mg_tunnel.attrib["TtlMode"]
                 }
@@ -1146,7 +1146,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     results['VLAN'] = vlans
     results['VLAN_MEMBER'] = vlan_members
 
-    results['TUNNEL_TABLE'] = get_ipinip_tunnels(tunnel_intfs, devices, hostname)
+    results['TUNNEL'] = get_ipinip_tunnels(tunnel_intfs, devices, hostname)
 
     for nghbr in list(neighbors.keys()):
         # remove port not in port_config.ini

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -259,6 +259,9 @@
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>25.1.1.10</d5p1:IPPrefix>
         </Address>
+        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+          <a:IPPrefix>10.7.0.196/26</a:IPPrefix>
+        </ManagementAddress>
         <Hostname>switch2-t0</Hostname>
         <HwSku>Force10-S6000</HwSku>
       </Device>

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -126,6 +126,9 @@
           <SubInterface/>
         </PortChannel>
       </PortChannelInterfaces>
+      <TunnelInterfaces>
+        <TunnelInterface Name="MuxTunnel0" Type="IPInIP" AttachTo="Loopback0" DifferentiatedServicesCodePointMode="uniform" EcnEncapsulationMode="standard" EcnDecapsulationMode="copy_from_outer" TtlMode="pipe" />
+      </TunnelInterfaces>
       <VlanInterfaces>
         <VlanInterface>
           <Name>ab1</Name>
@@ -232,10 +235,31 @@
         <StartPort>U</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
+      <DeviceLinkBase i:type="LogicalLink">
+        <ElementType>LogicalLink</ElementType>
+        <Bandwidth>0</Bandwidth>
+        <ChassisInternal>false</ChassisInternal>
+        <EndDevice>switch-t0</EndDevice>
+        <EndPort>MuxTunnel0</EndPort>
+        <FlowControl>false</FlowControl>
+        <StartDevice>switch2-t0</StartDevice>
+        <StartPort>MuxTunnel0</StartPort>
+        <Validate>true</Validate>
+      </DeviceLinkBase>
     </DeviceInterfaceLinks>
     <Devices>
       <Device i:type="ToRRouter">
+        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>26.1.1.10</d5p1:IPPrefix>
+        </Address>
         <Hostname>switch-t0</Hostname>
+        <HwSku>Force10-S6000</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>25.1.1.10</d5p1:IPPrefix>
+        </Address>
+        <Hostname>switch2-t0</Hostname>
         <HwSku>Force10-S6000</HwSku>
       </Device>
       <Device i:type="LeafRouter">
@@ -252,6 +276,31 @@
       </Device>
     </Devices>
   </PngDec>
+<LinkMetadataDeclaration>
+  <Link xmlns:d3p1="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+    <d3p1:LinkMetadata>
+        <d3p1:Name i:nil="true" />
+        <d3p1:Properties>
+          <d3p1:DeviceProperty>
+            <d3p1:Name>DevicePeeringLink</d3p1:Name>
+            <d3p1:Reference i:nil="true" />
+            <d3p1:Value>True</d3p1:Value>
+          </d3p1:DeviceProperty>
+          <d3p1:DeviceProperty>
+            <d3p1:Name>UpperTOR</d3p1:Name>
+            <d3p1:Reference i:nil="true" />
+            <d3p1:Value>switch-t0</d3p1:Value>
+          </d3p1:DeviceProperty>
+          <d3p1:DeviceProperty>
+            <d3p1:Name>LowerTOR</d3p1:Name>
+            <d3p1:Reference i:nil="true" />
+            <d3p1:Value>switch2-t0</d3p1:Value>
+          </d3p1:DeviceProperty>
+        </d3p1:Properties>
+        <d3p1:Key>switch2-t0:MuxTunnel0;switch-t0:MuxTunnel0</d3p1:Key>
+      </d3p1:LinkMetadata>
+  </Link>
+</LinkMetadataDeclaration>
 <MetadataDeclaration>
  <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
   <a:DeviceMetadata>
@@ -372,6 +421,6 @@
       </ManagementInterfaces>
     </DeviceInfo>
   </DeviceInfos>
-  <Hostname>switch-T0</Hostname>
+  <Hostname>switch-t0</Hostname>
   <HwSku>Force10-S6000</HwSku>
 </DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -187,14 +187,16 @@ class TestCfgGenCaseInsensitive(TestCase):
 
     def test_minigraph_tunnel_table(self):
         result = minigraph.parse_xml(self.sample_graph, self.port_config)
-        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "TUNNEL_TABLE[\'MUX_TUNNEL_0\']"'
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "TUNNEL_TABLE"'
         expected_tunnel = {
-            "tunnel_type": "IPINIP",
-            "dst_ip": "26.1.1.10",
-            "dscp_mode": "uniform",
-            "encap_ecn_mode": "standard",
-            "decap_ecn_mode": "copy_from_outer",
-            "ttl_mode": "pipe"
+            "MUX_TUNNEL_0": {
+                "tunnel_type": "IPINIP",
+                "dst_ip": "26.1.1.10",
+                "dscp_mode": "uniform",
+                "encap_ecn_mode": "standard",
+                "decap_ecn_mode": "copy_from_outer",
+                "ttl_mode": "pipe"
+            }
         }
 
         output = self.run_script(argument)

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -170,3 +170,21 @@ class TestCfgGenCaseInsensitive(TestCase):
                 self.assertTrue(port["mux_cable"])
             else:
                 self.assertTrue("mux_cable" not in port)
+
+    def test_minigraph_tunnel_table(self):
+        result = minigraph.parse_xml(self.sample_graph, self.port_config)
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "TUNNEL_TABLE[\'MUX_TUNNEL_0\']"'
+        expected_tunnel = {
+            "tunnel_type": "IPINIP",
+            "dst_ip": "26.1.1.10",
+            "dscp_mode": "uniform",
+            "encap_ecn_mode": "standard",
+            "decap_ecn_mode": "copy_from_outer",
+            "ttl_mode": "pipe"
+        }
+
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            expected_tunnel
+        )

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -187,14 +187,14 @@ class TestCfgGenCaseInsensitive(TestCase):
 
     def test_minigraph_tunnel_table(self):
         result = minigraph.parse_xml(self.sample_graph, self.port_config)
-        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "TUNNEL_TABLE"'
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "TUNNEL"'
         expected_tunnel = {
             "MUX_TUNNEL_0": {
                 "tunnel_type": "IPINIP",
                 "dst_ip": "26.1.1.10",
                 "dscp_mode": "uniform",
                 "encap_ecn_mode": "standard",
-                "decap_ecn_mode": "copy_from_outer",
+                "ecn_mode": "copy_from_outer",
                 "ttl_mode": "pipe"
             }
         }

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -186,12 +186,11 @@ class TestCfgGenCaseInsensitive(TestCase):
                 self.assertTrue("mux_cable" not in port)
 
     def test_minigraph_tunnel_table(self):
-        result = minigraph.parse_xml(self.sample_graph, self.port_config)
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "TUNNEL"'
         expected_tunnel = {
             "MuxTunnel0": {
                 "tunnel_type": "IPINIP",
-                "dst_ip": "10.1.0.32/32",
+                "dst_ip": "10.1.0.32",
                 "dscp_mode": "uniform",
                 "encap_ecn_mode": "standard",
                 "ecn_mode": "copy_from_outer",

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -189,9 +189,9 @@ class TestCfgGenCaseInsensitive(TestCase):
         result = minigraph.parse_xml(self.sample_graph, self.port_config)
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "TUNNEL"'
         expected_tunnel = {
-            "MUX_TUNNEL_0": {
+            "MuxTunnel0": {
                 "tunnel_type": "IPINIP",
-                "dst_ip": "26.1.1.10",
+                "dst_ip": "10.1.0.32/32",
                 "dscp_mode": "uniform",
                 "encap_ecn_mode": "standard",
                 "ecn_mode": "copy_from_outer",

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -121,7 +121,21 @@ class TestCfgGenCaseInsensitive(TestCase):
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
-            utils.to_dict("{'switch-01t1': {'lo_addr': '10.1.0.186/32', 'mgmt_addr': '10.7.0.196/26', 'hwsku': 'Force10-S6000', 'type': 'LeafRouter', 'deployment_id': '2'}}")
+            utils.to_dict("{" \
+                "'switch-01t1': {" \
+                    "'lo_addr': '10.1.0.186/32'," \
+                    "'mgmt_addr': '10.7.0.196/26'," \
+                    "'hwsku': 'Force10-S6000'," \
+                    "'type': 'LeafRouter'," \
+                    "'deployment_id': '2'" \
+                "}," \
+                "'switch2-t0': {" \
+                    "'hwsku': 'Force10-S6000'," \
+                    "'lo_addr': '25.1.1.10'," \
+                    "'mgmt_addr': '10.7.0.196/26'," \
+                    "'type': 'ToRRouter'" \
+                "}" \
+            "}")
         )
 
 #     everflow portion is not used


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
IP-in-IP tunnel support
**- How I did it**
Take tunnel info from `<TunnelInterface>` tag in minigraph, and create tables in config_DB:
```
"TUNNEL": {
    "MUX_TUNNEL_0": {
        "tunnel_type": "IPINIP",
        "dst_ip": "26.1.1.10",
        "dscp_mode": "uniform",
        "encap_ecn_mode": "standard",
        "ecn_mode": "copy_from_outer",
        "ttl_mode": "pipe"
    }
}
```
**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
