### PR TITLE
Fix for missing dependencies in the DPKG framework

### DIFF
--- a/platform/vs/rules.dep
+++ b/platform/vs/rules.dep
@@ -2,6 +2,7 @@ include $(PLATFORM_PATH)/syncd-vs.dep
 include $(PLATFORM_PATH)/sonic-version.dep
 include $(PLATFORM_PATH)/docker-sonic-vs.dep
 include $(PLATFORM_PATH)/docker-syncd-vs.dep
+include $(PLATFORM_PATH)/docker-gbsyncd-vs.dep
 include $(PLATFORM_PATH)/one-image.dep
 include $(PLATFORM_PATH)/onie.dep
 include $(PLATFORM_PATH)/kvm-image.dep

--- a/rules/functions
+++ b/rules/functions
@@ -117,6 +117,7 @@ define add_dbg_docker
 $(2)_PATH = $($(1)_PATH)
 $(2)_DBG_DEPENDS += $($(1)_DBG_DEPENDS)
 $(2)_DBG_IMAGE_PACKAGES += $($(1)_DBG_IMAGE_PACKAGES)
+$(2)_PYTHON_DEBS += $($(1)_PYTHON_DEBS)
 $(2)_PYTHON_WHEELS += $($(1)_PYTHON_WHEELS)
 $(2)_LOAD_DOCKERS += $($(1)_LOAD_DOCKERS)
 $(2)_CACHE_MODE += $($(1)_CACHE_MODE)

--- a/rules/sonic-platform-common.dep
+++ b/rules/sonic-platform-common.dep
@@ -2,7 +2,7 @@
 SPATH       := $($(SONIC_PLATFORM_COMMON_PY2)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-platform-common.mk rules/sonic-platform-common.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
-SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files|grep -Ev "sonic_sfp|sonic_eeprom"))
+SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files|grep -Ev "^sonic_sfp|^sonic_eeprom"))
 
 $(SONIC_PLATFORM_COMMON_PY2)_CACHE_MODE  := GIT_CONTENT_SHA 
 $(SONIC_PLATFORM_COMMON_PY2)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)

--- a/rules/sonic-ztp.dep
+++ b/rules/sonic-ztp.dep
@@ -2,7 +2,7 @@
 SPATH       := $($(SONIC_ZTP)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-ztp.mk rules/sonic-ztp.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
-SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files|grep -Ev "inband-ztp-ip|dhclient-exit-hooks.d/ztp"))
+SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files|grep -Ev "dhclient-enter-hooks.d|dhclient-exit-hooks.d"))
 
 
 $(SONIC_ZTP)_CACHE_MODE  := GIT_CONTENT_SHA 


### PR DESCRIPTION
1. Fixes the missing DPKG file for gbsyncd-vs package
2. Fixes the softlink issue on the Platform-common and ztp package
3. Fixes the PYTHNON_DEBS list is missing for DBG dockers.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
