### PR TITLE
[sonic-host-services] Report unit test coverage

### DIFF
--- a/src/sonic-host-services/pytest.ini
+++ b/src/sonic-host-services/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=scripts --cov-report html --cov-report term --cov-report xml


### PR DESCRIPTION
**- Why I did it**

To view unit test coverage of sonic-host-services package upon build

**- How I did it**

Add pytest.ini file with necessary options to report coverage

**- How to verify it**

Build the sonic-host-services package, ensure that unit test coverage is output to stdout

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012