### PR TITLE
[201811] Restore from TACACS backup during config-update as needed

### DIFF
--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 CONFIG_DB_INDEX=4
+TACACS_JSON_BACKUP=tacacs.json
 
 reload_minigraph()
 {
@@ -15,6 +16,11 @@ reload_minigraph()
         acl-loader update full /etc/sonic/acl.json
     fi
     config qos reload
+    if [ -r /etc/sonic/old_config/${TACACS_JSON_BACKUP} ]; then
+        sonic-cfggen -j /etc/sonic/old_config/${TACACS_JSON_BACKUP} --write-to-db
+    else
+        echo "Missing tacacs json to restore tacacs credentials"
+    fi
     DEVICE_TYPE=`sonic-cfggen -m -v DEVICE_METADATA.localhost.type`
     if [ "${DEVICE_TYPE}" != "MgmtToRRouter" ]; then
         pfcwd start_default


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
During upgrade, if config is loaded from minigraph, it would miss TACACS credentials. This leads to device losing remote user accessibility

**- How I did it**
During update graph, when config is loaded from minigraph, look for TACACS credentials back-up and load that if available

**- How to verify it**
Remove /etc/sonic/config-db.json, save TACACS credentials in /etc/sonic/tacacs.json and do a Image upgrade. Do image upgrade and boot into new image. Verify remote user access is available.

NOTE: This change is available in master via PR #6285

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
