### PR TITLE
[FRR] remove the whole block of outchannel properly

### DIFF
--- a/src/sonic-frr/patch/0007-frr-remove-frr-log-outchannel-to-var-log-frr.log.patch
+++ b/src/sonic-frr/patch/0007-frr-remove-frr-log-outchannel-to-var-log-frr.log.patch
@@ -1,6 +1,6 @@
-From 1f150992b074d07bce5157d203319512a3aeb4dc Mon Sep 17 00:00:00 2001
+From 31464e3fd0f677bc15286e99d4a30e2e33480c53 Mon Sep 17 00:00:00 2001
 From: Ying Xie <ying.xie@microsoft.com>
-Date: Wed, 18 Nov 2020 19:24:51 +0000
+Date: Wed, 25 Nov 2020 22:28:43 +0000
 Subject: [PATCH] [frr] remove frr log outchannel to /var/log/frr.log
 
 SONiC runs frr inside a docker and the logs are sent to base image
@@ -10,19 +10,36 @@ space eventually.
 
 Signed-off-by: Ying Xie <ying.xie@microsoft.com>
 ---
- tools/etc/rsyslog.d/45-frr.conf | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ tools/etc/rsyslog.d/45-frr.conf | 19 -------------------
+ 1 file changed, 19 deletions(-)
 
 diff --git a/tools/etc/rsyslog.d/45-frr.conf b/tools/etc/rsyslog.d/45-frr.conf
-index ff7cd4831..af3c2c109 100644
+index feeeb13f1..fcd23d23a 100644
 --- a/tools/etc/rsyslog.d/45-frr.conf
 +++ b/tools/etc/rsyslog.d/45-frr.conf
-@@ -2,7 +2,7 @@
+@@ -2,25 +2,6 @@
  # to /var/log/frr/frr.log, then drops the message so it does
  # not also go to /var/log/syslog, so the messages are not duplicated
  
 -$outchannel frr_log,/var/log/frr/frr.log
-+$outchannel frr_log
+-if  $programname == 'babeld' or
+-    $programname == 'bgpd' or
+-    $programname == 'eigrpd' or
+-    $programname == 'frr' or
+-    $programname == 'isisd' or
+-    $programname == 'fabricd' or
+-    $programname == 'ldpd' or
+-    $programname == 'nhrpd' or
+-    $programname == 'ospf6d' or
+-    $programname == 'ospfd' or
+-    $programname == 'pimd' or
+-    $programname == 'ripd' or
+-    $programname == 'ripngd' or
+-    $programname == 'vrrpd' or
+-    $programname == 'watchfrr' or
+-    $programname == 'zebra'
+-    then :omfile:$frr_log
+-
  if  $programname == 'babeld' or
      $programname == 'bgpd' or
      $programname == 'eigrpd' or


### PR DESCRIPTION
**- Why I did it**
Fix issue #6043 

**- How I did it**
We are disabling in container frr log. The log entries are sent to base image and are logged in /var/log/quagga/bgpd.log.

However, we need to remove the whole outchannel config block to avoid an error message raised by rsyslogd.

**- How to verify it**
Without the change, test_autorestart bgp container will fail on loganalyer errors. With the change, restarting bgp container is no longer generating error message and the test will pass.

The log generated by frr continued appearing in /var/log/quagga/bgpd.log

- [ ] 201811
- [x] 201911
- [ ] 202006

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
