### PR TITLE
Enhacement on supervisord log severity on process exit status

### DIFF
--- a/src/supervisor/patch/0002-process-exit-logseverity.patch
+++ b/src/supervisor/patch/0002-process-exit-logseverity.patch
@@ -1,0 +1,45 @@
+diff --git a/supervisor/process.py b/supervisor/process.py
+index 5f73e6b..4caf450 100644
+--- a/supervisor/process.py
++++ b/supervisor/process.py
+@@ -539,6 +539,13 @@ class Subprocess:
+             msg = "stopped: %s (%s)" % (processname, msg)
+             self._assertInState(ProcessStates.STOPPING)
+             self.change_state(ProcessStates.STOPPED)
++            if exit_expected:
++               self.config.options.logger.info(msg)
++            else:
++               if "SIGTERM" in msg or "SIGKILL" in msg:
++                  self.config.options.logger.warn(msg)
++               else:
++                  self.config.options.logger.critical(msg)
+
+         elif too_quickly:
+             # the program did not stay up long enough to make it to RUNNING
+@@ -548,6 +555,7 @@ class Subprocess:
+             msg = "exited: %s (%s)" % (processname, msg + "; not expected")
+             self._assertInState(ProcessStates.STARTING)
+             self.change_state(ProcessStates.BACKOFF)
++            self.config.options.logger.warn(msg)
+
+         else:
+             # this finish was not the result of a stop request, the
+@@ -569,13 +577,17 @@ class Subprocess:
+                 # expected exit code
+                 msg = "exited: %s (%s)" % (processname, msg + "; expected")
+                 self.change_state(ProcessStates.EXITED, expected=True)
++                self.config.options.logger.info(msg)
+             else:
+                 # unexpected exit code
+                 self.spawnerr = 'Bad exit code %s' % es
+                 msg = "exited: %s (%s)" % (processname, msg + "; not expected")
+                 self.change_state(ProcessStates.EXITED, expected=False)
++                if "SIGTERM" in msg or "SIGKILL" in msg:
++                    self.config.options.logger.warn(msg)
++                else:
++                    self.config.options.logger.critical(msg)
+
+-        self.config.options.logger.info(msg)
+
+         self.pid = 0
+         self.config.options.close_parent_pipes(self.pipes)

--- a/src/supervisor/patch/series
+++ b/src/supervisor/patch/series
@@ -1,2 +1,3 @@
 # This series applies on GIT commit 34b690aea8cf7572d73765c95c54a83261d69aad
 0001-Prevent-excessive-hanging-and-crashes-if-system-cloc.patch
+0002-process-exit-logseverity.patch


### PR DESCRIPTION
added log severity based on the exit status of a process. 

What I did

Supervisord logs all process exit status with INFO log level. 
Change to log a process exit status with different severities/

Here is guidline
INFO: for graceful exits
WARN: SIGTERM or SIGKILLfor planned but non-graceful exits
CRIT: for any unplanned and non-graceful exit of processes

How I did it

modified finish() in process.py to  check the exit status and provide a proper log level. 

How to verify it
Here are some outputs
UT: # docker stop pmon
root@sonic:/home/admin# show logging supervisord | grep 'stopped\|exited'
Nov 18 18:55:15.179829 sonic INFO pmon#supervisord 2020-11-18 18:54:38,765 INFO stopped: syseepromd (exit status 0)
Nov 18 18:55:15.179909 sonic INFO pmon#supervisord 2020-11-18 18:54:38,819 INFO stopped: psud (exit status 0)
Nov 18 18:55:15.179990 sonic INFO pmon#supervisord 2020-11-18 18:54:38,926 INFO stopped: xcvrd (exit status 0)
Nov 18 18:55:15.180071 sonic INFO pmon#supervisord 2020-11-18 18:54:40,933 INFO stopped: rsyslogd (exit status 0)
Nov 18 18:55:15.180154 sonic INFO pmon#supervisord 2020-11-18 18:54:40,936 WARN stopped: supervisor-proc-exit-listener (terminated by SIGTERM)
Nov 18 18:55:25.190196 sonic INFO pmon#supervisord 2020-11-18 18:55:20,882 INFO exited: start (exit status 0; expected)
Nov 18 18:55:25.190361 sonic INFO pmon#supervisord 2020-11-18 18:55:24,748 INFO exited: lm-sensors (exit status 0; expected)
Nov 18 18:55:35.200165 sonic INFO pmon#supervisord 2020-11-18 18:55:32,921 INFO exited: dependent-startup (exit status 0; expected)

UT: Process  core dumped
Nov 18 22:06:03.628315 sonic INFO bgp#supervisord 2020-11-18 22:06:01,022 INFO exited: bgpmon (terminated by SIGQUIT (core dumped); not expected)

