### PR TITLE
[bgpcfgd]: Support default action for "Allow prefix" feature

### DIFF
--- a/dockers/docker-fpm-frr/TSA
+++ b/dockers/docker-fpm-frr/TSA
@@ -6,9 +6,9 @@ function check_not_installed()
   config=$(vtysh -c "show run")
   for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p');
   do
-    echo "$config" | grep -q "route-map $route_map_name permit 2"
+    echo "$config" | grep -q "route-map $route_map_name permit 20"
     c=$((c+$?))
-    echo "$config" | grep -q "route-map $route_map_name deny 3"
+    echo "$config" | grep -q "route-map $route_map_name deny 30"
     c=$((c+$?))
   done
   return $c

--- a/dockers/docker-fpm-frr/TSB
+++ b/dockers/docker-fpm-frr/TSB
@@ -7,10 +7,10 @@ function check_installed()
   config=$(vtysh -c "show run")
   for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p');
   do
-    echo "$config" | grep -q "route-map $route_map_name permit 2"
+    echo "$config" | grep -q "route-map $route_map_name permit 20"
     c=$((c+$?))
     e=$((e+1))
-    echo "$config" | grep -q "route-map $route_map_name deny 3"
+    echo "$config" | grep -q "route-map $route_map_name deny 30"
     c=$((c+$?))
     e=$((e+1))
   done

--- a/dockers/docker-fpm-frr/TSC
+++ b/dockers/docker-fpm-frr/TSC
@@ -6,9 +6,9 @@ function check_not_installed()
   config=$(vtysh -c "show run")
   for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | egrep 'V4|V6');
   do
-    echo "$config" | grep -q "route-map $route_map_name permit 2"
+    echo "$config" | grep -q "route-map $route_map_name permit 20"
     c=$((c+$?))
-    echo "$config" | grep -q "route-map $route_map_name deny 3"
+    echo "$config" | grep -q "route-map $route_map_name deny 30"
     c=$((c+$?))
   done
   return $c
@@ -21,10 +21,10 @@ function check_installed()
   config=$(vtysh -c "show run")
   for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | egrep 'V4|V6');
   do
-    echo "$config" | grep -q "route-map $route_map_name permit 2"
+    echo "$config" | grep -q "route-map $route_map_name permit 20"
     c=$((c+$?))
     e=$((e+1))
-    echo "$config" | grep -q "route-map $route_map_name deny 3"
+    echo "$config" | grep -q "route-map $route_map_name deny 30"
     c=$((c+$?))
     e=$((e+1))
   done

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
@@ -3,14 +3,22 @@
 !
 !
 !
-{% if constants.bgp.allow_list is defined and constants.bgp.allow_list.enabled is defined and constants.bgp.allow_list.enabled %}
-{%   if constants.bgp.allow_list.default_action is defined and constants.bgp.allow_list.default_action.strip() == 'deny' %}
+{% if constants.bgp.allow_list is defined and constants.bgp.allow_list.enabled is defined and constants.bgp.allow_list.enabled and constants.bgp.allow_list.drop_community is defined %}
+!
+!
+! please don't remove. 65535 entries are default rules
+! which works when allow_list is enabled, but new configuration
+! is not applied
+!
+{%   if allow_list_default_action == 'deny' %}
+!
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 65535
   set community no-export additive
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 65535
   set community no-export additive
 {%   else %}
+!
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 65535
   set community {{ constants.bgp.allow_list.drop_community }} additive
 !
@@ -18,13 +26,22 @@ route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 65535
   set community {{ constants.bgp.allow_list.drop_community }} additive
 {%   endif %}
 !
-route-map FROM_BGP_PEER_V4 permit 2
+bgp community-list standard allow_list_default_community permit no-export
+bgp community-list standard allow_list_default_community permit {{ constants.bgp.allow_list.drop_community }}
+!
+route-map FROM_BGP_PEER_V4 permit 10
   call ALLOW_LIST_DEPLOYMENT_ID_0_V4
   on-match next
 !
