### PR TITLE
[relay]: Prevent Buffer Overrun Of Malformed DHCP Packet

### DIFF
--- a/src/isc-dhcp/patch/0011-dhcp-relay-Prevent-Buffer-Overrun.patch
+++ b/src/isc-dhcp/patch/0011-dhcp-relay-Prevent-Buffer-Overrun.patch
@@ -1,7 +1,7 @@
-From 2fcfd6277ab5105f970a4e2872a0040bc8fc8744 Mon Sep 17 00:00:00 2001
+From 19e400c1040e3621db6a0d8dd70d18c431d1a848 Mon Sep 17 00:00:00 2001
 From: Tamer Ahmed <tamer.ahmed@microsoft.com>
 Date: Sat, 28 Nov 2020 16:28:37 -0800
-Subject: [PATCH] [relay] Prevent Buffer Overrun
+Subject: [PATCH] [dhcp-relay] Prevent Buffer Overrun
 
 The add/strip relay agent options do not take into account the buffer
 length and so it is possible to overrun the buffer. The issue will
@@ -13,10 +13,10 @@ signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
-index e158efe..4c6997f 100644
+index 055d97f..1cd99b9 100644
 --- a/relay/dhcrelay.c
 +++ b/relay/dhcrelay.c
-@@ -1469,7 +1469,7 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+@@ -1527,7 +1527,7 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
  	/* Commence processing after the cookie. */
  	sp = op = &packet->options[4];
  

--- a/src/isc-dhcp/patch/0011-relay-Prevent-Buffer-Overrun.patch
+++ b/src/isc-dhcp/patch/0011-relay-Prevent-Buffer-Overrun.patch
@@ -1,0 +1,30 @@
+From 2fcfd6277ab5105f970a4e2872a0040bc8fc8744 Mon Sep 17 00:00:00 2001
+From: Tamer Ahmed <tamer.ahmed@microsoft.com>
+Date: Sat, 28 Nov 2020 16:28:37 -0800
+Subject: [PATCH] [relay] Prevent Buffer Overrun
+
+The add/strip relay agent options do not take into account the buffer
+length and so it is possible to overrun the buffer. The issue will
+result in contents from previous packet being aded to the current one.
+
+signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>
+---
+ relay/dhcrelay.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
+index e158efe..4c6997f 100644
+--- a/relay/dhcrelay.c
++++ b/relay/dhcrelay.c
+@@ -1469,7 +1469,7 @@ add_relay_agent_options(struct interface_info *ip, struct dhcp_packet *packet,
+ 	/* Commence processing after the cookie. */
+ 	sp = op = &packet->options[4];
+ 
+-	while (op < max) {
++	while ((op < max) && (op < (((u_int8_t *)packet) + length))) {
+ 		switch(*op) {
+ 			/* Skip padding... */
+ 		      case DHO_PAD:
+-- 
+2.17.1
+

--- a/src/isc-dhcp/patch/0011-relay-Prevent-Buffer-Overrun.patch
+++ b/src/isc-dhcp/patch/0011-relay-Prevent-Buffer-Overrun.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] [relay] Prevent Buffer Overrun
 
 The add/strip relay agent options do not take into account the buffer
 length and so it is possible to overrun the buffer. The issue will
-result in contents from previous packet being aded to the current one.
+result in contents from previous packet being added to the current one.
 
 signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>
 ---

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -9,3 +9,4 @@
 0008-Don-t-skip-down-interfaces-when-discovering-interfac.patch
 0009-Support-for-dual-tor-scenario.patch
 0010-Bugfix-correctly-set-interface-netmask.patch
+0011-relay-Prevent-Buffer-Overrun.patch

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -9,4 +9,4 @@
 0008-Don-t-skip-down-interfaces-when-discovering-interfac.patch
 0009-Support-for-dual-tor-scenario.patch
 0010-Bugfix-correctly-set-interface-netmask.patch
-0011-relay-Prevent-Buffer-Overrun.patch
+0011-dhcp-relay-Prevent-Buffer-Overrun.patch


### PR DESCRIPTION
The add/strip relay agent options do not take into account the buffer
length and so it is possible to overrun the buffer. The issue will
result in contents from previous packet being added to the current one.

closes #6052  
resolves #6052 

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
