### PR TITLE
IXS7215:fix for dynamic changes reading DOM and LED

### DIFF
--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/plugins/led_control.py
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/plugins/led_control.py
@@ -37,9 +37,8 @@ class LedControl(LedControlBase):
         self._initDefaultConfig()
 
     def _initDefaultConfig(self):
-        # For the D1 box the port leds are controlled by Trident3 LED program
-        # The fan tray leds will be managed with the new thermalctl daemon / chassis class based API
-        # leaving only the system leds to be done old style
+        # The fan tray leds and system led managed by new chassis class API
+        # leaving only a couple other front panel leds to be done old style
         DBG_PRINT("starting system leds")
         self._initSystemLed()
         DBG_PRINT(" led done")
@@ -77,31 +76,39 @@ class LedControl(LedControlBase):
         while True:
             # Front Panel FAN Panel LED setting in register 0x08
             if (self.chassis.get_fan(0).get_status() == self.chassis.get_fan(1).get_status() == True):
-                if oldfan != 0x1:
-                    if (os.path.isfile("/sys/class/gpio/fanLedAmber/value")):
-                        self._set_i2c_register("/sys/class/gpio/fanLedAmber/value", 0)
-                        self._set_i2c_register("/sys/class/gpio/fanLedGreen/value", 1)
+                if (os.path.isfile("/sys/class/gpio/fanLedAmber/value")):
+                    if oldfan != 0x1:
+                        rv = self._set_i2c_register("/sys/class/gpio/fanLedAmber/value", 0)
+                        rv = self._set_i2c_register("/sys/class/gpio/fanLedGreen/value", 1)
                         oldfan = 0x1
+                else:
+                        oldfan = 0xf
             else:
-                if oldfan != 0x0:
-                    if (os.path.isfile("/sys/class/gpio/fanLedGreen/value")):
-                        self._set_i2c_register("/sys/class/gpio/fanLedGreen/value", 0)
-                        self._set_i2c_register("/sys/class/gpio/fanLedAmber/value", 1)
+                if (os.path.isfile("/sys/class/gpio/fanLedGreen/value")):
+                    if oldfan != 0x0:
+                        rv = self._set_i2c_register("/sys/class/gpio/fanLedGreen/value", 0)
+                        rv = self._set_i2c_register("/sys/class/gpio/fanLedAmber/value", 1)
                         oldfan = 0x0
+                else:
+                    oldfan = 0xf
 
             # Front Panel PSU Panel LED setting in register 0x09
             if (self.chassis.get_psu(0).get_status() == self.chassis.get_psu(1).get_status() == True):
-                if oldpsu != 0x1:
-                    if (os.path.isfile("/sys/class/gpio/psuLedAmber/value")):
-                        self._set_i2c_register("/sys/class/gpio/psuLedAmber/value", 0)
-                        self._set_i2c_register("/sys/class/gpio/psuLedGreen/value", 1)
+                if (os.path.isfile("/sys/class/gpio/psuLedAmber/value")):
+                    if oldpsu != 0x1:
+                        rv = self._set_i2c_register("/sys/class/gpio/psuLedAmber/value", 0)
+                        rv = self._set_i2c_register("/sys/class/gpio/psuLedGreen/value", 1)
                         oldpsu = 0x1
+                else:
+                    oldpsu = 0xf
             else:
-                if oldpsu != 0x0:
-                    if (os.path.isfile("/sys/class/gpio/psuLedGreen/value")):
-                        self._set_i2c_register("/sys/class/gpio/psuLedGreen/value", 0)
-                        self._set_i2c_register("/sys/class/gpio/psuLedAmber/value", 1)
+                if (os.path.isfile("/sys/class/gpio/psuLedGreen/value")):
+                    if oldpsu != 0x0:
+                        rv = self._set_i2c_register("/sys/class/gpio/psuLedGreen/value", 0)
+                        rv = self._set_i2c_register("/sys/class/gpio/psuLedAmber/value", 1)
                         oldpsu = 0x0
+                else:
+                    oldpsu = 0xf
             time.sleep(6)
 
     # Helper method to map SONiC port name to index

--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/plugins/led_control.py
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/plugins/led_control.py
@@ -78,16 +78,16 @@ class LedControl(LedControlBase):
             if (self.chassis.get_fan(0).get_status() == self.chassis.get_fan(1).get_status() == True):
                 if (os.path.isfile("/sys/class/gpio/fanLedAmber/value")):
                     if oldfan != 0x1:
