### PR TITLE
[frr] remove FRR rsyslog file outchannel

### DIFF
--- a/src/sonic-frr/patch/0007-frr-remove-frr-log-outchannel-to-var-log-frr.log.patch
+++ b/src/sonic-frr/patch/0007-frr-remove-frr-log-outchannel-to-var-log-frr.log.patch
@@ -1,0 +1,31 @@
+From 1f150992b074d07bce5157d203319512a3aeb4dc Mon Sep 17 00:00:00 2001
+From: Ying Xie <ying.xie@microsoft.com>
+Date: Wed, 18 Nov 2020 19:24:51 +0000
+Subject: [PATCH] [frr] remove frr log outchannel to /var/log/frr.log
+
+SONiC runs frr inside a docker and the logs are sent to base image
+via rsyslog and recorded already. There is no need to keep the
+frr.log inside the docker. It will grow and take all harddrive
+space eventually.
+
+Signed-off-by: Ying Xie <ying.xie@microsoft.com>
+---
+ tools/etc/rsyslog.d/45-frr.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/etc/rsyslog.d/45-frr.conf b/tools/etc/rsyslog.d/45-frr.conf
+index ff7cd4831..af3c2c109 100644
+--- a/tools/etc/rsyslog.d/45-frr.conf
++++ b/tools/etc/rsyslog.d/45-frr.conf
+@@ -2,7 +2,7 @@
+ # to /var/log/frr/frr.log, then drops the message so it does
+ # not also go to /var/log/syslog, so the messages are not duplicated
+ 
+-$outchannel frr_log,/var/log/frr/frr.log
++$outchannel frr_log
+ if  $programname == 'babeld' or
+     $programname == 'bgpd' or
+     $programname == 'eigrpd' or
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -4,3 +4,4 @@
 0004-Allow-BGP-attr-NEXT_HOP-to-be-0.0.0.0-due-to-allevia.patch
 0005-nexthops-compare-vrf-only-if-ip-type.patch
 0006-changes-for-making-snmp-socket-non-blocking.patch
+0007-frr-remove-frr-log-outchannel-to-var-log-frr.log.patch


### PR DESCRIPTION
**- Why I did it**
frr is creating /var/log/frr/frr.log inside the frr docker and letting it grow. It will eventually exhaust hard drive space.

To fixe issue #5965 

**- How I did it**
Remove rsyslog file outchannel so that frr won't generate /var/log/frr/frr.log inside the docker.

**- How to verify it**
Manually removed the outchannel and restart BGP docker, making sure that /var/log/frr/frr.log is no longer created inside the docker.

While restarting bgp docker, observed that base image /var/log/quagga/bgpd.log continued to grow and captured all FRR logs.

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [x] 201911
- [ ] 202006


Signed-off-by: Ying Xie <ying.xie@microsoft.com>
