### PR TITLE
Fix the host image version path permission issue

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -578,7 +578,7 @@ sudo du -hsx $FILESYSTEM_ROOT
 sudo mkdir -p $FILESYSTEM_ROOT/var/lib/docker
 sudo mksquashfs $FILESYSTEM_ROOT $FILESYSTEM_SQUASHFS -e boot -e var/lib/docker -e $PLATFORM_DIR
 
-sudo scripts/collect_host_image_version_files.sh $TARGET_PATH $FILESYSTEM_ROOT
+scripts/collect_host_image_version_files.sh $TARGET_PATH $FILESYSTEM_ROOT
 
 if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
     # Remove qemu arm bin executable used for cross-building

--- a/scripts/collect_host_image_version_files.sh
+++ b/scripts/collect_host_image_version_files.sh
@@ -4,6 +4,7 @@ TARGET=$1
 FILESYSTEM_ROOT=$2
 VERSIONS_PATH=$TARGET/versions/host-image
 
+[ -d $VERSIONS_PATH ] && sudo rm -rf $VERSIONS_PATH
 mkdir -p $VERSIONS_PATH
 
 sudo LANG=C chroot $FILESYSTEM_ROOT post_run_buildinfo


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

$ ls -ld target/versions/host-image/
drwxr-xr-x 4 **root root** 4096 Jan  1 11:16 target/versions/host-image/

Unable to run "git clean -ffdx" and "git reset --hard 
Access to the path '/agent/_work/1/s/target/versions/host-image/pre-versions/versions-deb-buster-amd64' is denied.)) (Access to the path '/agent/_work/1/s/target/versions/host-image/pre-versions/versions-deb-buster-amd64' is denied.
Relative Change: https://github.com/Azure/sonic-buildimage/pull/6289/files

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
