### PR TITLE
[check_install.py] Convert to Python 3

### DIFF
--- a/check_install.py
+++ b/check_install.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-import pexpect
 import argparse
+import pexpect
 import sys
 import time
+
 
 def main():
 
@@ -30,7 +31,7 @@ def main():
             p = pexpect.spawn("telnet 127.0.0.1 %s" % args.p, timeout=600, logfile=sys.stdout)
             break
         except Exception as e:
-            print str(e)
+            print(str(e))
             i += 1
             if i == 10:
                 raise

--- a/check_install.py
+++ b/check_install.py
@@ -22,13 +22,13 @@ def main():
 
     login_prompt = 'sonic login:'
     passwd_prompt = 'Password:'
-    cmd_prompt = "%s@sonic:~\$ $" % args.u
+    cmd_prompt = "{}@sonic:~\$ $".format(args.u)
     grub_selection = "The highlighted entry will be executed"
 
     i = 0
     while True:
         try:
-            p = pexpect.spawn("telnet 127.0.0.1 %s" % args.p, timeout=600, logfile=sys.stdout)
+            p = pexpect.spawn("telnet 127.0.0.1 {}".format(args.p), timeout=600, logfile=sys.stdout, encoding='utf-8')
             break
         except Exception as e:
             print(str(e))

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y \
         libtinyxml2-dev \
         python \
         python-pip \
+        python3 \
         python3-pip \
         libncurses5-dev \
         texinfo \
@@ -386,9 +387,11 @@ RUN apt-get install python-meld3
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0
+RUN pip3 install pexpect==4.6.0
 
 # For sonic-swss-common testing
 RUN pip2 install Pympler==0.8
+RUN pip3 install Pympler==0.8
 
 # For sonic_yang_model build
 RUN pip2 install pyang==2.1.1

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -57,7 +57,6 @@ RUN apt-get update && apt-get install -y \
         libtinyxml2-dev \
         python \
         python-pip \
-        python3 \
         python3-pip \
         libncurses5-dev \
         texinfo \
@@ -387,11 +386,9 @@ RUN apt-get install python-meld3
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0
-RUN pip3 install pexpect==4.6.0
 
 # For sonic-swss-common testing
 RUN pip2 install Pympler==0.8
-RUN pip3 install Pympler==0.8
 
 # For sonic_yang_model build
 RUN pip2 install pyang==2.1.1


### PR DESCRIPTION
**- Why I did it**

As part of moving all SONiC code from Python 2 (no longer supported) to Python 3

**- How I did it**

- Convert check_install.py script to Python 3
- Reorganize imports per PEP8 standard
- Two blank lines precede functions per PEP8 standard

**- How to verify it**

Ensure check_install.py script still functions correctly

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006