### PR TITLE
[CENTEC ARM64]LIBSAIREDIS isn't depend on CENTEC_SAI, Remove this dependency

### DIFF
--- a/platform/centec-arm64/docker-syncd-centec.mk
+++ b/platform/centec-arm64/docker-syncd-centec.mk
@@ -10,6 +10,9 @@ $(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(SYNCD_DBG) \
                                 $(LIBSAIMETADATA_DBG) \
                                 $(LIBSAIREDIS_DBG)
 
+SONIC_STRETCH_DOCKERS += $(DOCKER_SYNCD_BASE)
+SONIC_STRETCH_DBG_DOCKERS += $(DOCKER_SYNCD_BASE_DBG)
+
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/warmboot:/var/warmboot
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf

--- a/platform/centec-arm64/rules.mk
+++ b/platform/centec-arm64/rules.mk
@@ -11,5 +11,13 @@ SONIC_ALL += $(SONIC_ONE_IMAGE) \
              $(DOCKER_FPM)
 #             $(DOCKER_SYNCD_CENTEC_RPC)
 
+# Inject centec sai into syncd
+$(SYNCD)_DEPENDS += $(CENTEC_SAI)
+$(SYNCD)_UNINSTALLS += $(CENTEC_SAI)
+
+ifeq ($(ENABLE_SYNCD_RPC),y)
+$(SYNCD)_DEPENDS += $(LIBSAITHRIFT_DEV)
+endif
+
 # Runtime dependency on centec sai is set only for syncd
 $(SYNCD)_RDEPENDS += $(CENTEC_SAI)

--- a/platform/centec-arm64/rules.mk
+++ b/platform/centec-arm64/rules.mk
@@ -11,8 +11,5 @@ SONIC_ALL += $(SONIC_ONE_IMAGE) \
              $(DOCKER_FPM)
 #             $(DOCKER_SYNCD_CENTEC_RPC)
 
-# Inject centec sai into sairedis
-$(LIBSAIREDIS)_DEPENDS += $(CENTEC_SAI) $(LIBSAITHRIFT_DEV_CENTEC)
-
 # Runtime dependency on centec sai is set only for syncd
 $(SYNCD)_RDEPENDS += $(CENTEC_SAI)

--- a/platform/centec-arm64/sai.mk
+++ b/platform/centec-arm64/sai.mk
@@ -4,5 +4,6 @@ export CENTEC_SAI_VERSION = 1.6.3-1
 export CENTEC_SAI = libsai_$(CENTEC_SAI_VERSION)_$(PLATFORM_ARCH).deb
 
 $(CENTEC_SAI)_URL = https://github.com/CentecNetworks/sonic-binaries/raw/master/$(PLATFORM_ARCH)/sai/$(CENTEC_SAI)
+$(eval $(call add_conflict_package,$(CENTEC_SAI),$(LIBSAIVS_DEV)))
 SONIC_ONLINE_DEBS += $(CENTEC_SAI)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Build depends have been optimized in PR #4880 and PR #5039. These optimizations need to be merged to Centec ARM64 platform. 

**- How I did it**
Remove the dependency

**- How to verify it**
Compile Centec ARM64 based images

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
LIBSAIREDIS isn't depend on CENTEC_SAI, Remove this dependency

**- A picture of a cute animal (not mandatory but encouraged)**
