### PR TITLE
[Monit] Enable/disable Monit when starting/stopping the service.

### DIFF
--- a/dockers/docker-database/base_image_files/monit_database
+++ b/dockers/docker-database/base_image_files/monit_database
@@ -5,3 +5,4 @@
 ###############################################################################
 check program database|redis_server with path "/usr/bin/process_checker database /usr/bin/redis-server"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_database

--- a/dockers/docker-fpm-frr/base_image_files/monit_bgp
+++ b/dockers/docker-fpm-frr/base_image_files/monit_bgp
@@ -10,18 +10,24 @@
 ###############################################################################
 check program bgp|zebra with path "/usr/bin/process_checker bgp /usr/lib/frr/zebra"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_bgp
 
 check program bgp|fpmsyncd with path "/usr/bin/process_checker bgp fpmsyncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_bgp
 
 check program bgp|bgpd with path "/usr/bin/process_checker bgp /usr/lib/frr/bgpd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_bgp
 
 check program bgp|staticd with path "/usr/bin/process_checker bgp /usr/lib/frr/staticd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_bgp
 
 check program bgp|bgpcfgd with path "/usr/bin/process_checker bgp /usr/bin/python3 /usr/local/bin/bgpcfgd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_bgp
 
 check program bgp|bgpmon with path "/usr/bin/process_checker bgp /usr/bin/python3 /usr/local/bin/bgpmon"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_bgp

--- a/dockers/docker-lldp/base_image_files/monit_lldp
+++ b/dockers/docker-lldp/base_image_files/monit_lldp
@@ -7,9 +7,12 @@
 ###############################################################################
 check program lldp|lldpd_monitor with path "/usr/bin/process_checker lldp lldpd:"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_lldp
 
 check program lldp|lldp_syncd with path "/usr/bin/process_checker lldp python2 -m lldp_syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_lldp
 
 check program lldp|lldpmgrd with path "/usr/bin/process_checker lldp python3 /usr/bin/lldpmgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_lldp

--- a/dockers/docker-orchagent/base_image_files/monit_swss
+++ b/dockers/docker-orchagent/base_image_files/monit_swss
@@ -14,30 +14,40 @@
 ##############################################################################
 check program swss|orchagent with path "/usr/bin/process_checker swss /usr/bin/orchagent -d /var/log/swss"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_swss
 
 check program swss|portsyncd with path "/usr/bin/process_checker swss /usr/bin/portsyncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_swss
 
 check program swss|neighsyncd with path "/usr/bin/process_checker swss /usr/bin/neighsyncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_swss
 
 check program swss|vrfmgrd with path "/usr/bin/process_checker swss /usr/bin/vrfmgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_swss
 
 check program swss|vlanmgrd with path "/usr/bin/process_checker swss /usr/bin/vlanmgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_swss
 
 check program swss|intfmgrd with path "/usr/bin/process_checker swss /usr/bin/intfmgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_swss
 
 check program swss|portmgrd with path "/usr/bin/process_checker swss /usr/bin/portmgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_swss
 
 check program swss|buffermgrd with path "/usr/bin/process_checker swss /usr/bin/buffermgrd -l"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_swss
 
 check program swss|nbrmgrd with path "/usr/bin/process_checker swss /usr/bin/nbrmgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_swss
 
 check program swss|vxlanmgrd with path "/usr/bin/process_checker swss /usr/bin/vxlanmgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_swss

--- a/dockers/docker-sflow/base_image_files/monit_sflow
+++ b/dockers/docker-sflow/base_image_files/monit_sflow
@@ -5,3 +5,4 @@
 ###############################################################################
 check program sflow|sflowmgrd with path "/usr/bin/process_checker sflow /usr/bin/sflowmgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_sflow

--- a/dockers/docker-snmp/base_image_files/monit_snmp
+++ b/dockers/docker-snmp/base_image_files/monit_snmp
@@ -6,6 +6,8 @@
 ###############################################################################
 check program snmp|snmpd with path "/usr/bin/process_checker snmp /usr/sbin/snmpd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_snmp
 
 check program snmp|snmp_subagent with path "/usr/bin/process_checker snmp python3 -m sonic_ax_impl"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_snmp

--- a/dockers/docker-sonic-restapi/base_image_files/monit_restapi
+++ b/dockers/docker-sonic-restapi/base_image_files/monit_restapi
@@ -5,3 +5,4 @@
 ###############################################################################
 check program restapi|restapi with path "/usr/bin/process_checker restapi /usr/sbin/go-server-server"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_restapi

