### PR TITLE
[yang_model_test]: Tests for default value of docker_routing_config_m…

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
+++ b/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
@@ -81,6 +81,10 @@ class Test_yang_models:
                 'desc': 'Configure undefined packet_action in ACL_RULE table.',
                 'eStr': self.defaultYANGFailure['InvalidValue'] + ['PACKET_ACTION']
             },
+            'ACL_TABLE_EMPTY_PORTS': {
+                'desc': 'Configure ACL_TABLE with empty ports.',
+                'eStr': self.defaultYANGFailure['None']
+            },
             'ACL_TABLE_UNDEFINED_TABLE_TYPE': {
                 'desc': 'Configure undefined acl_table_type in ACL_TABLE table.',
                 'eStr': self.defaultYANGFailure['InvalidValue'] + ['type']
@@ -208,6 +212,14 @@ class Test_yang_models:
                 'verify': {'xpath': '/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname',
                     'key': 'sonic-device_metadata:default_bgp_status',
                     'value': 'up'
+                }
+            },
+            'DEVICE_METADATA_DEFAULT_DOCKER_ROUTING_CONFIG_MODE': {
+                'desc': 'DEVICE_METADATA DEFAULT VALUE FOR DOCKER_ROUTING_CONFIG_MODE FIELD.',
+                'eStr': self.defaultYANGFailure['Verify'],
+                'verify': {'xpath': '/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname',
+                    'key': 'sonic-device_metadata:docker_routing_config_mode',
+                    'value': 'unified'
                 }
             },
             'DEVICE_METADATA_DEFAULT_PFCWD_STATUS': {

--- a/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
@@ -242,6 +242,20 @@
 		}
 	},
 
+    "ACL_TABLE_EMPTY_PORTS": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [{
+                    "ACL_TABLE_NAME": "NO-NSW-PACL-V4",
+                    "policy_desc": "Filter IPv4",
+                    "type": "L3",
+                    "stage": "EGRESS",
+                    "ports": [""]
+                }]
+            }
+        }
+    },
+
 	"ACL_RULE_UNDEFINED_PACKET_ACTION": {
 		"sonic-acl:sonic-acl": {
 			"sonic-acl:ACL_RULE": {
@@ -832,6 +846,19 @@
                 "platform": "Stone-DX010",
                 "hostname": "DUT-ASW",
                 "bgp_asn": "65000"
+                }
+            }
+        }
+    },
+
+    "DEVICE_METADATA_DEFAULT_DOCKER_ROUTING_CONFIG_MODE": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                "default_bgp_status": "up",
+                "platform": "Stone-DX010",
+                "hostname": "DUT-CSW",
+                "bgp_asn": "65001"
                 }
             }
         }


### PR DESCRIPTION
…ode and Empty ACL ports.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Tests for default value of docker_routing_config_mode and Empty ACL ports.
**- How I did it**
Added tests in src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
**- How to verify it**
Build The PKG.
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
