### PR TITLE
[system-health] Make `run_command()` Python 3-compliant

### DIFF
--- a/src/system-health/health_checker/utils.py
+++ b/src/system-health/health_checker/utils.py
@@ -8,7 +8,7 @@ def run_command(command):
     :return: Output of the shell command.
     """
     try:
-        process = subprocess.Popen(command, shell=True, text=True, stdout=subprocess.PIPE)
+        process = subprocess.Popen(command, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
         return process.communicate()[0]
     except Exception:
         return None

--- a/src/system-health/health_checker/utils.py
+++ b/src/system-health/health_checker/utils.py
@@ -8,8 +8,8 @@ def run_command(command):
     :return: Output of the shell command.
     """
     try:
-        process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
-        return process.communicate()[0].encode('utf-8')
+        process = subprocess.Popen(command, shell=True, text=True, stdout=subprocess.PIPE)
+        return process.communicate()[0]
     except Exception:
         return None
 


### PR DESCRIPTION
**- Why I did it**

- Pass `universal_newlines=True` parameter to `subprocess.Popen()`; no longer use `.encode('utf-8')` on resulting stdout.

This was missed in https://github.com/Azure/sonic-buildimage/pull/5886

Note: I would prefer to use `text=True` instead of `universal_newlines=True`, as the former is an alias only available in Python 3 and is more understandable than the latter. However, Even though the setup.py file for this package only specifies Python 3, the LGTM tool finds other Python 2 code in the repo and validates the code as Python 2 code and alerts that `text=True` is an invalid parameter. Will stick with `universal_newlines=True` for now. Once all Python code in the repo has been converted to Python 3, I will change all `universal_newlines=True` to `text=True`.

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012