### PR TITLE
[Arista] Add placeholder system-health configuration for all platforms

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7050_qx32/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7050_qx32s/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7050_qx32s/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7050cx3_32s/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7050cx3_32s/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7060_cx32s/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7060_cx32s/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7060cx2_32s/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7060cx2_32s/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7060dx4_32/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7060dx4_32/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7060px4_32/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7060px4_32/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7170_32c/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7170_32c/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7170_32cd/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7170_32cd/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7170_64c/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7170_64c/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7260cx3_64/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7260cx3_64/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7280cr3_32d4/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7280cr3_32d4/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7280cr3_32p4/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7280cr3_32p4/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7800_sup/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7800_sup/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/system_health_monitoring_config.json
@@ -1,0 +1,1 @@
+../x86_64-arista_common/system_health_monitoring_config.json

--- a/device/arista/x86_64-arista_common/system_health_monitoring_config.json
+++ b/device/arista/x86_64-arista_common/system_health_monitoring_config.json
@@ -1,0 +1,16 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.temperature",
+        "PSU2 Fan",
+        "PSU1 Fan"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "orange",
+        "normal": "green",
+        "booting": "orange_blink"
+    }
+}


### PR DESCRIPTION
**- Why I did it**

Prevent system-healthd from service from failing at boot time due to missing configuration.
Also adds basic support for healthd.
The following caveat exists with this placeholder configuration:
 - No PSU monitoring (sensors/fans)
 - No ASIC temperature monitoring

**- How I did it**

Added `system_health_monitoring_config.json` to all Arista platforms.

**- How to verify it**

Check `systemctl status system-health` after boot.
No healthd errors in `/var/log/syslog`.
Verify that the output of `journalctl -u system-health` is sane.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add placeholder system-health configuration for all Arista platforms
