### PR TITLE
[device/celestica]: Add placeholder healthd configuration

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/system_health_monitoring_config.json
+++ b/device/celestica/x86_64-cel_e1031-r0/system_health_monitoring_config.json
@@ -1,0 +1,16 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.temperature",
+        "PSU2 Fan",
+        "PSU1 Fan"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "orange",
+        "normal": "green",
+        "booting": "orange_blink"
+    }
+}

--- a/device/celestica/x86_64-cel_midstone-r0/system_health_monitoring_config.json
+++ b/device/celestica/x86_64-cel_midstone-r0/system_health_monitoring_config.json
@@ -1,0 +1,16 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.temperature",
+        "PSU2 Fan",
+        "PSU1 Fan"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "orange",
+        "normal": "green",
+        "booting": "orange_blink"
+    }
+}

--- a/device/celestica/x86_64-cel_seastone-r0/system_health_monitoring_config.json
+++ b/device/celestica/x86_64-cel_seastone-r0/system_health_monitoring_config.json
@@ -1,0 +1,16 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.temperature",
+        "PSU2 Fan",
+        "PSU1 Fan"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "orange",
+        "normal": "green",
+        "booting": "orange_blink"
+    }
+}

--- a/device/celestica/x86_64-cel_seastone_2-r0/system_health_monitoring_config.json
+++ b/device/celestica/x86_64-cel_seastone_2-r0/system_health_monitoring_config.json
@@ -1,0 +1,16 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.temperature",
+        "PSU2 Fan",
+        "PSU1 Fan"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "orange",
+        "normal": "green",
+        "booting": "orange_blink"
+    }
+}

--- a/device/celestica/x86_64-cel_silverstone-r0/system_health_monitoring_config.json
+++ b/device/celestica/x86_64-cel_silverstone-r0/system_health_monitoring_config.json
@@ -1,0 +1,16 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.temperature",
+        "PSU2 Fan",
+        "PSU1 Fan"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "orange",
+        "normal": "green",
+        "booting": "orange_blink"
+    }
+}


### PR DESCRIPTION
**- Why I did it**
- system-healthd from service from failing at boot time due to missing configuration.

**- How I did it**

- Added basic config with system_health_monitoring_config.json to all Celestica devices.

**- How to verify it**

- Check systemctl status system-health after boot.
- No healthd errors in /var/log/syslog.
- Verify that the output of journalctl -u system-health is sane.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202006
- [ ] 202012
