### PR TITLE
[minigraph.py]: Remove prefix length from peer switch loopback address

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -66,8 +66,10 @@ def get_peer_switch_info(link_metadata, devices):
         if "PeerSwitch" in data:
             peer_hostname = data["PeerSwitch"]
             peer_lo_addr = devices[peer_hostname]["lo_addr"] 
+            peer_lo_addr = ipaddress.ip_network(UNICODE_TYPE(peer_lo_addr))
+
             peer_switch_table[peer_hostname] = {
-                'address_ipv4': peer_lo_addr
+                'address_ipv4': str(peer_lo_addr.network_address)
             }
 
     return peer_switch_table

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -268,7 +268,7 @@
     <Devices>
       <Device i:type="ToRRouter">
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
-          <d5p1:IPPrefix>26.1.1.10</d5p1:IPPrefix>
+          <d5p1:IPPrefix>26.1.1.10/32</d5p1:IPPrefix>
         </Address>
         <Hostname>switch-t0</Hostname>
         <HwSku>Force10-S6000</HwSku>
@@ -276,7 +276,7 @@
       </Device>
       <Device i:type="ToRRouter">
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
-          <d5p1:IPPrefix>25.1.1.10</d5p1:IPPrefix>
+          <d5p1:IPPrefix>25.1.1.10/32</d5p1:IPPrefix>
         </Address>
         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
           <a:IPPrefix>10.7.0.196/26</a:IPPrefix>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -146,7 +146,7 @@ class TestCfgGenCaseInsensitive(TestCase):
             },
             'switch2-t0': {
                 'hwsku': 'Force10-S6000',
-                'lo_addr': '25.1.1.10',
+                'lo_addr': '25.1.1.10/32',
                 'mgmt_addr': '10.7.0.196/26',
                 'type': 'ToRRouter'
             },


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
PEER_SWITCH table in config DB expects a standalone IP address w/o a prefix length
**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6006991/101709351-25206800-3a44-11eb-8677-8226fbe473ca.png)
