### PR TITLE
Add the vtysh command with newly added "-n"  option for multi asic  to  the read_only_cmds

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -29,7 +29,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog*, \
                                  /usr/bin/lldpctl, \
                                  /usr/bin/sensors, \
                                  /usr/bin/tail -F /var/log/syslog, \
-                                 /usr/bin/vtysh -c show *, \
+                                 /usr/bin/vtysh -c show *, /usr/bin/vtysh -n [0-9] -c show *, \
                                  /usr/local/bin/decode-syseeprom, \
                                  /usr/local/bin/generate_dump, \
                                  /usr/local/bin/lldpshow, \

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -29,7 +29,8 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog*, \
                                  /usr/bin/lldpctl, \
                                  /usr/bin/sensors, \
                                  /usr/bin/tail -F /var/log/syslog, \
-                                 /usr/bin/vtysh -c show *, /usr/bin/vtysh -n [0-9] -c show *, \
+                                 /usr/bin/vtysh -c show *, \
+                                 /usr/bin/vtysh -n [0-9] -c show *, \
                                  /usr/local/bin/decode-syseeprom, \
                                  /usr/local/bin/generate_dump, \
                                  /usr/local/bin/lldpshow, \


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
In multi asic platforms the "show ip bgp summary" commands is not available for user with read only privileges, so fix this the vtysh command with the new` "-n"` option, added for multi asic platforms, needs to be added to the READ_ONLY_COMMANDS list in the sudoers files 

**- How I did it**
Add the command `vtysh -n [0-9] -c show *` to list of READ_ONLY_COMMANDS in the sudoers files

**- How to verify it**
Verify show ip bgp summary is working for user accounts with read-only privilages

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
