### PR TITLE
[frr]: change frr debug package to extra to avoid build break for dbg…

### DIFF
--- a/rules/frr.mk
+++ b/rules/frr.mk
@@ -18,13 +18,13 @@ FRR_PYTHONTOOLS = frr-pythontools_$(FRR_VERSION)-sonic-$(FRR_SUBVERSION)_all.deb
 $(eval $(call add_extra_package,$(FRR),$(FRR_PYTHONTOOLS)))
 
 FRR_DBG = frr-dbgsym_$(FRR_VERSION)-sonic-$(FRR_SUBVERSION)_$(CONFIGURED_ARCH).deb
-$(eval $(call add_derived_package,$(FRR),$(FRR_DBG)))
+$(eval $(call add_extra_package,$(FRR),$(FRR_DBG)))
 
 FRR_SNMP = frr-snmp_$(FRR_VERSION)-sonic-$(FRR_SUBVERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_extra_package,$(FRR),$(FRR_SNMP)))
 
 FRR_SNMP_DBG = frr-snmp-dbgsym_$(FRR_VERSION)-sonic-$(FRR_SUBVERSION)_$(CONFIGURED_ARCH).deb
-$(eval $(call add_derived_package,$(FRR),$(FRR_SNMP_DBG)))
+$(eval $(call add_extra_package,$(FRR),$(FRR_SNMP_DBG)))
 
 export FRR FRR_PYTHONTOOLS FRR_DBG FRR_SNMP FRR_SNMP_DBG
 


### PR DESCRIPTION
… image

build frr dbg image force to install frr in the build process
which breaks the current build and is uneccessary.

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
build frr dbg image force to install frr in the build process
which breaks the current build and is uneccessary.

**- How I did it**
change from derived to extra package type

**- How to verify it**
build docker-fpm-frr-dbg and verify the debug docker is correct.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
