### PR TITLE
[slave-buster] Armhf sairedis build fix

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -322,6 +322,22 @@ RUN apt-get update && apt-get install -y \
         python-lxml \
         libexpat1-dev
 
+# Build fix for ARMHF buster libsairedis
+{%- if CONFIGURED_ARCH == "armhf" %}
+       # Install doxygen build dependency packages
+       RUN apt install -y libxapian-dev yui-compressor libclang-3.9-dev texlive-extra-utils \
+           texlive-font-utils  rdfind llvm-6.0-dev libclang-6.0-dev sassc
+
+       # Update doxygen with 64bit file offset patch
+       RUN dget -u http://deb.debian.org/debian/pool/main/d/doxygen/doxygen_1.8.13-10.dsc && \
+           cd doxygen-1.8.13 && \
+           sed -i '56 a add_definitions(-D_FILE_OFFSET_BITS=64)' CMakeLists.txt && \
+           DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -b && \
+           cd .. && \
+           dpkg -i ./doxygen_1.8.13-10_armhf.deb && \
+           rm -fr doxygen*
+{%- endif %}
+
 ## Config dpkg
 ## install the configuration file if it’s currently missing
 RUN sudo augtool --autosave "set /files/etc/dpkg/dpkg.cfg/force-confmiss"


### PR DESCRIPTION
Doxygen https://github.com/opencomputeproject/SAI/blob/master/Makefile#L23
 SAI submodule in libsairedis builds meta using doxygen
 Debian buster doxygen for ARMHF (32bit) fails to recursively
 read subdirectories to parse the header files.
 This issue is described at https://bugs.launchpad.net/qemu/+bug/1805913
 The solution to this is to add FILE_OFFSET_BITS to 64 as desribed at
 https://bugzilla.kernel.org/show_bug.cgi?id=205957

  This issue is not seen in stretch which has glibc 2.24 and is seen only
  on buster which has glibc version 2.28. The above bugs needs to be
  tracked to get rid of this PR change, once debian moves forward to next
  version.

 This PR addresses the readdir() issue for 32bit arch, by adding
 cflag _FILE_OFFSET_BITS=64 through cmake definition to the doxygen
 source downloaded from the debian buster.

Signed-off-by: Antony Rheneus <arheneus@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
