### PR TITLE
[determine-reboot-cause] Fixed improper reboot-cause for software reboot case

### DIFF
--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -189,7 +189,7 @@ def main():
     # Else the software_reboot_cause will be treated as the reboot cause
     if proc_cmdline_reboot_cause is not None:
         previous_reboot_cause = software_reboot_cause
-    elif hardware_reboot_cause is not REBOOT_CAUSE_NON_HARDWARE:
+    elif REBOOT_CAUSE_NON_HARDWARE not in hardware_reboot_cause:
         previous_reboot_cause = hardware_reboot_cause
     else:
         previous_reboot_cause = software_reboot_cause


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

**- Why I did it**
**show reboot-cause** shows wrong cause for "sudo reboot" command:
```
admin@sonic:~$ show reboot-cause 
Non-Hardware (N/A)
```

**- How I did it**
Correct comparison for  REBOOT_CAUSE_NON_HARDWARE in determine-reboot-cause 

**- How to verify it**
Issued "sudo reboot" and then "show reboot-cause" when switch started. The output was:

```
admin@sonic:~$ show reboot-cause 
User issued 'reboot' command [User: admin, Time: Sun 10 Jan 2021 06:10:44 PM UTC]
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
