### PR TITLE
[bgpcfgd]: Add on-match next rule for set ipv6 next-hop prefer-global

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
@@ -36,6 +36,7 @@ route-map TO_BGP_PEER_V4 permit 100
 !
 !
 route-map FROM_BGP_PEER_V6 permit 1
+ on-match next
  set ipv6 next-hop prefer-global
 !
 route-map FROM_BGP_PEER_V6 permit 100

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/policies.conf.j2
@@ -9,6 +9,7 @@ route-map TO_BGP_INTERNAL_PEER_V4 permit 100
 !
 !
 route-map FROM_BGP_INTERNAL_PEER_V6 permit 1
+ on-match next
  set ipv6 next-hop prefer-global
 !
 route-map FROM_BGP_INTERNAL_PEER_V6 permit 100

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all.conf
@@ -20,6 +20,7 @@ route-map FROM_BGP_PEER_V4 permit 100
 route-map TO_BGP_PEER_V4 permit 100
 !
 route-map FROM_BGP_PEER_V6 permit 1
+ on-match next
  set ipv6 next-hop prefer-global
 !
 route-map FROM_BGP_PEER_V6 permit 100

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_base.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_base.conf
@@ -6,6 +6,7 @@ route-map FROM_BGP_PEER_V4 permit 100
 route-map TO_BGP_PEER_V4 permit 100
 !
 route-map FROM_BGP_PEER_V6 permit 1
+ on-match next
  set ipv6 next-hop prefer-global
 !
 route-map FROM_BGP_PEER_V6 permit 100

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_deny.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_deny.conf
@@ -20,6 +20,7 @@ route-map FROM_BGP_PEER_V4 permit 100
 route-map TO_BGP_PEER_V4 permit 100
 !
 route-map FROM_BGP_PEER_V6 permit 1
+ on-match next
  set ipv6 next-hop prefer-global
 !
 route-map FROM_BGP_PEER_V6 permit 100

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v4.conf
@@ -1,5 +1,5 @@
 !
-! template: bgpd/templates/general/instance.conf.j2
+! template: bgpd/templates/internal/instance.conf.j2
 !
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
@@ -12,5 +12,5 @@
     neighbor 10.10.10.10 activate
   exit-address-family
 !
-! end of template: bgpd/templates/general/instance.conf.j2
+! end of template: bgpd/templates/internal/instance.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_back_v6.conf
@@ -1,5 +1,5 @@
 !
-! template: bgpd/templates/general/instance.conf.j2
+! template: bgpd/templates/internal/instance.conf.j2
 !
   neighbor fc::10 remote-as 555
   neighbor fc::10 description remote_peer
@@ -12,5 +12,5 @@
     neighbor fc::10 activate
   exit-address-family
 !
-! end of template: bgpd/templates/general/instance.conf.j2
+! end of template: bgpd/templates/internal/instance.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v4.conf
@@ -1,5 +1,5 @@
 !
-! template: bgpd/templates/general/instance.conf.j2
+! template: bgpd/templates/internal/instance.conf.j2
 !
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
@@ -10,5 +10,5 @@
     neighbor 10.10.10.10 activate
   exit-address-family
 !
-! end of template: bgpd/templates/general/instance.conf.j2
+! end of template: bgpd/templates/internal/instance.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_front_v6.conf
@@ -1,5 +1,5 @@
 !
-! template: bgpd/templates/general/instance.conf.j2
+! template: bgpd/templates/internal/instance.conf.j2
 !
   neighbor fc::10 remote-as 555
   neighbor fc::10 description remote_peer
@@ -10,5 +10,5 @@
     neighbor fc::10 activate
   exit-address-family
 !
-! end of template: bgpd/templates/general/instance.conf.j2
+! end of template: bgpd/templates/internal/instance.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_back.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_back.conf
@@ -1,5 +1,5 @@
 !
-! template: bgpd/templates/general/peer-group.conf.j2
+! template: bgpd/templates/internal/peer-group.conf.j2
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
@@ -16,5 +16,5 @@
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
   exit-address-family
 !
-! end of template: bgpd/templates/general/peer-group.conf.j2
+! end of template: bgpd/templates/internal/peer-group.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_front.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_front.conf
@@ -1,5 +1,5 @@
 !
-! template: bgpd/templates/general/peer-group.conf.j2
+! template: bgpd/templates/internal/peer-group.conf.j2
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
@@ -14,5 +14,5 @@
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
   exit-address-family
 !
-! end of template: bgpd/templates/general/peer-group.conf.j2
+! end of template: bgpd/templates/internal/peer-group.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/policies.conf/result_back.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/policies.conf/result_back.conf
@@ -1,11 +1,12 @@
 !
-! template: bgpd/templates/general/policies.conf.j2
+! template: bgpd/templates/internal/policies.conf.j2
 !
 route-map FROM_BGP_INTERNAL_PEER_V4 permit 100
 !
 route-map TO_BGP_INTERNAL_PEER_V4 permit 100
 !
 route-map FROM_BGP_INTERNAL_PEER_V6 permit 1
+ on-match next
  set ipv6 next-hop prefer-global
 !
 route-map FROM_BGP_INTERNAL_PEER_V6 permit 100
@@ -18,5 +19,5 @@ route-map FROM_BGP_INTERNAL_PEER_V4 permit 2
 route-map FROM_BGP_INTERNAL_PEER_V6 permit 2
  set originator-id 10.10.10.10
 !
-! end of template: bgpd/templates/general/policies.conf.j2
+! end of template: bgpd/templates/internal/policies.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/policies.conf/result_front.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/policies.conf/result_front.conf
@@ -1,16 +1,17 @@
 !
-! template: bgpd/templates/general/policies.conf.j2
+! template: bgpd/templates/internal/policies.conf.j2
 !
 route-map FROM_BGP_INTERNAL_PEER_V4 permit 100
 !
 route-map TO_BGP_INTERNAL_PEER_V4 permit 100
 !
 route-map FROM_BGP_INTERNAL_PEER_V6 permit 1
+ on-match next
  set ipv6 next-hop prefer-global
 !
 route-map FROM_BGP_INTERNAL_PEER_V6 permit 100
 !
 route-map TO_BGP_INTERNAL_PEER_V6 permit 100
 !
-! end of template: bgpd/templates/general/policies.conf.j2
+! end of template: bgpd/templates/internal/policies.conf.j2
 !


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Without the rule, IPv6 route-map entries were skipped.
**- How I did it**
Added 'on-match next' rule after 'set ipv6 next-hop prefer-global.
Updated a test to check that we have 'on-match next' rule with the 'set ipv6 next-hop prefer-global'

**- How to verify it**
Build an image. Run on your dut. Add a route-map entry after 'set ipv6 next-hop prefer-global'. Check that the route-map entry works  
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