--- a/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
+++ b/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
@@ -6,6 +6,8 @@
 ###############################################################################
 check program telemetry|telemetry with path "/usr/bin/process_checker telemetry /usr/sbin/telemetry"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_telemetry
 
 check program telemetry|dialout_client with path "/usr/bin/process_checker telemetry /usr/sbin/dialout_client_cli"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_telemetry

--- a/dockers/docker-teamd/base_image_files/monit_teamd
+++ b/dockers/docker-teamd/base_image_files/monit_teamd
@@ -6,6 +6,8 @@
 ###############################################################################
 check program teamd|teamsyncd with path "/usr/bin/process_checker teamd /usr/bin/teamsyncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_teamd
 
 check program teamd|teammgrd with path "/usr/bin/process_checker teamd /usr/bin/teammgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_teamd

--- a/files/build_templates/per_namespace/bgp.service.j2
+++ b/files/build_templates/per_namespace/bgp.service.j2
@@ -10,11 +10,11 @@ StartLimitBurst=3
 
 [Service]
 User=root
-ExecStartPre=/usr/bin/monit -g monit_group_bgp monitor
+ExecStartPre=-/usr/bin/monit -g monit_group_bgp monitor
 ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=/usr/bin/monit -g monit_group_bgp unmonitor
+ExecStopPost=-/usr/bin/monit -g monit_group_bgp unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/bgp.service.j2
+++ b/files/build_templates/per_namespace/bgp.service.j2
@@ -9,11 +9,12 @@ StartLimitIntervalSec=1200
 StartLimitBurst=3
 
 [Service]
-User={{ sonicadmin_user }}
+User=root
+ExecStartPre=/usr/bin/monit -g monit_group_bgp monitor
 ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-
+ExecStopPost=/usr/bin/monit -g monit_group_bgp unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/bgp.service.j2
+++ b/files/build_templates/per_namespace/bgp.service.j2
@@ -13,8 +13,8 @@ User=root
 ExecStartPre=-/usr/bin/monit -g monit_group_bgp monitor
 ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
+ExecStop=-/usr/bin/monit -g monit_group_bgp unmonitor
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=-/usr/bin/monit -g monit_group_bgp unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/database.service.j2
+++ b/files/build_templates/per_namespace/database.service.j2
@@ -14,9 +14,11 @@ StartLimitBurst=3
 
 [Service]
 User=root
+ExecStartPre=-/usr/bin/monit -g monit_group_database monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
+ExecStopPost=-/usr/bin/monit -g monit_group_database unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/database.service.j2
+++ b/files/build_templates/per_namespace/database.service.j2
@@ -17,8 +17,8 @@ User=root
 ExecStartPre=-/usr/bin/monit -g monit_group_database monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
+ExecStop=-/usr/bin/monit -g monit_group_database unmonitor
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=-/usr/bin/monit -g monit_group_database unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/lldp.service.j2
+++ b/files/build_templates/per_namespace/lldp.service.j2
@@ -12,11 +12,11 @@ StartLimitBurst=3
 
 [Service]
 User=root
-ExecStartPre=/usr/bin/monit -g monit_group_lldp monitor
+ExecStartPre=-/usr/bin/monit -g monit_group_lldp monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=/usr/bin/monit -g monit_group_lldp unmonitor
+ExecStopPost=-/usr/bin/monit -g monit_group_lldp unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/lldp.service.j2
+++ b/files/build_templates/per_namespace/lldp.service.j2
@@ -11,10 +11,12 @@ StartLimitIntervalSec=1200
 StartLimitBurst=3
 
 [Service]
-User={{ sonicadmin_user }}
+User=root
+ExecStartPre=/usr/bin/monit -g monit_group_lldp monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
+ExecStopPost=/usr/bin/monit -g monit_group_lldp unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/lldp.service.j2
+++ b/files/build_templates/per_namespace/lldp.service.j2
@@ -15,8 +15,8 @@ User=root
 ExecStartPre=-/usr/bin/monit -g monit_group_lldp monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
