### PR TITLE
[201811][warm-reboot] Remove warmboot file path that overrides the default path

### DIFF
--- a/src/sonic-device-data/src/sai.vs_profile
+++ b/src/sonic-device-data/src/sai.vs_profile
@@ -1,5 +1,3 @@
-SAI_WARM_BOOT_READ_FILE=/var/cache/sai_warmboot.bin
-SAI_WARM_BOOT_WRITE_FILE=/var/cache/sai_warmboot.bin
 SAI_VS_SWITCH_TYPE=SAI_VS_SWITCH_TYPE_BCM56850
 SAI_VS_HOSTIF_USE_TAP_DEVICE=true
 SAI_VS_INTERFACE_LANE_MAP_FILE=/usr/share/sonic/hwsku/lanemap.ini


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

This PR adds the changes in https://github.com/Azure/sonic-buildimage/pull/6198 to 201811 branch to support warm-reboot image upgrade for kvm images.

**- Why I did it**
The sai.profile file in kvm images overrides the warmboot file with path `/var/cache/sai_warmboot.bin`. Since the directory `/var/cache` is not mounted in syncd, it will be cleared in an image upgrade, the warm-reboot image upgrade will fail if the file is put in the directory.

**- How I did it**
Remove the path that overrides the default path. The warmboot file path will then be the default value `/var/warmboot/sai-warmboot.bin`. Since `/var/warmboot/` is mounted by `/host/warmboot/` in the host, it could survive an image upgrade.

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
