### PR TITLE
[Arista 7050cx3] add dummy MMU configurations for Arista-7050CX3-32S-C32

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers.json.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers.json.j2
@@ -1,0 +1,2 @@
+{%- set default_topo = 't0' %}
+{%- include 'buffers_config.j2' %}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t0.j2
@@ -1,0 +1,54 @@
+
+{%- set default_cable = '300m' %}
+
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '300m'
+        }
+-%}
+
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(0,64) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx * 4)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "10875072",
+            "type": "ingress",
+            "mode": "dynamic",
+            "xoff": "4194112"
+        },
+        "egress_lossy_pool": {
+            "size": "9243812",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "15982720",
+            "type": "egress",
+            "mode": "static"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"1518",
+            "static_th":"15982720"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"1518",
+            "dynamic_th":"3"
+        }
+    },
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t0.j2
@@ -10,7 +10,7 @@
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
-    {%- for port_idx in range(0,64) %}
+    {%- for port_idx in range(0,32) %}
         {%- if PORT_ALL.append("Ethernet%d" % (port_idx * 4)) %}{%- endif %}
     {%- endfor %}
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t0.j2
@@ -2,8 +2,8 @@
 {%- set default_cable = '300m' %}
 
 {%- set ports2cable = {
-        'torrouter_server'       : '300m',
-        'leafrouter_torrouter'   : '300m',
+        'torrouter_server'       : '5m',
+        'leafrouter_torrouter'   : '40m',
         'spinerouter_leafrouter' : '300m'
         }
 -%}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t1.j2
@@ -1,0 +1,54 @@
+
+{%- set default_cable = '300m' %}
+
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '300m'
+        }
+-%}
+
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(0,64) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx * 4)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "10875072",
+            "type": "ingress",
+            "mode": "dynamic",
+            "xoff": "4194112"
+        },
+        "egress_lossy_pool": {
+            "size": "9243812",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "15982720",
+            "type": "egress",
+            "mode": "static"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"1518",
+            "static_th":"15982720"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"1518",
+            "dynamic_th":"3"
+        }
+    },
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t1.j2
@@ -2,7 +2,7 @@
 {%- set default_cable = '300m' %}
 
 {%- set ports2cable = {
-        'torrouter_server'       : '5mm',
+        'torrouter_server'       : '5m',
         'leafrouter_torrouter'   : '40m',
         'spinerouter_leafrouter' : '300m'
         }
@@ -10,7 +10,7 @@
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}
-    {%- for port_idx in range(0,64) %}
+    {%- for port_idx in range(0,32) %}
         {%- if PORT_ALL.append("Ethernet%d" % (port_idx * 4)) %}{%- endif %}
     {%- endfor %}
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t1.j2
@@ -2,8 +2,8 @@
 {%- set default_cable = '300m' %}
 
 {%- set ports2cable = {
-        'torrouter_server'       : '300m',
-        'leafrouter_torrouter'   : '300m',
+        'torrouter_server'       : '5mm',
+        'leafrouter_torrouter'   : '40m',
         'spinerouter_leafrouter' : '300m'
         }
 -%}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/qos.json.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/qos.json.j2
@@ -1,0 +1,21 @@
+{%- macro generate_wred_profiles() %}
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "2097152",
+            "green_min_threshold"    : "250000",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+{%- endmacro %}
+
+{%- include 'qos_config.j2' %}


### PR DESCRIPTION
**- Why I did it**
On Arista-7050CX3-32S-C32, there are constant stream of errors like following.

Nov  3 21:56:24.415190 str2-7050cx3-acs-06 NOTICE swss#orchagent: :- registerInWdDb: No lossless TC found on port Ethernet68

Which causes:
1. loganalyzer to claim test failed.
2. leaving the system without MMU configuration. Which couldn't be good for any IO test.

**- How I did it**
Added these MMU configuraions are copied from another platform and guaranteed to be incorrect for hwsku Arista-7050CX3-32S-C32.

Adding them so that we have A MMU configuration and the system won't throw a whole bunch of errors and leave MMU unconfigured. The correct MMU configuration will come later.

This configuration is definitely not suitable for testing system performance or QoS behavior.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Test will have  chance to pass, e.g.:
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0001-single_lag] PASSED                                                                                                  [  4%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0001-lacp_rate] PASSED                                                                                                   [  8%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0001-fallback] SKIPPED                                                                                                   [ 12%]
pc/test_lag_2.py::test_lag[str2-7050cx3-acs-06|PortChannel0003-single_lag] PASSED                                                                                                  [ 16%]
