### PR TITLE
[minigraph.py]: Don't create mux table entries for servers w/o loopbacks

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1506,14 +1506,17 @@ def get_mux_cable_entries(mux_cable_ports, neighbors, devices):
             neighbor = neighbors[intf]['name']
             entry['state'] = 'auto'
 
-            # Always force a /32 prefix for server IPv4 loopbacks
-            server_ipv4_lo_addr = devices[neighbor]['lo_addr'].split("/")[0]
-            server_ipv4_lo_prefix = ipaddress.ip_network(UNICODE_TYPE(server_ipv4_lo_addr))
-            entry['server_ipv4'] = str(server_ipv4_lo_prefix)
+            if devices[neighbor]['lo_addr'] is not None:
+                # Always force a /32 prefix for server IPv4 loopbacks
+                server_ipv4_lo_addr = devices[neighbor]['lo_addr'].split("/")[0]
+                server_ipv4_lo_prefix = ipaddress.ip_network(UNICODE_TYPE(server_ipv4_lo_addr))
+                entry['server_ipv4'] = str(server_ipv4_lo_prefix)
 
-            if 'lo_addr_v6' in devices[neighbor]:
-                entry['server_ipv6'] = devices[neighbor]['lo_addr_v6']
-            mux_cable_table[intf] = entry 
+                if 'lo_addr_v6' in devices[neighbor]:
+                    entry['server_ipv6'] = devices[neighbor]['lo_addr_v6']
+                mux_cable_table[intf] = entry 
+            else:
+                print("Warning: no server IPv4 loopback found for {}, skipping mux cable table entry".format(neighbor))
 
     return mux_cable_table
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Avoid sonic-cfggen crashing when a server does not have a configured loopback address in the minigraph
**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6006991/104664020-16e8eb80-5683-11eb-8cdf-7c0963fb8224.png)
