### PR TITLE
[celestica]: blacklist i2c_mux_pca9541 module

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/installer.conf
+++ b/device/celestica/x86_64-cel_seastone-r0/installer.conf
@@ -1,3 +1,3 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich,i2c_mux_pca9541"


### PR DESCRIPTION
device use i2c_mux_pca954x driver. recently, sonic kernel
enabled i2c_mux_pca9541 driver and it causes i2c mux probe failure.
blacklist pca9541 driver resolves the probe failure below.

    Nov 10 08:14:52.839345 sonic WARNING kernel: [ 10.900019] pca954x 0-0071: probe failed

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fix #5877

device use i2c_mux_pca854x driver. recently, sonic kernel
enabled i2c_mux_pca9541 driver and it causes i2c mux probe failure.
blacklist pca9541 driver resolves the probe failure below.

    Nov 10 08:14:52.839345 sonic WARNING kernel: [ 10.900019] pca954x 0-0071: probe failed

**- How I did it**
blacklist i2c_mux_pca9541 at using kernel cmdline

**- How to verify it**
modify the cmdline and verify manually on the dut.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
