### PR TITLE
[hostcfgd] check cached state instead of the next state

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -252,9 +252,10 @@ class HostConfigDaemon:
 
 
     def update_feature_state(self, feature_name, state, feature_table):
-        if state == "always_enabled":
-            syslog.syslog(syslog.LOG_INFO, "Feature '{}' service is always enabled"
-                          .format(feature_name))
+        if self.cached_feature_states[feature_name] == "always_enabled":
+            if state != "always_enabled":
+                syslog.syslog(syslog.LOG_INFO, "Feature '{}' service is always enabled"
+                              .format(feature_name))
             return
         has_timer = ast.literal_eval(feature_table[feature_name].get('has_timer', 'False'))
         has_global_scope = ast.literal_eval(feature_table[feature_name].get('has_global_scope', 'True'))

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -256,7 +256,13 @@ class HostConfigDaemon:
             if state != "always_enabled":
                 syslog.syslog(syslog.LOG_INFO, "Feature '{}' service is always enabled"
                               .format(feature_name))
+                entry = self.config_db.get_entry('FEATURE', feature_name)
+                entry['state'] = 'always_enabled'
+                self.config_db.set_entry('FEATURE', feature_name, entry)
             return
+
+        self.cached_feature_states[feature_name] = state
+
         has_timer = ast.literal_eval(feature_table[feature_name].get('has_timer', 'False'))
         has_global_scope = ast.literal_eval(feature_table[feature_name].get('has_global_scope', 'True'))
         has_per_asic_scope = ast.literal_eval(feature_table[feature_name].get('has_per_asic_scope', 'False'))
@@ -376,7 +382,6 @@ class HostConfigDaemon:
 
         # Enable/disable the container service if the feature state was changed from its previous state.
         if self.cached_feature_states[feature_name] != state:
-            self.cached_feature_states[feature_name] = state
             self.update_feature_state(feature_name, state, feature_table)
 
     def start(self):


### PR DESCRIPTION
**- Why I did it**
'always_enabled' feature can still be disabled/enabled.

**- How I did it**
When checking if a feature is 'always_enabled', check the cached state to prevent new change to be accepted.
Fix an issue where cache value is updated before all the check is done.
Restore 'always_enabled' value in config db if someone wants to change.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Without the change:
root@str2-dx010-acs-6:/home/admin# show feature status
Feature         State           AutoRestart
--------------  --------------  --------------
...
teamd           always_enabled  enabled
...

root@str2-dx010-acs-6:/home/admin# config feature state  teamd disabled
root@str2-dx010-acs-6:/home/admin# show feature status
Feature         State           AutoRestart
--------------  --------------  --------------
...
teamd           disabled        enabled
...

With the fix:
root@str2-dx010-acs-6:/home/admin# config feature state  teamd disabled
root@str2-dx010-acs-6:/home/admin# show feature status                
Feature         State           AutoRestart
--------------  --------------  --------------
...
teamd           always_enabled  enabled
...

- [ ] 201811
- [x] 201911
- [ ] 202006
