### PR TITLE
[platform-drv/cls] Dx010: fix pca9548 downstream device address collision

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -42,7 +42,7 @@ start)
         echo -n "Setting up board... "
 
         modprobe i2c-dev
-        modprobe i2c-mux-pca954x
+        modprobe i2c-mux-pca954x force-deselect-on-exit=1
         modprobe dx010_wdt
         modprobe leds-dx010
         modprobe lm75

--- a/platform/broadcom/sonic-platform-modules-cel/dx010/cfg/dx010-modules.conf
+++ b/platform/broadcom/sonic-platform-modules-cel/dx010/cfg/dx010-modules.conf
@@ -11,5 +11,4 @@ i2c-mux
 i2c-smbus
 
 i2c-mux-gpio
-i2c-mux-pca954x
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fix the i2c device to address conflicts behind the PCA9548 switch.

**- How I did it**
Load the i2c-mux-pca954x with parameter __force-deselect-on-exit=1__.

**- How to verify it**
Stress read the temperature that has the same I2C address with the following steps:
1. Run the stress temperature sensors read of **lm75b-i2c-5-48** and **lm75b-i2c-14-48**.
2. Heat up one of the temperature sensors.
3. Inspect that the temperature read value. 
 - The temperature of the heat-up sensor should raise up.
 - The temperature of another sensor MUST be steady. 

Test Log: [5.lm75b-i2c-5-48_lm75b-i2c-14-48-pca9548-force-close.log](https://github.com/Azure/sonic-buildimage/files/5523785/5.lm75b-i2c-5-48_lm75b-i2c-14-48-pca9548-force-close.log)

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fix DX010 i2c device addresses conflicts behind the PCA9548 switch.

**- A picture of a cute animal (not mandatory but encouraged)**
