### PR TITLE
[voq/systemlag] Lag id boundary setting for system lag functionality

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -101,6 +101,19 @@ function preStartAction()
     updateSyslogConf
 }
 
+{%- if docker_container_name == "database" %}
+
+function setPlatformLagIdBoundaries()
+{
+    CHASSIS_CONF=/usr/share/sonic/device/$PLATFORM/chassisdb.conf
+    if [ -f "$CHASSIS_CONF" ]; then
+        source $CHASSIS_CONF
+        $SONIC_DB_CLI CHASSIS_APP_DB SET "SYSTEM_LAG_ID_START" "$lag_id_start"
+        $SONIC_DB_CLI CHASSIS_APP_DB SET "SYSTEM_LAG_ID_END" "$lag_id_end"
+    fi
+}
+{%- endif %}
+
 function postStartAction()
 {
 {%- if docker_container_name == "database" %}
@@ -162,6 +175,7 @@ function postStartAction()
                  ($(docker exec -i ${DOCKERNAME} $SONIC_DB_CLI CHASSIS_APP_DB PING | grep -c True) -gt 0) ]]; do
            sleep 1
         done
+        setPlatformLagIdBoundaries
         REDIS_SOCK="/var/run/redis-chassis/redis_chassis.sock"
     fi
     chgrp -f redis $REDIS_SOCK && chmod -f 0760 $REDIS_SOCK


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

System lag in VOQ based chassis systems requires unique id for system port aggregator id attribute in LAG object.
This id is generated by lag id generator within set boundary. The boundaries are system capability specific and should
be set during system boot. 

Ref: https://github.com/Azure/SONiC/pull/697

**- How I did it**

Changes for setting platform specific lag id boundary id in the chassis
app db. The platform specific lag id boundaries are supplied via
chassisdb.conf in the supervisor card. The lag_id_start and lag_id_end boundary values sourced
from this file are set in chassis app db which will be used by lag id
allocator to allocate unique lag id in atomic fashion

**- How to verify it**

- Update chassisdb.conf in supervisor card with two parameters "lag_id_start" and "lag_id_end"
- Reboot the system. 
- Connect to redis-chassis server. There should be "SYSTEM_LAG_ID_START" and "SYSTEM_LAG_ID_END" keys set with value as given in the chassisdb.conf.
- Verify that LAG id objects are created in ASIC DB.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->


**- Description for the changelog**
- doker_image_ctl.j2 modified to create database.sh with script modification to write lag id keys in chassis app db

**- A picture of a cute animal (not mandatory but encouraged)**
