### PR TITLE
[buffers_config.j2]: Use correct cable lengths for backend devices

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -57,6 +57,8 @@ def
                          {%- set roles2 = neighbor_role + '_' + switch_role %}
                          {%- set roles1 = roles1 | lower %}
                          {%- set roles2 = roles2 | lower %}
+                         {%- set roles1 = roles1.replace('backend', '') %}
+                         {%- set roles2 = roles2.replace('backend', '') %}
                 {%- endif %}
                 {%- if roles1 in ports2cable %}
                     {%- if cable_len.append(ports2cable[roles1]) %}{% endif %}
@@ -74,6 +76,7 @@ def
                 {%- if local_port[1] == port_name %}
                     {%- set roles3 = switch_role + '_' + 'server' %}
                     {%- set roles3 = roles3 | lower %}
+                    {%- set roles3 = roles3.replace('backend', '') %}
                     {%- if roles3 in ports2cable %}
                         {%- if cable_len.append(ports2cable[roles3]) %}{% endif %}
                     {%- endif %}


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Backend devices do not have cable lengths properly configured because the device role is not recognized in the buffers_config template.

**- How I did it**
Remove 'backend' from the device roles so that backend devices are configured the same as non-backend devices

**- How to verify it**
Render the template on a device with type 'BackEndTorRouter' or 'BackEndLeafRouter' and confirm that the cable lengths are set correctly.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
