### PR TITLE
[determine-reboot-cause] Skip invoking platform code for unit tests for hardware_reboot_cause

### DIFF
--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -111,6 +111,9 @@ def find_hardware_reboot_cause():
     except ImportError:
         sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
         hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
+    except:
+        sonic_logger.log_warning("Unknown exception caught in platform library. Unable to detect hardware reboot causes.")
+        hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
 
     if hardware_reboot_cause_major:
         sonic_logger.log_info("Platform api indicates reboot cause {}".format(hardware_reboot_cause_major))

--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -100,7 +100,7 @@ def find_proc_cmdline_reboot_cause():
     return proc_cmdline_reboot_cause
 
 
-def find_hardware_reboot_cause():
+def get_reboot_cause_from_platform():
     # Find hardware reboot cause using sonic_platform library
     try:
         import sonic_platform
@@ -111,10 +111,12 @@ def find_hardware_reboot_cause():
     except ImportError:
         sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
         hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
-    except:
-        sonic_logger.log_warning("Unknown exception caught in platform library. Unable to detect hardware reboot causes.")
-        hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
 
+    return hardware_reboot_cause_major, hardware_reboot_cause_minor
+
+
+def find_hardware_reboot_cause():
+    hardware_reboot_cause_major, hardware_reboot_cause_minor = get_reboot_cause_from_platform()
     if hardware_reboot_cause_major:
         sonic_logger.log_info("Platform api indicates reboot cause {}".format(hardware_reboot_cause_major))
     else:

--- a/src/sonic-host-services/tests/determine-reboot-cause_test.py
+++ b/src/sonic-host-services/tests/determine-reboot-cause_test.py
@@ -99,8 +99,9 @@ class TestDetermineRebootCause(object):
             assert result == "fast-reboot"
 
     def test_find_hardware_reboot_cause(self):
-        result = find_hardware_reboot_cause()
-        assert result == "Non-Hardware (N/A)"
+        with mock.patch("determine_reboot_cause.get_reboot_cause_from_platform", return_value=("Powerloss", None)):
+            result = find_hardware_reboot_cause()
+            assert result == "Powerloss (None)"
 
     def test_get_reboot_cause_dict_watchdog(self):
         reboot_cause_dict = get_reboot_cause_dict(REBOOT_CAUSE_WATCHDOG, "", GEN_TIME_WATCHDOG) 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->
Fix unit tests in `determine-reboot-cause` to skip calling platform module libraries in unit test scope.

**- Why I did it**
MELLANOX build is failing for the recent PRs. The errors are due to platform library being invoked in a unit test for `determine-reboot-cause` script.

```
[2020-12-30T11:03:13.516Z] tests/determine-reboot-cause_test.py:102: 
[2020-12-30T11:03:13.516Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[2020-12-30T11:03:13.516Z] scripts/determine-reboot-cause:107: in find_hardware_reboot_cause
[2020-12-30T11:03:13.516Z]     platform  = sonic_platform.platform.Platform()
[2020-12-30T11:03:13.516Z] /usr/local/lib/python3.7/dist-packages/sonic_platform/platform.py:21: in __init__
[2020-12-30T11:03:13.516Z]     self._chassis.initialize_components()
[2020-12-30T11:03:13.516Z] /usr/local/lib/python3.7/dist-packages/sonic_platform/chassis.py:167: in initialize_components
[2020-12-30T11:03:13.516Z]     self._component_list.extend(ComponentCPLD.get_component_list())
[2020-12-30T11:03:13.516Z] /usr/local/lib/python3.7/dist-packages/sonic_platform/component.py:745: in get_component_list
[2020-12-30T11:03:13.516Z]     cpld_number = cls._read_generic_file(cls.CPLD_NUMBER_FILE, cls.CPLD_NUMBER_MAX_LENGTH)
[2020-12-30T11:03:13.516Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

[2020-12-30T11:03:13.516Z]         try:
[2020-12-30T11:03:13.516Z]             with io.open(filename, 'r') as fileobj:
[2020-12-30T11:03:13.516Z]                 result = fileobj.read(len)
[2020-12-30T11:03:13.516Z]         except IOError as e:
[2020-12-30T11:03:13.516Z]             if not ignore_errors:
[2020-12-30T11:03:13.516Z] >               raise RuntimeError("Failed to read file {} due to {}".format(filename, repr(e)))
[2020-12-30T11:03:13.516Z] E               RuntimeError: Failed to read file /var/run/hw-management/config/cpld_num due to FileNotFoundError(2, 'No such file or directory')
```

**- How I did it**
Modified unit tests to use mock utility to skip calling sonic_platform libraries.

**- How to verify it**
Executed unit tests and Mellanox PR build expected to pass now.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
