### PR TITLE
Implement Kdump configuration handler

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -42,6 +42,13 @@ def obfuscate(data):
         return data
 
 
+def run_cmd(cmd, log_err = True):
+    try:
+        subprocess.check_call(cmd, shell = True)
+    except Exception as err:
+        if log_err:
+            syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}"
+                  .format(err.cmd, err.returncode, err.output))
 
 class Iptables(object):
     def __init__(self):
@@ -226,6 +233,55 @@ class AaaCfg(object):
         with open(NSS_TACPLUS_CONF, 'w') as f:
             f.write(nss_tacplus_conf)
 
+class KdumpCfg(object):
+    def __init__(self, CfgDb):
+        self.config_db = CfgDb
+        self.kdump_defaults = { "enabled" : "false",
+                                "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                                "num_dumps": "3" }
+
+    def load(self, kdump_table):
+        syslog.syslog(syslog.LOG_INFO, "KdumpCfg load ...")
+        data = {}
+        kdump_conf = kdump_table.get("config", {})
+        for row in self.kdump_defaults:
+            value = self.kdump_defaults.get(row)
+            if kdump_conf.get(row) is not None:
+                value = kdump_conf.get(row)
+            else:
+                self.config_db.mod_entry("KDUMP", "config", { row : value})
+            data[row] = value
+        self.kdump_update("config", data, True)
+
+    def kdump_update(self, key, data, isLoad):
+        syslog.syslog(syslog.LOG_INFO, "Kdump global configuration update")
+        if key == "config":
+            # Admin mode
+            kdump_enabled = self.kdump_defaults["enabled"]
+            if data.get("enabled") is not None:
+                kdump_enabled = data.get("enabled")
+            if kdump_enabled.lower() == "true":
+                enabled = True
+            else:
+                enabled = False
+            if enabled:
+                run_cmd("sonic-kdump-config --enable")
+            else:
+                run_cmd("sonic-kdump-config --disable")
+
+            # Memory configuration
+            memory = self.kdump_defaults["memory"]
+            if data.get("memory") is not None:
+                memory = data.get("memory")
+            if isLoad or data.get("memory") is not None:
+                run_cmd("sonic-kdump-config --memory " + memory)
+
+            # Num dumps
+            num_dumps = self.kdump_defaults["num_dumps"]
+            if data.get("num_dumps") is not None:
+                num_dumps = data.get("num_dumps")
+            if isLoad or data.get("num_dumps") is not None:
+                run_cmd("sonic-kdump-config --num_dumps " + num_dumps)
 
 class HostConfigDaemon:
     def __init__(self):
@@ -240,6 +296,9 @@ class HostConfigDaemon:
 
         self.is_multi_npu = device_info.is_multi_npu()
 
+        # Load Kdump configuration
+        self.kdumpCfg = KdumpCfg(self.config_db)
+        self.kdumpCfg.load(self.config_db.get_table('KDUMP'))
 
     def load(self):
         aaa = self.config_db.get_table('AAA')
@@ -378,6 +437,10 @@ class HostConfigDaemon:
             self.cached_feature_states[feature_name] = state
             self.update_feature_state(feature_name, state, feature_table)
 
+    def kdump_handler (self, key, data):
+        syslog.syslog(syslog.LOG_INFO, 'Kdump handler...')
+        self.kdumpCfg.kdump_update(key, data, False)
+
     def start(self):
 
         self.config_db.subscribe('AAA', lambda table, key, data: self.aaa_handler(key, data))
@@ -385,6 +448,7 @@ class HostConfigDaemon:
         self.config_db.subscribe('TACPLUS', lambda table, key, data: self.tacacs_global_handler(key, data))
         self.config_db.subscribe('LOOPBACK_INTERFACE', lambda table, key, data: self.lpbk_handler(key, data))
         self.config_db.subscribe('FEATURE', lambda table, key, data: self.feature_state_handler(key, data))
+        self.config_db.subscribe('KDUMP', lambda table, key, data: self.kdump_handler(key, data))
 
         # Update all feature states once upon starting
         self.update_all_feature_states()


### PR DESCRIPTION
- Kdump configurations stored and manipulated in ConfigDB are now processed
by hostcfgd and applied asynchronously

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Allow Kdump configuration to be stored and manipulated in ConfigDB. Configuration
change events are handled by hostcfgd asynchronously.

**- How I did it**
Added ConfigDB change handlers for the KDUMP table in hostcfgd service

**- How to verify it**
config kdump disable
config kdump enable
config kdump memory <xxx>
config kdump num-dumps <xxx>


**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Implement Kdump configuration handlers

**- A picture of a cute animal (not mandatory but encouraged)**
