### PR TITLE
Fix post-reboot errors in platforms without sonic_platform package

### DIFF
--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -98,17 +98,22 @@ def find_proc_cmdline_reboot_cause():
 
     return proc_cmdline_reboot_cause
 
+
 def get_reboot_cause_from_platform():
     # Until all platform vendors have provided sonic_platform packages,
     # if there is no sonic_platform package installed, we only provide
     # software-related reboot causes.
+    hardware_reboot_cause_major = str()
+    hardware_reboot_cause_minor = str()
     try:
         import sonic_platform
         platform  = sonic_platform.platform.Platform()
         chassis  = platform.get_chassis()
-        return chassis.get_reboot_cause()
+        hardware_reboot_cause_major, hardware_reboot_cause_minor = chassis.get_reboot_cause()
     except ImportError as err:
         sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
+
+    return hardware_reboot_cause_major, hardware_reboot_cause_minor
 
 
 def find_hardware_reboot_cause():

--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -110,7 +110,7 @@ def get_reboot_cause_from_platform():
         platform  = sonic_platform.platform.Platform()
         chassis  = platform.get_chassis()
         hardware_reboot_cause_major, hardware_reboot_cause_minor = chassis.get_reboot_cause()
-    except ImportError as err:
+    except ImportError:
         sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
 
     return hardware_reboot_cause_major, hardware_reboot_cause_minor

--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -108,8 +108,6 @@ def find_hardware_reboot_cause():
         chassis  = platform.get_chassis()
         hardware_reboot_cause_major, hardware_reboot_cause_minor = chassis.get_reboot_cause()
         sonic_logger.log_info("Platform api returns reboot cause {}, {}".format(hardware_reboot_cause_major, hardware_reboot_cause_minor))
-        if hardware_reboot_cause_major == REBOOT_CAUSE_HARDWARE_OTHER:
-            hardware_reboot_cause_major = "{} ({})".format(hardware_reboot_cause_major, hardware_reboot_cause_minor)
     except ImportError:
         sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
         hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
@@ -119,7 +117,8 @@ def find_hardware_reboot_cause():
     else:
         sonic_logger.log_info("No reboot cause found from platform api")
 
-    return hardware_reboot_cause_major, hardware_reboot_cause_minor
+    hardware_reboot_cause = "{} ({})".format(hardware_reboot_cause_major, hardware_reboot_cause_minor)
+    return hardware_reboot_cause
 
 
 def get_reboot_cause_dict(previous_reboot_cause, comment, gen_time):
@@ -161,14 +160,16 @@ def main():
         os.remove(PREVIOUS_REBOOT_CAUSE_FILE)
 
     hardware_reboot_cause = None
-    additional_reboot_info = None
+    # This variable is kept for future-use purpose. When proc_cmd_line/vendor/software provides
+    # any additional_reboot_info it will be stored as a "comment" in REBOOT_CAUSE_HISTORY_FILE
+    additional_reboot_info = "N/A"
 
     # 1. Check if the previous reboot was warm/fast reboot by testing whether there is "fast|fastfast|warm" in /proc/cmdline
     proc_cmdline_reboot_cause = find_proc_cmdline_reboot_cause()
 
     # 2. Check if the previous reboot was caused by hardware
     #    If yes, the hardware reboot cause will be treated as the reboot cause
-    (hardware_reboot_cause, additional_reboot_info) = find_hardware_reboot_cause()
+    hardware_reboot_cause = find_hardware_reboot_cause()
 
     # 3. If there is a REBOOT_CAUSE_FILE, it will contain any software-related
     #    reboot info. We will use it as the previous cause.

--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -40,7 +40,8 @@ REBOOT_TYPE_KEXEC_PATTERN_WARM = ".*SONIC_BOOT_TYPE=(warm|fastfast).*"
 REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
 
 REBOOT_CAUSE_UNKNOWN = "Unknown"
-
+REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
+REBOOT_CAUSE_HARDWARE_OTHER = "Hardware - Other"
 
 # Global logger class instance
 sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
@@ -99,48 +100,27 @@ def find_proc_cmdline_reboot_cause():
     return proc_cmdline_reboot_cause
 
 
