### PR TITLE
[hostcfgd]: wait  till system initialization is done before starting hostcfgd

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -467,7 +467,8 @@ class HostConfigDaemon:
         syslog.syslog(syslog.LOG_INFO,
                       "Waiting for systemctl to finish initialization")
         self.wait_till_system_init_done()
-        syslog.syslog(syslog.LOG_INFO, "starting update of feature states")
+        syslog.syslog(syslog.LOG_INFO,
+                      "systemctl has finished initialization -- proceeding ...")
 
         # Update all feature states once upon starting
         self.update_all_feature_states()

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -382,11 +382,6 @@ class HostConfigDaemon:
 
 
     def update_all_feature_states(self):
-        syslog.syslog(syslog.LOG_INFO,
-                      "Waiting for systemctl to finish initialization")
-        self.wait_till_system_init_done()
-        syslog.syslog(syslog.LOG_INFO, "starting update of feature states")
-        
         feature_table = self.config_db.get_table('FEATURE')
         for feature_name in feature_table:
             if not feature_name:
@@ -468,6 +463,11 @@ class HostConfigDaemon:
         self.config_db.subscribe('LOOPBACK_INTERFACE', lambda table, key, data: self.lpbk_handler(key, data))
         self.config_db.subscribe('FEATURE', lambda table, key, data: self.feature_state_handler(key, data))
         self.config_db.subscribe('KDUMP', lambda table, key, data: self.kdump_handler(key, data))
+
+        syslog.syslog(syslog.LOG_INFO,
+                      "Waiting for systemctl to finish initialization")
+        self.wait_till_system_init_done()
+        syslog.syslog(syslog.LOG_INFO, "starting update of feature states")
 
         # Update all feature states once upon starting
         self.update_all_feature_states()

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -382,6 +382,11 @@ class HostConfigDaemon:
 
 
     def update_all_feature_states(self):
+        syslog.syslog(syslog.LOG_INFO,
+                      "Waiting for systemctl to finish initialization")
+        self.wait_till_system_init_done()
+        syslog.syslog(syslog.LOG_INFO, "starting update of feature states")
+        
         feature_table = self.config_db.get_table('FEATURE')
         for feature_name in feature_table:
             if not feature_name:
@@ -455,13 +460,7 @@ class HostConfigDaemon:
         systemctl_cmd = "sudo systemctl is-system-running --wait --quiet"
         subprocess.call(systemctl_cmd, shell=True)
 
-
     def start(self):
-
-        syslog.syslog(syslog.LOG_INFO,
-                      "Waiting for systemctl to finish initialization")
-        self.wait_till_system_init_done()
-        syslog.syslog(syslog.LOG_INFO, "starting hostcfgd...")
 
         self.config_db.subscribe('AAA', lambda table, key, data: self.aaa_handler(key, data))
         self.config_db.subscribe('TACPLUS_SERVER', lambda table, key, data: self.tacacs_server_handler(key, data))

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -300,6 +300,7 @@ class HostConfigDaemon:
         self.kdumpCfg = KdumpCfg(self.config_db)
         self.kdumpCfg.load(self.config_db.get_table('KDUMP'))
 
+
     def load(self):
         aaa = self.config_db.get_table('AAA')
         tacacs_global = self.config_db.get_table('TACPLUS')
@@ -447,7 +448,20 @@ class HostConfigDaemon:
         syslog.syslog(syslog.LOG_INFO, 'Kdump handler...')
         self.kdumpCfg.kdump_update(key, data, False)
 
+    def wait_till_system_init_done(self):
+
+        # No need to print the output in the log file so using the "--quiet"
+        # flag
+        systemctl_cmd = "sudo systemctl is-system-running --wait --quiet"
+        subprocess.call(systemctl_cmd, shell=True)
+
+
     def start(self):
