### PR TITLE
[Mellanox] Fix issue: fan.get_presence always return false for 201911

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -151,7 +151,7 @@ class Fan(FanBase):
             if self.always_presence:
                 status = 1
             else:
-                read_int_from_file(os.path.join(FAN_PATH, self.fan_presence_path), 0)
+                status = read_int_from_file(os.path.join(FAN_PATH, self.fan_presence_path), 0)
 
         return status == 1
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

There is a missing variable assignment in fan.get_presence, and it causes fan.get_presence always return false.

**- How I did it**

Set the variable with proper value

**- How to verify it**

Run platform regressions 

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
