### PR TITLE
[sonic-config-engine] Pin 'importlib-resources' package to v3.3.1 for Python 2

### DIFF
--- a/src/sonic-bgpcfgd/setup.py
+++ b/src/sonic-bgpcfgd/setup.py
@@ -18,7 +18,6 @@ setuptools.setup(
         'jinja2>=2.10',
         'netaddr==0.8.0',
         'pyyaml==5.3.1',
-        'zipp==1.2.0', # importlib-resources needs zipp and seems to have a bug where it will try to import too new of a version for Python 2
     ],
     setup_requires = [
         'pytest-runner',

--- a/src/sonic-config-engine/setup.py
+++ b/src/sonic-config-engine/setup.py
@@ -30,7 +30,8 @@ else:
         'future',
         'Jinja2<3.0.0',
         'pyangbind==0.6.0',
-        'zipp==1.2.0', # importlib-resources needs zipp and seems to have a bug where it will try to install too new of a version for Python 2
+        'zipp==1.2.0',  # importlib-resources needs zipp and seems to have a bug where it will try to install too new of a version for Python 2
+        'importlib-resources==3.3.1'  # importlib-resources v4.0.0 was released 2020-12-23 and drops support for Python 2
     ]
 
 


### PR DESCRIPTION
**- Why I did it**

importlib-resources v4.0.0 was released today (2020-12-23) and drops support for Python 2. This caused the sonic-config-engine Python 2 wheel build to fail.

Reference: https://pypi.org/project/importlib-resources/

Example failure:

```
16:23:36    File "/sonic/src/sonic-config-engine/tests/../sonic-cfggen", line 33, in <module>
16:23:36      import netaddr
16:23:36    File "/sonic/src/sonic-config-engine/.eggs/netaddr-0.8.0-py2.7.egg/netaddr/__init__.py", line 18, in <module>
16:23:36      from netaddr.core import (AddrConversionError, AddrFormatError,
16:23:36    File "/sonic/src/sonic-config-engine/.eggs/netaddr-0.8.0-py2.7.egg/netaddr/core.py", line 11, in <module>
16:23:36      from netaddr.compat import _callable, _iter_dict_keys
16:23:36    File "/sonic/src/sonic-config-engine/.eggs/netaddr-0.8.0-py2.7.egg/netaddr/compat.py", line 93, in <module>
16:23:36      import importlib_resources as _importlib_resources
16:23:36    File "/sonic/src/sonic-config-engine/.eggs/importlib_resources-4.0.0-py2.7.egg/importlib_resources/__init__.py", line 3, in <module>
16:23:36      from ._common import (
16:23:36    File "/sonic/src/sonic-config-engine/.eggs/importlib_resources-4.0.0-py2.7.egg/importlib_resources/_common.py", line 6, in <module>
16:23:36      from pathlib import Path
16:23:36  ImportError: No module named pathlib
16:23:36  ERROR
```

**- How I did it**

- Pin 'importlib-resources' package to v3.3.1 for Python 2
- Unrelated: remove pinned version of zipp for sonic-bgpcfgd because we no longer build a Python 2 version of that package.

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
