### PR TITLE
[bgpcfgd]: Use peer commands for BBR, not peer-group

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -16,10 +16,20 @@
 {% if neighbor_addr | ipv4 %}
   address-family ipv4
     neighbor {{ neighbor_addr }} peer-group PEER_V4
+{%   if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
+{%     if CONFIG_DB__BGP_BBR['status'] == 'enabled' %}
+    neighbor {{ neighbor_addr }} allowas-in 1
+{%     endif %}
+{%   endif %}
 !
 {% elif neighbor_addr | ipv6 %}
   address-family ipv6
     neighbor {{ neighbor_addr }} peer-group PEER_V6
+{%   if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
+{%     if CONFIG_DB__BGP_BBR['status'] == 'enabled' %}
+    neighbor {{ neighbor_addr }} allowas-in 1
+{%     endif %}
+{%   endif %}
 !
 {% endif %}
 !

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
@@ -6,10 +6,6 @@
   address-family ipv4
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor PEER_V4 allowas-in 1
-{% elif CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
-{%   if CONFIG_DB__BGP_BBR['status'] == 'enabled' %}
-    neighbor PEER_V4 allowas-in 1
-{%   endif %}
 {% endif %}
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
@@ -18,10 +14,6 @@
   address-family ipv6
 {% if CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
     neighbor PEER_V6 allowas-in 1
-{% elif CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
-{%   if CONFIG_DB__BGP_BBR['status'] == 'enabled' %}
-    neighbor PEER_V6 allowas-in 1
-{%   endif %}
 {% endif %}
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_all_v4.json
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_all_v4.json
@@ -1,4 +1,12 @@
 {
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "LeafRouter"
+        }
+    },
+   "CONFIG_DB__BGP_BBR": {
+        "status": "enabled"
+   },
     "neighbor_addr": "10.10.10.10",
     "bgp_session": {
         "asn": "555",

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_all_v6.json
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_all_v6.json
@@ -1,4 +1,12 @@
 {
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "LeafRouter"
+        }
+    },
+   "CONFIG_DB__BGP_BBR": {
+        "status": "enabled"
+   },
     "neighbor_addr": "fc::10",
     "bgp_session": {
         "asn": "555",

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_base_v4.json
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_base_v4.json
@@ -1,7 +1,12 @@
 {
     "CONFIG_DB__DEVICE_METADATA": {
-        "localhost": {}
+        "localhost": {
+            "type": "LeafRouter"
+        }
     },
+   "CONFIG_DB__BGP_BBR": {
+        "status": "disabled"
+   },
     "neighbor_addr": "10.10.10.10",
     "bgp_session": {
         "asn": "555",

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_base_v6.json
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_base_v6.json
@@ -1,7 +1,12 @@
 {
     "CONFIG_DB__DEVICE_METADATA": {
-        "localhost": {}
+        "localhost": {
+            "type": "LeafRouter"
+        }
     },
+   "CONFIG_DB__BGP_BBR": {
+        "status": "disabled"
+   },
     "neighbor_addr": "fc00::2",
     "bgp_session": {
         "asn": "555",

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_all_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_all_v4.conf
@@ -7,6 +7,7 @@
   neighbor 10.10.10.10 shutdown
   address-family ipv4
     neighbor 10.10.10.10 peer-group PEER_V4
+    neighbor 10.10.10.10 allowas-in 1
     neighbor 10.10.10.10 route-reflector-client
     neighbor 10.10.10.10 next-hop-self
     neighbor 10.10.10.10 activate

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_all_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_all_v6.conf
@@ -7,6 +7,7 @@
   neighbor fc::10 shutdown
   address-family ipv6
     neighbor fc::10 peer-group PEER_V6
+    neighbor fc::10 allowas-in 1
     neighbor fc::10 route-reflector-client
     neighbor fc::10 next-hop-self
     neighbor fc::10 activate


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
FRR 7.2.1 has a bug: when 'allowas-in' is configured on peer-group, and we remove that configuration, the neighbors, which had that configuration, keeps that configuration.

**- How I did it**
To fix the bug I apply the configuration to all neighbors, which are configured with the peer-groups, which should support BBR.

**- How to verify it**
1. Build an image
2. Run on your dut
3. Check that the test https://github.com/Azure/sonic-mgmt/blob/master/tests/bgp/test_bgp_bbr.py not fails

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
