### PR TITLE
[sonic-py-common] Add 'universal_newlines=True' arg to all Popen calls to properly support Python 3

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -407,7 +407,7 @@ def get_system_mac(namespace=None):
         hw_mac_entry_cmds = [mac_address_cmd]
 
     for get_mac_cmd in hw_mac_entry_cmds:
-        proc = subprocess.Popen(get_mac_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.Popen(get_mac_cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (mac, err) = proc.communicate()
         if err:
             continue
@@ -439,6 +439,7 @@ def get_system_routing_stack():
         proc = subprocess.Popen(command,
                                 stdout=subprocess.PIPE,
                                 shell=True,
+                                universal_newlines=True,
                                 stderr=subprocess.STDOUT)
         stdout = proc.communicate()[0]
         proc.wait()
@@ -473,7 +474,7 @@ def is_warm_restart_enabled(container_name):
 def is_fast_reboot_enabled():
     fb_system_state = 0
     cmd = 'sonic-db-cli STATE_DB get "FAST_REBOOT|system"'
-    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
     (stdout, stderr) = proc.communicate()
 
     if proc.returncode != 0:

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -149,6 +149,7 @@ def get_current_namespace():
     proc = subprocess.Popen(command,
                             stdout=subprocess.PIPE,
                             shell=True,
+                            universal_newlines=True,
                             stderr=subprocess.STDOUT)
     try:
         stdout, stderr = proc.communicate()


### PR DESCRIPTION
**- Why I did it**

The behavior of `subprocess.Popen()` changed in Python 3 such that stdin, stdout and stderr are treated as bytes by default. Adding the `universal_newlines=True` argument changes this behavior to return strings, matching the behavior of Python 2.

**- How to verify it**'

Call the affected functions using both Python 2 and Python 3 and ensure both provide the same, correct results.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
