### PR TITLE
[multi-asic][vs]: Update topology script to retrieve hwsku from minigraph

### DIFF
--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/topology.sh
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/topology.sh
@@ -8,10 +8,10 @@ NUM_INTERFACES_PER_ASIC=32
 
 start () {
     # Move external links into assigned frontend namespaces
-    # eth0  - eth15: asic2 
-    # eth16 - eth31: asic3 
-    # eth32 - eth47: asic4
-    # eth48 - eth63: asic5
+    # eth1  - eth16: asic0
+    # eth17 - eth32: asic1 
+    # eth33 - eth48: asic2
+    # eth49 - eth64: asic3
     for ASIC in `seq $FIRST_FRONTEND_ASIC $LAST_FRONTEND_ASIC`; do
         for NUM in `seq 1 16`; do
             ORIG="eth$((16 * $ASIC + $NUM))"
@@ -54,8 +54,8 @@ stop() {
     for ASIC in `seq $FIRST_FRONTEND_ASIC $LAST_FRONTEND_ASIC`; do
         for NUM in `seq 1 16`; do
             TEMP="eth999"
-            OLD="eth$((16 * $ASIC + $NUM))"
-            NAME="eth$((16 * $ASIC + $NUM - 1))"
+            OLD="eth$(($NUM))"
+            NAME="eth$((16 * $ASIC + $NUM))"
             sudo ip netns exec asic$ASIC ip link set dev $OLD down
             sudo ip netns exec asic$ASIC ip link set dev $OLD name $TEMP
             sudo ip netns exec asic$ASIC ip link set dev $TEMP netns 1

--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/topology.sh
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/topology.sh
@@ -22,6 +22,7 @@ start () {
             ip link set dev $ORIG name $TEMP # rename to prevent conflicts before renaming in new namespace
             ip link set dev $TEMP netns asic$ASIC
             sudo ip netns exec asic$ASIC ip link set $TEMP name $NEW # rename to final interface name
+            sudo ip netns exec asic$ASIC ip link set dev $NEW mtu 9100
             sudo ip netns exec asic$ASIC ip link set $NEW up 
         done
     done
@@ -43,7 +44,9 @@ start () {
                 sudo ip netns exec asic$BACKEND ip link set $TEMP_BACK name $BACK_NAME
                 sudo ip netns exec asic$FRONTEND ip link set $TEMP_FRONT name $FRONT_NAME
 
+                sudo ip netns exec asic$BACKEND ip link set dev $BACK_NAME mtu 9100
                 sudo ip netns exec asic$BACKEND ip link set $BACK_NAME up
+                sudo ip netns exec asic$FRONTEND ip link set dev $FRONT_NAME mtu 9100
                 sudo ip netns exec asic$FRONTEND ip link set $FRONT_NAME up
             done
         done

--- a/files/image_config/topology/topology.sh
+++ b/files/image_config/topology/topology.sh
@@ -8,14 +8,17 @@
 start() {
     TOPOLOGY_SCRIPT="topology.sh"
     PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
-    HWSKU=${HWSKU:-`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]' 2>&1`}
+    HWSKU=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]' 2>&1`
     if [[ $? -ne 0 || HWSKU == "" ]]; then
             if [[ -f "/etc/sonic/minigraph.xml" ]]; then
                 HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
-                if [[ $? -ne 0 ]]; then
+                if [[ $? -ne 0 || HWSKU == "" ]]; then
                     echo "Failed to get HWSKU"
                     exit
                 fi
+            else
+                echo "Failed to get HWSKU"
+                exit
             fi
     fi
     /usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT start
@@ -23,14 +26,17 @@ start() {
 stop() {
     TOPOLOGY_SCRIPT="topology.sh"
     PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
-    HWSKU=${HWSKU:-`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]' 2>&1`}
-    if [[ $? -ne 0 ]]; then
+    HWSKU=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]' 2>&1`
+    if [[ $? -ne 0 || HWSKU == "" ]]; then
             if [[ -f "/etc/sonic/minigraph.xml" ]]; then
                 HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
-                if [[ $? -ne 0 ]]; then
+                if [[ $? -ne 0 || HWSKU == "" ]]; then
                     echo "Failed to get HWSKU"
                     exit
                 fi
+            else
+                echo "Failed to get HWSKU"
+                exit
             fi
     fi
     /usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT stop

--- a/files/image_config/topology/topology.sh
+++ b/files/image_config/topology/topology.sh
@@ -9,7 +9,7 @@ start() {
     TOPOLOGY_SCRIPT="topology.sh"
     PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
     HWSKU=${HWSKU:-`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]' 2>&1`}
-    if [[ $? -ne 0 ]]; then
+    if [[ $? -ne 0 || HWSKU == "" ]]; then
             if [[ -f "/etc/sonic/minigraph.xml" ]]; then
                 HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
                 if [[ $? -ne 0 ]]; then

--- a/files/image_config/topology/topology.sh
+++ b/files/image_config/topology/topology.sh
@@ -7,15 +7,33 @@
 
 start() {
     TOPOLOGY_SCRIPT="topology.sh"
-    PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
-    HWSKU=${HWSKU:-`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`}
+    PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+    HWSKU=${HWSKU:-`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]' 2>&1`}
+    if [[ $? -ne 0 ]]; then
+            if [[ -f "/etc/sonic/minigraph.xml" ]]; then
+                HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
+                if [[ $? -ne 0 ]]; then
+                    echo "Failed to get HWSKU"
+                    exit
+                fi
+            fi
+    fi
     /usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT start
 }
 stop() {
     TOPOLOGY_SCRIPT="topology.sh"
-    PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
-    HWSKU=${HWSKU:-`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`}
-    usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT stop 
+    PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+    HWSKU=${HWSKU:-`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]' 2>&1`}
+    if [[ $? -ne 0 ]]; then
+            if [[ -f "/etc/sonic/minigraph.xml" ]]; then
+                HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
+                if [[ $? -ne 0 ]]; then
+                    echo "Failed to get HWSKU"
+                    exit
+                fi
+            fi
+    fi
+    /usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT stop
 }
 
 # read SONiC immutable variables

--- a/files/image_config/topology/topology.sh
+++ b/files/image_config/topology/topology.sh
@@ -1,45 +1,49 @@
 #!/bin/bash
 # This script is invoked by topology.service only
-# for multi-asic virtual platform. For multi-asic platform 
-# multiple Database instances are present 
+# for multi-asic virtual platform. For multi-asic platform
+# multiple Database instances are present
 # and HWKSU information is retrieved from first database instance.
 #
+
+get_hwsku() {
+    # Get HWSKU from config_db. If HWSKU is not available in config_db
+    # get HWSKU from minigraph.xml if minigraph file exists.
+    HWSKU=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]' 2>&1`
+    if [[ $? -ne 0 || $HWSKU == "" ]]; then
+            if [[ -f "/etc/sonic/minigraph.xml" ]]; then
+                HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
+                if [[ $? -ne 0 || $HWSKU == "" ]]; then
+                    HWSKU=""
+                fi
+            else
+                HWSKU=""
+            fi
+    fi
+    echo "${HWSKU}"
+}
 
 start() {
     TOPOLOGY_SCRIPT="topology.sh"
     PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
-    HWSKU=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]' 2>&1`
-    if [[ $? -ne 0 || HWSKU == "" ]]; then
-            if [[ -f "/etc/sonic/minigraph.xml" ]]; then
-                HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
-                if [[ $? -ne 0 || HWSKU == "" ]]; then
-                    echo "Failed to get HWSKU"
-                    exit 1 
-                fi
-            else
-                echo "Failed to get HWSKU"
-                exit 1
-            fi
+    HWSKU=`get_hwsku`
+    if [[ $HWSKU != "" ]]; then
+        /usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT start
+    else
+        echo "Failed to get HWSKU"
+        exit 1
     fi
-    /usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT start
 }
+
 stop() {
     TOPOLOGY_SCRIPT="topology.sh"
     PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
-    HWSKU=`sonic-cfggen -d -v 'DEVICE_METADATA["localhost"]["hwsku"]' 2>&1`
-    if [[ $? -ne 0 || HWSKU == "" ]]; then
-            if [[ -f "/etc/sonic/minigraph.xml" ]]; then
-                HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
-                if [[ $? -ne 0 || HWSKU == "" ]]; then
-                    echo "Failed to get HWSKU"
-                    exit 1
-                fi
-            else
-                echo "Failed to get HWSKU"
-                exit 1
-            fi
+    HWSKU=`get_hwsku`
+    if [[ $HWSKU != "" ]]; then
+        /usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT stop
+    else
+        echo "Failed to get HWSKU"
+        exit 1
     fi
-    /usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT stop
 }
 
 # read SONiC immutable variables

--- a/files/image_config/topology/topology.sh
+++ b/files/image_config/topology/topology.sh
@@ -14,11 +14,11 @@ start() {
                 HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
                 if [[ $? -ne 0 || HWSKU == "" ]]; then
                     echo "Failed to get HWSKU"
-                    exit
+                    exit 1 
                 fi
             else
                 echo "Failed to get HWSKU"
-                exit
+                exit 1
             fi
     fi
     /usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT start
@@ -32,11 +32,11 @@ stop() {
                 HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
                 if [[ $? -ne 0 || HWSKU == "" ]]; then
                     echo "Failed to get HWSKU"
-                    exit
+                    exit 1
                 fi
             else
                 echo "Failed to get HWSKU"
-                exit
+                exit 1
             fi
     fi
     /usr/share/sonic/device/$PLATFORM/$HWSKU/$TOPOLOGY_SCRIPT stop


### PR DESCRIPTION
Update topology script to retrieve hwsku from minigraph
if hwsku information is not available in config_db.
Fix clean up of interfaces in msft_multi_asic_vs hwsku
topology script.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
When bringing up multi-asic VS switch, topology service is started during boot up.
Topology service starts a shell script which runs the topology script present in /usr/share/sonic/device/<platfrom>/<hwsku> directory. To invoke hwsku specific script, the topology script tries to retrieve hwsku information from config_db.
During initial boot up config_db might not be populated. In order to start topology service before config_db is updated,
update topology script to get hwsku information from minigraph.xml if it is available.
This will be helpful to bring up multi-asic VS testbed by loading minigraph and  starting topology service.

**- How I did it**
- Update topology.sh script to retrieve hwsku information from minigraph.xml.
- Fix clean up function on msft_multi_asic_vs toplogy script.

**- How to verify it**
- single-asic VS - no change; topology service is only enabled for multi-asic VS.
- multi-asic VS - Bring up multi-asic VS image, copy minigraph to vs image, start topology service. Topology service should be successful.
-  to test clean up function fix, start topology service - make sure interfaces are created and moved to the right namespaces.
stop topology service - make sure namespace do not have any interface and all front end interfaces are present in default namespace.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
