### PR TITLE
[DellEMC]: EEPROM platform API Python3 compliance changes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/eeprom.py
@@ -11,7 +11,6 @@
 try:
     import os.path
     from sonic_eeprom import eeprom_tlvinfo
-    import binascii
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -40,7 +39,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not self.is_valid_tlvinfo_header(eeprom):
             return
 
-        total_length = (ord(eeprom[9]) << 8) | ord(eeprom[10])
+        total_length = (eeprom[9] << 8) | eeprom[10]
         tlv_index = self._TLV_INFO_HDR_LEN
         tlv_end = self._TLV_INFO_HDR_LEN + total_length
 
@@ -49,16 +48,16 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
                 break
 
             tlv = eeprom[tlv_index:tlv_index + 2
-                         + ord(eeprom[tlv_index + 1])]
-            code = "0x%02X" % (ord(tlv[0]))
+                         + eeprom[tlv_index + 1]]
+            code = "0x%02X" % tlv[0]
 
             name, value = self.decoder(None, tlv)
 
             self.eeprom_tlv_dict[code] = value
-            if ord(eeprom[tlv_index]) == self._TLV_CODE_CRC_32:
+            if eeprom[tlv_index] == self._TLV_CODE_CRC_32:
                 break
 
-            tlv_index += ord(eeprom[tlv_index+1]) + 2
+            tlv_index += eeprom[tlv_index+1] + 2
 
     def serial_number_str(self):
         """
@@ -68,7 +67,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
                          self.eeprom_data, self._TLV_CODE_SERIAL_NUMBER)
         if not is_valid:
             return "N/A"
-        return results[2]
+        return results[2].decode('ascii')
 
     def base_mac_addr(self, e):
         """
@@ -79,7 +78,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid or t[1] != 6:
             return super(eeprom_tlvinfo.TlvInfoDecoder, self).switchaddrstr(t)
 
-        return ":".join([binascii.b2a_hex(T) for T in t[2]])
+        return ":".join(["{:02x}".format(T) for T in t[2]]).upper()
 
     def modelstr(self):
         """
@@ -90,7 +89,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def part_number_str(self):
         """
@@ -101,7 +100,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def serial_str(self):
         """
@@ -112,7 +111,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def revision_str(self):
         """
@@ -123,7 +122,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def system_eeprom_info(self):
         """
@@ -132,5 +131,3 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         found in the system EEPROM.
         """
         return self.eeprom_tlv_dict
-
-

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
@@ -11,7 +11,6 @@
 
 try:
     from sonic_eeprom import eeprom_tlvinfo
-    import binascii
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -30,7 +29,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
 
         try:
             if self.is_module:
-                self.write_eeprom("\x00\x00")
+                self.write_eeprom(b"\x00\x00")
                 self.eeprom_data = self.read_eeprom_bytes(256)
             else:
                 self.eeprom_data = self.read_eeprom()
@@ -48,7 +47,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
             if not self.is_valid_tlvinfo_header(eeprom):
                 return
 
-            total_length = (ord(eeprom[9]) << 8) | ord(eeprom[10])
+            total_length = (eeprom[9] << 8) | eeprom[10]
             tlv_index = self._TLV_INFO_HDR_LEN
             tlv_end = self._TLV_INFO_HDR_LEN + total_length
 
@@ -57,22 +56,21 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
                     break
 
                 tlv = eeprom[tlv_index:tlv_index + 2
-                             + ord(eeprom[tlv_index + 1])]
-                code = "0x%02X" % (ord(tlv[0]))
+                             + eeprom[tlv_index + 1]]
+                code = "0x%02X" % tlv[0]
 
-                if ord(tlv[0]) == self._TLV_CODE_VENDOR_EXT:
-                    value = str((ord(tlv[2]) << 24) | (ord(tlv[3]) << 16) |
-                                (ord(tlv[4]) << 8) | ord(tlv[5]))
-                    value += str(tlv[6:6 + ord(tlv[1])])
+                if tlv[0] == self._TLV_CODE_VENDOR_EXT:
+                    value = str((tlv[2] << 24) | (tlv[3] << 16) |
+                                (tlv[4] << 8) | tlv[5])
+                    value += tlv[6:6 + tlv[1]].decode('ascii')
                 else:
                     name, value = self.decoder(None, tlv)
 
                 self.eeprom_tlv_dict[code] = value
