### PR TITLE
[ipinip.json.j2] align mellanox configuration dst_ip with other platf…

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -46,19 +46,18 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
+            "dst_ip":"{% for prefix in ipv4_addresses|sort %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
 {% if "mlnx" in DEVICE_METADATA.localhost.platform %}
-            "dst_ip":"{% for prefix in ipv4_loopback_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
             "dscp_mode":"uniform",
             "ecn_mode":"standard",
 {% else %}
-            "dst_ip":"{% for prefix in ipv4_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
 {% endif %}
             "ttl_mode":"pipe"
         },
         "OP": "SET"
-    } 
+    }
 {% endif %}
 {% if ipv4_loopback_addresses and ipv6_loopback_addresses %}    ,
 {% endif %}
@@ -66,12 +65,11 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
+            "dst_ip":"{% for prefix in ipv6_addresses|sort %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
 {% if "mlnx" in DEVICE_METADATA.localhost.platform %}
-            "dst_ip":"{% for prefix in ipv6_loopback_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
             "dscp_mode":"uniform",
             "ecn_mode":"standard",
 {% else %}
-            "dst_ip":"{% for prefix in ipv6_addresses %}{{ prefix | ip }}{% if not loop.last %},{% endif %}{% endfor %}",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
 {% endif %}

--- a/src/sonic-config-engine/tests/multi_npu_data/py2/ipinip.json
+++ b/src/sonic-config-engine/tests/multi_npu_data/py2/ipinip.json
@@ -2,18 +2,18 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"8.0.0.0,10.1.0.32,10.1.0.3,10.0.0.0,10.1.0.1",
+            "dst_ip":"10.0.0.0,10.1.0.1,10.1.0.3,10.1.0.32,8.0.0.0",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
         "OP": "SET"
-    } 
+    }
     ,
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"fc00:1::32,fd00:1::32,fc00::1",
+            "dst_ip":"fc00:1::32,fc00::1,fd00:1::32",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"

--- a/src/sonic-config-engine/tests/multi_npu_data/py3/ipinip.json
+++ b/src/sonic-config-engine/tests/multi_npu_data/py3/ipinip.json
@@ -2,18 +2,18 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"8.0.0.0,10.1.0.32,10.1.0.1,10.1.0.3,10.0.0.0",
+            "dst_ip":"10.0.0.0,10.1.0.1,10.1.0.3,10.1.0.32,8.0.0.0",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
         "OP": "SET"
-    } 
+    }
     ,
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"fd00:1::32,fc00:1::32,fc00::1",
+            "dst_ip":"fc00:1::32,fc00::1,fd00:1::32",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"

--- a/src/sonic-config-engine/tests/sample_output/py2/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/ipinip.json
@@ -2,18 +2,18 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"10.1.0.32,10.0.0.58,10.0.0.60,10.0.0.62,10.0.0.56,192.168.0.1",
+            "dst_ip":"10.0.0.56,10.0.0.58,10.0.0.60,10.0.0.62,10.1.0.32,192.168.0.1",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
         "OP": "SET"
-    } 
+    }
     ,
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"fc00:1::32,fc00::7d,fc00::79,fc00::71,fc00::75",
+            "dst_ip":"fc00:1::32,fc00::71,fc00::75,fc00::79,fc00::7d",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"

--- a/src/sonic-config-engine/tests/sample_output/py3/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/ipinip.json
@@ -2,13 +2,13 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"10.1.0.32,10.0.0.56,10.0.0.58,10.0.0.60,10.0.0.62,192.168.0.1",
+            "dst_ip":"10.0.0.56,10.0.0.58,10.0.0.60,10.0.0.62,10.1.0.32,192.168.0.1",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
         },
         "OP": "SET"
-    } 
+    }
     ,
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {


### PR DESCRIPTION
…orms

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Mellanox already supports multiple destination IPs in IPinIP tunnel configuration, thus removing mellanox exception for IPinIP configuration.

**- How I did it**

Removed "dst_ip" field generation in mellanox platform condition.
Sorted the "dst_ip" list, so that it is easier to test against sample configuration in unit tests.
Aligned unit test sample.

**- How to verify it**

Run sonic-cfggen UT.
Upload image on the switch and run it.
Run decap tests from sonic-mgmt.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[ipinip.json.j2] align mellanox configuration dst_ip with other platforms

**- A picture of a cute animal (not mandatory but encouraged)**
