### PR TITLE
[Mellanox] Fix issue: need import initialize_sdk_handle in get_sdk_handle

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -113,7 +113,6 @@ class Chassis(ChassisBase):
 
     def initialize_sfp(self):
         from sonic_platform.sfp import SFP
-        from sonic_platform.sfp import initialize_sdk_handle
 
         self.sfp_module = SFP
 
@@ -137,6 +136,7 @@ class Chassis(ChassisBase):
 
     def get_sdk_handle(self):
         if not self.sdk_handle:
+            from sonic_platform.sfp import initialize_sdk_handle
             self.sdk_handle = initialize_sdk_handle()
             if self.sdk_handle is None:
                 logger.log_error('Failed to open SDK handle')


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Found test_sfp.py failed due to use a method without importing it.

**- How I did it**

Import the relevant python module

**- How to verify it**

Run the failed test case and it passed after the fix

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
