### PR TITLE
[sflow] Bump hsflowd version

### DIFF
--- a/src/sflow/hsflowd/Makefile
+++ b/src/sflow/hsflowd/Makefile
@@ -10,7 +10,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git clone https://github.com/sflow/host-sflow
 
 	pushd ./host-sflow
-	git checkout -b sflow tags/v2.0.26-4
+	git checkout -b sflow tags/v$(HSFLOWD_VERSION)-$(HSFLOWD_SUBVERSION)
 
         # Apply patch series
 	stg init


### PR DESCRIPTION
* Bump the hsflowd version in the Makefile using variables
  instead of hardcore.

Signed-off-by: Garrick He <garrick_he@dell.com>

**- Why I did it**
Even though we bumped the hsflowd version in sflow.mk, the new version is not picked up in the hsflowd Makefile because it is hardcoded. So the lastest images are still using the old version of hsflowd.

**- How I did it**
Updated the Makefile to use variables instead of hardcore the version.

**- How to verify it**
Rebuild sflow container and verify hsflowd version with (`hsflowd -v`) to ensure it is 2.0.28

**- Which release branch to backport (provide reason below if selected)**
N/A


**- Description for the changelog**
* Bump the hsflowd version in the Makefile using variables
  instead of hardcore.