UT: config reload
Nov 18 19:19:04.443390 sonic INFO pmon#supervisord 2020-11-18 19:15:19,959 INFO stopped: syseepromd (exit status 0)
Nov 18 19:19:04.443390 sonic INFO pmon#supervisord 2020-11-18 19:15:20,046 INFO stopped: psud (exit status 0)
Nov 18 19:19:04.443390 sonic INFO pmon#supervisord 2020-11-18 19:15:20,140 INFO stopped: xcvrd (exit status 0)
Nov 18 19:19:04.443390 sonic INFO pmon#supervisord 2020-11-18 19:15:22,146 INFO stopped: rsyslogd (exit status 0)
Nov 18 19:19:04.443444 sonic INFO pmon#supervisord 2020-11-18 19:15:22,149 WARN stopped: supervisor-proc-exit-listener (terminated by SIGTERM)
Nov 18 19:19:14.452742 sonic INFO pmon#supervisord 2020-11-18 19:19:10,247 INFO exited: start (exit status 0; expected)
Nov 18 19:19:17.697709 sonic INFO swss#supervisord 2020-11-18 19:19:15,692 WARN stopped: vxlanmgrd (terminated by SIGTERM)
Nov 18 19:19:17.697709 sonic INFO swss#supervisord 2020-11-18 19:19:15,699 WARN stopped: nbrmgrd (terminated by SIGTERM)
Nov 18 19:19:17.697709 sonic INFO swss#supervisord 2020-11-18 19:19:15,707 WARN stopped: vrfmgrd (terminated by SIGTERM)
Nov 18 19:19:17.697767 sonic INFO swss#supervisord 2020-11-18 19:19:16,712 WARN stopped: buffermgrd (terminated by SIGTERM)
Nov 18 19:19:17.697767 sonic INFO swss#supervisord 2020-11-18 19:19:16,716 WARN stopped: portmgrd (terminated by SIGTERM)
Nov 18 19:19:17.697833 sonic INFO swss#supervisord 2020-11-18 19:19:16,721 WARN stopped: intfmgrd (terminated by SIGTERM)
Nov 18 19:19:17.697833 sonic INFO swss#supervisord 2020-11-18 19:19:16,726 WARN stopped: vlanmgrd (terminated by SIGTERM)
Nov 18 19:19:17.697833 sonic INFO swss#supervisord 2020-11-18 19:19:16,729 WARN stopped: neighsyncd (terminated by SIGTERM)
Nov 18 19:19:19.438289 sonic INFO bgp#supervisord 2020-11-17 22:25:26,836 CRIT exited: bgpcfgd (exit status 1; not expected)
Nov 18 19:19:19.438682 sonic INFO bgp#supervisord 2020-11-17 22:25:27,857 WARN stopped: fpmsyncd (terminated by SIGTERM)
Nov 18 19:19:19.438762 sonic INFO bgp#supervisord 2020-11-17 22:25:27,860 WARN stopped: bgpmon (terminated by SIGTERM)
Nov 18 19:19:19.438851 sonic INFO bgp#supervisord 2020-11-17 22:25:27,866 WARN stopped: bgpd (terminated by SIGKILL)
Nov 18 19:19:19.438982 sonic INFO bgp#supervisord 2020-11-17 22:25:27,894 INFO exited: dependent-startup (exit status 3; expected)
Nov 18 19:19:19.439077 sonic INFO bgp#supervisord 2020-11-17 22:25:27,898 INFO stopped: zebra (exit status 0)
Nov 18 19:19:19.439157 sonic INFO bgp#supervisord 2020-11-17 22:25:27,902 INFO stopped: rsyslogd (exit status 0)
Nov 18 19:19:19.439283 sonic INFO bgp#supervisord 2020-11-17 22:25:27,905 WARN stopped: supervisor-proc-exit-listener (terminated by SIGTERM)
Nov 18 19:19:24.460369 sonic INFO pmon#supervisord 2020-11-18 19:19:14,590 INFO exited: lm-sensors (exit status 0; expected)
Nov 18 19:19:24.461032 sonic INFO pmon#supervisord 2020-11-18 19:19:21,986 INFO exited: dependent-startup (exit status 0; expected)
Nov 18 19:19:25.470111 sonic INFO syncd#supervisord: syncd [5] child /usr/bin/syncd exited status: 0
Nov 18 19:19:36.931198 sonic INFO swss#supervisord 2020-11-18 19:19:18,740 WARN stopped: orchagent (terminated by SIGTERM)
Nov 18 19:19:36.931276 sonic INFO swss#supervisord 2020-11-18 19:19:19,745 WARN stopped: portsyncd (terminated by SIGTERM)
Nov 18 19:19:36.931322 sonic INFO swss#supervisord 2020-11-18 19:19:19,749 INFO stopped: rsyslogd (exit status 0)
Nov 18 19:19:36.931378 sonic INFO swss#supervisord 2020-11-18 19:19:19,752 WARN stopped: supervisor-proc-exit-listener (terminated by SIGTERM)
Nov 18 19:19:38.051206 sonic INFO teamd#supervisord 2020-11-18 19:17:39,799 INFO stopped: teamsyncd (exit status 0)
Nov 18 19:19:38.051206 sonic INFO teamd#supervisord 2020-11-18 19:17:41,809 INFO stopped: tlm_teamd (exit status 0)
Nov 18 19:19:38.051206 sonic INFO teamd#supervisord 2020-11-18 19:17:42,812 CRIT stopped: teammgrd (exit status 255)
Nov 18 19:19:38.051206 sonic INFO teamd#supervisord 2020-11-18 19:17:43,818 INFO stopped: rsyslogd (exit status 0)
Nov 18 19:19:38.051262 sonic INFO teamd#supervisord 2020-11-18 19:17:43,820 WARN stopped: supervisor-proc-exit-listener (terminated by SIGTERM)
Nov 18 19:19:38.051390 sonic INFO teamd#supervisord 2020-11-18 19:19:36,635 INFO exited: start (exit status 0; expected)




