### PR TITLE
[device/accton/as4630-54pe] Fix accton driver not been installed

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_util.py
@@ -214,10 +214,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_inserted():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
+    if ret :
         return False
+    else :
+        return True
 
 #'modprobe cpr_4011_4mxx',
 


### PR DESCRIPTION
Accton util applies lsmod to check if drivers are installed.
But lsmod may return error on startup and skip module installation.

Signed-off-by: roy_lee <roy_lee@edge-core.com>

**- Why I did it**
Reported that sometimes the peripherals cannot be polled.

**- How I did it**
It's found that lsmod command may failed on startup, the accton util misjudges that drivers have been installed.
The change here is not to apply lsmod to poll installed drivers.

**- How to verify it**
The bug can be probably replicated during several time of reboot.
Replace with new script and reboot 100 times. 
Drivers are all well installed on these 100 reboot.  

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**


