### PR TITLE
[base-compatibility-version] introduce SONiC base OS compatibility ve…

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -452,6 +452,7 @@ sudo tee $FILESYSTEM_ROOT/etc/sonic/sonic_version.yml > /dev/null <<EOF
 build_version: '${SONIC_IMAGE_VERSION}'
 debian_version: '$(cat $FILESYSTEM_ROOT/etc/debian_version)'
 kernel_version: '$kversion'
+base_os_compatibility_version: ${BASE_OS_COMPATIBILITY_VERSION}
 asic_type: $sonic_asic_platform
 commit_id: '$(git rev-parse --short HEAD)'
 build_date: $(date -u)

--- a/platform/vs/sonic-version/build_sonic_version.sh
+++ b/platform/vs/sonic-version/build_sonic_version.sh
@@ -1,6 +1,7 @@
 tee $1 > /dev/null <<EOF
 build_version: '$sonic_version'
 asic_type: $sonic_asic_platform
+base_os_compatibility_version: ${BASE_OS_COMPATIBILITY_VERSION}
 commit_id: '$(git rev-parse --short HEAD)'
 build_date: $(date -u)
 build_number: ${BUILD_NUMBER:-0}

--- a/rules/base-os-compatibility-version.mk
+++ b/rules/base-os-compatibility-version.mk
@@ -1,0 +1,6 @@
+# Define SONiC base OS compatibility version.
+# SONiC packages dependning on specific SONiC base image features (kernel change, etc.)
+# may define a dependency on specific version pattern.
+
+BASE_OS_COMPATIBILITY_VERSION = 1.0.0
+

--- a/slave.mk
+++ b/slave.mk
@@ -60,6 +60,7 @@ export CONFIGURED_ARCH
 export PYTHON_WHEELS_PATH
 export IMAGE_DISTRO
 export IMAGE_DISTRO_DEBS_PATH
+export BASE_OS_COMPATIBILITY_VERSION
 
 ###############################################################################
 ## Utility rules


### PR DESCRIPTION
…rsion number

Signed-off-by: Stepan Blyshchak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->
This PR is part of [SONiC Application Extension](https://github.com/stepanblyschak/SONiC/blob/sonic-app-ext-3/doc/sonic-application-extention/sonic-application-extention-hld.md)

**- Why I did it**
To record SONiC version that follows semantic versioning spec.

**- How I did it**
Include a new entry in sonic_version.yml.

**- How to verify it**
Build an image and cat /etc/sonic/sonic_version.yml.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
