### PR TITLE
[led][cherry-pick]: Skip ledinit if there is no led_proc_init.soc file for broadco…

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/start_led.sh
+++ b/platform/broadcom/docker-syncd-brcm/start_led.sh
@@ -2,6 +2,12 @@
 
 PLATFORM_DIR=/usr/share/sonic/platform
 SYNCD_SOCKET_FILE=/var/run/sswsyncd/sswsyncd.socket
+LED_PROC_INIT_SOC=${PLATFORM_DIR}/led_proc_init.soc
+
+if [ ! -f "$LED_PROC_INIT_SOC" ]; then
+   echo "No soc led configuration found under $LED_SOC_INIT_SOC"
+   exit 0
+fi
 
 # Function: wait until syncd has created the socket for bcmcmd to connect to
 wait_syncd() {
@@ -30,8 +36,8 @@ wait_syncd() {
 }
 
 # If this platform has an initialization file for the Broadcom LED microprocessor, load it
-if [[ -r ${PLATFORM_DIR}/led_proc_init.soc && ! -f /var/warmboot/warm-starting ]]; then
+if [[ -r "$LED_PROC_INIT_SOC" && ! -f /var/warmboot/warm-starting ]]; then
     wait_syncd
 fi
 
-/usr/bin/bcmcmd -t 60 "rcload /usr/share/sonic/platform/led_proc_init.soc"
+/usr/bin/bcmcmd -t 60 "rcload $LED_PROC_INIT_SOC"


### PR DESCRIPTION
cherry #5483 to 201911.

[led]: Skip ledinit if there is no led_proc_init.soc file for broadcom platform (#5483)
    
    Some platforms don't leverage the brcm led coprocessor.
    However ledinit will try to load a non existing file and exit with an
    error code.
    This change is a cosmetic fix mostly.
    
    - How to verify it
    
    Boot a platform without the configuration and verify in the syslog that the exit status of ledinit is 0
    Boot a platform with the configuration and verify in the syslog that the exit status of ledinit is 0 and the leds are working.
    Verified by adding a dumb led_proc_init.soc on an Arista platform which usually doesn't use it.


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**
Verified on Arista-7260cx3, and no warning log is observed after this update;

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
