### PR TITLE
Upgrade to SAI BCM 4.2.1.5-6 to pick up the fib hash patch (CS0001138…

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_4.2.1.5-4_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/libsaibcm_4.2.1.5-4_amd64.deb?sv=2015-04-05&sr=b&sig=dHfQf95FxgLBlnrGJwv6pIkAYAc6mOGbz9vvUMfxFvg%3D&se=2034-07-28T05%3A53%3A21Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_4.2.1.5-4_amd64.deb
+BRCM_SAI = libsaibcm_4.2.1.5-6_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/libsaibcm_4.2.1.5-6_amd64.deb?sv=2015-04-05&sr=b&sig=%2BZXgixWQWbDP5gEEID4wmkAT2vB%2FW%2BAiDIHs9z1FuZQ%3D&se=2034-08-18T02%3A06%3A57Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_4.2.1.5-6_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/libsaibcm-dev_4.2.1.5-4_amd64.deb?sv=2015-04-05&sr=b&sig=n98j842RZy%2BwQh4CtOku7jz6wgV%2BusbTl9NkeRndBrE%3D&se=2037-01-13T05%3A54%3A34Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/libsaibcm-dev_4.2.1.5-6_amd64.deb?sv=2015-04-05&sr=b&sig=fGd05XpZ%2FuIJ6UP7Cr39Ctz8%2Bnh4e6O6gqXFdgOTok0%3D&se=2034-08-18T02%3A06%3A24Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
…8674) and the fdb invalid port patch (CS00011298546)

**- Why I did it**
In SAI 4.2.1.5 there are two issues discovered by nightly test:
1. FIB Hashing issue where it does not evenly distribute to all LAG members and thus causing fib test failure.  A patch to address this issue was provided by BRCM (CS00011388674) and validated with a private build.
2. FDB event has invalid port, flooding syslog with error messages.  A patch to address this was also provided by BRCM (CS00011298546) and validated with a private build. 

**- How to verify it**
For the fib hash issue please refer to (https://github.com/Azure/sonic-buildimage/issues/5681).
For the FDB invalid port issue please refer to (https://github.com/Azure/sonic-buildimage/issues/5616).

**- Description for the changelog**
Moving BRCM SAI 4.2.1.5 to 4.2.1.5-6 to pick up fix for FIB Hashing issue (CS00011388674) and FDB Invalid Port issue (CS00011298546).

Fixes #5681 
Fixes #5616 
