### PR TITLE
[201811][bcm SAI] ugprade Broadcom SAI to version 3.5.3.6-2

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.5.3.5-3_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm_3.5.3.5-3_amd64.deb?sv=2019-10-10&st=2020-10-28T16%3A16%3A17Z&se=2040-10-29T16%3A16%3A00Z&sr=b&sp=r&sig=g57JqV9YzbGXegUvCCjSht4A59zZP3I01CA6X%2Bh4J80%3D"
+BRCM_SAI = libsaibcm_3.5.3.6-2_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm_3.5.3.6-2_amd64.deb?sv=2019-10-10&st=2021-01-07T19%3A44%3A15Z&se=2036-01-08T19%3A44%3A00Z&sr=b&sp=r&sig=VgJZNnPYfITkP1pLhisBdNmWKKRuaLCVNWVGgUnUW3Q%3D"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.5.3.5-3_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.5.3.6-2_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm-dev_3.5.3.5-3_amd64.deb?sv=2019-10-10&st=2020-10-28T16%3A14%3A38Z&se=2040-10-29T16%3A14%3A00Z&sr=b&sp=r&sig=ZgAYr3cUmpxJgsnNezW8x6cbB%2B6uDQQdG%2BW1BsALeIM%3D"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm-dev_3.5.3.6-2_amd64.deb?sv=2019-10-10&st=2021-01-07T19%3A42%3A40Z&se=2036-01-08T19%3A42%3A00Z&sr=b&sp=r&sig=V18w8%2BSnrhUXEOJhcyaYXiagBolg0f0Dr0TqsO7YJ9A%3D"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
**- Why I did it**
ugprade Broadcom SAI to version 3.5.3.6-2

- Rebase to Broadcom release 3.5.3.6.
- Taking fixes for: CS00011229318, CS00010775359, CS00011331832, CS00011444035, CS00011222060 and CS00010318905
- Taking CS00011581499 patch from Broadcom.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

