### PR TITLE
[201911][hostcfgd]:wait updating the feature table till system init is done

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -257,8 +257,7 @@ class HostConfigDaemon:
                 stdout=subprocess.PIPE,
             )
             output = proc.communicate()[0].rstrip('\n')
-            if output.lower() == "initializing" or \
-                    output.lower() == "starting":
+            if output.lower() in ["initializing", "starting"]:
                 time.sleep(1)
                 continue
 

--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -3,6 +3,7 @@
 
 import ast
 import os
+import time
 import sys
 import subprocess
 import syslog
@@ -247,6 +248,21 @@ class HostConfigDaemon:
         lpbk_table = self.config_db.get_table('LOOPBACK_INTERFACE')
         self.iptables.load(lpbk_table)
 
+    def wait_till_system_init_done(self):
+        systemctl_cmd = "sudo systemctl is-system-running"
+        while True:
+            proc = subprocess.Popen(
+                systemctl_cmd,
+                shell=True,
+                stdout=subprocess.PIPE,
+            )
+            output = proc.communicate()[0].rstrip('\n')
+            if output.lower() == "initializing" or \
+                    output.lower() == "starting":
+                time.sleep(1)
+                continue
+
+            return
 
     def update_feature_state(self, feature_name, state, feature_table):
         if state == "always_enabled":
@@ -382,6 +398,13 @@ class HostConfigDaemon:
         self.config_db.subscribe('TACPLUS', lambda table, key, data: self.tacacs_global_handler(key, data))
         self.config_db.subscribe('LOOPBACK_INTERFACE', lambda table, key, data: self.lpbk_handler(key, data))
         self.config_db.subscribe('FEATURE', lambda table, key, data: self.feature_state_handler(key, data))
+
+        if self.is_multi_npu:
+            syslog.syslog(syslog.LOG_INFO,
+                          "Waiting for systemctl to finish initialization")
+            self.wait_till_system_init_done()
+            syslog.syslog(syslog.LOG_INFO,
+                          "systemctl has finished initialization -- proceeding ...")
 
         # Update all feature states once upon starting
         self.update_all_feature_states()


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The change is done to make sure the system initialization is done before starting the hostcfgd  sets the feature states.

**- How I did it**
This is port of the PR https://github.com/Azure/sonic-buildimage/pull/6232. 
Since the systemctl version in 201911 doesnt support `--wait`. 
Added a function to check the output of ` systemctl is-system-running ` every second, till the command system is done booting up.

For now this change is only applicable to multi asic platforms based on the testing  this change will be extended to all platforms in the future PR.

**- How to verify it**
Checkout journctl command output to see 

<pre>
admin@sonic:~$ sudo journalctl -u hostcfgd
-- Logs begin at Thu 2020-12-17 01:40:15 UTC, end at Thu 2020-12-17 06:15:50 UTC. --
Dec 17 01:40:36 sonic systemd[1]: Started Host config enforcer daemon.
Dec 17 01:40:36 sonic hostcfgd[4362]: ConfigDB connect success
Dec 17 01:40:36 sonic hostcfgd[4362]: Waiting for systemctl to finish initialization
Dec 17 01:40:36 sonic sudo[4438]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:36 sonic sudo[4438]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:37 sonic sudo[4950]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:37 sonic sudo[4950]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:39 sonic sudo[5465]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:39 sonic sudo[5465]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:40 sonic sudo[6179]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:40 sonic sudo[6179]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:41 sonic sudo[6473]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:41 sonic sudo[6473]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:42 sonic sudo[6859]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:42 sonic sudo[6859]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:43 sonic sudo[7082]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:43 sonic sudo[7082]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:44 sonic sudo[7642]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:44 sonic sudo[7642]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:44 sonic sudo[7642]: pam_unix(sudo:session): session closed for user root
Dec 17 01:40:45 sonic sudo[8134]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:45 sonic sudo[8134]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:45 sonic sudo[8134]: pam_unix(sudo:session): session closed for user root
Dec 17 01:40:46 sonic sudo[8383]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:46 sonic sudo[8383]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:47 sonic sudo[8567]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:47 sonic sudo[8567]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:48 sonic sudo[8843]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:48 sonic sudo[8843]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:49 sonic sudo[9176]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:49 sonic sudo[9176]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:50 sonic sudo[9502]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:50 sonic sudo[9502]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:51 sonic sudo[10074]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:51 sonic sudo[10074]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:52 sonic sudo[10415]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:52 sonic sudo[10415]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:53 sonic sudo[10663]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:53 sonic sudo[10663]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:55 sonic sudo[11077]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:55 sonic sudo[11077]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:56 sonic sudo[11506]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:56 sonic sudo[11506]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:57 sonic sudo[12206]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:57 sonic sudo[12206]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:58 sonic sudo[12412]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:58 sonic sudo[12412]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:59 sonic sudo[12580]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl is-system-running
Dec 17 01:40:59 sonic sudo[12580]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:59 sonic hostcfgd[4362]: starting updating the feature states
Dec 17 01:40:59 sonic hostcfgd[4362]: Running cmd: 'sudo systemctl unmask lldp.service'
Dec 17 01:40:59 sonic sudo[12584]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl unmask lldp.service
Dec 17 01:40:59 sonic sudo[12584]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:59 sonic hostcfgd[4362]: Running cmd: 'sudo systemctl enable lldp.service'
Dec 17 01:40:59 sonic sudo[12625]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl enable lldp.service
Dec 17 01:40:59 sonic sudo[12625]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:59 sonic hostcfgd[4362]: Running cmd: 'sudo systemctl start lldp.service'
Dec 17 01:40:59 sonic sudo[12653]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl start lldp.service
Dec 17 01:40:59 sonic sudo[12653]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:59 sonic hostcfgd[4362]: Running cmd: 'sudo systemctl unmask lldp.service'
Dec 17 01:40:59 sonic sudo[12659]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl unmask lldp.service
Dec 17 01:40:59 sonic sudo[12659]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:59 sonic hostcfgd[4362]: Running cmd: 'sudo systemctl enable lldp.service'
Dec 17 01:40:59 sonic sudo[12686]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl enable lldp.service
Dec 17 01:40:59 sonic sudo[12686]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:59 sonic sudo[12686]: pam_unix(sudo:session): session closed for user root
Dec 17 01:40:59 sonic sudo[12686]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl enable lldp.service
Dec 17 01:40:59 sonic sudo[12686]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:59 sonic sudo[12686]: pam_unix(sudo:session): session closed for user root
Dec 17 01:40:59 sonic hostcfgd[4362]: Running cmd: 'sudo systemctl start lldp.service'
Dec 17 01:40:59 sonic sudo[12711]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl start lldp.service
Dec 17 01:40:59 sonic sudo[12711]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:59 sonic hostcfgd[4362]: Running cmd: 'sudo systemctl unmask lldp@0.service'
Dec 17 01:40:59 sonic sudo[12715]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl unmask lldp@0.service
Dec 17 01:40:59 sonic sudo[12715]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 17 01:40:59 sonic hostcfgd[4362]: Running cmd: 'sudo systemctl enable lldp@0.service'
Dec 17 01:40:59 sonic sudo[12747]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/systemctl enable lldp@0.service
Dec 17 01:40:59 sonic sudo[12747]: pam_unix(sudo:session): session opened for user root by (uid=0)
</pre>
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
