### PR TITLE
[celestica dx010] comment out the initialization of PCA9541

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -63,7 +63,14 @@ start)
 
         # Attach PCA9541 Ox70 Master Selector
         chmod 755 /sys/bus/i2c/devices/i2c-${devnum}/new_device
-        echo pca9541 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/new_device
+        # FIXME: commenting out the following line.
+        #        there had been no pca9541 driver loaded on Celestica platform,
+        #        the recent addition of this driver casued following line
+        #        becoming effictive, but negatively impacted the platform
+        #        stability. Commenting it out restores the original behavior
+        #        on Celestica platform.
+        #        This change should be further analyzed and updated.
+        # echo pca9541 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/new_device
         sleep 1
 
         # Attach PCA9548 0x71 Channel Extender for Main Board


### PR DESCRIPTION
**- Why I did it**

The original code tried to initialize PCA9541 without having the driver loaded. As result the initialization didn't take effect.

Recently PCA9541 driver was added to the kernel and since then the initialization takes effect and has negatively impacted the
platform stability.

**- How I did it**

Commenting the initialization code out to restore the original behavior while analyzing further.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Manually made the change on a device subject to the issue. Reboot the device and the device becomes healthy. Particularly, able to access psu status. And can run test_link_flap without triggering sanity check failures.

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006
