### PR TITLE
Fix bgp crash after BGP allow list configuration is added

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_allow_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_allow_list.py
@@ -149,7 +149,7 @@ class BGPAllowListMgr(Manager):
         if cmds:
             self.cfg_mgr.push_list(cmds)
             peer_groups = self.__find_peer_group_by_deployment_id(deployment_id)
-            self.cfg_mgr.restart_peers(peer_groups)
+            self.cfg_mgr.restart_peer_groups(peer_groups)
             log_debug("BGPAllowListMgr::__update_policy. The peers configuration scheduled for updates")
         else:
             log_debug("BGPAllowListMgr::__update_policy. Nothing to update")
@@ -179,7 +179,7 @@ class BGPAllowListMgr(Manager):
         if cmds:
             self.cfg_mgr.push_list(cmds)
             peer_groups = self.__find_peer_group_by_deployment_id(deployment_id)
-            self.cfg_mgr.restart_peers(peer_groups)
+            self.cfg_mgr.restart_peer_groups(peer_groups)
             log_debug("BGPAllowListMgr::__remove_policy. 'Allow list' policy was scheduled for removal")
         else:
             log_debug("BGPAllowListMgr::__remove_policy. Nothing to remove")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

This change is to fix the bgp crash issue after BGP allow list configuration is added. If load BGP allow list configuration, the `bgp` service will crash:
```
admin@vlab-03:~$ cat /tmp/allow_list.json 
{
  "BGP_ALLOWED_PREFIXES": {
    "DEPLOYMENT_ID|0": {
      "prefixes_v6": [
        "2000:172:16:10::/64"
      ], 
      "prefixes_v4": [
        "172.16.10.0/24"
      ]
    }, 
    "DEPLOYMENT_ID|0|1010:1010": {
      "prefixes_v6": [
        "2000:172:16:30::/64"
      ], 
      "prefixes_v4": [
        "172.16.30.0/24"
      ]
    }
  }
admin@vlab-03:~$ sonic-cfggen -j /tmp/allow_list.json -w
admin@vlab-03:~$ docker ps -a
CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS                     PORTS               NAMES
78fd2e87f307        docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe鈥   About an hour ago   Up About an hour                               mgmt-framework
37c0c65a2cc8        docker-sonic-telemetry:latest        "/usr/local/bin/supe鈥   About an hour ago   Up About an hour                               telemetry
9ba16c3d5e43        docker-snmp:latest                   "/usr/local/bin/supe鈥   About an hour ago   Up About an hour                               snmp
3f25676e2c32        docker-router-advertiser:latest      "/usr/bin/docker-ini鈥   About an hour ago   Up About an hour                               radv
5ef7df0e93c7        docker-dhcp-relay:latest             "/usr/bin/docker_ini鈥   About an hour ago   Up About an hour                               dhcp_relay
602368e364ea        docker-lldp:latest                   "/usr/bin/docker-lld鈥   About an hour ago   Up About an hour                               lldp
6ee737ba8a6e        docker-gbsyncd-vs:latest             "/usr/local/bin/supe鈥   About an hour ago   Up About an hour                               gbsyncd
0e2ebfe47927        docker-syncd-vs:latest               "/usr/local/bin/supe鈥   About an hour ago   Up About an hour                               syncd
4235976d3a3e        docker-teamd:latest                  "/usr/local/bin/supe鈥   About an hour ago   Up About an hour                               teamd
cf452c9c3f76        docker-orchagent:latest              "/usr/bin/docker-ini鈥   About an hour ago   Up About an hour                               swss
c3317f9c8d1d        docker-fpm-frr:latest                "/usr/bin/docker_ini鈥   18 hours ago        Exited (0) 5 seconds ago                       bgp
fa59168dcb00        docker-platform-monitor:latest       "/usr/bin/docker_ini鈥   18 hours ago        Up About an hour                               pmon
af3d94e5e8d8        docker-database:latest               "/usr/local/bin/dock鈥   18 hours ago        Up About an hour                               database
admin@vlab-03:~$ sudo systemctl status bgp
鈼 bgp.service - BGP container
   Loaded: loaded (/lib/systemd/system/bgp.service; enabled; vendor preset: enabled)
   Active: activating (auto-restart) since Wed 2020-12-02 05:20:54 UTC; 527ms ago
  Process: 14230 ExecStartPre=/usr/local/bin/bgp.sh start (code=exited, status=0/SUCCESS)
  Process: 14315 ExecStart=/usr/local/bin/bgp.sh wait (code=exited, status=0/SUCCESS)
  Process: 14658 ExecStop=/usr/local/bin/bgp.sh stop (code=exited, status=0/SUCCESS)
 Main PID: 14315 (code=exited, status=0/SUCCESS)
```

**- Why I did it**
This change is to fix the bgp crash issue after BGP allow list configuration is loaded.

The issue was a typo introduced in #6006. In that change, the BGP allow list
configuration manager was updated to use a method of common ConfigMgr
for restarting peer groups. However, the method name 'restart_peers' was
used instead of the correct 'restart_peer_groups'.

**- How I did it**
This change updated the managers_allow_list.py to use correct method
'restart_peer_groups' instead of 'restart_peers' for restarting peer groups.

**- How to verify it**
* Replace `/usr/local/lib/python3.7/dist-packages/bgpcfgd/managers_allow_list.py` with the updated version in bgp docker. 
* Restart bgp service by `sudo systemctl restart bgp`.
* Run the BGP allow list automation: https://github.com/Azure/sonic-mgmt/blob/master/tests/bgp/test_bgp_allow_list.py
* All test cases passed.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
