### PR TITLE
[minigraph.py]: Prefer parsing device type from <ElementType> 

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -83,8 +83,6 @@ def parse_device(device):
     hwsku = None
     name = None
     deployment_id = None
-    if str(QName(ns3, "type")) in device.attrib:
-        d_type = device.attrib[str(QName(ns3, "type"))]
 
     for node in device:
         if node.tag == str(QName(ns, "Address")):
@@ -99,6 +97,12 @@ def parse_device(device):
             hwsku = node.text
         elif node.tag == str(QName(ns, "DeploymentId")):
             deployment_id = node.text
+        elif node.tag == str(QName(ns, "ElementType")):
+            d_type = node.text
+
+    if d_type is None and str(QName(ns3, "type")) in device.attrib:
+        d_type = device.attrib[str(QName(ns3, "type"))]
+
     return (lo_prefix, lo_prefix_v6, mgmt_prefix, name, hwsku, d_type, deployment_id)
 
 def parse_png(png, hname):

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -266,7 +266,8 @@
       </DeviceLinkBase>
     </DeviceInterfaceLinks>
     <Devices>
-      <Device i:type="ToRRouter">
+      <Device i:type="i:ToRRouter">
+        <ElementType>ToRRouter</ElementType>
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>26.1.1.10/32</d5p1:IPPrefix>
         </Address>

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -266,7 +266,7 @@
       </DeviceLinkBase>
     </DeviceInterfaceLinks>
     <Devices>
-      <Device i:type="i:ToRRouter">
+      <Device xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution" i:type="a:ToRRouter">
         <ElementType>ToRRouter</ElementType>
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>26.1.1.10/32</d5p1:IPPrefix>


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
In some minigraph deployments, the `type` attribute in the `<Device>` tag (`<PngDec> -> <Devices>`) sometimes includes the XML namespace (e.g. instead of "BackEndLeafRouter" the value is "a:BackEndLeafRouter").

**- How I did it**
When parsing devices, prefer the `<ElementType>` tag usually found inside of `<Device>`, and use the `type` attribute as a fallback in case it is not found.

**- How to verify it**
Run the sonic-config-engine tests

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6006991/101841264-7428d480-3afa-11eb-8f0e-c6d8f1e6dcf4.png)
