### PR TITLE
[makefile] re-organize makefile so init only execute once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ ifeq ($(NOSTRETCH), 0)
 	make -f Makefile.work stretch
 endif
 
-clean reset init configure showtag sonic-slave-build sonic-slave-bash :
+init:
+	@echo "+++ Making $@ +++"
+	make -f Makefile.work $@
+
+clean configure reset showtag sonic-slave-build sonic-slave-bash :
 	@echo "+++ Making $@ +++"
 ifeq ($(NOJESSIE), 0)
 	make -f Makefile.work $@


### PR DESCRIPTION
**- Why I did it**
make init executed 3 times, which is unnecessary.

**- How I did it**
reorganize the makefile so that init only executed once.

**- How to verify it**
make reset
make init

- [ ] 201811
- [ ] 201911
- [ ] 202006
