### PR TITLE
Fix for missing dependency in frr module

### DIFF
--- a/rules/frr.dep
+++ b/rules/frr.dep
@@ -2,9 +2,24 @@
 SPATH       := $($(FRR)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/frr.mk rules/frr.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
-SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
+DEP_FILES   += $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files |grep -Ev '^frr$$$$'))
+
+# Account for source files under the frr submodule directory as well.
+# Remove all the symbolic link files
+FRR_SPATH   := $(SPATH)/frr
+SMDEP_FILES := $(addprefix $(FRR_SPATH)/,$(shell cd $(FRR_SPATH) && git ls-files \
+			| grep -Ev -e 'debian/changelog$$$$' \
+			-e '^tests/topotests/bgp_instance_del_test/ce[0-9]$$$$' \
+			-e '^tests/topotests/bgp_instance_del_test/r[0-9]$$$$' \
+			-e '^tests/topotests/bgp_instance_del_test/scripts$$$$' \
+			-e '^tests/topotests/bgp_instance_del_test/customize.py$$$$' \
+			-e '^tests/topotests/bgp_rfapi_basic_sanity_config2/customize.py$$$$' \
+			-e '^tests/topotests/bgp_rfapi_basic_sanity_config2/scripts$$$$' \
+			-e '^tests/topotests/bgp_rfapi_basic_sanity_config2/test_bgp_rfapi_basic_sanity_config2.py$$$$' \
+			))
 
 $(FRR)_CACHE_MODE  := GIT_CONTENT_SHA 
 $(FRR)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
 $(FRR)_DEP_FILES   := $(DEP_FILES)
-
+$(FRR)_SMDEP_FILES := $(SMDEP_FILES)
+$(FRR)_SMDEP_PATHS := $(FRR_SPATH)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

The soinc-frr module has src/sonic-frr/frr submodule.  The FRR sub module dependency files are not added to the DPKG file tracking.  The patch includes the following.

1. Included the submodule dependency files
2. Removes the symbolic files.

**- Why I did it**
Missing depdency files in the FRR module.

**- How I did it**
Added missing sub module files.

**- How to verify it**
make target/debs/buster/frr_7.2.1-sonic-0_amd64.deb

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
