### PR TITLE
[201911][Arista] Use thermalctld instead of fancontrol

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7050_qx32/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7050_qx32/thermal_policy.json
+++ b/device/arista/x86_64-arista_7050_qx32/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_7050_qx32s/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7050_qx32s/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7050_qx32s/thermal_policy.json
+++ b/device/arista/x86_64-arista_7050_qx32s/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_7050cx3_32s/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7050cx3_32s/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7050cx3_32s/thermal_policy.json
+++ b/device/arista/x86_64-arista_7050cx3_32s/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_7060_cx32s/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7060_cx32s/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7060_cx32s/thermal_policy.json
+++ b/device/arista/x86_64-arista_7060_cx32s/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_7060cx2_32s/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7060cx2_32s/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7060cx2_32s/thermal_policy.json
+++ b/device/arista/x86_64-arista_7060cx2_32s/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_7060px4_32/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7060px4_32/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7060px4_32/thermal_policy.json
+++ b/device/arista/x86_64-arista_7060px4_32/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_7170_32c/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7170_32c/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7170_32c/thermal_policy.json
+++ b/device/arista/x86_64-arista_7170_32c/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_7170_32cd/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7170_32cd/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7170_32cd/thermal_policy.json
+++ b/device/arista/x86_64-arista_7170_32cd/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_7170_64c/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7170_64c/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7170_64c/thermal_policy.json
+++ b/device/arista/x86_64-arista_7170_64c/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_7260cx3_64/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7260cx3_64/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7260cx3_64/thermal_policy.json
+++ b/device/arista/x86_64-arista_7260cx3_64/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_7280cr3_32p4/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7280cr3_32p4/pmon_daemon_control.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/pmon_daemon_control_skip_thermalctld.json
+../x86_64-arista_common/pmon_daemon_control.json

--- a/device/arista/x86_64-arista_7280cr3_32p4/thermal_policy.json
+++ b/device/arista/x86_64-arista_7280cr3_32p4/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/thermal_policy.json

--- a/device/arista/x86_64-arista_common/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_common/pmon_daemon_control.json
@@ -1,0 +1,4 @@
+{
+    "skip_fancontrol": true
+}
+

--- a/device/arista/x86_64-arista_common/thermal_policy.json
+++ b/device/arista/x86_64-arista_common/thermal_policy.json
@@ -1,0 +1,60 @@
+{   
+    "thermal_control_algorithm": {
+        "run_at_boot_up": "true",
+        "fan_speed_when_suspend": "100"
+    },
+    "info_types": [
+        {
+            "type": "control_info"
+        },
+        {
+            "type": "fan_info"
+        },
+        {
+            "type": "thermal_info"
+        }
+    ],
+    "policies": [
+        {
+            "name": "any thermal critical",
+            "conditions": [
+                {
+                    "type": "thermal.any.critical"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "fan.all.set_speed",
+                    "speed": "100"
+                }
+            ]
+        },
+        {
+            "name": "any thermal overheat",
+            "conditions": [
+                {
+                    "type": "thermal.any.overheat"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "fan.all.set_speed",
+                    "speed": "100"
+                }
+            ]
+        },
+        {
+            "name": "normal operations",
+            "conditions": [
+                {
+                    "type": "normal"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "thermal_control.control"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
There is a preference to use thermalctld instead of fancontrol for 201911 release branch. The Arista platform submodule updates and thermal policies in the platforms will allow Arista devices to use thermalctld instead of fancontrol.

**- How I did it**
I cherry-picked the necessary commits from master branch for sonic-platform-modules-arista into 201911 branch. I've also added the file to skip fancontrol and added the thermal policies json.

**- How to verify it**
On Gardena, Upperlake, Clearlake, and Lodoga thermalctld is up and running with no errors. Fans show ~29%.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
