### PR TITLE
[Nokia ixs7215] Add SW assist for platform entropy & fix inband mgmt

### DIFF
--- a/platform/marvell-armhf/sonic-platform-nokia/debian/sonic-platform-nokia-7215.install
+++ b/platform/marvell-armhf/sonic-platform-nokia/debian/sonic-platform-nokia-7215.install
@@ -3,3 +3,5 @@ nokia-7215_plt_setup.sh usr/sbin
 7215/service/nokia-7215init.service  etc/systemd/system
 7215/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/armhf-nokia_ixs7215_52x-r0
 7215/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/armhf-nokia_ixs7215_52x-r0
+entropy.py etc/
+inband_mgmt.sh etc/

--- a/platform/marvell-armhf/sonic-platform-nokia/entropy.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/entropy.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+import fcntl, struct
+import time
+from os import path
+
+RNDADDENTROPY=0x40085203
+
+def avail():
+  with open("/proc/sys/kernel/random/entropy_avail", mode='r') as avail:
+      return int(avail.read())
+
+if path.exists("/proc/sys/kernel/random/entropy_avail"):
+    while 1:
+        while avail() < 2048:
+            with open('/dev/urandom', 'rb') as urnd, open("/dev/random", mode='wb') as rnd:
+                d = urnd.read(512)
+                t = struct.pack('ii', 4 * len(d), len(d)) + d
+                fcntl.ioctl(rnd, RNDADDENTROPY, t)
+        time.sleep(30)

--- a/platform/marvell-armhf/sonic-platform-nokia/inband_mgmt.sh
+++ b/platform/marvell-armhf/sonic-platform-nokia/inband_mgmt.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+#inband_mgmt
+
+inband_mgmt(){
+ # In this platform, one of the network ports is used as mgmt interface.
+ # This script periodically monitors inband management port eth0 and
+ # assigns IP address to eth0 if needed.
+ if [ ! -f /host/machine.conf ]; then
+     exit 0
+ fi
+ #wait for n/w port init to complete
+ sleep 60
+ while :; do
+   ip -br link show eth0 2> /dev/null
+   if [ $? -eq 0 ]; then
+       ip address show eth0 | grep -qw "inet" 2>/dev/null
+       if [ $? -ne 0 ]; then
+           ifconfig eth0 down
+           systemctl restart networking
+       fi
+       sleep 120
+   else
+     sleep 3
+   fi
+ done
+}
+(inband_mgmt > /dev/null)&

--- a/platform/marvell-armhf/sonic-platform-nokia/nokia-7215_plt_setup.sh
+++ b/platform/marvell-armhf/sonic-platform-nokia/nokia-7215_plt_setup.sh
@@ -30,6 +30,9 @@ main()
 {
     fw_uboot_env_cfg
     echo "Nokia-IXS7215: /dev/mtd0 FW_ENV_DEFAULT"
+
+    python /etc/entropy.py &
+    /bin/sh /etc/inband_mgmt.sh
 }
 
 main $@


### PR DESCRIPTION
This PR provides the following updates to the Nokia ixs7215 platform

1. The Marvell Armada-38x SOC requires SW assistance to improve the system
   entropy value available early on in the Sonic boot sequence.
2. The Nokia ixs7215 platform does not have a dedicated Out-Of-Band (OOB) mgmt
   port and thus requires additional logic to optionally support configuring
   front panel port 48 as an In-Band mgmt port. This commit provides additional
   logic to manage and maintain the operation of this In-Band mgmt port.

These changes are similar to those made for the Marvell et6448m platform as provided in PR#      https://github.com/Azure/sonic-buildimage/pull/5749

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
- Improve random number generation during early Sonic initialization by providing SW updates to Linux entropy value.
- Improve handling of platform In-Band management port

**- How I did it**
- Provide logic to update the entropy value via updates to /dev/random
- Provide logic to monitor the state of the In-Band mgmt port and restart when required.

**- How to verify it**
- Confirm presence of /etc/entropy.py
- Confirm via ps command that inband_mgmt.sh is running on the Sonic host

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
