### PR TITLE
[Mellanox] Support max/min speed for PSU fan for 201911 (#5682)

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -1,0 +1,57 @@
+def read_str_from_file(file_path, default='', raise_exception=False):
+    """
+    Read string content from file
+    :param file_path: File path
+    :param default: Default return value if any exception occur
+    :param raise_exception: Raise exception to caller if True else just return default value
+    :return: String content of the file
+    """
+    try:
+        with open(file_path, 'r') as f:
+            value = f.read().strip()
+    except (ValueError, IOError) as e:
+        if not raise_exception:
+            value = default
+        else:
+            raise e
+
+    return value
+
+
+def read_int_from_file(file_path, default=0, raise_exception=False):
+    """
+    Read content from file and cast it to integer
+    :param file_path: File path
+    :param default: Default return value if any exception occur
+    :param raise_exception: Raise exception to caller if True else just return default value
+    :return: Integer value of the file content
+    """
+    try:
+        with open(file_path, 'r') as f:
+            value = int(f.read().strip())
+    except (ValueError, IOError) as e:
+        if not raise_exception:
+            value = default
+        else:
+            raise e
+
+    return value
+
+
+def write_file(file_path, content, raise_exception=False):
+    """
+    Write the given value to a file
+    :param file_path: File path
+    :param content: Value to write to the file
+    :param raise_exception: Raise exception to caller if True
+    :return: True if write success else False
+    """
+    try:
+        with open(file_path, 'w') as f:
+            f.write(str(content))
+    except (ValueError, IOError) as e:
+        if not raise_exception:
+            return False
+        else:
+            raise e
+    return True


### PR DESCRIPTION
Cherry-pick Azure#5682 to 201911

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

As new hw-mgmt expose the sysfs for PSU fan max speed, we need support max/min speed for PSU fan in mellanox platform API.

**- How I did it**

Read the max fan speed from sysfs.

**- How to verify it**

Manual test and run existing regression.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
