### PR TITLE
[Monit process_checker] Convert to Python 3

### DIFF
--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python3
+
 import argparse
 import sys
 import syslog
@@ -16,10 +17,10 @@ def check_process_existence(container_name, process_cmdline):
     config_db.connect()
     feature_table = config_db.get_table("FEATURE")
 
-    if container_name in feature_table.keys():
+    if container_name in feature_table:
         # We look into the 'FEATURE' table to verify whether the container is disabled or not.
         # If the container is diabled, we exit.
-        if ("state" in feature_table[container_name].keys()
+        if ("state" in feature_table[container_name]
                 and feature_table[container_name]["state"] == "disabled"):
             sys.exit(0)
         else:


### PR DESCRIPTION
**- Why I did it**

As part of moving all SONiC code from Python 2 (no longer supported) to Python 3

**- How I did it**

- Convert process_checker script to Python 3

**- How to verify it**

Ensure check_install.py script still functions correctly

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006