### PR TITLE
[Nokia]: Enable Telemetry for armhf and provide required qos files

### DIFF
--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/buffers.json.j2
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/buffers.json.j2
@@ -1,0 +1,8 @@
+{# Default values placeholder M0- Marvell SAI TBD buffers configuration #}
+
+{% set default_cable = '40m' %}
+{% set default_ports_num = 54 -%}
+
+{# Port configuration to cable length look-up table #}
+{# Each record describes mapping of DUT (DUT port) role and neighbor role to cable length #}
+{# Roles described in the minigraph #}

--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/qos.json.j2
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/qos.json.j2
@@ -1,0 +1,1 @@
+# this file empty temporarily until qos supported SAI Marvell 

--- a/platform/marvell-armhf/rules.mk
+++ b/platform/marvell-armhf/rules.mk
@@ -10,7 +10,6 @@ include $(PLATFORM_PATH)/linux-kernel-armhf.mk
 include $(PLATFORM_PATH)/platform-et6448m.mk
 include $(PLATFORM_PATH)/platform-nokia.mk
 
-INCLUDE_SYSTEM_TELEMETRY = ""
 ENABLE_SYNCD_RPC = ""
 INCLUDE_MGMT_FRAMEWORK = ""
 

--- a/slave.mk
+++ b/slave.mk
@@ -116,7 +116,7 @@ ifeq ($(SONIC_INCLUDE_SYSTEM_TELEMETRY),y)
 INCLUDE_SYSTEM_TELEMETRY = y
 endif
 
-ifneq (,$(filter $(CONFIGURED_ARCH), armhf arm64))
+ifneq (,$(filter $(CONFIGURED_ARCH), arm64))
     # Workaround: Force disable Telmetry for ARM, will be removed after fixing issue
     # Issue: qemu crashes when it uses "go get url"
     # Qemu Support: https://bugs.launchpad.net/qemu/+bug/1838946


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
To enable Telemetry on armhf architecture and provide required qos/buffers files that 
config qos reload --no-dynamic-buffer now requires for the Nokia ixs7215 

**- How I did it**
Removed the hardcoded disable of Telemetry in slave.mk for armhf architecture and provided 
required qos/buffers files for the config qos reload code to succeed as stubs since they do not 
generate buffer settings to Marvell SAI for this MO based role

**- How to verify it**
config load_minigraph -y succeeds for OC testing 

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
