### PR TITLE
[Arista] Better handle arbitrary tmpfs in boot0

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -130,9 +130,26 @@ update_next_boot() {
     fi
 }
 
+is_in_memory() {
+    local file="$1"
+    local filedev=$(df "$file" | tail -n 1 | tr -s ' ' | cut -f6 -d' ')
+    local filedevfs=$(mount | grep " $filedev " | cut -f5 -d' ')
+
+    case "$filedevfs" in
+       tmpfs|ramfs) return 0;;
+       *) return 1;;
+    esac
+}
+
 move_swi_to_tmpfs() {
     local oldswi="$1"
     local newswi="$swi_tmpfs/$(basename $oldswi)"
+
+    # check if the swi is already in memory
+    if ! $in_aboot && is_in_memory "$oldswi"; then
+       echo "$oldswi"
+       return 0
+    fi
 
     mkdir -p "$swi_tmpfs"
     if ! $in_aboot && ! mount | grep -q ' /tmp type tmpfs'; then


### PR DESCRIPTION
**- Why I did it**

To limit IO and space usage on the flash device the `boot0` script makes sure the SWI is in memory.
Because SONiC maps `/tmp` on the flash, some logic is required to make sure of it.
However it is possible for some provisioning mechanism to already download the swi in a memory file system.
This was not properly handled by the `boot0` script.
It now properly detect if the image is on a `tmpfs` or a `ramfs` and keep it there if that is the case.

**- How I did it**

Check the filesystem on which the SWI pointed by `swipath` lies.
If this filesystem is a `ramfs` or a `tmpfs` the `move_swi_to_tmpfs` becomes a no-op.
Made sure the cleanup logic would not behave unexpectedly.

**- How to verify it**

In SONiC:

1) Download the swi under `/tmp` and makes sure it gets moved to `/tmp/tmp-swi` which gets mounted for that purpose.
Make sure `/tmp/tmp-swi` gets unmounted once the install process is done.

2) Create a new mountpoint under `/ram` using either `ramfs` or `tmpfs` and download the swi there.
Install the swi using sonic-installer and makes sure the image doesn't get moved by looking at the logs.

**- Which release branch to backport (provide reason below if selected)**

None, master will receive an independent fix soon.

**- Description for the changelog**

Better handle arbitrary tmpfs mounts in boot0