### PR TITLE
[Centec ARM64]Upgrade Centec syncd docker to buster and Enable Telemetry on ARM64

### DIFF
--- a/platform/centec-arm64/docker-syncd-centec.mk
+++ b/platform/centec-arm64/docker-syncd-centec.mk
@@ -10,9 +10,6 @@ $(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(SYNCD_DBG) \
                                 $(LIBSAIMETADATA_DBG) \
                                 $(LIBSAIREDIS_DBG)
 
-SONIC_STRETCH_DOCKERS += $(DOCKER_SYNCD_BASE)
-SONIC_STRETCH_DBG_DOCKERS += $(DOCKER_SYNCD_BASE_DBG)
-
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/warmboot:/var/warmboot
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf

--- a/platform/centec-arm64/docker-syncd-centec/Dockerfile.j2
+++ b/platform/centec-arm64/docker-syncd-centec/Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM docker-config-engine-stretch
+FROM docker-config-engine-buster
 
 ARG docker_container_name
 RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%syslogtag%/;" /etc/rsyslog.conf
@@ -19,7 +19,7 @@ RUN apt-get update \
     net-tools           \
     iputils-ping
 
-RUN apt-get -y install libpcap-dev libxml2-dev python-dev swig libsensors4-dev libjemalloc1 nfs-common
+RUN apt-get -y install libpcap-dev libxml2-dev python-dev swig libsensors4-dev nfs-common
 
 RUN dpkg -i \
 {% for deb in docker_syncd_centec_debs.split(' ') -%}

--- a/platform/centec/docker-syncd-centec.mk
+++ b/platform/centec/docker-syncd-centec.mk
@@ -10,9 +10,6 @@ $(DOCKER_SYNCD_CENTEC)_DEPENDS += $(SYNCD_DBG) \
                                   $(LIBSAIMETADATA_DBG) \
                                   $(LIBSAIREDIS_DBG)
 
-SONIC_STRETCH_DOCKERS += $(DOCKER_SYNCD_BASE)
-SONIC_STRETCH_DBG_DOCKERS += $(DOCKER_SYNCD_BASE_DBG)
-
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_CENTEC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd

--- a/platform/centec/docker-syncd-centec/Dockerfile.j2
+++ b/platform/centec/docker-syncd-centec/Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM docker-config-engine-stretch
+FROM docker-config-engine-buster
 
 ARG docker_container_name
 RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%syslogtag%/;" /etc/rsyslog.conf

--- a/slave.mk
+++ b/slave.mk
@@ -116,14 +116,6 @@ ifeq ($(SONIC_INCLUDE_SYSTEM_TELEMETRY),y)
 INCLUDE_SYSTEM_TELEMETRY = y
 endif
 
-ifneq (,$(filter $(CONFIGURED_ARCH), arm64))
-    # Workaround: Force disable Telmetry for ARM, will be removed after fixing issue
-    # Issue: qemu crashes when it uses "go get url"
-    # Qemu Support: https://bugs.launchpad.net/qemu/+bug/1838946
-    # Golang Support: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/golang-nuts/1txPOGa4aGc
-INCLUDE_SYSTEM_TELEMETRY = n
-endif
-
 ifeq ($(SONIC_INCLUDE_RESTAPI),y)
 INCLUDE_RESTAPI = y
 endif


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
1. Enable telemetry by default for ARM64 arch
2. Upgrade Centec syncd docker to buster

**- How I did it**
1. Remove the hardcoded disable of telemetry in slave.mk for ARM64 architecture
2. Use docker-config-engine-buster for syncd docker
3. Remove libjemalloc1 from Dockerfile.j2 for Centec ARM64 syncd docker . libjemalloc1 is replaced by libjemalloc2 in buster, and libjemalloc2 have been installed in docker-base-buster

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
