### PR TITLE
[SAI 3.7] Update the SAI version in the bcm SAI debian package.

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
 BRCM_SAI = libsaibcm_3.7.5.2-1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.5.2-1_amd64.deb?sv=2015-04-05&sr=b&sig=%2FHUrjpYZ0MPspo4jBc08d4pn4AWVS6%2Be3BID5qPNvs0%3D&se=2034-09-08T18%3A09%3A54Z&sp=r"
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.5.2-1_amd64.deb?sv=2015-04-05&sr=b&sig=9nPXIgFsF3GsypmaSUV2cZ1t2FQbInjfahVLX64%2BinQ%3D&se=2034-09-15T20%3A34%3A43Z&sp=r"
 BRCM_SAI_DEV = libsaibcm-dev_3.7.5.2-1_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.5.2-1_amd64.deb?sv=2015-04-05&sr=b&sig=qbyqn%2F9ueIH1ffWMjbhbUn15RRgt%2BFpvpFUOlspXkqs%3D&se=2034-09-08T18%3A10%3A31Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.5.2-1_amd64.deb?sv=2015-04-05&sr=b&sig=SCd4ZhnKQX3SGFIpClVMWp5%2FgJtAXFtDXzUClMV3AOA%3D&se=2034-09-15T20%3A35%3A22Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
**- Why I did it**
Update the version of the SAI debian package to reflect the actual version 3.7.5.2-1

**- How I did it**
Updated the changelog in the SAI 3.7 package and build the image 

**- How to verify it**
Check the debian package version 
```
root@str--acs-1:/# dpkg -l| grep libsaibcm
ii  libsaibcm    3.7.5.2-1      amd64        Switch Abstraction Interface sdk based on Broadcom SAI
```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
