### PR TITLE
[Mellanox] PSU led platform API fixes

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
@@ -273,7 +273,8 @@ class SystemLed(Led):
 class SharedLed(object):
     LED_PRIORITY = {
         Led.STATUS_LED_COLOR_RED: 0,
-        Led.STATUS_LED_COLOR_GREEN: 1
+        Led.STATUS_LED_COLOR_OFF: 1,
+        Led.STATUS_LED_COLOR_GREEN: 2
     }
 
     def __init__(self, led):
@@ -286,9 +287,11 @@ class SharedLed(object):
     def update_status_led(self):
         target_color = Led.STATUS_LED_COLOR_GREEN
         for virtual_led in self._virtual_leds:
-            if SharedLed.LED_PRIORITY[virtual_led.get_led_color()] < SharedLed.LED_PRIORITY[target_color]:
-                target_color = virtual_led.get_led_color()
-
+            try:
+                if SharedLed.LED_PRIORITY[virtual_led.get_led_color()] < SharedLed.LED_PRIORITY[target_color]:
+                    target_color = virtual_led.get_led_color()
+            except KeyError:
+                return False
         return self._led.set_status(target_color)
 
     def get_status(self):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
@@ -273,8 +273,7 @@ class SystemLed(Led):
 class SharedLed(object):
     LED_PRIORITY = {
         Led.STATUS_LED_COLOR_RED: 0,
-        Led.STATUS_LED_COLOR_OFF: 1,
-        Led.STATUS_LED_COLOR_GREEN: 2
+        Led.STATUS_LED_COLOR_GREEN: 1
     }
 
     def __init__(self, led):
@@ -305,8 +304,13 @@ class ComponentFaultyIndicator(object):
         self._shared_led.add_virtual_leds(self)
 
     def set_status(self, color):
+        current_color = self._color
         self._color = color
-        return self._shared_led.update_status_led()
+        if self._shared_led.update_status_led():
+            return True
+        else:
+            self._color = current_color
+            return False
 
     def get_led_color(self):
         return self._color


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fix return False if unsupported color request.

**- How I did it**
Return 'False' when unsupported led color is requested, preventing an exception.

**- How to verify it**
Try to set PSU LED color to unsupported color with Mellanox platform device.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
