### PR TITLE
DellEMC S6100: Handle bytearray in eeprom plugin

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/plugins/eeprom.py
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/plugins/eeprom.py
@@ -28,4 +28,4 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
 
         # 'results' is a list containing 3 elements, type (int), length (int),
         # and value (string) of the requested TLV
-        return results[2]
+        return results[2].decode('ascii')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Make Dell S6100 eeprom plugin handle `bytearray` returned by TlvInfoDecoder 
Resolves #6081 

**- How I did it**

Decode the 'serial number' in bytearray type to string.

**- How to verify it**

Execute `decode-syseeprom -s` and verify the output format. 

```
root@S6100-7758:/home/admin# decode-syseeprom -s
50YQG02
root@S6100-7758:/home/admin# show version

SONiC Software Version: SONiC.S6100_eeprom.0-dirty-20201202.144431
Distribution: Debian 10.6
Kernel: 4.19.0-9-2-amd64
Build commit: 443f81f9
Build date: Wed Dec  2 09:58:05 UTC 2020
Built by: abalac@sonic-maa

Platform: x86_64-dell_s6100_c2538-r0
HwSKU: Force10-S6100
ASIC: broadcom
Serial Number: 50YQG02
Uptime: 16:57:24 up  1:34,  1 user,  load average: 2.25, 3.32, 3.28
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC S6100: Handle bytearray in eeprom plugin

**- A picture of a cute animal (not mandatory but encouraged)**
