### PR TITLE
Fix a number of LGTM alerts

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -186,7 +186,7 @@ class SfpUtil(SfpUtilBase):
         phy_port_dict = {}
         status = True
 
-        if self.db_sel == None:
+        if self.db_sel is None:
             from swsscommon import swsscommon
             self.state_db = swsscommon.DBConnector("STATE_DB",
                                                    REDIS_TIMEOUT_USECS,

--- a/files/build_scripts/generate_asic_config_checksum.py
+++ b/files/build_scripts/generate_asic_config_checksum.py
@@ -57,7 +57,7 @@ def generate_checksum(checksum_files):
 def main():
     config_files = sorted(get_config_files(CONFIG_FILES))
     checksum = generate_checksum(config_files)
-    if checksum == None:
+    if checksum is None:
         exit(1)
 
     with open(OUTPUT_FILE, 'w') as output:

--- a/files/image_config/corefile_uploader/core_uploader.py
+++ b/files/image_config/corefile_uploader/core_uploader.py
@@ -219,7 +219,6 @@ class Handler(FileSystemEventHandler):
     def upload_file(fname, fpath, coref):
         daemonname = fname.split(".")[0]
         i = 0
-        fail_msg = ""
         
         while True:
             try:

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor.py
@@ -20,19 +20,13 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time
-    import traceback
     import commands
-    from tabulate import tabulate
     from as4630_54pe.fanutil import FanUtil
     from as4630_54pe.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor_fan.py
@@ -22,19 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
-    
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor_psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor_psu.py
@@ -22,18 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_util.py
@@ -29,13 +29,12 @@ command:
     set         : change board setting with fan|led|sfp
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 PROJECT_NAME = 'as4630_54pe'
 version = '0.0.1'
@@ -53,7 +52,6 @@ hwmon_types = {'led': ['diag','fan','loc','psu1','psu2'],
                'fan2': ['fan'],
                'fan3': ['fan'],
                'fan4': ['fan'],
-               'fan5': ['fan'],
                'fan5': ['fan'],
               }
 hwmon_nodes = {'led': ['brightness'] ,

--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_monitor.py
@@ -23,18 +23,11 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
     import signal
-    from tabulate import tabulate
     from as5712_54x.fanutil import FanUtil
     from as5712_54x.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_util.py
@@ -31,11 +31,11 @@ command:
 
 import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 PROJECT_NAME = 'as5712_54x'
 version = '0.2.0'
@@ -546,7 +546,7 @@ def cpld_path_of_port(port_index):
 
 def get_path_sfp_tx_dis(port_index):
     cpld_p = cpld_path_of_port(port_index)
-    if cpld_p == None:
+    if cpld_p is None:
         return False, ''
     else:
         dev = cpld_p+"module_tx_disable_"+str(port_index)
@@ -554,7 +554,7 @@ def get_path_sfp_tx_dis(port_index):
 
 def get_path_sfp_presence(port_index):
     cpld_p = cpld_path_of_port(port_index)
-    if cpld_p == None:
+    if cpld_p is None:
         return False, ''
     else:
         dev = cpld_p+"module_present_"+str(port_index)

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54t/utils/accton_as5812_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54t/utils/accton_as5812_monitor.py
@@ -23,19 +23,13 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
     import signal
-    from tabulate import tabulate
     from as5812_54t.fanutil import FanUtil
     from as5812_54t.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54t/utils/accton_as5812_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54t/utils/accton_as5812_util.py
@@ -30,13 +30,12 @@ command:
     set         : change board setting with fan|led|sfp    
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/utils/accton_as5812_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/utils/accton_as5812_monitor.py
@@ -23,19 +23,13 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
     import signal
-    from tabulate import tabulate
     from as5812_54x.fanutil import FanUtil
     from as5812_54x.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/utils/accton_as5812_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/utils/accton_as5812_util.py
@@ -31,11 +31,11 @@ command:
 
 import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 PROJECT_NAME = 'as5812_54x'
 version = '0.2.0'
@@ -546,7 +546,7 @@ def cpld_path_of_port(port_index):
 
 def get_path_sfp_tx_dis(port_index):
     cpld_p = cpld_path_of_port(port_index)
-    if cpld_p == None:
+    if cpld_p is None:
         return False, ''
     else:
         dev = cpld_p+"module_tx_disable_"+str(port_index)
@@ -554,7 +554,7 @@ def get_path_sfp_tx_dis(port_index):
 
 def get_path_sfp_presence(port_index):
     cpld_p = cpld_path_of_port(port_index)
-    if cpld_p == None:
+    if cpld_p is None:
         return False, ''
     else:
         dev = cpld_p+"module_present_"+str(port_index)

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_monitor.py
@@ -25,18 +25,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
     import signal
-    from tabulate import tabulate
     from as5835_54t.fanutil import FanUtil
     from as5835_54t.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_monitor_fan.py
@@ -22,18 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
     
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_monitor_psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_monitor_psu.py
@@ -22,18 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_util.py
@@ -30,13 +30,12 @@ command:
     set         : change board setting with fan|led|sfp    
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_monitor.py
@@ -24,18 +24,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
     import signal
-    from tabulate import tabulate
     from as5835_54x.fanutil import FanUtil
     from as5835_54x.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_monitor_fan.py
@@ -22,18 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
     
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_monitor_psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_monitor_psu.py
@@ -22,18 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_util.py
@@ -30,13 +30,12 @@ command:
     set         : change board setting with fan|led|sfp    
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as6712-32x/utils/accton_as6712_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as6712-32x/utils/accton_as6712_monitor.py
@@ -24,17 +24,11 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
     from as6712_32x.fanutil import FanUtil
     from as6712_32x.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as6712-32x/utils/accton_as6712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as6712-32x/utils/accton_as6712_util.py
@@ -37,13 +37,12 @@ command:
     set         : change board setting with fan|led|sfp
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 PROJECT_NAME = 'as6712_32x'
 version = '0.2.0'

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54x/utils/accton_as7312_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54x/utils/accton_as7312_monitor.py
@@ -24,18 +24,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
     import signal
-    from tabulate import tabulate
     from as7312_54x.fanutil import FanUtil
     from as7312_54x.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54x/utils/accton_as7312_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54x/utils/accton_as7312_util.py
@@ -30,13 +30,12 @@ command:
     set         : change board setting with fan|led|sfp    
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54xs/utils/accton_as7312_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54xs/utils/accton_as7312_monitor.py
@@ -24,18 +24,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
     import signal
-    from tabulate import tabulate
     from as7312_54xs.fanutil import FanUtil
     from as7312_54xs.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54xs/utils/accton_as7312_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54xs/utils/accton_as7312_util.py
@@ -30,13 +30,12 @@ command:
     set         : change board setting with fan|led|sfp    
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/utils/accton_as7315_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/utils/accton_as7315_monitor.py
@@ -24,18 +24,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
     import signal
-    from tabulate import tabulate
     from as7315_27xb.fanutil import FanUtil
     from as7315_27xb.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/utils/accton_as7315_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/utils/accton_as7315_util.py
@@ -30,13 +30,12 @@ command:
     set         : change board setting with fan|led|sfp    
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor.py
@@ -24,17 +24,12 @@
 
 try:
     import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
     from as7326_56x.fanutil import FanUtil
     from as7326_56x.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor_fan.py
@@ -22,19 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
-    
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor_psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_monitor_psu.py
@@ -22,18 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_util.py
@@ -39,13 +39,12 @@ command:
     set         : change board setting with fan|led|sfp
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/accton_as7712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/accton_as7712_util.py
@@ -30,13 +30,12 @@ command:
     set         : change board setting with fan|led|sfp    
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32x/utils/accton_as7716_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32x/utils/accton_as7716_monitor.py
@@ -23,17 +23,11 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
     from as7716_32x.fanutil import FanUtil
     from as7716_32x.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32x/utils/accton_as7716_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32x/utils/accton_as7716_util.py
@@ -30,13 +30,12 @@ command:
     set         : change board setting with fan|led|sfp
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 PROJECT_NAME = 'as7716_32x'
 version = '0.0.1'
@@ -54,7 +53,6 @@ hwmon_types = {'led': ['diag','fan','loc','psu1','psu2'],
                'fan2': ['fan'],
                'fan3': ['fan'],
                'fan4': ['fan'],
-               'fan5': ['fan'],
                'fan5': ['fan'],
               }
 hwmon_nodes = {'led': ['brightness'] ,

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/utils/accton_as7716_32xb_drv_handler.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/utils/accton_as7716_32xb_drv_handler.py
@@ -22,18 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
     import commands
-    from tabulate import tabulate    
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/utils/accton_as7716_32xb_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/utils/accton_as7716_32xb_monitor.py
@@ -23,17 +23,11 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
     from as7716_32x.fanutil import FanUtil
     from as7716_32x.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/utils/accton_as7716_32xb_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/utils/accton_as7716_32xb_util.py
@@ -30,13 +30,11 @@ command:
     set         : change board setting with fan|led|sfp
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
-import time
-from collections import namedtuple
 
 PROJECT_NAME = 'as7716_32xb'
 version = '0.0.1'
@@ -54,7 +52,6 @@ hwmon_types = {'led': ['diag','fan','loc','psu1','psu2'],
                'fan2': ['fan'],
                'fan3': ['fan'],
                'fan4': ['fan'],
-               'fan5': ['fan'],
                'fan5': ['fan'],
               }
 hwmon_nodes = {'led': ['brightness'] ,

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor.py
@@ -24,17 +24,12 @@
 
 try:
     import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback    
-    from tabulate import tabulate
     from as7726_32x.fanutil import FanUtil
     from as7726_32x.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor_fan.py
@@ -22,19 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
-    
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor_psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_monitor_psu.py
@@ -22,18 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
@@ -30,13 +30,12 @@ command:
     set         : change board setting with fan|led|sfp
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 PROJECT_NAME = 'as7726_32x'
 version = '0.0.1'
@@ -54,7 +53,6 @@ hwmon_types = {'led': ['diag','fan','loc','psu1','psu2'],
                'fan2': ['fan'],
                'fan3': ['fan'],
                'fan4': ['fan'],
-               'fan5': ['fan'],
                'fan5': ['fan'],
               }
 hwmon_nodes = {'led': ['brightness'] ,

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_monitor.py
@@ -24,18 +24,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
-    import types
     import time  # this is only being used as part of the example
-    import traceback
     import signal
-    from tabulate import tabulate
     from as7816_64x.fanutil import FanUtil
     from as7816_64x.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_util.py
@@ -30,14 +30,12 @@ command:
     set         : change board setting with fan|led|sfp    
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
-
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_monitor.py
@@ -20,19 +20,13 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
     import commands
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback    
-    from tabulate import tabulate
     from as9716_32d.fanutil import FanUtil
     from as9716_32d.thermalutil import ThermalUtil
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_monitor_fan.py
@@ -22,19 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
-    
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_monitor_psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_monitor_psu.py
@@ -22,18 +22,12 @@
 # ------------------------------------------------------------------
 
 try:
-    import os
-    import sys, getopt
-    import subprocess
-    import click
-    import imp
+    import getopt
+    import sys
     import logging
     import logging.config
     import logging.handlers
-    import types
     import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_util.py
@@ -30,13 +30,12 @@ command:
     set         : change board setting with fan|led|sfp
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 PROJECT_NAME = 'as9716_32d'
 version = '0.0.1'
@@ -54,7 +53,6 @@ hwmon_types = {'led': ['diag','fan','loc','psu1','psu2'],
                'fan2': ['fan'],
                'fan3': ['fan'],
                'fan4': ['fan'],
-               'fan5': ['fan'],
                'fan5': ['fan'],
               }
 hwmon_nodes = {'led': ['brightness'] ,

--- a/platform/broadcom/sonic-platform-modules-accton/minipack/utils/accton_minipack_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/minipack/utils/accton_minipack_util.py
@@ -37,13 +37,12 @@ command:
     set         : change board setting with led|sfp
 """
 
-import os
 import commands
-import sys, getopt
+import getopt
+import sys
 import logging
 import re
 import time
-from collections import namedtuple
 
 PROJECT_NAME = 'minipack'
 version = '0.2.0'

--- a/platform/broadcom/sonic-platform-modules-accton/minipack/utils/setup_qsfp_eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-accton/minipack/utils/setup_qsfp_eeprom.py
@@ -22,8 +22,8 @@
 
 try:
     import os
-    import sys, getopt
-    import subprocess
+    import getopt
+    import sys
     import subprocess
     import click
     import imp

--- a/platform/nephos/sonic-platform-modules-cig/cs5435-54p/utils/cig_cs5435_misc.py
+++ b/platform/nephos/sonic-platform-modules-cig/cs5435-54p/utils/cig_cs5435_misc.py
@@ -335,7 +335,7 @@ def system_get_lswtemp():
         return 25
 
 #    chp = subprocess.Popen("docker ps --filter name=syncd", shell=True, stdout=subprocess.PIPE)
-#   if chp.poll() == None:
+#   if chp.poll() is None:
 #       misclogger.info("No subp.")
 #       chp.kill()
 #

--- a/platform/nephos/sonic-platform-modules-cig/cs6436-54p/utils/cig_cs6436_misc.py
+++ b/platform/nephos/sonic-platform-modules-cig/cs6436-54p/utils/cig_cs6436_misc.py
@@ -335,7 +335,7 @@ def system_get_lswtemp():
         return 25
 
 #    chp = subprocess.Popen("docker ps --filter name=syncd", shell=True, stdout=subprocess.PIPE)
-#   if chp.poll() == None:
+#   if chp.poll() is None:
 #       misclogger.info("No subp.")
 #       chp.kill()
 #

--- a/platform/nephos/sonic-platform-modules-cig/cs6436-56p/utils/cig_cs6436_misc.py
+++ b/platform/nephos/sonic-platform-modules-cig/cs6436-56p/utils/cig_cs6436_misc.py
@@ -335,7 +335,7 @@ def system_get_lswtemp():
         return 25
 
 #    chp = subprocess.Popen("docker ps --filter name=syncd", shell=True, stdout=subprocess.PIPE)
-#   if chp.poll() == None:
+#   if chp.poll() is None:
 #       misclogger.info("No subp.")
 #       chp.kill()
 #

--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from natsort import natsorted
 
 def generate_t1_sample_config(data):

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1,15 +1,10 @@
 from __future__ import print_function
 
-import calendar
-from ipaddress import IPv4Address, IPv4Network, ip_address, ip_network
+import ipaddress
 import math
 import os
 import sys
-import socket
-import struct
 import json
-import copy
-import ipaddress
 from collections import defaultdict
 
 from lxml import etree as ET
@@ -809,7 +804,7 @@ def parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_m
                 intf_name = pc_member[1]
                 break
 
-        if intf_name == None:
+        if intf_name is None:
             print('Warning: cannot find any interfaces that belong to %s' % (pc_intf), file=sys.stderr)
             continue
 
@@ -1314,8 +1309,8 @@ def get_tunnel_entries(tunnel_intfs, lo_intfs, hostname):
     lo_addr = ''
     # Use the first IPv4 loopback as the tunnel destination IP
     for addr in lo_intfs.keys():
-        ip_addr = ip_network(UNICODE_TYPE(addr[1]))
-        if isinstance(ip_addr, IPv4Network):
+        ip_addr = ipaddress.ip_network(UNICODE_TYPE(addr[1]))
+        if isinstance(ip_addr, ipaddress.IPv4Network):
             lo_addr = str(ip_addr.network_address)
             break
 

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -1,10 +1,10 @@
 try:
-    import os
-    import sys
-    import json
     import ast
+    import json
+    import os
     import re
-    from collections import OrderedDict
+    import sys
+
     from swsssdk import ConfigDBConnector
     from sonic_py_common import device_info
 except ImportError as e:


### PR DESCRIPTION
Fix 259 alerts reported by the LGTM tool:

- 245 for Unused import
- 7 for Testing equality to None
- 5 for Duplicate key in dict literal
- 1 for Module is imported more than once
- 1 for Unused local variable