### PR TITLE
[docker-wait-any] Convert to Python 3, install dependency in host OS

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -414,7 +414,7 @@ done < files/image_config/sysctl/sysctl-net.conf
 sudo augtool --autosave "$sysctl_net_cmd_string" -r $FILESYSTEM_ROOT
 
 # docker Python API package is needed by Ansible docker module as well as some SONiC applications
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install 'docker==4.3.1'
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install 'docker==4.1.0'
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'docker==4.3.1'
 
 ## Note: keep pip installed for maintainance purpose

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -413,13 +413,15 @@ done < files/image_config/sysctl/sysctl-net.conf
 
 sudo augtool --autosave "$sysctl_net_cmd_string" -r $FILESYSTEM_ROOT
 
-## docker Python API package is needed by Ansible docker module
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'docker==4.1.0'
+# docker Python API package is needed by Ansible docker module as well as some SONiC applications
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install 'docker==4.3.1'
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'docker==4.3.1'
+
 ## Note: keep pip installed for maintainance purpose
 
 ## Get gcc and python dev pkgs
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install gcc libpython2.7-dev
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'netifaces==0.10.7'
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install 'netifaces==0.10.7'
 
 ## Create /var/run/redis folder for docker-database to mount
 sudo mkdir -p $FILESYSTEM_ROOT/var/run/redis

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -117,6 +117,9 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install ipaddr
 # Install Python module for psutil
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install psutil
 
+# Install Python 3 library for the Docker Engine API
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install docker==4.3.1
+
 # Install SwSS SDK Python 3 package
 # Note: the scripts will be overwritten by corresponding Python 2 package
 if [ -e {{swsssdk_py3_wheel_path}} ]; then

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -117,9 +117,6 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install ipaddr
 # Install Python module for psutil
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install psutil
 
-# Install Python 3 library for the Docker Engine API
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install docker==4.3.1
-
 # Install SwSS SDK Python 3 package
 # Note: the scripts will be overwritten by corresponding Python 2 package
 if [ -e {{swsssdk_py3_wheel_path}} ]; then

--- a/files/image_config/misc/docker-wait-any
+++ b/files/image_config/misc/docker-wait-any
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
     docker-wait-any
@@ -23,7 +23,7 @@
     cases where we need the dependent container to be warm-restarted without
     affecting other services (eg: warm restart of teamd service)
 
-    NOTE: This script is written against docker Python package 4.1.0. Newer
+    NOTE: This script is written against docker Python package 4.3.1. Newer
     versions of docker may have a different API.
 """
 import argparse
@@ -68,7 +68,6 @@ def main():
     docker_client = APIClient(base_url='unix://var/run/docker.sock')
 
     parser  = argparse.ArgumentParser(description='Wait for dependent docker services',
-                                      version='1.0.0',
                                       formatter_class=argparse.RawTextHelpFormatter,
                                       epilog="""
 Examples:


### PR DESCRIPTION
**- Why I did it**

As part of moving all SONiC code from Python 2 (no longer supported) to Python 3

**- How I did it**

- Convert docker-wait-any script to Python 3
- Install Python 3 Docker Engine API in host OS

**- How to verify it**

Ensure docker-wait-any script still functions correctly

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006