### PR TITLE
[Platform][nokia]: python3-smbus package add with python3 and jinja fixes 

### DIFF
--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/buffers.json.j2
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/buffers.json.j2
@@ -2,7 +2,9 @@
 
 {% set default_cable = '40m' %}
 {% set default_ports_num = 54 -%}
+{}
 
 {# Port configuration to cable length look-up table #}
 {# Each record describes mapping of DUT (DUT port) role and neighbor role to cable length #}
 {# Roles described in the minigraph #}
+

--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/buffers.json.j2
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/buffers.json.j2
@@ -2,9 +2,9 @@
 
 {% set default_cable = '40m' %}
 {% set default_ports_num = 54 -%}
-{}
 
 {# Port configuration to cable length look-up table #}
 {# Each record describes mapping of DUT (DUT port) role and neighbor role to cable length #}
 {# Roles described in the minigraph #}
+{}
 

--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/qos.json.j2
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/qos.json.j2
@@ -1,1 +1,2 @@
-# this file empty temporarily until qos supported SAI Marvell 
+{# this file empty temporarily until qos supported SAI Marvell #}
+{}

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -21,6 +21,7 @@ RUN apt-get update &&   \
         librrd-dev      \
         rrdtool         \
         python-smbus    \
+        python3-smbus   \
         ethtool         \
         dmidecode       \
         i2c-tools

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
@@ -210,7 +210,7 @@ class Sfp(SfpBase):
             sysfsfile_eeprom.seek(offset)
             raw = sysfsfile_eeprom.read(num_bytes)
             for n in range(0, num_bytes):
-                eeprom_raw[n] = hex(ord(raw[n]))[2:].zfill(2)
+                eeprom_raw[n] = hex(raw[n])[2:].zfill(2)
         except Exception as e:
             pass
         finally:

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/watchdog.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/watchdog.py
@@ -15,7 +15,7 @@ from sonic_py_common import logger
 """ ioctl constants """
 IO_READ = 0x80000000
 IO_SIZE_INT = 0x00040000
-IO_TYPE_WATCHDOG = ord('W') << 8
+IO_TYPE_WATCHDOG = 'W' << 8
 
 WDR_INT = IO_READ | IO_SIZE_INT | IO_TYPE_WATCHDOG
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
fix platform driver breakage due to python3 upgrade and fix load minigraph errors with config load_minigraph -y

**- How I did it**
added python3-smbus to the pmon docker template since the previous was python2 specific 
fixed additional "ord" python2 specific code 
fixed the jinja templates used by qos reload - the template logic required data to be parsed 

**- How to verify it**
run "show platform XXX" commands and verify output
run "sudo config load_minigraph -y" and verify configuration 
run "show interfaces XXX" and verify output 

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
