### PR TITLE
Anchor "libprotobuf-dev" version to a specific version by using debian control file dependency

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_4.2.1.5-9_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/buster/libsaibcm_4.2.1.5-9_amd64.deb?sv=2015-04-05&sr=b&sig=Rbqq%2FH4B71%2BWGzAzTuM3qxEdwpEnuxqFdGIMDpuN8t0%3D&se=2034-09-16T01%3A36%3A13Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_4.2.1.5-9_amd64.deb
+BRCM_SAI = libsaibcm_4.2.1.5-10_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/buster/libsaibcm_4.2.1.5-10_amd64.deb?sv=2019-12-12&st=2021-01-12T07%3A30%3A31Z&se=2035-01-13T07%3A30%3A00Z&sr=b&sp=r&sig=yCGwk%2FW%2Fg%2FaFxhr0oNSTZ%2BVy5B6kX1WDEsbbyz9J088%3D"
+BRCM_SAI_DEV = libsaibcm-dev_4.2.1.5-10_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/buster/libsaibcm-dev_4.2.1.5-9_amd64.deb?sv=2015-04-05&sr=b&sig=C%2Bo7YTkA2076LRfet1rHHlFu%2F6b9qoQiHljjaZCVa20%3D&se=2034-09-16T01%3A37%3A38Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.2/master/buster/libsaibcm-dev_4.2.1.5-10_amd64.deb?sv=2019-12-12&st=2021-01-12T07%3A32%3A43Z&se=2035-01-13T07%3A32%3A00Z&sr=b&sp=r&sig=wuCNc6pa12JQCBi%2BM9rLWvVI92ldan9hKNF%2BfVfUWN8%3D"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
**- Why I did it**
From time to time the BRCM SAI debian built may be using one version of libprotobuf-dev while a different version being picked during installation.  This causes the installation failure.  We should anchor to a specific version during SAI debian build via the debian control file dependency specification to eliminate this type of failures.

**- How I did it**
Change the SAI debian control file to specify a specific dependency version:
       Depends: libprotobuf-dev, libprotobuf-lite17, libprotobuf17
Remove the use of "sudo apt install -y libprotobuf-dev" at build script.

**- How to verify it**
Incorporate this new SAI debian on a private sonic-buildimage and build for BRCM binary and installed to a BRCM SKU DUT to validate the entire process did not encounter any issue and that DUT boots up fine as previous version.

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
Anchor "libprotobuf-dev" version to a specific version by using debian control file dependency
