### PR TITLE
[as4630-54pe] Fix issue for management port eth2 change to eth0

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/service/as4630-54pe-platform-handle-mgmt-interface.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/service/as4630-54pe-platform-handle-mgmt-interface.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Accton AS4630-54PE Platform handle management interface service
+After=sysinit.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/handle_mgmt_interface.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/handle_mgmt_interface.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/handle_mgmt_interface.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#Due to the hardware design, as4630-54pe use "eth2" instead of "eth0" as management interface.
+#Rename netdev "eth0" and "eth2" to swap original "eth2" to "eth0".
+ifconfig eth0 down
+ip link set eth0 name eth3
+ip link set eth2 name eth0
+ifconfig eth0 up


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
A model names: as4630-54pe is exited.
Our management port is using eth2, but now need to change to using eth0.
**- How I did it**
I add a service in the platform, and when bootup the system, this service will call a shell script to let eth2 to eth0.
**- How to verify it**
After the modify, I set eth0 new ipaddress in my local side:
using "ifconfig eth0 192.168.1.12"
and ping 192.168.1.37 is success。

Test log:
root@sonic:~# ifconfig eth0 192.168.1.12
root@sonic:~#
root@sonic:~# ping 192.168.1.37
PING 192.168.1.37 (192.168.1.37) 56(84) bytes of data.
64 bytes from 192.168.1.37: icmp_seq=1 ttl=128 time=2.52 ms
64 bytes from 192.168.1.37: icmp_seq=2 ttl=128 time=1.49 ms
64 bytes from 192.168.1.37: icmp_seq=3 ttl=128 time=1.92 ms
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add to two file:
sonic-buildimage/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/service/as4630-54pe-platform-handle-mgmt-interface.service
sonic-buildimage/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/handle_mgmt_interface.sh

**- A picture of a cute animal (not mandatory but encouraged)**
