### PR TITLE
DellEMC Z9264f: Fix show version error

### DIFF
--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/eeprom.py
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/eeprom.py
@@ -10,6 +10,7 @@
 #############################################################################
 
 try:
+    import os.path
     from sonic_eeprom import eeprom_tlvinfo
 except ImportError, e:
     raise ImportError (str(e) + "- required module not found")


### PR DESCRIPTION

**- Why I did it**
Executing "show version" in DellEMC Z9264f reports following error:
root@sonic:~# show version

SONiC Software Version: SONiC.201911.30-781abed7
Distribution: Debian 9.13
Kernel: 4.9.0-11-2-amd64
Build commit: 781abed7
Build date: Mon Nov 2 15:13:34 UTC 2020
Built by: johnar@jenkins-worker-8

Platform: x86_64-dellemc_z9264f_c3538-r0
HwSKU: DellEMC-Z9264f-C64
ASIC: broadcom
Traceback (most recent call last):
File "/usr/bin/decode-syseeprom", line 166, in <module>
exit(main())
File "/usr/bin/decode-syseeprom", line 50, in main
t = class_('board', '','','')
File "/usr/share/sonic/device/x86_64-dellemc_z9264f_c3538-r0/plugins/eeprom.py", line 24, in _init_
if os.path.exists(f):
NameError: global name 'os' is not defined
Serial Number:
Uptime: 07:08:49 up 3 min, 1 user, load average: 0.69, 0.76, 0.34
**- How I did it**
import os.path in eeprom.py to fix the issue 
**- How to verify it**
Execute show version after fix
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