-route-map FROM_BGP_PEER_V6 permit 2
+route-map FROM_BGP_PEER_V4 permit 11
+  match community allow_list_default_community
+!
+route-map FROM_BGP_PEER_V6 permit 10
   call ALLOW_LIST_DEPLOYMENT_ID_0_V6
   on-match next
+!
+route-map FROM_BGP_PEER_V6 permit 11
+  match community allow_list_default_community
 !
 {% endif %}
 !

--- a/dockers/docker-fpm-frr/frr/bgpd/tsa/bgpd.tsa.isolate.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/tsa/bgpd.tsa.isolate.conf.j2
@@ -1,5 +1,5 @@
-route-map {{ route_map_name }} permit 2
+route-map {{ route_map_name }} permit 20
   match {{ ip_protocol }} address prefix-list PL_Loopback{{ ip_version }}
   set community {{ constants.bgp.traffic_shift_community }}
-route-map {{ route_map_name }} deny 3
+route-map {{ route_map_name }} deny 30
 !

--- a/dockers/docker-fpm-frr/frr/bgpd/tsa/bgpd.tsa.unisolate.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/tsa/bgpd.tsa.unisolate.conf.j2
@@ -1,3 +1,3 @@
-no route-map {{ route_map_name }} permit 2
-no route-map {{ route_map_name }} deny 3
+no route-map {{ route_map_name }} permit 20
+no route-map {{ route_map_name }} deny 30
 !

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_allow_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_allow_list.py
@@ -36,8 +36,6 @@ class BGPAllowListMgr(Manager):
             db,
             table,
         )
-        self.cfg_mgr = common_objs["cfg_mgr"]
-        self.constants = common_objs["constants"]
         self.key_re = re.compile(r"^DEPLOYMENT_ID\|\d+\|\S+$|^DEPLOYMENT_ID\|\d+$")
         self.enabled = self.__get_enabled()
         self.__load_constant_lists()
@@ -63,7 +61,8 @@ class BGPAllowListMgr(Manager):
             prefixes_v4 = str(data['prefixes_v4']).split(",")
         if "prefixes_v6" in data:
             prefixes_v6 = str(data['prefixes_v6']).split(",")
-        self.__update_policy(deployment_id, community_value, prefixes_v4, prefixes_v6)
+        default_action_community = self.__get_default_action_community(data)
+        self.__update_policy(deployment_id, community_value, prefixes_v4, prefixes_v6, default_action_community)
         return True
 
     def __set_handler_validate(self, key, data):
@@ -96,6 +95,9 @@ class BGPAllowListMgr(Manager):
         if not prefixes_v4 and not prefixes_v6:
             log_err("BGPAllowListMgr::Received BGP ALLOWED 'SET' message with no prefixes specified: %s" % str(data))
             return False
+        if "default_action" in data and data["default_action"] != "permit" and data["default_action"] != "deny":
+            log_err("BGPAllowListMgr::Received BGP ALLOWED 'SET' message with invalid 'default_action' field: '%s'" % str(data))
+            return False
         return True
 
     def del_handler(self, key):
@@ -124,13 +126,14 @@ class BGPAllowListMgr(Manager):
             return False
         return True
 
-    def __update_policy(self, deployment_id, community_value, prefixes_v4, prefixes_v6):
+    def __update_policy(self, deployment_id, community_value, prefixes_v4, prefixes_v6, default_action):
         """
         Update "allow list" policy with parameters
         :param deployment_id: deployment id which policy will be changed
         :param community_value: community value to match for the updated policy
         :param prefixes_v4: a list of v4 prefixes for the updated policy
         :param prefixes_v6: a list of v6 prefixes for the updated policy
+        :param default_action: the default action for the policy. should be either 'permit' or 'deny'
         """
         # update all related entries with the information
         info = deployment_id, community_value, str(prefixes_v4), str(prefixes_v6)
