### PR TITLE
[minigraph.py]: Check for empty cluster tag before parsing

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -255,7 +255,7 @@ def parse_png(png, hname, dpg_ecmp_content = None):
                 if name == hname:
                     cluster = device.find(str(QName(ns, "ClusterName")))
 
-                    if cluster != None and "str" in cluster.text.lower():
+                    if cluster != None and cluster.text != None and "str" in cluster.text.lower():
                         is_storage_device = True
 
         if child.tag == str(QName(ns, "DeviceInterfaceLinks")):


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Some non-production minigraphs will have an empty `ClusterName` tag

**- How I did it**
Check if `ClusterName` tag is empty before trying to access text

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6006991/104500626-87184400-5593-11eb-948b-220df78661f7.png)