-                        rv = self._set_i2c_register("/sys/class/gpio/fanLedAmber/value", 0)
-                        rv = self._set_i2c_register("/sys/class/gpio/fanLedGreen/value", 1)
+                        self._set_i2c_register("/sys/class/gpio/fanLedAmber/value", 0)
+                        self._set_i2c_register("/sys/class/gpio/fanLedGreen/value", 1)
                         oldfan = 0x1
                 else:
                         oldfan = 0xf
             else:
                 if (os.path.isfile("/sys/class/gpio/fanLedGreen/value")):
                     if oldfan != 0x0:
-                        rv = self._set_i2c_register("/sys/class/gpio/fanLedGreen/value", 0)
-                        rv = self._set_i2c_register("/sys/class/gpio/fanLedAmber/value", 1)
+                        self._set_i2c_register("/sys/class/gpio/fanLedGreen/value", 0)
+                        self._set_i2c_register("/sys/class/gpio/fanLedAmber/value", 1)
                         oldfan = 0x0
                 else:
                     oldfan = 0xf
@@ -96,16 +96,16 @@ class LedControl(LedControlBase):
             if (self.chassis.get_psu(0).get_status() == self.chassis.get_psu(1).get_status() == True):
                 if (os.path.isfile("/sys/class/gpio/psuLedAmber/value")):
                     if oldpsu != 0x1:
-                        rv = self._set_i2c_register("/sys/class/gpio/psuLedAmber/value", 0)
-                        rv = self._set_i2c_register("/sys/class/gpio/psuLedGreen/value", 1)
+                        self._set_i2c_register("/sys/class/gpio/psuLedAmber/value", 0)
+                        self._set_i2c_register("/sys/class/gpio/psuLedGreen/value", 1)
                         oldpsu = 0x1
                 else:
                     oldpsu = 0xf
             else:
                 if (os.path.isfile("/sys/class/gpio/psuLedGreen/value")):
                     if oldpsu != 0x0:
-                        rv = self._set_i2c_register("/sys/class/gpio/psuLedGreen/value", 0)
-                        rv = self._set_i2c_register("/sys/class/gpio/psuLedAmber/value", 1)
+                        self._set_i2c_register("/sys/class/gpio/psuLedGreen/value", 0)
+                        self._set_i2c_register("/sys/class/gpio/psuLedAmber/value", 1)
                         oldpsu = 0x0
                 else:
                     oldpsu = 0xf

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
@@ -166,8 +166,6 @@ class Sfp(SfpBase):
         self.dom_tx_power_supported = False
         self.calibration = 0
 
-        self._dom_capability_detect()
-
     def __convert_string_to_num(self, value_str):
         if "-inf" in value_str:
             return 'N/A'
@@ -402,6 +400,7 @@ class Sfp(SfpBase):
 
         if self.sfp_type == SFP_TYPE:
 
+            self._dom_capability_detect()
             if not self.dom_supported:
                 return transceiver_dom_info_dict
 
@@ -487,6 +486,7 @@ class Sfp(SfpBase):
 
             offset = SFP_MODULE_ADDRA2_OFFSET
 
+            self._dom_capability_detect()
             if not self.dom_supported:
                 return transceiver_dom_threshold_info_dict
 
@@ -533,6 +533,7 @@ class Sfp(SfpBase):
         Returns:
             A Boolean, True if reset enabled, False if disabled
         """
+        self._dom_capability_detect()
         if not self.dom_supported:
             return False
         if self.sfp_type == COPPER_TYPE:
@@ -710,6 +711,7 @@ class Sfp(SfpBase):
             if sfpd_obj is None:
                 return None
 
+            self._dom_capability_detect()
             if self.dom_supported:
                 sfpd_obj._calibration_type = self.calibration
 
@@ -747,6 +749,7 @@ class Sfp(SfpBase):
             if sfpd_obj is None:
                 return None
 
+            self._dom_capability_detect()
             if self.dom_supported:
                 sfpd_obj._calibration_type = self.calibration
 


### PR DESCRIPTION
     - clean up corner condition when SDK reset and SFP's move

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
fix rare corner conditions
 system leds -  in some conditions when CPSS has been reset the gpio driver led state it controls should be reset also
 dom support in sfp - change reading of SFP+ dom capability from init routine to dynamic check - works any daemon

**- How I did it**

**- How to verify it**
   combinations of “sudo systemctl restart swss” “sudo systemctl restart syncd” and swapping SFP+ types around
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
