### PR TITLE
[minigraph.py]: Force /128 prefix for server IPv6 loopbacks

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1512,8 +1512,10 @@ def get_mux_cable_entries(mux_cable_ports, neighbors, devices):
                 server_ipv4_lo_prefix = ipaddress.ip_network(UNICODE_TYPE(server_ipv4_lo_addr))
                 entry['server_ipv4'] = str(server_ipv4_lo_prefix)
 
-                if 'lo_addr_v6' in devices[neighbor]:
-                    entry['server_ipv6'] = devices[neighbor]['lo_addr_v6']
+                if 'lo_addr_v6' in devices[neighbor] and devices[neighbor]['lo_addr_v6'] is not None:
+                    server_ipv6_lo_addr = devices[neighbor]['lo_addr_v6'].split('/')[0]
+                    server_ipv6_lo_prefix = ipaddress.ip_network(UNICODE_TYPE(server_ipv6_lo_addr))
+                    entry['server_ipv6'] = str(server_ipv6_lo_prefix)
                 mux_cable_table[intf] = entry 
             else:
                 print("Warning: no server IPv4 loopback found for {}, skipping mux cable table entry".format(neighbor))

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -303,7 +303,7 @@
           <d5p1:IPPrefix>10.10.10.1/32</d5p1:IPPrefix>
         </Address>
         <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
-          <d5p1:IPPrefix>fe80::0001/128</d5p1:IPPrefix>
+          <d5p1:IPPrefix>fe80::0001/80</d5p1:IPPrefix>
         </AddressV6>
         <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
           <d5p1:IPPrefix>10.0.0.1/32</d5p1:IPPrefix>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -165,7 +165,7 @@ class TestCfgGenCaseInsensitive(TestCase):
             'server1': {
                 'hwsku': 'server-sku',
                 'lo_addr': '10.10.10.1/32',
-                'lo_addr_v6': 'fe80::0001/128',
+                'lo_addr_v6': 'fe80::0001/80',
                 'mgmt_addr': '10.0.0.1/32',
                 'type': 'Server'
             },
@@ -275,12 +275,12 @@ class TestCfgGenCaseInsensitive(TestCase):
             'Ethernet4': {
                 'state': 'auto',
                 'server_ipv4': '10.10.10.1/32',
-                'server_ipv6': 'fe80::0001/128'
+                'server_ipv6': 'fe80::1/128'
             },
             'Ethernet8': {
                 'state': 'auto',
                 'server_ipv4': '10.10.10.2/32',
-                'server_ipv6': 'fe80::0002/128'
+                'server_ipv6': 'fe80::2/128'
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Meet the requirement for the MUX_CABLE table that IPv6 loopbacks have a /128 prefix

**- How I did it**
Manually remove existing prefix by splitting IP string, then use Python's `ipaddress` module to implicitly add /128 prefix.

Note that this change only affects the MUX_CABLE table, all other tables continue to use the loopback address provided in minigraph.

**- How to verify it**
Run the sonic-config-engine tests

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
