### PR TITLE
DellEMC S6100: Update reboot-cause determination to support new firmware

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/track_reboot_reason.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/track_reboot_reason.sh
@@ -34,6 +34,7 @@ if [[ -d /host/reboot-cause/platform ]]; then
     fi
 fi
 
+SMF_FPGA_VERSION=$((16#$(io_rd_wr.py --get --offset 0x200 | cut -d " " -f 3)))
 SMF_BIOS_REG=$(io_rd_wr.py --get --offset 0x203 | cut -d " " -f 3)
 SMF_BIOS_REG=$((16#$SMF_BIOS_REG))
 bios_secondary_boot=$(($SMF_BIOS_REG & 1))
@@ -143,27 +144,46 @@ update_mailbox_register(){
 
     _get_smf_reset_register
     if [[ -d /sys/devices/platform/SMF.512/hwmon/ ]]; then
-        is_thermal_reboot=$(_is_thermal_reset)
-
-        is_wd_reboot=$(_is_watchdog_reset)
-
         por=$(cat $SMF_POWERON_REASON)
         rst=$(cat $SMF_RESET_REASON)
         mbr=$(cat $MAILBOX_POWERON_REASON)
         reason=$(echo $mbr | cut -d 'x' -f2)
         logger -p user.info -t DELL_S6100_REBOOT_CAUSE "POR: $por, RST: $rst, MBR: $mbr"
-        if [[ $reason = "ff" ]]; then
-            echo "None" > $REBOOT_REASON_FILE
-            echo 0xbb > $MAILBOX_POWERON_REASON
-        elif [[ $is_thermal_reboot = 1 ]]; then
-            echo 0xee > $MAILBOX_POWERON_REASON
-        elif [[ $is_wd_reboot = 1 ]] && [[ $reason != "cc" ]]; then
-            echo 0xdd > $MAILBOX_POWERON_REASON
-        elif [[ $reason = "cc" ]]; then
-            echo 0xaa > $MAILBOX_POWERON_REASON
+
+        SMF_FPGA_VERSION_MAJOR=$(( (SMF_FPGA_VERSION & 0xF0) >> 4 ))
+        SMF_FPGA_VERSION_MINOR=$(( SMF_FPGA_VERSION & 0x0F ))
+
+        if [[ -e $BIOS_VERSION_FILE ]] && [[ $SMF_FPGA_VERSION_MAJOR -ge 1 ]] && [[ $SMF_FPGA_VERSION_MINOR -ge 4 ]]; then
+
+            if [[ $reason = "cc" ]]; then
+                echo 0xaa > $MAILBOX_POWERON_REASON
+            elif [[ $SMF_RESET = "11" ]]; then
+                echo 0xee > $MAILBOX_POWERON_REASON
+            elif [[ $SMF_RESET = "33" ]]; then
+                echo 0xdd > $MAILBOX_POWERON_REASON
+            else
+                echo "Unknown software reboot" > $REBOOT_CAUSE_FILE
+                echo 0x99 > $MAILBOX_POWERON_REASON
+            fi
+
         else
-            _is_unknown_reset $is_thermal_reboot
-            echo 0x99 > $MAILBOX_POWERON_REASON
+            is_thermal_reboot=$(_is_thermal_reset)
+
+            is_wd_reboot=$(_is_watchdog_reset)
+
+            if [[ $reason = "ff" ]]; then
+                echo "None" > $REBOOT_REASON_FILE
+                echo 0xbb > $MAILBOX_POWERON_REASON
+            elif [[ $is_thermal_reboot = 1 ]]; then
+                echo 0xee > $MAILBOX_POWERON_REASON
+            elif [[ $is_wd_reboot = 1 ]] && [[ $reason != "cc" ]]; then
+                echo 0xdd > $MAILBOX_POWERON_REASON
+            elif [[ $reason = "cc" ]]; then
+                echo 0xaa > $MAILBOX_POWERON_REASON
+            else
+                _is_unknown_reset $is_thermal_reboot
+                echo 0x99 > $MAILBOX_POWERON_REASON
+            fi
         fi
     fi
 }

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/track_reboot_reason.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/track_reboot_reason.sh
@@ -8,6 +8,7 @@ nvram_missing=0
 REBOOT_CAUSE_FILE=/host/reboot-cause/reboot-cause.txt
 REBOOT_REASON_FILE=/host/reboot-cause/platform/reboot_reason
 BIOS_VERSION_FILE=/host/reboot-cause/platform/bios_minor_version
+SMF_MSS_VERSION_FILE=/sys/devices/platform/SMF.512/hwmon/*/smf_firmware_ver
 SMF_POWERON_REASON=/sys/devices/platform/SMF.512/hwmon/*/smf_poweron_reason
 SMF_RESET_REASON=/sys/devices/platform/SMF.512/hwmon/*/smf_reset_reason
 MAILBOX_POWERON_REASON=/sys/devices/platform/SMF.512/hwmon/*/mb_poweron_reason
@@ -150,10 +151,15 @@ update_mailbox_register(){
         reason=$(echo $mbr | cut -d 'x' -f2)
         logger -p user.info -t DELL_S6100_REBOOT_CAUSE "POR: $por, RST: $rst, MBR: $mbr"
 
+        SMF_MSS_VERSION=$(cat $SMF_MSS_VERSION_FILE)
+        SMF_MSS_VERSION_MAJOR=$(echo $SMF_MSS_VERSION | cut -d '.' -f1)
+        SMF_MSS_VERSION_MINOR=$(echo $SMF_MSS_VERSION | cut -d '.' -f2)
         SMF_FPGA_VERSION_MAJOR=$(( (SMF_FPGA_VERSION & 0xF0) >> 4 ))
         SMF_FPGA_VERSION_MINOR=$(( SMF_FPGA_VERSION & 0x0F ))
 
-        if [[ -e $BIOS_VERSION_FILE ]] && [[ $SMF_FPGA_VERSION_MAJOR -ge 1 ]] && [[ $SMF_FPGA_VERSION_MINOR -ge 4 ]]; then
+        if [[ -e $BIOS_VERSION_FILE ]] \
+           && [[ $SMF_MSS_VERSION_MAJOR -ge 2 ]] && [[ $SMF_MSS_VERSION_MINOR -ge 7 ]] \
+           && [[ $SMF_FPGA_VERSION_MAJOR -ge 1 ]] && [[ $SMF_FPGA_VERSION_MINOR -ge 4 ]]; then
 
             if [[ $reason = "cc" ]]; then
                 echo 0xaa > $MAILBOX_POWERON_REASON


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

For determining reboot-cause while running newer BIOS, SMF firmware.

**- How I did it**

Made changes in reboot-cause determination script to add support for behavior of newer firmware.

**- How to verify it**

Performed different type of resets and verified "show reboot-cause" provides the correct reason.
Logs: [UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/5487072/UT_logs.txt)

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC S6100: Update reboot-cause determination to support new firmware

**- A picture of a cute animal (not mandatory but encouraged)**
