### PR TITLE
[201911][caclmgrd] Accomadating case insensitive rule props for Control plane ACLs

### DIFF
--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -396,6 +396,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 acl_rules = {}
 
                 for ((rule_table_name, rule_id), rule_props) in self._rules_db_info.iteritems():
+                    rule_props = {k.upper(): v for k,v in rule_props.items()}
                     if rule_table_name == table_name:
                         if not rule_props:
                             self.log_warning("rule_props for rule_id {} empty or null!".format(rule_id))

--- a/files/image_config/caclmgrd/caclmgrd
+++ b/files/image_config/caclmgrd/caclmgrd
@@ -396,7 +396,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 acl_rules = {}
 
                 for ((rule_table_name, rule_id), rule_props) in self._rules_db_info.iteritems():
-                    rule_props = {k.upper(): v for k,v in rule_props.items()}
+                    rule_props = {k.upper(): v for k,v in rule_props.iteritems()}
                     if rule_table_name == table_name:
                         if not rule_props:
                             self.log_warning("rule_props for rule_id {} empty or null!".format(rule_id))


### PR DESCRIPTION
**- Why I did it**
To make Control plane ACLs handle case insensitive ACL rules. Currently, it handles only upper case ACL rules.

**- How I did it**
I set the rule prop dictionary to be all upper case before reading the rule props for processing.

**- How to verify it**
Configure ACL rules with any combination of case of ACL rules, either it be upper case or lower case. All rules should be created properly in the switch and working properly.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
The change is a one line change in caclmgrd script.

**- A picture of a cute animal (not mandatory but encouraged)**
