### PR TITLE
[sonic-slave]: pin bitarray to 1.6.1

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -404,6 +404,8 @@ RUN pip2 install \
 # Install pyangbind here, outside sonic-config-engine dependencies, as pyangbind causes enum34 to be installed.
 # enum34 causes Python 're' package to not work properly as it redefines an incompatible enum.py module
 # https://github.com/robshakir/pyangbind/issues/232
+# bitarray 1.6.2 triggers build issue
+RUN pip3 install bitarray==1.6.1
 RUN pip3 install pyangbind==0.8.1
 RUN pip3 uninstall -y enum34
 

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -336,6 +336,8 @@ RUN pip2 install --force-reinstall --upgrade "Jinja2<3.0.0"
 # Install pyangbind here, outside sonic-config-engine dependencies, as pyangbind causes enum34 to be installed.
 # enum34 causes Python 're' package to not work properly as it redefines an incompatible enum.py module
 # https://github.com/robshakir/pyangbind/issues/232
+# bitarray 1.6.2 triggers build issue
+RUN pip3 install bitarry==1.6.1
 RUN pip3 install pyangbind==0.8.1
 RUN pip3 uninstall -y enum34
 

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -337,7 +337,7 @@ RUN pip2 install --force-reinstall --upgrade "Jinja2<3.0.0"
 # enum34 causes Python 're' package to not work properly as it redefines an incompatible enum.py module
 # https://github.com/robshakir/pyangbind/issues/232
 # bitarray 1.6.2 triggers build issue
-RUN pip3 install bitarry==1.6.1
+RUN pip3 install bitarray==1.6.1
 RUN pip3 install pyangbind==0.8.1
 RUN pip3 uninstall -y enum34
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fix #6512

bitarray 1.6.2 triggers following build issue

  Downloading bitarray-1.6.2.tar.gz (55 kB)
    ERROR: Command errored out with exit status 1:
    FileNotFoundError: [Errno 2] No such file or directory: 'bitarray/bitarray.h'

Signed-off-by: Guohan Lu <lguohan@gmail.com>

**- How I did it**
ping bitarray to 1.6.1

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
