### PR TITLE
NTP service ordering

### DIFF
--- a/files/image_config/ntp/ntp-config.service
+++ b/files/image_config/ntp/ntp-config.service
@@ -2,6 +2,7 @@
 Description=Update NTP configuration
 Requires=updategraph.service
 After=updategraph.service
+Before=ntp.service
 
 [Service]
 Type=oneshot

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -29,4 +29,4 @@ get_database_reboot_type
 echo "Disabling NTP long jump for reboot type ${reboot_type} ..."
 modify_ntp_default "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"
 
-systemctl restart ntp
+systemctl --no-block restart ntp


### PR DESCRIPTION
Signed-off-by: Prabhu Sreenivasan <prabhu.sreenivasan@broadcom.com>


**- Why I did it**
Make sure ntp-config service is executed before ntpd

**- How I did it**
Updated ntp-config service files to force dependency with ntp service. Also resolved circular dependency with --no-block flag. (needed as ntp-config service internally invokes systemd to restart ntp which in turn waits for ntp-config to complete)

**- How to verify it**
Existing ntp pytest.

**- Which release branch to backport (provide reason below if selected)**


**- Description for the changelog**
Adjusted the ordering of ntp-config service to run before ntp service. 
Avoided circular dependency due to above change with --no-block flag


**- A picture of a cute animal (not mandatory but encouraged)**
