### PR TITLE
[supervisord]: use abspath as supervisord entrypoint

### DIFF
--- a/dockers/docker-basic_router/Dockerfile
+++ b/dockers/docker-basic_router/Dockerfile
@@ -19,4 +19,4 @@ RUN mv /deps/basic_router /usr/sbin/basic_router
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -55,7 +55,7 @@ if [[ $DATABASE_TYPE == "chassisdb" ]]; then
     # generate all redis server supervisord configuration file
     sonic-cfggen -j $db_cfg_file_tmp -t /usr/share/sonic/templates/supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
     rm $db_cfg_file_tmp
-    exec supervisord
+    exec /usr/local/bin/supervisord
     exit 0
 fi
 
@@ -79,4 +79,4 @@ else
 fi
 rm $db_cfg_file_tmp
 
-exec supervisord
+exec /usr/local/bin/supervisord

--- a/dockers/docker-dhcp-relay/docker_init.sh
+++ b/dockers/docker-dhcp-relay/docker_init.sh
@@ -19,6 +19,6 @@ sonic-cfggen $CFGGEN_PARAMS
 chmod +x /usr/bin/wait_for_intf.sh
 
 # The docker container should start this script as PID 1, so now that supervisord is
-# properly configured, we exec supervisord so that it runs as PID 1 for the
+# properly configured, we exec /usr/local/bin/supervisord so that it runs as PID 1 for the
 # duration of the container's lifetime
-exec supervisord
+exec /usr/local/bin/supervisord

--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -66,4 +66,4 @@ chmod 0755 /usr/sbin/bgp-unisolate
 mkdir -p /var/sonic
 echo "# Config files managed by sonic-config-engine" > /var/sonic/config_status
 
-exec supervisord
+exec /usr/local/bin/supervisord

