### PR TITLE
Update sonic-cli start script and resolve package dependencies

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -17,6 +17,8 @@ RUN pip install connexion==1.1.15 \
 		six==1.11.0 \
 		urllib3==1.21.1
 
+RUN apt-get -y install libcurl3-gnutls libpython2.7
+
 COPY \
 {% for deb in docker_sonic_mgmt_framework_debs.split(' ') -%}
 debs/{{ deb }}{{' '}}

--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -17,8 +17,6 @@ RUN pip install connexion==1.1.15 \
 		six==1.11.0 \
 		urllib3==1.21.1
 
-RUN apt-get -y install libcurl3-gnutls libpython2.7
-
 COPY \
 {% for deb in docker_sonic_mgmt_framework_debs.split(' ') -%}
 debs/{{ deb }}{{' '}}

--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -7,7 +7,7 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y g++ python-dev libxml2
+    apt-get install -y g++ python-dev libxml2 libcurl3-gnutls libpython2.7 libcjson-dev
 
 RUN pip install connexion==1.1.15 \
 		setuptools==21.0.0 \

--- a/dockers/docker-sonic-mgmt-framework/base_image_files/sonic-cli
+++ b/dockers/docker-sonic-mgmt-framework/base_image_files/sonic-cli
@@ -1,4 +1,21 @@
 #!/bin/bash
 
-docker exec -it mgmt-framework /usr/sbin/cli/clish_start "$@"
-
+# Disallow CLI for the root user, since we don't have auth certs for root
+if [[ "$(id -u)" == 0 ]]
+then
+    echo "FATAL: root cannot launch CLI" >&2
+    exit 1
+fi
+TIMEOUT=605
+if [[ "$1" =~ "prompt=" ]]
+then
+   SYSTEM_NAME=`echo $1 | cut -d"=" -f2`
+   shift
+   docker exec -e SYSTEM_NAME=$SYSTEM_NAME -e CLI_USER="$USER" -u $(id -u):$(id -g) -it mgmt-framework /usr/sbin/cli/clish_start -t "$TIMEOUT" "$@"
+else
+   docker exec -e CLI_USER="$USER" -e SYSTEM_NAME=$HOSTNAME -u $(id -u):$(id -g) -it mgmt-framework /usr/sbin/cli/clish_start -t "$TIMEOUT" "$@"
+fi
+ret=$?
+if [ $ret -ne 0 ]; then
+   [[ -e /tmp/fast-reboot-progress || -e /tmp/reboot-progress ]] && sleep infinity
+fi

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -305,7 +305,8 @@ RUN apt-get update && apt-get install -y \
         libxml2-utils \
         xsltproc \
         python-lxml \
-        libexpat1-dev
+        libexpat1-dev \
+        libcurl3-gnutls
 
 ## Config dpkg
 ## install the configuration file if it’s currently missing

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -306,7 +306,8 @@ RUN apt-get update && apt-get install -y \
         xsltproc \
         python-lxml \
         libexpat1-dev \
-        libcurl3-gnutls
+        libcurl3-gnutls \
+        libcjson-dev
 
 ## Config dpkg
 ## install the configuration file if it’s currently missing

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -298,8 +298,7 @@ RUN apt-get update && apt-get install -y \
         libxml2-utils \
         xsltproc \
         python-lxml \
-        libexpat1-dev \
-        libcurl3-gnutls
+        libexpat1-dev
 
 ## Config dpkg
 ## install the configuration file if it’s currently missing

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -298,7 +298,8 @@ RUN apt-get update && apt-get install -y \
         libxml2-utils \
         xsltproc \
         python-lxml \
-        libexpat1-dev
+        libexpat1-dev \
+        libcurl3-gnutls
 
 ## Config dpkg
 ## install the configuration file if it’s currently missing


### PR DESCRIPTION
**- Why I did it**
As part of mgmt-framework CLI enhancement - Azure/sonic-mgmt-framework#72

**- How I did it**
update the bash script to launch Klish
update the Dockerfile.j2 to resolve dependent packages

**- How to verify it**
Incremental buster build with Azure/sonic-mgmt-framework#72

**- Which release branch to backport (provide reason below if selected)**

 201811 
 201911
 202006

**- Description for the changelog**

Update the Klish start script:
support CLI session timeout, prompt string with hostname, disallow CLI for the root user, disallow user to enter commands in click prompt after reboot command is issued in KLISH mode
add dependent libraries for Kish parser enhancement
