### PR TITLE
Remove shebangs from setup.py files

### DIFF
--- a/src/sonic-bgpcfgd/setup.py
+++ b/src/sonic-bgpcfgd/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import setuptools
 
 setuptools.setup(

--- a/src/sonic-yang-mgmt/setup.py
+++ b/src/sonic-yang-mgmt/setup.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-"""The setup script."""
-
 from setuptools import setup, find_packages
 
 # read me

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-"""The setup script."""
-
 from setuptools import setup, find_packages
 
 # read me


### PR DESCRIPTION
setup.py files are not executable, and thus have no need for shebangs.

- Also remove unnecessary comments