### PR TITLE
[libyang] Adding LFS support for arm32

### DIFF
--- a/src/libyang/patch/large_file_support_arm32.patch
+++ b/src/libyang/patch/large_file_support_arm32.patch
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8635ba1..39f0741 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -436,3 +436,6 @@ endif(ENABLE_BUILD_FUZZ_TARGETS)
+ if(GEN_LANGUAGE_BINDINGS AND GEN_CPP_BINDINGS)
+     add_subdirectory(swig)
+ endif()
++
++#Enable large file support for 32-bit arch
++add_definitions(-D_FILE_OFFSET_BITS=64)

--- a/src/libyang/patch/series
+++ b/src/libyang/patch/series
@@ -1,2 +1,3 @@
 libyang.patch
 swig.patch
+large_file_support_arm32.patch


### PR DESCRIPTION
Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
In the emulated armhf environment, the function readdir()returns NULL on a ext4 file system directory. When running the libyang test cases, it will require to load the plugins from the files (such as metadata.so), because the readdir() is failing, the plugins can’t be loaded in the emulated armhf environment, so it causes libyang test error. This error is a combination of the following reasons.
• Emulation of a 32-bit target from a 64-bit host –> qemu from x86_64 to armhf
• Glibc version > 2.27 – Debian buster is using glibc 2.28
**- How I did it**
Enabled large file support by setting _FILE_OFFSET_BITS=64 for libyang.
**- How to verify it**
Compiled and verified libyang unit tests in arm32, amr64 and intel

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