-                if ord(eeprom[tlv_index]) == self._TLV_CODE_CRC_32:
+                if eeprom[tlv_index] == self._TLV_CODE_CRC_32:
                     break
 
-                tlv_index += ord(eeprom[tlv_index+1]) + 2
-
+                tlv_index += eeprom[tlv_index+1] + 2
 
     def serial_number_str(self):
         (is_valid, results) = self.get_tlv_field(
@@ -80,7 +78,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def base_mac_addr(self):
         (is_valid, results) = self.get_tlv_field(
@@ -88,7 +86,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid or results[1] != 6:
             return super(TlvInfoDecoder, self).switchaddrstr(e)
 
-        return ":".join([binascii.b2a_hex(T) for T in results[2]])
+        return ":".join(["{:02x}".format(T) for T in results[2]]).upper()
 
     def modelstr(self):
         if self.is_module:
@@ -100,7 +98,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def part_number_str(self):
         (is_valid, results) = self.get_tlv_field(
@@ -108,7 +106,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def serial_str(self):
         (is_valid, results) = self.get_tlv_field(
@@ -116,7 +114,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def revision_str(self):
         (is_valid, results) = self.get_tlv_field(
@@ -124,7 +122,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def system_eeprom_info(self):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/eeprom.py
@@ -11,7 +11,6 @@
 
 try:
     from sonic_eeprom import eeprom_tlvinfo
-    import binascii
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -33,7 +32,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
             if not self.is_valid_tlvinfo_header(eeprom):
                 return
 
-            total_length = (ord(eeprom[9]) << 8) | ord(eeprom[10])
+            total_length = (eeprom[9] << 8) | eeprom[10]
             tlv_index = self._TLV_INFO_HDR_LEN
             tlv_end = self._TLV_INFO_HDR_LEN + total_length
 
@@ -42,28 +41,29 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
                     break
 
                 tlv = eeprom[tlv_index:tlv_index + 2
-                             + ord(eeprom[tlv_index + 1])]
-                code = "0x%02X" % (ord(tlv[0]))
+                             + eeprom[tlv_index + 1]]
+                code = "0x%02X" % tlv[0]
 
-                if ord(tlv[0]) == self._TLV_CODE_VENDOR_EXT:
-                    value = str((ord(tlv[2]) << 24) | (ord(tlv[3]) << 16) |
-                                (ord(tlv[4]) << 8) | ord(tlv[5]))
-                    value += str(tlv[6:6 + ord(tlv[1])])
+                if tlv[0] == self._TLV_CODE_VENDOR_EXT:
+                    value = str((tlv[2] << 24) | (tlv[3] << 16) |
+                                (tlv[4] << 8) | tlv[5])
+                    value += tlv[6:6 + tlv[1]].decode('ascii')
                 else:
                     name, value = self.decoder(None, tlv)
 
                 self.eeprom_tlv_dict[code] = value
-                if ord(eeprom[tlv_index]) == self._TLV_CODE_CRC_32:
+                if eeprom[tlv_index] == self._TLV_CODE_CRC_32:
                     break
 
-                tlv_index += ord(eeprom[tlv_index+1]) + 2
+                tlv_index += eeprom[tlv_index+1] + 2
 
     def serial_number_str(self):
         (is_valid, results) = self.get_tlv_field(
                          self.eeprom_data, self._TLV_CODE_SERIAL_NUMBER)
         if not is_valid:
             return "N/A"
-        return results[2]
+
+        return results[2].decode('ascii')
 
     def base_mac_addr(self):
         (is_valid, t) = self.get_tlv_field(
@@ -71,7 +71,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid or t[1] != 6:
             return super(TlvInfoDecoder, self).switchaddrstr(e)
 
-        return ":".join([binascii.b2a_hex(T) for T in t[2]])
+        return ":".join(["{:02x}".format(T) for T in t[2]]).upper()
 
     def modelstr(self):
         (is_valid, results) = self.get_tlv_field(
@@ -79,7 +79,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def part_number_str(self):
         (is_valid, results) = self.get_tlv_field(
@@ -87,7 +87,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def serial_str(self):
         (is_valid, results) = self.get_tlv_field(
@@ -95,7 +95,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def revision_str(self):
         (is_valid, results) = self.get_tlv_field(
@@ -103,7 +103,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def system_eeprom_info(self):
         """

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/eeprom.py
@@ -12,7 +12,6 @@
 try:
     import os.path
     from sonic_eeprom import eeprom_tlvinfo
-    import binascii
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -41,7 +40,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
             if not self.is_valid_tlvinfo_header(eeprom):
                 return
 
-            total_length = (ord(eeprom[9]) << 8) | ord(eeprom[10])
+            total_length = (eeprom[9] << 8) | eeprom[10]
             tlv_index = self._TLV_INFO_HDR_LEN
             tlv_end = self._TLV_INFO_HDR_LEN + total_length
 
@@ -50,21 +49,21 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
                     break
 
                 tlv = eeprom[tlv_index:tlv_index + 2
-                             + ord(eeprom[tlv_index + 1])]
-                code = "0x%02X" % (ord(tlv[0]))
+                             + eeprom[tlv_index + 1]]
+                code = "0x%02X" % tlv[0]
 
-                if ord(tlv[0]) == self._TLV_CODE_VENDOR_EXT:
-                    value = str((ord(tlv[2]) << 24) | (ord(tlv[3]) << 16) |
-                                (ord(tlv[4]) << 8) | ord(tlv[5]))
-                    value += str(tlv[6:6 + ord(tlv[1])])
+                if tlv[0] == self._TLV_CODE_VENDOR_EXT:
+                    value = str((tlv[2] << 24) | (tlv[3] << 16) |
+                                (tlv[4] << 8) | tlv[5])
+                    value += tlv[6:6 + tlv[1]].decode('ascii')
                 else:
                     name, value = self.decoder(None, tlv)
 
                 self.eeprom_tlv_dict[code] = value
-                if ord(eeprom[tlv_index]) == self._TLV_CODE_CRC_32:
+                if eeprom[tlv_index] == self._TLV_CODE_CRC_32:
                     break
 
-                tlv_index += ord(eeprom[tlv_index+1]) + 2
+                tlv_index += eeprom[tlv_index+1] + 2
 
     def serial_number_str(self):
         """
@@ -74,7 +73,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
                          self.eeprom_data, self._TLV_CODE_SERIAL_NUMBER)
         if not is_valid:
             return "N/A"
-        return results[2]
+        return results[2].decode('ascii')
 
     def base_mac_addr(self):
         """
@@ -85,7 +84,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid or t[1] != 6:
             return super(TlvInfoDecoder, self).switchaddrstr(e)
 
-        return ":".join([binascii.b2a_hex(T) for T in t[2]])
+        return ":".join(["{:02x}".format(T) for T in t[2]]).upper()
 
     def modelstr(self):
         """
@@ -96,7 +95,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def part_number_str(self):
         """
@@ -107,7 +106,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def serial_str(self):
         """
@@ -118,7 +117,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def revision_str(self):
         """
@@ -129,7 +128,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         if not is_valid:
             return "N/A"
 
-        return results[2]
+        return results[2].decode('ascii')
 
     def system_eeprom_info(self):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Make EEPROM platform APIs Python3 compliant in DellEMC platforms.

**- How I did it**

Handle `bytearray` type returned by `read_eeprom` and `read_eeprom_bytes` methods.

**- How to verify it**

Wrote a python script to load Chassis class and then call the APIs accordingly.
Logs:  [UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/5561422/UT_logs.txt)

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[DellEMC]: EEPROM platform API Python3 compliance changes

**- A picture of a cute animal (not mandatory but encouraged)**
