### PR TITLE
[build-docker-buster]: Install libboost 1.171 In Build Docker

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -61,7 +61,6 @@ RUN apt-get update && apt-get install -y \
         dh-exec \
         kmod \
         libtinyxml2-6a \
-        libboost-program-options1.67-dev \
         libtinyxml2-dev \
         python \
         python-pip \
@@ -121,7 +120,6 @@ RUN apt-get update && apt-get install -y \
         module-assistant \
 # For thrift build\
         gem2deb \
-        libboost-all-dev \
         libevent-dev \
         libglib2.0-dev \
         libqt4-dev \
@@ -321,7 +319,27 @@ RUN apt-get update && apt-get install -y \
         docbook-to-man       \
         docbook-utils        \
 # For kdump-tools
-        libbz2-dev
+        libbz2-dev \
+# For linkmgrd
+        libboost1.71-dev \
+        libboost-program-options1.71-dev \
+        libboost-system1.71-dev \
+        libboost-thread1.71-dev \
+        libboost-atomic1.71-dev \
+        libboost-chrono1.71-dev \
+        libboost-container1.71-dev \
+        libboost-context1.71-dev \
+        libboost-contract1.71-dev \
+        libboost-coroutine1.71-dev \
+        libboost-date-time1.71-dev \
+        libboost-fiber1.71-dev \
+        libboost-filesystem1.71-dev \
+        libboost-graph-parallel1.71-dev \
+        libboost-log1.71-dev \
+        libboost-regex1.71-dev \
+        googletest \
+        libgtest-dev \
+        libgcc-8-dev
 
 # Build fix for ARMHF buster libsairedis
 {%- if CONFIGURED_ARCH == "armhf" %}


### PR DESCRIPTION
Installing newst buster version of libboost (v1.71) in build docker.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**- Why I did it**
version 1.71 of libboost is required by linkmgrd

**- How I did it**
Installed dev version of libboost 1.71 in build docker

**- How to verify it**
*.deb builds OK

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
