### PR TITLE
Telemetry Certificate Copy Across Image Upgrade.

### DIFF
--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -313,7 +313,7 @@ check_all_config_db_present()
 do_config_migration()
 {
     # Identify list of files to migrate
-    copy_list="minigraph.xml snmp.yml acl.json frr"
+    copy_list="minigraph.xml snmp.yml acl.json frr telemetry"
 
     # Migrate all configuration files from old to new
     copy_config_files_and_directories $copy_list


### PR DESCRIPTION
Why/What I did:
To copy telemetry certificate during image upgrade from previous image to new image
Closing Issue https://github.com/Azure/sonic-buildimage/issues/5955.

How I did:

Added "telemetry directory" to the list of files/directory that gest copied when new images booted.


How I verify:

- Verified Telemetry Certificate are restored from 201811 to 201911
- Verified Telemetry Certificate are restored from 201911 to 201911




