### PR TITLE
[device/accton] Fix accton driver not been installed

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_util.py
@@ -240,11 +240,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_inserted():
-    ret, lsmod = log_os_system("ls /sys/module/ | grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if not lsmod:
+    if ret :
         return False
-
+    else :
+        return True
 
 kos = [
 'depmod -ae',

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54t/utils/accton_as5812_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54t/utils/accton_as5812_util.py
@@ -145,11 +145,12 @@ def log_os_system(cmd, show):
     return  status, output
             
 def driver_check():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
-        return False   
-    return True
+    if ret :
+        return False
+    else :
+        return True
 			
 kos = [
 'modprobe i2c_dev',

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/utils/accton_as5812_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/utils/accton_as5812_util.py
@@ -240,10 +240,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_inserted():
-    ret, lsmod = log_os_system("ls /sys/module | grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
+    if ret :
         return False
+    else :
+        return True
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_util.py
@@ -145,11 +145,12 @@ def log_os_system(cmd, show):
     return  status, output
             
 def driver_check():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
-        return False   
-    return True
+    if ret :
+        return False
+    else :
+        return True
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_util.py
@@ -145,11 +145,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_check():
-    ret, lsmod = log_os_system("ls /sys/module/ | grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
+    if ret :
         return False
-    return True
+    else :
+        return True
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as6712-32x/utils/accton_as6712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as6712-32x/utils/accton_as6712_util.py
@@ -249,10 +249,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_inserted():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
+    if ret :
         return False
+    else :
+        return True
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54x/utils/accton_as7312_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54x/utils/accton_as7312_util.py
@@ -150,11 +150,12 @@ def log_os_system(cmd, show):
 
 
 def driver_check():
-    (ret, lsmod) = log_os_system('ls /sys/module/ | grep accton', 0)
-    logging.info('mods:' + lsmod)
-    if not lsmod:
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
+    logging.info('mods:'+lsmod)
+    if ret :
         return False
-    return True
+    else :
+        return True
 
 
 kos = [

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54xs/utils/accton_as7312_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54xs/utils/accton_as7312_util.py
@@ -145,11 +145,12 @@ def log_os_system(cmd, show):
     return  status, output
             
 def driver_check():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
-        return False   
-    return True
+    if ret :
+        return False
+    else :
+        return True
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/utils/accton_as7315_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/utils/accton_as7315_util.py
@@ -147,11 +147,12 @@ def log_os_system(cmd, show):
     return  status, output
             
 def driver_check():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
-        return False   
-    return True
+    if ret :
+        return False
+    else :
+        return True
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_util.py
@@ -178,11 +178,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_check():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
+    if ret :
         return False
-    return True
+    else :
+        return True
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/accton_as7712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/accton_as7712_util.py
@@ -145,11 +145,12 @@ def log_os_system(cmd, show):
     return  status, output
             
 def driver_check():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
-        return False   
-    return True
+    if ret :
+        return False
+    else :
+        return True
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32x/utils/accton_as7716_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32x/utils/accton_as7716_util.py
@@ -267,10 +267,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_inserted():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
+    if ret :
         return False
+    else :
+        return True
 
 #'modprobe cpr_4011_4mxx',
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/utils/accton_as7716_32xb_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/utils/accton_as7716_32xb_util.py
@@ -240,10 +240,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_inserted():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
+    if ret :
         return False
+    else :
+        return True
 
 
 kos = [

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
@@ -248,10 +248,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_inserted():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
+    if ret :
         return False
+    else :
+        return True
 
 def cpld_reset_mac():
     ret, lsmod = log_os_system("i2cset -y 0 0x77 0x1", 0)

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_util.py
@@ -167,11 +167,12 @@ def log_os_system(cmd, show):
     return  status, output
             
 def driver_check():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
-        return False   
-    return True
+    if ret :
+        return False
+    else :
+        return True
 
 
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_util.py
@@ -254,10 +254,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_inserted():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
+    if ret :
         return False
+    else :
+        return True
 
 
 kos = [

--- a/platform/broadcom/sonic-platform-modules-accton/minipack/utils/accton_minipack_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/minipack/utils/accton_minipack_util.py
@@ -181,10 +181,12 @@ def log_os_system(cmd, show):
     return  status, output
 
 def driver_inserted():
-    ret, lsmod = log_os_system("lsmod| grep accton", 0)
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
-    if len(lsmod) ==0:
+    if ret :
         return False
+    else :
+        return True
 
 
 


### PR DESCRIPTION
Accton util applies lsmod to check if drivers are installed.
But lsmod may return error on startup and skip module installation.

Signed-off-by: Brandon Chuang <brandon_chuang@edge-core.com>

- Why I did it
Reported that sometimes the peripherals cannot be polled.

- How I did it
It's found that lsmod command may failed on startup, the accton util misjudges that drivers have been installed.
The change here is not to apply lsmod to poll installed drivers.

- How to verify it
The bug can be probably replicated during several time of reboot.
Replace with new script and reboot 100 times.
Drivers are all well installed on these 100 reboot.

- Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006

- Description for the changelog