@@ -146,6 +149,8 @@ class BGPAllowListMgr(Manager):
         cmds += self.__update_community(names['community'], community_value)
         cmds += self.__update_allow_route_map_entry(self.V4, names['pl_v4'], names['community'], names['rm_v4'])
         cmds += self.__update_allow_route_map_entry(self.V6, names['pl_v6'], names['community'], names['rm_v6'])
+        cmds += self.__update_default_route_map_entry(names['rm_v4'], default_action)
+        cmds += self.__update_default_route_map_entry(names['rm_v6'], default_action)
         if cmds:
             self.cfg_mgr.push_list(cmds)
             peer_groups = self.__find_peer_group_by_deployment_id(deployment_id)
@@ -364,6 +369,52 @@ class BGPAllowListMgr(Manager):
         if not community_name.endswith(self.EMPTY_COMMUNITY):
             cmds.append(" match community %s" % community_name)
         return cmds
+
+    def __update_default_route_map_entry(self, route_map_name, default_action_community):
+        """
+        Add or update default action rule for the route-map.
+        Default action rule is hardcoded into route-map permit 65535
+        :param route_map_name: name of the target route_map
+        :param default_action_community: community value to mark not-matched prefixes
+        """
+        info = route_map_name, default_action_community
+        log_debug("BGPAllowListMgr::__update_default_route_map_entry. rm='%s' set_community='%s'" % info)
+        current_default_action_value = self.__parse_default_action_route_map_entry(route_map_name)
+        if current_default_action_value != default_action_community:
+            return [
+                'route-map %s permit 65535' % route_map_name,
+                ' set community %s additive' % default_action_community
+            ]
+        else:
+            return []
+
+    def __parse_default_action_route_map_entry(self, route_map_name):
+        """
+        Parse default-action route-map entry
+        :param route_map_name: Name of the route-map to parse
+        :return: a community value used for default action
+        """
+        log_debug("BGPAllowListMgr::__parse_default_action_route_map_entries. rm='%s'" % route_map_name)
+        match_string = 'route-map %s permit 65535' % route_map_name
+        match_community = re.compile(r'^set community (\S+) additive$')
+        inside_route_map = False
+        community_value = ""
+        conf = self.cfg_mgr.get_text()
+        for line in conf + [""]:
+            s_line = line.strip()
+            if inside_route_map:
+                matched = match_community.match(s_line)
+                if matched:
+                    community_value = matched.group(1)
+                    break
+                else:
+                    log_err("BGPAllowListMgr::Found incomplete route-map '%s' entry. seq_no=65535" % route_map_name)
+                inside_route_map = False
+            elif s_line == match_string:
+                inside_route_map = True
+        if community_value == "":
+            log_err("BGPAllowListMgr::Default action community value is not found. route-map '%s' entry. seq_no=65535" % route_map_name)
+        return community_value
 
     def __remove_allow_route_map_entry(self, af, allow_address_pl_name, community_name, route_map_name):
         """
@@ -624,3 +675,26 @@ class BGPAllowListMgr(Manager):
         :return: prefix list ip family
         """
         return 'ip' if af == self.V4 else 'ipv6'
+
+    def __get_default_action_community(self, data):
+        """
+        Determine the default action community based on the request.
+        If request doesn't contain "default_action" field - the default_action value
+        from the constants is being used
+        :param data: SET request data
+        :return: returns community value for "default_action"
+        """
+        drop_community = self.constants["bgp"]["allow_list"]["drop_community"]
+        if "default_action" in data:
+            if data["default_action"] == "deny":
+                return "no-export"
+            else: # "permit"
+                return drop_community
+        else:
+            if "default_action" in self.constants["bgp"]["allow_list"]:
+                if self.constants["bgp"]["allow_list"]["default_action"].strip() == "deny":
+                    return "no-export"
+                else:
+                    return drop_community
+            else:
+                return drop_community

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/param_all.json
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/param_all.json
@@ -4,9 +4,9 @@
         "bgp": {
             "allow_list": {
                 "enabled": true,
-                "default_action": "permit",
                 "drop_community": "12345:12345"
             }
         }
