### PR TITLE
[armhf] Compilation fixes for armhf arch

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -31,12 +31,7 @@ set -x -e
 CONFIGURED_ARCH=$([ -f .arch ] && cat .arch || echo amd64)
 
 ## docker engine version (with platform)
-if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
-    # Version name differs between ARCH, copying same version as in sonic-slave docker
-    DOCKER_VERSION=18.06.3~ce~3-0~debian
-else
-    DOCKER_VERSION=5:18.09.8~3-0~debian-$IMAGE_DISTRO
-fi
+DOCKER_VERSION=5:18.09.8~3-0~debian-$IMAGE_DISTRO
 LINUX_KERNEL_VERSION=4.19.0-9-2
 
 ## Working directory to prepare the file system
@@ -202,6 +197,10 @@ sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install apt-transport-https \
                                                        curl \
                                                        gnupg2 \
                                                        software-properties-common
+if [[ $CONFIGURED_ARCH == armhf ]]; then
+    # update ssl ca certificates for secure pem
+    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT c_rehash
+fi
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT curl -o /tmp/docker.gpg -fsSL https://download.docker.com/linux/debian/gpg
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-key add /tmp/docker.gpg
 sudo LANG=C chroot $FILESYSTEM_ROOT rm /tmp/docker.gpg

--- a/dockers/docker-base-stretch/Dockerfile.j2
+++ b/dockers/docker-base-stretch/Dockerfile.j2
@@ -40,6 +40,7 @@ COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 # pre-install fundamental packages
 RUN apt-get update &&        \
     apt-get -y install       \
+        curl                 \
         less                 \
         perl                 \
         procps               \
@@ -49,8 +50,6 @@ RUN apt-get update &&        \
 # Install dependencies of supervisor
         python-pkg-resources \
         python-meld3         \
-# Install redis-tools
-        redis-tools=5:5.0.3-3~bpo9+2     \
 # common dependencies
         libpython2.7         \
         libdaemon0           \
@@ -69,6 +68,22 @@ RUN apt-get update &&        \
 
 # Install a newer version of rsyslog from stretch-backports to support -iNONE
 RUN apt-get -y -t stretch-backports install rsyslog
+
+# Install redis-tools
+
+{% if CONFIGURED_ARCH == "armhf" %}
+    RUN curl -o  redis-tools_6.0.6-1~bpo10+1_armhf.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1_bpo10+1_armhf.deb?sv=2015-04-05&sr=b&sig=67vHAMxsl%2BS3X1KsqhdYhakJkGdg5FKSPgU8kUiw4as%3D&se=2030-10-24T04%3A22%3A40Z&sp=r"
+    RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_armhf.deb || apt-get install -f -y
+    RUN rm redis-tools_6.0.6-1~bpo10+1_armhf.deb
+{% elif CONFIGURED_ARCH == "arm64" %}
+    RUN curl -o  redis-tools_6.0.6-1~bpo10+1_arm64.deb  "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1_bpo10+1_arm64.deb?sv=2015-04-05&sr=b&sig=GbkJV2wWln3hoz27zKi5erdk3NDKrAFrQriA97bcRCY%3D&se=2030-10-24T04%3A22%3A21Z&sp=r"
+    RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_arm64.deb || apt-get install -f -y
+    RUN rm redis-tools_6.0.6-1~bpo10+1_arm64.deb
+{% else %}
+    RUN curl -o redis-tools_6.0.6-1~bpo10+1_amd64.deb "https://sonicstorage.blob.core.windows.net/packages/redis/redis-tools_6.0.6-1~bpo10+1_amd64.deb?sv=2015-04-05&sr=b&sig=73zbmjkf3pi%2Bn0R8Hy7CWT2EUvOAyzM5aLYJWCLySGM%3D&se=2030-09-06T19%3A44%3A59Z&sp=r"
+    RUN dpkg -i redis-tools_6.0.6-1~bpo10+1_amd64.deb || apt-get install -f -y
+    RUN rm redis-tools_6.0.6-1~bpo10+1_amd64.deb
+{% endif %}
 
 # For templating
 RUN pip install j2cli

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -426,6 +426,9 @@ RUN apt-get install -y \
            curl \
            gnupg2 \
            software-properties-common
+{%- if CONFIGURED_ARCH == "armhf" %}
+    RUN update-ca-certificates --fresh
+{%- endif %}
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
 RUN add-apt-repository \
            "deb [arch={{ CONFIGURED_ARCH }}] https://download.docker.com/linux/debian \


### PR DESCRIPTION
[armhf] Update SSL CA certificates to verify downloads
[redis] Using redis-tools from blob sonic-storage for docker-base-stretch

Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- What I did it**
1. Update SSL ca certificates for verifying secure downloads (specific to arm).
2. Changed redis tools version to redis-tools_6.0.6-1~bpo10 and using redis-tools from blob sonic-storage for docker-base-stretch
**- How I did it**

**- How to verify it**
Compiled and verified for armhf arch

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
