### PR TITLE
[buildimage][master] fix enable SONIC_DEBUG_ON compiling error

### DIFF
--- a/src/hiredis/Makefile
+++ b/src/hiredis/Makefile
@@ -18,9 +18,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	fakeroot debian/rules -j$(SONIC_CONFIG_MAKE_JOBS) binary
 	popd
 
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(HIREDIS_DBG) $(DEST)/
-endif
+	$(foreach dbg_deb, $(HIREDIS_DBG), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/hiredis/Makefile
+++ b/src/hiredis/Makefile
@@ -19,7 +19,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 ifneq ($(wildcard $(HIREDIS_DBG)),)
-	DERIVED_TARGETS += $(HIREDIS_DBG)
+	mv $(HIREDIS_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 

--- a/src/hiredis/Makefile
+++ b/src/hiredis/Makefile
@@ -3,7 +3,8 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = libhiredis0.14_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
-DERIVED_TARGETS = libhiredis0.14-dbgsym_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb libhiredis-dev_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+HIREDIS_DBG = libhiredis0.14-dbgsym_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS = libhiredis-dev_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf hiredis-$(HIREDIS_VERSION)
@@ -17,6 +18,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	fakeroot debian/rules -j$(SONIC_CONFIG_MAKE_JOBS) binary
 	popd
 
-	mv $* $(DERIVED_TARGETS) $(DEST)/
+ifneq ($(wildcard $(HIREDIS_DBG)),)
+	DERIVED_TARGETS += $(HIREDIS_DBG)
+endif
+	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/hiredis/Makefile
+++ b/src/hiredis/Makefile
@@ -18,7 +18,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	fakeroot debian/rules -j$(SONIC_CONFIG_MAKE_JOBS) binary
 	popd
 
-ifneq ($(wildcard $(HIREDIS_DBG)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(HIREDIS_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/isc-dhcp/Makefile
+++ b/src/isc-dhcp/Makefile
@@ -28,7 +28,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Move the newly-built .deb packages to the destination directory
 	mv $* $(DEST)/
-ifneq ($(wildcard $(DERIVED_TARGETS)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(DERIVED_TARGETS) $(DEST)/
 endif
 

--- a/src/isc-dhcp/Makefile
+++ b/src/isc-dhcp/Makefile
@@ -28,8 +28,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Move the newly-built .deb packages to the destination directory
 	mv $* $(DEST)/
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(DERIVED_TARGETS) $(DEST)/
-endif
+	$(foreach dbg_deb, $(DERIVED_TARGETS), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/isc-dhcp/Makefile
+++ b/src/isc-dhcp/Makefile
@@ -27,6 +27,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 	# Move the newly-built .deb packages to the destination directory
-	mv $(DERIVED_TARGETS) $* $(DEST)/
+	mv $* $(DEST)/
+ifneq ($(wildcard $(DERIVED_TARGETS)),)
+	mv $(DERIVED_TARGETS) $(DEST)/
+endif
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -34,9 +34,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(TEAM_DBG) $(DEST)/
-endif
+	$(foreach dbg_deb, $(TEAM_DBG), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -35,7 +35,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 ifneq ($(wildcard $(TEAM_DBG)),)
-	DERIVED_TARGETS += $(TEAM_DBG)
+	mv $(TEAM_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -34,7 +34,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
-ifneq ($(wildcard $(TEAM_DBG)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(TEAM_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -3,12 +3,12 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = libteam5_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb
+TEAM_DBG = libteam5-dbgsym_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
+ 		  libteamdctl0-dbgsym_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
+ 		  libteam-utils-dbgsym_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS = libteam-dev_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
 		  libteamdctl0_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
-		  libteam-utils_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
-		  libteam5-dbgsym_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
-		  libteamdctl0-dbgsym_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
-		  libteam-utils-dbgsym_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb
+		  libteam-utils_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtain libteam
@@ -34,6 +34,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
+ifneq ($(wildcard $(TEAM_DBG)),)
+	DERIVED_TARGETS += $(TEAM_DBG)
+endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/libyang/Makefile
+++ b/src/libyang/Makefile
@@ -22,7 +22,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	pushd debs
 ifneq ($(wildcard $(LIBYANG_DBG)),)
-	DERIVED_TARGETS += $(LIBYANG_DBG)
+	mv $(LIBYANG_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 	popd

--- a/src/libyang/Makefile
+++ b/src/libyang/Makefile
@@ -3,7 +3,7 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = $(LIBYANG)
-DERIVED_TARGETS = $(LIBYANG_DEV) $(LIBYANG_DBG) $(LIBYANG_PY2) $(LIBYANG_PY3) $(LIBYANG_CPP)
+DERIVED_TARGETS = $(LIBYANG_DEV) $(LIBYANG_PY2) $(LIBYANG_PY3) $(LIBYANG_CPP)
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
         # Obtaining the libyang
@@ -21,8 +21,10 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	make build-deb
 
 	pushd debs
-	mv $* $(DEST)/
-	mv $(DERIVED_TARGETS) $(DEST)/
+ifneq ($(wildcard $(LIBYANG_DBG)),)
+	DERIVED_TARGETS += $(LIBYANG_DBG)
+endif
+	mv $(DERIVED_TARGETS) $* $(DEST)/
 	popd
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/libyang/Makefile
+++ b/src/libyang/Makefile
@@ -21,9 +21,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	make build-deb
 
 	pushd debs
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(LIBYANG_DBG) $(DEST)/
-endif
+	$(foreach dbg_deb, $(LIBYANG_DBG), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 	popd
 

--- a/src/libyang/Makefile
+++ b/src/libyang/Makefile
@@ -21,7 +21,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	make build-deb
 
 	pushd debs
-ifneq ($(wildcard $(LIBYANG_DBG)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(LIBYANG_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/lldpd/Makefile
+++ b/src/lldpd/Makefile
@@ -39,9 +39,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 	# Move the newly-built .deb packages to the destination directory
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(LLDPD_DBG) $(DEST)/
-endif
+	$(foreach dbg_deb, $(LLDPD_DBG), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/lldpd/Makefile
+++ b/src/lldpd/Makefile
@@ -40,7 +40,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Move the newly-built .deb packages to the destination directory
 ifneq ($(wildcard $(LLDPD_DBG)),)
-	DERIVED_TARGETS += $(LLDPD_DBG)
+	mv $(LLDPD_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 

--- a/src/lldpd/Makefile
+++ b/src/lldpd/Makefile
@@ -3,7 +3,7 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = $(LLDPD)
-DERIVED_TARGETS = $(LIBLLDPCTL) $(LLDPD_DBG)
+DERIVED_TARGETS = $(LIBLLDPCTL)
 
 LLDP_URL = https://sonicstorage.blob.core.windows.net/debian/pool/main/l/lldpd
 
@@ -39,6 +39,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 	# Move the newly-built .deb packages to the destination directory
-	mv $* $(DERIVED_TARGETS) $(DEST)/
+ifneq ($(wildcard $(LLDPD_DBG)),)
+	DERIVED_TARGETS += $(LLDPD_DBG)
+endif
+	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/lldpd/Makefile
+++ b/src/lldpd/Makefile
@@ -39,7 +39,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 	# Move the newly-built .deb packages to the destination directory
-ifneq ($(wildcard $(LLDPD_DBG)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(LLDPD_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/lm-sensors/Makefile
+++ b/src/lm-sensors/Makefile
@@ -29,7 +29,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 ifneq ($(wildcard $(SENSORS_DBG)),)
-	DERIVED_TARGETS += $(SENSORS_DBG)
+	mv $(SENSORS_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 

--- a/src/lm-sensors/Makefile
+++ b/src/lm-sensors/Makefile
@@ -28,7 +28,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	DEB_BUILD_OPTIONS=nocheck PROG_EXTRA=sensord dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
-ifneq ($(wildcard $(SENSORS_DBG)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(SENSORS_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/lm-sensors/Makefile
+++ b/src/lm-sensors/Makefile
@@ -28,9 +28,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	DEB_BUILD_OPTIONS=nocheck PROG_EXTRA=sensord dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(SENSORS_DBG) $(DEST)/
-endif
+	$(foreach dbg_deb, $(SENSORS_DBG), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/lm-sensors/Makefile
+++ b/src/lm-sensors/Makefile
@@ -4,12 +4,12 @@ SHELL = /bin/bash
 
 
 MAIN_TARGET = $(LM_SENSORS)
+SENSORS_DBG = $(LM_SENSORS_DBG) \
+			  $(LIBSENSORS_DBG) \
+			  $(SENSORD_DBG)
 DERIVED_TARGETS = fancontrol_$(LM_SENSORS_VERSION_FULL)_all.deb \
 				  $(LIBSENSORS) \
-				  sensord_$(LM_SENSORS_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-				  $(LM_SENSORS_DBG) \
-				  $(LIBSENSORS_DBG) \
-				  $(SENSORD_DBG)
+				  sensord_$(LM_SENSORS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf lm-sensors-$(LM_SENSORS_VERSION)
@@ -28,6 +28,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	DEB_BUILD_OPTIONS=nocheck PROG_EXTRA=sensord dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
+ifneq ($(wildcard $(SENSORS_DBG)),)
+	DERIVED_TARGETS += $(SENSORS_DBG)
+endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/monit/Makefile
+++ b/src/monit/Makefile
@@ -29,8 +29,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Move the newly-built .deb packages to the destination directory
 	mv $* $(DEST)/
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(DERIVED_TARGETS) $(DEST)/
-endif
+	$(foreach dbg_deb, $(DERIVED_TARGETS), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/monit/Makefile
+++ b/src/monit/Makefile
@@ -29,7 +29,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Move the newly-built .deb packages to the destination directory
 	mv $* $(DEST)/
-ifneq ($(wildcard $(DERIVED_TARGETS)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(DERIVED_TARGETS) $(DEST)/
 endif
 

--- a/src/monit/Makefile
+++ b/src/monit/Makefile
@@ -28,6 +28,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 	# Move the newly-built .deb packages to the destination directory
-	mv $(DERIVED_TARGETS) $* $(DEST)/
+	mv $* $(DEST)/
+ifneq ($(wildcard $(DERIVED_TARGETS)),)
+	mv $(DERIVED_TARGETS) $(DEST)/
+endif
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/openssh/Makefile
+++ b/src/openssh/Makefile
@@ -24,8 +24,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 	mv $* $(DEST)/
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(DERIVED_TARGETS) $(DEST)/
-endif
+	$(foreach dbg_deb, $(DERIVED_TARGETS), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/openssh/Makefile
+++ b/src/openssh/Makefile
@@ -24,7 +24,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 	mv $* $(DEST)/
-ifneq ($(wildcard $(DERIVED_TARGETS)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(DERIVED_TARGETS) $(DEST)/
 endif
 

--- a/src/openssh/Makefile
+++ b/src/openssh/Makefile
@@ -23,6 +23,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
-	mv $(DERIVED_TARGETS) $* $(DEST)/
+	mv $* $(DEST)/
+ifneq ($(wildcard $(DERIVED_TARGETS)),)
+	mv $(DERIVED_TARGETS) $(DEST)/
+endif
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/redis/Makefile
+++ b/src/redis/Makefile
@@ -26,7 +26,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 ifneq ($(wildcard $(REDIS_DBG)),)
-	DERIVED_TARGETS += REDIS_DBG
+	mv $(REDIS_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 	popd

--- a/src/redis/Makefile
+++ b/src/redis/Makefile
@@ -25,7 +25,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
-ifneq ($(wildcard $(REDIS_DBG)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(REDIS_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/redis/Makefile
+++ b/src/redis/Makefile
@@ -25,9 +25,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(REDIS_DBG) $(DEST)/
-endif
+	$(foreach dbg_deb, $(REDIS_DBG), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 	popd
 

--- a/src/redis/Makefile
+++ b/src/redis/Makefile
@@ -6,9 +6,9 @@ REDIS_VERSION = 5.0.3
 REDIS_VERSION_FULL = $(REDIS_VERSION)-3~bpo9+2
 
 MAIN_TARGET = redis-server_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+REDIS_DBG = redis-tools-dbgsym_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS = redis-tools_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  redis-sentinel_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  redis-tools-dbgsym_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+		  redis-sentinel_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf  redis_build
@@ -25,6 +25,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
+ifneq ($(wildcard $(REDIS_DBG)),)
+	DERIVED_TARGETS += REDIS_DBG
+endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 	popd
 

--- a/src/sflow/hsflowd/Makefile
+++ b/src/sflow/hsflowd/Makefile
@@ -24,7 +24,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --buildinfo-option=-u. --changes-option=-u.
 
 	mv $* $(DEST)/
-ifneq ($(wildcard $(DERIVED_TARGET)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(DERIVED_TARGET) $(DEST)/
 endif
 	popd

--- a/src/sflow/hsflowd/Makefile
+++ b/src/sflow/hsflowd/Makefile
@@ -23,7 +23,10 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --buildinfo-option=-u. --changes-option=-u.
 
-	mv $(DERIVED_TARGET) $* $(DEST)/
+	mv $* $(DEST)/
+ifneq ($(wildcard $(DERIVED_TARGET)),)
+	mv $(DERIVED_TARGET) $(DEST)/
+endif
 	popd
 
 $(addprefix $(DEST)/, $(DERIVED_TARGET)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/sflow/hsflowd/Makefile
+++ b/src/sflow/hsflowd/Makefile
@@ -24,9 +24,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --buildinfo-option=-u. --changes-option=-u.
 
 	mv $* $(DEST)/
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(DERIVED_TARGET) $(DEST)/
-endif
+	$(foreach dbg_deb, $(DERIVED_TARGET), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 	popd
 
 $(addprefix $(DEST)/, $(DERIVED_TARGET)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -3,11 +3,11 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = libsnmp-base_$(SNMPD_VERSION_FULL)_all.deb
+SNMPDS_DBG = snmp-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
+		  snmpd-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS = snmptrapd_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmp_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmpd_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  snmp-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  snmpd-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp30_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp30-dbg_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-dev_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
@@ -33,6 +33,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	fakeroot debian/rules -j$(SONIC_CONFIG_MAKE_JOBS) binary
 	popd
 
+ifneq ($(wildcard $(SNMPDS_DBG)),)
+	DERIVED_TARGETS) += $(SNMPDS_DBG)
+endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -34,7 +34,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 ifneq ($(wildcard $(SNMPDS_DBG)),)
-	DERIVED_TARGETS) += $(SNMPDS_DBG)
+	mv $(SNMPDS_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 

--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -33,9 +33,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	fakeroot debian/rules -j$(SONIC_CONFIG_MAKE_JOBS) binary
 	popd
 
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(SNMPDS_DBG) $(DEST)/
-endif
+	mv $* $(DEST)/
+	$(foreach dbg_deb, $(SNMPDS_DBG), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -33,7 +33,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	fakeroot debian/rules -j$(SONIC_CONFIG_MAKE_JOBS) binary
 	popd
 
-ifneq ($(wildcard $(SNMPDS_DBG)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(SNMPDS_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -23,9 +23,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git rev-parse --short HEAD | xargs git checkout
 	git branch -D $(FRR_BRANCH)
 	popd
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(FRRS_DBG) $(DEST)/
-endif
+
+	$(foreach dbg_deb, $(FRRS_DBG), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 	mv $(DERIVED_TARGET) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGET)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -24,7 +24,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git branch -D $(FRR_BRANCH)
 	popd
 ifneq ($(wildcard $(FRRS_DBG)),)
-	DERIVED_TARGET += $(FRRS_DBG)
+	mv $(FRRS_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGET) $* $(DEST)/
 

--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -23,7 +23,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git rev-parse --short HEAD | xargs git checkout
 	git branch -D $(FRR_BRANCH)
 	popd
-ifneq ($(wildcard $(FRRS_DBG)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(FRRS_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGET) $* $(DEST)/

--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -3,7 +3,8 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = $(FRR)
-DERIVED_TARGET = $(FRR_PYTHONTOOLS) $(FRR_DBG) $(FRR_SNMP) $(FRR_SNMP_DBG)
+FRRS_DBG = $(FRR_DBG) $(FRR_SNMP_DBG)
+DERIVED_TARGET = $(FRR_PYTHONTOOLS) $(FRR_SNMP)
 SUFFIX = $(shell date +%Y%m%d\.%H%M%S)
 STG_BRANCH = stg_temp.$(SUFFIX)
 
@@ -22,6 +23,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git rev-parse --short HEAD | xargs git checkout
 	git branch -D $(FRR_BRANCH)
 	popd
+ifneq ($(wildcard $(FRRS_DBG)),)
+	DERIVED_TARGET += $(FRRS_DBG)
+endif
 	mv $(DERIVED_TARGET) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGET)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/swig/Makefile
+++ b/src/swig/Makefile
@@ -16,7 +16,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
-ifneq ($(wildcard $(SWIG_DBG)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	mv $(SWIG_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/

--- a/src/swig/Makefile
+++ b/src/swig/Makefile
@@ -17,7 +17,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 ifneq ($(wildcard $(SWIG_DBG)),)
-	DERIVED_TARGETS += $(SWIG_DBG)
+	mv $(SWIG_DBG) $(DEST)/
 endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 

--- a/src/swig/Makefile
+++ b/src/swig/Makefile
@@ -3,7 +3,7 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = $(SWIG_BASE)
-DERIVED_TARGETS = $(SWIG) $(SWIG_DBG)
+DERIVED_TARGETS = $(SWIG)
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -fr ./swig-$(SWIG_VERSION) *.deb
@@ -16,6 +16,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
+ifneq ($(wildcard $(SWIG_DBG)),)
+	DERIVED_TARGETS += $(SWIG_DBG)
+endif
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/swig/Makefile
+++ b/src/swig/Makefile
@@ -16,9 +16,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 
-ifneq ($(wildcard *dbgsym*.deb),)
-	mv $(SWIG_DBG) $(DEST)/
-endif
+	$(foreach dbg_deb, $(SWIG_DBG), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/systemd-sonic-generator/Makefile
+++ b/src/systemd-sonic-generator/Makefile
@@ -3,11 +3,15 @@ CFLAGS=-std=gnu99
 
 BINARY = systemd-sonic-generator
 MAIN_TARGET = $(BINARY)_1.0.0_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS = $(BINARY)-dbgsym_1.0.0_$(CONFIGURED_ARCH).deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -us -uc -b
 	mv ../$(MAIN_TARGET) $(DEST)/
-	rm ../$(BINARY)-* ../$(BINARY)_*
+	rm ../$(BINARY)_*
+ifneq ($(wildcard $(DERIVED_TARGETS)),)
+	rm ../$(DERIVED_TARGETS)
+endif
 
 $(BINARY): systemd-sonic-generator.c
 	rm -f ./systemd-sonic-generator

--- a/src/systemd-sonic-generator/Makefile
+++ b/src/systemd-sonic-generator/Makefile
@@ -9,9 +9,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -us -uc -b
 	mv ../$(MAIN_TARGET) $(DEST)/
 	rm ../$(BINARY)_*
-ifneq ($(wildcard *dbgsym*.deb),)
-	rm ../$(DERIVED_TARGETS)
-endif
+	$(foreach dbg_deb, $(DERIVED_TARGETS), \
+		{ if [ -e $(dbg_deb) ]; then mv $(dbg_deb) $(DEST)/; fi };)
 
 $(BINARY): systemd-sonic-generator.c
 	rm -f ./systemd-sonic-generator

--- a/src/systemd-sonic-generator/Makefile
+++ b/src/systemd-sonic-generator/Makefile
@@ -9,7 +9,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -us -uc -b
 	mv ../$(MAIN_TARGET) $(DEST)/
 	rm ../$(BINARY)_*
-ifneq ($(wildcard $(DERIVED_TARGETS)),)
+ifneq ($(wildcard *dbgsym*.deb),)
 	rm ../$(DERIVED_TARGETS)
 endif
 


### PR DESCRIPTION
Signed-off-by: tim-rj <sonic_rd@ruijie.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
fix https://github.com/Azure/sonic-buildimage/issues/5982
**- How I did it**
check dbgsym debs exist on folder before move to target/debs/xxx
**- How to verify it**
set SONIC_DEBUG_ON=y and compile the whole image

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
If SONIC_DEBUG_ON or SONIC_PROFILING_ON set to y, no dbgsym debs will trip from the origin deb, so mv dbgsym deb to some other folders will fail and compiling will stop.

**- A picture of a cute animal (not mandatory but encouraged)**
