### PR TITLE
Move frr logs from syslog to /var/log/frr/*.log

### DIFF
--- a/files/image_config/logrotate/logrotate.d/rsyslog
+++ b/files/image_config/logrotate/logrotate.d/rsyslog
@@ -28,8 +28,8 @@
 /var/log/syslog
 /var/log/teamd.log
 /var/log/telemetry.log
-/var/log/quagga/bgpd.log
-/var/log/quagga/zebra.log
+/var/log/frr/bgpd.log
+/var/log/frr/zebra.log
 /var/log/swss/sairedis.rec
 /var/log/swss/swss.rec
 {

--- a/files/image_config/rsyslog/rsyslog.d/00-sonic.conf
+++ b/files/image_config/rsyslog/rsyslog.d/00-sonic.conf
@@ -1,6 +1,6 @@
 ## Quagga rules
 
-if re_match($programname, "bgp[0-9]*#(frr|zebra)") then {
+if re_match($programname, "bgp[0-9]*#(frr|zebra|staticd|watchfrr)") then {
     /var/log/frr/zebra.log
     stop
 }

--- a/files/image_config/rsyslog/rsyslog.d/00-sonic.conf
+++ b/files/image_config/rsyslog/rsyslog.d/00-sonic.conf
@@ -1,15 +1,12 @@
 ## Quagga rules
 
-if $programname == ["bgp#quagga",
-                    "bgp#watchquagga",
-                    "bgp#zebra"]
-    then {
-    /var/log/quagga/zebra.log
+if re_match($programname, "bgp[0-9]*#(frr|zebra)") then {
+    /var/log/frr/zebra.log
     stop
 }
 
-if $programname == "bgp#bgpd" then {
-    /var/log/quagga/bgpd.log
+if re_match($programname, "bgp[0-9]*#bgpd") then {
+    /var/log/frr/bgpd.log
     stop
 }
 


### PR DESCRIPTION
**- Why I did it**
Move frr logs from syslog from the directory /var/log/quagga/*.log to  /var/log/frr/*.log

**- How I did it**
Updated the rsyslog config files.

**- How to verify it**
In multi-asic, the following logs were seen in the respective files.
```
admin@str--acs-1:/var/log/frr$ ls -lrt
total 560
-rw-r----- 1 root adm   3793 Nov 29 01:59 zebra.log
-rw-r----- 1 root adm 561672 Nov 29 02:00 bgpd.log

bgpd.log

Nov 25 23:20:43.881961 str--acs-1 INFO bgp2#bgpd[67]: %ADJCHANGE: neighbor 2603:10e2:400:1::11(str--acs-1) in vrf default Up
Nov 25 23:20:43.882390 str--acs-1 INFO bgp4#bgpd[67]: %ADJCHANGE: neighbor 2603:10e2:400:1::12(str--acs-1) in vrf default Up
Nov 25 23:20:44.076345 str--acs-1 INFO bgp4#bgpd[67]: %ADJCHANGE: neighbor 2603:10e2:400:1::2(str--acs-1) in vrf default Up
Nov 25 23:20:44.076617 str--acs-1 INFO bgp0#bgpd[67]: %ADJCHANGE: neighbor 2603:10e2:400:1::1(str--acs-1) in vrf default Up

zebra.log

Nov 25 23:27:55.680763 str--acs-1 NOTICE bgp1#zebra[60]: client 27 disconnected. 0 vnc routes removed from the rib 
Nov 25 23:27:55.682354 str--acs-1 INFO bgp1#zebra[60]: Zebra final shutdown
Nov 29 01:59:53.084121 str--acs-1 INFO bgp4#zebra[60]: connection to the FPM has gone down: closed socket in read
Nov 29 01:59:54.091942 str--acs-1 WARNING bgp4#zebra[60]: [EC 4043309116] Client 'bgp' encountered an error and is shutting 
```
In Single ASIC the following logs were seen in the respective files.

```
bgpd.log

Nov 30 20:23:37.537854 str-s6000-on-2 INFO bgp#bgpd[54]: %ADJCHANGE: neighbor 10.0.0.25(Unknown) in vrf default Up
Nov 30 20:23:37.562374 str-s6000-on-2 INFO bgp#bgpd[54]: %ADJCHANGE: neighbor 10.0.0.5(Unknown) in vrf default Up
Nov 30 20:23:37.562756 str-s6000-on-2 INFO bgp#bgpd[54]: %ADJCHANGE: neighbor fc00::7a(Unknown) in vrf default Up
Nov 30 20:23:37.563020 str-s6000-on-2 INFO bgp#bgpd[54]: %ADJCHANGE: neighbor fc00::62(Unknown) in vrf default Up
Nov 30 20:23:37.564967 str-s6000-on-2 INFO bgp#bgpd[54]: %NOTIFICATION: rcvd End-of-RIB for IPv4 Unicast from 10.0.0.59 in vrf default

zebra.log

Nov 30 20:19:06.535731 str-s6000-on-2 NOTICE bgp#zebra[47]: client 25 says hello and bids fair to announce only bgp routes vrf=0
Nov 30 20:19:06.535731 str-s6000-on-2 NOTICE bgp#zebra[47]: client 28 says hello and bids fair to announce only vnc routes vrf=0
Nov 30 20:19:54.527926 str-s6000-on-2 WARNING bgp#staticd[51]: route_notify_owner: Route 0.0.0.0/0 over-ridden by better route for table: 254

```


**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
