### PR TITLE
lldp defect miscellaneous fixes as patches 

### DIFF
--- a/src/lldpd/patch/0010-Ported-fix-for-length-exceeded-from-lldp-community.patch
+++ b/src/lldpd/patch/0010-Ported-fix-for-length-exceeded-from-lldp-community.patch
@@ -1,0 +1,35 @@
+From fdb789c348fdcde6d5ef8b837d7f33718bc0862b Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Mon, 23 Nov 2020 20:47:28 -0800
+Subject: [PATCH] Ported fix for https://github.com/lldpd/lldpd/issues/408 from
+ community
+
+---
+ src/lib/atom.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib/atom.c b/src/lib/atom.c
+index f81d3bb..75c1275 100644
+--- a/src/lib/atom.c
++++ b/src/lib/atom.c
+@@ -327,7 +327,7 @@ _lldpctl_do_something(lldpctl_conn_t *conn,
+ 			conn->state_data[0] = 0;
+ 	}
+ 	if (conn->state == state_send &&
+-	    (state_data == NULL || !strncmp(conn->state_data, state_data, sizeof(conn->state_data)))) {
++	    (state_data == NULL || !strncmp(conn->state_data, state_data, sizeof(conn->state_data) - 1))) {
+ 		/* We need to send the currently built message */
+ 		rc = lldpctl_send(conn);
+ 		if (rc < 0)
+@@ -335,7 +335,7 @@ _lldpctl_do_something(lldpctl_conn_t *conn,
+ 		conn->state = state_recv;
+ 	}
+ 	if (conn->state == state_recv &&
+-	    (state_data == NULL || !strncmp(conn->state_data, state_data, sizeof(conn->state_data)))) {
++	    (state_data == NULL || !strncmp(conn->state_data, state_data, sizeof(conn->state_data) - 1))) {
+ 		/* We need to receive the answer */
+ 		while ((rc = ctl_msg_recv_unserialized(&conn->input_buffer,
+ 			    &conn->input_buffer_len,
+-- 
+2.12.2
+

--- a/src/lldpd/patch/0011-fix-med-location-len.patch
+++ b/src/lldpd/patch/0011-fix-med-location-len.patch
@@ -1,0 +1,47 @@
+From e9bf329eee94d6d49a17da35aea189179aeed3c6 Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Thu, 24 Dec 2020 09:27:49 -0800
+Subject: [PATCH] From 5c3479463a919193213213e2d8634c754c09aa51 Mon Sep 17
+ 00:00:00 2001 From: Vincent Bernat <vincent@bernat.ch> Date: Sun, 6 Dec 2020
+ 14:21:04 +0100 Subject: [PATCH] lib: fix LLDP-MED location parsing in
+ liblldpctl
+
+Some bounds were not checked correctly when parsing LLDP-MED civic
+location fields. This triggers out-of-bound reads (no write) in
+lldpcli, ultimately leading to a crash.
+
+Fix #420
+Signed-off-by: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+---
+ src/lib/atoms/med.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib/atoms/med.c b/src/lib/atoms/med.c
+index e1b20fd..595dba4 100644
+--- a/src/lib/atoms/med.c
++++ b/src/lib/atoms/med.c
+@@ -540,6 +540,7 @@ _lldpctl_atom_get_str_med_location(lldpctl_atom_t *atom, lldpctl_key_t key)
+ 		return NULL;
+ 	case lldpctl_k_med_location_country:
+ 		if (m->location->format != LLDP_MED_LOCFORMAT_CIVIC) break;
++		if (m->location->data_len < 4) return NULL;
+ 		value = _lldpctl_alloc_in_atom(atom, 3);
+ 		if (!value) return NULL;
+ 		memcpy(value, m->location->data + 2, 2);
+@@ -732,8 +733,11 @@ _lldpctl_atom_iter_med_caelements_list(lldpctl_atom_t *atom)
+ {
+ 	struct _lldpctl_atom_med_caelements_list_t *plist =
+ 	    (struct _lldpctl_atom_med_caelements_list_t *)atom;
+-	struct ca_iter *iter = _lldpctl_alloc_in_atom(atom, sizeof(struct ca_iter));
+-	if (!iter) return NULL;
++	struct ca_iter *iter;
++	if (plist->parent->location->data_len < 4 ||
++	    *(uint8_t*)plist->parent->location->data < 3 ||
++	    !(iter = _lldpctl_alloc_in_atom(atom, sizeof(struct ca_iter))))
++		return NULL;
+ 	iter->data = (uint8_t*)plist->parent->location->data + 4;
+ 	iter->data_len = *(uint8_t*)plist->parent->location->data - 3;
+ 	return (lldpctl_atom_iter_t*)iter;
+-- 
+2.12.2
+

--- a/src/lldpd/patch/series
+++ b/src/lldpd/patch/series
@@ -3,3 +3,5 @@
 0004-lldpctl-put-a-lock-around-some-commands-to-avoid-rac.patch
 0006-lib-fix-memory-leak.patch
 0007-lib-fix-memory-leak-when-handling-I-O.patch
+0010-Ported-fix-for-length-exceeded-from-lldp-community.patch
+0011-fix-med-location-len.patch


### PR DESCRIPTION
The details are as follows:


    1. 0010-Ported-fix-for-length-exceeded-from-lldp-community.patch
    Ported fix lldpd/lldpd#408 from LLDP community.
    lib: remove limit on system description length

    The limit was introduced in 9c49ced while fixing a memory leak.
    The state data is used to ensure we don't interleave operations. We
    need to handle the case where the value is truncated because it is
    larger than the allocated size.

    Fix #408.
    2. 0011-fix-med-location-len.patch
    Ported fix lldpd/lldpd#422 from community.
    lib: fix LLDP-MED location parsing in liblldpctl

    Some bounds were not checked correctly when parsing LLDP-MED civic
    location fields. This triggers out-of-bound reads (no write) in
    lldpcli, ultimately leading to a crash.

    Fix #420

Signed-off-by: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
