### PR TITLE
[sonic-device-data] Convert Python files to Python 3

### DIFF
--- a/src/sonic-device-data/tests/config_checker
+++ b/src/sonic-device-data/tests/config_checker
@@ -1,19 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+import glob
 import re
 import sys
-import glob
 
 permitted_properties = []
 
+
 def usage():
-    print "Usage: " + sys.argv[0] + " <config_file>"
+    print("Usage: " + sys.argv[0] + " <config_file>")
     sys.exit(1)
 
-def check_property(p):
 
+def check_property(p):
     if p in permitted_properties:
         return True
     return False
+
 
 def check_file(file_name):
     try:
@@ -58,14 +61,14 @@ def check_file(file_name):
 
                 if not check_property(p):
                     file_ok = False
-                    print("[line %d] Error: %s is not permitted" % (lineno, p))
+                    print("[line {}] Error: {} is not permitted".format(lineno, p))
             if file_ok:
-                print "Result: " + file_name + " PASSED the config check!"
+                print("Result: " + file_name + " PASSED the config check!")
             else:
-                print "Result: " + file_name + " FAILED the config check!"
+                print("Result: " + file_name + " FAILED the config check!")
             return file_ok
     except IOError:
-        print "Error: Cannot open file " + file_name
+        print("Error: Cannot open file " + file_name)
         return False
 
 
@@ -92,6 +95,7 @@ def main(argv):
 
     if not all_good:
         sys.exit(-1)
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/src/sonic-device-data/tests/media_checker
+++ b/src/sonic-device-data/tests/media_checker
@@ -1,14 +1,16 @@
-#!/usr/bin/env python
-import re
-import sys
+#!/usr/bin/env python3
+
 import glob
 import json
+import re
+import sys
 
 level1_keys = ["GLOBAL_MEDIA_SETTINGS","PORT_MEDIA_SETTINGS"]
 setting_keys = ["preemphasis","idriver","ipredriver"]
 lane_prefix = "lane"
 comma_separator = ","
 range_separator = "-"
+
 
 def check_lane_and_value(lane_name, lane_value):
     if lane_prefix in lane_name:
@@ -18,30 +20,32 @@ def check_lane_and_value(lane_name, lane_value):
             return True
 
         except ValueError:
-            print "Invalid lane values " + lane_name + " " + lane_value
+            print("Invalid lane values " + lane_name + " " + lane_value)
             return False
 
     else:
         return False
 
+
 def usage():
-    print "Usage: " + sys.argv[0] + " <media_settings_file>"
+    print("Usage: " + sys.argv[0] + " <media_settings_file>")
     sys.exit(1)
+
 
 def check_media_dict(vendor_dict):
     if len(vendor_dict) == 0:
-        print "Expecting values for media type " + keys
+        print("Expecting values for media type " + keys)
         return False
 
     for vendor_key in vendor_dict:
         value_dict = vendor_dict[vendor_key]
         if len(value_dict) == 0:
-            print "Expecting settings for vendor type " + vendor_key
+            print("Expecting settings for vendor type " + vendor_key)
             return False
 
         for value_key in value_dict:
             if value_key not in setting_keys:
-                print "Unknown media setting " + value_key
+                print("Unknown media setting " + value_key)
                 return False
 
             lane_dict = value_dict[value_key]
@@ -50,6 +54,7 @@ def check_media_dict(vendor_dict):
                     return False
     return True
 
+
 def check_valid_port(port_name):
     try:
         val = int(port_name.strip())
@@ -57,16 +62,18 @@ def check_valid_port(port_name):
     except ValueError:
         return False
 
+
 def check_port_keys(port_media_dict):
     for port in port_media_dict:
 
         if not check_valid_port(port):
-            print "Invalid port name " + port
+            print("Invalid port name " + port)
             return False
 
         if not check_media_dict(port_media_dict[port]):
             return False
     return True
+
 
 def check_global_keys(global_media_dict):
     for keys in global_media_dict:
@@ -77,22 +84,22 @@ def check_global_keys(global_media_dict):
                     range_list = port.split(range_separator)
                     for port_val in range_list:
                         if not check_valid_port(port_val):
-                            print "Error: Unrecognized port number " + port_val
-                            print "Invalid range " + port
+                            print("Error: Unrecognized port number " + port_val)
+                            print("Invalid range " + port)
                             return False
                 else:
                     if not check_valid_port(port):
-                        print "Error: Unrecognized portname " + port
+                        print("Error: Unrecognized portname " + port)
                         return False
         elif range_separator in keys:
             range_list = keys.split(range_separator)
             for port_val in range_list:
                 if not check_valid_port(port_val):
-                    print "Error: Unrecognized portname " + port_val
-                    print "Invalid range " + keys
+                    print("Error: Unrecognized portname " + port_val)
+                    print("Invalid range " + keys)
                     return False
         else:
-            print "Invalid range " + keys
+            print("Invalid range " + keys)
             return False
 
         if not check_media_dict(global_media_dict[keys]):
@@ -110,7 +117,7 @@ def check_file(media_settings_file):
 
         for key_l1 in media_dict:
             if key_l1 not in level1_keys:
-                print "Error: Unknown key " + key_l1 + " at top level"
+                print("Error: Unknown key " + key_l1 + " at top level")
                 return False
         if "GLOBAL_MEDIA_SETTINGS" in media_dict:
             if not check_global_keys(media_dict["GLOBAL_MEDIA_SETTINGS"]):
@@ -121,11 +128,11 @@ def check_file(media_settings_file):
 
 
     except IOError:
-        print "Error: Cannot open file " + media_settings_file
+        print("Error: Cannot open file " + media_settings_file)
         return False
-    except ValueError,e:
-        print "Error in parsing json file " + media_settings_file + " "
-        print str(e)
+    except ValueError as e:
+        print("Error in parsing json file " + media_settings_file + " ")
+        print(str(e))
         return False
 
     return True
@@ -146,14 +153,15 @@ def main(argv):
     for f in files:
         good = check_file(f)
         if good:
-            print "File " + f + " passed validity check"
+            print("File " + f + " passed validity check")
         else:
-            print "File " + f + " failed validity check"
+            print("File " + f + " failed validity check")
 
         all_good = all_good and good
 
     if not all_good:
         sys.exit(-1)
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/src/sonic-device-data/tests/platform_json_checker
+++ b/src/sonic-device-data/tests/platform_json_checker
@@ -1,17 +1,9 @@
-#!/usr/bin/env python
-try:
-    import re
-    import sys
-    import glob
-    import json
-except ImportError as e:
-    raise ImportError (str(e) + "- required module not found")
+#!/usr/bin/env python3
 
-# TODO: need to remove basestring once migrate to Python 3 and just change to str
-try:
-    basestring
-except NameError:
-    basestring = str
+import glob
+import json
+import re
+import sys
 
 # Global variable
 PORT_ATTRIBUTES = ["index", "lanes", "alias_at_lanes", "breakout_modes"]
@@ -20,23 +12,25 @@ PORT_REG = "Ethernet(\d+)"
 PLATFORM_JSON = '*platform.json'
 INTF_KEY = "interfaces"
 
+
 def usage():
-    print "Usage: " + sys.argv[0] + " <platform_json_file>"
+    print("Usage: " + sys.argv[0] + " <platform_json_file>")
     sys.exit(1)
+
 
 def check_port_attr(port_attr):
     for each_key in port_attr:
         if each_key not in PORT_ATTRIBUTES:
-            print "Error: "+ each_key + " is not the correct Port attribute."
+            print("Error: "+ each_key + " is not the correct Port attribute.")
             return False
         if not port_attr[each_key]:
-            print "Error: "+ each_key + " has no value."
+            print("Error: "+ each_key + " has no value.")
             return False
-        # TODO: need to remove basestring once migrate to Python 3 and just change to str
-        if not isinstance(port_attr[each_key], basestring):
-            print "Error:value type of  "+ each_key + " must be string."
+        if not isinstance(port_attr[each_key], str):
+            print("Error:value type of  "+ each_key + " must be string.")
             return False
     return True
+
 
 def check_file(platform_json_file):
     try:
@@ -48,28 +42,29 @@ def check_file(platform_json_file):
             # Validate port at top level
             port_id = re.search(PORT_REG, each_port)
             if port_id is  None:
-                print "Error: Unknown Interface " + str(each_port) + " at top level"
+                print("Error: Unknown Interface " + str(each_port) + " at top level")
                 return False
 
-            total_attr = len(port_dict[INTF_KEY][each_port].keys())
+            total_attr = len(list(port_dict[INTF_KEY][each_port].keys()))
             port_attr = port_dict[INTF_KEY][each_port]
 
             if total_attr != ATTR_LEN:
                 missing_attr = ', '.join(set(PORT_ATTRIBUTES).difference(list(port_attr)))
-                print "Error: " + missing_attr + " of " + each_port + " is/are missing"
+                print("Error: " + missing_attr + " of " + each_port + " is/are missing")
                 return False
 
             #Validate port attributes for each port
             if not check_port_attr(port_attr):
                 return False
     except IOError:
-        print "Error: Cannot open file " + platform_json_file
+        print("Error: Cannot open file " + platform_json_file)
         return False
-    except ValueError,e:
-        print "Error in parsing json file " + platform_json_file + " "
-        print str(e)
+    except ValueError as e:
+        print("Error in parsing json file " + platform_json_file + " ")
+        print(str(e))
         return False
     return True
+
 
 def main(argv):
     if len(argv) > 0 and argv[0] == "-h":
@@ -86,14 +81,15 @@ def main(argv):
     for f in files:
         good = check_file(f)
         if good:
-            print "File " + f + " passed validity check"
+            print("File " + f + " passed validity check")
         else:
-            print "File " + f + " failed validity check"
+            print("File " + f + " failed validity check")
 
         all_good = all_good and good
 
     if not all_good:
         sys.exit(-1)
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
**- Why I did it**

As part of moving all SONiC code from Python 2 (no longer supported) to Python 3

**- How I did it**

- Convert config_checker, media_checker and platform_json_checker scripts to Python 3
- Reorganize imports per PEP8 standard
- Two blank lines precede functions per PEP8 standard

**- How to verify it**

Ensure scripts still function correctly

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006