-def get_reboot_cause_from_platform():
-    # Until all platform vendors have provided sonic_platform packages,
-    # if there is no sonic_platform package installed, we only provide
-    # software-related reboot causes.
-    hardware_reboot_cause_major = "N/A"
-    hardware_reboot_cause_minor = "N/A"
+def find_hardware_reboot_cause():
+    # Find hardware reboot cause using sonic_platform library
     try:
         import sonic_platform
         platform  = sonic_platform.platform.Platform()
         chassis  = platform.get_chassis()
         hardware_reboot_cause_major, hardware_reboot_cause_minor = chassis.get_reboot_cause()
+        sonic_logger.log_info("Platform api returns reboot cause {}, {}".format(hardware_reboot_cause_major, hardware_reboot_cause_minor))
+        if hardware_reboot_cause_major == REBOOT_CAUSE_HARDWARE_OTHER:
+            hardware_reboot_cause_major = "{} ({})".format(hardware_reboot_cause_major, hardware_reboot_cause_minor)
     except ImportError:
         sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
+        hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
 
-    return hardware_reboot_cause_major, hardware_reboot_cause_minor
-
-
-def find_hardware_reboot_cause():
-    hardware_reboot_cause = None
-
-    REBOOT_CAUSE_HARDWARE_OTHER = "Hardware - Other"
-    REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
-    REBOOT_CAUSE_HARDWARE_NA = "N/A"
-
-    hardware_reboot_cause_major, hardware_reboot_cause_minor = get_reboot_cause_from_platform()
-    sonic_logger.log_info("Platform api returns reboot cause {}, {}".format(hardware_reboot_cause_major, hardware_reboot_cause_minor))
-
-    if hardware_reboot_cause_major == REBOOT_CAUSE_NON_HARDWARE or hardware_reboot_cause_major == REBOOT_CAUSE_HARDWARE_NA:
-        # The reboot was not caused by hardware. If there is a REBOOT_CAUSE_FILE, it will
-        # contain any software-related reboot info. We will use it as the previous cause.
-        pass
-    elif hardware_reboot_cause_major == REBOOT_CAUSE_HARDWARE_OTHER:
-        hardware_reboot_cause = "{} ({})".format(hardware_reboot_cause_major, hardware_reboot_cause_minor)
-    else:
-        hardware_reboot_cause = hardware_reboot_cause_major
-
-    if hardware_reboot_cause:
-        sonic_logger.log_info("Platform api indicates reboot cause {}".format(hardware_reboot_cause))
+    if hardware_reboot_cause_major:
+        sonic_logger.log_info("Platform api indicates reboot cause {}".format(hardware_reboot_cause_major))
     else:
         sonic_logger.log_info("No reboot cause found from platform api")
 
-    return hardware_reboot_cause, hardware_reboot_cause_minor
+    return hardware_reboot_cause_major, hardware_reboot_cause_minor
+
 
 def get_reboot_cause_dict(previous_reboot_cause, comment, gen_time):
     # resultant dictionary
@@ -203,7 +183,7 @@ def main():
     # Else the software_reboot_cause will be treated as the reboot cause
     if proc_cmdline_reboot_cause is not None:
         previous_reboot_cause = software_reboot_cause
-    elif hardware_reboot_cause is not None:
+    elif hardware_reboot_cause is not REBOOT_CAUSE_NON_HARDWARE:
         previous_reboot_cause = hardware_reboot_cause
     else:
         previous_reboot_cause = software_reboot_cause

--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -103,8 +103,8 @@ def get_reboot_cause_from_platform():
     # Until all platform vendors have provided sonic_platform packages,
     # if there is no sonic_platform package installed, we only provide
     # software-related reboot causes.
-    hardware_reboot_cause_major = str()
-    hardware_reboot_cause_minor = str()
+    hardware_reboot_cause_major = "N/A"
+    hardware_reboot_cause_minor = "N/A"
     try:
         import sonic_platform
         platform  = sonic_platform.platform.Platform()
@@ -121,11 +121,12 @@ def find_hardware_reboot_cause():
 
     REBOOT_CAUSE_HARDWARE_OTHER = "Hardware - Other"
     REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
+    REBOOT_CAUSE_HARDWARE_NA = "N/A"
 
     hardware_reboot_cause_major, hardware_reboot_cause_minor = get_reboot_cause_from_platform()
     sonic_logger.log_info("Platform api returns reboot cause {}, {}".format(hardware_reboot_cause_major, hardware_reboot_cause_minor))
 
