### PR TITLE
[sonic-utilities] Add Python 3 sonic-yang-mgmt package as a dependency

### DIFF
--- a/rules/sonic-utilities.mk
+++ b/rules/sonic-utilities.mk
@@ -15,6 +15,7 @@ $(SONIC_UTILITIES_PY2)_DEPENDS += $(SONIC_PY_COMMON_PY2) \
                                   $(SWSSSDK_PY2) \
                                   $(SONIC_CONFIG_ENGINE_PY2) \
                                   $(SONIC_YANG_MGMT_PY2) \
+                                  $(SONIC_YANG_MGMT_PY3) \
                                   $(SONIC_YANG_MODELS_PY3)
 $(SONIC_UTILITIES_PY2)_DEBS_DEPENDS = $(LIBYANG) \
                                       $(LIBYANG_CPP) \


### PR DESCRIPTION
**- Why I did it**

Recently updated the sonic-utilities Jenkins build environment [here](https://github.com/Azure/sonic-build-tools/pull/185) to begin running tests on the Python 3 version of the sonic-utilities package. However, the build is failing because it attempts to copy the Python 3 sonic-yang-mgmt package from the artifacts of the latest VS build, but the package does not exist because there are no targets which specify it as a dependency. This PR will ensure the Python 3 package is built during the image build process.

**- How I did it**

Add Python 3 sonic-yang-mgmt package as a dependency in sonic-utilities makefile.

**- How to verify it**

Ensure sonic_yang_mgmt-1.0-py3-none-any.whl appears in the artifacts of the VS image build

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
