### PR TITLE
Use default values for healthd if config file is missing on the device.

### DIFF
--- a/src/system-health/scripts/healthd
+++ b/src/system-health/scripts/healthd
@@ -72,8 +72,7 @@ class HealthDaemon(DaemonBase):
         chassis = sonic_platform.platform.Platform().get_chassis()
         manager = HealthCheckerManager()
         if not manager.config.config_file_exists():
-            self.log_warning("System health configuration file not found, exit...")
-            return
+            self.log_warning("System health configuration file not found, using default health monitoring config...")
         while 1:
             state, stat = manager.check(chassis)
             if state == HealthCheckerManager.STATE_RUNNING:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->
Fixes https://github.com/Azure/sonic-buildimage/issues/6072
Use default values for health monitoring config if config file is missing in the device.
Some platforms have the health monitoring config: https://github.com/Azure/sonic-buildimage/blob/master/device/mellanox/x86_64-mlnx_msn2700-r0/system_health_monitoring_config.json
While others don't have it:
https://github.com/Azure/sonic-buildimage/tree/master/device/dell/x86_64-dell_s6100_c2538-r0

**- Why I did it**
To fix the error seen during starting SONiC system health monitor
```
Nov 30 16:27:25.418807 str-7260cx3-acs-7 WARNING healthd[3434]: System health configuration file not found, exit...
Nov 30 16:27:25.451956 str-7260cx3-acs-7 INFO systemd[1]: system-health.service: Succeeded.
Nov 30 16:27:25.804127 str-7260cx3-acs-7 INFO systemd[1]: system-health.service: Service RestartSec=100ms expired, scheduling restart.
Nov 30 16:27:25.804626 str-7260cx3-acs-7 INFO systemd[1]: system-health.service: Scheduled restart job, restart counter is at 21.
Nov 30 16:27:25.805026 str-7260cx3-acs-7 INFO systemd[1]: Stopped SONiC system health monitor.
Nov 30 16:27:25.805461 str-7260cx3-acs-7 WARNING systemd[1]: system-health.service: Start request repeated too quickly.
Nov 30 16:27:25.805786 str-7260cx3-acs-7 WARNING systemd[1]: system-health.service: Failed with result 'start-limit-hit'.
Nov 30 16:27:25.806091 str-7260cx3-acs-7 ERR systemd[1]: Failed to start SONiC system health monitor.
```

**- How I did it**
Removed the return value, and let the infinite loop continue with default values for the config.

**- How to verify it**
Added the fix locally in the Python file on the device.
Before fix:
```
root@str-s6100-acs-4:~# systemctl status system-health
â— system-health.service - SONiC system health monitor
   Loaded: loaded (/lib/systemd/system/system-health.service; enabled-runtime; vendor preset: enabled)
   Active: failed (Result: start-limit-hit) since Wed 2020-12-02 09:12:18 UTC; 2min 21s ago
  Process: 4027 ExecStart=/usr/local/bin/healthd (code=exited, status=0/SUCCESS)
 Main PID: 4027 (code=exited, status=0/SUCCESS)

Dec 02 09:12:18 str-s6100-acs-4 systemd[1]: system-health.service: Service RestartSec=100ms expired, scheduling restart.
Dec 02 09:12:18 str-s6100-acs-4 systemd[1]: system-health.service: Scheduled restart job, restart counter is at 16.
Dec 02 09:12:18 str-s6100-acs-4 systemd[1]: Stopped SONiC system health monitor.
Dec 02 09:12:18 str-s6100-acs-4 systemd[1]: system-health.service: Start request repeated too quickly.
Dec 02 09:12:18 str-s6100-acs-4 systemd[1]: system-health.service: Failed with result 'start-limit-hit'.
Dec 02 09:12:18 str-s6100-acs-4 systemd[1]: Failed to start SONiC system health monitor.
root@str-s6100-acs-4:~# 
```
After fix:
```
root@str-s6100-acs-4:~# systemctl status system-health
â— system-health.service - SONiC system health monitor
   Loaded: loaded (/lib/systemd/system/system-health.service; enabled-runtime; vendor preset: enabled)
   Active: active (running) since Wed 2020-12-02 09:17:22 UTC; 1min 16s ago
 Main PID: 1391 (healthd)
    Tasks: 1 (limit: 4915)
   Memory: 43.2M
   CGroup: /system.slice/system-health.service
           â””â”€1391 /usr/bin/python /usr/local/bin/healthd

Dec 02 09:17:22 str-s6100-acs-4 systemd[1]: Started SONiC system health monitor.
Dec 02 09:17:23 str-s6100-acs-4 healthd[1391]: Starting up...
Dec 02 09:17:25 str-s6100-acs-4 healthd[1391]: System health configuration file not found, using default health monitoring config...
root@str-s6100-acs-4:~#
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
