### PR TITLE
[Arista] Better handle arbitrary tmpfs in boot0

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -65,13 +65,18 @@ if [ $# -ne 0 ]; then
     exit 1
 fi
 
+mountpoint_for_file() {
+   local file="$1"
+   df "$file" | tail -1 | tr -s " " | cut -d ' ' -f6
+}
+
 # extract mount point from the swi path, e.g., /mnt/flash/sonic.swi --> /mnt/flash
 if [ -z "$target_path" ]; then
     if [ -z "$swipath" ]; then
        err "target_path= is required when swipath= is not provided"
        exit 1
     fi
-    target_path=$(df "$swipath" | tail -1 | tr -s " " | cut -d ' ' -f6)
+    target_path=$(mountpoint_for_file "$swipath")
 fi
 image_path="$target_path/$image_name"
 hook_path="$image_path/platform/hooks"
@@ -221,8 +226,19 @@ find_first_initrd_under() {
     find "$path" -name 'initrd.img-*' -type f | head -n 1
 }
 
+is_file_in_memory() {
+    local file="$1"
+    local filemnt=$(mountpoint_for_file "$file")
+    local filemntfs=$(mount | grep " $filemnt " | cut -f5 -d' ')
+
+    case "$filemntfs" in
+       tmpfs|ramfs) return 0;;
+       *) return 1;;
+    esac
+}
+
 get_tmpfs() {
-    local tmpfs="${1:-$(mktemp -d)}"
+    local tmpfs="$(mktemp -d)"
 
     mkdir -p "$tmpfs"
     if ! $in_aboot && ! mount | grep -q ' /tmp type tmpfs'; then
@@ -234,16 +250,27 @@ get_tmpfs() {
 
 clean_tmpfs() {
     local tmpfs="$1"
+
+    case "$tmpfs" in
+       /tmp) return 0;;
+       /tmp/*);; # only cleanup tmpfs created by this script
+       *) return 0;;
+    esac
+
     if mount | grep -q "$tmpfs"; then
         umount "$tmpfs" || :
-    else
-        rm -rf "$tmpfs"
     fi
 }
 
 move_swi_to_tmpfs() {
     local oldswi="$1"
-    local tmpfs="$(get_tmpfs "$swi_tmpfs")"
+
+    if is_file_in_memory "$oldswi"; then
+       echo "$oldswi"
+       return 0
+    fi
+
+    local tmpfs="$(get_tmpfs)"
     local newswi="$tmpfs/$(basename "$oldswi")"
 
     mv "$oldswi" "$newswi"
@@ -252,7 +279,7 @@ move_swi_to_tmpfs() {
 
 cleanup_swi_tmpfs() {
    rm -f "$swipath"
-   clean_tmpfs "$(dirname "$swipath")"
+   clean_tmpfs "$(mountpoint_for_file "$swipath")"
 }
 
 mount_relpath() {
@@ -351,7 +378,7 @@ extract_image() {
         chmod a+r "$installer_image_path"
     else
         info "Remove installer"
-        cleanup_swi_tmpfs "$(basename "$swipath")"
+        cleanup_swi_tmpfs "$swipath"
     fi
 
     ## use new reduced-size boot swi


### PR DESCRIPTION
**- Why I did it**

To limit IO and space usage on the flash device the `boot0` script makes sure the SWI is in memory.
Because SONiC maps `/tmp` on the flash, some logic is required to make sure of it.
However it is possible for some provisioning mechanism to already download the swi in a memory file system.
This case was not handled properly by the `boot0` script.
It now detect if the image is on a `tmpfs` or a `ramfs` and keep it there if that is the case.

The cleanup method has been updated accordingly and will only cleanup
the mount path if it's below /tmp/ as to not affect user mounted paths.

**- How I did it**

Check the filesystem on which the SWI pointed by `swipath` lies.
If this filesystem is a `ramfs` or a `tmpfs` the `move_swi_to_tmpfs` becomes a no-op.
Made sure the cleanup logic would not behave unexpectedly.

**- How to verify it**

In SONiC:

1) Download the swi under `/tmp` and makes sure it gets moved to `/tmp/tmp-swi` which gets mounted for that purpose.
Make sure `/tmp/tmp-swi` gets unmounted once the install process is done.

2) Create a new mountpoint under `/ram` using either `ramfs` or `tmpfs` and download the swi there.
Install the swi using sonic-installer and makes sure the image doesn't get moved by looking at the logs.

**- Which release branch to backport (provide reason below if selected)**

Already in 201911.

**- Description for the changelog**

Better handle arbitrary tmpfs mounts in boot0