### PR TITLE
Fix py3 version changed even version control enabled issue

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -25,6 +25,7 @@ log_err()
 # Get the real command not hooked by sonic-build-hook package
 get_command()
 {
+    # Change the PATH env to get the real command by excluding the command in the hooked folders
     local path=$(echo $PATH | sed 's#[^:]*buildinfo/scripts:##' | sed "s#/usr/local/sbin:##")
     local command=$(PATH=$path which $1)
     echo $command

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -22,15 +22,19 @@ log_err()
     echo "$1" 1>&2
 }
 
+# Get the real command not hooked by sonic-build-hook package
 get_command()
 {
-    local path=$(echo $PATH | sed 's#[^:]*buildinfo/scripts:##' | sed "s#/usr/sbin:##" | sed "s#/usr/local/sbin:##")
+    local path=$(echo $PATH | sed 's#[^:]*buildinfo/scripts:##' | sed "s#/usr/local/sbin:##")
     local command=$(PATH=$path which $1)
     echo $command
 }
 
 check_version_control()
 {
+    # The env variable SONIC_VERSION_CONTROL_COMPONENTS examples:
+    # all            -- match all components
+    # py2,py3,deb    -- match py2, py3 and deb only
     if [[ ",$SONIC_VERSION_CONTROL_COMPONENTS," == *,all,* ]] || [[ ",$SONIC_VERSION_CONTROL_COMPONENTS," == *,$1,* ]]; then
         echo "y"
     else

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -24,7 +24,7 @@ log_err()
 
 get_command()
 {
-    local path=$(echo $PATH | sed 's#[^:]*buildinfo/scripts:##' | sed "s#/usr/sbin:##")
+    local path=$(echo $PATH | sed 's#[^:]*buildinfo/scripts:##' | sed "s#/usr/sbin:##" | sed "s#/usr/local/sbin:##")
     local command=$(PATH=$path which $1)
     echo $command
 }

--- a/src/sonic-build-hooks/scripts/symlink_build_hooks
+++ b/src/sonic-build-hooks/scripts/symlink_build_hooks
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 HOOK_PATH=/usr/local/share/buildinfo/hooks
-TARGET_PATH=/usr/sbin
-[ -d /usr/local/sbin ] && TARGET_PATH=/usr/local/sbin
+TARGET_PATH=/usr/local/sbin
 FILES=$(ls $HOOK_PATH)
 
 usage()

--- a/src/sonic-build-hooks/scripts/symlink_build_hooks
+++ b/src/sonic-build-hooks/scripts/symlink_build_hooks
@@ -2,6 +2,7 @@
 
 HOOK_PATH=/usr/local/share/buildinfo/hooks
 TARGET_PATH=/usr/sbin
+[ -d /usr/local/sbin ] && TARGET_PATH=/usr/local/sbin
 FILES=$(ls $HOOK_PATH)
 
 usage()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The pip3 is installed the /usr/local/bin, the hook command pip3 does not work correctly. Change to use /usr/local/sbin.

**- How I did it**

**- How to verify it**
Enable the version control and set the version of the pip package importlib-metadata to 3.3.0, run the following command.
pip3 install importlib-metadata
Before fixing the issue, the version 3.4.0 is installed.
After fixing the issue, the version 3.3.0 installed as expected.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
