### PR TITLE
[broadcom]: match the brcm sai filename version to control file version

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,6 +1,6 @@
-BRCM_SAI = libsaibcm_4.2.1.5-8_amd64.deb
+BRCM_SAI = libsaibcm_4.2.1.5-7_amd64.deb
 $(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/buster/libsaibcm_4.2.1.5-8_amd64.deb?sv=2019-12-12&st=2020-12-18T18%3A41%3A23Z&se=2030-12-19T18%3A41%3A00Z&sr=b&sp=r&sig=GFNMn0borytUTFQJf%2F5A0J452XsQ%2FqnzBw5GyjFuYHw%3D"
-BRCM_SAI_DEV = libsaibcm-dev_4.2.1.5-8_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_4.2.1.5-7_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
 $(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/buster/libsaibcm-dev_4.2.1.5-8_amd64.deb?sv=2019-12-12&st=2020-12-18T18%3A42%3A03Z&se=2030-12-19T18%3A42%3A00Z&sr=b&sp=r&sig=J%2BbRtZVVcZTLs3uqzZs9zObLKFxRgzvJkFL5iyJ48mA%3D"
 


### PR DESCRIPTION
the control file version is 4.2.1.5-7

sonic$ sudo dpkg -i target/debs/buster/libsaibcm-dev_4.2.1.5-8_amd64.deb
(Reading database ... 175880 files and directories currently installed.)
Preparing to unpack .../libsaibcm-dev_4.2.1.5-8_amd64.deb ...
Unpacking libsaibcm-dev (4.2.1.5-7) over (4.2.1.5-7) ...
Setting up libsaibcm-dev (4.2.1.5-7) ...
lgh@491d842369cf:/sonic$ sudo dpkg -i target/debs/buster/libsaibcm_4.2.1.5-8_amd64.deb
(Reading database ... 175880 files and directories currently installed.)
Preparing to unpack .../libsaibcm_4.2.1.5-8_amd64.deb ...
Unpacking libsaibcm (4.2.1.5-7) over (4.2.1.5-7) ...
Setting up libsaibcm (4.2.1.5-7) ...
Processing triggers for libc-bin (2.28-10) ...

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
match the filename version and the control file version

**- How I did it**
change the filename version

**- How to verify it**
check build

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
