### PR TITLE
Syncd containers still based on Stretch must still use Python 2

### DIFF
--- a/platform/barefoot/docker-syncd-bfn/supervisord.conf
+++ b/platform/barefoot/docker-syncd-bfn/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
+command=python2 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/broadcom/docker-syncd-brcm/supervisord.conf
+++ b/platform/broadcom/docker-syncd-brcm/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
+command=python2 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/centec-arm64/docker-syncd-centec/supervisord.conf
+++ b/platform/centec-arm64/docker-syncd-centec/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
+command=python2 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/centec/docker-syncd-centec/supervisord.conf
+++ b/platform/centec/docker-syncd-centec/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
+command=python2 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0
@@ -12,7 +12,7 @@ exitcodes=0,3
 events=PROCESS_STATE
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/innovium/docker-syncd-invm/supervisord.conf
+++ b/platform/innovium/docker-syncd-invm/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
+command=python2 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0

--- a/platform/marvell-arm64/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell-arm64/docker-syncd-mrvl/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
+command=python2 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/marvell-armhf/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell-armhf/docker-syncd-mrvl/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
+command=python2 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/marvell/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell/docker-syncd-mrvl/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
+command=python2 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected

--- a/platform/nephos/docker-syncd-nephos/supervisord.conf
+++ b/platform/nephos/docker-syncd-nephos/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
+command=python2 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED
 autostart=true
 autorestart=unexpected


### PR DESCRIPTION
**- Why I did it**

Some syncd containers are still based on Debian Stretch, and thus do not have Python 3 available. For these containers, we must still rely on Python 2 to run supervisord_dependent_startup and supervisor-proc-exit-listener

**- How I did it**

Explicitly start supervisord_dependent_startup and supervisor-proc-exit-listener with Python 2 in syncd containers which are still based on Debian Stretch.

**- How to verify it**

Ensure the syncd container starts properly and both supervisord_dependent_startup and supervisor-proc-exit-listener do not exit unexpectedly.