### PR TITLE
preventing default fallback route lookup from user-defined VRF table …

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -78,16 +78,16 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     # management port up rules
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }} metric 201
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }} pref 1003
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    up ip rule add pref 32764 to {{ route }} table {{ vrf_table }}
+    up ip rule add to {{ route }} table {{ vrf_table }} pref 1004
 {% endfor %}
     # management port down rules
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
-    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete pref 32765 from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
+    pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }} pref 1003
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
-    pre-down ip rule delete pref 32764 to {{ route }} table {{ vrf_table }}
+    pre-down ip rule delete to {{ route }} table {{ vrf_table }} pref 1004
 {% endfor %}
 {# TODO: COPP policy type rules #}
 {% endfor %}

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces
@@ -21,11 +21,11 @@ iface eth0 inet static
     # management port up rules
     up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table default
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
+    up ip -4 rule add from 10.0.0.100/32 table default pref 1003
     # management port down rules
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table default
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table default
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table default
+    pre-down ip -4 rule delete from 10.0.0.100/32 table default pref 1003
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -35,11 +35,11 @@ iface eth0 inet6 static
     # management port up rules
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
+    up ip -6 rule add from 2603:10e2:0:2902::8/128 table default pref 1003
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table default
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table default
+    pre-down ip -6 rule delete from 2603:10e2:0:2902::8/128 table default pref 1003
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -31,15 +31,15 @@ iface eth0 inet static
     # management port up rules
     up ip -4 route add default via 10.0.0.1 dev eth0 table 5000 metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table 5000
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table 5000
-    up ip rule add pref 32764 to 11.11.11.11 table 5000
-    up ip rule add pref 32764 to 22.22.22.0/23 table 5000
+    up ip -4 rule add from 10.0.0.100/32 table 5000 pref 1003
+    up ip rule add to 11.11.11.11 table 5000 pref 1004
+    up ip rule add to 22.22.22.0/23 table 5000 pref 1004
     # management port down rules
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 5000
-    pre-down ip rule delete pref 32764 to 11.11.11.11 table 5000
-    pre-down ip rule delete pref 32764 to 22.22.22.0/23 table 5000
+    pre-down ip -4 rule delete from 10.0.0.100/32 table 5000 pref 1003
+    pre-down ip rule delete to 11.11.11.11 table 5000 pref 1004
+    pre-down ip rule delete to 22.22.22.0/23 table 5000 pref 1004
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -50,11 +50,11 @@ iface eth0 inet6 static
     # management port up rules
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 5000 metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 5000
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    up ip -6 rule add from 2603:10e2:0:2902::8/128 table 5000 pref 1003
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    pre-down ip -6 rule delete from 2603:10e2:0:2902::8/128 table 5000 pref 1003
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces
@@ -21,11 +21,11 @@ iface eth0 inet static
     # management port up rules
     up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table default
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
+    up ip -4 rule add from 10.0.0.100/32 table default pref 1003
     # management port down rules
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table default
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table default
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table default
+    pre-down ip -4 rule delete from 10.0.0.100/32 table default pref 1003
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -35,11 +35,11 @@ iface eth0 inet6 static
     # management port up rules
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
+    up ip -6 rule add from 2603:10e2:0:2902::8/128 table default pref 1003
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table default
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table default
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table default
+    pre-down ip -6 rule delete from 2603:10e2:0:2902::8/128 table default pref 1003
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -31,15 +31,15 @@ iface eth0 inet static
     # management port up rules
     up ip -4 route add default via 10.0.0.1 dev eth0 table 5000 metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table 5000
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table 5000
-    up ip rule add pref 32764 to 11.11.11.11 table 5000
-    up ip rule add pref 32764 to 22.22.22.0/23 table 5000
+    up ip -4 rule add from 10.0.0.100/32 table 5000 pref 1003
+    up ip rule add to 11.11.11.11 table 5000 pref 1004
+    up ip rule add to 22.22.22.0/23 table 5000 pref 1004
     # management port down rules
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 5000
-    pre-down ip rule delete pref 32764 to 11.11.11.11 table 5000
-    pre-down ip rule delete pref 32764 to 22.22.22.0/23 table 5000
+    pre-down ip -4 rule delete from 10.0.0.100/32 table 5000 pref 1003
+    pre-down ip rule delete to 11.11.11.11 table 5000 pref 1004
+    pre-down ip rule delete to 22.22.22.0/23 table 5000 pref 1004
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -50,11 +50,11 @@ iface eth0 inet6 static
     # management port up rules
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 5000 metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 5000
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    up ip -6 rule add from 2603:10e2:0:2902::8/128 table 5000 pref 1003
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 5000
+    pre-down ip -6 rule delete from 2603:10e2:0:2902::8/128 table 5000 pref 1003
 #
 source /etc/network/interfaces.d/*
 #


### PR DESCRIPTION


**- Why I did it**
Please refer to https://github.com/Azure/sonic-swss/pull/1557
This fix is needed as it prevents default fallback route lookup from user-defined VRF table to local table(default vrf).

**- How I did it**
The details of fix is in 
https://github.com/Azure/sonic-swss/pull/1557
In the current change sample output and j2 files have been changed in accordance with the changes in above PR.
**- How to verify it**
Please refer to below output after fix :
admin@sonic: ip -4 rule ls
1000: from all lookup [l3mdev-table]
1003: from 10.59.133.11 lookup mgmt
1004: from all to 10.0.0.0/8 lookup mgmt
32765: from all lookup local
32766: from all lookup main
32767: from all lookup default
admin@sonic:

admin@sonic: ip -6 rule ls
1000: from all lookup [l3mdev-table]
1003: from 2100::2 lookup mgmt
32765: from all lookup local
32766: from all lookup main
admin@sonic:

