### PR TITLE
[teamd]: Remove extensive debug output for libteamdctl

### DIFF
--- a/src/libteam/patch/0011-Remove-extensive-debug-output.patch
+++ b/src/libteam/patch/0011-Remove-extensive-debug-output.patch
@@ -1,0 +1,25 @@
+From 19928173ce022f499c59b719179e7ad9a4bafb7f Mon Sep 17 00:00:00 2001
+From: Pavel Shirshov <pavelsh@microsoft.com>
+Date: Mon, 9 Nov 2020 13:21:55 -0800
+Subject: [PATCH] Remove extensive debug output
+
+---
+ libteamdctl/cli_usock.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libteamdctl/cli_usock.c b/libteamdctl/cli_usock.c
+index 0dc97ae..d3fbdba 100644
+--- a/libteamdctl/cli_usock.c
++++ b/libteamdctl/cli_usock.c
+@@ -163,7 +163,7 @@ static int cli_usock_method_call(struct teamdctl *tdc, const char *method_name,
+ 	char *replystr;
+ 	int err;
+ 
+-	dbg(tdc, "usock: Calling method \"%s\"", method_name);
++	/* dbg(tdc, "usock: Calling method \"%s\"", method_name); */
+ 	err= myasprintf(&msg, "%s\n%s\n", TEAMD_USOCK_REQUEST_PREFIX,
+ 					  method_name);
+ 	if (err)
+-- 
+2.29.2.windows.2
+

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -8,3 +8,4 @@
 0008-libteam-Add-warm_reboot-mode.patch
 0009-Fix-ifinfo_link_with_port-race-condition-with-newlink.patch
 0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch
+0011-Remove-extensive-debug-output.patch


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->
resolves #5855

**- Why I did it**
Remove extensive output in teamd to fix #5855 

**- How I did it**
By commenting out the debug output in the code

**- How to verify it**
Build and image, run on your dut. Check that `grep 'usock: calling method' /var/log/teamd.log` shows nothing.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