--- a/dockers/docker-fpm-gobgp/Dockerfile.j2
+++ b/dockers/docker-fpm-gobgp/Dockerfile.j2
@@ -27,4 +27,4 @@ COPY ["daemons", "/etc/quagga/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-fpm-quagga/Dockerfile.j2
+++ b/dockers/docker-fpm-quagga/Dockerfile.j2
@@ -36,4 +36,4 @@ COPY ["*.j2", "/usr/share/sonic/templates/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-iccpd/Dockerfile.j2
+++ b/dockers/docker-iccpd/Dockerfile.j2
@@ -31,4 +31,4 @@ RUN apt-get clean -y      && \
     apt-get autoremove -y && \
     rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-lldp/docker-lldp-init.sh
+++ b/dockers/docker-lldp/docker-lldp-init.sh
@@ -2,4 +2,4 @@
 #Generate supervisord.conf based on device metadata
 mkdir -p /etc/supervisor/conf.d/
 sonic-cfggen -d -t /usr/share/sonic/templates/supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
-exec supervisord
+exec /usr/local/bin/supervisord

--- a/dockers/docker-nat/Dockerfile.j2
+++ b/dockers/docker-nat/Dockerfile.j2
@@ -35,4 +35,4 @@ COPY ["critical_processes", "/etc/supervisor"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-orchagent/docker-init.sh
+++ b/dockers/docker-orchagent/docker-init.sh
@@ -25,4 +25,4 @@ if [ "$VLAN" != "" ]; then
     cp /usr/share/sonic/templates/ndppd.conf /etc/supervisor/conf.d/
 fi
 
-exec supervisord
+exec /usr/local/bin/supervisord

--- a/dockers/docker-platform-monitor/docker_init.sh
+++ b/dockers/docker-platform-monitor/docker_init.sh
@@ -40,4 +40,4 @@ if [ $HAVE_FANCONTROL_CONF -eq 1 ]; then
     /bin/cp -f $FANCONTROL_CONF_FILE /etc/
 fi
 
-exec supervisord
+exec /usr/local/bin/supervisord

--- a/dockers/docker-router-advertiser/docker-init.sh
+++ b/dockers/docker-router-advertiser/docker-init.sh
@@ -14,4 +14,4 @@ sonic-cfggen $CFGGEN_PARAMS
 
 chmod +x /usr/bin/wait_for_link.sh
 
-exec supervisord
+exec /usr/local/bin/supervisord

--- a/dockers/docker-sflow/Dockerfile.j2
+++ b/dockers/docker-sflow/Dockerfile.j2
@@ -32,4 +32,4 @@ COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 COPY ["port_index_mapper.py", "/usr/bin"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-snmp/Dockerfile.j2
+++ b/dockers/docker-snmp/Dockerfile.j2
@@ -76,4 +76,4 @@ COPY ["critical_processes", "/etc/supervisor"]
 # Although exposing ports is not needed for host net mode, keep it for possible bridge mode
 EXPOSE 161/udp 162/udp
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -36,4 +36,4 @@ RUN apt-get remove -y g++ python-dev
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-restapi/Dockerfile.j2
+++ b/dockers/docker-sonic-restapi/Dockerfile.j2
@@ -25,4 +25,4 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -28,4 +28,4 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -27,4 +27,4 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/barefoot/docker-saiserver-bfn/Dockerfile
+++ b/platform/barefoot/docker-saiserver-bfn/Dockerfile
@@ -34,4 +34,4 @@ COPY ["profile.ini", "portmap.ini", "/etc/sai/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /deps
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/barefoot/docker-syncd-bfn-rpc/Dockerfile.j2
+++ b/platform/barefoot/docker-syncd-bfn-rpc/Dockerfile.j2
@@ -49,4 +49,4 @@ RUN apt-get update \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
  
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/barefoot/docker-syncd-bfn/Dockerfile.j2
+++ b/platform/barefoot/docker-syncd-bfn/Dockerfile.j2
@@ -36,4 +36,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/broadcom/docker-saiserver-brcm/Dockerfile.j2
+++ b/platform/broadcom/docker-saiserver-brcm/Dockerfile.j2
@@ -33,4 +33,4 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
@@ -48,4 +48,4 @@ RUN apt-get update \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm/Dockerfile.j2
@@ -32,4 +32,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/cavium/docker-saiserver-cavm/Dockerfile
+++ b/platform/cavium/docker-saiserver-cavm/Dockerfile
@@ -27,4 +27,4 @@ COPY ["portmap.ini", "profile.ini", "/etc/sai/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf deps
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/cavium/docker-syncd-cavm-rpc/Dockerfile.j2
+++ b/platform/cavium/docker-syncd-cavm-rpc/Dockerfile.j2
@@ -48,4 +48,4 @@ RUN apt-get update \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/cavium/docker-syncd-cavm/Dockerfile.j2
+++ b/platform/cavium/docker-syncd-cavm/Dockerfile.j2
@@ -32,4 +32,4 @@ COPY ["profile.ini", "/etc/ssw/AS7512/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/centec-arm64/docker-syncd-centec-rpc/Dockerfile.j2
+++ b/platform/centec-arm64/docker-syncd-centec-rpc/Dockerfile.j2
@@ -48,4 +48,4 @@ RUN apt-get update \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
  
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/centec-arm64/docker-syncd-centec/Dockerfile.j2
+++ b/platform/centec-arm64/docker-syncd-centec/Dockerfile.j2
@@ -34,4 +34,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/centec/docker-syncd-centec-rpc/Dockerfile.j2
+++ b/platform/centec/docker-syncd-centec-rpc/Dockerfile.j2
@@ -48,4 +48,4 @@ RUN apt-get update \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
  
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/centec/docker-syncd-centec/Dockerfile.j2
+++ b/platform/centec/docker-syncd-centec/Dockerfile.j2
@@ -30,4 +30,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/innovium/docker-syncd-invm-rpc/Dockerfile.j2
+++ b/platform/innovium/docker-syncd-invm-rpc/Dockerfile.j2
@@ -50,4 +50,4 @@ RUN apt-get update \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/innovium/docker-syncd-invm/Dockerfile.j2
+++ b/platform/innovium/docker-syncd-invm/Dockerfile.j2
@@ -30,4 +30,4 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell-arm64/docker-syncd-mrvl-rpc/Dockerfile.j2
+++ b/platform/marvell-arm64/docker-syncd-mrvl-rpc/Dockerfile.j2
@@ -48,4 +48,4 @@ RUN apt-get update \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell-arm64/docker-syncd-mrvl/Dockerfile.j2
+++ b/platform/marvell-arm64/docker-syncd-mrvl/Dockerfile.j2
@@ -34,4 +34,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell-armhf/docker-syncd-mrvl-rpc/Dockerfile.j2
+++ b/platform/marvell-armhf/docker-syncd-mrvl-rpc/Dockerfile.j2
@@ -48,4 +48,4 @@ RUN apt-get update \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell-armhf/docker-syncd-mrvl/Dockerfile.j2
+++ b/platform/marvell-armhf/docker-syncd-mrvl/Dockerfile.j2
@@ -34,4 +34,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell/docker-syncd-mrvl-rpc/Dockerfile.j2
+++ b/platform/marvell/docker-syncd-mrvl-rpc/Dockerfile.j2
@@ -48,4 +48,4 @@ RUN apt-get update \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/marvell/docker-syncd-mrvl/Dockerfile.j2
+++ b/platform/marvell/docker-syncd-mrvl/Dockerfile.j2
@@ -30,4 +30,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/mellanox/docker-saiserver-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-saiserver-mlnx/Dockerfile.j2
@@ -44,4 +44,4 @@ COPY ["sai_2700.xml", "/usr/share/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -62,4 +62,4 @@ RUN apt-get clean -y && \
     apt-get autoremove -y && \
     rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -39,4 +39,4 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor/"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/nephos/docker-syncd-nephos-rpc/Dockerfile.j2
+++ b/platform/nephos/docker-syncd-nephos-rpc/Dockerfile.j2
@@ -48,4 +48,4 @@ RUN apt-get update \
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/nephos/docker-syncd-nephos/Dockerfile.j2
+++ b/platform/nephos/docker-syncd-nephos/Dockerfile.j2
@@ -43,4 +43,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/vs/docker-gbsyncd-vs/Dockerfile.j2
+++ b/platform/vs/docker-gbsyncd-vs/Dockerfile.j2
@@ -31,4 +31,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -170,4 +170,4 @@ RUN mkdir -p /var/warmboot/teamd
 ENV PLATFORM=x86_64-kvm_x86_64-r0
 ENV HWSKU=Force10-S6000
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/vs/docker-syncd-vs/Dockerfile.j2
+++ b/platform/vs/docker-syncd-vs/Dockerfile.j2
@@ -31,4 +31,4 @@ COPY ["critical_processes", "/etc/supervisor/"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
-ENTRYPOINT ["supervisord"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
use abspath makes the entrypoint not affected by PATH env.

**- How I did it**
see above

**- How to verify it**
build docker-sonic-vs and tested locally

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