+ExecStop=-/usr/bin/monit -g monit_group_lldp unmonitor
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=-/usr/bin/monit -g monit_group_lldp unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/swss.service.j2
+++ b/files/build_templates/per_namespace/swss.service.j2
@@ -19,9 +19,11 @@ StartLimitBurst=3
 [Service]
 User=root
 Environment=sonic_asic_platform={{ sonic_asic_platform }}
+ExecStartPre=/usr/bin/monit -g monit_group_swss monitor
 ExecStartPre=/usr/local/bin/swss.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/swss.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/swss.sh stop{% if multi_instance == 'true' %} %i{% endif %}
+ExecStopPost=/usr/bin/monit -g monit_group_swss unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/swss.service.j2
+++ b/files/build_templates/per_namespace/swss.service.j2
@@ -19,11 +19,11 @@ StartLimitBurst=3
 [Service]
 User=root
 Environment=sonic_asic_platform={{ sonic_asic_platform }}
-ExecStartPre=/usr/bin/monit -g monit_group_swss monitor
+ExecStartPre=-/usr/bin/monit -g monit_group_swss monitor
 ExecStartPre=/usr/local/bin/swss.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/swss.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/swss.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=/usr/bin/monit -g monit_group_swss unmonitor
+ExecStopPost=-/usr/bin/monit -g monit_group_swss unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/swss.service.j2
+++ b/files/build_templates/per_namespace/swss.service.j2
@@ -22,8 +22,8 @@ Environment=sonic_asic_platform={{ sonic_asic_platform }}
 ExecStartPre=-/usr/bin/monit -g monit_group_swss monitor
 ExecStartPre=/usr/local/bin/swss.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/swss.sh wait{% if multi_instance == 'true' %} %i{% endif %}
+ExecStop=-/usr/bin/monit -g monit_group_swss unmonitor
 ExecStop=/usr/local/bin/swss.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=-/usr/bin/monit -g monit_group_swss unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/syncd.service.j2
+++ b/files/build_templates/per_namespace/syncd.service.j2
@@ -22,9 +22,11 @@ Before=ntp-config.service
 [Service]
 User=root
 Environment=sonic_asic_platform={{ sonic_asic_platform }}
+ExecStartPre=/usr/bin/monit -g monit_group_syncd monitor
 ExecStartPre=/usr/local/bin/syncd.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/syncd.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/syncd.sh stop{% if multi_instance == 'true' %} %i{% endif %}
+ExecStopPost=/usr/bin/monit -g monit_group_syncd unmonitor
 {% if sonic_asic_platform == 'mellanox' %}
 TimeoutStartSec=150
 {% endif %}

--- a/files/build_templates/per_namespace/syncd.service.j2
+++ b/files/build_templates/per_namespace/syncd.service.j2
@@ -25,8 +25,8 @@ Environment=sonic_asic_platform={{ sonic_asic_platform }}
 ExecStartPre=-/usr/bin/monit -g monit_group_syncd monitor
 ExecStartPre=/usr/local/bin/syncd.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/syncd.sh wait{% if multi_instance == 'true' %} %i{% endif %}
+ExecStop=-/usr/bin/monit -g monit_group_syncd unmonitor
 ExecStop=/usr/local/bin/syncd.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=-/usr/bin/monit -g monit_group_syncd unmonitor
 {% if sonic_asic_platform == 'mellanox' %}
 TimeoutStartSec=150
 {% endif %}

--- a/files/build_templates/per_namespace/syncd.service.j2
+++ b/files/build_templates/per_namespace/syncd.service.j2
@@ -22,11 +22,11 @@ Before=ntp-config.service
 [Service]
 User=root
 Environment=sonic_asic_platform={{ sonic_asic_platform }}
-ExecStartPre=/usr/bin/monit -g monit_group_syncd monitor
+ExecStartPre=-/usr/bin/monit -g monit_group_syncd monitor
 ExecStartPre=/usr/local/bin/syncd.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/syncd.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/syncd.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=/usr/bin/monit -g monit_group_syncd unmonitor
+ExecStopPost=-/usr/bin/monit -g monit_group_syncd unmonitor
 {% if sonic_asic_platform == 'mellanox' %}
 TimeoutStartSec=150
 {% endif %}

--- a/files/build_templates/per_namespace/teamd.service.j2
+++ b/files/build_templates/per_namespace/teamd.service.j2
@@ -9,11 +9,11 @@ StartLimitBurst=3
 
 [Service]
 User=root
