### PR TITLE
 [zebra]fix the assert issue when the nexthop type of ip route entry is  blackhole.

### DIFF
--- a/src/sonic-frr/patch/0007-fix-the-assert-issue-when-the-nexthop-type-is-blackhole.patch
+++ b/src/sonic-frr/patch/0007-fix-the-assert-issue-when-the-nexthop-type-is-blackhole.patch
@@ -1,7 +1,8 @@
-From e49b72c301082bc60eac5b8093490e9296d566d7 Mon Sep 17 00:00:00 2001
+From aa5980af6325482d56093fe40a2406b43c013be5 Mon Sep 17 00:00:00 2001
 From: wangshengjun <wangshengjun@asterfusion.com>
-Date: Mon, 16 Nov 2020 16:40:42 +0800
-Subject: [PATCH] zebra:fix the assert issue when the nexthop type is blockhole
+Date: Mon, 16 Nov 2020 17:41:27 +0800
+Subject: [PATCH] zebra:fix the assert issue when the nexthop type is
+ blackhole.
 
 Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>
 ---

--- a/src/sonic-frr/patch/0007-fix-the-assert-issue-when-the-nexthop-type-is-blockhole.patch
+++ b/src/sonic-frr/patch/0007-fix-the-assert-issue-when-the-nexthop-type-is-blockhole.patch
@@ -1,0 +1,25 @@
+From e49b72c301082bc60eac5b8093490e9296d566d7 Mon Sep 17 00:00:00 2001
+From: wangshengjun <wangshengjun@asterfusion.com>
+Date: Mon, 16 Nov 2020 16:40:42 +0800
+Subject: [PATCH] zebra:fix the assert issue when the nexthop type is blockhole
+
+Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>
+---
+ zebra/zebra_fpm_netlink.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/zebra/zebra_fpm_netlink.c b/zebra/zebra_fpm_netlink.c
+index 74aab82..24c62c6 100644
+--- a/zebra/zebra_fpm_netlink.c
++++ b/zebra/zebra_fpm_netlink.c
+@@ -331,6 +331,7 @@ static int netlink_route_info_fill(netlink_route_info_t *ri, int cmd,
+ 				ri->rtm_type = RTN_BLACKHOLE;
+ 				break;
+ 			}
++			return 1;
+ 		}
+ 
+ 		if ((cmd == RTM_NEWROUTE
+-- 
+2.7.4
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -4,4 +4,4 @@
 0004-Allow-BGP-attr-NEXT_HOP-to-be-0.0.0.0-due-to-allevia.patch
 0005-nexthops-compare-vrf-only-if-ip-type.patch
 0006-changes-for-making-snmp-socket-non-blocking.patch
-0007-fix-the-assert-issue-when-the-nexthop-type-is-blockhole.patch
+0007-fix-the-assert-issue-when-the-nexthop-type-is-blackhole.patch

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -4,3 +4,4 @@
 0004-Allow-BGP-attr-NEXT_HOP-to-be-0.0.0.0-due-to-allevia.patch
 0005-nexthops-compare-vrf-only-if-ip-type.patch
 0006-changes-for-making-snmp-socket-non-blocking.patch
+0007-fix-the-assert-issue-when-the-nexthop-type-is-blockhole.patch


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
When adding the route entry which nexthop type is blackhole, the process of zebra crashed
**- How I did it**
admin@sonic:~$ vtysh
Hello, this is FRRouting (version 7.2.1-sonic).
Copyright 1996-2005 Kunihiro Ishiguro, et al.
sonic# configure
sonic(config)# ip route 10.0.0.0/8 blackhole
sonic(config)# admin@sonic:~$ show logging | grep zebra
Nov 16 09:03:24.160321 sonic INFO bgp#supervisord: zebra zebra: zebra/zebra_fpm.c:993: zfpm_build_route_updates: Assertion `data_len' failed.
Nov 16 09:03:26.851960 sonic INFO bgp#supervisor-proc-exit-listener: Process zebra exited unxepectedly. Terminating supervisor...

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
