### PR TITLE
[device/accton] As7816-64x, fix memory leakage on accton fan monitor.

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_monitor.py
@@ -54,6 +54,9 @@ class accton_as7816_monitor(object):
 
     def __init__(self, log_file, log_level):
         """Needs a logger and a logger level."""
+
+        self.thermal = ThermalUtil()
+        self.fan = FanUtil()
         # set up logging to file
         logging.basicConfig(
             filename=log_file,
@@ -83,8 +86,8 @@ class accton_as7816_monitor(object):
            4: [max_duty, 57000, sys.maxsize],
         }
   
-        thermal = ThermalUtil()
-        fan = FanUtil()
+        thermal = self.thermal
+        fan = self.fan
         for x in range(fan.get_idx_fan_start(), fan.get_num_fans()+1):
             fan_status = fan.get_fan_status(x)
             if fan_status is None:


### PR DESCRIPTION
Signed-off-by: roy_lee <roy_lee@edge-core.com>

**- Why I did it**
It's been reported that accton fan monitor process keeps consuming memory after few days.
The amount of memory occupied increases in linear and never leased.

**- How I did it**
Just move declaration of thermal and fan object outside the loop.

**- How to verify it**
Just put in on for more than 5 days, check if the memory of accton fan montor increases.
- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
Just move declaration of thermal and fan object outside the loop.
