### PR TITLE
[sflow] Clean-up sFlow container and port_index_mapper.py script

### DIFF
--- a/dockers/docker-sflow/Dockerfile.j2
+++ b/dockers/docker-sflow/Dockerfile.j2
@@ -12,9 +12,6 @@ RUN apt-get update      && \
             dmidecode      \
             libmnl0=1.0.4-2
 
-RUN pip install \
-        pyroute2==0.5.3
-
 {% if docker_sflow_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("debs/", docker_sflow_debs.split(' '), "/debs/") }}

--- a/dockers/docker-sflow/port_index_mapper.py
+++ b/dockers/docker-sflow/port_index_mapper.py
@@ -28,12 +28,12 @@ class PortIndexMapper(object):
         self.state_db = SonicV2Connector(host='127.0.0.1', decode_responses=True)
         self.state_db.connect(self.state_db.STATE_DB, False)
         self.sel = swsscommon.Select()
-        self.tlbs = [swsscommon.SubscriberStateTable(self.appl_db, t)
+        self.tbls = [swsscommon.SubscriberStateTable(self.appl_db, t)
                      for t in tbl_lst]
 
         self.cur_interfaces = {}
 
-        for t in self.tlbs:
+        for t in self.tbls:
             self.sel.addSelectable(t)
 
     def set_port_index_table_entry(self, key, index, ifindex):
@@ -69,11 +69,12 @@ class PortIndexMapper(object):
         while True:
             (state, c) = self.sel.select(SELECT_TIMEOUT_MS)
             if state == swsscommon.Select.OBJECT:
-                for t in self.tlbs:
+                for t in self.tbls:
                     (key, op, cfvs) = t.pop()
                     if op == 'DEL' and key in self.cur_interfaces:
                         self.update_db(key, op)
                     elif (op == 'SET' and key != 'PortInitDone' and
+                            key != 'PortConfigDone' and
                             key not in self.cur_interfaces):
                         self.update_db(key, op)
             elif state == swsscomm.Select.ERROR:
@@ -86,9 +87,10 @@ class PortIndexMapper(object):
         while True:
             (state, c) = self.sel.select(SELECT_TIMEOUT_MS)
             if state == swsscommon.Select.OBJECT:
-                for t in self.tlbs:
+                for t in self.tbls:
                     (key, op, cfvs) = t.pop()
-                    if key and key != 'PortInitDone':
+                    if (key and key != 'PortInitDone' and
+                            key != 'PortConfigDone'):
                         self.update_db(key, op)
             else:
                 break


### PR DESCRIPTION
* Fix some spelling error and add addition check in port_index_mapper.py
  script.
* Remove unneeded pyroute2 python module from sFlow container

Signed-off-by: Garrick He <garrick_he@dell.com>

**- Why I did it**
This PR just addresses some minor spelling issue in the port_index_mapper.py script and removes an unneeded module.

**- How I did it**
Update a 2 files

**- How to verify it**
Check the stateDB to ensure PORT_INDEX_TABLE is created and ensure the pyroute2 module is not installed.

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
* Fix some spelling error and add addition check in port_index_mapper.py
  script.
* Remove unneeded pyroute2 python module from sFlow container