-ExecStartPre=/usr/bin/monit -g monit_group_teamd monitor
+ExecStartPre=-/usr/bin/monit -g monit_group_teamd monitor
 ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=/usr/bin/monit -g monit_group_teamd unmonitor
+ExecStopPost=-/usr/bin/monit -g monit_group_teamd unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/teamd.service.j2
+++ b/files/build_templates/per_namespace/teamd.service.j2
@@ -8,10 +8,12 @@ StartLimitIntervalSec=1200
 StartLimitBurst=3
 
 [Service]
-User={{ sonicadmin_user }}
+User=root
+ExecStartPre=/usr/bin/monit -g monit_group_teamd monitor
 ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
+ExecStopPost=/usr/bin/monit -g monit_group_teamd unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/per_namespace/teamd.service.j2
+++ b/files/build_templates/per_namespace/teamd.service.j2
@@ -12,8 +12,8 @@ User=root
 ExecStartPre=-/usr/bin/monit -g monit_group_teamd monitor
 ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start{% if multi_instance == 'true' %} %i{% endif %}
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
+ExecStop=-/usr/bin/monit -g monit_group_teamd unmonitor
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
-ExecStopPost=-/usr/bin/monit -g monit_group_teamd unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/restapi.service.j2
+++ b/files/build_templates/restapi.service.j2
@@ -9,8 +9,8 @@ User=root
 ExecStartPre=-/usr/bin/monit -g monit_group_restapi monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
+ExecStop=-/usr/bin/monit -g monit_group_restapi unmonitor
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-ExecStopPost=-/usr/bin/monit -g monit_group_restapi unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/restapi.service.j2
+++ b/files/build_templates/restapi.service.j2
@@ -5,10 +5,12 @@ After=updategraph.service
 Before=ntp-config.service
 
 [Service]
-User={{ sonicadmin_user }}
+User=root
+ExecStartPre=-/usr/bin/monit -g monit_group_restapi monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+ExecStopPost=-/usr/bin/monit -g monit_group_restapi unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/sflow.service.j2
+++ b/files/build_templates/sflow.service.j2
@@ -7,10 +7,12 @@ StartLimitIntervalSec=1200
 StartLimitBurst=3
 
 [Service]
-User={{ sonicadmin_user }}
+User=root
+ExecStartPre=-/usr/bin/monit -g monit_group_sflow monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+ExecStopPost=-/usr/bin/monit -g monit_group_sflow unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/sflow.service.j2
+++ b/files/build_templates/sflow.service.j2
@@ -11,8 +11,8 @@ User=root
 ExecStartPre=-/usr/bin/monit -g monit_group_sflow monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
+ExecStop=-/usr/bin/monit -g monit_group_sflow unmonitor
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-ExecStopPost=-/usr/bin/monit -g monit_group_sflow unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -9,9 +9,12 @@ StartLimitIntervalSec=1200
 StartLimitBurst=3
 
 [Service]
+User=root
+ExecStartPre=/usr/bin/monit -g monit_group_snmp monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+ExecStopPost=/usr/bin/monit -g monit_group_snmp unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -13,8 +13,8 @@ User=root
 ExecStartPre=-/usr/bin/monit -g monit_group_snmp monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
+ExecStop=-/usr/bin/monit -g monit_group_snmp unmonitor
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-ExecStopPost=-/usr/bin/monit -g monit_group_snmp unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -10,11 +10,11 @@ StartLimitBurst=3
 
 [Service]
 User=root
-ExecStartPre=/usr/bin/monit -g monit_group_snmp monitor
+ExecStartPre=-/usr/bin/monit -g monit_group_snmp monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-ExecStopPost=/usr/bin/monit -g monit_group_snmp unmonitor
+ExecStopPost=-/usr/bin/monit -g monit_group_snmp unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/telemetry.service.j2
+++ b/files/build_templates/telemetry.service.j2
@@ -7,10 +7,12 @@ StartLimitIntervalSec=1200
 StartLimitBurst=3
 
 [Service]
-User={{ sonicadmin_user }}
+User=root
+ExecStartPre=/usr/bin/monit -g monit_group_telemetry monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
+ExecStopPost=/usr/bin/monit -g monit_group_telemetry unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/telemetry.service.j2
+++ b/files/build_templates/telemetry.service.j2
@@ -8,11 +8,11 @@ StartLimitBurst=3
 
 [Service]
 User=root
