### PR TITLE
Set preference for forced mgmt routes

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -80,14 +80,14 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    up ip rule add to {{ route }} table {{ vrf_table }}
+    up ip rule add pref 32764 to {{ route }} table {{ vrf_table }}
 {% endfor %}
     # management port down rules
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    pre-down ip rule delete to {{ route }} table {{ vrf_table }}
+    pre-down ip rule delete pref 32764 to {{ route }} table {{ vrf_table }}
 {% endfor %}
 {# TODO: COPP policy type rules #}
 {% endfor %}

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -47,10 +47,14 @@ iface eth0 inet6 static
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 5000 metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 5000
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    up ip rule add pref 32764 to 11.11.11.11 table default
+    up ip rule add pref 32764 to 22.22.22.0/23 table default
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
     pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    pre-down ip rule delete pref 32764 to 11.11.11.11 table default
+    pre-down ip rule delete pref 32764 to 22.22.22.0/23 table default
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -32,10 +32,14 @@ iface eth0 inet static
     up ip -4 route add default via 10.0.0.1 dev eth0 table 5000 metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table 5000
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table 5000
+    up ip rule add pref 32764 to 11.11.11.11 table 5000
+    up ip rule add pref 32764 to 22.22.22.0/23 table 5000
     # management port down rules
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
     pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 5000
+    pre-down ip rule delete pref 32764 to 11.11.11.11 table 5000
+    pre-down ip rule delete pref 32764 to 22.22.22.0/23 table 5000
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -47,14 +51,10 @@ iface eth0 inet6 static
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 5000 metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 5000
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 5000
-    up ip rule add pref 32764 to 11.11.11.11 table default
-    up ip rule add pref 32764 to 22.22.22.0/23 table default
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
     pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 5000
-    pre-down ip rule delete pref 32764 to 11.11.11.11 table default
-    pre-down ip rule delete pref 32764 to 22.22.22.0/23 table default
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -47,10 +47,14 @@ iface eth0 inet6 static
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 5000 metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 5000
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    up ip rule add pref 32764 to 11.11.11.11 table default
+    up ip rule add pref 32764 to 22.22.22.0/23 table default
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
     pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    pre-down ip rule delete pref 32764 to 11.11.11.11 table default
+    pre-down ip rule delete pref 32764 to 22.22.22.0/23 table default
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -32,10 +32,14 @@ iface eth0 inet static
     up ip -4 route add default via 10.0.0.1 dev eth0 table 5000 metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table 5000
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table 5000
+    up ip rule add pref 32764 to 11.11.11.11 table 5000
+    up ip rule add pref 32764 to 22.22.22.0/23 table 5000
     # management port down rules
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
     pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 5000
+    pre-down ip rule delete pref 32764 to 11.11.11.11 table 5000
+    pre-down ip rule delete pref 32764 to 22.22.22.0/23 table 5000
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -47,14 +51,10 @@ iface eth0 inet6 static
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 5000 metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 5000
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 5000
-    up ip rule add pref 32764 to 11.11.11.11 table default
-    up ip rule add pref 32764 to 22.22.22.0/23 table default
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
     pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 5000
-    pre-down ip rule delete pref 32764 to 11.11.11.11 table default
-    pre-down ip rule delete pref 32764 to 22.22.22.0/23 table default
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/t0-sample-graph-mvrf.xml
+++ b/src/sonic-config-engine/tests/t0-sample-graph-mvrf.xml
@@ -394,6 +394,11 @@
         <a:Name>switch-t0</a:Name>
         <a:Properties>
           <a:DeviceProperty>
+            <a:Name>ForcedMgmtRoutes</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>11.11.11.11;22.22.22.0/23</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
             <a:Name>ErspanDestinationIpv4</a:Name>
             <a:Reference i:nil="true"/>
             <a:Value>2.2.2.2</a:Value>


### PR DESCRIPTION
**- Why I did it**
When forced mgmt routes are present, the issue fixed as part of https://github.com/Azure/sonic-buildimage/pull/5754 is not complete.

**- How I did it**
Added a preference(priority) field to forced mgmt route ip rules

**- How to verify it**
Verified on device 

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
