### PR TITLE
[L2 switch mode] Update l2switch.j2 template

### DIFF
--- a/src/sonic-config-engine/data/l2switch.j2
+++ b/src/sonic-config-engine/data/l2switch.j2
@@ -2,16 +2,16 @@
     "DEVICE_METADATA": {{ DEVICE_METADATA | tojson }},
     {% set ns = {'firstPrinted': False} -%}
     "PORT": {
-        {%- for key,value in PORT.items() -%}
+        {%- for key, value in PORT.items() -%}
         {%- if ns.firstPrinted %},{% endif %}
 
         "{{ key }}": {
-            {%- for keyPort,valuePort in value.items() %}
+            {%- for keyPort, valuePort in value.items() %}
 
-            "{{ keyPort }}": "{{ valuePort }}",
+            {% if keyPort != "admin_status" %}"{{ keyPort }}": "{{ valuePort }}",{% endif %}
             {%- endfor %}
 
-            "admin_status": "up"
+            "admin_status": "{{ value.admin_status|default("up") }}"
         }
         {%- if ns.update({'firstPrinted': True}) %}{% endif -%}
         {%- endfor %}

--- a/src/sonic-config-engine/data/l2switch.j2
+++ b/src/sonic-config-engine/data/l2switch.j2
@@ -6,11 +6,11 @@
         {%- if ns.firstPrinted %},{% endif %}
 
         "{{ key }}": {
-            {%- for k,v in value.items() %}
+            {%- for keyPort,valuePort in value.items() %}
 
-            "{{ k }}": "{{ v }}",
+            "{{ keyPort }}": "{{ valuePort }}",
             {%- endfor %}
-            
+
             "admin_status": "up"
         }
         {%- if ns.update({'firstPrinted': True}) %}{% endif -%}

--- a/src/sonic-config-engine/data/l2switch.j2
+++ b/src/sonic-config-engine/data/l2switch.j2
@@ -6,8 +6,11 @@
         {%- if ns.firstPrinted %},{% endif %}
 
         "{{ key }}": {
-            "alias": "{{ value.alias }}",
-            "lanes": "{{ value.lanes }}",
+            {%- for k,v in value.items() %}
+
+            "{{ k }}": "{{ v }}",
+            {%- endfor %}
+            
             "admin_status": "up"
         }
         {%- if ns.update({'firstPrinted': True}) %}{% endif -%}

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -106,6 +106,14 @@ class TestJ2Files(TestCase):
 
         self.assertTrue(json.dumps(sample_output_json, sort_keys=True) == json.dumps(output_json, sort_keys=True))
 
+        template_dir = os.path.join(self.test_dir, '..', 'data', 'l2switch.j2')
+        argument = '-t ' + template_dir + ' -k Mellanox-SN2700-D48C8 -p ' + self.t0_port_config
+        output = self.run_script(argument)
+        print(json.dumps(output_json, sort_keys=True))
+        print(json.dumps(sample_output_json, sort_keys=True))
+
+        self.assertTrue(json.dumps(sample_output_json, sort_keys=True) == json.dumps(output_json, sort_keys=True))
+
     def test_qos_arista7050_render_template(self):
         arista_dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', 'arista', 'x86_64-arista_7050_qx32s', 'Arista-7050-QX-32S')
         qos_file = os.path.join(arista_dir_path, 'qos.json.j2')

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -109,8 +109,6 @@ class TestJ2Files(TestCase):
         template_dir = os.path.join(self.test_dir, '..', 'data', 'l2switch.j2')
         argument = '-t ' + template_dir + ' -k Mellanox-SN2700-D48C8 -p ' + self.t0_port_config
         output = self.run_script(argument)
-        print(json.dumps(output_json, sort_keys=True))
-        print(json.dumps(sample_output_json, sort_keys=True))
 
         self.assertTrue(json.dumps(sample_output_json, sort_keys=True) == json.dumps(output_json, sort_keys=True))
 

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -107,8 +107,9 @@ class TestJ2Files(TestCase):
         self.assertTrue(json.dumps(sample_output_json, sort_keys=True) == json.dumps(output_json, sort_keys=True))
 
         template_dir = os.path.join(self.test_dir, '..', 'data', 'l2switch.j2')
-        argument = '-t ' + template_dir + ' -k Mellanox-SN2700-D48C8 -p ' + self.t0_port_config
+        argument = '-t ' + template_dir + ' -k Mellanox-SN2700 -p ' + self.t0_port_config
         output = self.run_script(argument)
+        output_json = json.loads(output)
 
         self.assertTrue(json.dumps(sample_output_json, sort_keys=True) == json.dumps(output_json, sort_keys=True))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The l2switch.j2 template does not include all fields for PORT. This could be incompatible with the 201911 image or later. 

**- How I did it**
Update l2switch.j2 template and add a unit test.

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
