### PR TITLE
[multi-asic] Enhancing monit process checker for multi-asic.

### DIFF
--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -6,7 +6,7 @@ import sys
 import syslog
 
 import psutil
-from sonic_py_common import device_info, multi_asic
+from sonic_py_common import multi_asic
 import swsssdk
 
 

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -1,11 +1,13 @@
 #!/usr/bin/python3
 
 import argparse
+import ast
 import sys
 import syslog
 
 import psutil
 import swsssdk
+from sonic_py_common import device_info, multi_asic
 
 
 def check_process_existence(container_name, process_cmdline):
@@ -27,20 +29,61 @@ def check_process_existence(container_name, process_cmdline):
             # We leveraged the psutil library to help us check whether the process is running or not.
             # If the process entity is found in process tree and it is also in the 'running' or 'sleeping'
             # state, then it will be marked as 'running'.
+
+            # For given feature we get the host and network namespace instances it's processes should be running
+            # based on it's scope and add it to expected set.
+
+            # From psutil we get number of running instances of the processes and add it to the the actual set
+
+            # Difference bwetween expected and actual set provides instances where the processes are not running
+            # and will be logged as syslog message by monit
+
+            process_namespace_expected_set = set()
+            process_namespace_found_set = set()
+
+            has_global_scope = ast.literal_eval(feature_table[container_name].get('has_global_scope', 'True'))
+            has_per_asic_scope = ast.literal_eval(feature_table[container_name].get('has_per_asic_scope', 'False'))
+
+            if has_global_scope:
+                process_namespace_expected_set.add(multi_asic.DEFAULT_NAMESPACE)
+
+            if has_per_asic_scope:
+               process_namespace_expected_set.update(multi_asic.get_namespace_list())
+
             is_running = False
-            for process in psutil.process_iter(["cmdline", "status"]):
-                try:
-                    if ((' '.join(process.cmdline())).startswith(process_cmdline) and process.status() in ["running", "sleeping"]):
-                        is_running = True
-                        break
-                except psutil.NoSuchProcess:
-                    pass
+
+            for process in psutil.process_iter(["cmdline", "status", "pid"]):
+                 try:
+                     if ((' '.join(process.cmdline())).startswith(process_cmdline) and process.status() in ["running", "sleeping"]):
+                         process_namespace_found_set.add(multi_asic.get_current_namespace(process.info['pid']))
+                 except psutil.NoSuchProcess:
+                     pass
+
+            process_namespace_diff_set = process_namespace_expected_set.difference(process_namespace_found_set)
+
+            if not process_namespace_diff_set:
+                is_running = True
 
             if not is_running:
-                # If this script is run by Monit, then the following output will be appended to
-                # Monit's syslog message.
-                print("'{}' is not running.".format(process_cmdline))
-                sys.exit(1)
+                 # If this script is run by Monit, then the following output will be appended to
+                 # Monit's syslog message.
+
+                 host_display_str = ""
+                 namespace_display_str = ""
+
+                 for ns in process_namespace_diff_set:
+                     if ns == multi_asic.DEFAULT_NAMESPACE:
+                         host_display_str = " in host"
+                     else:
+                         if not namespace_display_str:
+                             namespace_display_str = " in namespace " + ns
+                         else:
+                             namespace_display_str += ", " + ns
+
+                 join_str = " and" if host_display_str and namespace_display_str else ""
+
+                 print("'{}' is not running{}{}{}".format(process_cmdline, host_display_str, join_str, namespace_display_str))
+                 sys.exit(1)
     else:
         syslog.syslog(syslog.LOG_ERR, "container '{}' is not included in SONiC image or the given container name is invalid!"
                       .format(container_name))

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -48,23 +48,18 @@ def check_process_existence(container_name, process_cmdline):
                 process_namespace_expected_set.add(multi_asic.DEFAULT_NAMESPACE)
 
             if has_per_asic_scope:
-               process_namespace_expected_set.update(multi_asic.get_namespace_list())
-
-            is_running = False
+                process_namespace_expected_set.update(multi_asic.get_namespace_list())
 
             for process in psutil.process_iter(["cmdline", "status", "pid"]):
-                 try:
-                     if ((' '.join(process.cmdline())).startswith(process_cmdline) and process.status() in ["running", "sleeping"]):
+                try:
+                    if ((' '.join(process.cmdline())).startswith(process_cmdline) and process.status() in ["running", "sleeping"]):
                          process_namespace_found_set.add(multi_asic.get_current_namespace(process.info['pid']))