-    }
+    },
+    "allow_list_default_action": "permit"
 }

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/param_deny.json
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/param_deny.json
@@ -4,9 +4,9 @@
         "bgp": {
             "allow_list": {
                 "enabled": true,
-                "default_action": "deny",
                 "drop_community": "12345:12345"
             }
         }
-    }
+    },
+    "allow_list_default_action": "deny"
 }

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all.conf
@@ -1,19 +1,32 @@
 !
 ! template: bgpd/templates/general/policies.conf.j2
 !
+! please don't remove. 65535 entries are default rules
+! which works when allow_list is enabled, but new configuration
+! is not applied
+!
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 65535
   set community 12345:12345 additive
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 65535
   set community 12345:12345 additive
 !
-route-map FROM_BGP_PEER_V4 permit 2
+bgp community-list standard allow_list_default_community permit no-export
+bgp community-list standard allow_list_default_community permit 12345:12345
+!
+route-map FROM_BGP_PEER_V4 permit 10
   call ALLOW_LIST_DEPLOYMENT_ID_0_V4
   on-match next
 !
-route-map FROM_BGP_PEER_V6 permit 2
+route-map FROM_BGP_PEER_V4 permit 11
+  match community allow_list_default_community
+!
+route-map FROM_BGP_PEER_V6 permit 10
   call ALLOW_LIST_DEPLOYMENT_ID_0_V6
   on-match next
+!
+route-map FROM_BGP_PEER_V6 permit 11
+  match community allow_list_default_community
 !
 route-map FROM_BGP_PEER_V4 permit 100
 !

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_deny.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_deny.conf
@@ -1,19 +1,32 @@
 !
 ! template: bgpd/templates/general/policies.conf.j2
 !
+! please don't remove. 65535 entries are default rules
+! which works when allow_list is enabled, but new configuration
+! is not applied
+!
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 65535
   set community no-export additive
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 65535
   set community no-export additive
 !
-route-map FROM_BGP_PEER_V4 permit 2
+bgp community-list standard allow_list_default_community permit no-export
+bgp community-list standard allow_list_default_community permit 12345:12345
+!
+route-map FROM_BGP_PEER_V4 permit 10
   call ALLOW_LIST_DEPLOYMENT_ID_0_V4
   on-match next
 !
-route-map FROM_BGP_PEER_V6 permit 2
+route-map FROM_BGP_PEER_V4 permit 11
+  match community allow_list_default_community
+!
+route-map FROM_BGP_PEER_V6 permit 10
   call ALLOW_LIST_DEPLOYMENT_ID_0_V6
   on-match next
+!
+route-map FROM_BGP_PEER_V6 permit 11
+  match community allow_list_default_community
 !
 route-map FROM_BGP_PEER_V4 permit 100
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/tsa/isolate.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/tsa/isolate.conf
@@ -1,5 +1,5 @@
-route-map test_rm_name permit 2
+route-map test_rm_name permit 20
   match ip address prefix-list PL_LoopbackV4
   set community 12345:555
-route-map test_rm_name deny 3
+route-map test_rm_name deny 30
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/tsa/unisolate.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/tsa/unisolate.conf
@@ -1,3 +1,3 @@
-no route-map test_rm permit 2
-no route-map test_rm deny 3
+no route-map test_rm permit 20
+no route-map test_rm deny 30
 !

--- a/src/sonic-bgpcfgd/tests/test_allow_list.py
+++ b/src/sonic-bgpcfgd/tests/test_allow_list.py
@@ -18,7 +18,9 @@ global_constants = {
                     "deny 0::/0 le 59",
                     "deny 0::/0 ge 65"
                 ]
-            }
+            },
+            "default_action": "permit",
+            "drop_community": "123:123"
         }
     }
 }
@@ -64,7 +66,12 @@ def test_set_handler_with_community():
                 "prefixes_v4": "10.20.30.0/24,30.50.0.0/16",
                 "prefixes_v6": "fc00:20::/64,fc00:30::/64",
         }),
