### PR TITLE
[DPB] update flex counter yang model, fix BUFFER_POOL_WATERMARK

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
@@ -850,7 +850,7 @@
                 "PORT_BUFFER_DROP": {
                     "FLEX_COUNTER_STATUS": "enable"
                 },
-                "BUFFER_POOL_WATERMARK_KEY": {
+                "BUFFER_POOL_WATERMARK": {
                     "FLEX_COUNTER_STATUS": "enable"
                 },
                 "QUEUE": {
@@ -1689,7 +1689,7 @@
             "PORT_BUFFER_DROP": {
                 "FLEX_COUNTER_STATUS": "enable"
             },
-            "BUFFER_POOL_WATERMARK_KEY": {
+            "BUFFER_POOL_WATERMARK": {
                 "FLEX_COUNTER_STATUS": "enable"
             },
             "QUEUE": {

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -27,7 +27,7 @@ module sonic-flex_counter {
 
             /* below are in alphabetical order */
 
-            container BUFFER_POOL_WATERMARK_KEY {
+            container BUFFER_POOL_WATERMARK {
                 /* BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
DPB fall with log errors:
```
Dec 10 16:30:38.260263 sonic ERR ConfigMgmt: Data Loading Failed#012All Keys are not parsed in FLEX_COUNTER_TABLE#012dict_keys(['BUFFER_POOL_WATERMARK'])
Dec 10 16:30:38.260560 sonic ERR ConfigMgmt: ConfigMgmt Class creation failed
```

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
