### PR TITLE
ntp-systemd-wrapper file is getting overwritten

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -290,6 +290,7 @@ sudo cp $IMAGE_CONFIGS/ntp/ntp-config.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_S
 echo "ntp-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo cp $IMAGE_CONFIGS/ntp/ntp-config.sh $FILESYSTEM_ROOT/usr/bin/
 sudo cp $IMAGE_CONFIGS/ntp/ntp.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
+sudo cp $IMAGE_CONFIGS/ntp/ntp-systemd-wrapper $FILESYSTEM_ROOT/usr/lib/ntp/
 
 # Copy warmboot-finalizer files
 sudo LANG=C cp $IMAGE_CONFIGS/warmboot-finalizer/finalize-warmboot.sh $FILESYSTEM_ROOT/usr/local/bin/finalize-warmboot.sh


### PR DESCRIPTION
Signed-off-by: Prabhu Sreenivasan <prabhu.sreenivasan@broadcom.com>


**- Why I did it**
ntp-systemd-wrapper file from files/image_config/ntp was not getting picked up.

**- How I did it**
Added a line on sonic_debian_extension.j2 to copy over the file from files/image_config/ntp after installing the debian package.

**- How to verify it**
cross check the file after loading a fresh image.


