### PR TITLE
[NVMe] Add NVMe SSD disc type support to installer.sh script

### DIFF
--- a/files/initramfs-tools/modules
+++ b/files/initramfs-tools/modules
@@ -4,3 +4,4 @@ vfat
 nls_ascii
 nls_cp437
 nls_utf8
+nvme

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -107,8 +107,8 @@ if [ "$install_env" != "build" ]; then
     onie_dev=$(blkid | grep ONIE-BOOT | head -n 1 | awk '{print $1}' |  sed -e 's/:.*$//')
     blk_dev=$(echo $onie_dev | sed -e 's/[1-9][0-9]*$//' | sed -e 's/\([0-9]\)\(p\)/\1/')
 
+    # check if we have an nvme device
     blk_suffix=
-    echo $blk_dev | grep -q mmcblk && blk_suffix="p"
     echo $blk_dev | grep -q nvme0 && blk_suffix="p"
 
     # Note: ONIE has no mount setting for / with device node, so below will be empty string

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -106,6 +106,11 @@ fi
 if [ "$install_env" != "build" ]; then
     onie_dev=$(blkid | grep ONIE-BOOT | head -n 1 | awk '{print $1}' |  sed -e 's/:.*$//')
     blk_dev=$(echo $onie_dev | sed -e 's/[1-9][0-9]*$//' | sed -e 's/\([0-9]\)\(p\)/\1/')
+
+    blk_suffix=
+    echo $blk_dev | grep -q mmcblk && blk_suffix="p"
+    echo $blk_dev | grep -q nvme0 && blk_suffix="p"
+
     # Note: ONIE has no mount setting for / with device node, so below will be empty string
     cur_part=$(cat /proc/mounts | awk "{ if(\$2==\"/\") print \$1 }" | grep $blk_dev || true)
 
@@ -225,7 +230,7 @@ create_demo_gpt_partition()
     echo "Partition #$demo_part is available"
 
     # Create new partition
-    echo "Creating new $demo_volume_label partition ${blk_dev}$demo_part ..."
+    echo "Creating new $demo_volume_label partition ${blk_dev}${blk_suffix}$demo_part ..."
 
     if [ "$demo_type" = "DIAG" ] ; then
         # set the GPT 'system partition' attribute bit for the DIAG
@@ -424,6 +429,7 @@ image_dir="image-$image_version"
 if [ "$install_env" = "onie" ]; then
     eval $create_demo_partition $blk_dev
     demo_dev=$(echo $blk_dev | sed -e 's/\(mmcblk[0-9]\)/\1p/')$demo_part
+    echo $blk_dev | grep -q nvme0 && demo_dev=$(echo $blk_dev | sed -e 's/\(nvme[0-9]n[0-9]\)/\1p/')$demo_part
 
     # Make filesystem
     mkfs.ext4 -L $demo_volume_label $demo_dev


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
In order to install a SONiC image on top of a NVMe SSD disc properly with ONIE we must configure it properly on the installer.sh script.

**- How I did it**
Added relevant data to 'installer.sh' script to support nvme.

**- How to verify it**
Try to install a SONiC image including this PR on a system with a NVMe disc installed and a compatible ONIE.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
