### PR TITLE
Upgrade pip2 after upgrading pip3

### DIFF
--- a/dockers/docker-config-engine-buster/Dockerfile.j2
+++ b/dockers/docker-config-engine-buster/Dockerfile.j2
@@ -15,8 +15,8 @@ RUN apt-get update         && \
         python-setuptools     \
         python3-setuptools
 
-RUN pip2 install --upgrade pip
 RUN pip3 install --upgrade pip
+RUN pip2 install --upgrade pip
 RUN apt-get purge -y python-pip python3-pip
 
 # For sonic-config-engine Python 3 package

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -334,8 +334,8 @@ RUN export VERSION=1.14.2 \
  && echo 'export PATH=$PATH:$GOROOT/bin' >> /etc/bash.bashrc \
  && rm go$VERSION.linux-*.tar.gz
 
-RUN pip2 install --upgrade pip
 RUN pip3 install --upgrade pip
+RUN pip2 install --upgrade pip
 RUN apt-get purge -y python-pip python3-pip
 
 # For building Python packages

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -330,8 +330,8 @@ RUN export VERSION=1.14.2 \
  && echo 'export PATH=$PATH:$GOROOT/bin' >> /etc/bash.bashrc \
  && rm go$VERSION.linux-*.tar.gz
 
-RUN pip2 install --upgrade pip
 RUN pip3 install --upgrade pip
+RUN pip2 install --upgrade pip
 RUN apt-get purge -y python-pip python3-pip
 
 # For p4 build


### PR DESCRIPTION
Upgrading pip3 after pip2 caused the `pip` command to be aliased to the `pip3` command. However, since we are still transitioning from Python 2 to Python 3, most `pip` commands in the codebase are expecting `pip` to alias to `pip2`. The proper solution here is to explicitly call `pip2` and `pip3`, and no longer call `pip`, however this will require extensive changes and testing, so to quickly fix this issue, we upgraded pip2 after pip3 to ensure that pip2 is installed after pip3.

**- Why I did it**
Fix issues introduced via https://github.com/Azure/sonic-buildimage/pull/5656

**- How I did it**

Upgrade pip2 after pip3 in slave containers and config engine container.

**- How to verify it**

Ensure image builds are all containers start properly

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006