### PR TITLE
Pin version of m2crypto Python package in slave containers

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -303,8 +303,6 @@ RUN apt-get update && apt-get install -y \
         libevent-dev \
 # For libyang
         swig \
-# For SWI Tools
-        python-m2crypto \
 # For build dtb
         device-tree-compiler \
 # For sonic-mgmt-framework
@@ -443,6 +441,9 @@ RUN apt-get update
 RUN apt-get install -y docker-ce=5:18.09.5~3-0~debian-buster docker-ce-cli=5:18.09.5~3-0~debian-buster
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
+
+# Install m2crypto package, needed by SWI tools
+RUN pip2 install m2crypto==0.36.0
 
 # Install swi tools
 RUN pip2 install git+https://github.com/aristanetworks/swi-tools.git@d51761ec0bb93c73039233f3c01ed48235ffad00

--- a/sonic-slave-jessie/Dockerfile.j2
+++ b/sonic-slave-jessie/Dockerfile.j2
@@ -357,5 +357,8 @@ RUN echo "deb [arch={{ CONFIGURED_ARCH }}] http://archive.debian.org/debian jess
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 RUN apt-get -y -o Acquire::Check-Valid-Until=false install ca-certificates-java=20161107~bpo8+1 openjdk-8-jdk
 
+# Install m2crypto package, needed by SWI tools
+RUN pip install m2crypto==0.36.0
+
 # Install swi tools
 RUN python -m pip install git+https://github.com/aristanetworks/swi-tools.git@d51761ec0bb93c73039233f3c01ed48235ffad00

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -290,8 +290,6 @@ RUN apt-get update && apt-get install -y \
         libevent-dev \
 # For libyang
         swig \
-# For SWI Tools
-        python-m2crypto \
 # For sonic-mgmt-framework
         autoconf \
         m4 \
@@ -437,6 +435,9 @@ RUN apt-get install -y docker-ce=5:18.09.5~3-0~debian-stretch docker-ce-cli=5:18
 RUN apt-get install -y docker-ce=18.06.3~ce~3-0~debian
 {%- endif %}
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker
+
+# Install m2crypto package, needed by SWI tools
+RUN pip install m2crypto==0.36.0
 
 # Install swi tools
 RUN pip2 install git+https://github.com/aristanetworks/swi-tools.git@d51761ec0bb93c73039233f3c01ed48235ffad00


### PR DESCRIPTION
**- Why I did it**

The maintainers of the m2crypto Python package pushed two new versions of the package to PyPI today, version 0.37.0 followed a few hours later by 0.37.1 (https://pypi.org/project/M2Crypto/0.37.1/#history). It appears as though these packages are failing to build/install properly in our image.

The problem was noticed in the Jessie container, where we were not previously explicitly installing the Debian m2crypto package. As part of this PR, I install m2crypto via pip in the Jessie container and pin down the version. I also modified the Stretch and Buster Dockerfiles to install the package vi pip in the same fashion for consistency.

**- How I did it**

Install m2crypto via pip and pin down version to 0.36.0, the last known working version.

**- How to verify it**

Build an image successfully

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
