### PR TITLE
[master][build] fix compile error when enable notrip

### DIFF
--- a/src/hiredis/Makefile
+++ b/src/hiredis/Makefile
@@ -3,7 +3,12 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = libhiredis0.14_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
-DERIVED_TARGETS = libhiredis0.14-dbgsym_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb libhiredis-dev_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+DBG_TARGETS = libhiredis0.14-dbgsym_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS = libhiredis-dev_$(HIREDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf hiredis-$(HIREDIS_VERSION)

--- a/src/isc-dhcp/Makefile
+++ b/src/isc-dhcp/Makefile
@@ -3,7 +3,12 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = $(ISC_DHCP_RELAY)
-DERIVED_TARGETS = $(ISC_DHCP_RELAY_DBG)
+DBG_TARGETS = $(ISC_DHCP_RELAY_DBG)
+DERIVED_TARGETS =
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Remove any stale files

--- a/src/libteam/Makefile
+++ b/src/libteam/Makefile
@@ -3,12 +3,16 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = libteam5_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb
-DERIVED_TARGETS = libteam-dev_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
-		  libteamdctl0_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
-		  libteam-utils_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
-		  libteam5-dbgsym_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
+DBG_TARGETS = libteam5-dbgsym_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
 		  libteamdctl0-dbgsym_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
 		  libteam-utils-dbgsym_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS = libteam-dev_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
+		  libteamdctl0_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb \
+		  libteam-utils_$(LIBTEAM_VERSION)_$(CONFIGURED_ARCH).deb
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtain libteam

--- a/src/libyang/Makefile
+++ b/src/libyang/Makefile
@@ -3,7 +3,12 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = $(LIBYANG)
-DERIVED_TARGETS = $(LIBYANG_DEV) $(LIBYANG_DBG) $(LIBYANG_PY2) $(LIBYANG_PY3) $(LIBYANG_CPP)
+DBG_TARGETS = $(LIBYANG_DBG)
+DERIVED_TARGETS = $(LIBYANG_DEV) $(LIBYANG_PY2) $(LIBYANG_PY3) $(LIBYANG_CPP)
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
         # Obtaining the libyang

--- a/src/lldpd/Makefile
+++ b/src/lldpd/Makefile
@@ -3,7 +3,8 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = $(LLDPD)
-DERIVED_TARGETS = $(LIBLLDPCTL) $(LLDPD_DBG)
+DBG_TARGETS = $(LLDPD_DBG)
+DERIVED_TARGETS = $(LIBLLDPCTL)
 
 LLDP_URL = https://sonicstorage.blob.core.windows.net/debian/pool/main/l/lldpd
 
@@ -14,6 +15,10 @@ DEBIAN_FILE = lldpd_$(LLDPD_VERSION_FULL).debian.tar.xz
 DSC_FILE_URL = $(LLDP_URL)/$(DSC_FILE)
 ORIG_FILE_URL = $(LLDP_URL)/$(ORIG_FILE)
 DEBIAN_FILE_URL = $(LLDP_URL)/$(DEBIAN_FILE)
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Remove any stale files

--- a/src/lm-sensors/Makefile
+++ b/src/lm-sensors/Makefile
@@ -4,12 +4,16 @@ SHELL = /bin/bash
 
 
 MAIN_TARGET = $(LM_SENSORS)
+DBG_TARGETS = $(LM_SENSORS_DBG) \
+			  $(LIBSENSORS_DBG) \
+			  $(SENSORD_DBG)
 DERIVED_TARGETS = fancontrol_$(LM_SENSORS_VERSION_FULL)_all.deb \
 				  $(LIBSENSORS) \
-				  sensord_$(LM_SENSORS_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-				  $(LM_SENSORS_DBG) \
-				  $(LIBSENSORS_DBG) \
-				  $(SENSORD_DBG)
+				  sensord_$(LM_SENSORS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf lm-sensors-$(LM_SENSORS_VERSION)

--- a/src/monit/Makefile
+++ b/src/monit/Makefile
@@ -3,7 +3,12 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = monit_$(MONIT_VERSION)_$(CONFIGURED_ARCH).deb
-DERIVED_TARGETS = monit-dbgsym_$(MONIT_VERSION)_$(CONFIGURED_ARCH).deb
+DBG_TARGETS = monit-dbgsym_$(MONIT_VERSION)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS =
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Remove any stale files

--- a/src/openssh/Makefile
+++ b/src/openssh/Makefile
@@ -3,7 +3,13 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = openssh-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
-DERIVED_TARGETS = openssh-server-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
+DBG_TARGETS = openssh-server-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS =
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
+
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtain openssh: https://salsa.debian.org/ssh-team/openssh/-/tree/debian/1%257.9p1-10+deb10u2

--- a/src/redis/Makefile
+++ b/src/redis/Makefile
@@ -6,9 +6,13 @@ REDIS_VERSION = 5.0.3
 REDIS_VERSION_FULL = $(REDIS_VERSION)-3~bpo9+2
 
 MAIN_TARGET = redis-server_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+DBG_TARGETS = redis-tools-dbgsym_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS = redis-tools_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  redis-sentinel_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  redis-tools-dbgsym_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+		  redis-sentinel_$(REDIS_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf  redis_build

--- a/src/sflow/hsflowd/Makefile
+++ b/src/sflow/hsflowd/Makefile
@@ -3,7 +3,12 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = $(HSFLOWD)
-DERIVED_TARGET = $(HSFLOWD_DBG)
+DBG_TARGETS = $(HSFLOWD_DBG)
+DERIVED_TARGET =
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -fr ./host-sflow

--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -3,17 +3,21 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = libsnmp-base_$(SNMPD_VERSION_FULL)_all.deb
+DBG_TARGETS = snmp-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
+		  snmpd-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS = snmptrapd_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmp_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmpd_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  snmp-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  snmpd-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp30_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp30-dbg_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-dev_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-perl_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  python-netsnmp_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  tkmib_$(SNMPD_VERSION_FULL)_all.deb
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf net-snmp-$(SNMPD_VERSION)

--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -3,9 +3,14 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = $(FRR)
-DERIVED_TARGET = $(FRR_PYTHONTOOLS) $(FRR_DBG) $(FRR_SNMP) $(FRR_SNMP_DBG)
+DBG_TARGETS = $(FRR_DBG) $(FRR_SNMP_DBG)
+DERIVED_TARGET = $(FRR_PYTHONTOOLS) $(FRR_SNMP)
 SUFFIX = $(shell date +%Y%m%d\.%H%M%S)
 STG_BRANCH = stg_temp.$(SUFFIX)
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGET += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Build the package

--- a/src/swig/Makefile
+++ b/src/swig/Makefile
@@ -3,7 +3,12 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = $(SWIG_BASE)
-DERIVED_TARGETS = $(SWIG) $(SWIG_DBG)
+DBG_TARGETS = $(SWIG_DBG)
+DERIVED_TARGETS = $(SWIG)
+
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+$(eval DERIVED_TARGETS += $(DBG_TARGETS))
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -fr ./swig-$(SWIG_VERSION) *.deb

--- a/src/systemd-sonic-generator/Makefile
+++ b/src/systemd-sonic-generator/Makefile
@@ -3,11 +3,15 @@ CFLAGS=-std=gnu99
 
 BINARY = systemd-sonic-generator
 MAIN_TARGET = $(BINARY)_1.0.0_$(CONFIGURED_ARCH).deb
+DBG_TARGETS = $(BINARY)-dbgsym_1.0.0_$(CONFIGURED_ARCH).deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	dpkg-buildpackage -us -uc -b
 	mv ../$(MAIN_TARGET) $(DEST)/
-	rm ../$(BINARY)-* ../$(BINARY)_*
+	rm ../$(BINARY)_*
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),nostrip)
+	rm ../$(DBG_TARGETS)
+endif
 
 $(BINARY): systemd-sonic-generator.c
 	rm -f ./systemd-sonic-generator


### PR DESCRIPTION
Signed-off-by: tim-rj <sonic_rd@ruijie.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
fix https://github.com/Azure/sonic-buildimage/issues/5982
**- How I did it**
check notrip option before handle dbgsym debs
**- How to verify it**
set SONIC_DEBUGGING_ON=y / SONIC_PROFING_ON and compile the whole image
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
If SONIC_DEBUG_ON or SONIC_PROFILING_ON set to y, no dbgsym debs will trip from the origin deb, so mv dbgsym deb to some other folders will fail and compiling will stop.

**- A picture of a cute animal (not mandatory but encouraged)**
