### PR TITLE
[Monit] Monitoring the running status of containers.

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -309,8 +309,8 @@ sudo cp $IMAGE_CONFIGS/monit/conf.d/* $FILESYSTEM_ROOT/etc/monit/conf.d/
 sudo chmod 600 $FILESYSTEM_ROOT/etc/monit/conf.d/*
 sudo cp $IMAGE_CONFIGS/monit/process_checker $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/process_checker
-sudo cp $IMAGE_CONFIGS/monit/monitoring_containers $FILESYSTEM_ROOT/usr/bin/
-sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/monitoring_containers
+sudo cp $IMAGE_CONFIGS/monit/container_checker $FILESYSTEM_ROOT/usr/bin/
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/container_checker
 
 
 # Install custom-built openssh sshd

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -309,6 +309,9 @@ sudo cp $IMAGE_CONFIGS/monit/conf.d/* $FILESYSTEM_ROOT/etc/monit/conf.d/
 sudo chmod 600 $FILESYSTEM_ROOT/etc/monit/conf.d/*
 sudo cp $IMAGE_CONFIGS/monit/process_checker $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/process_checker
+sudo cp $IMAGE_CONFIGS/monit/monitoring_containers $FILESYSTEM_ROOT/usr/bin/
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/monitoring_containers
+
 
 # Install custom-built openssh sshd
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/openssh-server_*.deb

--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -31,3 +31,5 @@ check program routeCheck with path "/usr/local/bin/route_check.py"
     every 5 cycles
     if status != 0 for 3 cycle then alert repeat every 1 cycles
 
+check program monitoring_containers with path "/usr/bin/monitoring_containers"
+    if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles

--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -31,5 +31,5 @@ check program routeCheck with path "/usr/local/bin/route_check.py"
     every 5 cycles
     if status != 0 for 3 cycle then alert repeat every 1 cycles
 
-check program monitoring_containers with path "/usr/bin/container_checker"
+check program container_checker with path "/usr/bin/container_checker"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles

--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -31,5 +31,5 @@ check program routeCheck with path "/usr/local/bin/route_check.py"
     every 5 cycles
     if status != 0 for 3 cycle then alert repeat every 1 cycles
 
-check program monitoring_containers with path "/usr/bin/monitoring_containers"
+check program monitoring_containers with path "/usr/bin/container_checker"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -5,6 +5,7 @@ import sys
 
 import swsssdk
 from sonic_py_common import multi_asic
+from sonic_py_common.logger import Logger
 
 SYSLOG_IDENTIFIER = "container_checker"
 
@@ -94,7 +95,6 @@ def main():
     current_running_containers = get_current_running_containers(logger)
 
     not_running_containers = expected_running_containers.difference(current_running_containers)
-
     if not_running_containers:
         logger.log_error("Containers not running: " + ", ".join(not_running_containers))
         sys.exit(4)

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -4,11 +4,12 @@
 container_checker
 
 This script is intended to be run by Monit. It will write an alerting message into
-syslog if it found containers which were expected to run but were not running. Note
-that if print(...) statement in this script was executed, the string in it will be 
-appended to Monit syslog messages.
+syslog if it found containers which were expected to run but were not running. At
+the same time, if some containers were unexpected to run, it also writes an alerting
+syslog message. Note that if print(...) statement in this script was executed, the
+string in it will be appended to Monit syslog messages.
 
-The following is an example in Monit configuration file to show how Monit will run 
+The following is an example in Monit configuration file to show how Monit will run
 this script:
 
 check program container_checker with path "/usr/bin/container_checker"

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -11,7 +11,7 @@ The following is an example in Monit configuration file to show how Monit will r
 this script:
 
 check program container_checker with path "/usr/bin/container_checker"
-    if status != 0 for 5 times within 5 cycles then alert repeat every
+    if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
 
 """
 import subprocess

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -42,7 +42,7 @@ def get_command_result(command):
         print("Failed to execute the command '{}'. Error: '{}'".format(command, err))
         sys.exit(2)
 
-    return command_stdout.split("\n")[:-1]
+    return command_stdout.rstrip().split("\n")
 
 
 def get_expected_running_containers():

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -5,11 +5,6 @@ import sys
 
 import swsssdk
 from sonic_py_common import multi_asic
-from sonic_py_common.logger import Logger
-
-SYSLOG_IDENTIFIER = "container_checker"
-logger = Logger(SYSLOG_IDENTIFIER)
-logger.set_min_log_priority_info()
 
 
 def get_command_result(command):
@@ -24,14 +19,14 @@ def get_command_result(command):
                                          shell=True, universal_newlines=True)
         command_stdout, command_stderr = proc_instance.communicate()
         if proc_instance.returncode != 0:
-            logger.log_error("Failed to execute the command '{}'. Return code: '{}'".format(
+            print("Failed to execute the command '{}'. Return code: '{}'".format(
                 command, proc_instance.returncode))
             sys.exit(1)
     except OSError as os_err:
-        logger.log_error("Failed to execute the command '{}'. Error: '{}'".format(command, os_err))
+        print("Failed to execute the command '{}'. Error: '{}'".format(command, os_err))
         sys.exit(2)
     except ValueError as val_err:
-        logger.log_error("Failed to execute the command '{}'. Error: '{}'".format(command, val_err))
+        print("Failed to execute the command '{}'. Error: '{}'".format(command, val_err))
         sys.exit(3)
 
     return command_stdout.split("\n")
@@ -96,7 +91,7 @@ def main():
 
     not_running_containers = expected_running_containers.difference(current_running_containers)
     if not_running_containers:
-        logger.log_error("Containers not running: " + ", ".join(not_running_containers))
+        print("Containers not running: " + ", ".join(not_running_containers))
         sys.exit(4)
 
 

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import sys
 import subprocess
+import sys
 
 import swsssdk
 from sonic_py_common import multi_asic

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -24,7 +24,7 @@ from sonic_py_common import multi_asic
 
 def get_command_result(command):
     """
-    @summary: This function will execture the command and return the result.
+    @summary: This function will execute the command and return the resulting output.
     @return: A string which contains the output of command.
     """
     command_stdout = ""
@@ -37,12 +37,9 @@ def get_command_result(command):
             print("Failed to execute the command '{}'. Return code: '{}'".format(
                 command, proc_instance.returncode))
             sys.exit(1)
-    except OSError as os_err:
-        print("Failed to execute the command '{}'. Error: '{}'".format(command, os_err))
+    except (OSError, ValueError) as err:
+        print("Failed to execute the command '{}'. Error: '{}'".format(command, err))
         sys.exit(2)
-    except ValueError as val_err:
-        print("Failed to execute the command '{}'. Error: '{}'".format(command, val_err))
-        sys.exit(3)
 
     return command_stdout.split("\n")
 
@@ -107,6 +104,11 @@ def main():
     not_running_containers = expected_running_containers.difference(current_running_containers)
     if not_running_containers:
         print("Containers not running: " + ", ".join(not_running_containers))
+        sys.exit(3)
+
+    unexpected_running_containers = current_running_containers.difference(expected_running_containers)
+    if unexpected_running_containers:
+        print("Unexpected running containers: " + ", ".join(unexpected_running_containers))
         sys.exit(4)
 
 

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -8,8 +8,11 @@ from sonic_py_common import multi_asic
 from sonic_py_common.logger import Logger
 
 SYSLOG_IDENTIFIER = "container_checker"
+logger = Logger(SYSLOG_IDENTIFIER)
+logger.set_min_log_priority_info()
 
-def get_command_result(command, logger):
+
+def get_command_result(command):
     """
     @summary: This function will execture the command and return the result.
     @return: A string which contains the output of command.
@@ -65,7 +68,7 @@ def get_expected_running_containers():
     return expected_running_containers
 
 
-def get_current_running_containers(logger):
+def get_current_running_containers():
     """
     @summary: This function will get the current running container list by analyzing the
               output of command `docker ps`.
@@ -74,7 +77,7 @@ def get_current_running_containers(logger):
     running_containers = set()
 
     command = "docker ps"
-    command_stdout = get_command_result(command, logger)
+    command_stdout = get_command_result(command)
     for line in command_stdout:
         if line and "CONTAINER ID" not in line:
             running_containers.add(line.split()[-1].strip())
@@ -88,11 +91,8 @@ def main():
               and the containers which were expected to run. If containers which were exepcted
               to run were not running, then an alerting message will be written into syslog.
     """
-    logger = Logger(SYSLOG_IDENTIFIER)
-    logger.set_min_log_priority_info()
-
     expected_running_containers = get_expected_running_containers()
-    current_running_containers = get_current_running_containers(logger)
+    current_running_containers = get_current_running_containers()
 
     not_running_containers = expected_running_containers.difference(current_running_containers)
     if not_running_containers:

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -1,10 +1,9 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import sys
 import subprocess
 
 import swsssdk
-
 from sonic_py_common import multi_asic
 
 
@@ -81,11 +80,11 @@ def get_current_running_containers():
     return running_containers
 
 
-def monitoring_containers_and_alerting():
+def main():
     """
     @summary: This function will compare the difference between the current running containers
               and the containers which were expected to run. If containers which were exepcted
-              to run but not running, then an alerting message will be written into syslog.
+              to run were not running, then an alerting message will be written into syslog.
     """
     expected_running_containers = get_expected_running_containers()
     current_running_containers = get_current_running_containers()
@@ -106,10 +105,6 @@ def monitoring_containers_and_alerting():
             print("Container '{}' was not running.".format(log_message))
 
         sys.exit(4)
-
-
-def main():
-    monitoring_containers_and_alerting()
 
 
 if __name__ == "__main__":

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 """
 container_checker
 
@@ -12,8 +13,8 @@ this script:
 
 check program container_checker with path "/usr/bin/container_checker"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
-
 """
+
 import subprocess
 import sys
 

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -86,7 +86,7 @@ def get_current_running_containers():
 
     command = "docker ps"
     command_stdout = get_command_result(command)
-    for line in command_stdout:
+    for line in command_stdout[1:]:
         running_containers.add(line.split()[-1].strip())
 
     return running_containers

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -34,11 +34,11 @@ def get_command_result(command):
 
 def get_expected_running_containers():
     """
-    @summary: This function will get the expected running container list by following the rule:
+    @summary: This function will get the expected running containers by following the rule:
               The 'state' field of container in 'FEATURE' table should not be 'disabled'. Then
-              if the device has Multi-ASIC, this function will generate list by determining the
-              value of field 'has_global_scope', the number of ASICs and the value of field of
-              'has_per_asic_scope'. If the device has single ASIC, just put the container name into
+              if the device has Multi-ASIC, this function will get container list by determining the
+              value of field 'has_global_scope', the number of ASICs and the value of field
+              'has_per_asic_scope'. If the device has single ASIC, the container name was put into
               the list.
     @return:  A set which contains the expected running containers.
     """

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -6,8 +6,9 @@ import sys
 import swsssdk
 from sonic_py_common import multi_asic
 
+SYSLOG_IDENTIFIER = "container_checker"
 
-def get_command_result(command):
+def get_command_result(command, logger):
     """
     @summary: This function will execture the command and return the result.
     @return: A string which contains the output of command.
@@ -19,14 +20,14 @@ def get_command_result(command):
                                          shell=True, universal_newlines=True)
         command_stdout, command_stderr = proc_instance.communicate()
         if proc_instance.returncode != 0:
-            print("Failed to execute the command '{}'. Return code: '{}'".format(
+            logger.log_error("Failed to execute the command '{}'. Return code: '{}'".format(
                 command, proc_instance.returncode))
             sys.exit(1)
     except OSError as os_err:
-        print("Failed to execute the command '{}'. Error: '{}'".format(command, os_err))
+        logger.log_error("Failed to execute the command '{}'. Error: '{}'".format(command, os_err))
         sys.exit(2)
     except ValueError as val_err:
-        print("Failed to execute the command '{}'. Error: '{}'".format(command, val_err))
+        logger.log_error("Failed to execute the command '{}'. Error: '{}'".format(command, val_err))
         sys.exit(3)
 
     return command_stdout.split("\n")
@@ -63,7 +64,7 @@ def get_expected_running_containers():
     return expected_running_containers
 
 
-def get_current_running_containers():
+def get_current_running_containers(logger):
     """
     @summary: This function will get the current running container list by analyzing the
               output of command `docker ps`.
@@ -72,7 +73,7 @@ def get_current_running_containers():
     running_containers = set()
 
     command = "docker ps"
-    command_stdout = get_command_result(command)
+    command_stdout = get_command_result(command, logger)
     for line in command_stdout:
         if line and "CONTAINER ID" not in line:
             running_containers.add(line.split()[-1].strip())
@@ -86,24 +87,16 @@ def main():
               and the containers which were expected to run. If containers which were exepcted
               to run were not running, then an alerting message will be written into syslog.
     """
+    logger = Logger(SYSLOG_IDENTIFIER)
+    logger.set_min_log_priority_info()
+
     expected_running_containers = get_expected_running_containers()
-    current_running_containers = get_current_running_containers()
+    current_running_containers = get_current_running_containers(logger)
 
     not_running_containers = expected_running_containers.difference(current_running_containers)
 
     if not_running_containers:
-        log_message = ""
-        for container_name in not_running_containers:
-            if not log_message:
-                log_message = container_name
-            else:
-                log_message += ", " + container_name
-
-        if len(not_running_containers) > 1:
-            print("Containers '{}' were not running.".format(log_message))
-        else:
-            print("Container '{}' was not running.".format(log_message))
-
+        logger.log_error("Containers not running: " + ", ".join(not_running_containers))
         sys.exit(4)
 
 

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
+"""
+container_checker
 
+This script is intended to be run by Monit. It will write an alerting message into
+syslog if it found containers which were expected to run but were not running. Note
+that if print(...) statement in this script was executed, the string in it will be 
+appended to Monit syslog messages.
+
+The following is an example in Monit configuration file to show how Monit will run 
+this script:
+
+check program container_checker with path "/usr/bin/container_checker"
+    if status != 0 for 5 times within 5 cycles then alert repeat every
+
+"""
 import subprocess
 import sys
 

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -103,7 +103,7 @@ def main():
 
     not_running_containers = expected_running_containers.difference(current_running_containers)
     if not_running_containers:
-        print("Containers not running: " + ", ".join(not_running_containers))
+        print("Expected containers not running: " + ", ".join(not_running_containers))
         sys.exit(3)
 
     unexpected_running_containers = current_running_containers.difference(expected_running_containers)

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -42,7 +42,7 @@ def get_command_result(command):
         print("Failed to execute the command '{}'. Error: '{}'".format(command, err))
         sys.exit(2)
 
-    return command_stdout.split("\n")
+    return command_stdout.split("\n")[:-1]
 
 
 def get_expected_running_containers():
@@ -87,8 +87,7 @@ def get_current_running_containers():
     command = "docker ps"
     command_stdout = get_command_result(command)
     for line in command_stdout:
-        if line and "CONTAINER ID" not in line:
-            running_containers.add(line.split()[-1].strip())
+        running_containers.add(line.split()[-1].strip())
 
     return running_containers
 

--- a/files/image_config/monit/monitoring_containers
+++ b/files/image_config/monit/monitoring_containers
@@ -1,0 +1,114 @@
+#!/usr/bin/python
+
+import sys
+import subprocess
+
+import swsssdk
+
+from sonic_py_common import multi_asic
+
+def get_command_result(command):
+    """
+    @summary: This function will execture the command and return the result.
+    @return: A string which contains the output of command.
+    """
+    command_stdout = ""
+
+    try:
+        proc_instance = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, 
+                                         shell=True, universal_newlines=True)
+        command_stdout, command_stderr = proc_instance.communicate()
+        if proc_instance.returncode != 0:
+            print("Failed to execute the command '{}'. Return code: '{}'".format(
+                command, proc_instance.returncode))
+            sys.exit(1)
+    except OSError as os_err:
+        print("Failed to execute the command '{}'. Error: '{}'".format(command, os_err))
+        sys.exit(2)
+    except ValueError as val_err:
+        print("Failed to execute the command '{}'. Error: '{}'".format(command, val_err))
+        sys.exit(3)
+
+    return command_stdout.split("\n")
+
+
+def get_expected_running_containers():
+    """
+    @summary: This function will get the expected running container list by following the rule:
+              The 'state' field of container in 'FEATURE' table should not be 'disabled'. Then
+              if the device has Multi-ASIC, this function will generate list by determining the
+              value of field 'has_global_scope', the number of ASICs and the value of field of
+              'has_per_asic_scope'. If the device has single ASIC, just put the container name into
+              the list.
+    @return:  A set which contains the expected running containers.
+    """
+    config_db = swsssdk.ConfigDBConnector()
+    config_db.connect()
+    feature_table = config_db.get_table("FEATURE")
+
+    expected_running_containers = set()
+
+    for container_name in feature_table.keys():
+        if feature_table[container_name]["state"] != "disabled":
+            if multi_asic.is_multi_asic():
+                if feature_table[container_name]["has_global_scope"] == "True":
+                    expected_running_containers.add(container_name)
+                if feature_table[container_name]["has_per_asic_scope"] == "True":
+                    num_asics = multi_asic.get_num_asics()
+                    for asic_id in range(num_asics):
+                        expected_running_containers.add(container_name + str(asic_id))
+            else:
+                expected_running_containers.add(container_name)
+
+    return expected_running_containers
+
+
+def get_current_running_containers():
+    """
+    @summary: This function will get the current running container list by analyzing the
+              output of command `docker ps`.
+    @return:  A set which contains the current running contianers.
+    """
+    running_containers = set()
+
+    command = "docker ps"
+    command_stdout = get_command_result(command)
+    for line in command_stdout:
+        if line and "CONTAINER ID" not in line:
+            running_containers.add(line.split()[-1].strip())
+
+    return running_containers
+
+
+def monitoring_containers_and_alerting():
+    """
+    @summary: This function will compare the difference between the current running containers
+              and the containers which were expected to run. If containers which were exepcted
+              to run but not running, then an alerting message will be written into syslog.
+    """
+    expected_running_containers = get_expected_running_containers()
+    current_running_containers = get_current_running_containers()
+
+    not_running_containers = expected_running_containers.difference(current_running_containers)
+
+    if not_running_containers:
+        log_message = ""
+        for container_name in not_running_containers:
+            if not log_message:
+                log_message = container_name
+            else:
+                log_message += ", " + container_name
+        
+        if len(not_running_containers) > 1:
+            print("Containers '{}' were not running.".format(log_message))
+        else:
+            print("Container '{}' was not running.".format(log_message))
+
+        sys.exit(4)
+
+
+def main():
+    monitoring_containers_and_alerting()
+
+if __name__ == "__main__":
+    main()

--- a/files/image_config/monit/monitoring_containers
+++ b/files/image_config/monit/monitoring_containers
@@ -7,6 +7,7 @@ import swsssdk
 
 from sonic_py_common import multi_asic
 
+
 def get_command_result(command):
     """
     @summary: This function will execture the command and return the result.
@@ -15,7 +16,7 @@ def get_command_result(command):
     command_stdout = ""
 
     try:
-        proc_instance = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, 
+        proc_instance = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                          shell=True, universal_newlines=True)
         command_stdout, command_stderr = proc_instance.communicate()
         if proc_instance.returncode != 0:
@@ -98,7 +99,7 @@ def monitoring_containers_and_alerting():
                 log_message = container_name
             else:
                 log_message += ", " + container_name
-        
+
         if len(not_running_containers) > 1:
             print("Containers '{}' were not running.".format(log_message))
         else:
@@ -109,6 +110,7 @@ def monitoring_containers_and_alerting():
 
 def main():
     monitoring_containers_and_alerting()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION

**- Why I did it**
This PR aims to monitor the running status of each container. Currently the auto-restart feature was enabled. If a critical process exited unexpected, the container will be restarted. If the container was restarted 3 times during 20 minutes, then it will not run anymore unless we cleared the flag using the command `sudo systemctl reset-failed <container_name>` manually. 

**- How I did it**
We will employ Monit to monitor a script. This script will generate the expected running container list and compare it with the current running containers. If there are containers which were expected to run but were not running, then an alerting message will be written into syslog.

**- How to verify it**
I tested this feature on a lab device `str-a7050-acs-3` which has single ASIC and `str2-n3164-acs-3` which has a Multi-ASIC. First I manually stopped a container by running the command `sudo systemctl stop <container_name>`, then I checked whether there was an alerting message in the syslog.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
