### PR TITLE
frr: Miscellaneous fixes in bgp and zebra

### DIFF
--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -10,6 +10,16 @@ STG_BRANCH = stg_temp.$(SUFFIX)
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Build the package
 	pushd ./frr
+	# delete previously created temporary branches, if any
+	git checkout master
+	git branch | grep stg_temp | xargs --no-run-if-empty git branch -D
+	if [ `git branch | grep $(FRR_BRANCH)` ]
+	then
+		echo "Branch named $(FRR_BRANCH) already exists"
+		git branch -D $(FRR_BRANCH)
+	else
+		echo "Branch named $(FRR_BRANCH) does not exist"
+	fi
 	git checkout -b $(FRR_BRANCH) origin/$(FRR_BRANCH)
 	stg branch --create $(STG_BRANCH) $(FRR_TAG)
 	stg import -s ../patch/series

--- a/src/sonic-frr/patch/0012-BGP-keepalive-timer-wasn-t-reset-in.patch
+++ b/src/sonic-frr/patch/0012-BGP-keepalive-timer-wasn-t-reset-in.patch
@@ -1,0 +1,32 @@
+From 2c8210f2b31c2e833df936ceb725d9d685c0d2be Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Fri, 8 Jan 2021 23:12:00 -0800
+Subject: [PATCH] BGP keepalive timer wasn't reset in case of duplicate 
+ connection. Identified the fix and found the similar FRR PR. Pulling 
+ following ones: 5429, 5368, and 5446.
+
+---
+ bgpd/bgp_packet.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/bgpd/bgp_packet.c b/bgpd/bgp_packet.c
+index f26c8a6a2..e5c15f547 100644
+--- a/bgpd/bgp_packet.c
++++ b/bgpd/bgp_packet.c
+@@ -506,6 +506,13 @@ void bgp_keepalive_send(struct peer *peer)
+ {
+ 	struct stream *s;
+ 
++	if (peer->fd < 0)
++	{
++		if (bgp_debug_keepalive(peer))
++			zlog_debug("%s: Null fd, failed to send KEEPALIVE", peer->host);
++		return;
++	}
++
+ 	s = stream_new(BGP_MAX_PACKET_SIZE);
+ 
+ 	/* Make keepalive packet. */
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/0014-Link-local-scope-was-not-set-while.patch
+++ b/src/sonic-frr/patch/0014-Link-local-scope-was-not-set-while.patch
@@ -1,0 +1,46 @@
+From f48d4860b5588df9222ed917447e336cfe899d9e Mon Sep 17 00:00:00 2001
+From: Syed Hasan Raza Naqvi <syed.naqvi@broadcom.com>
+Date: Wed, 8 Jan 2020 00:44:17 -0800
+Subject: [PATCH] Link local scope was not set while binding
+ socket with local address causing socket errors for bgp ipv6 link local
+ neighbors. 
+ The corresponding pull request is https://github.com/FRRouting/frr/pull/7434
+Change-Id: I6211f545e288164ff1576103f10be503555dfccd
+---
+ bgpd/bgp_network.c | 5 +++++
+ bgpd/bgp_zebra.c   | 3 +++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/bgpd/bgp_network.c b/bgpd/bgp_network.c
+index a4b91f698..4b7b8f2ab 100644
+--- a/bgpd/bgp_network.c
++++ b/bgpd/bgp_network.c
+@@ -579,6 +579,11 @@ static int bgp_update_address(struct interface *ifp, const union sockunion *dst,
+ 		return 1;
+ 
+ 	prefix2sockunion(sel, addr);
++
++	if (IN6_IS_ADDR_LINKLOCAL(&addr->sin6.sin6_addr)) {
++		addr->sin6.sin6_scope_id = ifp->ifindex;
++	}
++
+ 	return 0;
+ }
+ 
+diff --git a/bgpd/bgp_zebra.c b/bgpd/bgp_zebra.c
+index dcb9fa8c8..42226d2cc 100644
+--- a/bgpd/bgp_zebra.c
++++ b/bgpd/bgp_zebra.c
+@@ -802,6 +802,9 @@ bool bgp_zebra_nexthop_set(union sockunion *local, union sockunion *remote,
+ 								? peer->conf_if
+ 								: peer->ifname,
+ 							peer->bgp->vrf_id);
++			else if (peer->update_if)
++				ifp = if_lookup_by_name(peer->update_if,
++						peer->bgp->vrf_id);
+ 		} else if (peer->update_if)
+ 			ifp = if_lookup_by_name(peer->update_if,
+ 						peer->bgp->vrf_id);
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/0015-Holdtime-and-keepalive-parameters-w.patch
+++ b/src/sonic-frr/patch/0015-Holdtime-and-keepalive-parameters-w.patch
@@ -1,0 +1,30 @@
+From 82e00c4162ae70815f8b6c58a3574268720affb2 Mon Sep 17 00:00:00 2001
+From: Syed Hasan Raza Naqvi <syed.naqvi@broadcom.com>
+Date: Fri, 22 May 2020 17:12:40 -0700
+Subject: [PATCH]  Holdtime and keepalive parameters weren't
+ copied from peer-group to peer-group members.  Fixed the issue by copying
+ holdtime and keepalive parameters from peer-group to its members.
+ The corresponding pull request is https://github.com/FRRouting/frr/pull/7435.
+Change-Id: I50b91dde2b8cad2000ce97f1d11f1434c22b4055
+---
+ bgpd/bgpd.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bgpd/bgpd.c b/bgpd/bgpd.c
+index 3fb6c9f11..1b67522b1 100644
+--- a/bgpd/bgpd.c
++++ b/bgpd/bgpd.c
+@@ -4989,8 +4989,8 @@ int peer_timers_set(struct peer *peer, uint32_t keepalive, uint32_t holdtime)
+ 
+ 		/* Set flag and configuration on peer-group member. */
+ 		SET_FLAG(member->flags, PEER_FLAG_TIMER);
+-		PEER_ATTR_INHERIT(peer, peer->group, holdtime);
+-		PEER_ATTR_INHERIT(peer, peer->group, keepalive);
++		PEER_ATTR_INHERIT(member, peer->group, holdtime);
++		PEER_ATTR_INHERIT(member, peer->group, keepalive);
+ 	}
+ 
+ 	return 0;
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/0016-Aggregate-member-route-was-enqueued.patch
+++ b/src/sonic-frr/patch/0016-Aggregate-member-route-was-enqueued.patch
@@ -1,0 +1,52 @@
+From cedcd601b54f9f561c5bf289e0862215d9820464 Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Fri, 8 Jan 2021 23:30:34 -0800
+Subject: [PATCH] Aggregate member route was enqueued for  recalculation while 
+ bgp instance was deleted. As part of aggregate member  route deletion, the 
+ aggregate route is reinstalled with self-peer as source,  but self-peer is 
+ already removed. Assert() for null peer pointer is path  attribute aborts 
+ bgp.
+
+Fix :
+When bgp instance is in the state of deletion, or self-peer is null,
+avoid installation of aggregate-prefix as part of aggregate member
+delete.
+When all of the aggregate members are removed, the aggregate prefix is
+automatically removed from zebra.
+The pull request is https://github.com/FRRouting/frr/pull/7433/files
+---
+ bgpd/bgp_route.c | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/bgpd/bgp_route.c b/bgpd/bgp_route.c
+index 0e91b9955..056ea5848 100644
+--- a/bgpd/bgp_route.c
++++ b/bgpd/bgp_route.c
+@@ -6276,14 +6276,19 @@ static void bgp_aggregate_install(
+ 			bgp_aggregate_delete(bgp, p, afi, safi, aggregate);
+ 			return;
+ 		}
+-
+-		new = info_make(ZEBRA_ROUTE_BGP, BGP_ROUTE_AGGREGATE, 0,
++		/* Do not install the aggregate route if BGP is in the
++		* process of termination.
++		*/
++		if (bgp->peer_self &&
++			!CHECK_FLAG(bgp->flags, BGP_FLAG_DELETE_IN_PROGRESS)) {
++			new = info_make(ZEBRA_ROUTE_BGP, BGP_ROUTE_AGGREGATE, 0,
+ 				bgp->peer_self, attr, dest);
+ 
+-		SET_FLAG(new->flags, BGP_PATH_VALID);
++			SET_FLAG(new->flags, BGP_PATH_VALID);
++			bgp_path_info_add(dest, new);
++			bgp_process(bgp, dest, afi, safi);
++		}
+ 
+-		bgp_path_info_add(dest, new);
+-		bgp_process(bgp, dest, afi, safi);
+ 	} else {
+ 		for (pi = orig; pi; pi = pi->next)
+ 			if (pi->peer == bgp->peer_self
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/0018-When-user-is-config-connect-timer-i.patch
+++ b/src/sonic-frr/patch/0018-When-user-is-config-connect-timer-i.patch
@@ -1,0 +1,71 @@
+From 28c0e4c2aeaf92704f145a1b928086c7842be102 Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Sat, 9 Jan 2021 01:32:33 -0800
+Subject: [PATCH] When user is config connect timer, it doesn't reflect 
+ immediately. It reflect when next time neighbor is tried to reconnect.
+
+Fix: Code is change to update the connect timer immediately if BGP
+session is not in establish state.
+---
+ bgpd/bgpd.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/bgpd/bgpd.c b/bgpd/bgpd.c
+index 22962a65c..bb832464e 100644
+--- a/bgpd/bgpd.c
++++ b/bgpd/bgpd.c
+@@ -5119,6 +5119,12 @@ int peer_timers_connect_set(struct peer *peer, uint32_t connect)
+ 	peer->connect = connect;
+ 	peer->v_connect = connect;
+ 
++	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP) && (peer->status != Established) ) {
++		if (peer_active(peer))
++			BGP_EVENT_ADD(peer, BGP_Stop);
++		BGP_EVENT_ADD(peer, BGP_Start);
++	}
++
+ 	/* Skip peer-group mechanics for regular peers. */
+ 	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+ 		return 0;
+@@ -5136,6 +5142,12 @@ int peer_timers_connect_set(struct peer *peer, uint32_t connect)
+ 		SET_FLAG(member->flags, PEER_FLAG_TIMER_CONNECT);
+ 		member->connect = connect;
+ 		member->v_connect = connect;
++
++		if (member->status != Established) {
++			if (peer_active(member))
++				BGP_EVENT_ADD(member, BGP_Stop);
++			BGP_EVENT_ADD(member, BGP_Start);
++		}
+ 	}
+ 
+ 	return 0;
+@@ -5162,6 +5174,12 @@ int peer_timers_connect_unset(struct peer *peer)
+ 	else
+ 		peer->v_connect = peer->bgp->default_connect_retry;
+ 
++	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP) && (peer->status != Established) ) {
++		if (peer_active(peer))
++			BGP_EVENT_ADD(peer, BGP_Stop);
++		BGP_EVENT_ADD(peer, BGP_Start);
++	}
++
+ 	/* Skip peer-group mechanics for regular peers. */
+ 	if (!CHECK_FLAG(peer->sflags, PEER_STATUS_GROUP))
+ 		return 0;
+@@ -5179,6 +5197,12 @@ int peer_timers_connect_unset(struct peer *peer)
+ 		UNSET_FLAG(member->flags, PEER_FLAG_TIMER_CONNECT);
+ 		member->connect = 0;
+ 		member->v_connect = peer->bgp->default_connect_retry;
++
++		if (member->status != Established) {
++			if (peer_active(member))
++				BGP_EVENT_ADD(member, BGP_Stop);
++			BGP_EVENT_ADD(member, BGP_Start);
++		}
+ 	}
+ 
+ 	return 0;
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/0019-when-vrf-add-is-received-add-Vrf-na.patch
+++ b/src/sonic-frr/patch/0019-when-vrf-add-is-received-add-Vrf-na.patch
@@ -1,0 +1,46 @@
+From 743d562892a6d57b932b3d89c1a416a3827dd20a Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Sat, 9 Jan 2021 01:41:40 -0800
+Subject: [PATCH] when vrf add is received, add Vrf-name to the interface 
+ database. This is needed while binding the VRF interface to the BGP socket
+ https://github.com/FRRouting/frr/pull/7432
+
+---
+ bgpd/bgp_main.c | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/bgpd/bgp_main.c b/bgpd/bgp_main.c
+index fa67cfd56..d8d3867e7 100644
+--- a/bgpd/bgp_main.c
++++ b/bgpd/bgp_main.c
+@@ -261,16 +261,23 @@ static __attribute__((__noreturn__)) void bgp_exit(int status)
+ static int bgp_vrf_new(struct vrf *vrf)
+ {
+ 	if (BGP_DEBUG(zebra, ZEBRA))
+-		zlog_debug("VRF Created: %s(%u)", vrf->name, vrf->vrf_id);
+-
+-	return 0;
++		zlog_info("VRF Creation message received: %s(%u)", vrf->name, vrf->vrf_id);
++        struct interface *ifp;
++        ifp = if_get_by_name(vrf->name, vrf->vrf_id);
++        if (ifp)
++        {
++		if (BGP_DEBUG(zebra, ZEBRA))
++			zlog_info("VRF interface Created: %s(%u) ifindex %d", ifp->name, ifp->vrf_id, ifp->ifindex);
++        }
++        return 0;
+ }
+ 
+ static int bgp_vrf_delete(struct vrf *vrf)
+ {
+ 	if (BGP_DEBUG(zebra, ZEBRA))
+ 		zlog_debug("VRF Deletion: %s(%u)", vrf->name, vrf->vrf_id);
+-
++        /* No need to delete vrf here as it will be deleted when BGP client receives
++           ZEBRA_VRF_DELETE message from zebra */
+ 	return 0;
+ }
+ 
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/0032-Remove-the-assert-since-in-the-case.patch
+++ b/src/sonic-frr/patch/0032-Remove-the-assert-since-in-the-case.patch
@@ -1,0 +1,36 @@
+From bacdacefe8ceffeb656d8ac17a64e9d4dd46819f Mon Sep 17 00:00:00 2001
+From: Kishore Kunal <kishore.kunal@broadcom.com>
+Date: Mon, 27 Jan 2020 14:19:42 -0800
+Subject: [PATCH] [JIRA SONIC-16617] Remove the assert since in the case where
+ l3vni was in the oper down state, it is possoble that the function return len
+ as zero. Asserts are already present in the called function, so no need to
+ have assert here. So removing the assert at this location.
+
+Change-Id: Ic119c21223b7a372528e49cf1d26e0f3c69aabbc
+---
+ zebra/zebra_fpm.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/zebra/zebra_fpm.c b/zebra/zebra_fpm.c
+index 4c27e1344..0ae88204c 100644
+--- a/zebra/zebra_fpm.c
++++ b/zebra/zebra_fpm.c
+@@ -996,8 +996,13 @@ static int zfpm_build_route_updates(void)
+ 		if (write_msg) {
+ 			data_len = zfpm_encode_route(dest, re, (char *)data,
+ 						     buf_end - data, &msg_type);
+-
+-			assert(data_len);
++			/*
++			 * It is possible that zfpm_encode_route return zero, when route is not required to be
++			 * send to the FPM, like in case of l3vni, if oper status for the l3vni is not up, route
++			 * should not be send to FPM. If there are issue with encoding assert is already present
++			 * in the function netlink_route_info_encode.
++			 */
++			//assert(data_len);
+ 			if (data_len) {
+ 				hdr->msg_type = msg_type;
+ 				msg_len = fpm_data_len_to_msg_len(data_len);
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/0033-While-putting-the-route-for-route-s.patch
+++ b/src/sonic-frr/patch/0033-While-putting-the-route-for-route-s.patch
@@ -1,0 +1,48 @@
+From 89e6a0d31668044419489a378f725cb8452169fc Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Sat, 9 Jan 2021 04:56:24 -0800
+Subject: [PATCH]  While putting the route for route  selection, it is checking
+ for flag in destination. Which looks like didn't  got cleaned correctly,
+ resetting the flag so that next time route calculation  can be triggered in
+ the Zebra.
+
+---
+ zebra/rib.h       | 1 +
+ zebra/zebra_vrf.c | 2 ++
+ 2 files changed, 3 insertions(+)
+
+diff --git a/zebra/rib.h b/zebra/rib.h
+index 38f802979..f70c0901f 100644
+--- a/zebra/rib.h
++++ b/zebra/rib.h
+@@ -174,6 +174,7 @@ struct route_entry {
+  *              don't generate routes
+  */
+ #define MQ_SIZE 7
++#define RESET_FROM_ALL_MQ 0x3f
+ struct meta_queue {
+ 	struct list *subq[MQ_SIZE];
+ 	uint32_t size; /* sum of lengths of all subqueues */
+diff --git a/zebra/zebra_vrf.c b/zebra/zebra_vrf.c
+index be4fb29aa..3f95e449e 100644
+--- a/zebra/zebra_vrf.c
++++ b/zebra/zebra_vrf.c
+@@ -223,6 +223,7 @@ static int zebra_vrf_disable(struct vrf *vrf)
+ 				       rnode)) {
+ 			dest = rib_dest_from_rnode(rnode);
+ 			if (dest && rib_dest_vrf(dest) == zvrf) {
++				UNSET_FLAG(dest->flags, RESET_FROM_ALL_MQ);
+ 				route_unlock_node(rnode);
+ 				list_delete_node(zrouter.mq->subq[i], lnode);
+ 				zrouter.mq->size--;
+@@ -274,6 +275,7 @@ static int zebra_vrf_delete(struct vrf *vrf)
+ 				       rnode)) {
+ 			dest = rib_dest_from_rnode(rnode);
+ 			if (dest && rib_dest_vrf(dest) == zvrf) {
++				UNSET_FLAG(dest->flags, RESET_FROM_ALL_MQ);
+ 				route_unlock_node(rnode);
+ 				list_delete_node(zrouter.mq->subq[i], lnode);
+ 				zrouter.mq->size--;
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/0034-zebra-vrf-delete-issue.patch
+++ b/src/sonic-frr/patch/0034-zebra-vrf-delete-issue.patch
@@ -1,0 +1,88 @@
+From dce7fb46e91850bd2742b1a788f336a2713e7106 Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Sat, 9 Jan 2021 05:07:40 -0800
+Subject: [PATCH] Unable to  access the vtysh and all FRR CLIs are timing OUT
+ after config reload two  times
+
+Due to zebra starting during/prior to configuration being replayed,
+there is huge churn of stale vrf delete followed by new vrf add. This
+can cause timing race condition where vrf delete could be missed and
+further same vrf add would get rejected instead of treating last arrived
+vrf add as update.
+
+Treat vrf add for existing vrf as update.
+Implicitly disable this VRF to cleanup routes and other functions as part of vrf disable.
+Update vrf_id for the vrf and update vrf_id tree.
+Re-enable VRF so that all routes are freshly installed.
+
+Above 3 steps are mandatory since it can happen that with config reload
+stale routes which are installed in vrf-1 table might contain routes from
+older vrf-0 table which might have got deleted due to missing vrf-0 in new configuration.
+FRR community pull request: https://github.com/FRRouting/frr/pull/7508
+---
+ zebra/if_netlink.c | 48 +++++++++++++++++++++++++++++-------------------
+ 1 file changed, 29 insertions(+), 19 deletions(-)
+
+diff --git a/zebra/if_netlink.c b/zebra/if_netlink.c
+index 90a08bbd6..c910056fe 100644
+--- a/zebra/if_netlink.c
++++ b/zebra/if_netlink.c
+@@ -335,26 +335,36 @@ static void netlink_vrf_change(struct nlmsghdr *h, struct rtattr *tb,
+ 			zlog_debug("RTM_NEWLINK for VRF %s(%u) table %u", name,
+ 				   ifi->ifi_index, nl_table_id);
+ 
+-		if (!vrf_lookup_by_id((vrf_id_t)ifi->ifi_index)) {
+-			vrf_id_t exist_id;
++                /*Treat VRF add for existing vrf as update
++                 * Update VRF ID and also update in VRF ID table
++                 */
++                if (name)
++                        vrf = vrf_lookup_by_name(name);
++                if (vrf && (vrf_id_t)ifi->ifi_index != VRF_UNKNOWN
++                                && vrf->vrf_id != VRF_UNKNOWN
++                                && vrf->vrf_id != (vrf_id_t)ifi->ifi_index) {
++                        zlog_info("Vrf Update event: %s old id: %u table:%u new id: %u table: %u",
++                                        name, vrf->vrf_id, ((struct zebra_vrf*)vrf->info)->table_id,
++                                        (vrf_id_t)ifi->ifi_index, nl_table_id);
++
++                        /*Disable the vrf to simulate implicit delete
++                         * so that all stale routes are deleted
++                         * This vrf will be enabled down the line*/
++                        vrf_disable(vrf);
++
++
++                        RB_REMOVE(vrf_id_head, &vrfs_by_id, vrf);
++                        vrf->vrf_id = (vrf_id_t)ifi->ifi_index;
++                        RB_INSERT(vrf_id_head, &vrfs_by_id, vrf);
++
++                } else {
++                        /*
++                         * vrf_get is implied creation if it does not exist
++                         */
++                        vrf = vrf_get((vrf_id_t)ifi->ifi_index,
++                                        name); // It would create vrf
++                }
+ 
+-			exist_id = vrf_lookup_by_table(nl_table_id, ns_id);
+-			if (exist_id != VRF_DEFAULT) {
+-				vrf = vrf_lookup_by_id(exist_id);
+-
+-				flog_err(
+-					EC_ZEBRA_VRF_MISCONFIGURED,
+-					"VRF %s id %u table id overlaps existing vrf %s, misconfiguration exiting",
+-					name, ifi->ifi_index, vrf->name);
+-				exit(-1);
+-			}
+-		}
+-
+-		/*
+-		 * vrf_get is implied creation if it does not exist
+-		 */
+-		vrf = vrf_get((vrf_id_t)ifi->ifi_index,
+-			      name); // It would create vrf
+ 		if (!vrf) {
+ 			flog_err(EC_LIB_INTERFACE, "VRF %s id %u not created",
+ 				 name, ifi->ifi_index);
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/0036-Updated-the-comparison-functions-appropriately.patch
+++ b/src/sonic-frr/patch/0036-Updated-the-comparison-functions-appropriately.patch
@@ -1,0 +1,28 @@
+From c1b47255413f7d36dafba06197373fdf95dfca7a Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Sat, 9 Jan 2021 05:17:10 -0800
+Subject: [PATCH] any configuration for next-hop-self change will not take 
+ effect if this flag is not reset
+
+---
+ bgpd/bgp_route.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/bgpd/bgp_route.c b/bgpd/bgp_route.c
+index 056ea5848..6d58d13a2 100644
+--- a/bgpd/bgp_route.c
++++ b/bgpd/bgp_route.c
+@@ -1858,6 +1858,10 @@ bool subgroup_announce_check(struct bgp_dest *dest, struct bgp_path_info *pi,
+ 	/* For modify attribute, copy it to temporary structure. */
+ 	*attr = *piattr;
+ 
++	/* Remove rmap flags that got copied from inbound rmap. Otherwise inbound
++	* next-hop filters impact outbound next-hop */
++	RESET_FLAG(attr->rmap_change_flags);
++
+ 	/* If local-preference is not set. */
+ 	if ((peer->sort == BGP_PEER_IBGP || peer->sort == BGP_PEER_CONFED)
+ 	    && (!(attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LOCAL_PREF)))) {
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/0037-added-a-new-line-for-showing-established-neighbors-c.patch
+++ b/src/sonic-frr/patch/0037-added-a-new-line-for-showing-established-neighbors-c.patch
@@ -1,0 +1,44 @@
+From b22ef450f81894eb97bee10264bb2fc58406bff7 Mon Sep 17 00:00:00 2001
+From: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>
+Date: Sat, 9 Jan 2021 05:22:50 -0800
+Subject: [PATCH] added a new line for showing established neighbors count
+
+---
+ bgpd/bgp_vty.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/bgpd/bgp_vty.c b/bgpd/bgp_vty.c
+index 42bb98694..8593fb190 100644
+--- a/bgpd/bgp_vty.c
++++ b/bgpd/bgp_vty.c
+@@ -9192,7 +9192,7 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
+ {
+ 	struct peer *peer;
+ 	struct listnode *node, *nnode;
+-	unsigned int count = 0, dn_count = 0;
++	unsigned int count = 0, dn_count = 0, up_count = 0;
+ 	char timebuf[BGP_UPTIME_LEN], dn_flag[2];
+ 	char neighbor_buf[VTY_BUFSIZ];
+ 	int neighbor_col_default_width = 16;
+@@ -9508,6 +9508,8 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
+ 		filter = &peer->filter[afi][safi];
+ 
+ 		count++;
++		if (peer->status == Established)
++			up_count++;
+ 		/* Works for both failed & successful cases */
+ 		if (peer_dynamic_neighbor(peer))
+ 			dn_count++;
+@@ -9738,6 +9740,9 @@ static int bgp_show_summary(struct vty *vty, struct bgp *bgp, int afi, int safi,
+ 			vty_out(vty, "%d dynamic neighbor(s), limit %d\n",
+ 				dn_count, bgp->dynamic_neighbors_limit);
+ 		}
++
++		if (count)
++			vty_out(vty, "Total number of neighbors established %d\n", up_count);
+ 	}
+ 
+ 	return CMD_SUCCESS;
+-- 
+2.12.2
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -4,4 +4,15 @@
 0004-Allow-BGP-attr-NEXT_HOP-to-be-0.0.0.0-due-to-allevia.patch
 0005-nexthops-compare-vrf-only-if-ip-type.patch
 0007-frr-remove-frr-log-outchannel-to-var-log-frr.log.patch
+0012-BGP-keepalive-timer-wasn-t-reset-in.patch
+0014-Link-local-scope-was-not-set-while.patch
+0015-Holdtime-and-keepalive-parameters-w.patch
+0016-Aggregate-member-route-was-enqueued.patch
+0018-When-user-is-config-connect-timer-i.patch
+0019-when-vrf-add-is-received-add-Vrf-na.patch
+0032-Remove-the-assert-since-in-the-case.patch
+0033-While-putting-the-route-for-route-s.patch
+0034-zebra-vrf-delete-issue.patch
+0036-Updated-the-comparison-functions-appropriately.patch
+0037-added-a-new-line-for-showing-established-neighbors-c.patch
 


### PR DESCRIPTION
Signed-off-by: sudhanshukumar22 <sudhanshu.kumar@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
This contains the patches for the various fixes done in FRR bgp and zebra code. This also contains some patches which are already present in FRR community, but not yet present in sonic community. The fixes have been tested in Broadcom hardware.
Each patch has a commit description which describes the changes done for it. 
**- How I did it**
The fixes have been done during BGP protocol testing.
Change description:
1. src/sonic-frr/Makefile
this contains changes to remove temporary branches with name stg_temp and $(FRR_BRANCH). This ensures that if any earlier failed run leads to existence of these branches, they will be deleted so that new run can proceed fine.



2. src/sonic-frr/patch/0012-BGP-keepalive-timer-wasn-t-reset-in.patch
BGP keepalive timer wasn't reset in case of duplicate  connection. Identified the fix and found the similar FRR PR. This pulls the 
 following fixes from FRR community 5429, 5368, and 5446.

3. src/sonic-frr/patch/0013-Double-free-of-transitive-path-attribut-was-causing-.patch
Double free of transitive path attribut was causing the crash. This pulls fix 5436 from FRR community.

4. src/sonic-frr/patch/0014-Link-local-scope-was-not-set-while.patch 
Link local scope was not set while binding socket with local address causing socket errors for bgp ipv6 link local
 neighbors. 
 The corresponding pull request in FRR community is https://github.com/FRRouting/frr/pull/7434

5. src/sonic-frr/patch/0015-Holdtime-and-keepalive-parameters-w.patch
Holdtime and keepalive parameters weren't copied from peer-group to peer-group members.  Fixed the issue by copying
 holdtime and keepalive parameters from peer-group to its members.
 The corresponding pull request is https://github.com/FRRouting/frr/pull/7435

6. src/sonic-frr/patch/0016-Aggregate-member-route-was-enqueued.patch 
Aggregate member route was enqueued for
 recalculation while bgp instance was deleted. As part of aggregate member
 route deletion, the aggregate route is reinstalled with self-peer as source,
 but self-peer is already removed. Assert() for null peer pointer is path
 attribute aborts bgp.
Fix :
When bgp instance is in the state of deletion, or self-peer is null,
avoid installation of aggregate-prefix as part of aggregate member
delete.
When all of the aggregate members are removed, the aggregate prefix is
automatically removed from zebra.
The pull request is https://github.com/FRRouting/frr/pull/7433/files


7. src/sonic-frr/patch/0018-When-user-is-config-connect-timer-i.patch
When user is config connect timer, it doesn't reflect
 immediately. It reflect when next time neighbor is tried to reconnect.

Fix: Code is change to update the connect timer immediately if BGP
session is not in establish state. The corresponding pull request in FRR community is
https://github.com/FRRouting/frr/pull/7449

8. src/sonic-frr/patch/0019-when-vrf-add-is-received-add-Vrf-na.patch 
when vrf add is received, add Vrf-name to the interface
 database. This is needed while binding the VRF interface to the BGP socket. This defect was found when password setting on the BGP socket was not honored after reboot. In this case, there were 2 BGP sockets, one on default VRF and another on user VRF. Password was configured on socket with default VRF (not on BGP socket with user VRF) and system was rebooted. After reboot, the BGP socket on user VRF came up, but was not binded to user-VRF since the BGP socket came up before receiving new VRF create message from Zebra. Hence, there were 2 sockets on default VRF, one with password and another without password. BGP neighborship was established on default VRF using the 2nd socket even though it should not form because of password setting. The corresponding pull request is 
https://github.com/FRRouting/frr/pull/7432





9. src/sonic-frr/patch/0032-Remove-the-assert-since-in-the-case.patch 
Remove the assert since in the case where
 l3vni was in the oper down state, it is possoble that the function return len
 as zero. Asserts are already present in the called function, so no need to
 have assert here. So removing the assert at this location.

10. src/sonic-frr/patch/0033-While-putting-the-route-for-route-s.patch
While putting the route for route
 selection, it is checking for flag in destination. Which looks like didn't
 got cleaned correctly, resetting the flag so that next time route calculation
 can be triggered in the Zebra.

11. src/sonic-frr/patch/0034-zebra-vrf-delete-issue.patch
Unable to access the vtysh and all FRR CLIs are timing OUT after config reload two
 times.
Due to zebra starting during/prior to configuration being replayed,
there is huge churn of stale vrf delete followed by new vrf add. This
can cause timing race condition where vrf delete could be missed and
further same vrf add would get rejected instead of treating last arrived
vrf add as update.

Treat vrf add for existing vrf as update.
Implicitly disable this VRF to cleanup routes and other functions as part of vrf disable.
Update vrf_id for the vrf and update vrf_id tree.
Re-enable VRF so that all routes are freshly installed.

Above 3 steps are mandatory since it can happen that with config reload
stale routes which are installed in vrf-1 table might contain routes from
older vrf-0 table which might have got deleted due to missing vrf-0 in new configuration.
FRR community pull request: https://github.com/FRRouting/frr/pull/7508


12. src/sonic-frr/patch/0036-Updated-the-comparison-functions-appropriately.patch 
any configuration for next-hop-self change will not take
 effect if this flag is not reset     at bgpd/bgp_route.c:1936

13. src/sonic-frr/patch/0037-added-a-new-line-for-showing-established-neighbors-c.patch 
added a new line for showing established neighbors count
This enhances the show bgp summary command to display the established neighbors count.

**- How to verify it**
We can verify it using BGP protocol testing.
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
