### PR TITLE
Fix for - execvp: /bin/bash: Argument list too long error

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -325,9 +325,9 @@ define SHOW_WHY
 	@echo "[ FLAGS  FILE    ] : [$($(1)_FILE_FLAGS)] " >> $($(1)_DST_PATH)/$(1).log
 	@echo "[ FLAGS  DEPENDS ] : [$($(1)_DEP_FLAGS_ALL)] " >> $($(1)_DST_PATH)/$(1).log
 	@echo "[ FLAGS  DIFF    ] : [$($(1)_FLAGS_DIFF)] " >> $($(1)_DST_PATH)/$(1).log
-	@echo "[ DEP    DEPENDS ] : [$($(1)_DEP_FILES_MODIFIED)] " >> $($(1)_DST_PATH)/$(1).log
-	@echo "[ SMDEP  DEPENDS ] : [$($(1)_SMDEP_FILES_MODIFIED)] " >> $($(1)_DST_PATH)/$(1).log
-	@echo "[ TARGET DEPENDS ] : [$?] " >> $($(1)_DST_PATH)/$(1).log
+	@$(file >>$($(1)_DST_PATH)/$(1).log, "[ DEP    DEPENDS ] : [$($(1)_DEP_FILES_MODIFIED)] ")
+	@$(file >>$($(1)_DST_PATH)/$(1).log, "[ SMDEP  DEPENDS ] : [$($(1)_SMDEP_FILES_MODIFIED)] ")
+	@$(file >>$($(1)_DST_PATH)/$(1).log, "[ TARGET DEPENDS ] : [$?] ")
 endef
 
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->
Fix #5692 
It fixes the folling error when DPKG cache enabled.

make: execvp: /bin/bash: Argument list too long
make: *** [slave.mk:389: target/debs/buster/sonic-device-data_1.0-1_all.deb] Error 127

**- Why I did it**
Number of dependent file list is more than 2K which causes bash arg long error. 

**- How I did it**
Used file operation to store the dependency list.

**- How to verify it**
Build with dpkg enabled

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
