### PR TITLE
Updated BBR to use peer group name as prefix.

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -113,9 +113,10 @@ class BBRMgr(Manager):
         for af in ["ipv4", "ipv6"]:
             cmds.append(" address-family %s" % af)
             for pg_name in sorted(self.bbr_enabled_pgs.keys()):
-                if pg_name in available_peer_groups and af in self.bbr_enabled_pgs[pg_name]:
-                    cmds.append("  %sneighbor %s allowas-in 1" % (prefix_of_commands, pg_name))
-                    peer_groups_to_restart.add(pg_name)
+                for peer_group_name in available_peer_groups:
+                    if peer_group_name.startswith(pg_name) and af in self.bbr_enabled_pgs[pg_name]:
+                        cmds.append("  %sneighbor %s allowas-in 1" % (prefix_of_commands, peer_group_name))
+                        peer_groups_to_restart.add(peer_group_name)
         return cmds, list(peer_groups_to_restart)
 
     def __get_available_peer_groups(self):

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -269,7 +269,7 @@ def __set_prepare_config_common(status, bbr_enabled_pgs, available_pgs, expected
         }
     }
     m.bbr_enabled_pgs = bbr_enabled_pgs
-    m._BBRMgr__get_available_peer_groups = MagicMock(return_value = available_pgs)
+    m._BBRMgr__get_available_peer_groups = MagicMock(return_value = sorted(available_pgs))
     cmds, peer_groups = m._BBRMgr__set_prepare_config(status)
     assert cmds == expected_cmds
     assert set(peer_groups) == (available_pgs if not bbr_applied_pgs else bbr_applied_pgs)
@@ -336,12 +336,12 @@ def test___set_prepare_config_enabled_multiple_peers():
              'router bgp 65500',
         ' address-family ipv4',
         '  neighbor PEER_V4 allowas-in 1',
-        '  neighbor PEER_V4_DEPLOYMENT_ID_1 allowas-in 1',
         '  neighbor PEER_V4_DEPLOYMENT_ID_0 allowas-in 1',
+        '  neighbor PEER_V4_DEPLOYMENT_ID_1 allowas-in 1',
         ' address-family ipv6',
-        '  neighbor PEER_V6_DEPLOYMENT_ID_1 allowas-in 1',
-        '  neighbor PEER_V6_DEPLOYMENT_ID_0 allowas-in 1',
         '  neighbor PEER_V6 allowas-in 1',
+        '  neighbor PEER_V6_DEPLOYMENT_ID_0 allowas-in 1',
+        '  neighbor PEER_V6_DEPLOYMENT_ID_1 allowas-in 1',
         ],
         {"PEER_V4", "PEER_V4_DEPLOYMENT_ID_0", "PEER_V4_DEPLOYMENT_ID_1", "PEER_V6", "PEER_V6_DEPLOYMENT_ID_0", "PEER_V6_DEPLOYMENT_ID_1"})
 
@@ -354,12 +354,12 @@ def test___set_prepare_config_disabled_multiple_peers():
              'router bgp 65500',
         ' address-family ipv4',
         '  no neighbor PEER_V4 allowas-in 1',
-        '  no neighbor PEER_V4_DEPLOYMENT_ID_1 allowas-in 1',
         '  no neighbor PEER_V4_DEPLOYMENT_ID_0 allowas-in 1',
+        '  no neighbor PEER_V4_DEPLOYMENT_ID_1 allowas-in 1',
         ' address-family ipv6',
-        '  no neighbor PEER_V6_DEPLOYMENT_ID_1 allowas-in 1',
-        '  no neighbor PEER_V6_DEPLOYMENT_ID_0 allowas-in 1',
         '  no neighbor PEER_V6 allowas-in 1',
+        '  no neighbor PEER_V6_DEPLOYMENT_ID_0 allowas-in 1',
+        '  no neighbor PEER_V6_DEPLOYMENT_ID_1 allowas-in 1',
         ],
         {"PEER_V4", "PEER_V4_DEPLOYMENT_ID_0", "PEER_V4_DEPLOYMENT_ID_1", "PEER_V6", "PEER_V6_DEPLOYMENT_ID_0", "PEER_V6_DEPLOYMENT_ID_1"})
 

--- a/src/sonic-bgpcfgd/tests/test_bbr.py
+++ b/src/sonic-bgpcfgd/tests/test_bbr.py
@@ -252,7 +252,7 @@ def test___set_validation_4():
 def test___set_validation_5():
     __set_validation_common("all", {"status": "disabled"}, None, True)
 
