### PR TITLE
[database-chassis] Fix how database-chassis starts

### DIFF
--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -50,8 +50,6 @@ if [[ $DATABASE_TYPE == "chassisdb" ]]; then
     # Docker init for database-chassis
     echo "Init docker-database-chassis..."
     update_chassisdb_config -j $db_cfg_file_tmp -k -p $chassis_db_port
-    mkdir -p /var/run/redis/sonic-db
-    cp /etc/default/sonic-db/database_config.json /var/run/redis/sonic-db
     # generate all redis server supervisord configuration file
     sonic-cfggen -j $db_cfg_file_tmp -t /usr/share/sonic/templates/supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf
     rm $db_cfg_file_tmp

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -144,6 +144,10 @@ function postStartAction()
         # Add redis UDS to the redis group and give read/write access to the group
         REDIS_SOCK="/var/run/redis${DEV}/redis.sock"
     else
+        until [[ ($(docker exec -i ${DOCKERNAME} pgrep -x -c supervisord) -gt 0) &&
+                 ($(docker exec -i ${DOCKERNAME} $SONIC_DB_CLI CHASSIS_APP_DB PING | grep -c True) -gt 0) ]]; do
+           sleep 1
+        done
         REDIS_SOCK="/var/run/redis-chassis/redis_chassis.sock"
     fi
     chgrp -f redis $REDIS_SOCK && chmod -f 0760 $REDIS_SOCK


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

The database-chassis service crash when the platform boots due to missing waits.
The /usr/bin/database.sh script tries to operate on a missing socket and fails.
It eventually ends up working though it needs fixing.

**- How I did it**

We now wait for the chassis database to be ready the same way we do database.

**- How to verify it**

During boot the database-chassis is not reported as failed by `systemctl list-units`

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix how database-chassis starts
