### PR TITLE
[barefoot] Fix y_profile_set to not reset link

### DIFF
--- a/device/barefoot/x86_64-accton_as9516_32d-r0/syncd.conf
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/syncd.conf
@@ -7,12 +7,18 @@ y_profile_set() {
         return
     fi
 
+    if [[ $(readlink /opt/bfn/install) =~ "install_y"  ]]; then
+        echo "/opt/bfn/install is a link to Y profile"
+        return
+    fi
+
     Y_PROFILE=$(ls -d /opt/bfn/install_y*_profile 2> /dev/null | head -1)
     if [[ -z $Y_PROFILE  ]]; then
         echo "No P4 profile found for Newport"
         return
     fi
 
+    echo "Link /opt/bfn/install to $Y_PROFILE"
     ln -srfn $Y_PROFILE /opt/bfn/install
 }
 


### PR DESCRIPTION
For this platform, it is expected to work on any Y profile. but after the latest changes, the first Y profile is always used.

**- Why I did it**
To be able to set another Y profile

**- How I did it**
Extend logic to check if the Y profile is already used
**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**


- [ ] 201811
- [ ] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
