### PR TITLE
Fix the ExecStart path for process-reboot-cause

### DIFF
--- a/src/sonic-host-services-data/debian/sonic-host-services-data.process-reboot-cause.service
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.process-reboot-cause.service
@@ -1,7 +1,8 @@
 [Unit]
-Description=Reboot cause determination service
-After=rc-local.service
+Description=Retrieve the reboot cause from the history files and save them to StateDB
+Requires=database.service
+After=database.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/process-reboot-cause
+ExecStart=/usr/local/bin/process-reboot-cause


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The path should be /usr/local/bin not /usr/bin
**- How I did it**
Change the ExecStart path
**- How to verify it**
Check if it starts
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Addresses an issue mentioned in https://github.com/Azure/sonic-buildimage/issues/6009, but does not close the issue.

**- A picture of a cute animal (not mandatory but encouraged)**
