### PR TITLE
BRCM SAI 4.2.1.5-9 Fix _brcm_sai_indexed_data_get () with unexpected queue causing _brcm_sai_switch_assert () after warm reboot

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_4.2.1.5-7_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/buster/libsaibcm_4.2.1.5-8_amd64.deb?sv=2019-12-12&st=2020-12-18T18%3A41%3A23Z&se=2030-12-19T18%3A41%3A00Z&sr=b&sp=r&sig=GFNMn0borytUTFQJf%2F5A0J452XsQ%2FqnzBw5GyjFuYHw%3D"
-BRCM_SAI_DEV = libsaibcm-dev_4.2.1.5-7_amd64.deb
+BRCM_SAI = libsaibcm_4.2.1.5-9_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/buster/libsaibcm_4.2.1.5-9_amd64.deb?sv=2015-04-05&sr=b&sig=Rbqq%2FH4B71%2BWGzAzTuM3qxEdwpEnuxqFdGIMDpuN8t0%3D&se=2034-09-16T01%3A36%3A13Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_4.2.1.5-9_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/buster/libsaibcm-dev_4.2.1.5-8_amd64.deb?sv=2019-12-12&st=2020-12-18T18%3A42%3A03Z&se=2030-12-19T18%3A42%3A00Z&sr=b&sp=r&sig=J%2BbRtZVVcZTLs3uqzZs9zObLKFxRgzvJkFL5iyJ48mA%3D"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/buster/libsaibcm-dev_4.2.1.5-9_amd64.deb?sv=2015-04-05&sr=b&sig=C%2Bo7YTkA2076LRfet1rHHlFu%2F6b9qoQiHljjaZCVa20%3D&se=2034-09-16T01%3A37%3A38Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
**- Why I did it**
Starting from build (master) 176 the warm reboot on BRCM Platform started to experience syncd crash.  Upon further debug by Ying it was determined that the crash was related to the following new change:
[Dynamic buffer calc]  Support dynamic buffer calculation (#1338)

Ying also debugged further and found The crash was caused by buffer pool profile setting operation SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH 

A case has filed with BRCM while a potential fix was tried by Ying that seems to have addressed this issue and we are making this change available in master branch so that it will allow further feature validation/testing especially in the warm reboot area.
Once an official fix is provided by BRCM, we will then remove this in house fix and apply the official fix.

**- How to verify it**
Just perform warm reboot with any master code 175 or above you should see this issue or issue the following cmd will also cause the crash: "mmuconfig -p egress_lossy_profile -a 0"

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
BRCM SAI 4.2.1.5-9 Fix _brcm_sai_indexed_data_get () with unexpected queue causing _brcm_sai_switch_assert () after warm reboot