### PR TITLE
[DPB] [Mellanox] added capability files for SN4700 platform 

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/hwsku.json
@@ -1,100 +1,100 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet8": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet16": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet24": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet32": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet40": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet48": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet56": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet64": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet72": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet80": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet88": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet96": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet104": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet112": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet120": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet128": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet136": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet144": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet152": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet160": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet168": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet176": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet184": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet192": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet200": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet208": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet216": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet224": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet232": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet240": {
-            "default_brkout_mode": "1x400G[200G]"
-        }, 
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
+        },
         "Ethernet248": {
-            "default_brkout_mode": "1x400G[200G]"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/platform.json
@@ -4,193 +4,193 @@
             "index": "1,1,1,1,1,1,1,1", 
             "lanes": "0,1,2,3,4,5,6,7", 
             "alias_at_lanes": "etp1a, etp1b, etp1c, etp1d, etp1e, etp1f, etp1g, etp1h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet8": {
             "index": "2,2,2,2,2,2,2,2", 
             "lanes": "8,9,10,11,12,13,14,15", 
             "alias_at_lanes": "etp2a, etp2b, etp2c, etp2d, etp2e, etp2f, etp2g, etp2h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet16": {
             "index": "3,3,3,3,3,3,3,3", 
             "lanes": "16,17,18,19,20,21,22,23", 
             "alias_at_lanes": "etp3a, etp3b, etp3c, etp3d, etp3e, etp3f, etp3g, etp3h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet24": {
             "index": "4,4,4,4,4,4,4,4", 
             "lanes": "24,25,26,27,28,29,30,31", 
             "alias_at_lanes": "etp4a, etp4b, etp4c, etp4d, etp4e, etp4f, etp4g, etp4h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet32": {
             "index": "5,5,5,5,5,5,5,5", 
             "lanes": "32,33,34,35,36,37,38,39", 
             "alias_at_lanes": "etp5a, etp5b, etp5c, etp5d, etp5e, etp5f, etp5g, etp5h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet40": {
             "index": "6,6,6,6,6,6,6,6", 
             "lanes": "40,41,42,43,44,45,46,47", 
             "alias_at_lanes": "etp6a, etp6b, etp6c, etp6d, etp6e, etp6f, etp6g, etp6h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet48": {
             "index": "7,7,7,7,7,7,7,7", 
             "lanes": "48,49,50,51,52,53,54,55", 
             "alias_at_lanes": "etp7a, etp7b, etp7c, etp7d, etp7e, etp7f, etp7g, etp7h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet56": {
             "index": "8,8,8,8,8,8,8,8", 
             "lanes": "56,57,58,59,60,61,62,63", 
             "alias_at_lanes": "etp8a, etp8b, etp8c, etp8d, etp8e, etp8f, etp8g, etp8h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet64": {
             "index": "9,9,9,9,9,9,9,9", 
             "lanes": "64,65,66,67,68,69,70,71", 
             "alias_at_lanes": "etp9a, etp9b, etp9c, etp9d, etp9e, etp9f, etp9g, etp9h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet72": {
             "index": "10,10,10,10,10,10,10,10", 
             "lanes": "72,73,74,75,76,77,78,79", 
             "alias_at_lanes": "etp10a, etp10b, etp10c, etp10d, etp10e, etp10f, etp10g, etp10h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet80": {
             "index": "11,11,11,11,11,11,11,11", 
             "lanes": "80,81,82,83,84,85,86,87", 
             "alias_at_lanes": "etp11a, etp11b, etp11c, etp11d, etp11e, etp11f, etp11g, etp11h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet88": {
             "index": "12,12,12,12,12,12,12,12", 
             "lanes": "88,89,90,91,92,93,94,95", 
             "alias_at_lanes": "etp12a, etp12b, etp12c, etp12d, etp12e, etp12f, etp12g, etp12h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet96": {
             "index": "13,13,13,13,13,13,13,13", 
             "lanes": "96,97,98,99,100,101,102,103", 
             "alias_at_lanes": "etp13a, etp13b, etp13c, etp13d, etp13e, etp13f, etp13g, etp13h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet104": {
             "index": "14,14,14,14,14,14,14,14", 
             "lanes": "104,105,106,107,108,109,110,111", 
             "alias_at_lanes": "etp14a, etp14b, etp14c, etp14d, etp14e, etp14f, etp14g, etp14h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet112": {
             "index": "15,15,15,15,15,15,15,15", 
             "lanes": "112,113,114,115,116,117,118,119", 
             "alias_at_lanes": "etp15a, etp15b, etp15c, etp15d, etp15e, etp15f, etp15g, etp15h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet120": {
             "index": "16,16,16,16,16,16,16,16", 
             "lanes": "120,121,122,123,124,125,126,127", 
             "alias_at_lanes": "etp16a, etp16b, etp16c, etp16d, etp16e, etp16f, etp16g, etp16h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet128": {
             "index": "17,17,17,17,17,17,17,17", 
             "lanes": "128,129,130,131,132,133,134,135", 
             "alias_at_lanes": "etp17a, etp17b, etp17c, etp17d, etp17e, etp17f, etp17g, etp17h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet136": {
             "index": "18,18,18,18,18,18,18,18", 
             "lanes": "136,137,138,139,140,141,142,143", 
             "alias_at_lanes": "etp18a, etp18b, etp18c, etp18d, etp18e, etp18f, etp18g, etp18h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet144": {
             "index": "19,19,19,19,19,19,19,19", 
             "lanes": "144,145,146,147,148,149,150,151", 
             "alias_at_lanes": "etp19a, etp19b, etp19c, etp19d, etp19e, etp19f, etp19g, etp19h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet152": {
             "index": "20,20,20,20,20,20,20,20", 
             "lanes": "152,153,154,155,156,157,158,159", 
             "alias_at_lanes": "etp20a, etp20b, etp20c, etp20d, etp20e, etp20f, etp20g, etp20h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet160": {
             "index": "21,21,21,21,21,21,21,21", 
             "lanes": "160,161,162,163,164,165,166,167", 
             "alias_at_lanes": "etp21a, etp21b, etp21c, etp21d, etp21e, etp21f, etp21g, etp21h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet168": {
             "index": "22,22,22,22,22,22,22,22", 
             "lanes": "168,169,170,171,172,173,174,175", 
             "alias_at_lanes": "etp22a, etp22b, etp22c, etp22d, etp22e, etp22f, etp22g, etp22h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet176": {
             "index": "23,23,23,23,23,23,23,23", 
             "lanes": "176,177,178,179,180,181,182,183", 
             "alias_at_lanes": "etp23a, etp23b, etp23c, etp23d, etp23e, etp23f, etp23g, etp23h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet184": {
             "index": "24,24,24,24,24,24,24,24", 
             "lanes": "184,185,186,187,188,189,190,191", 
             "alias_at_lanes": "etp24a, etp24b, etp24c, etp24d, etp24e, etp24f, etp24g, etp24h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet192": {
             "index": "25,25,25,25,25,25,25,25", 
             "lanes": "192,193,194,195,196,197,198,199", 
             "alias_at_lanes": "etp25a, etp25b, etp25c, etp25d, etp25e, etp25f, etp25g, etp25h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet200": {
             "index": "26,26,26,26,26,26,26,26", 
             "lanes": "200,201,202,203,204,205,206,207", 
             "alias_at_lanes": "etp26a, etp26b, etp26c, etp26d, etp26e, etp26f, etp26g, etp26h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet208": {
             "index": "27,27,27,27,27,27,27,27", 
             "lanes": "208,209,210,211,212,213,214,215", 
             "alias_at_lanes": "etp27a, etp27b, etp27c, etp27d, etp27e, etp27f, etp27g, etp27h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet216": {
             "index": "28,28,28,28,28,28,28,28", 
             "lanes": "216,217,218,219,220,221,222,223", 
             "alias_at_lanes": "etp28a, etp28b, etp28c, etp28d, etp28e, etp28f, etp28g, etp28h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet224": {
             "index": "29,29,29,29,29,29,29,29", 
             "lanes": "224,225,226,227,228,229,230,231", 
             "alias_at_lanes": "etp29a, etp29b, etp29c, etp29d, etp29e, etp29f, etp29g, etp29h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet232": {
             "index": "30,30,30,30,30,30,30,30", 
             "lanes": "232,233,234,235,236,237,238,239", 
             "alias_at_lanes": "etp30a, etp30b, etp30c, etp30d, etp30e, etp30f, etp30g, etp30h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet240": {
             "index": "31,31,31,31,31,31,31,31", 
             "lanes": "240,241,242,243,244,245,246,247", 
             "alias_at_lanes": "etp31a, etp31b, etp31c, etp31d, etp31e, etp31f, etp31g, etp31h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }, 
         "Ethernet248": {
             "index": "32,32,32,32,32,32,32,32", 
             "lanes": "248,249,250,251,252,253,254,255", 
             "alias_at_lanes": "etp32a, etp32b, etp32c, etp32d, etp32e, etp32f, etp32g, etp32h", 
-            "breakout_modes": "1x400G[200G],2x200G[100G,40G],4x100G"
+            "breakout_modes": "1x400G[200G,100G,50G,40G,25G,10G,1G],2x200G[100G,50G,40G,25G,10G,1G],4x100G[50G,40G,25G,10G,1G]"
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

`platform.json` and `hwsku.json` files has not a full set of speeds for split modes

**- How I did it**

Extended set of speeds for split modes for `SN4700` platform

**- How to verify it**

Manually run DPB CLI commands

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
