### PR TITLE
[multi-ASIC] util changes with the BGP_INTERNAL_NEIGHBOR table.

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
@@ -3,6 +3,11 @@
 !
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
+{# set the bgp neighbor timers if they have not default values #}
+{% if     (bgp_session['keepalive'] is defined and bgp_session['keepalive'] | int != 60)
+      or  (bgp_session['holdtime'] is defined  and bgp_session['holdtime']  | int != 180) %}
+  neighbor {{ neighbor_addr }} timers {{ bgp_session['keepalive'] | default("60") }} {{ bgp_session['holdtime'] | default("180") }}
+{% endif %}
 !
 {% if neighbor_addr | ipv4 %}
   address-family ipv4

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
@@ -3,11 +3,7 @@
 !
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
-{# set the bgp neighbor timers if they have not default values #}
-{% if     (bgp_session['keepalive'] is defined and bgp_session['keepalive'] | int != 60)
-      or  (bgp_session['holdtime'] is defined  and bgp_session['holdtime']  | int != 180) %}
-  neighbor {{ neighbor_addr }} timers {{ bgp_session['keepalive'] | default("60") }} {{ bgp_session['holdtime'] | default("180") }}
-{% endif %}
+  neighbor {{ neighbor_addr }} timers 3 10
 !
 {% if neighbor_addr | ipv4 %}
   address-family ipv4

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v4.conf
@@ -4,7 +4,6 @@
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
   neighbor 10.10.10.10 timers 5 30
-  neighbor 10.10.10.10 shutdown
   address-family ipv4
     neighbor 10.10.10.10 peer-group INTERNAL_PEER_V4
     neighbor 10.10.10.10 route-map FROM_BGP_INTERNAL_PEER_V4 in

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v4.conf
@@ -3,7 +3,7 @@
 !
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
-  neighbor 10.10.10.10 timers 5 30
+  neighbor 10.10.10.10 timers 3 10
   address-family ipv4
     neighbor 10.10.10.10 peer-group INTERNAL_PEER_V4
     neighbor 10.10.10.10 route-map FROM_BGP_INTERNAL_PEER_V4 in

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v6.conf
@@ -4,7 +4,6 @@
   neighbor fc::10 remote-as 555
   neighbor fc::10 description remote_peer
   neighbor fc::10 timers 5 30
-  neighbor fc::10 shutdown
   address-family ipv6
     neighbor fc::10 peer-group INTERNAL_PEER_V6
     neighbor fc::10 route-map FROM_BGP_INTERNAL_PEER_V6 in

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v6.conf
@@ -3,7 +3,7 @@
 !
   neighbor fc::10 remote-as 555
   neighbor fc::10 description remote_peer
-  neighbor fc::10 timers 5 30
+  neighbor fc::10 timers 3 10
   address-family ipv6
     neighbor fc::10 peer-group INTERNAL_PEER_V6
     neighbor fc::10 route-map FROM_BGP_INTERNAL_PEER_V6 in

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v4.conf
@@ -3,7 +3,7 @@
 !
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
-  neighbor 10.10.10.10 timers 5 30
+  neighbor 10.10.10.10 timers 3 10
   address-family ipv4
     neighbor 10.10.10.10 peer-group INTERNAL_PEER_V4
     neighbor 10.10.10.10 next-hop-self force

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v4.conf
@@ -4,7 +4,6 @@
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
   neighbor 10.10.10.10 timers 5 30
-  neighbor 10.10.10.10 shutdown
   address-family ipv4
     neighbor 10.10.10.10 peer-group INTERNAL_PEER_V4
     neighbor 10.10.10.10 next-hop-self force

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v6.conf
@@ -4,7 +4,6 @@
   neighbor fc::10 remote-as 555
   neighbor fc::10 description remote_peer
   neighbor fc::10 timers 5 30
-  neighbor fc::10 shutdown
   address-family ipv6
     neighbor fc::10 peer-group INTERNAL_PEER_V6
     neighbor fc::10 next-hop-self force

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v6.conf
@@ -3,7 +3,7 @@
 !
   neighbor fc::10 remote-as 555
   neighbor fc::10 description remote_peer
-  neighbor fc::10 timers 5 30
+  neighbor fc::10 timers 3 10
   address-family ipv6
     neighbor fc::10 peer-group INTERNAL_PEER_V6
     neighbor fc::10 next-hop-self force

--- a/src/sonic-bgpcfgd/tests/test_templates.py
+++ b/src/sonic-bgpcfgd/tests/test_templates.py
@@ -104,6 +104,18 @@ def test_general_instance():
     test_data = load_tests("general", "instance.conf")
     run_tests("general_instance", *test_data)
 
+def test_internal_policies():
+    test_data = load_tests("internal", "policies.conf")
+    run_tests("internal_policies", *test_data)
+
+def test_internal_pg():
+    test_data = load_tests("internal", "peer-group.conf")
+    run_tests("internal_pg", *test_data)
+
+def test_internal_instance():
+    test_data = load_tests("internal", "instance.conf")
+    run_tests("internal_instance", *test_data)
+
 def test_dynamic_policies():
     test_data = load_tests("dynamic", "policies.conf")
     run_tests("dynamic_policies", *test_data)

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -21,6 +21,7 @@ INTERNAL_PORT = 'Int'
 PORT_CHANNEL_CFG_DB_TABLE = 'PORTCHANNEL'
 PORT_CFG_DB_TABLE = 'PORT'
 BGP_NEIGH_CFG_DB_TABLE = 'BGP_NEIGHBOR'
+BGP_INTERNAL_NEIGH_CFG_DB_TABLE = 'BGP_INTERNAL_NEIGHBOR'
 NEIGH_DEVICE_METADATA_CFG_DB_TABLE = 'DEVICE_NEIGHBOR_METADATA'
 DEFAULT_NAMESPACE = ''
 PORT_ROLE = 'role'
@@ -332,20 +333,10 @@ def is_bgp_session_internal(bgp_neigh_ip, namespace=None):
     for ns in ns_list:
 
         config_db = connect_config_db_for_ns(ns)
-        bgp_sessions = config_db.get_table(BGP_NEIGH_CFG_DB_TABLE)
-        if bgp_neigh_ip not in bgp_sessions:
-            continue
-
-        bgp_neigh_name = bgp_sessions[bgp_neigh_ip]['name']
-        neighbor_metadata = config_db.get_table(
-            NEIGH_DEVICE_METADATA_CFG_DB_TABLE)
-
-        if ((neighbor_metadata) and
-            (neighbor_metadata[bgp_neigh_name]['type'].lower() ==
-             ASIC_NAME_PREFIX)):
+        bgp_sessions = config_db.get_table(BGP_INTERNAL_NEIGH_CFG_DB_TABLE)
+        if bgp_neigh_ip in bgp_sessions:
             return True
-        else:
-            return False
+
     return False
 
 def get_front_end_namespaces():


### PR DESCRIPTION
**- Why I did it**
Update the routine is_bgp_session_internal() by checking the BGP_INTERNAL_NEIGHBOR table. 
Additionally to address the review comment https://github.com/Azure/sonic-buildimage/pull/5520#discussion_r513721041
Add timer settings as will in the internal session templates and keep it minimal as these sessions which will always be up.
Updates to the internal tests data + add all of it to template tests.

**- How I did it**
Updated the APIs and the template files.

**- How to verify it**
Verified the internal BGP sessions are displayed correctly with show commands with this API is_bgp_session_internal()

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
