### PR TITLE
[enable_counters.py] Convert to Python 3

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -1,15 +1,18 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+import time
 
 import swsssdk
-import time
+
 
 def enable_counter_group(db, name):
     info = {}
     info['FLEX_COUNTER_STATUS'] = 'enable'
     db.mod_entry("FLEX_COUNTER_TABLE", name, info)
 
+
 def enable_counters():
-    db = swsssdk.ConfigDBConnector()
+    db = swsssdk.ConfigDBConnector(decode_responses=True)
     db.connect()
     enable_counter_group(db, 'PORT')
     enable_counter_group(db, 'RIF')
@@ -20,9 +23,11 @@ def enable_counters():
     enable_counter_group(db, 'BUFFER_POOL_WATERMARK')
     enable_counter_group(db, 'PORT_BUFFER_DROP')
 
+
 def get_uptime():
     with open('/proc/uptime') as fp:
         return float(fp.read().split(' ')[0])
+
 
 def main():
     # If the switch was just started (uptime less than 5 minutes),
@@ -34,6 +39,7 @@ def main():
     else:
         time.sleep(60)
     enable_counters()
+
 
 if __name__ == '__main__':
     main()

--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -12,7 +12,7 @@ def enable_counter_group(db, name):
 
 
 def enable_counters():
-    db = swsssdk.ConfigDBConnector(decode_responses=True)
+    db = swsssdk.ConfigDBConnector()
     db.connect()
     enable_counter_group(db, 'PORT')
     enable_counter_group(db, 'RIF')


### PR DESCRIPTION
**- Why I did it**

As part of moving all SONiC code from Python 2 (no longer supported) to Python 3

**- How I did it**

- Convert enable_counters.py script to Python 3
- Reorganize imports per PEP8 standard
- Two blank lines precede functions per PEP8 standard

**- How to verify it**

Ensure enable_counters.py script still functions correctly

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006