### PR TITLE
[hostimage] No need to mark packages as auto since all debootstrap installed packages are fundamental and will not be removed

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -103,7 +103,6 @@ sudo LANG=C chroot $FILESYSTEM_ROOT mount
 ## Pointing apt to public apt mirrors and getting latest packages, needed for latest security updates
 sudo cp files/apt/sources.list.$CONFIGURED_ARCH $FILESYSTEM_ROOT/etc/apt/sources.list
 sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages},no-check-valid-until} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
-sudo LANG=C chroot $FILESYSTEM_ROOT bash -c 'apt-mark auto `apt-mark showmanual`'
 
 ## Note: set lang to prevent locale warnings in your chroot
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y update


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Originally this line is used to mark all previously installed packages (deboostrap installed) as auto, so later if no other packages depend on anyone of them, it will be auto removed. Seems we gained little from this line, so let's remove it.

**- How I did it**

**- How to verify it**
Check the build log after `sudo LANG=C chroot ./fsroot apt-get -y autoremove` and the removed packages are unchanged.
```
The following packages will be REMOVED:
  binutils binutils-common binutils-x86-64-linux-gnu cpp cpp-8 gcc-8 libasan5
  libatomic1 libbinutils libc-dev-bin libc6-dev libcc1-0 libexpat1-dev
  libgcc-8-dev libgomp1 libisl19 libitm1 liblsan0 libmpc3 libmpfr6 libmpx2
  libquadmath0 libtsan0 libubsan1 linux-libc-dev
0 upgraded, 0 newly installed, 25 to remove and 5 not upgraded.
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
