### PR TITLE
[platform/dx010] Remove unused pca9541 device init line

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -61,17 +61,6 @@ start)
         [ $found -eq 0 ] && echo "cannot find iSMT" && exit 1
 
         i2cset -y ${devnum} 0x70 0x10 0x00 0x01 i
-
-        # Attach PCA9541 Ox70 Master Selector
-        chmod 755 /sys/bus/i2c/devices/i2c-${devnum}/new_device
-        # FIXME: commenting out the following line.
-        #        there had been no pca9541 driver loaded on Celestica platform,
-        #        the recent addition of this driver casued following line
-        #        becoming effictive, but negatively impacted the platform
-        #        stability. Commenting it out restores the original behavior
-        #        on Celestica platform.
-        #        This change should be further analyzed and updated.
-        # echo pca9541 0x70 > /sys/bus/i2c/devices/i2c-${devnum}/new_device
         sleep 1
 
         # Attach PCA9548 0x71 Channel Extender for Main Board


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Remove the unused codes addressed in #5891 on Dx010 platform.

**- How I did it**

Update the DX1010 init script.

**- How to verify it**

Boot the DX010 with the updated init script and check for all I2C device can be inited successfully.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Remove unused pca954x device init from DX010 init script 

**- A picture of a cute animal (not mandatory but encouraged)**
