### PR TITLE
[sonic-device-data]: Update BRCM Tunnel/ECMP Parameter For 7050cx3 48x50G+8x100G

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
@@ -1,5 +1,4 @@
 host_as_route_disable=1
-sai_trap_group_priority=1000
 use_all_splithorizon_groups=1
 riot_enable=1
 sai_tunnel_support=1
@@ -8,6 +7,7 @@ riot_overlay_l3_egress_mem_size=32768
 l3_ecmp_levels=3
 riot_overlay_ecmp_resilient_hash_size=16384
 flow_init_mode=1
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2
 bcm_num_cos=10

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
@@ -1,3 +1,13 @@
+host_as_route_disable=1
+sai_trap_group_priority=1000
+use_all_splithorizon_groups=1
+riot_enable=1
+sai_tunnel_support=1
+riot_overlay_l3_intf_mem_size=4096
+riot_overlay_l3_egress_mem_size=32768
+l3_ecmp_levels=3
+riot_overlay_ecmp_resilient_hash_size=16384
+flow_init_mode=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2
 bcm_num_cos=10

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
@@ -1,3 +1,13 @@
+host_as_route_disable=1
+sai_trap_group_priority=1000
+use_all_splithorizon_groups=1
+riot_enable=1
+sai_tunnel_support=1
+riot_overlay_l3_intf_mem_size=4096
+riot_overlay_l3_egress_mem_size=32768
+l3_ecmp_levels=3
+riot_overlay_ecmp_resilient_hash_size=16384
+flow_init_mode=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2
 bcm_num_cos=8

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
@@ -1,5 +1,4 @@
 host_as_route_disable=1
-sai_trap_group_priority=1000
 use_all_splithorizon_groups=1
 riot_enable=1
 sai_tunnel_support=1
@@ -8,6 +7,7 @@ riot_overlay_l3_egress_mem_size=32768
 l3_ecmp_levels=3
 riot_overlay_ecmp_resilient_hash_size=16384
 flow_init_mode=1
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2
 bcm_num_cos=8

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -1,3 +1,13 @@
+sai_trap_group_priority
+use_all_splithorizon_groups
+riot_enable
+sai_tunnel_support
+riot_overlay_l3_intf_mem_size
+riot_overlay_l3_egress_mem_size
+l3_ecmp_levels
+riot_overlay_ecmp_resilient_hash_size
+flow_init_mode
+sai_load_hw_config
 arl_clean_timeout_usec
 asf_mem_profile
 bcm_linkscan_interval
@@ -220,12 +230,3 @@ pbmp_gport_stack
 reglist_enable
 scache_filename
 host_as_route_disable
-sai_trap_group_priority
-use_all_splithorizon_groups
-riot_enable
-sai_tunnel_support
-riot_overlay_l3_intf_mem_size
-riot_overlay_l3_egress_mem_size
-l3_ecmp_levels
-riot_overlay_ecmp_resilient_hash_size
-flow_init_mode

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -219,3 +219,13 @@ serdes_fec_enable
 pbmp_gport_stack
 reglist_enable
 scache_filename
+host_as_route_disable
+sai_trap_group_priority
+use_all_splithorizon_groups
+riot_enable
+sai_tunnel_support
+riot_overlay_l3_intf_mem_size
+riot_overlay_l3_egress_mem_size
+l3_ecmp_levels
+riot_overlay_ecmp_resilient_hash_size
+flow_init_mode


### PR DESCRIPTION
Update Tunnel and ECMP paramaters for brcm 7050cx3 48x50G+8x100G SKU.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
To enable new IPinIP tunnel feature for dual ToR

**- How I did it**
Add new parameter for brcm 7050cx3 48x50G+8x100G SKU

**- How to verify it**
Verified on target and tunnel are created.

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
