### PR TITLE
[Multi Asic] support of swss.rec and sairedis.rec for multi asic

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -41,6 +41,11 @@ then
     ORCHAGENT_ARGS+="-i $asic_id "
 fi
 
+# for multi asic platforms add the asic name to the record file names
+if [[ "$NAMESPACE_ID" ]]; then
+    ORCHAGENT_ARGS+="-f swss.asic$NAMESPACE_ID.rec -j sairedis.asic$NAMESPACE_ID.rec "
+fi
+
 # Add platform specific arguments if necessary
 if [ "$platform" == "broadcom" ]; then
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"

--- a/files/image_config/logrotate/logrotate.d/rsyslog
+++ b/files/image_config/logrotate/logrotate.d/rsyslog
@@ -95,10 +95,10 @@
             if [ $NUM_ASIC -gt 1 ]; then
                 log_file=$1
                 log_file_name=${log_file#/var/log/swss/}
-                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name:$log_file_name"
+                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name: $log_file_name"
                 pgrep -xa orchagent | grep $log_file_name | awk '{ print $1; }' | xargs /bin/kill -HUP 2>/dev/null || true
             else
-                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA"
+                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name: $1"
                 pgrep -x orchagent | xargs /bin/kill -HUP 2>/dev/null || true
             fi
         else

--- a/files/image_config/logrotate/logrotate.d/rsyslog
+++ b/files/image_config/logrotate/logrotate.d/rsyslog
@@ -30,8 +30,8 @@
 /var/log/telemetry.log
 /var/log/frr/bgpd.log
 /var/log/frr/zebra.log
-/var/log/swss/sairedis.*.rec
-/var/log/swss/swss.*.rec
+/var/log/swss/sairedis*.rec
+/var/log/swss/swss*.rec
 {
     size 1M
     rotate 5000
@@ -87,11 +87,18 @@
         if [ $(echo $1 | grep -c "/var/log/swss/") -gt 0 ]; then
             # for multi asic platforms, there are multiple orchagents
             # send the SIGHUP only to the orchagent the which needs log file rotation
-            if [ $(pgrep -x orchagent | wc -l) -gt 0 ]; then
+            PLATFORM=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+            ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
+            if [ -f "$ASIC_CONF" ]; then
+                . $ASIC_CONF
+            fi
+            if [ $NUM_ASIC -gt 1 ]; then
                 log_file=$1
                 log_file_name=${log_file#/var/log/swss/}
+                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name:$log_file_name"
                 pgrep -xa orchagent | grep $log_file_name | awk '{ print $1; }' | xargs /bin/kill -HUP 2>/dev/null || true
             else
+                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA"
                 pgrep -x orchagent | xargs /bin/kill -HUP 2>/dev/null || true
             fi
         else

--- a/files/image_config/logrotate/logrotate.d/rsyslog
+++ b/files/image_config/logrotate/logrotate.d/rsyslog
@@ -30,8 +30,8 @@
 /var/log/telemetry.log
 /var/log/frr/bgpd.log
 /var/log/frr/zebra.log
-/var/log/swss/sairedis.rec
-/var/log/swss/swss.rec
+/var/log/swss/sairedis.*.rec
+/var/log/swss/swss.*.rec
 {
     size 1M
     rotate 5000
@@ -85,7 +85,15 @@
     endscript
     postrotate
         if [ $(echo $1 | grep -c "/var/log/swss/") -gt 0 ]; then
-            pgrep -x orchagent | xargs /bin/kill -HUP 2>/dev/null || true
+            # for multi asic platforms, there are multiple orchagents
+            # send the SIGHUP only to the which needs log file rotation
+            if [ $(pgrep -x orchagent | wc -l) -gt 0 ]; then
+                log_file=$1
+                log_file_name=${log_file#/var/log/swss/}
+                pgrep -xa orchagent | grep $log_file_name | awk '{ print $1; }' | xargs /bin/kill -HUP 2>/dev/null || true
+            else
+                pgrep -x orchagent | xargs /bin/kill -HUP 2>/dev/null || true
+            fi
         else
             /bin/kill -HUP $(cat /var/run/rsyslogd.pid)
         fi

--- a/files/image_config/logrotate/logrotate.d/rsyslog
+++ b/files/image_config/logrotate/logrotate.d/rsyslog
@@ -86,7 +86,7 @@
     postrotate
         if [ $(echo $1 | grep -c "/var/log/swss/") -gt 0 ]; then
             # for multi asic platforms, there are multiple orchagents
-            # send the SIGHUP only to the which needs log file rotation
+            # send the SIGHUP only to the orchagent the which needs log file rotation
             if [ $(pgrep -x orchagent | wc -l) -gt 0 ]; then
                 log_file=$1
                 log_file_name=${log_file#/var/log/swss/}


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
This PR has the changes to support having different swss.rec and sairedis.rec for each asic.
The logrotate script is updated as well

**- How I did it**
- Update the orchagent.sh script to use the logfile name options in these PRs(https://github.com/Azure/sonic-swss/pull/1546 and https://github.com/Azure/sonic-sairedis/pull/747) 
In multi asic platforms the record files will be different for each asic, with the format `swss.asic{x}.rec `and `sairedis.asic{x}.rec` 

- Update the logrotate script for multiasic platform .

**- How to verify it**
The following tests are done to verify
**Verification logs multi asic**
 - Check the record files are created
```
 admin@sonic:/var/log/swss$ ls -l
total 29532
-rw-r--r-- 1 root root 4497346 Dec 29 23:12 sairedis.asic0.rec
-rw-r--r-- 1 root root 3236040 Dec 29 23:12 sairedis.asic1.rec
-rw-r--r-- 1 root root 1938290 Dec 29 23:12 sairedis.asic2.rec
-rw-r--r-- 1 root root 2009720 Dec 29 23:12 sairedis.asic3.rec
-rw-r--r-- 1 root root 3089764 Dec 29 23:12 sairedis.asic4.rec
-rw-r--r-- 1 root root 3090256 Dec 29 23:12 sairedis.asic5.rec
-rw-r--r-- 1 root root 2746843 Dec 29 23:12 swss.asic0.rec
-rw-r--r-- 1 root root 1813896 Dec 29 23:12 swss.asic1.rec
-rw-r--r-- 1 root root 2110988 Dec 29 23:12 swss.asic2.rec
-rw-r--r-- 1 root root 2148698 Dec 29 23:12 swss.asic3.rec
-rw-r--r-- 1 root root 1766758 Dec 29 23:12 swss.asic4.rec
-rw-r--r-- 1 root root 1766644 Dec 29 23:12 swss.asic5.rec
```
 - logrotate manually
` admin@sonic:/var/log/swss$ sudo /usr/sbin/logrotate   /etc/logrotate.conf /dev/null 2>&1`

- Verify the files are rotated
```
admin@sonic:/var/log/swss$ ls -l
total 29544
-rw-r--r-- 1 root root       0 Dec 29 23:13 sairedis.asic0.rec
-rw-r--r-- 1 root root 4497346 Dec 29 23:12 sairedis.asic0.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 sairedis.asic1.rec
-rw-r--r-- 1 root root 3236040 Dec 29 23:12 sairedis.asic1.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 sairedis.asic2.rec
-rw-r--r-- 1 root root 1938290 Dec 29 23:12 sairedis.asic2.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 sairedis.asic3.rec
-rw-r--r-- 1 root root 2009720 Dec 29 23:12 sairedis.asic3.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 sairedis.asic4.rec
-rw-r--r-- 1 root root 3089764 Dec 29 23:12 sairedis.asic4.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 sairedis.asic5.rec
-rw-r--r-- 1 root root 3090256 Dec 29 23:12 sairedis.asic5.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 swss.asic0.rec
-rw-r--r-- 1 root root 2746843 Dec 29 23:12 swss.asic0.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 swss.asic1.rec
-rw-r--r-- 1 root root 1813896 Dec 29 23:12 swss.asic1.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 swss.asic2.rec
-rw-r--r-- 1 root root 2110988 Dec 29 23:12 swss.asic2.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 swss.asic3.rec
-rw-r--r-- 1 root root 2148698 Dec 29 23:12 swss.asic3.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 swss.asic4.rec
-rw-r--r-- 1 root root 1766758 Dec 29 23:12 swss.asic4.rec.1
-rw-r--r-- 1 root root       0 Dec 29 23:13 swss.asic5.rec
-rw-r--r-- 1 root root 1766644 Dec 29 23:12 swss.asic5.rec.1
```
- Check the syslogs
```
admin@sonic:/var/log/swss$ sudo grep -i "Sending SIGHUP to OA" /var/log/syslog
Dec 29 23:13:14.409308 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:sairedis.asic0.rec
Dec 29 23:13:14.699731 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:sairedis.asic1.rec
Dec 29 23:13:14.988207 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:sairedis.asic2.rec
Dec 29 23:13:15.277998 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:sairedis.asic3.rec
Dec 29 23:13:15.572765 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:sairedis.asic4.rec
Dec 29 23:13:15.861483 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:sairedis.asic5.rec
Dec 29 23:13:16.149143 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:swss.asic0.rec
Dec 29 23:13:16.438341 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:swss.asic1.rec
Dec 29 23:13:16.729833 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:swss.asic2.rec
Dec 29 23:13:17.019212 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:swss.asic3.rec
Dec 29 23:13:17.317649 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:swss.asic4.rec
Dec 29 23:13:17.616700 sonic INFO logrotate: Sending SIGHUP to OA log_file_name:swss.asic5.rec

```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
