### PR TITLE
Adding more encompassing UT for ECMP minigraph parsing

### DIFF
--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -237,6 +237,20 @@ class TestCfgGen(TestCase):
                                          " '200:200:200:200::2', '200:200:200:200::3', '200:200:200:200::4', '200:200:200:200::5', '200:200:200:200::6',"
                                          " '200:200:200:200::7', '200:200:200:200::8', '200:200:200:200::9']")
 
+    def test_minigraph_ecmp_members_values(self):
+        argument = '-m "' + self.ecmp_graph + '" -p "' + self.mlnx_port_config + '" -v \"FG_NHG_MEMBER.values()|list|sort\"'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), "[{'link': 'Ethernet36', 'bank': 0, 'FG_NHG': 'fgnhg_v4'}, {'link': 'Ethernet44', 'bank': 0, 'FG_NHG': 'fgnhg_v4'},"
+                                         " {'link': 'Ethernet52', 'bank': 0, 'FG_NHG': 'fgnhg_v4'}, {'link': 'Ethernet60', 'bank': 0, 'FG_NHG': 'fgnhg_v4'},"
+                                         " {'link': 'Ethernet68', 'bank': 0, 'FG_NHG': 'fgnhg_v4'}, {'link': 'Ethernet40', 'bank': 1, 'FG_NHG': 'fgnhg_v4'},"
+                                         " {'link': 'Ethernet48', 'bank': 1, 'FG_NHG': 'fgnhg_v4'}, {'link': 'Ethernet56', 'bank': 1, 'FG_NHG': 'fgnhg_v4'},"
+                                         " {'link': 'Ethernet64', 'bank': 1, 'FG_NHG': 'fgnhg_v4'}, {'link': 'Ethernet72', 'bank': 1, 'FG_NHG': 'fgnhg_v4'},"
+                                         " {'link': 'Ethernet36', 'bank': 0, 'FG_NHG': 'fgnhg_v6'}, {'link': 'Ethernet44', 'bank': 0, 'FG_NHG': 'fgnhg_v6'},"
+                                         " {'link': 'Ethernet52', 'bank': 0, 'FG_NHG': 'fgnhg_v6'}, {'link': 'Ethernet60', 'bank': 0, 'FG_NHG': 'fgnhg_v6'},"
+                                         " {'link': 'Ethernet68', 'bank': 0, 'FG_NHG': 'fgnhg_v6'}, {'link': 'Ethernet40', 'bank': 1, 'FG_NHG': 'fgnhg_v6'},"
+                                         " {'link': 'Ethernet48', 'bank': 1, 'FG_NHG': 'fgnhg_v6'}, {'link': 'Ethernet56', 'bank': 1, 'FG_NHG': 'fgnhg_v6'},"
+                                         " {'link': 'Ethernet64', 'bank': 1, 'FG_NHG': 'fgnhg_v6'}, {'link': 'Ethernet72', 'bank': 1, 'FG_NHG': 'fgnhg_v6'}]")
+
     def test_minigraph_ecmp_neighbors(self):
         argument = '-m "' + self.ecmp_graph + '" -p "' + self.mlnx_port_config + '" -v "NEIGH.keys()|list|sort"'
         output = self.run_script(argument)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
For further UT coverage for minigraph.py ECMP parsing
**- How I did it**
Added UT(s) to test_cfggen.py
**- How to verify it**
Local Testing / sonic-buildimage build jobs 
**- Description for the changelog**
<!--
Adds UT for further coverage for minigraph.py ECMP parsing
-->


**- A picture of a cute animal (not mandatory but encouraged)**
