### PR TITLE
[multi-asic] Updated teamdctl bash script to support for multi-asic

### DIFF
--- a/dockers/docker-teamd/base_image_files/teamdctl
+++ b/dockers/docker-teamd/base_image_files/teamdctl
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+[ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
+
+function help()
+{
+    echo -e "Usage: $0 -n [0 to $(($NUM_ASIC-1))] [OPTION]... " 1>&2; exit 1;
+}
+
 DOCKER_EXEC_FLAGS="i"
 
 # Determine whether stdout is on a terminal
@@ -7,4 +14,30 @@ if [ -t 1 ] ; then
     DOCKER_EXEC_FLAGS+="t"
 fi
 
-docker exec -$DOCKER_EXEC_FLAGS teamd teamdctl "$@"
+DEV=""
+PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
+
+# Parse the device specific asic conf file, if it exists
+ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
+[ -f $ASIC_CONF ] && . $ASIC_CONF
+
+if [[ ($NUM_ASIC -gt 1) ]]; then
+    while getopts ":n:h:" opt; do
+        case "${opt}" in
+            h) help
+               ;;
+            n) DEV=${OPTARG}
+               [ $DEV -lt $NUM_ASIC -a  $DEV -ge 0 ] || help
+               ;;
+        esac
+    done
+
+    if [ -z "${DEV}" ]; then
+        help
+    fi
+
+    # Skip the arguments -n <inst> while passing to docker command
+    shift 2
+fi
+
+docker exec -$DOCKER_EXEC_FLAGS teamd$DEV teamdctl "$@"


### PR DESCRIPTION
What I did:
Enhanced teamdctl bash script to work for Multi-asic. Added option -n [0 to n] (asic number).
Changes are similar to other scripts swssloglevel/bcmcmd that has multi-asic support.

Why I did:
Some of sonic-mgmt test case (test_lag_2.py)  uses teamdctl command from test script.

How I Verify:
Usage: /usr/bin/teamdctl -n [0 to n] [OPTION]...

Single ASIC:

```
teamdctl PortChannel0002 state
setup:
  runner: lacp
ports:
  Ethernet0
    link watches:
      link summary: up
```
Multi ASIC

```
teamdctl -n 0 PortChannel0002 state
setup:
  runner: lacp
ports:
  Ethernet0
    link watches:
      link summary: up
      instance[link_watch_0]:
        name: ethtool
        link: up
        down count: 0
    runner:
      aggregator ID: 139, Selected
      selected: yes
      state: current
  Ethernet4
    link watches:
      link summary: up
      instance[link_watch_0]:
        name: ethtool
        link: up
        down count: 0
    runner:
      aggregator ID: 139, Selected
      selected: yes
      state: current
runner:
  active: yes
  fast rate: no

```