### PR TITLE
[marvell][platform] Checking file presence before access

### DIFF
--- a/platform/marvell-armhf/sonic-platform-et6448m/entropy.py
+++ b/platform/marvell-armhf/sonic-platform-et6448m/entropy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import fcntl, struct
 import time
+from os import path
 
 RNDADDENTROPY=0x40085203
 
@@ -8,10 +9,11 @@ def avail():
   with open("/proc/sys/kernel/random/entropy_avail", mode='r') as avail:
       return int(avail.read())
 
-while 1:
-    while avail() < 2048:
-        with open('/dev/urandom', 'rb') as urnd, open("/dev/random", mode='wb') as rnd:
-            d = urnd.read(512)
-            t = struct.pack('ii', 4 * len(d), len(d)) + d
-            fcntl.ioctl(rnd, RNDADDENTROPY, t)
-    time.sleep(30)
+if path.exists("/proc/sys/kernel/random/entropy_avail"):
+    while 1:
+        while avail() < 2048:
+            with open('/dev/urandom', 'rb') as urnd, open("/dev/random", mode='wb') as rnd:
+                d = urnd.read(512)
+                t = struct.pack('ii', 4 * len(d), len(d)) + d
+                fcntl.ioctl(rnd, RNDADDENTROPY, t)
+        time.sleep(30)

--- a/platform/marvell-armhf/sonic-platform-et6448m/inband_mgmt.sh
+++ b/platform/marvell-armhf/sonic-platform-et6448m/inband_mgmt.sh
@@ -10,6 +10,9 @@ inband_mgmt(){
 # order.
 # NOTE: In the nokia platform the following sequence is performed by the Nokia
 # platform service init script and thus should not be performed here
+ if [ ! -f /host/machine.conf ]; then
+     exit 0
+ fi
  grep ^onie_platform /host/machine.conf 2>/dev/null | grep nokia >/dev/null
  if [ $? != 0 ]; then
      rmmod i2c-dev


### PR DESCRIPTION
Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- What I did it**
In marvell_et644m platform scripts, I have added a check to confirm the file availability before accessing it.

**- How to verify it**
Verified the modified scripts on marvell-armhf platform

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
