### PR TITLE
kdump: Add default kdump command line arguments

### DIFF
--- a/files/image_config/kdump/kdump-tools
+++ b/files/image_config/kdump/kdump-tools
@@ -1,3 +1,6 @@
+# Default configuration
+KDUMP_CMDLINE_APPEND="irqpoll nr_cpus=1 nousb systemd.unit=kdump-tools.service ata_piix.prefer_ms_hyperv=0"
+
 # ---------------------------------------------------------------------------
 # Additional Kdump environment settings used in SONiC
 #


### PR DESCRIPTION
The default /etc/default/kdump-tools file provided by the kdump-tools
package doesn't set a value for KDUMP_CMDLINE_APPEND.

The default kdump command line arguments need to be set in order
to extend them to use additional arguments required for SONiC
platforms.

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

Fixes https://github.com/Azure/sonic-buildimage/pull/6113

**- Why I did it**
kdump-tools.service is not starting as the kdump specific command line arguments are not passed to the crash kernel

**- How I did it**
Specify the default KDUMP_CMDLINE_APPEND value as part of SONiC specific kdump configuration file.

**- How to verify it**
config kdump enable
reboot
echo c > /proc/sysrq-trigger
show kdump files
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
kdump: Add default kdump command line arguments

**- A picture of a cute animal (not mandatory but encouraged)**
