### PR TITLE
[docker-platform-monitor] Explicitly install Python 2 'enum34' package to fix Arista platforms

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -21,6 +21,16 @@ RUN apt-get update &&   \
         dmidecode       \
         i2c-tools
 
+# On Arista devices, the sonic_platform wheel is not installed in the container.
+# Instead, the installation directory is mounted from the host OS. However, this method
+# doesn't ensure all dependencies are installed in the container. So here we
+# install any dependencies required by the Arista sonic_platform package.
+# TODO: eliminate the need to install these explicitly.
+# NOTE: Only install enum34 for Python 2, as our version of Python 3 is 3.7, which
+# contains 'enum' as part of the standard library. Installing enum34 there will
+# cause conflicts.
+RUN pip2 install enum34
+
 {% if docker_platform_monitor_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("debs/", docker_platform_monitor_debs.split(' '), "/debs/") }}


### PR DESCRIPTION
**- Why I did it**

Recent changes to dependencies caused the 'enum34' package to cease being installed for Python 2 in the PMon container. This broke Arista platforms, where the Arista sonic_platform package imports 'enum'. This is because on Arista devices, the sonic_platform wheel is not installed in the container. Instead, the installation directory is mounted from the host OS. However, this method doesn't ensure all dependencies are installed in the container.

**- How I did it**

Install Python 2 'enum34' package explicitly in PMon container for now.

**- How to verify it**
Ensure sonic_platform package functions properly in the PMon container on Arista devices.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006