### PR TITLE
[Arista] Rename chip in sensors.conf for 7170 platform

### DIFF
--- a/device/arista/x86_64-arista_7170_64c/sensors.conf
+++ b/device/arista/x86_64-arista_7170_64c/sensors.conf
@@ -20,7 +20,7 @@ chip "max6658-i2c-8-4c"
     set temp2_min -55
     ignore temp2
 
-chip "dps1900-i2c-6-58"
+chip "pmbus-i2c-6-58"
     label temp1 "PSU1 primary hotspot temp"
     label temp2 "PSU1 inlet temp"
     label temp3 "PSU1 exhaust temp"
@@ -31,7 +31,7 @@ chip "dps1900-i2c-6-58"
     ignore fan2
     ignore fan3
 
-chip "dps1900-i2c-7-58"
+chip "pmbus-i2c-7-58"
     label temp1 "PSU2 primary hotspot temp"
     label temp2 "PSU2 inlet temp"
     label temp3 "PSU2 exhaust temp"


### PR DESCRIPTION
Rename chip name dps1900-i2c-X-58 to pmbus-i2c-X-58 in sensors.conf for Arista 7170 due to latest updates for Arista driver submodules #5686. After these updates adapter dps1900 was renamed and sensors.conf file is not applied properly. Issue was observed started from BFN SONiC image 16. See logs below
SONiC 13
```
admin@sonic:~$ sensors -A -u
dps1900-i2c-7-58
vin:
in1_input: 0.000
in1_alarm: 0.000
vout1:
in2_input: 0.000
in2_lcrit: 10.750
in2_crit: 14.250
in2_lcrit_alarm: 0.000
in2_crit_alarm: 0.000
fan1:
fan1_input: 7888.000
fan1_alarm: 0.000
fan1_fault: 0.000
PSU2 primary hotspot temp:
temp1_input: 0.000
temp1_alarm: 0.000
PSU2 inlet temp:
temp2_input: 0.000
temp2_alarm: 0.000
iin:
curr1_input: 0.000
curr1_max: 10.000
curr1_max_alarm: 0.000
iout1:
curr2_input: 0.000
curr2_max: 71.875
curr2_crit: 74.375
curr2_max_alarm: 0.000
curr2_crit_alarm: 0.000
```

SONiC 16
```
admin@sonic:~$ sensors -A -u
pmbus-i2c-6-58
vin:
in1_input: 225.750
in1_alarm: 0.000
vout1:
in2_input: 12.005
in2_lcrit: 10.750
in2_crit: 14.250
in2_lcrit_alarm: 0.000
in2_crit_alarm: 0.000
fan1:
fan1_input: 7760.000
fan1_alarm: 0.000
fan1_fault: 0.000
temp1:
temp1_input: 28.000
temp1_alarm: 0.000
temp2:
temp2_input: 15.000
temp2_alarm: 0.000
temp3:
temp3_input: 32.000
temp3_alarm: 0.000
pin:
power1_input: 237.000
power1_alarm: 0.000
pout1:
power2_input: 219.250
pout2:
power3_input: 219.250
iin:
curr1_input: 1.064
curr1_max: 10.000
curr1_max_alarm: 0.000
iout1:
curr2_input: 18.250
curr2_max: 71.875
curr2_crit: 74.375
curr2_max_alarm: 0.000
curr2_crit_alarm: 0.000
iout2:
curr3_input: 18.250
curr3_crit: 74.375
curr3_crit_alarm: 0.000
```

Note: Issue is observed only on SONiC master and CT sensors is failed on SONiC master 

Signed-off-by: Nazar Tkachuk <nazarx.tkachuk@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
CT sensors is failed on platform x86_64-arista_7170_64c

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
