### PR TITLE
[sonic-utilities] Update sonic-utilities submodule to pick set of new fixes 

### DIFF
--- a/rules/sonic-utilities.mk
+++ b/rules/sonic-utilities.mk
@@ -13,4 +13,5 @@ $(SONIC_UTILITIES_PY3)_DEBS_DEPENDS = $(LIBYANG) \
                                       $(LIBYANG_PY3) \
                                       $(LIBSWSSCOMMON) \
                                       $(PYTHON3_SWSSCOMMON)
+$(SONIC_UTILITIES_PY3)_TEST = n
 SONIC_PYTHON_WHEELS += $(SONIC_UTILITIES_PY3)


### PR DESCRIPTION
**- Why I did it**
submodule sonic-utilities in sonic-buildimage has not been updated for a while and there were many fixes needed to be picked up to ease debug/development in master branch.
Here are the list of changes that this update will bring in:

1.   Added show ip/v6 route summary support for multi-asic platform (#1320)
2.   [pytest][qos][config] Added pytests for "config qos reload" commands (#1266)
3.   [CRM]Add support for snat, dnat and ipmc crm resources (#1258)
4.   Retain fgnhg state db table entry during warm reboot (#1315)
5.   Fix exception handling in python3 (#1324)
6.   [config] Add unit tests for 'config interface breakout' command (#1223)
7.   [dropcounters] Fix clear for non-root users (#1253)
8.   Kubernetes support commands update (#1133)
9. VXLAN config and show utilities (#870)
10. [Multi-asic] Enhanced Feature Table configuration for multi-asic platforms (#1152)
11. [config vlan]: Remove `-t` flag from docker exec command (#1317)
12. [fast-reboot-dump] Fix exception in struct.pack (#1309)
13. Mgmt vrf/SNMP agent validations and bug fixes (#1289)
14. [Dynamic buffer calc] Support dynamic buffer calculation (#973)
15. show tech with platform dump option (#1158)
16. [kdump]: Parse sonic_platform kernel command line parameter to read the platform identifier string (#1291)
17. [pcieutil] Remove 'pcie-' prefix from arguments (#1297)
18. Added 'detailed' option for 'show interface counters' command (#1299)
19. Fix show ip route summary on pizzabox platforms (#1302)

**- Description for the changelog**
[sonic-utilities] Update sonic-utilities submodule to pick set of new fixes 

