### PR TITLE
Enable PG drop counters by default

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -34,6 +34,7 @@ def enable_counters():
     enable_counter_group(db, 'QUEUE')
     enable_counter_group(db, 'PFCWD')
     enable_counter_group(db, 'PG_WATERMARK')
+    enable_counter_group(db, 'PG_DROP')
     enable_counter_group(db, 'QUEUE_WATERMARK')
     enable_counter_group(db, 'BUFFER_POOL_WATERMARK')
     enable_counter_group(db, 'PORT_BUFFER_DROP')


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

**depends on** : 
https://github.com/Azure/sonic-swss/pull/1600 , 
https://github.com/Azure/sonic-utilities/pull/1355

**merge priority:**
https://github.com/Azure/sonic-swss/pull/1600
https://github.com/Azure/sonic-utilities/pull/1355
https://github.com/Azure/sonic-buildimage/pull/6444

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
PG drop counters should be enabled by default

**- How I did it**
Add PG drop counter enable option to dockers/docker-orchagent/enable_counters.py

**- How to verify it**
run `counterpoll show` CLI command and then you will see **PG_STAT_DROP** enabled there

**- Which release branch to backport (provide reason below if selected)**
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