-def __set_prepare_config_common(status, bbr_enabled_pgs, available_pgs, expected_cmds):
+def __set_prepare_config_common(status, bbr_enabled_pgs, available_pgs, expected_cmds, bbr_applied_pgs=None):
     cfg_mgr = MagicMock()
     common_objs = {
         'directory': Directory(),
@@ -272,7 +272,7 @@ def __set_prepare_config_common(status, bbr_enabled_pgs, available_pgs, expected
     m._BBRMgr__get_available_peer_groups = MagicMock(return_value = available_pgs)
     cmds, peer_groups = m._BBRMgr__set_prepare_config(status)
     assert cmds == expected_cmds
-    assert set(peer_groups) == available_pgs
+    assert set(peer_groups) == (available_pgs if not bbr_applied_pgs else bbr_applied_pgs)
 
 def test___set_prepare_config_enabled():
     __set_prepare_config_common("enabled", {
@@ -327,7 +327,41 @@ def test___set_prepare_config_disabled_part():
         '  no neighbor PEER_V4 allowas-in 1',
         '  no neighbor PEER_V6 allowas-in 1',
     ])
+def test___set_prepare_config_enabled_multiple_peers():
+    __set_prepare_config_common("enabled", {
+                "PEER_V4": ["ipv4"],
+                "PEER_V6": ["ipv6"],
+        }, {"PEER_V4", "PEER_V4_DEPLOYMENT_ID_0", "PEER_V4_DEPLOYMENT_ID_1", "PEER_V6", "PEER_V6_DEPLOYMENT_ID_0", "PEER_V6_DEPLOYMENT_ID_1", "PEER_INVALID"},
+        [
+             'router bgp 65500',
+        ' address-family ipv4',
+        '  neighbor PEER_V4 allowas-in 1',
+        '  neighbor PEER_V4_DEPLOYMENT_ID_1 allowas-in 1',
+        '  neighbor PEER_V4_DEPLOYMENT_ID_0 allowas-in 1',
+        ' address-family ipv6',
+        '  neighbor PEER_V6_DEPLOYMENT_ID_1 allowas-in 1',
+        '  neighbor PEER_V6_DEPLOYMENT_ID_0 allowas-in 1',
+        '  neighbor PEER_V6 allowas-in 1',
+        ],
+        {"PEER_V4", "PEER_V4_DEPLOYMENT_ID_0", "PEER_V4_DEPLOYMENT_ID_1", "PEER_V6", "PEER_V6_DEPLOYMENT_ID_0", "PEER_V6_DEPLOYMENT_ID_1"})
 
+def test___set_prepare_config_disabled_multiple_peers():
+    __set_prepare_config_common("disabled", {
+                "PEER_V4": ["ipv4"],
+                "PEER_V6": ["ipv6"],
+        }, {"PEER_V4", "PEER_V4_DEPLOYMENT_ID_0", "PEER_V4_DEPLOYMENT_ID_1", "PEER_V6", "PEER_V6_DEPLOYMENT_ID_0", "PEER_V6_DEPLOYMENT_ID_1", "PEER_INVALID"},
+        [
+             'router bgp 65500',
+        ' address-family ipv4',
+        '  no neighbor PEER_V4 allowas-in 1',
+        '  no neighbor PEER_V4_DEPLOYMENT_ID_1 allowas-in 1',
+        '  no neighbor PEER_V4_DEPLOYMENT_ID_0 allowas-in 1',
+        ' address-family ipv6',
+        '  no neighbor PEER_V6_DEPLOYMENT_ID_1 allowas-in 1',
+        '  no neighbor PEER_V6_DEPLOYMENT_ID_0 allowas-in 1',
+        '  no neighbor PEER_V6 allowas-in 1',
+        ],
+        {"PEER_V4", "PEER_V4_DEPLOYMENT_ID_0", "PEER_V4_DEPLOYMENT_ID_1", "PEER_V6", "PEER_V6_DEPLOYMENT_ID_0", "PEER_V6_DEPLOYMENT_ID_1"})
 
 def test__get_available_peer_groups():
     cfg_mgr = MagicMock()


### PR DESCRIPTION
Why/What I did:

Currently BBR Manager looks for peer-group name to start with value define in constants.yml (https://github.com/Azure/sonic-buildimage/blob/master/files/image_config/constants/constants.yml#L40). Peer-name need to be exact string match.

The change in this PR is to make BBR configured for peer-group if it's name starts with (prefixed) with the string define in constants.yml.

This is needed because Peer name can have deployment id at the end with the string "DEPLOYMENT_ID_NUM".
Eg: TIER0_V4_DEPLOYMENT_ID_0

How I verify:

- Added Unit test cases (test___set_prepare_config_enabled_multiple_peers and test___set_prepare_config_disabled_multiple_peers)

```
adosi@68cd7f721b7f:/sonic/src/sonic-bgpcfgd$ pytest tests/test_bbr.py::test___set_prepare_config_enabled_multiple_peers
============================================================================================== test session starts ==============================================================================================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /sonic/src/sonic-bgpcfgd, inifile: pytest.ini
plugins: cov-2.4.0
collected 29 items

tests/test_bbr.py .

---------- coverage: platform linux2, python 2.7.13-final-0 ----------
Name                             Stmts   Miss  Cover
----------------------------------------------------
bgpcfgd/__init__.py                  0      0   100%
bgpcfgd/__main__.py                  3      3     0%
bgpcfgd/config.py                   69     69     0%
bgpcfgd/directory.py                63     36    43%
bgpcfgd/frr.py                      49     49     0%
bgpcfgd/log.py                      15      6    60%
bgpcfgd/main.py                     53     53     0%
bgpcfgd/manager.py                  41     23    44%
bgpcfgd/managers_allow_list.py     425    425     0%
bgpcfgd/managers_bbr.py             95     59    38%
bgpcfgd/managers_bgp.py            192    192     0%
bgpcfgd/managers_db.py               9      9     0%
bgpcfgd/managers_intf.py            33     33     0%
bgpcfgd/managers_setsrc.py          44     44     0%
bgpcfgd/runner.py                   44     44     0%
bgpcfgd/template.py                 64     42    34%
bgpcfgd/utils.py                    19     19     0%
bgpcfgd/vars.py                      1      0   100%
----------------------------------------------------
TOTAL                             1219   1106     9%


=========================================================================================== 1 passed in 0.15 seconds ======================================================================================

```
