### PR TITLE
sonic-buildimage: Update Readme with Innovium support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The SONiC installer contains all docker images needed. SONiC uses one image for 
 - PLATFORM=cavium
 - PLATFORM=centec
 - PLATFORM=nephos
+- PLATFORM=innovium
 - PLATFORM=p4
 - PLATFORM=vs
 
@@ -200,6 +201,7 @@ This may take a while, but it is a one-time action, so please be patient.
   - docker-syncd-cavm.gz: docker image for the daemon to sync database and Cavium switch ASIC (gzip tar archive)
   - docker-syncd-mlnx.gz: docker image for the daemon to sync database and Mellanox switch ASIC (gzip tar archive)
   - docker-syncd-nephos.gz: docker image for the daemon to sync database and Nephos switch ASIC (gzip tar archive)
+  - docker-syncd-invm.gz: docker image for the daemon to sync database and Innovium switch ASIC (gzip tar archive)
   - docker-sonic-p4.gz: docker image for all-in-one for p4 software switch (gzip tar archive)
   - docker-sonic-vs.gz: docker image for all-in-one for software virtual switch (gzip tar archive)
   - docker-sonic-mgmt.gz: docker image for [managing, configuring and monitoring SONiC](https://github.com/Azure/sonic-mgmt) (gzip tar archive)


### PR DESCRIPTION

**- Why I did it**
Innovium make target and syncd docker image information was missing

**- How I did it**
Added Innovium make target and syncd docker image information

**- How to verify it**
Verified 
https://sonic-jenkins.westus2.cloudapp.azure.com/job/innovium/job/buildimage-invm-201911/lastSuccessfulBuild/artifact/target/docker-syncd-invm.gz

**- Which release branch to backport (provide reason below if selected)**

- [ X] 201911
- [X ] 202006

**- Description for the changelog**
Update Readme with Innovium support

