### PR TITLE
[bgpd] Check zebra is ready to connect when starting bgpd

### DIFF
--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -55,6 +55,7 @@ COPY ["TSB", "/usr/bin/TSB"]
 COPY ["TSC", "/usr/bin/TSC"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
+COPY ["bgpd.sh", "/usr/bin/"]
 RUN chmod a+x /usr/bin/TSA && \
     chmod a+x /usr/bin/TSB && \
     chmod a+x /usr/bin/TSC

--- a/dockers/docker-fpm-frr/bgpd.sh
+++ b/dockers/docker-fpm-frr/bgpd.sh
@@ -28,7 +28,6 @@ shift $((OPTIND-1))
 timeout 5s bash -c -- "until </dev/tcp/${addr}/${port}; do sleep 0.1;done"
 if [ "$?" != "0" ]; then
     logger "Error: zebra is not ready to accept connections"
-    exit 1
 fi
 
 exec /usr/lib/frr/bgpd "$@"

--- a/dockers/docker-fpm-frr/bgpd.sh
+++ b/dockers/docker-fpm-frr/bgpd.sh
@@ -3,15 +3,32 @@
 addr="127.0.0.1"
 port=2601
 
-while getopts ":A:P:" opt; do
+function help()
+{
+    echo "This script aims to ensure zebra is ready to accept connections before starting bgpd"
+    echo "Usage: $0 [options] [bgpd options]"
+    echo "Options:"
+    echo " -a   Zebra address"
+    echo " -o   Zebra port"
+    exit 1
+}
+
+while getopts ":a:o:h" opt; do
     case "${opt}" in
-        A) addr=${OPTARG}
+        h) help
             ;;
-        P) port=${OPTARG}
+        a) addr=${OPTARG}
+            ;;
+        o) port=${OPTARG}
             ;;
     esac
 done
+shift $((OPTIND-1))
 
 timeout 5s bash -c -- "until </dev/tcp/${addr}/${port}; do sleep 0.1;done"
+if [ "$?" != "0" ]; then
+    logger "Error: zebra is not ready to accept connections"
+    exit 1
+fi
 
 exec /usr/lib/frr/bgpd "$@"

--- a/dockers/docker-fpm-frr/bgpd.sh
+++ b/dockers/docker-fpm-frr/bgpd.sh
@@ -27,7 +27,7 @@ shift $((OPTIND-1))
 
 timeout 5s bash -c -- "until </dev/tcp/${addr}/${port}; do sleep 0.1;done"
 if [ "$?" != "0" ]; then
-    logger "Error: zebra is not ready to accept connections"
+    logger -p error "Error: zebra is not ready to accept connections"
 fi
 
 exec /usr/lib/frr/bgpd "$@"

--- a/dockers/docker-fpm-frr/bgpd.sh
+++ b/dockers/docker-fpm-frr/bgpd.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+addr="127.0.0.1"
+port=2601
+
+while getopts ":A:P:" opt; do
+    case "${opt}" in
+        A) addr=${OPTARG}
+            ;;
+        P) port=${OPTARG}
+            ;;
+    esac
+done
+
+timeout 5s bash -c -- "until </dev/tcp/${addr}/${port}; do sleep 0.1;done"
+
+exec /usr/lib/frr/bgpd "$@"

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -51,7 +51,7 @@ dependent_startup=true
 dependent_startup_wait_for=zebra:running
 
 [program:bgpd]
-command=/usr/lib/frr/bgpd -A 127.0.0.1 -M snmp
+command=/usr/bin/bgpd.sh -A 127.0.0.1 -M snmp
 priority=5
 stopsignal=KILL
 autostart=false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
There is a race condition between zebra server accepts connections and bgpd tries to connect. Bgpd has a chance to try to connect before zebra is ready. In this scenario, bgpd will try again after 10 seconds and operate as normal within these 10 seconds. As a consequence, whatever bgpd tries to sent to zebra will be missing in the 10 seconds. To avoid such a scenario, bgpd should start after zebra is ready to accept connections.

Fix https://github.com/Azure/sonic-buildimage/issues/5026

**- How I did it**
Check and wait until zebra is ready to accept connections before starting bgpd.

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
