### PR TITLE
[DPB][YANG] extended yang-model - added 'buffer_model' field

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -194,7 +194,8 @@
                 "mac": "00:11:22:33:dd:5a",
                 "hostname": "asw.dc",
                 "bgp_asn": "64850",
-                "hwsku": "Stone"
+                "hwsku": "Stone",
+                "buffer_model": "dynamic"
             }
         },
         "VLAN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -32,5 +32,15 @@
     "DEVICE_METADATA_TYPE_INCORRECT_PATTERN": {
 	"desc": "DEVICE_METADATA_TYPE_INCORRECT_PATTERN pattern failure.",
 	"eStrKey" : "Pattern"
+    },
+    "DEVICE_METADATA_CORRECT_BUFFER_MODEL_PATTERN": {
+        "desc": "DEVICE_METADATA correct value for BUFFER_MODEL field"
+    },
+    "DEVICE_METADATA_CORRECT_BUFFER_MODEL_PATTERN2": {
+        "desc": "DEVICE_METADATA correct value for BUFFER_MODEL field"
+    },
+    "DEVICE_METADATA_INCORRECT_BUFFER_MODEL_PATTERN": {
+        "desc": "DEVICE_METADATA wrong value for BUFFER_MODEL field.",
+        "eStr": ["pattern", "does not satisfy"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -90,5 +90,32 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_CORRECT_BUFFER_MODEL_PATTERN": {
+        "sonic-device_metadata:sonic-device_metadata": {
+             "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                "buffer_model": "dynamic"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_CORRECT_BUFFER_MODEL_PATTERN2": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                "buffer_model": "traditional"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_INCORRECT_BUFFER_MODEL_PATTERN": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                "buffer_model": "incorrect_pattern"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -89,6 +89,18 @@ module sonic-device_metadata {
                         pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC";
                     }
                 }
+
+                leaf buffer_model {
+                    description "This leaf is added for dynamic buffer calculation.
+                                The dynamic model represents the model in which the buffer configurations,
+                                like the headroom sizes and buffer pool sizes, are dynamically calculated based
+                                on the ports' speed, cable length, and MTU. This model is used by Mellanox so far.
+                                The traditional model represents the model in which all the buffer configurations
+                                are statically configured in CONFIG_DB tables. This is the default model used by all other vendors";
+                    type string {
+                        pattern "dynamic|traditional";
+                    }
+                }
             }
             /* end of container localhost */
         }


### PR DESCRIPTION
Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

The fix for the issue [[DPB][YANG] sonic-device_metadata.yang is not aligned with newest changes in CONFIG_DB](https://github.com/Azure/sonic-buildimage/issues/6330)

**- How I did it**

CONFIG_DB was extended with the field `buffer_model` - added representation of this field inside the  [sonic-device_metadata.yang](https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/yang-models/sonic-device_metadata.yang) 

**- How to verify it**

Run the command `config interface breakout <interface> <breakout_mode>`

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
