### PR TITLE
[DPB][YANG-models] extended regex pattern according to Mellanox systems speeds requirements

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
+++ b/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
@@ -218,6 +218,14 @@ class Test_yang_models:
             'DEVICE_METADATA_TYPE_INCORRECT_PATTERN': {
                 'desc': 'DEVICE_METADATA_TYPE_INCORRECT_PATTERN pattern failure.',
                 'eStr': self.defaultYANGFailure['Pattern']
+            },
+            'BREAKOUT_CFG_CORRECT_MODES': {
+                'desc': 'BREAKOUT_CFG correct breakout modes',
+                'eStr': self.defaultYANGFailure['None']
+            },
+            'BREAKOUT_CFG_INCORRECT_MODES': {
+                'desc': 'BREAKOUT_CFG wrong breakout modes',
+                'eStr': self.defaultYANGFailure['Pattern']
             }
         }
 

--- a/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
@@ -1746,5 +1746,61 @@
         "UNKNOWN_TABLE": {
             "Error": "This Table is for testing, This Table does not have YANG models."
         }
-    }
+	},
+	"BREAKOUT_CFG_CORRECT_MODES": {
+		"sonic-breakout_cfg:sonic-breakout_cfg": {
+			"sonic-breakout_cfg:BREAKOUT_CFG": {
+				"BREAKOUT_CFG_LIST": [
+					{
+						"brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]",
+						"port": "Ethernet0"
+					},
+					{
+						"brkout_mode": "2x100G[50G,40G,25G,10G,1G]",
+						"port": "Ethernet8"
+					},
+					{
+						"brkout_mode": "4x50G[40G,25G,10G,1G]",
+						"port": "Ethernet4"
+					},
+					{
+						"brkout_mode": "1x25G[10G]",
+						"port": "Ethernet12"
+					},
+					{
+						"brkout_mode": "1x100G[50G,40G,25G,10G]",
+						"port": "Ethernet16"
+					},
+					{
+						"brkout_mode": "2x50G[40G,25G,10G]",
+						"port": "Ethernet20"
+					},
+					{
+						"brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
+						"port": "Ethernet24"
+					}
+				]
+			}
+		}
+	},
+	"BREAKOUT_CFG_INCORRECT_MODES": {
+		"sonic-breakout_cfg:sonic-breakout_cfg": {
+			"sonic-breakout_cfg:BREAKOUT_CFG": {
+				"BREAKOUT_CFG_LIST": [
+					{
+						"brkout_mode": "1x500G[100G,50G,40G,25G,10G,1G]",
+						"port": "Ethernet0"
+					},
+					{
+						"brkout_mode": "2x300G[50G,40G,25G,1G]",
+						"port": "Ethernet8"
+					},
+					{
+						"brkout_mode": "5x50G[40G,25G]",
+						"port": "Ethernet4"
+					}
+				]
+			}
+		}
+	}
 }

--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -51,7 +51,7 @@ module sonic-breakout_cfg {
                          * Add any other breakout-mode to allow Dynamic Port
                          * Breakout to that breakout-mode.
                          */
-                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]';
+                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]';
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -51,7 +51,7 @@ module sonic-breakout_cfg {
                          * Add any other breakout-mode to allow Dynamic Port
                          * Breakout to that breakout-mode.
                          */
-                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]|1x25G\[10G,1G\]|1x100G\[50G,40G,25G,10G,1G\]|2x50G\[40G,25G,10G,1G\]|4x25G\[10G,1G\]';
+                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]|1x25G\[10G,1G\]|1x100G\[50G,40G,25G,10G,1G\]|2x50G\[40G,25G,10G,1G\]|4x25G\[10G,1G\]|1x400G\[200G,100G,50G,40G,25G,10G,1G\]|2x200G\[100G,50G,40G,25G,10G,1G\]|4x100G\[50G,40G,25G,10G,1G\]';
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -51,7 +51,7 @@ module sonic-breakout_cfg {
                          * Add any other breakout-mode to allow Dynamic Port
                          * Breakout to that breakout-mode.
                          */
-                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]';
+                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]|1x25G\[10G,1G\]|1x100G\[50G,40G,25G,10G,1G\]|2x50G\[40G,25G,10G,1G\]|4x25G\[10G,1G\]';
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -51,7 +51,7 @@ module sonic-breakout_cfg {
                          * Add any other breakout-mode to allow Dynamic Port
                          * Breakout to that breakout-mode.
                          */
-                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G';
+                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]';
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -63,7 +63,7 @@ module sonic-port{
 				leaf speed {
 					mandatory true;
 					type uint32 {
-						range 1..100000;
+						range 1..400000;
 					}
 				}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

All Mellanox platforms require DPB modes with a specific set of speeds [example](https://github.com/Azure/sonic-buildimage/pull/6021/files)

**- How I did it**

Extended regex pattern inside YANG model.
Supported platforms: `SN2010`, `SN2100`, `SN2410`, `SN2700`, `SN3420`, `SN3700`, `SN3700C`, `SN3800`, `SN4600C`, `SN4410`, `SN4700`

**- How to verify it**

Manually tested DPB CLI on all platform with all modes

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
