### PR TITLE
Moving BRCM SAI 4.2.1.3 to 4.2.1.3-1 to pick up fix for CS00011396506…

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_4.2.1.3_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/libsaibcm_4.2.1.3_amd64.deb?sv=2015-04-05&sr=b&sig=aA0Ltk2jteFuJZdr1ldj%2F5e6o7R0U5S%2FqVWvutPC7k0%3D&se=2021-08-31T04%3A08%3A35Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_4.2.1.3_amd64.deb
+BRCM_SAI = libsaibcm_4.2.1.3-1_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/libsaibcm_4.2.1.3-1_amd64.deb?sv=2015-04-05&sr=b&sig=1%2BrMfgxeSc%2BXJUPw6X%2FhNGxe4KUp15Oqq1lVwMJGiW0%3D&se=2034-07-20T03%3A20%3A08Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_4.2.1.3-1_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/libsaibcm-dev_4.2.1.3_amd64.deb?sv=2015-04-05&sr=b&sig=r%2FWgs1VEFo07sbfYK%2FDZmk83QKTzwSSe%2F3%2BN3k3uAcY%3D&se=2022-01-30T22%3A55%3A04Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/libsaibcm-dev_4.2.1.3-1_amd64.deb?sv=2015-04-05&sr=b&sig=lTzaCynflt5UO7Ltf2Z%2B6zHJ4R%2BFj421kupIGO4%2FOCI%3D&se=2034-07-20T03%3A19%3A27Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
… to fix CRM nexthop resource in-use leak

**- Why I did it**
SAI 4.2.1.3 has a CRM resource leak issue with nexthop resource for both IPV4 and IPV6.  A patch to address this issue was provided by BRCM and validated with a private build.  merging this fix to master branch.

**- How to verify it**
For details about CRM issue please refer to (https://github.com/Azure/sonic-buildimage/issues/5583).
Repeated the test procedure and validated that the leak is no longer observed with SAI 4.2.1.3-1

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [x] 202006

Only if 202006 is also SAI4.2.1 based.

**- Description for the changelog**
Moving BRCM SAI 4.2.1.3 to 4.2.1.3-1 to pick up fix for CS00011396506 to fix CRM nexthop (IPV4/IPV6) resource in-use leak

Fixes #5583