### PR TITLE
[platform/broadcom] DX010: configure pca954x device with idle_state

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -42,7 +42,7 @@ start)
         echo -n "Setting up board... "
 
         modprobe i2c-dev
-        modprobe i2c-mux-pca954x force-deselect-on-exit=1
+        modprobe i2c-mux-pca954x
         modprobe dx010_wdt
         modprobe leds-dx010
         modprobe lm75
@@ -74,6 +74,11 @@ start)
         # Attach PCA9548 0x77 Channel Extender for Fan's EEPROMs
         echo pca9548 0x77 > /sys/bus/i2c/devices/i2c-${devnum}/new_device
         sleep 1
+
+        # Set the PCA9548 mux behavior
+        echo -2 > /sys/bus/i2c/drivers/pca954x/${devnum}-0071/idle_state
+        echo -2 > /sys/bus/i2c/drivers/pca954x/${devnum}-0073/idle_state
+        echo -2 > /sys/bus/i2c/drivers/pca954x/${devnum}-0077/idle_state
 
         # Attach syseeprom
         echo 24lc64t 0x50 > /sys/bus/i2c/devices/i2c-12/new_device


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Use the proper way to initialize the per-device configuration of the PCA954x MUX driver.

**- How I did it**
Configure the PCA9548 device behavior with the idle_state sysfs provides by the driver. Refer to the [sonic-linux-kernel#177](https://github.com/Azure/sonic-linux-kernel/pull/177)

**- How to verify it**
Boot the DX010 device and read the idle_state sysfs of each device.  The result must be -2 (deselect channel on exit).

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
dx010 use idle_state sysfs for pca9548 device configuration.

**- A picture of a cute animal (not mandatory but encouraged)**