-        [],
+        [
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V4 permit 65535',
+            ' set community 123:123 additive',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V6 permit 65535',
+            ' set community 123:123 additive'
+        ],
         [
             'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_1010:2020_V4 seq 10 deny 0.0.0.0/0 le 17',
             'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_1010:2020_V4 seq 20 permit 10.20.30.0/24 le 32',
@@ -90,7 +97,12 @@ def test_set_handler_no_community():
                 "prefixes_v4": "20.20.30.0/24,40.50.0.0/16",
                 "prefixes_v6": "fc01:20::/64,fc01:30::/64",
         }),
-        [],
+        [
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V4 permit 65535',
+            ' set community 123:123 additive',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V6 permit 65535',
+            ' set community 123:123 additive',
+        ],
         [
             'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_empty_V4 seq 10 deny 0.0.0.0/0 le 17',
             'ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_empty_V4 seq 20 permit 20.20.30.0/24 le 32',
@@ -184,6 +196,10 @@ def test_set_handler_with_community_data_is_already_presented():
             'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V6 permit 10',
             ' match ipv6 address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_1010:2020_V6',
             ' match community COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_1010:2020',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V4 permit 65535',
+            ' set community 123:123 additive',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V6 permit 65535',
+            ' set community 123:123 additive',
             ""
         ],
         []
@@ -206,6 +222,10 @@ def test_set_handler_no_community_data_is_already_presented():
         ' match ip address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_empty_V4',
         'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V6 permit 30000',
         ' match ipv6 address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_empty_V6',
