### PR TITLE
[libyang1] Adding LFS support for arm32

### DIFF
--- a/src/libyang1/Makefile
+++ b/src/libyang1/Makefile
@@ -28,6 +28,9 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	pushd libyang-$(LIBYANG1_VERSION)
 	sed -i 's/set(LIBYANG_MAJOR_SOVERSION 1)/set(LIBYANG_MAJOR_SOVERSION 2)/' CMakeLists.txt
 	sed -i 's/libyang1/libyang2/' debian/libyang1.install
+	# Enable large file support for 32-bit arch
+	echo 'add_definitions(-D_FILE_OFFSET_BITS=64)' >> CMakeLists.txt
+
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 	popd
 


### PR DESCRIPTION
Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

- Why I did it
In the emulated armhf environment, the function readdir()returns NULL on a ext4 file system directory. When running the libyang1 test cases, it will require to load the plugins from the files (such as metadata.so), because the readdir() is failing, the plugins can’t be loaded in the emulated armhf environment, so it causes libyang1 test error. This error is a combination of the following reasons.
• Emulation of a 32-bit target from a 64-bit host –> qemu from x86_64 to armhf
• Glibc version > 2.27 – Debian buster is using glibc 2.28
- How I did it
Enabled large file support by setting _FILE_OFFSET_BITS=64 for libyang1.
- How to verify it
Compiled and verified libyang1 unit tests in arm32

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
