### PR TITLE
[bgpmon] Fix `dict_keys` unsubscriptable error

### DIFF
--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -68,8 +68,8 @@ class BgpStateGet:
     def update_new_peer_states(self, peer_dict):
         peer_l = peer_dict["peers"].keys()
         self.new_peer_l.extend(peer_l)
-        for i in range (0, len(peer_l)):
-            self.new_peer_state[peer_l[i]] = peer_dict["peers"][peer_l[i]]["state"]
+        for peer in peer_l:
+            self.new_peer_state[peer] = peer_dict["peers"][peer]["state"]
 
     # Get a new snapshot of BGP neighbors and store them in the "new" location
     def get_all_neigh_states(self):


### PR DESCRIPTION
Simply looping through `dict_key` object instead of index-subscribing to
fix this.

fixes #5858 

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
`bgpmon` fails to run and flooding syslogs with errors like:
```
Nov  8 03:30:20.736704 str-dx010-acs-4 INFO bgp#/bgpmon: bgpmon service started
Nov  8 03:30:24.209370 str-dx010-acs-4 INFO bgp#supervisord 2020-11-08 03:30:19,574 ERRO pool dependent-startup event buffer overflowed, discarding event 3948
Nov  8 03:30:24.209370 str-dx010-acs-4 INFO bgp#supervisord 2020-11-08 03:30:19,575 INFO exited: bgpmon (exit status 1; not expected)
Nov  8 03:30:24.209370 str-dx010-acs-4 INFO bgp#supervisord 2020-11-08 03:30:20,576 ERRO pool dependent-startup event buffer overflowed, discarding event 3949
Nov  8 03:30:24.209370 str-dx010-acs-4 INFO bgp#supervisord 2020-11-08 03:30:20,578 INFO spawned: 'bgpmon' with pid 4285
Nov  8 03:30:24.209370 str-dx010-acs-4 INFO bgp#supervisord 2020-11-08 03:30:20,581 ERRO pool dependent-startup event buffer overflowed, discarding event 3950
Nov  8 03:30:24.209370 str-dx010-acs-4 INFO bgp#supervisord 2020-11-08 03:30:20,581 INFO success: bgpmon entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
Nov  8 03:30:34.799388 str-dx010-acs-4 ERR monit[479]: 'lldp|lldpmgrd' status failed (1) -- 'python /usr/bin/lldpmgrd' is not running.
Nov  8 03:30:34.965631 str-dx010-acs-4 ERR monit[479]: 'bgp|bgpcfgd' status failed (1) -- '/usr/bin/python /usr/local/bin/bgpcfgd' is not running.
Nov  8 03:30:35.012222 str-dx010-acs-4 ERR monit[479]: 'bgp|bgpmon' status failed (1) -- '/usr/bin/python /usr/local/bin/bgpmon' is not running.
Nov  8 03:30:36.058032 str-dx010-acs-4 INFO bgp#supervisord: bgpmon Traceback (most recent call last):
Nov  8 03:30:36.058032 str-dx010-acs-4 INFO bgp#supervisord: bgpmon   File "/usr/local/bin/bgpmon", line 8, in <module>
Nov  8 03:30:36.058149 str-dx010-acs-4 INFO bgp#supervisord: bgpmon     sys.exit(main())
Nov  8 03:30:36.058149 str-dx010-acs-4 INFO bgp#supervisord: bgpmon   File "/usr/local/lib/python3.7/dist-packages/bgpmon/bgpmon.py", line 166, in main
Nov  8 03:30:36.058173 str-dx010-acs-4 INFO bgp#supervisord: bgpmon     bgp_state_get.get_all_neigh_states()
Nov  8 03:30:36.058191 str-dx010-acs-4 INFO bgp#supervisord: bgpmon   File "/usr/local/lib/python3.7/dist-packages/bgpmon/bgpmon.py", line 88, in get_all_neigh_states
Nov  8 03:30:36.058191 str-dx010-acs-4 INFO bgp#supervisord: bgpmon     self.update_new_peer_states(value)
Nov  8 03:30:36.058256 str-dx010-acs-4 INFO bgp#supervisord: bgpmon   File "/usr/local/lib/python3.7/dist-packages/bgpmon/bgpmon.py", line 72, in update_new_peer_states
Nov  8 03:30:36.058256 str-dx010-acs-4 INFO bgp#supervisord: bgpmon     self.new_peer_state[peer_l[i]] = peer_dict["peers"][peer_l[i]]["state"]
Nov  8 03:30:36.058256 str-dx010-acs-4 INFO bgp#supervisord: bgpmon TypeError: 'dict_keys' object is not subscriptable
```

**- How I did it**

**- How to verify it**
```
admin@str-dx010-acs-4:~$ show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 2
RIB entries 3, using 552 bytes of memory
Peers 4, using 83680 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600          0          0         0      0       0  never      Active          ARISTA01T1
10.0.0.59      4  64600          0          0         0      0       0  never      Active          ARISTA02T1
10.0.0.61      4  64600          0          0         0      0       0  never      Connect         ARISTA03T1
10.0.0.63      4  64600          0          0         0      0       0  never      Idle            ARISTA04T1

Total number of neighbors 4
admin@str-dx010-acs-4:~$
admin@str-dx010-acs-4:~$ redis-cli -n 6
127.0.0.1:6379[6]> keys "NEIGH*"
1) "NEIGH_STATE_TABLE|fc00::7e"
2) "NEIGH_STATE_TABLE|10.0.0.63"
3) "NEIGH_STATE_TABLE|fc00::7a"
4) "NEIGH_STATE_TABLE|10.0.0.61"
5) "NEIGH_STATE_TABLE|fc00::72"
6) "NEIGH_STATE_TABLE|fc00::76"
7) "NEIGH_STATE_TABLE|10.0.0.57"
8) "NEIGH_STATE_TABLE|10.0.0.59"
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
