### PR TITLE
[determine-reboot-cause] Ignore non-hardware reboot cause

### DIFF
--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -189,7 +189,7 @@ def main():
     # Else the software_reboot_cause will be treated as the reboot cause
     if proc_cmdline_reboot_cause is not None:
         previous_reboot_cause = software_reboot_cause
-    elif hardware_reboot_cause is not REBOOT_CAUSE_NON_HARDWARE:
+    elif REBOOT_CAUSE_NON_HARDWARE not in hardware_reboot_cause:
         previous_reboot_cause = hardware_reboot_cause
     else:
         previous_reboot_cause = software_reboot_cause

--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -164,35 +164,22 @@ def main():
     if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE):
         os.remove(PREVIOUS_REBOOT_CAUSE_FILE)
 
-    hardware_reboot_cause = None
     # This variable is kept for future-use purpose. When proc_cmd_line/vendor/software provides
     # any additional_reboot_info it will be stored as a "comment" in REBOOT_CAUSE_HISTORY_FILE
     additional_reboot_info = "N/A"
 
-    # 1. Check if the previous reboot was warm/fast reboot by testing whether there is "fast|fastfast|warm" in /proc/cmdline
+    # Check if the previous reboot was warm/fast reboot by testing whether there is "fast|fastfast|warm" in /proc/cmdline
     proc_cmdline_reboot_cause = find_proc_cmdline_reboot_cause()
 
-    # 2. Check if the previous reboot was caused by hardware
-    #    If yes, the hardware reboot cause will be treated as the reboot cause
-    hardware_reboot_cause = find_hardware_reboot_cause()
-
-    # 3. If there is a REBOOT_CAUSE_FILE, it will contain any software-related
-    #    reboot info. We will use it as the previous cause.
-    software_reboot_cause = find_software_reboot_cause()
-
-    # The main decision logic of the reboot cause:
-    # If there is a reboot cause indicated by /proc/cmdline, it should be warmreboot/fastreboot
-    #   the software_reboot_cause which is the content of /hosts/reboot-cause/reboot-cause.txt
-    #   will be treated as the reboot cause
-    # Elif there is a reboot cause indicated by platform API,
-    #   the hardware_reboot_cause will be treated as the reboot cause
-    # Else the software_reboot_cause will be treated as the reboot cause
-    if proc_cmdline_reboot_cause is not None:
-        previous_reboot_cause = software_reboot_cause
-    elif REBOOT_CAUSE_NON_HARDWARE not in hardware_reboot_cause:
-        previous_reboot_cause = hardware_reboot_cause
+    # If /proc/cmdline does not indicate reboot cause, check if the previous reboot was caused by hardware
+    if proc_cmdline_reboot_cause is None:
+        previous_reboot_cause = find_hardware_reboot_cause()
+        if previous_reboot_cause.startswith(REBOOT_CAUSE_NON_HARDWARE):
+            # If the reboot cause is non-hardware, get the reboot cause from REBOOT_CAUSE_FILE
+            previous_reboot_cause = find_software_reboot_cause()
     else:
-        previous_reboot_cause = software_reboot_cause
+        # Get the reboot cause from REBOOT_CAUSE_FILE
+        previous_reboot_cause = find_software_reboot_cause()
 
     # Current time
     reboot_cause_gen_time = str(datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S'))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Reboot cause prints "Non-Hardware" instead of showing software reboot cause.

```
admin@vlab-01:~$ show reboot-cause
Non-Hardware (N/A)
admin@vlab-01:~$
```
**- How I did it**
Fixed the handling for Non Hardware reboot cause. Ignore if `Non-Hardware` is present in the hardware_reboot_cause output.

This will make software reboot cause to be taken as the effective reboot-cause.
**- How to verify it**
With fix, the hardware reboot cause is ignored (if it is non hw):
```
admin@vlab-01:~$ show reboot-cause 
User issued 'warm-reboot' command [User: admin, Time: Mon 04 Jan 2021 05:20:49 PM UTC]
admin@vlab-01:~$ 
```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
