### PR TITLE
[201911] Updated BBR to use peer group name as prefix.

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -116,10 +116,11 @@ class BBRMgr(Manager):
         for af in ["ipv4", "ipv6"]:
             cmds.append(" address-family %s" % af)
             for pg_name in sorted(self.bbr_enabled_pgs.keys()):
-                if pg_name in available_peer_groups and af in self.bbr_enabled_pgs[pg_name]:
-                    for peer in available_peers_per_pg[pg_name]:
-                        cmds.append("  %sneighbor %s allowas-in 1" % (prefix_of_commands, peer))
-                    peer_groups_to_restart.add(pg_name)
+                for peer_group_name in available_peer_groups:
+                    if peer_group_name.startswith(pg_name) and af in self.bbr_enabled_pgs[pg_name]:
+                        for peer in available_peers_per_pg[peer_group_name]:
+                            cmds.append("  %sneighbor %s allowas-in 1" % (prefix_of_commands, peer))
+                        peer_groups_to_restart.add(peer_group_name)
         return cmds, list(peer_groups_to_restart)
 
     def __get_available_peer_groups(self):


### PR DESCRIPTION
What/Why I did:

Same change as in master (PR https://github.com/Azure/sonic-buildimage/pull/6515) for 201911.
In 201911 BBR is configured for each peer instead of peer-group. 

How I verify:

- Manually Verified BBR is enabled/disabled correctly for the peer in the peer-group.

neighbor 10.0.0.33 peer-group TIER0_V4_DEPLOYMENT_ID_0
neighbor 10.0.0.63 peer-group TIER0_V4_DEPLOYMENT_ID_2
neighbor 10.0.0.33 allowas-in 1
 neighbor 10.0.0.63 allowas-in 1
 neighbor fc00::7a peer-group TIER0_V6_DEPLOYMENT_ID_0
 neighbor fc00::7e peer-group TIER0_V6_DEPLOYMENT_ID_2
neighbor fc00::7a allowas-in 1
neighbor fc00::7e allowas-in 1

- Added Unit test

```
adosi@68cd7f721b7f:/sonic/src/sonic-bgpcfgd$ pytest tests/test_bbr.py
============================================================================================== test session starts ==============================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /sonic/src/sonic-bgpcfgd, inifile: pytest.ini
plugins: cov-2.4.0
collected 28 items

tests/test_bbr.py ............................

---------- coverage: platform linux2, python 2.7.13-final-0 ----------
Name                             Stmts   Miss  Cover
----------------------------------------------------
bgpcfgd/__init__.py                  0      0   100%
bgpcfgd/__main__.py                  3      3     0%
bgpcfgd/config.py                   69     69     0%
bgpcfgd/directory.py                63     34    46%
bgpcfgd/frr.py                      49     49     0%
bgpcfgd/log.py                      15      5    67%
bgpcfgd/main.py                     53     53     0%
bgpcfgd/manager.py                  41     23    44%
bgpcfgd/managers_allow_list.py     425    425     0%
bgpcfgd/managers_bbr.py             98      0   100%
bgpcfgd/managers_bgp.py            192    192     0%
bgpcfgd/managers_db.py               9      9     0%
bgpcfgd/managers_intf.py            33     33     0%
bgpcfgd/managers_setsrc.py          44     44     0%
bgpcfgd/runner.py                   44     44     0%
bgpcfgd/template.py                 64     42    34%
bgpcfgd/utils.py                    19     19     0%
bgpcfgd/vars.py                      1      0   100%
----------------------------------------------------
TOTAL                             1222   1044    15%


=========================================================================================== 28 passed in 0.23 seconds ===========================================================================================
```

