### PR TITLE
[sonic-py-common] Added an API to get file path containing SONiC version

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -298,7 +298,10 @@ def get_sonic_version_info():
     return data
 
 def get_sonic_version_file():
-    return os.path.join(os.sep, "etc", "sonic", "sonic_version.yml")
+    if not os.path.isfile(SONIC_VERSION_YAML_PATH):
+        return None
+
+    return SONIC_VERSION_YAML_PATH
 
 #
 # Multi-NPU functionality

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -297,6 +297,8 @@ def get_sonic_version_info():
 
     return data
 
+def get_sonic_version_file():
+    return os.path.join(os.sep, "etc", "sonic", "sonic_version.yml")
 
 #
 # Multi-NPU functionality


### PR DESCRIPTION
**- Why I did it**

Added an API to get the file path containing SONiC version so that the API can be mocked during unit tests.

**- How I did it**

Added the API.

**- How to verify it**

Manual verification.

```
Last login: Mon Dec 28 18:32:34 2020 from 100.127.20.23
admin@str-s6000-acs-9:~$ python3
Python 3.7.3 (default, Jul 25 2020, 13:03:44) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sonic_py_common import device_info                                                                                                                                           
>>> device_info.get_sonic_version_file()
'/etc/sonic/sonic_version.yml'
>>> 
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Added an API to get file path containing SONiC version
-->


**- A picture of a cute animal (not mandatory but encouraged)**
