### PR TITLE
[build_templates]: Start SNMP timer after SWSS service

### DIFF
--- a/files/build_templates/snmp.timer
+++ b/files/build_templates/snmp.timer
@@ -1,6 +1,7 @@
 [Unit]
 Description=Delays snmp container until SONiC has started
 Conflicts=snmp.service
+After=swss.service
 
 [Timer]
 OnUnitActiveSec=0 sec


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

Fixes #5663 

**- Why I did it**
It's currently possible for the SNMP timer to conflict with `config reload` (specifically if the timer triggers while `config reload` is stopping the SWSS service). `config reload` triggers SWSS to shutdown, which causes SNMP to shutdown, which conflicts with the SNMP timer causing SNMP to startup. See the linked issue for more details.

**- How I did it**
Including the `After` ordering dependency forces the SNMP timer to wait until SWSS finishes stopping, preventing the conflict. If there is an ordering dependency between two units (e.g. one unit is ordered `After` another), if one unit is shutting down while the other is starting up, the shutdown will always be ordered before the startup. In this case, that means that the SNMP timer is forced to wait for the SWSS shutdown to complete. Only then can the SNMP timer proceed. See [here](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Before=) for more details.

It's important to note that the `After` dependency will not cause SWSS to be started when the SNMP timer fires (assuming that SWSS has not yet been started). The existing `Requisite` dependency in the SNMP service will also not cause SWSS to be started, instead it will cause the SNMP service to fail if SWSS is not active.

**- How to verify it**
Execute a `config reload`. In another terminal connected to the same device, execute `systemctl start snmp.time` as soon as the `config reload` prints "Executing stop of service swss...". The `config reload` should continue as normal.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
