### PR TITLE
[slave-buster] Armhf sairedis build fix

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -336,6 +336,10 @@ RUN apt-get update && apt-get install -y \
            cd .. && \
            dpkg -i ./doxygen_1.8.13-10_armhf.deb && \
            rm -fr doxygen*
+
+       # Aspell is unable to locate the language dictionaries.
+       # Re-installing aspell-en dictionary to fix it.
+       RUN apt-get install --reinstall -y aspell-en
 {%- endif %}
 
 ## Config dpkg


### PR DESCRIPTION
Aspell check in sairedis SAI submodule in armhf(32-bit) fails with "lang
dictionary not found" error.
(https://github.com/opencomputeproject/SAI/blob/master/meta/style.pm#L58)
This issue is described at https://bugs.launchpad.net/qemu/+bug/1805913
and similar to https://github.com/Azure/sonic-buildimage/pull/6239
Re-installing aspell language dictionary in slave docker resolves this issue.

Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
