### PR TITLE
Fix bind-mount of /var/log/swss directory in multi-asic setup

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -387,6 +387,9 @@ start() {
         -v /var/run/redis-chassis:/var/run/redis-chassis:ro \
         -v /usr/share/sonic/device/$PLATFORM/$HWSKU/$DEV:/usr/share/sonic/hwsku:ro \
 {%- endif %}
+{%- if docker_container_name == "swss" %}
+        -v /var/log/swss$DEV:/var/log/swss:rw \
+{%- endif %}
         $REDIS_MNT \
         -v /usr/share/sonic/device/$PLATFORM:/usr/share/sonic/platform:ro \
 {%- if sonic_asic_platform != "mellanox" %}

--- a/files/image_config/logrotate/logrotate.d/rsyslog
+++ b/files/image_config/logrotate/logrotate.d/rsyslog
@@ -30,8 +30,8 @@
 /var/log/telemetry.log
 /var/log/frr/bgpd.log
 /var/log/frr/zebra.log
-/var/log/swss/sairedis.rec
-/var/log/swss/swss.rec
+/var/log/swss*/sairedis.rec
+/var/log/swss*/swss.rec
 {
     size 1M
     rotate 5000
@@ -84,7 +84,7 @@
         done
     endscript
     postrotate
-        if [ $(echo $1 | grep -c "/var/log/swss/") -gt 0 ]; then
+        if [ $(echo $1 | grep -c "/var/log/swss") -gt 0 ]; then
             pgrep -x orchagent | xargs /bin/kill -HUP 2>/dev/null || true
         else
             /bin/kill -HUP $(cat /var/run/rsyslogd.pid)

--- a/rules/docker-orchagent.mk
+++ b/rules/docker-orchagent.mk
@@ -29,7 +29,6 @@ $(DOCKER_ORCHAGENT)_RUN_OPT += -v /etc/network/interfaces:/etc/network/interface
 $(DOCKER_ORCHAGENT)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interfaces.d/:ro
 $(DOCKER_ORCHAGENT)_RUN_OPT += -v /host/machine.conf:/host/machine.conf:ro
 $(DOCKER_ORCHAGENT)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_ORCHAGENT)_RUN_OPT += -v /var/log/swss:/var/log/swss:rw
 
 $(DOCKER_ORCHAGENT)_BASE_IMAGE_FILES += swssloglevel:/usr/bin/swssloglevel
 $(DOCKER_ORCHAGENT)_BASE_IMAGE_FILES += monit_swss:/etc/monit/conf.d


### PR DESCRIPTION
This change is to make sure that each asic in multi-asic devices has its
/var/log/swss directory mounted at a different mount point on the host.

**- Why I did it**
On single-asic setups, /var/log/swss directory of the swss container is bind-mounted onto the host at /var/log/swss to get easy access to swss logs. On multi-asic setups, the current model doesn't work because the host's directory becomes shared across all swss containers, thus swss logs of one container gets overwritten by the logs of other containers.

**- How I did it**
/var/log/swss of each swss container is now mounted at /var/log/swss$DEV on the host.

**- How to verify it**
Verified manually on a multi-asic device.
