### PR TITLE
[sonic-config-engine/minigraph] Enable console mgmt feature for console device

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -36,6 +36,7 @@ spine_chassis_frontend_role = 'SpineChassisFrontendRouter'
 chassis_backend_role = 'ChassisBackendRouter'
 
 backend_device_types = ['BackEndToRRouter', 'BackEndLeafRouter']
+console_device_types = ['MgmtTsToR']
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
 VLAN_SUB_INTERFACE_VLAN_ID = '10'
 
@@ -1316,6 +1317,13 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     # Special parsing for spine chassis frontend routers
     if current_device['type'] == spine_chassis_frontend_role:
         parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_members, devices)
+
+    # Enable console management feature for console swtich
+    results['CONSOLE_SWITCH'] = {
+        'console_mgmt' : {
+            'enabled' : 'yes' if current_device['type'] in console_device_types else 'no'
+        }
+    }
 
     return results
 

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -121,6 +121,13 @@ class TestCfgGenCaseInsensitive(TestCase):
             utils.to_dict("{'PortChannel01': {'admin_status': 'up', 'min_links': '1', 'members': ['Ethernet4'], 'mtu': '9100'}}")
         )
 
+    def test_minigraph_console_mgmt_feature(self):
+        argument = '-m "' + self.sample_graph + '" -v CONSOLE_SWITCH'
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict("{'console_mgmt': {'enabled': 'no'}}"))
+
     def test_minigraph_console_port(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v CONSOLE_PORT'
         output = self.run_script(argument)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Enable console mgmt feature for console device while parsing minigraph.

**- How I did it**

1. Introduced a list `console_device_types` which contains the device types that support console management feature
2. Inject `CONSOLE_SWITCH:console_mgmt` table with `enabled:yes` or `enabled:no`

Please notice that the `CONSOLE_SWTICH` conversion between minigraph to config_db is single direction only. There is no field indicate the `CONSOLE_SWTICH` table directly in minigraph.

**- How to verify it**

Added unit tests and passed.
```
test_minigraph_console_mgmt_feature (tests.test_minigraph_case.TestCfgGenCaseInsensitive) ... ok
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**

Enable console mgmt feature for console device when parsing minigraph.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
