### PR TITLE
Enhanced Feature table to support 'always_enabled' value for state and auto-restart fields.

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -18,15 +18,15 @@
         }
     },
 {%- set features = [("bgp", "enabled", false, "enabled"),
-                   ("database", "enabled", false, "disabled"),
+                   ("database", "always_enabled", false, "always_enabled"),
                    ("dhcp_relay", "enabled", false, "enabled"),
                    ("lldp", "enabled", false, "enabled"),
                    ("pmon", "enabled", false, "enabled"),
                    ("radv", "enabled", false, "enabled"),
                    ("snmp", "enabled", true, "enabled"),
-                   ("swss", "enabled", false, "enabled"),
-                   ("syncd", "enabled", false, "enabled"),
-                   ("teamd", "enabled", false, "enabled")] %}
+                   ("swss", "always_enabled", false, "enabled"),
+                   ("syncd", "always_enabled", false, "enabled"),
+                   ("teamd", "always_enabled", false, "enabled")] %}
 {%- if sonic_asic_platform == "vs" %}{% do features.append(("gbsyncd", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_iccpd == "y" %}{% do features.append(("iccpd", "disabled", false, "enabled")) %}{% endif %}
 {%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", true, "enabled")) %}{% endif %}

--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -95,8 +95,8 @@ def main(argv):
 
             # If auto-restart feature is not disabled and at the same time
             # a critical process exited unexpectedly, terminate supervisor
-            if ((restart_feature != 'disabled') and expected == 0 and
-                (processname in critical_process_list or groupname in critical_group_list)):
+            if (restart_feature != 'disabled' and expected == 0 and
+               (processname in critical_process_list or groupname in critical_group_list)):
                 MSG_FORMAT_STR = "Process {} exited unxepectedly. Terminating supervisor..."
                 msg = MSG_FORMAT_STR.format(payload_headers['processname'])
                 syslog.syslog(syslog.LOG_INFO, msg)

--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -77,27 +77,26 @@ def main(argv):
             groupname = payload_headers['groupname']
 
             # Read the status of auto-restart feature from Config_DB.
-            if container_name != 'database':
-                config_db = swsssdk.ConfigDBConnector()
-                config_db.connect()
-                features_table = config_db.get_table(FEATURE_TABLE_NAME)
-                if not features_table:
-                    syslog.syslog(syslog.LOG_ERR, "Unable to retrieve features table from Config DB. Exiting...")
-                    sys.exit(2)
+            config_db = swsssdk.ConfigDBConnector()
+            config_db.connect()
+            features_table = config_db.get_table(FEATURE_TABLE_NAME)
+            if not features_table:
+                syslog.syslog(syslog.LOG_ERR, "Unable to retrieve features table from Config DB. Exiting...")
+                sys.exit(2)
 
-                if container_name not in features_table:
-                    syslog.syslog(syslog.LOG_ERR, "Unable to retrieve feature '{}'. Exiting...".format(container_name))
-                    sys.exit(3)
+            if container_name not in features_table:
+                syslog.syslog(syslog.LOG_ERR, "Unable to retrieve feature '{}'. Exiting...".format(container_name))
+                sys.exit(3)
 
-                restart_feature = features_table[container_name].get('auto_restart')
-                if not restart_feature:
-                    syslog.syslog(syslog.LOG_ERR, "Unable to determine auto-restart feature status for '{}'. Exiting...".format(container_name))
-                    sys.exit(4)
+            restart_feature = features_table[container_name].get('auto_restart')
+            if not restart_feature:
+                syslog.syslog(syslog.LOG_ERR, "Unable to determine auto-restart feature status for '{}'. Exiting...".format(container_name))
+                sys.exit(4)
 
-            # If container is database or auto-restart feature is enabled and at the same time
+            # If auto-restart feature is not disabled and at the same time
             # a critical process exited unexpectedly, terminate supervisor
-            if ((container_name == 'database' or restart_feature == 'enabled') and expected == 0 and
-                    (processname in critical_process_list or groupname in critical_group_list)):
+            if ((restart_feature != 'disabled') and expected == 0 and
+                (processname in critical_process_list or groupname in critical_group_list)):
                 MSG_FORMAT_STR = "Process {} exited unxepectedly. Terminating supervisor..."
                 msg = MSG_FORMAT_STR.format(payload_headers['processname'])
                 syslog.syslog(syslog.LOG_INFO, msg)

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -252,6 +252,10 @@ class HostConfigDaemon:
 
 
     def update_feature_state(self, feature_name, state, feature_table):
+        if state == "always_enabled":
+            syslog.syslog(syslog.LOG_INFO, "Feature '{}' service is always enabled"
+                          .format(feature_name))
+            return
         has_timer = ast.literal_eval(feature_table[feature_name].get('has_timer', 'False'))
         has_global_scope = ast.literal_eval(feature_table[feature_name].get('has_global_scope', 'True'))
         has_per_asic_scope = ast.literal_eval(feature_table[feature_name].get('has_per_asic_scope', 'False'))


### PR DESCRIPTION
Why I did:
Fixes Issue#https://github.com/Azure/sonic-buildimage/issues/5999

How I did:

- Added new flag value 'always_enabled' for the state and auto-restart field of feature table

- init_cfg.json is updated to initialize state field of database/swss/syncd/teamd feature and auto-restart field of database feature 
  as always_enabled 

- Once the state/auto-restart value is initialized as "always_enabled" it is immutable and cannot be change via feature config commands. (config feature..) PR#https://github.com/Azure/sonic-utilities/pull/1271

- hostcfgd will not take any action if state field value is 'always_enabled'

- Since we have always_enabled field for auto-restart updated supervisor-proc-exit-listener
   not to have special check for database and always rely  on value from Feature table.

How I Verify:

- Cli command

```
admin@str-xxx-2:/var/log$ show feature status
Feature     State           AutoRestart
----------  --------------  --------------
acms        enabled         enabled
bgp         enabled         enabled
database    always_enabled  always_enabled
dhcp_relay  enabled         enabled
lldp        enabled         enabled
pmon        enabled         enabled
radv        enabled         enabled
snmp        enabled         enabled
swss        always_enabled  enabled
syncd       always_enabled  enabled
teamd       always_enabled  enabled
telemetry   enabled         enabled

```

- Hostcfgd skip the processing via syslog

`Nov 25 01:02:44.925773 str-xxx-2 INFO hostcfgd: Feature 'teamd' service is always enabled`

- Made sure auto-restart works fine for swss/syncd/teamd 
