### PR TITLE
[multi-asic] Enhanced the getMount() API and  docker mount point check 

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -45,7 +45,7 @@ function updateSyslogConf()
 
 function getMountPoint()
 {
-    echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.basename(mnts[0]['Source'])" 2>/dev/null
+    echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.abspath(mnts[0]['Source'])" 2>/dev/null
 }
 
 function getBootType()
@@ -189,9 +189,14 @@ start() {
     {%- if docker_container_name == "database" %}
     # Don't mount HWSKU in {{docker_container_name}} container.
     HWSKU=""
+    MOUNTPATH=""
     {%- else %}
     # Obtain our HWSKU as we will mount directories with these names in each docker
     HWSKU=${HWSKU:-`$SONIC_CFGGEN -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`}
+    MOUNTPATH="/usr/share/sonic/device/$PLATFORM/$HWSKU"
+    if [ "$DEV" ]; then
+        MOUNTPATH="$MOUNTPATH/$DEV"
+    fi
     {%- endif %}
     DOCKERCHECK=`docker inspect --type container ${DOCKERNAME} 2>/dev/null`
     if [ "$?" -eq "0" ]; then
@@ -200,7 +205,7 @@ start() {
         {%- else %}
         DOCKERMOUNT=`getMountPoint "$DOCKERCHECK"`
         {%- endif %}
-        if [ x"$DOCKERMOUNT" == x"$HWSKU" ]; then
+        if [ x"$DOCKERMOUNT" == x"$MOUNTPATH" ]; then
             {%- if docker_container_name == "database" %}
             echo "Starting existing ${DOCKERNAME} container"
             {%- else %}


### PR DESCRIPTION
Why I did:
API getMount() API was not updated to handle multi-asic platforms
because of which mount point comparison always return FALSE
and we were always creating new container image when doing config load_minigraph/reload/reboot.

How I did:
Updated API getMount() to return abspath() for Docker Mount Point
and use that one for mount point comparison

How I Verify:

- Verify on Single ASIC platforms behavior is same as present

- Verify on Multi-asic platforms we do not create new container when doing config load_minigraph/reload/reboot.

- Also sonic-mgmt copp test were failing on Multi-asic platform 
since test case update copp.json in swss docker and restart docker but that
change did not took impact since we were creating new container. 
After this changes test case is working fine



