### PR TITLE
[psu] Fix incorrect file path for voltage, current and power.

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/psu.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/psu.py
@@ -82,7 +82,7 @@ class Psu(PsuBase):
         if vout_label_path:
             dir_name = os.path.dirname(vout_label_path)
             basename = os.path.basename(vout_label_path)
-            in_num = list(filter(str.isdigit, basename))
+            in_num = ''.join(list(filter(str.isdigit, basename)))
             vout_path = os.path.join(
                 dir_name, voltage_name.format(in_num))
             vout_val = self.__read_txt_file(vout_path)
@@ -105,7 +105,7 @@ class Psu(PsuBase):
         if curr_label_path:
             dir_name = os.path.dirname(curr_label_path)
             basename = os.path.basename(curr_label_path)
-            cur_num = list(filter(str.isdigit, basename))
+            cur_num = ''.join(list(filter(str.isdigit, basename)))
             cur_path = os.path.join(
                 dir_name, current_name.format(cur_num))
             cur_val = self.__read_txt_file(cur_path)
@@ -128,7 +128,7 @@ class Psu(PsuBase):
         if pw_label_path:
             dir_name = os.path.dirname(pw_label_path)
             basename = os.path.basename(pw_label_path)
-            pw_num = list(filter(str.isdigit, basename))
+            pw_num = ''.join(list(filter(str.isdigit, basename)))
             pw_path = os.path.join(
                 dir_name, current_name.format(pw_num))
             pw_val = self.__read_txt_file(pw_path)

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/psu.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/psu.py
@@ -92,7 +92,7 @@ class Psu(PsuBase):
         if vout_label_path:
             dir_name = os.path.dirname(vout_label_path)
             basename = os.path.basename(vout_label_path)
-            in_num = list(filter(str.isdigit, basename))
+            in_num = ''.join(list(filter(str.isdigit, basename)))
             vout_path = os.path.join(
                 dir_name, voltage_name.format(in_num))
             vout_val = self._api_helper.read_txt_file(vout_path)
@@ -115,7 +115,7 @@ class Psu(PsuBase):
         if curr_label_path:
             dir_name = os.path.dirname(curr_label_path)
             basename = os.path.basename(curr_label_path)
-            cur_num = list(filter(str.isdigit, basename))
+            cur_num = ''.join(list(filter(str.isdigit, basename)))
             cur_path = os.path.join(
                 dir_name, current_name.format(cur_num))
             cur_val = self._api_helper.read_txt_file(cur_path)
@@ -138,7 +138,7 @@ class Psu(PsuBase):
         if pw_label_path:
             dir_name = os.path.dirname(pw_label_path)
             basename = os.path.basename(pw_label_path)
-            pw_num = list(filter(str.isdigit, basename))
+            pw_num = ''.join(list(filter(str.isdigit, basename)))
             pw_path = os.path.join(
                 dir_name, current_name.format(pw_num))
             pw_val = self._api_helper.read_txt_file(pw_path)


### PR DESCRIPTION

Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fixes https://github.com/Azure/sonic-buildimage/issues/6126.
There is a bug in getting the path of voltage, current and power. The list object is directly converted to string to format the file path. As a result, ```read_txt_file``` will get ```None``` value and a ```WARNING``` will be recorded. This commit fix the issue.

**- How I did it**
Add a ```join``` to convert ```list``` to ```string```.

**- How to verify it**
Verified on DX010, and no WARNING is seen after this update.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix incorrect file path for voltage, current and power.

**- A picture of a cute animal (not mandatory but encouraged)**
