### PR TITLE
[201811][syncd] Fix directory mount for vs syncd docker

### DIFF
--- a/platform/vs/docker-syncd-vs.mk
+++ b/platform/vs/docker-syncd-vs.mk
@@ -11,6 +11,4 @@ $(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(SYNCD_VS_DBG) \
 									$(LIBSAIREDIS_DBG) \
 									$(LIBSAIVS_DBG)
 
-SONIC_INSTALL_DOCKER_IMAGES += $(DOCKER_SYNCD_VS)
-
-$(DOCKER_SYNCD_VS)_RUN_OPT += -v /host/warmboot:/var/warmboot
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/warmboot:/var/warmboot


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Since `DOCKER_SYNCD_VS` is no longer being used, the mount option does not properly mount the warmboot file directory. Fix the mount option so that the directory is properly mounted.

**- How I did it**
Use `DOCKER_SYNCD_BASE` instead of `DOCKER_SYNCD_VS`

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
