### PR TITLE
[Barefoot]: fix unresolved SFP type on Newport/Montara

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
@@ -14,17 +14,14 @@ class Chassis(ChassisBase):
     """
     def __init__(self):
         ChassisBase.__init__(self)
-        SFP_PORT_END = Sfp.port_end()
-        PORTS_IN_BLOCK = (SFP_PORT_END + 1)
-        MAX_PSU = Psu.get_num_psus()
 
         self._eeprom = Eeprom()
 
-        for index in range(0, PORTS_IN_BLOCK):
+        for index in range(Sfp.port_start(), Sfp.port_end() + 1):
             sfp_node = Sfp(index)
             self._sfp_list.append(sfp_node)
 
-        for i in range(1, MAX_PSU + 1):
+        for i in range(1, Psu.get_num_psus() + 1):
             psu = Psu(i)
             self._psu_list.append(psu)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
`show interface status` and `sfpshow eeprom` commands show not correct information about sfp status.
`show interface status` command result:
```
admin@sonic:~$ show interfaces status
  Interface            Lanes    Speed    MTU    FEC        Alias    Vlan    Oper    Admin             Type    Asym PFC
-----------  ---------------  -------  -----  -----  -----------  ------  ------  -------  ---------------  ----------
  Ethernet0          0,1,2,3     100G   9100    N/A    Ethernet0  routed    down       up              N/A         N/A
  Ethernet8        8,9,10,11     100G   9100    N/A    Ethernet8  routed    down       up  QSFP28 or later         N/A
 Ethernet16      16,17,18,19     100G   9100    N/A   Ethernet16  routed    down       up  QSFP28 or later         N/A
 Ethernet24      24,25,26,27     100G   9100    N/A   Ethernet24  routed    down       up  QSFP28 or later         N/A
```
For example `sfpshow eeprom` show something like this:
```
admin@sonic:~$ sfpshow eeprom
Ethernet0: SFP EEPROM Not detected

Ethernet8: SFP EEPROM detected
...
```

Also command `sfpshow presence` show `Not present` for Ethernet0
```
admin@sonic:~$ sfpshow presence
Port         Presence
-----------  -----------
Ethernet0    Not present
Ethernet8    Present
Ethernet16   Present
```

**- How I did it**

**- How to verify it**
After fix must be correct SFP status in `show interface status` command.
Before:
```
admin@sonic:~$ show interfaces status
  Interface            Lanes    Speed    MTU    FEC        Alias    Vlan    Oper    Admin             Type    Asym PFC
-----------  ---------------  -------  -----  -----  -----------  ------  ------  -------  ---------------  ----------
  Ethernet0          0,1,2,3     100G   9100    N/A    Ethernet0  routed    down       up              N/A         N/A
  Ethernet8        8,9,10,11     100G   9100    N/A    Ethernet8  routed    down       up  QSFP28 or later         N/A
 Ethernet16      16,17,18,19     100G   9100    N/A   Ethernet16  routed    down       up  QSFP28 or later         N/A
 Ethernet24      24,25,26,27     100G   9100    N/A   Ethernet24  routed    down       up  QSFP28 or later         N/A
```
After:
```
admin@sonic:~$ show interfaces status
  Interface            Lanes    Speed    MTU    FEC        Alias    Vlan    Oper    Admin             Type    Asym PFC
-----------  ---------------  -------  -----  -----  -----------  ------  ------  -------  ---------------  ----------
  Ethernet0          0,1,2,3     100G   9100    N/A    Ethernet0  routed    down       up  QSFP28 or later         N/A
  Ethernet8        8,9,10,11     100G   9100    N/A    Ethernet8  routed    down       up  QSFP28 or later         N/A
 Ethernet16      16,17,18,19     100G   9100    N/A   Ethernet16  routed    down       up  QSFP28 or later         N/A
 Ethernet24      24,25,26,27     100G   9100    N/A   Ethernet24  routed    down       up  QSFP28 or later         N/A
```
Also must be resolved `sfpshow eeprom` and `sfpshow presence` commands.
```
admin@sonic:~$ sfpshow presence
Port         Presence
-----------  ----------
Ethernet0    Present
Ethernet8    Present
Ethernet16   Present
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
