### PR TITLE
[DellEMC] Add platform-modules as prerequisite for determine-reboot-cause

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/systemd/platform-modules-s5232f.service
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/systemd/platform-modules-s5232f.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Dell S5232f Platform modules
-Before=pmon.service
+Before=pmon.service determine-reboot-cause.service
 DefaultDependencies=no
 
 [Service]

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/systemd/platform-modules-s6000.service
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/systemd/platform-modules-s6000.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Dell S6000 Platform modules
 After=local-fs.target
-Before=pmon.service
+Before=pmon.service determine-reboot-cause.service
 
 [Service]
 Type=oneshot

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/systemd/platform-modules-s6100.service
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/systemd/platform-modules-s6100.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Dell S6100 Platform modules
-Before=pmon.service
+Before=pmon.service determine-reboot-cause.service
 DefaultDependencies=no
 
 [Service]

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/systemd/platform-modules-z9100.service
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/systemd/platform-modules-z9100.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Dell Z9100 Platform modules
-Before=pmon.service
+Before=pmon.service determine-reboot-cause.service
 DefaultDependencies=no
 
 [Service]

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/systemd/platform-modules-z9264f.service
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/systemd/platform-modules-z9264f.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Dell Z9264f Platform modules
-Before=pmon.service
+Before=pmon.service determine-reboot-cause.service
 DefaultDependencies=no
 
 [Service]

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/systemd/platform-modules-z9332f.service
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/systemd/platform-modules-z9332f.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Dell Z9332f Platform modules
-Before=pmon.service
+Before=pmon.service determine-reboot-cause.service
 DefaultDependencies=no
 
 [Service]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

To ensure platform initialization is complete before `determine-reboot-cause.service` executes. 
resolves #6082 

**- How I did it**

Added a systemd rule to make platform-modules service as a prerequisite for determine-reboot-cause service. 

**- How to verify it**

Verify determine-reboot-cause.service is executed and reset reason is updated.
Logs: [UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/5753901/UT_logs.txt)
 
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[DellEMC] Add platform-modules as prerequisite for determine-reboot-cause

**- A picture of a cute animal (not mandatory but encouraged)**
