### PR TITLE
[warm boot finalizer] only wait for enabled components to reconcile

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -28,7 +28,7 @@ function debug()
 }
 
 
-function set_component_list()
+function get_component_list()
 {
     CP_LIST=${!RECONCILE_COMPONENTS[@]}
     COMPONENT_LIST=""

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -28,7 +28,7 @@ function debug()
 }
 
 
-function filter_component_list()
+function set_component_list()
 {
     CP_LIST=${!RECONCILE_COMPONENTS[@]}
     COMPONENT_LIST=""
@@ -66,7 +66,7 @@ function wait_for_database_service()
 }
 
 
-function get_component_state()
+function set_component_state()
 {
     sonic-db-cli STATE_DB hget "WARM_RESTART_TABLE|$1" state
 }
@@ -126,7 +126,7 @@ fi
 
 restore_counters_folder
 
-filter_component_list
+get_component_list
 
 debug "Waiting for components: '${COMPONENT_LIST}' to reconcile ..."
 

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -34,7 +34,7 @@ function set_component_list()
     COMPONENT_LIST=""
     for cp in ${CP_LIST}; do
         service=${RECONCILE_COMPONENTS[${cp}]}
-	status=$(sonic-db-cli CONFIG_DB HGET "FEATURE|${service}" state)
+        status=$(sonic-db-cli CONFIG_DB HGET "FEATURE|${service}" state)
         if [[ x"${status}" == x"enabled" || x"${status}" == x"always_enabled" ]]; then
             COMPONENT_LIST="${COMPONENT_LIST} ${cp}"
         fi

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -4,15 +4,12 @@ VERBOSE=no
 
 # Define components that needs to reconcile during warm
 # boot:
-#       The key would be the component name that would
-#           reconcile.
-#       The value is the name of the service that the
-#           component belongs to.
+#       The key is the name of the service that the components belong to.
+#       The value is list of component names that will reconcile.
 declare -A RECONCILE_COMPONENTS=( \
-                        ["orchagent"]="swss"    \
-                        ["neighsyncd"]="swss"   \
-                        ["bgp"]="bgp"           \
-                        ["natsyncd"]="nat"      \
+                        ["swss"]="orchagent neighsyncd" \
+                        ["bgp"]="bgp"                   \
+                        ["nat"]="natsyncd"              \
                        )
 EXP_STATE="reconciled"
 
@@ -30,13 +27,13 @@ function debug()
 
 function get_component_list()
 {
-    CP_LIST=${!RECONCILE_COMPONENTS[@]}
+    SVC_LIST=${!RECONCILE_COMPONENTS[@]}
     COMPONENT_LIST=""
-    for cp in ${CP_LIST}; do
-        service=${RECONCILE_COMPONENTS[${cp}]}
+    for service in ${SVC_LIST}; do
+        components=${RECONCILE_COMPONENTS[${service}]}
         status=$(sonic-db-cli CONFIG_DB HGET "FEATURE|${service}" state)
         if [[ x"${status}" == x"enabled" || x"${status}" == x"always_enabled" ]]; then
-            COMPONENT_LIST="${COMPONENT_LIST} ${cp}"
+            COMPONENT_LIST="${COMPONENT_LIST} ${components}"
         fi
     done
 }

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -28,13 +28,13 @@ function debug()
 }
 
 
-function set_component_list()
+function filter_component_list()
 {
     CP_LIST=${!RECONCILE_COMPONENTS[@]}
     COMPONENT_LIST=""
     for cp in ${CP_LIST}; do
         service=${RECONCILE_COMPONENTS[${cp}]}
-        status=$(show feature status | grep "^${service}" | awk '{ print $2 }')
+	status=$(sonic-db-cli CONFIG_DB HGET "FEATURE|${service}" state)
         if [[ x"${status}" == x"enabled" || x"${status}" == x"always_enabled" ]]; then
             COMPONENT_LIST="${COMPONENT_LIST} ${cp}"
         fi
@@ -126,7 +126,7 @@ fi
 
 restore_counters_folder
 
-set_component_list
+filter_component_list
 
 debug "Waiting for components: '${COMPONENT_LIST}' to reconcile ..."
 

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -66,7 +66,7 @@ function wait_for_database_service()
 }
 
 
-function set_component_state()
+function get_component_state()
 {
     sonic-db-cli STATE_DB hget "WARM_RESTART_TABLE|$1" state
 }


### PR DESCRIPTION
**- Why I did it**
Fix issue #6383 

**- How I did it**

Define the component with its associated service. Only wait for components that have associated service enabled to reconcile during warm reboot.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**- How to verify it**
Run warm reboot with the change (note that 'natsyncd' is no longer in the wait list:
/var/log/syslog.1:Jan 14 18:28:41.239710 str-7260cx3-acs-1 NOTICE root: WARMBOOT_FINALIZER : Wait for database to become ready...
/var/log/syslog.1:Jan 14 18:28:41.730254 str-7260cx3-acs-1 NOTICE root: WARMBOOT_FINALIZER : Database is ready...
/var/log/syslog.1:Jan 14 18:28:42.104362 str-7260cx3-acs-1 NOTICE root: WARMBOOT_FINALIZER : Restoring counters folder after warmboot...
/var/log/syslog.1:Jan 14 18:28:46.043684 str-7260cx3-acs-1 NOTICE root: WARMBOOT_FINALIZER : Waiting for components: ' neighsyncd bgp orchagent' to reconcile ...
/var/log/syslog:Jan 14 18:30:55.913965 str-7260cx3-acs-1 NOTICE root: WARMBOOT_FINALIZER : Tearing down control plane assistant ...
/var/log/syslog:Jan 14 18:30:59.123504 str-7260cx3-acs-1 NOTICE root: WARMBOOT_FINALIZER : Save in-memory database after warm reboot ...
/var/log/syslog:Jan 14 18:30:59.727347 str-7260cx3-acs-1 NOTICE root: WARMBOOT_FINALIZER : Finalizing warmboot...

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