+        'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V4 permit 65535',
+        ' set community 123:123 additive',
+        'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V6 permit 65535',
+        ' set community 123:123 additive',
         ""
     ]
     common_objs = {
@@ -259,6 +279,10 @@ def test_set_handler_with_community_update_prefixes_add():
             'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V6 permit 10',
             ' match ipv6 address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_1010:2020_V6',
             ' match community COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_1010:2020',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V4 permit 65535',
+            ' set community 123:123 additive',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V6 permit 65535',
+            ' set community 123:123 additive',
             ""
         ],
         [
@@ -295,6 +319,10 @@ def test_set_handler_no_community_update_prefixes_add():
             ' match ip address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_empty_V4',
             'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V6 permit 30000',
             ' match ipv6 address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_5_COMMUNITY_empty_V6',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V4 permit 65535',
+            ' set community 123:123 additive',
+            'route-map ALLOW_LIST_DEPLOYMENT_ID_5_V6 permit 65535',
+            ' set community 123:123 additive',
             ""
         ],
         [
@@ -449,5 +477,115 @@ def test___to_prefix_list():
     assert res_v4 == ["permit 1.2.3.4/32", "permit 10.20.20.10/24 le 32"]
     res_v6 = mgr._BGPAllowListMgr__to_prefix_list(mgr.V6, ["fc00::1/128", "fc00::/64"])
     assert res_v6 == ["permit fc00::1/128", "permit fc00::/64 le 128"]
+
+@patch.dict("sys.modules", swsscommon=swsscommon_module_mock)
+def construct_BGPAllowListMgr(constants):
+    from bgpcfgd.managers_allow_list import BGPAllowListMgr
+    cfg_mgr = MagicMock()
+    common_objs = {
+        'directory': Directory(),
+        'cfg_mgr':   cfg_mgr,
+        'tf':        TemplateFabric(),
+        'constants': constants,
+    }
+    mgr = BGPAllowListMgr(common_objs, "CONFIG_DB", "BGP_ALLOWED_PREFIXES")
+    return mgr
+
+def test___get_enabled_enabled():
+    constants = {
+        "bgp": {
+            "allow_list": {
+                "enabled": True,
+            }
+        }
+    }
+    mgr = construct_BGPAllowListMgr(constants)
+    assert mgr._BGPAllowListMgr__get_enabled()
+
+def test___get_enabled_disabled_1():
+    constants = {
+        "bgp": {
+            "allow_list": {
+                "enabled": False,
+            }
+        }
+    }
+    mgr = construct_BGPAllowListMgr(constants)
+    assert not mgr._BGPAllowListMgr__get_enabled()
+
+def test___get_enabled_disabled_2():
+    constants = {
+        "bgp": {
+            "allow_list": {}
+        }
+    }
+    mgr = construct_BGPAllowListMgr(constants)
+    assert not mgr._BGPAllowListMgr__get_enabled()
+
+def test___get_enabled_disabled_3():
+    constants = {
+        "bgp": {}
+    }
+    mgr = construct_BGPAllowListMgr(constants)
+    assert not mgr._BGPAllowListMgr__get_enabled()
+
+def test___get_enabled_disabled_4():
+    constants = {}
+    mgr = construct_BGPAllowListMgr(constants)
+    assert not mgr._BGPAllowListMgr__get_enabled()
+
+def test___get_default_action_deny():
+    constants = {
+        "bgp": {
+            "allow_list": {
+                "enabled": True,
+                "default_action": "deny",
+                "drop_community": "123:123"
+            }
+        }
+    }
+    data = {}
+    mgr = construct_BGPAllowListMgr(constants)
+    assert mgr._BGPAllowListMgr__get_default_action_community(data) == "no-export"
+
+def test___get_default_action_permit_1():
+    constants = {
+        "bgp": {
+            "allow_list": {
+                "enabled": True,
+                "default_action": "permit",
+                "drop_community": "123:123"
+            }
+        }
+    }
+    data = {}
+    mgr = construct_BGPAllowListMgr(constants)
+    assert mgr._BGPAllowListMgr__get_default_action_community(data) == "123:123"
+
+def test___get_default_action_permit_2():
+    constants = {
+        "bgp": {
+            "allow_list": {
+                "enabled": True,
+                "drop_community": "123:123"
+            }
+        }
+    }
+    data = {}
+    mgr = construct_BGPAllowListMgr(constants)
+    assert mgr._BGPAllowListMgr__get_default_action_community(data) == "123:123"
+
+def test___get_default_action_permit_3():
+    constants = {
+        "bgp": {
+            "allow_list": {
+                "enabled": False,
+                "drop_community": "123:123"
+            }
+        }
+    }
+    data = {}
+    mgr = construct_BGPAllowListMgr(constants)
+    assert mgr._BGPAllowListMgr__get_default_action_community(data) == "123:123"
 
 # FIXME: more testcases for coverage


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->
1. Change TSA route-map entry sequence numbers to 20 and 30 instead of 2 and 3. With this change standard SONiC sequence number rules order should be following: 
   - 1 for ipv6 default nexthop rule. Applicable for ipv6 route-maps only
   - 10-11 for "Allow prefix" route-map rules
   - 20-30 for "TSA" rules
   - 100 and larger for standard rules
2. Add support dynamic default action for "Allow prefix"

**- Why I did it**
To enable dynamic default action parameter for "Allow prefix" feature.

**- How I did it**
I introduce another field into the "Allow prefix" controlling object.
I added field with name "default_action", which must have either "permit" or "deny" value
```
admin@str-s6100-acs-1:~$ cat 5
{
    "BGP_ALLOWED_PREFIXES": {
        "DEPLOYMENT_ID|0|1010:1010": {
            "prefixes_v4": [
                "10.20.0.0/16",
                "10.50.1.0/29"
            ],
            "prefixes_v6": [
                "fc01:10::/64",
                "fc02:20::/64"
            ],
            "default_action": "deny"
        },
        "DEPLOYMENT_ID|0": {
            "prefixes_v4": [
                "10.20.0.0/16",
                "10.50.1.0/29"
            ],
            "prefixes_v6": [
                "fc01:10::/64",
                "fc02:20::/64"
            ],
            "default_action": "deny"
        }
    }
}
```
When you apply this configuration to the DB by command: `sonic-cfggen -j  apply.json -w` this configuration would be rendered into the following change
```
--- out 2021-01-06 20:49:37.971745161 +0000
+++ z   2021-01-06 20:50:58.328321185 +0000
@@ -151,7 +151,7 @@
  set src 10.1.0.32
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 65535
- set community 5060:12345 additive
+ set community no-export additive
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 10
  match community COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010
@@ -161,7 +161,7 @@
  match ip address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V4
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 65535
- set community 5060:12345 additive
+ set community no-export additive
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 10
  match community COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010
```
That will mark differently prefixes which weren't matched by the "Allow prefix" rules.

By default or when "default_action" is not presented, the values from the [constants.yml](https://github.com/Azure/sonic-buildimage/blob/master/files/image_config/constants/constants.yml#L23) is used.

**- How to verify it**
1. Save this into apply.json file
```
admin@str-s6100-acs-1:~$ cat 5
{
    "BGP_ALLOWED_PREFIXES": {
        "DEPLOYMENT_ID|0|1010:1010": {
            "prefixes_v4": [
                "10.20.0.0/16",
                "10.50.1.0/29"
            ],
            "prefixes_v6": [
                "fc01:10::/64",
                "fc02:20::/64"
            ],
            "default_action": "deny"
        },
        "DEPLOYMENT_ID|0": {
            "prefixes_v4": [
                "10.20.0.0/16",
                "10.50.1.0/29"
            ],
            "prefixes_v6": [
                "fc01:10::/64",
                "fc02:20::/64"
            ],
            "default_action": "deny"
        }
    }
}
```
2. Apply with `sonic-cfggen -j  apply.json -w`
3. Check that the following configuration was added to the bgp config
```
--- z1  2021-01-06 21:35:56.589811834 +0000
+++ z2  2021-01-06 21:36:19.740828696 +0000
@@ -120,10 +120,27 @@
 !
 ip prefix-list PL_LoopbackV4 seq 5 permit 10.1.0.32/32
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.0/21
+ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010_V4 seq 10 deny 0.0.0.0/0 le 17
+ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010_V4 seq 20 permit 127.0.0.1/32
+ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010_V4 seq 30 permit 10.20.0.0/16 le 32
+ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010_V4 seq 40 permit 10.50.1.0/29 le 32
+ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V4 seq 10 deny 0.0.0.0/0 le 17
+ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V4 seq 20 permit 127.0.0.1/32
+ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V4 seq 30 permit 10.20.0.0/16 le 32
+ip prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V4 seq 40 permit 10.50.1.0/29 le 32
 !
 ipv6 prefix-list PL_LoopbackV6 seq 5 permit fc00:1::/64
 ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 10 permit fc02:1000::/64
+ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010_V6 seq 10 deny ::/0 le 59
+ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010_V6 seq 20 deny ::/0 ge 65
+ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010_V6 seq 30 permit fc01:10::/64 le 128
+ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010_V6 seq 40 permit fc02:20::/64 le 128
+ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V6 seq 10 deny ::/0 le 59
+ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V6 seq 20 deny ::/0 ge 65
+ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V6 seq 30 permit fc01:10::/64 le 128
+ipv6 prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V6 seq 40 permit fc02:20::/64 le 128
 !
+bgp community-list standard COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010 seq 5 permit 1010:1010
 bgp community-list standard allow_list_default_community seq 5 permit no-export
 bgp community-list standard allow_list_default_community seq 10 permit 5060:12345
 !
@@ -134,10 +151,24 @@
  set src 10.1.0.32
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 65535
- set community 5060:12345 additive
+ set community no-export additive
+!
+route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 10
+ match community COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010
+ match ip address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010_V4
+!
+route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 30000
+ match ip address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V4
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 65535
- set community 5060:12345 additive
+ set community no-export additive
+!
+route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 10
+ match community COMMUNITY_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010
+ match ipv6 address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_1010:1010_V6
+!
+route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 30000
+ match ipv6 address prefix-list PL_ALLOW_LIST_DEPLOYMENT_ID_0_COMMUNITY_empty_V6
 !
 route-map FROM_BGP_PEER_V4 permit 10
  call ALLOW_LIST_DEPLOYMENT_ID_0_V4
```


**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
