### PR TITLE
[update_chassisdb_config] Convert to Python 3

### DIFF
--- a/files/scripts/update_chassisdb_config
+++ b/files/scripts/update_chassisdb_config
@@ -1,12 +1,14 @@
-#!/usr/bin/python
+#!/usr/bin/python3
+
+import argparse
 import json
 import os
 import syslog
-import argparse
 
 database_config_file = "/var/run/redis/sonic-db/database_config.json"
 redis_chassis = 'redis_chassis'
 chassis_db = 'CHASSIS_APP_DB'
+
 
 def main():
     parser = argparse.ArgumentParser(description=
@@ -62,6 +64,7 @@ def main():
        json.dump(data_publish, write_file, indent=4, separators=(',', ': '))
     syslog.syslog(syslog.LOG_INFO,
        'remove chassis_db from config file {}'.format(jsonfile))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
**- Why I did it**

As part of moving all SONiC code from Python 2 (no longer supported) to Python 3

**- How I did it**

- Convert update_chassisdb_config script to Python 3
- Reorganize imports per PEP8 standard
- Two blank lines precede functions per PEP8 standard

**- How to verify it**

Ensure check_install.py script still functions correctly

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006