### PR TITLE
Add support for snat, dnat and ipmc crm resources

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -10,7 +10,7 @@
             "polling_interval": "300",
 {%- for crm_res in ["ipv4_route", "ipv6_route", "ipv4_nexthop", "ipv6_nexthop", "ipv4_neighbor",
                     "ipv6_neighbor", "nexthop_group_member", "nexthop_group", "acl_table",
-                    "acl_group", "acl_entry", "acl_counter", "fdb_entry"] %}
+                    "acl_group", "acl_entry", "acl_counter", "fdb_entry", "snat_entry", "dnat_entry", "ipmc_entry"] %}
             "{{crm_res}}_threshold_type": "percentage",
             "{{crm_res}}_low_threshold": "70",
             "{{crm_res}}_high_threshold": "85"{% if not loop.last %},{% endif -%}


### PR DESCRIPTION
Signed-off-by: Prabhu Sreenivasan <prabhu.sreenivasan@broadcom>

- What I did
Added support for snat, dnat and ipmc resources under CRM module.

- How I did it
New feature NAT adds new resources snat_enty and dnat_entry that needs to be monitored. ipmc_entry tracks IP multicast resources used by switch.

- How to verify it
sonic-utilities tests and crm spytest

- Associated PRs
Azure/sonic-swss#1511
Azure/sonic-utilities/pull/1258
