### PR TITLE
[sflow][port_index_mapper.py] Convert to Python 3; Use logger from sonic-py-common for uniform logging

### DIFF
--- a/dockers/docker-sflow/port_index_mapper.py
+++ b/dockers/docker-sflow/port_index_mapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ port_index_mapper
     A mapper service that watches for NetLink NEWLINK and DELLINKs
@@ -9,12 +9,13 @@
 """
 
 import os
-import sys
-import syslog
 import signal
+import sys
 import traceback
+
 from pyroute2 import IPDB
 from pyroute2.iproute import RTM_NEWLINK, RTM_DELLINK
+from sonic_py_common.logger import Logger
 from swsssdk import SonicV2Connector, port_util
 
 PORT_INDEX_TABLE_NAME = 'PORT_INDEX_TABLE'
@@ -23,9 +24,15 @@ SYSLOG_IDENTIFIER = 'port_index_mapper'
 ipdb = None
 state_db = None
 
+# Global logger instance
+logger = Logger(SYSLOG_IDENTIFIER)
+logger.set_min_log_priority_info()
+
+
 def set_port_index_table_entry(key, index, ifindex):
     state_db.set(state_db.STATE_DB, key, 'index', index)
     state_db.set(state_db.STATE_DB, key, 'ifindex', ifindex)
+
 
 def interface_callback(ipdb, nlmsg, action):
     global state_db
@@ -60,21 +67,22 @@ def interface_callback(ipdb, nlmsg, action):
         elif msgtype == RTM_DELLINK:
             state_db.delete(state_db.STATE_DB, _hash)
 
-    except Exception, e:
+    except Exception as e:
         t = sys.exc_info()[2]
         traceback.print_tb(t)
-        syslog.syslog(syslog.LOG_CRIT, "%s" % str(e))
+        logger.log_error(str(e))
         os.kill(os.getpid(), signal.SIGTERM)
+
 
 def main():
     global state_db, ipdb
-    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db = SonicV2Connector(host='127.0.0.1', decode_responses=True)
     state_db.connect(state_db.STATE_DB, False)
 
     ipdb = IPDB()
 
     # Initialize the table at startup.
-    ifnames = ipdb.by_name.keys()
+    ifnames = list(ipdb.by_name.keys())
     for ifname in ifnames:
         index = port_util.get_index_from_str(ifname)
         if index is None:
@@ -87,28 +95,28 @@ def main():
 
     signal.pause()
 
+
 def signal_handler(signum, frame):
-    syslog.syslog(syslog.LOG_NOTICE, "got signal %d" % signum)
+    logger.log_notice("got signal {}".format(signum))
     sys.exit(0)
+
 
 if __name__ == '__main__':
     rc = 0
     try:
-        syslog.openlog(SYSLOG_IDENTIFIER)
         signal.signal(signal.SIGTERM, signal_handler)
         signal.signal(signal.SIGINT, signal_handler)
         main()
-    except Exception, e:
+    except Exception as e:
         t = sys.exc_info()[2]
         traceback.print_tb(t)
-        syslog.syslog(syslog.LOG_CRIT, "%s" % str(e))
+        logger.log_error(str(e))
         rc = -1
     finally:
         if ipdb is not None:
             ipdb.release()
         else:
-            syslog.syslog(syslog.LOG_ERR, "ipdb undefined in signal_handler")
+            logger.log_error("ipdb undefined in signal_handler")
 
-        syslog.closelog()
         sys.exit(rc)
 


### PR DESCRIPTION
**- Why I did it**

As part of moving all SONiC code from Python 2 (no longer supported) to Python 3

**- How I did it**

- Convert port_index_mapper.py script to Python 3
- Use logger from sonic-py-common for uniform logging
- Reorganize imports alphabetically per PEP8 standard
- Two blank lines precede functions per PEP8 standard

**- How to verify it**

Ensure port_index_mapper.py still functions correctly

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006