### PR TITLE
Install the latest version of the sonic build hooks in slave container

### DIFF
--- a/scripts/prepare_slave_container_buildinfo.sh
+++ b/scripts/prepare_slave_container_buildinfo.sh
@@ -4,6 +4,9 @@ SLAVE_DIR=$1
 ARCH=$2
 DISTRO=$3
 
+# Install the latest debian package sonic-build-hooks in the slave container
+sudo dpkg -i --force-overwrite $SLAVE_DIR/buildinfo/sonic-build-hooks_*.deb > /dev/null
+
 # Enable the build hooks
 symlink_build_hooks
 

--- a/scripts/versions_manager.py
+++ b/scripts/versions_manager.py
@@ -190,6 +190,8 @@ class VersionModule:
             if ctype not in ctype_components:
                 ctype_components[ctype] = []
         for components in ctype_components.values():
+            if len(components) == 0:
+                continue
             config_component = self._get_config_for_ctype(components, dist, arch)
             config_components.append(config_component)
         config_module = VersionModule(self.name, config_components)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Install the latest version of the sonic build hooks in slave container
Fix version empty issue when generating version files.

**- How I did it**

**- How to verify it**
Checkout the latest master branch, without any exception after applying the fix.
make SONIC_CONFIG_BUILD_JOBS=1  INSTALL_DEBUG_TOOLS=y target/sonic-aboot-broadcom.swi
make freeze FREEZE_VERSION_OPTIONS=-r

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
