### PR TITLE
[files/build/versions]: support reproduceable build for git

### DIFF
--- a/src/sonic-build-hooks/hooks/git
+++ b/src/sonic-build-hooks/hooks/git
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+parse_config(){
+    . /usr/local/share/buildinfo/scripts/buildinfo_base.sh
+    [ -z $REAL_COMMAND ] && REAL_COMMAND=$(get_command git)
+
+    version_file=$VERSION_PATH/versions-git
+    new_version_file=$BUILD_VERSION_PATH/versions-git
+
+    MODE_CLONE=0
+    # parse input parameters
+    for i in "$@"
+    do
+        if [[ $i == "clone" ]];then
+            MODE_CLONE=1
+        fi
+    done
+}
+
+get_clone_path(){
+    # get paremater of clone path
+    while (( "$#" )); do
+        case $1 in
+            -b|--branch|--reference|--reference-if-able|-c|--config|--origin|-u|--upload-pack|-j|--jobs|--depth|--dissociate)
+                shift 2
+                ;;
+            clone|-l|--local|--no-hardlinks|-s|--shared|--dissociate|-q|--quiet|-v|--verbose|--progress|--server-option=*|--bare|--sparse|--filter=*|--template=*|--mirror|--reference|--shallow-*|--no-tags|--recurse-submodules*|--remote-submodules|--no-remote-submodules|--separate-git-dir*)
+                shift 1
+                ;;
+            *)
+                if [[ $URL == "" ]];then
+                    URL=$1
+                else
+                    clone_PATH=$1
+                fi
+                shift 1
+                ;;
+        esac
+    done
+
+    # if not specific clone path, get default clone path
+    [ -z $clone_PATH ] && clone_PATH=`echo $URL | rev | awk -F/ '{print$1}' | rev | awk -F. '{print$1}'`
+}
+
+main(){
+    parse_config "$@"
+    get_clone_path "$@"
+
+    # execute git.
+    $REAL_COMMAND "$@"
+    result=$?
+
+    # if sub command is not "clone", exit
+    if [[ $MODE_CLONE != 1 ]];then
+        exit $result
+    fi
+
+    pushd $clone_PATH &> /dev/null
+    commit_latest=`$REAL_COMMAND log -n 1 | head -n 1| awk '{print$2}'`
+    [ -f $version_file ] && commit=`grep $URL $version_file | awk -F, '{print$2}'`
+
+    # control version or record version file
+    if [[ $ENABLE_VERSION_CONTROL_GIT == "y" ]];then
+        # control version
+        [ ! -z $commit ] && $REAL_COMMAND reset --hard $commit &> /dev/null
+    else
+        # record version file
+        echo "$URL==$commit_latest" >> $new_version_file
+        sort $new_version_file -o $new_version_file -u &> /dev/null
+    fi
+    popd &> /dev/null
+
+    exit $result
+}
+
+main "$@"

--- a/src/sonic-build-hooks/hooks/git
+++ b/src/sonic-build-hooks/hooks/git
@@ -44,7 +44,6 @@ get_clone_path(){
 
 main(){
     parse_config "$@"
-    get_clone_path "$@"
 
     # execute git.
     $REAL_COMMAND "$@"
@@ -55,6 +54,7 @@ main(){
         exit $result
     fi
 
+    get_clone_path "$@"
     pushd $clone_PATH &> /dev/null
     commit_latest=`$REAL_COMMAND log -n 1 | head -n 1| awk '{print$2}'`
     [ -f $version_file ] && commit=`grep $URL $version_file | awk -F, '{print$2}'`


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Some component's make process need thirdparty source file which is downloaded by "git clone", not using a specific commit. When source file is changed, Build process may fail. 
**- How I did it**
1. Add a version file, files/build/versions/versions-git, to record thirdparty source code version(commit ID).
2. Replace git binary by a bash script. In the script, when 'git clone' is done, 'git reset' will reset HEAD to the commit recorded in the version file.
3. When update version file, you need to set parameter 'SONIC_VERSION_CONTROL_COMPONENTS ' and build. At last replace 'files/build/versions/versions-git' by 'files/build/versions/versions-git-latest'
**- How to verify it**
'files/build/versions/versions-git.log' records some infomation.
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Control thirdparty source code version used by 'git clone'

**- A picture of a cute animal (not mandatory but encouraged)**
