### PR TITLE
[init_cfg]: allow enable/disable swss/teamd/syncd services

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -25,9 +25,9 @@
                    ("pmon", "enabled", false, "enabled"),
                    ("radv", "enabled", false, "enabled"),
                    ("snmp", "enabled", true, "enabled"),
-                   ("swss", "always_enabled", false, "enabled"),
-                   ("syncd", "always_enabled", false, "enabled"),
-                   ("teamd", "always_enabled", false, "enabled")] %}
+                   ("swss", "enabled", false, "enabled"),
+                   ("syncd", "enabled", false, "enabled"),
+                   ("teamd", "enabled", false, "enabled")] %}
 {%- if sonic_asic_platform == "vs" %}{% do features.append(("gbsyncd", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_iccpd == "y" %}{% do features.append(("iccpd", "disabled", false, "enabled")) %}{% endif %}
 {%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", true, "enabled")) %}{% endif %}


### PR DESCRIPTION


Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
swss/teamd/syncd services were changed to always enabled
in commit fad481edc1796126bf92c9b9230303401b515364 as a workaround
for not letting hostcfgd start service during the bootup process.

commit 317a4b34106cd84054194ad2255a85978471c028 introduce
wait till full system bootup before updating feature states in hostcfgd.

Thus, workaround introduced in commit fad481ed can be removed

**- How I did it**
change teamd/swss/syncd to enabled state.

**- How to verify it**
check if hostcfgd update feature state after system fully bootup.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
