### PR TITLE
Update swi-tools in buster Dockerfile

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -496,7 +496,7 @@ RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
 RUN pip2 install m2crypto==0.36.0
 
 # Install swi tools
-RUN pip2 install git+https://github.com/aristanetworks/swi-tools.git@d51761ec0bb93c73039233f3c01ed48235ffad00
+RUN pip3 install git+https://github.com/aristanetworks/swi-tools.git@bead66bf261770237f7dd21ace3774ba04a017e9
 
 {% if CONFIGURED_ARCH != "amd64" -%}
 # Install node.js for azure pipeline


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

This is part of the python2 to python3 migration effort.

**- How I did it**

Fixed swi-tools code to work with `python3`
Updated the version of swi-tools downloaded by the `sonic-slave-buster/Dockerfile.j2`
Other Dockerfiles still use the `python2` version, though swi-tools is not used within the stretch builder.

**- How to verify it**

Build an image with `SONIC_ENABLE_IMAGE_SIGNATURE = y` and verify that build passes.
Install the image on a secureboot enabled product to verify that it works.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

It is pretty much a harmless change that push python2 to python3 conversion closer to the finish line.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update the swi-tools version used by buster Dockerfile