-                 except psutil.NoSuchProcess:
-                     pass
+                except psutil.NoSuchProcess:
+                    pass
 
             process_namespace_diff_set = process_namespace_expected_set.difference(process_namespace_found_set)
 
-            if not process_namespace_diff_set:
-                is_running = True
-
-            if not is_running:
+            if process_namespace_diff_set:
                  # If this script is run by Monit, then the following output will be appended to
                  # Monit's syslog message.
 

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -60,9 +60,6 @@ def check_process_existence(container_name, process_cmdline):
             process_namespace_diff_set = process_namespace_expected_set.difference(process_namespace_found_set)
 
             if process_namespace_diff_set:
-                 # If this script is run by Monit, then the following output will be appended to
-                 # Monit's syslog message.
-
                  host_display_str = ""
                  namespace_display_str = ""
 
@@ -76,7 +73,9 @@ def check_process_existence(container_name, process_cmdline):
                              namespace_display_str += ", " + ns
 
                  join_str = " and" if host_display_str and namespace_display_str else ""
-
+                 
+                 # If this script is run by Monit, then the following output will be appended to
+                 # Monit's syslog message.
                  print("'{}' is not running{}{}{}".format(process_cmdline, host_display_str, join_str, namespace_display_str))
                  sys.exit(1)
     else:

--- a/files/image_config/monit/process_checker
+++ b/files/image_config/monit/process_checker
@@ -6,8 +6,8 @@ import sys
 import syslog
 
 import psutil
-import swsssdk
 from sonic_py_common import device_info, multi_asic
+import swsssdk
 
 
 def check_process_existence(container_name, process_cmdline):

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -145,7 +145,7 @@ def get_current_namespace(pid=None):
     """
 
     net_namespace = None
-    command = ["sudo /bin/ip netns identify {}".format(str(os.getpid()) if not pid else str(pid))]
+    command = ["sudo /bin/ip netns identify {}".format(os.getpid() if not pid else pid)]
     proc = subprocess.Popen(command,
                             stdout=subprocess.PIPE,
                             shell=True,

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -138,14 +138,14 @@ def get_asic_id_from_name(asic_name):
         raise ValueError('Unknown asic namespace name {}'.format(asic_name))
 
 
-def get_current_namespace():
+def get_current_namespace(pid=None):
     """
     This API returns the network namespace in which it is
     invoked. In case of global namepace the API returns None
     """
 
     net_namespace = None
-    command = ["/bin/ip netns identify", str(os.getpid())]
+    command = ["sudo /bin/ip netns identify {}".format(str(os.getpid()) if not pid else str(pid))]
     proc = subprocess.Popen(command,
                             stdout=subprocess.PIPE,
                             shell=True,
@@ -159,6 +159,8 @@ def get_current_namespace():
             )
         if stdout.rstrip('\n') != "":
             net_namespace = stdout.rstrip('\n')
+        else:
+            net_namespace = DEFAULT_NAMESPACE
     except OSError as e:
         raise OSError("Error running command {}".format(command))
 


### PR DESCRIPTION
Why I did:
Enhanced the monit process checked to support multi-asic .

How I did:

- For given feature we get the host and network namespace instances it's processes should be running
based on it's scope (global/asic) and add it to expected set.
 
- From psutil we get number of running instances of the processes and add where it is running (host/network namespace) using "ip netns identify"  to the the actual set

- Difference between expected and actual set provides instances where the processes are not running
and will be logged as syslog message by monit

How I verify:

- O/P from Multi-asic platform

```
# Stop lldpmgrd in host lldp docker
admin@str2-xxxxx-acs-3:/var/log$ /usr/bin/process_checker lldp python /usr/bin/lldpmgrd
'python /usr/bin/lldpmgrd' is not running in host

# Stop ldpmgrd in lldp0 (asic0 namespace) docker
admin@str2-xxxx-acs-3:/var/log$ /usr/bin/process_checker lldp python /usr/bin/lldpmgrd
'python /usr/bin/lldpmgrd' is not running in host and in namespace asic0

# Stop ldpmgrd in lldp1 (asic1 namespace) docker
admin@str2-xxxxx-acs-3:/var/log$ /usr/bin/process_checker lldp python /usr/bin/lldpmgrd
'python /usr/bin/lldpmgrd' is not running in host and in namespace asic1, asic0
```
-  Verified on Single Asic platforms also.

