### PR TITLE
[sonic-config-engine] Adding dependent pkgs needed for arm compilation

### DIFF
--- a/dockers/docker-config-engine-buster/Dockerfile.j2
+++ b/dockers/docker-config-engine-buster/Dockerfile.j2
@@ -12,6 +12,10 @@ RUN apt-get update         && \
         python-dev            \
         python3-dev           \
         apt-utils             \
+{%- if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
+        libxslt-dev           \
+        libz-dev              \
+{%- endif %}
         python-setuptools     \
         python3-setuptools
 

--- a/dockers/docker-config-engine-stretch/Dockerfile.j2
+++ b/dockers/docker-config-engine-stretch/Dockerfile.j2
@@ -10,6 +10,10 @@ RUN apt-get update         && \
         build-essential       \
         python-pip            \
         python-dev            \
+{%- if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
+        libxslt-dev           \
+        libz-dev              \
+{%- endif %}
         python-setuptools
 
 RUN pip install --upgrade pip

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -149,6 +149,11 @@ sudo cp {{sonic_py_common_py3_wheel_path}} $FILESYSTEM_ROOT/$SONIC_PY_COMMON_PY3
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install $SONIC_PY_COMMON_PY3_WHEEL_NAME
 sudo rm -rf $FILESYSTEM_ROOT/$SONIC_PY_COMMON_PY3_WHEEL_NAME
 
+# Install dependency pkgs for SONiC config engine Python 2 package
+if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
+    sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install libxslt-dev libz-dev
+fi
+
 # Install SONiC config engine Python 2 package
 CONFIG_ENGINE_PY2_WHEEL_NAME=$(basename {{config_engine_py2_wheel_path}})
 sudo cp {{config_engine_py2_wheel_path}} $FILESYSTEM_ROOT/$CONFIG_ENGINE_PY2_WHEEL_NAME

--- a/rules/ntp.mk
+++ b/rules/ntp.mk
@@ -3,7 +3,7 @@
 NTP_VERSION = 4.2.8p12+dfsg
 export NTP_VERSION
 
-NTP = ntp_$(NTP_VERSION)-4+deb10u2_amd64.deb
+NTP = ntp_$(NTP_VERSION)-4+deb10u2_$(CONFIGURED_ARCH).deb
 $(NTP)_SRC_PATH = $(SRC_PATH)/ntp
 SONIC_MAKE_DEBS += $(NTP)
 SONIC_STRETCH_DEBS += $(NTP)

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -248,6 +248,9 @@ RUN apt-get update && apt-get install -y \
         python3-sphinx \
 # For sonic config engine testing
         python-dev \
+{%- if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
+        libxslt-dev \
+{%- endif %}
 # For lockfile
         procmail \
 # For gtest

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -244,6 +244,9 @@ RUN apt-get update && apt-get install -y \
         python3-sphinx \
 # For sonic config engine testing
         python-dev \
+{%- if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
+        libxslt-dev \
+{%- endif %}
 # For lockfile
         procmail \
 # For pam_tacplus build


### PR DESCRIPTION
Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
libxslt-dev and libz-dev are dependencies for lxml==4.6.1 which is required for pyangbind==0.8.1
**- How I did it**

**- How to verify it**
verified in armhf and arm64 archs
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