-    if hardware_reboot_cause_major == REBOOT_CAUSE_NON_HARDWARE:
+    if hardware_reboot_cause_major == REBOOT_CAUSE_NON_HARDWARE or hardware_reboot_cause_major == REBOOT_CAUSE_HARDWARE_NA:
         # The reboot was not caused by hardware. If there is a REBOOT_CAUSE_FILE, it will
         # contain any software-related reboot info. We will use it as the previous cause.
         pass

--- a/src/sonic-host-services/tests/determine-reboot-cause_test.py
+++ b/src/sonic-host-services/tests/determine-reboot-cause_test.py
@@ -100,7 +100,7 @@ class TestDetermineRebootCause(object):
 
     def test_find_hardware_reboot_cause(self):
         result = find_hardware_reboot_cause()
-        assert result == (REBOOT_CAUSE_NON_HARDWARE, "N/A")
+        assert result == "Non-Hardware (N/A)"
 
     def test_get_reboot_cause_dict_watchdog(self):
         reboot_cause_dict = get_reboot_cause_dict(REBOOT_CAUSE_WATCHDOG, "", GEN_TIME_WATCHDOG) 

--- a/src/sonic-host-services/tests/determine-reboot-cause_test.py
+++ b/src/sonic-host-services/tests/determine-reboot-cause_test.py
@@ -99,9 +99,8 @@ class TestDetermineRebootCause(object):
             assert result == "fast-reboot"
 
     def test_find_hardware_reboot_cause(self):
-        with mock.patch("determine_reboot_cause.get_reboot_cause_from_platform", return_value=("Powerloss", None)):
-            result = find_hardware_reboot_cause() 
-            assert result == ("Powerloss", None)
+        result = find_hardware_reboot_cause()
+        assert result == (REBOOT_CAUSE_NON_HARDWARE, "N/A")
 
     def test_get_reboot_cause_dict_watchdog(self):
         reboot_cause_dict = get_reboot_cause_dict(REBOOT_CAUSE_WATCHDOG, "", GEN_TIME_WATCHDOG) 
@@ -113,5 +112,5 @@ class TestDetermineRebootCause(object):
 
     @classmethod
     def teardown_class(cls):
-        print("TREARDOWN")
+        print("TEARDOWN")
 

