### PR TITLE
[TSA]: Use egrep to match TSA rules better 

### DIFF
--- a/dockers/docker-fpm-frr/TSA
+++ b/dockers/docker-fpm-frr/TSA
@@ -6,9 +6,9 @@ function check_not_installed()
   config=$(vtysh -c "show run")
   for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p');
   do
-    echo "$config" | grep -q "route-map $route_map_name permit 20"
+    echo "$config" | egrep -q "^route-map $route_map_name permit 20$"
     c=$((c+$?))
-    echo "$config" | grep -q "route-map $route_map_name deny 30"
+    echo "$config" | egrep -q "^route-map $route_map_name deny 30$"
     c=$((c+$?))
   done
   return $c

--- a/dockers/docker-fpm-frr/TSB
+++ b/dockers/docker-fpm-frr/TSB
@@ -7,10 +7,10 @@ function check_installed()
   config=$(vtysh -c "show run")
   for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p');
   do
-    echo "$config" | grep -q "route-map $route_map_name permit 20"
+    echo "$config" | egrep -q "^route-map $route_map_name permit 20$"
     c=$((c+$?))
     e=$((e+1))
-    echo "$config" | grep -q "route-map $route_map_name deny 30"
+    echo "$config" | egrep -q "^route-map $route_map_name deny 30$"
     c=$((c+$?))
     e=$((e+1))
   done

--- a/dockers/docker-fpm-frr/TSC
+++ b/dockers/docker-fpm-frr/TSC
@@ -6,9 +6,9 @@ function check_not_installed()
   config=$(vtysh -c "show run")
   for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | egrep 'V4|V6');
   do
-    echo "$config" | grep -q "route-map $route_map_name permit 20"
+    echo "$config" | egrep -q "^route-map $route_map_name permit 20$"
     c=$((c+$?))
-    echo "$config" | grep -q "route-map $route_map_name deny 30"
+    echo "$config" | egrep -q "^route-map $route_map_name deny 30$"
     c=$((c+$?))
   done
   return $c
@@ -21,10 +21,10 @@ function check_installed()
   config=$(vtysh -c "show run")
   for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | egrep 'V4|V6');
   do
-    echo "$config" | grep -q "route-map $route_map_name permit 20"
+    echo "$config" | egrep -q "^route-map $route_map_name permit 20$"
     c=$((c+$?))
     e=$((e+1))
-    echo "$config" | grep -q "route-map $route_map_name deny 30"
+    echo "$config" | egrep -q "^route-map $route_map_name deny 30$"
     c=$((c+$?))
     e=$((e+1))
   done


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Earlier today we found a bug in the SONiC TSA implementation.
TSC shows incorrect output (see below) in case we have a route-map which contains TSA route-map as a prefix.
```
admin@str-s6100-acs-1:~$ TSC
Traffic Shift Check:
System Mode: Not consistent
```
The reason is that TSC implementation has too loose regexps in TSA utilities, which match wrong route-map entries:
For example, current TSC matches following
```
route-map TO_BGP_PEER_V4 permit 200
route-map TO_BGP_PEER_V6 permit 200
```
But it should match only
```
route-map TO_BGP_PEER_V4 permit 20
route-map TO_BGP_PEER_V4 deny 30
route-map TO_BGP_PEER_V6 permit 20
route-map TO_BGP_PEER_V6 deny 30
```

**- How I did it**
I fixed it by using egrep with `^` and `$` regexp markers which match begin and end of the line.

**- How to verify it**
1. Add follwing entry to FRR config:
```
str-s6100-acs-1# 
str-s6100-acs-1# conf t
str-s6100-acs-1(config)# route-map TO_BGP_PEER_V4 permit 200 
str-s6100-acs-1(config-route-map)# end
```
2. Use the TSC command and check output. It should show normal.
```
admin@str-s6100-acs-1:~$ TSC
Traffic Shift Check:
System Mode: Normal```


**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**