+
+        syslog.syslog(syslog.LOG_INFO,
+                      "Waiting for systemctl to finish initialization")
+        self.wait_till_system_init_done()
+        syslog.syslog(syslog.LOG_INFO, "starting hostcfgd...")
 
         self.config_db.subscribe('AAA', lambda table, key, data: self.aaa_handler(key, data))
         self.config_db.subscribe('TACPLUS_SERVER', lambda table, key, data: self.tacacs_server_handler(key, data))


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The change is done to make sure the system initialization is done before starting the hostcfgd service.

**- How I did it**
use the command` systemctl is-system-running --wait ` to wait till system has finished booting up
**- How to verify it**
Checkout journctl command output if the hostcfgd is waiting
<pre>
admin@vlab-01:~$ sudo journalctl -u hostcfgd                                                                                                                                                                                 -- Logs begin at Thu 2020-12-17 01:06:59 UTC, end at Thu 2020-12-17 01:20:52 UTC. --                                                                                                                                         Dec 17 01:07:08 vlab-01 systemd[1]: Started Host config enforcer daemon.
Dec 17 01:07:08 vlab-01 /hostcfgd[849]: ConfigDB connect success
Dec 17 01:07:08 vlab-01 /hostcfgd[849]: KdumpCfg load ...
Dec 17 01:07:08 vlab-01 /hostcfgd[849]: Kdump global configuration update
Dec 17 01:07:10 vlab-01 sudo[1365]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/bin/docker ps
Dec 17 01:07:10 vlab-01 sudo[1365]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:07:11 vlab-01 sudo[1365]: pam_unix(sudo:session): session closed for user root
Dec 17 01:07:11 vlab-01 python3[1303]: :- operator(): DB '{APPL_DB}' is empty with pattern '_GEARBOX_TABLE:phy:*'!
Dec 17 01:07:11 vlab-01 sudo[1465]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/bin/docker ps
Dec 17 01:07:11 vlab-01 sudo[1465]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:07:11 vlab-01 sudo[1465]: pam_unix(sudo:session): session closed for user root
Dec 17 01:07:11 vlab-01 python3[1408]: :- operator(): DB '{APPL_DB}' is empty with pattern '_GEARBOX_TABLE:phy:*'!
Dec 17 01:07:11 vlab-01 hostcfgd[849]: kdump is already disabled
Dec 17 01:07:13 vlab-01 /hostcfgd[849]: Waiting for systemctl to finish initialization
Dec 17 01:07:13 vlab-01 sudo[1985]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/bin/systemctl is-system-running --wait --quiet
Dec 17 01:07:13 vlab-01 sudo[1985]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:07:14 vlab-01 sudo[1985]: pam_unix(sudo:session): session closed for user root
Dec 17 01:07:14 vlab-01 /hostcfgd[849]: starting update of feature states
Dec 17 01:07:14 vlab-01 /hostcfgd[849]: Running cmd: 'sudo systemctl stop sflow.service'
Dec 17 01:07:14 vlab-01 sudo[2261]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/bin/systemctl stop sflow.service
Dec 17 01:07:14 vlab-01 sudo[2261]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:07:14 vlab-01 sudo[2261]: pam_unix(sudo:session): session closed for user root
Dec 17 01:07:14 vlab-01 /hostcfgd[849]: Running cmd: 'sudo systemctl disable sflow.service'
Dec 17 01:07:14 vlab-01 sudo[2264]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/bin/systemctl disable sflow.service
Dec 17 01:07:14 vlab-01 sudo[2264]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:07:14 vlab-01 hostcfgd[849]: Unit /etc/systemd/system/sflow.service is masked, ignoring.
Dec 17 01:07:14 vlab-01 sudo[2264]: pam_unix(sudo:session): session closed for user root
Dec 17 01:07:14 vlab-01 /hostcfgd[849]: Running cmd: 'sudo systemctl mask sflow.service'
Dec 17 01:07:14 vlab-01 sudo[2288]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/bin/systemctl mask sflow.service
Dec 17 01:07:14 vlab-01 sudo[2288]: pam_unix(sudo:session): session opened for user root by (uid=0)
</pre>
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