--- a/src/system-health/scripts/healthd
+++ b/src/system-health/scripts/healthd
@@ -68,19 +68,22 @@ class HealthDaemon(DaemonBase):
         """
         self.log_notice("Starting up...")
 
-        import sonic_platform.platform
-        chassis = sonic_platform.platform.Platform().get_chassis()
-        manager = HealthCheckerManager()
-        if not manager.config.config_file_exists():
-            self.log_warning("System health configuration file not found, exit...")
-            return
-        while 1:
-            state, stat = manager.check(chassis)
-            if state == HealthCheckerManager.STATE_RUNNING:
-                self._process_stat(chassis, manager.config, stat)
+        try:
+            import sonic_platform.platform
+            chassis = sonic_platform.platform.Platform().get_chassis()
+            manager = HealthCheckerManager()
+            if not manager.config.config_file_exists():
+                self.log_warning("System health configuration file not found, exit...")
+                return
+            while 1:
+                state, stat = manager.check(chassis)
+                if state == HealthCheckerManager.STATE_RUNNING:
+                    self._process_stat(chassis, manager.config, stat)
 
-            if self.stop_event.wait(manager.config.interval):
-                break
+                if self.stop_event.wait(manager.config.interval):
+                    break
+        except ImportError as _:
+            self.log_warning("sonic_platform package not installed. Cannot start system-health daemon")
 
         self.deinit()
 

--- a/src/system-health/scripts/healthd
+++ b/src/system-health/scripts/healthd
@@ -82,7 +82,7 @@ class HealthDaemon(DaemonBase):
 
                 if self.stop_event.wait(manager.config.interval):
                     break
-        except ImportError as _:
+        except ImportError:
             self.log_warning("sonic_platform package not installed. Cannot start system-health daemon")
 
         self.deinit()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

Fix errors seen in VS image after reboot - both determine-reboot-cause and healtd fail with errors shown in syslog.

**- Why I did it**

Error seen during `determine-reboot-cause`:
```
Dec  4 11:09:03.985425 vlab-01 INFO determine-reboot-cause: Starting up...
Dec  4 11:09:03.985661 vlab-01 INFO determine-reboot-cause: /proc/cmdline indicates reboot type: warm-reboot
Dec  4 11:09:03.985817 vlab-01 WARNING determine-reboot-cause: sonic_platform package not installed. Unable to detect hardware reboot causes.
Dec  4 11:09:03.986717 vlab-01 INFO determine-reboot-cause[512]: Traceback (most recent call last):
Dec  4 11:09:03.986847 vlab-01 INFO determine-reboot-cause[512]:   File "/usr/local/bin/determine-reboot-cause", line 236, in <module>
Dec  4 11:09:03.986926 vlab-01 INFO determine-reboot-cause[512]:     main()
Dec  4 11:09:03.987047 vlab-01 INFO determine-reboot-cause[512]:   File "/usr/local/bin/determine-reboot-cause", line 185, in main
Dec  4 11:09:03.987126 vlab-01 INFO determine-reboot-cause[512]:     (hardware_reboot_cause, additional_reboot_info) = find_hardware_reboot_cause()
Dec  4 11:09:03.987251 vlab-01 INFO determine-reboot-cause[512]:   File "/usr/local/bin/determine-reboot-cause", line 120, in find_hardware_reboot_cause
Dec  4 11:09:03.987336 vlab-01 INFO determine-reboot-cause[512]:     hardware_reboot_cause_major, hardware_reboot_cause_minor = get_reboot_cause_from_platform()
Dec  4 11:09:03.987416 vlab-01 INFO determine-reboot-cause[512]: TypeError: cannot unpack non-iterable NoneType object
```

Error seen during starting `healthd` daemon:
```
Dec  4 11:09:13.290441 vlab-01 NOTICE healthd[1149]: Starting up...
Dec  4 11:09:13.290807 vlab-01 INFO healthd[1149]: Traceback (most recent call last):
Dec  4 11:09:13.290953 vlab-01 INFO healthd[1149]:   File "/usr/local/bin/healthd", line 108, in <module>
Dec  4 11:09:13.291081 vlab-01 INFO healthd[1149]:     main()
Dec  4 11:09:13.291455 vlab-01 INFO healthd[1149]:   File "/usr/local/bin/healthd", line 71, in run
Dec  4 11:09:13.291587 vlab-01 INFO healthd[1149]:     import sonic_platform.platform
Dec  4 11:09:13.291711 vlab-01 INFO healthd[1149]: ImportError: No module named sonic_platform.platform
```


**- How I did it**
Fixed the determine-reboot-cause bug, and added error handling for healthd in VS image.

**- How to verify it**

Verified manually in the VS setup:

```
Dec  8 23:07:12.832394 vlab-01 INFO determine-reboot-cause: Starting up...
Dec  8 23:07:12.832744 vlab-01 INFO determine-reboot-cause: /proc/cmdline indicates reboot type: warm-reboot
Dec  8 23:07:12.832914 vlab-01 WARNING determine-reboot-cause: sonic_platform package not installed. Unable to detect hardware reboot causes.
Dec  8 23:07:12.833073 vlab-01 INFO determine-reboot-cause: Platform api returns reboot cause N/A, N/A
Dec  8 23:07:12.833230 vlab-01 INFO determine-reboot-cause: No reboot cause found from platform api
Dec  8 23:07:12.833413 vlab-01 INFO determine-reboot-cause: /host/reboot-cause/reboot-cause.txt indicates the reboot cause: User issued 'warm-reboot' command [User: admin, Time: Tue 08 Dec 2020 11:06:10 PM UTC]
Dec  8 23:07:12.845156 vlab-01 INFO systemd[1]: determine-reboot-cause.service: Succeeded.
```
```
root@vlab-01:~# show reboot-cause 
User issued 'warm-reboot' command [User: admin, Time: Tue 08 Dec 2020 11:06:10 PM UTC]
root@vlab-01:~# 
root@vlab-01:~# 
root@vlab-01:~# show reboot-cause history 
Name                 Cause        Time                             User    Comment
-------------------  -----------  -------------------------------  ------  ---------
2020_12_08_23_07_12  warm-reboot  Tue 08 Dec 2020 11:06:10 PM UTC  admin   N/A
```
```
Dec  4 17:52:17.257849 vlab-01 NOTICE healthd[834]: Starting up...
Dec  4 17:52:17.276116 vlab-01 WARNING healthd[834]: sonic_platform package not installed. Cannot start system-health daemon
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
