### PR TITLE
[BGP]: Convert ip address to network address for the LOCAL_VLAN filter

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -19,13 +19,13 @@ ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTE
 {% endif %}
 {% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 and name not in vnet_intfs %}
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq {{ loop.index * 5 }} permit {{ prefix }}
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq {{ loop.index * 5 }} permit {{ prefix | ip_network }}/{{ prefix | prefixlen }}
 !
 {% endif %}
 {% endfor %}
 {% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
 {% if prefix | ipv6 and name not in vnet_intfs %}
-ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq {{ loop.index * 5 }} permit {{ prefix }}
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq {{ loop.index * 5 }} permit {{ prefix | ip_network }}/{{ prefix | prefixlen }}
 !
 {% endif %}
 {% endfor %}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -33,9 +33,9 @@ ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 10.10.10.1/24
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 10.10.10.0/24
 !
-ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 5 permit fc01::1/64
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 5 permit fc01::/64
 !
 !
 route-map HIDE_INTERNAL permit 10

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
@@ -11,9 +11,9 @@ ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 10.10.10.1/24
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 10.10.10.0/24
 !
-ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 15 permit fc01::1/64
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 15 permit fc01::/64
 !
 !
 route-map HIDE_INTERNAL permit 10

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
@@ -11,9 +11,9 @@ ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 10.10.10.1/24
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 10.10.10.0/24
 !
-ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 15 permit fc01::1/64
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 15 permit fc01::/64
 !
 !
 route-map HIDE_INTERNAL permit 10

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -51,9 +51,9 @@ ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 10.10.10.1/24
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 10.10.10.0/24
 !
-ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 5 permit fc01::1/64
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 5 permit fc01::/64
 !
 !
 route-map HIDE_INTERNAL permit 10

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -33,7 +33,7 @@ ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.1/27
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.0/27
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -51,7 +51,7 @@ ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.1/27
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.0/27
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -33,7 +33,7 @@ ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.1/27
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.0/27
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -51,7 +51,7 @@ ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.1/27
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.0/27
 !
 !
 !


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
To avoid log messages like:
```
Nov  5 22:12:10.741378 str-s6100-acs-1 INFO bgp#bgpd[55]: Prefix-list LOCAL_VLAN_IPV4_PREFIX prefix changed from 192.168.0.1/21 to 192.168.0.0/21 to match length
Nov  5 22:12:10.741378 str-s6100-acs-1 INFO bgp#bgpd[55]: Prefix-list LOCAL_VLAN_IPV6_PREFIX prefix changed from fc02:1000::1/64 to fc02:1000::/64 to match length
```
**- How I did it**
I used jinja2 filter inside of sonic-config-engine to convert ip host address with mask to the ip network address.

**- How to verify it**
Build an image and run on your DUT.
vtysh -c 'show run' | grep LOCAL_VLAN should show correct output
```
root@str-s6100-acs-1:~# sonic-cfggen -d -t /usr/share/sonic/templates/bgpd/bgpd.conf.j2 -y /etc/sonic/constants.yml | grep LOCAL_VLAN
ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.0/21
ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 10 permit fc02:1000::/64
```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
