### PR TITLE
[Mellanox] Make determine-reboot-cause service start after hw-management service

### DIFF
--- a/platform/mellanox/hw-management/0001-Make-SONiC-determine-reboot-cause-service-start-afte.patch
+++ b/platform/mellanox/hw-management/0001-Make-SONiC-determine-reboot-cause-service-start-afte.patch
@@ -1,0 +1,26 @@
+From 1a1011b6da491d35001df5a7204d4eecb2769767 Mon Sep 17 00:00:00 2001
+From: keboliu <kebol@mellanox.com>
+Date: Fri, 15 Jan 2021 14:41:16 +0800
+Subject: [PATCH] Make SONiC determine-reboot-cause service start after hw-mgmt
+ service
+
+Signed-off-by: Kebo Liu <kebol@nvidia.com>
+---
+ debian/hw-management.hw-management.service | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/debian/hw-management.hw-management.service b/debian/hw-management.hw-management.service
+index 39a2a54..2104b87 100755
+--- a/debian/hw-management.hw-management.service
++++ b/debian/hw-management.hw-management.service
+@@ -1,6 +1,7 @@
+ [Unit]
+ Description=Chassis HW management service of Mellanox systems
+ Documentation=man:hw-management.service(8)
++Before=determine-reboot-cause.service
+ 
+ [Service]
+ Type=oneshot
+-- 
+1.9.1
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

On the Mellanox platform, reboot cause is fetched from some certain sysfs which is created by the hw-management service. So determine-reboot-cause service shall start after hw-management, otherwise it could fail due to the related sysfs is not available yet.

**- How I did it**

Add a patch to the hw-management service to make sure determine-reboot-cause service should start after it.

**- How to verify it**

run on Mellanox platform to check whether determine-reboot-cause can be success on various reboot.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