-ExecStartPre=/usr/bin/monit -g monit_group_telemetry monitor
+ExecStartPre=-/usr/bin/monit -g monit_group_telemetry monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-ExecStopPost=/usr/bin/monit -g monit_group_telemetry unmonitor
+ExecStopPost=-/usr/bin/monit -g monit_group_telemetry unmonitor
 Restart=always
 RestartSec=30
 

--- a/files/build_templates/telemetry.service.j2
+++ b/files/build_templates/telemetry.service.j2
@@ -11,8 +11,8 @@ User=root
 ExecStartPre=-/usr/bin/monit -g monit_group_telemetry monitor
 ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
+ExecStop=-/usr/bin/monit -g monit_group_telemetry unmonitor
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
-ExecStopPost=-/usr/bin/monit -g monit_group_telemetry unmonitor
 Restart=always
 RestartSec=30
 

--- a/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
+++ b/platform/barefoot/docker-syncd-bfn/base_image_files/monit_syncd
@@ -5,3 +5,4 @@
 ###############################################################################
 check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd

--- a/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
+++ b/platform/broadcom/docker-syncd-brcm/base_image_files/monit_syncd
@@ -6,6 +6,8 @@
 ###############################################################################
 check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd
 
 check program syncd|dsserve with path "/usr/bin/process_checker syncd /usr/bin/dsserve /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd

--- a/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
+++ b/platform/cavium/docker-syncd-cavm/base_image_files/monit_syncd
@@ -5,3 +5,4 @@
 ###############################################################################
 check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd

--- a/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
+++ b/platform/centec/docker-syncd-centec/base_image_files/monit_syncd
@@ -5,3 +5,4 @@
 ###############################################################################
 check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd

--- a/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-arm64/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -5,3 +5,4 @@
 ###############################################################################
 check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd

--- a/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell-armhf/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -5,3 +5,4 @@
 ###############################################################################
 check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd

--- a/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
+++ b/platform/marvell/docker-syncd-mrvl/base_image_files/monit_syncd
@@ -5,3 +5,4 @@
 ###############################################################################
 check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd

--- a/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
+++ b/platform/mellanox/docker-syncd-mlnx/base_image_files/monit_syncd
@@ -5,3 +5,4 @@
 ###############################################################################
 check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd

--- a/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
+++ b/platform/nephos/docker-syncd-nephos/base_image_files/monit_syncd
@@ -6,6 +6,8 @@
 ###############################################################################
 check program syncd|syncd with path "/usr/bin/process_checker syncd /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd
 
 check program syncd|dsserve with path "/usr/bin/process_checker syncd /usr/bin/dsserve /usr/bin/syncd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+    group monit_group_syncd


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
When we ran the command `sudo config load`, `sudo config reload` or `sudo config load_minigraph`, the containers `swss`, `snmp`, `lldp`, `teamd`, `syncd`, `snmp`, `bgp`, `radv`, `pmon`, `dhcp_relay` and `telemetry` and `restapi` would be stopped and then started. Monit will generate false alerting messages into syslog to indicate some critical processes were not running during restarting these containers. So this PR aims to solve this problem. 

**- How I did it**
We borrowed the concept of `group` statement of Monit. Specifically the Monit configuration entries of each container were grouped together with the help of this `group` statement. When the container was stopped, the command `sudo monit -g <group_name> unmonitor` will stop monitoring the running status of critical processes in this container. When the container was started, the command `sudo monit -g <group_name> monitor` will start monitoring the running status of critical processes. In order to achieve monitoring and unmonitoring automatically, these two commands are placed in the systemd service file of each container.

In the systemd service file of each container, the command `sudo monit -g <group_name> monitor` will be run before the command to start the container. The reason is that if we put the command to start container first and this command failed to start container, then the rest commands would not execute. That means Monit could not generate the alerting message into syslog.

Another thing is I put a special character `-` before the command `-/usr/bin/monit -g <group_name> monitor` and `-/usr/bin/monit -g <group_name> unmonitor` to ignore the failure of these commands. Since we delayed Monit to do the monitoring 5 minutes when the device was up, these commands will fail to read the socket file until Monit created it 5 minutes later. 

Since Monit can only be ran by `root` privilege, I changed the `User=root` in the `[Service]` section of systemd service files.

**- How to verify it**
I tested and verified this method on two lab devices: `str-msn2700-04` and `str-a7050-acs-3`.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
