### PR TITLE
Mount /etc to /host_etc and symlink passwd and group files to host fo…

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -36,4 +36,7 @@ RUN apt-get remove -y g++ python-dev
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
+RUN ln -sf /host_etc/passwd /etc/passwd
+RUN ln -sf /host_etc/group /etc/group
+
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -28,4 +28,7 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
+RUN ln -sf /host_etc/passwd /etc/passwd
+RUN ln -sf /host_etc/group /etc/group
+
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/rules/docker-telemetry.mk
+++ b/rules/docker-telemetry.mk
@@ -27,6 +27,7 @@ $(DOCKER_TELEMETRY)_CONTAINER_NAME = telemetry
 $(DOCKER_TELEMETRY)_RUN_OPT += --privileged -t
 $(DOCKER_TELEMETRY)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_TELEMETRY)_RUN_OPT += -v /var/run/dbus:/var/run/dbus:rw
+$(DOCKER_TELEMETRY)_RUN_OPT += -v /etc:/host_etc:ro
 
 $(DOCKER_TELEMETRY)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)
 $(DOCKER_TELEMETRY)_BASE_IMAGE_FILES += monit_telemetry:/etc/monit/conf.d


### PR DESCRIPTION
…r group lookups for authorization

Signed-off-by: Eric Seifert <seiferteric@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Group lookups for authorization in REST server and telemetry require access to the host /etc/passwd and /etc/group files. These files should be available from being mounted to /host_etc in the containers, and the files should be symlinked.
**- How I did it**
Add mount option for telemetry, the same as mgmt-framework. Add symlink commands to both Dockerfiles
**- How to verify it**
Build mgmt-framework and telemetry containers and verify files are correctly symlinked to host files in container.
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Symlink /etc/passwd and /etc/group files on container to host equivalents mounted at /host_etc. 
