### PR TITLE
[ci]: cleanup fsroot reliably

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,11 +35,9 @@ stages:
         sudo modprobe overlay
         CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=rcache SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/broadcom"
         ENABLE_DOCKER_BASE_PULL=y make configure PLATFORM=broadcom
+        trap "sudo rm -rf fsroot" EXIT
         make USERNAME=admin SONIC_BUILD_JOBS=$(nproc) $CACHE_OPTIONS target/sonic-broadcom.bin
       displayName: 'Build sonic image'
-    - script: |
-        sudo rm -rf fsroot
-      displayName: 'Clean up build artifacts'
     - publish: $(System.DefaultWorkingDirectory)/
       artifact: sonic-buildimage.broadcom
       displayName: "Archive sonic image"
@@ -56,11 +54,9 @@ stages:
         sudo modprobe overlay
         CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=rcache SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/mellanox"
         ENABLE_DOCKER_BASE_PULL=y make configure PLATFORM=mellanox
+        trap "sudo rm -rf fsroot" EXIT
         make USERNAME=admin SONIC_BUILD_JOBS=$(nproc) $CACHE_OPTIONS target/sonic-mellanox.bin
       displayName: 'Build sonic image'
-    - script: |
-        sudo rm -rf fsroot
-      displayName: 'Clean up build artifacts'
     - publish: $(System.DefaultWorkingDirectory)/
       artifact: sonic-buildimage.mellanox
       displayName: "Archive sonic image"
@@ -78,12 +74,10 @@ stages:
         sudo modprobe overlay
         CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=rcache SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/vs"
         ENABLE_DOCKER_BASE_PULL=y make configure PLATFORM=vs
-        make USERNAME=admin SONIC_BUILD_JOBS=$(nproc) $CACHE_OPTIONS target/sonic-vs.img.gz
-        sudo cp target/sonic-vs.img.gz /nfs/azpl/kvmimage/sonic-vs.$(Build.BuildNumber).img.gz
+        trap "sudo rm -rf fsroot" EXIT
+        make USERNAME=admin SONIC_BUILD_JOBS=$(nproc) $CACHE_OPTIONS target/sonic-vs.img.gz && \
+            sudo cp target/sonic-vs.img.gz /nfs/azpl/kvmimage/sonic-vs.$(Build.BuildNumber).img.gz
       displayName: 'Build sonic image'
-    - script: |
-        sudo rm -rf fsroot
-      displayName: 'Clean up build artifacts'
     - publish: $(System.DefaultWorkingDirectory)/
       artifact: sonic-buildimage.kvm
       displayName: "Archive sonic image"


### PR DESCRIPTION
use trap to clean up fsroot reliably

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
cleanup fsroot reliably

**- How I did it**
use trap to clean up fsroot reliably

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
