### PR TITLE
[docker-vs][docker-orchagent] install python3 dependent packages for restore_neighbors.py

### DIFF
--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -44,6 +44,12 @@ RUN pip2 install \
          netifaces==0.10.7 \
          monotonic==1.5
 
+# Dependencies of restore_neighbors.py
+RUN pip3 install \
+         scapy==2.4.4 \
+         pyroute2==0.5.14 \
+         netifaces==0.10.9
+
 {% if ( CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" ) %}
 # Remove installed gcc
 RUN apt-get remove -y gcc-8

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -91,6 +91,12 @@ RUN pip2 install crontab
 RUN pip3 install pyangbind==0.8.1
 RUN pip3 uninstall -y enum34
 
+# Dependencies of restore_neighbors.py
+RUN pip3 install \
+         scapy==2.4.4 \
+         pyroute2==0.5.14 \
+         netifaces==0.10.9
+
 {% if docker_sonic_vs_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {%- for deb in docker_sonic_vs_debs.split(' ') %}


### PR DESCRIPTION
[docker-vs][docker-orchagent] install python3 dependent packages for restore_neighbors.py

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
convert restore_neighbor.py to support python3 as python2 is EOL.  See: https://github.com/Azure/sonic-swss/pull/1542

**- How I did it**
Install the necessary python3 dependent packages.

**- How to verify it**
swss vs tests and HW test.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
