### PR TITLE
Revert "[docker-base]: Rate limit priority INFO and lower in syslog"

### DIFF
--- a/dockers/docker-base-buster/etc/rsyslog.conf
+++ b/dockers/docker-base-buster/etc/rsyslog.conf
@@ -12,11 +12,10 @@
 $ModLoad imuxsock # provides support for local system logging
 
 #
-# Set a rate limit on messages from the container of priority INFO or lower (level 6 and above)
+# Set a rate limit on messages from the container
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000
-$SystemLogRateLimitSeverity 6
 
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability

--- a/dockers/docker-base-stretch/etc/rsyslog.conf
+++ b/dockers/docker-base-stretch/etc/rsyslog.conf
@@ -12,11 +12,10 @@
 $ModLoad imuxsock # provides support for local system logging
 
 #
-# Set a rate limit on messages from the container of priority INFO or lower (level 6 and above)
+# Set a rate limit on messages from the container
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000
-$SystemLogRateLimitSeverity 6
 
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability

--- a/dockers/docker-base/etc/rsyslog.conf
+++ b/dockers/docker-base/etc/rsyslog.conf
@@ -16,11 +16,10 @@
 $ModLoad imuxsock # provides support for local system logging
 
 #
-# Set a rate limit on messages from the container of priority INFO or lower (level 6 and above)
+# Set a rate limit on messages from the container
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000
-$SystemLogRateLimitSeverity 6
 
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability

--- a/files/image_config/rsyslog/rsyslog-container.conf.j2
+++ b/files/image_config/rsyslog/rsyslog-container.conf.j2
@@ -12,11 +12,10 @@
 $ModLoad imuxsock # provides support for local system logging
 
 #
-# Set a rate limit on messages from the container of priority INFO or lower (level 6 and above)
+# Set a rate limit on messages from the container
 #
 $SystemLogRateLimitInterval 300
 $SystemLogRateLimitBurst 20000
-$SystemLogRateLimitSeverity 6
 
 #$ModLoad imklog  # provides kernel logging support
 #$ModLoad immark  # provides --MARK-- message capability


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#5666

Since Azure/sonic-sairedis#680 has been merged, this is no longer necessary.