### PR TITLE
[docker-sonic-vs]: reduce the build steps for docker-sonic-vs

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -101,33 +101,23 @@ RUN pip3 install \
 
 {% if docker_sonic_vs_debs.strip() -%}
 # Copy locally-built Debian package dependencies
-{%- for deb in docker_sonic_vs_debs.split(' ') %}
-COPY debs/{{ deb }} /debs/
-{%- endfor %}
+COPY {%- for deb in docker_sonic_vs_debs.split(' ') %} debs/{{ deb }}{%- endfor %} /debs/
 
 # Install locally-built Debian packages and implicitly install their dependencies
-{%- for deb in docker_sonic_vs_debs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt /debs/{{ deb }}
-{%- endfor %}
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; {%- for deb in docker_sonic_vs_debs.split(' ') %} dpkg_apt /debs/{{ deb }};{%- endfor %}
 {%- endif %}
 
 {% if docker_sonic_vs_pydebs.strip() -%}
 # Copy locally-built Debian package dependencies
-{%- for deb in docker_sonic_vs_pydebs.split(' ') %}
-COPY python-debs/{{ deb }} /debs/
-{%- endfor %}
+COPY {%- for deb in docker_sonic_vs_pydebs.split(' ') %} python-debs/{{ deb }}{%- endfor %} /debs/
 
 # Install locally-built Debian packages and implicitly install their dependencies
-{%- for deb in docker_sonic_vs_pydebs.split(' ') %}
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; dpkg_apt /debs/{{ deb }}
-{%- endfor %}
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; }; {%- for deb in docker_sonic_vs_pydebs.split(' ') %} dpkg_apt /debs/{{ deb }};{%- endfor %}
 {%- endif %}
 
 {% if docker_sonic_vs_whls.strip() %}
 # copy all whl PKGs first,
-{% for whl in docker_sonic_vs_whls.split(' ') -%}
-COPY python-wheels/{{ whl }}  python-wheels/
-{% endfor %}
+copy {%- for whl in docker_sonic_vs_whls.split(' ') %} python-wheels/{{ whl }}{%- endfor %} python-wheels/
 
 # install PKGs after copying all PKGs to avoid dependency failure
 # use py3 to find python3 package, which is forced by wheel as of now


### PR DESCRIPTION


Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
combine multiple same operation into one operation to reduce
the build steps. this is to avoid max depth exceeded issue
in the build.

**- How I did it**
combine copy, apt_dpkg operations into one step.

**- How to verify it**
build docker-sonic-vs.

steps reduce from 131 to 75.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
