### PR TITLE
[bgpcfgd]: Fixes for BBR

### DIFF
--- a/files/image_config/constants/constants.yml
+++ b/files/image_config/constants/constants.yml
@@ -31,6 +31,7 @@ constants:
           - "deny 0::/0 ge 65"
     bbr:
       enabled: true
+      default_state: "disabled"
     peers:
       general: # peer_type
         db_table: "BGP_NEIGHBOR"

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -126,6 +126,7 @@ class BBRMgr(Manager):
         """
         re_pg = re.compile(r'^\s*neighbor\s+(\S+)\s+peer-group\s*$')
         res = set()
+        self.cfg_mgr.update()
         for line in self.cfg_mgr.get_text():
             m = re_pg.match(line)
             if m:

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -49,18 +49,23 @@ class BBRMgr(Manager):
         if not 'bgp' in self.constants:
             log_err("BBRMgr::Disabled: 'bgp' key is not found in constants")
             return
-        if 'bbr' in self.constants['bgp'] and \
-                'enabled' in self.constants['bgp']['bbr'] and \
-                self.constants['bgp']['bbr']['enabled']:
+        if 'bbr' in self.constants['bgp'] \
+                and 'enabled' in self.constants['bgp']['bbr'] \
+                and self.constants['bgp']['bbr']['enabled']:
             self.bbr_enabled_pgs = self.__read_pgs()
             if self.bbr_enabled_pgs:
                 self.enabled = True
-                self.directory.put(self.db_name, self.table_name, 'status', "enabled")
-                log_info("BBRMgr::Initialized and enabled")
+                if 'default_state' in self.constants['bgp']['bbr'] \
+                        and self.constants['bgp']['bbr']['default_state'] == 'enabled':
+                    default_status = "enabled"
+                else:
+                    default_status = "disabled"
+                self.directory.put(self.db_name, self.table_name, 'status', default_status)
+                log_info("BBRMgr::Initialized and enabled. Default state: '%s'" % default_status)
             else:
                 log_info("BBRMgr::Disabled: no BBR enabled peers")
         else:
-            log_info("BBRMgr::Disabled: not enabled in the constants")
+            log_info("BBRMgr::Disabled: no bgp.bbr.enabled in the constants")
 
     def __read_pgs(self):
         """

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -123,8 +123,6 @@ def __init_common(constants,
     assert m.directory.get("CONFIG_DB", "BGP_BBR", "status") == expected_status
     if expected_status == "enabled":
         assert m.enabled
-    else:
-        assert not m.enabled
     if expected_log_err is not None:
         mocked_log_err.assert_called_with(expected_log_err)
     if expected_log_info is not None:
@@ -135,17 +133,17 @@ def test___init_1():
 
 def test___init_2():
     constants = deepcopy(global_constants)
-    __init_common(constants, "BBRMgr::Disabled: not enabled in the constants", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
 
 def test___init_3():
     constants = deepcopy(global_constants)
     constants["bgp"]["bbr"] = { "123" : False }
-    __init_common(constants, "BBRMgr::Disabled: not enabled in the constants", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
 
 def test___init_4():
     constants = deepcopy(global_constants)
     constants["bgp"]["bbr"] = { "enabled" : False }
-    __init_common(constants, "BBRMgr::Disabled: not enabled in the constants", None, {}, "disabled")
+    __init_common(constants, "BBRMgr::Disabled: no bgp.bbr.enabled in the constants", None, {}, "disabled")
 
 def test___init_5():
     constants = deepcopy(global_constants)
@@ -164,7 +162,35 @@ def test___init_6():
             "bbr": expected_bbr_entries,
         }
     }
-    __init_common(constants, 'BBRMgr::Initialized and enabled', None, expected_bbr_entries, "enabled")
+    __init_common(constants, "BBRMgr::Initialized and enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
+
+def test___init_7():
+    expected_bbr_entries = {
+                "PEER_V4": ["ipv4"],
+                "PEER_V6": ["ipv6"],
+    }
+    constants = deepcopy(global_constants)
+    constants["bgp"]["bbr"] = { "enabled" : True, "default_state": "disabled" }
+    constants["bgp"]["peers"] = {
+        "general": {
+            "bbr": expected_bbr_entries,
+        }
+    }
+    __init_common(constants, "BBRMgr::Initialized and enabled. Default state: 'disabled'", None, expected_bbr_entries, "disabled")
+
+def test___init_8():
+    expected_bbr_entries = {
+                "PEER_V4": ["ipv4"],
+                "PEER_V6": ["ipv6"],
+    }
+    constants = deepcopy(global_constants)
+    constants["bgp"]["bbr"] = { "enabled" : True, "default_state": "enabled" }
+    constants["bgp"]["peers"] = {
+        "general": {
+            "bbr": expected_bbr_entries,
+        }
+    }
+    __init_common(constants, "BBRMgr::Initialized and enabled. Default state: 'enabled'", None, expected_bbr_entries, "enabled")
 
 @patch('bgpcfgd.managers_bbr.log_info')
 def read_pgs_common(constants, expected_log_info, expected_bbr_enabled_pgs, mocked_log_info):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The current implementation of BBR has two issues:
1. constants.yml uses key "bgp.bbr.enabled" as a key to enable disable BBR feature and as a default state for the BBR feature.
2. If the current configuration doesn't have some peer-groups, which are listed in constants.yml bgp.peers.*.bbr bgpcfgd will report an error of updating such peer-groups.
 
**- How I did it**
1. I added a key bgp.bbr.default_state with values "enabled" or "disabled" into constants.yml. Now bgp.bbr.enabled controls will bgpcfgd support BBR feature or not. And bgp.bbr.default_state control initial state of the BBR.
2. I added an extra-code to check what peer-groups in the current config. After that bgpcfgd skips all peer-groups from constants,yml which are not presented in bgp config. 

**- How to verify it**
Build an image and check the behaviour
```
admin@str-s6100-acs-1:~$ sonic-cfggen -j disable.txt -w    
admin@str-s6100-acs-1:~$ vtysh -c 'show run' | grep allow      
admin@str-s6100-acs-1:~$ sonic-cfggen -j enable.txt -w     
admin@str-s6100-acs-1:~$ vtysh -c 'show run' | grep allow
  neighbor PEER_V4 allowas-in 1
  neighbor PEER_V6 allowas-in 1

Nov 18 22:26:29.815909 str-s6100-acs-1 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-c', 'show running-config']'.
Nov 18 22:26:30.038863 str-s6100-acs-1 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-f', '/tmp/tmp5o11zi0e']'.
Nov 18 22:26:30.258212 str-s6100-acs-1 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-c', 'clear bgp peer-group PEER_V4 soft in']'.
Nov 18 22:26:30.476447 str-s6100-acs-1 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-c', 'clear bgp peer-group PEER_V6 soft in']'.
Nov 18 22:27:00.247345 str-s6100-acs-1 DEBUG bgp#bgpcfgd: Received message : '('all', 'SET', (('status', 'enabled'),))'
Nov 18 22:27:00.247853 str-s6100-acs-1 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-c', 'show running-config']'.
Nov 18 22:27:00.476119 str-s6100-acs-1 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-f', '/tmp/tmp_pptzt_j']'.
Nov 18 22:27:00.700638 str-s6100-acs-1 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-c', 'clear bgp peer-group PEER_V4 soft in']'.
Nov 18 22:27:00.920070 str-s6100-acs-1 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-c', 'clear bgp peer-group PEER_V6 soft in']'.

```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
