### PR TITLE
[201911] Fix Build error when installing pip

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -400,7 +400,7 @@ if [[ $CONFIGURED_ARCH == amd64 ]]; then
 fi
 
 ## docker-py is needed by Ansible docker module
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT easy_install pip
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT easy_install 'pip==20.3.3'
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'docker-py==1.6.0'
 ## Note: keep pip installed for maintainance purpose
 


### PR DESCRIPTION
What/Why I did:

With the release of pip21.0 (https://pypi.org/project/pip/#history)  on branch 201911 stretch build is failing with below error logs:
As per https://pypi.org/project/pip/ pip21.0 does not not support python2 from Jan 2021. To fix this tag the pip to 20.3.3 version which was being used last and is working fine. 

```
Writing /tmp/easy_install-RW_rZo/pip-21.0/setup.cfg
Running pip-21.0/setup.py -q bdist_egg --dist-dir /tmp/easy_install-RW_rZo/pip-21.0/egg-dist-tmp-OUShb6
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'project_urls'
  warnings.warn(msg)
warning: no files found matching 'docs/docutils.conf'
warning: no previously-included files found matching '.coveragerc'
warning: no previously-included files found matching '.mailmap'
warning: no previously-included files found matching '.appveyor.yml'
warning: no previously-included files found matching '.travis.yml'
warning: no previously-included files found matching '.readthedocs.yml'
warning: no previously-included files found matching '.pre-commit-config.yaml'
warning: no previously-included files found matching '.pre-commit-config-slow.yaml'
warning: no previously-included files found matching 'tox.ini'
warning: no previously-included files found matching 'noxfile.py'
warning: no files found matching '*.css' under directory 'docs'
warning: no previously-included files found matching 'src/pip/_vendor/six'
warning: no previously-included files found matching 'src/pip/_vendor/six/moves'
warning: no previously-included files matching '*.pyi' found under directory 'src/pip/_vendor'
no previously-included directories found matching '.github'
no previously-included directories found matching '.azure-pipelines'
no previously-included directories found matching 'docs/build'
no previously-included directories found matching 'news'
no previously-included directories found matching 'tasks'
no previously-included directories found matching 'tests'
no previously-included directories found matching 'tools'
  File "build/bdist.linux-x86_64/egg/pip/_internal/locations.py", line 107
    assert not (user and prefix), f"user={user} prefix={prefix}"
```

How I verify:
Build is successful after pip tag to 20.3.3