### PR TITLE
[frr] mount /var/log/frr onto frr docker and configure logrotate

### DIFF
--- a/files/image_config/logrotate/logrotate.d/rsyslog
+++ b/files/image_config/logrotate/logrotate.d/rsyslog
@@ -30,6 +30,7 @@
 /var/log/telemetry.log
 /var/log/quagga/bgpd.log
 /var/log/quagga/zebra.log
+/var/log/frr/frr.log
 /var/log/swss/sairedis.rec
 /var/log/swss/swss.rec
 {

--- a/rules/docker-fpm-frr.mk
+++ b/rules/docker-fpm-frr.mk
@@ -23,6 +23,7 @@ SONIC_DOCKER_DBG_IMAGES += $(DOCKER_FPM_FRR_DBG)
 $(DOCKER_FPM_FRR)_CONTAINER_NAME = bgp
 $(DOCKER_FPM_FRR)_RUN_OPT += --privileged -t
 $(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_FPM_FRR)_RUN_OPT += -v /var/log/frr:/var/log/frr:rw
 
 $(DOCKER_FPM_FRR)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)
 


### PR DESCRIPTION
**- Why I did it**
frr generates log at /var/log/frr/frr.log inside SONiC BGP docker. This log takes too much space. On a small hard drive platform, the log file took all space on harddrive and causing SONiC upgrade to fail.

to fix issue #5965 

**- How I did it**
Mount /var/log/frr path from base image to BGP docker and setup log rotate from the base image.

**- How to verify it**
To be updated

- [ ] 201811
- [x] 201911
- [ ] 202006

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

