### PR TITLE
Install 'wheel' package in sonic-slave-buster

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -346,7 +346,9 @@ RUN apt-get purge -y python-pip python3-pip
 
 # For building Python packages
 RUN pip2 install setuptools==40.8.0
+RUN pip2 install wheel==0.35.1
 RUN pip3 install setuptools==49.6.00
+RUN pip3 install wheel==0.35.1
 
 # For building sonic-utilities
 RUN pip2 install fastentrypoints


### PR DESCRIPTION
**- Why I did it**

Install the 'wheel' package in sonic-slave-buster container to eliminate error messages like the following:

```
  Running setup.py bdist_wheel for watchdog: started
  Running setup.py bdist_wheel for watchdog: finished with status 'error'
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-Qd3K08/watchdog/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-0AHpMe --python-tag cp27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for watchdog

```

These error messages appear to have no impact on the image build, because the Python package seems to still get installed successfully afterward, just the building of a wheel package fails. Therefore, this is more of a cosmetic fix than an actual bug.

**- How I did it**

Modify the sonic-slave-buster Dockerfile template; install the 'wheel' package.

**- How to verify it**
Check the image build logs and ensure that no `error: invalid command 'bdist_wheel'` messages appear in it.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
