### PR TITLE
openssh: Fix build break when using http proxy

### DIFF
--- a/src/openssh/Makefile
+++ b/src/openssh/Makefile
@@ -19,7 +19,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	stg import -s ../patch/series
 
 	# Build package
-	sudo apt-get -y build-dep openssh
+	sudo http_proxy=$(http_proxy) apt-get -y build-dep openssh
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 


### PR DESCRIPTION
The openssh build fails to retrieve dependent debian packages when operating
behind a proxy server.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fix build break when building from behind a proxy server.

**- How I did it**
Specify coordinates of proxy server when installing dependent packages.

**- How to verify it**
Build from behind a proxy server.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
