### PR TITLE
[Mellanox] Update FW upgrade script to use 'mlxfwmanager -d' option for specifying MST device in FW burn operation

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -29,6 +29,7 @@ declare -r SPC1_ASIC="spc1"
 declare -r SPC2_ASIC="spc2"
 declare -r SPC3_ASIC="spc3"
 declare -r UNKN_ASIC="unknown"
+declare -r UNKN_MST="unknown"
 
 declare -rA FW_FILE_MAP=( \
     [$SPC1_ASIC]="/etc/mlnx/fw-SPC.mfa" \
@@ -152,6 +153,18 @@ function GetAsicType() {
     exit "${EXIT_FAILURE}"
 }
 
+function GetMstDevice() {
+    local _MST_DEVICE="$(ls /dev/mst/*_pci_cr0 2>&1)"
+
+    if [[ ! -c "${_MST_DEVICE}" ]]; then
+        echo "${UNKN_MST}"
+    else 
+        echo "${_MST_DEVICE}"
+    fi
+
+    exit "${EXIT_SUCCESS}"
+}
+
 function RunCmd() {
     local ERROR_CODE="${EXIT_SUCCESS}"
 
@@ -207,7 +220,13 @@ function UpgradeFW() {
         ExitSuccess "firmware is up to date"
     else
         LogNotice "firmware upgrade is required. Installing compatible version..."
-        RunCmd "${BURN_CMD} -i ${_FW_FILE}"
+        local -r _MST_DEVICE="$(GetMstDevice)"
+        if [[ "${_MST_DEVICE}" = "${UNKN_MST}" ]]; then
+            LogWarning "could not find fastest mst device, using default device"
+            RunCmd "${BURN_CMD} -i ${_FW_FILE}"
+        else
+            RunCmd "${BURN_CMD} -d ${_MST_DEVICE} -i ${_FW_FILE}"
+        fi
     fi
 }
 

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -36,6 +36,12 @@ declare -rA FW_FILE_MAP=( \
     [$SPC3_ASIC]="/etc/mlnx/fw-SPC3.mfa" \
 )
 
+declare -rA MST_DEVICE_MAP=( \
+    [$SPC1_ASIC]="/dev/mst/mt52100_pci_cr0" \
+    [$SPC2_ASIC]="/dev/mst/mt53100_pci_cr0" \
+    [$SPC3_ASIC]="/dev/mst/mt53104_pci_cr0" \
+)
+
 IMAGE_UPGRADE="${NO_PARAM}"
 VERBOSE_LEVEL="${VERBOSE_MIN}"
 
@@ -175,6 +181,11 @@ function UpgradeFW() {
         ExitFailure "failed to detect ASIC type"
     fi
 
+    local -r _MST_DEVICE="${MST_DEVICE_MAP[$_ASIC_TYPE]}"
+    if [ ! -c "${_MST_DEVICE}" ]; then
+        ExitFailure "no such device: ${_MST_DEVICE}"
+    fi
+
     if [ ! -z "${_FS_MOUNTPOINT}" ]; then
         local -r _FW_FILE="${_FS_MOUNTPOINT}/${FW_FILE_MAP[$_ASIC_TYPE]}"
     else
@@ -207,7 +218,7 @@ function UpgradeFW() {
         ExitSuccess "firmware is up to date"
     else
         LogNotice "firmware upgrade is required. Installing compatible version..."
-        RunCmd "${BURN_CMD} -i ${_FW_FILE}"
+        RunCmd "${BURN_CMD} -d ${_MST_DEVICE} -i ${_FW_FILE}"
     fi
 }
 

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -36,12 +36,6 @@ declare -rA FW_FILE_MAP=( \
     [$SPC3_ASIC]="/etc/mlnx/fw-SPC3.mfa" \
 )
 
-declare -rA MST_DEVICE_MAP=( \
-    [$SPC1_ASIC]="/dev/mst/mt52100_pci_cr0" \
-    [$SPC2_ASIC]="/dev/mst/mt53100_pci_cr0" \
-    [$SPC3_ASIC]="/dev/mst/mt53104_pci_cr0" \
-)
-
 IMAGE_UPGRADE="${NO_PARAM}"
 VERBOSE_LEVEL="${VERBOSE_MIN}"
 
@@ -181,11 +175,6 @@ function UpgradeFW() {
         ExitFailure "failed to detect ASIC type"
     fi
 
-    local -r _MST_DEVICE="${MST_DEVICE_MAP[$_ASIC_TYPE]}"
-    if [ ! -c "${_MST_DEVICE}" ]; then
-        ExitFailure "no such device: ${_MST_DEVICE}"
-    fi
-
     if [ ! -z "${_FS_MOUNTPOINT}" ]; then
         local -r _FW_FILE="${_FS_MOUNTPOINT}/${FW_FILE_MAP[$_ASIC_TYPE]}"
     else
@@ -218,7 +207,7 @@ function UpgradeFW() {
         ExitSuccess "firmware is up to date"
     else
         LogNotice "firmware upgrade is required. Installing compatible version..."
-        RunCmd "${BURN_CMD} -d ${_MST_DEVICE} -i ${_FW_FILE}"
+        RunCmd "${BURN_CMD} -i ${_FW_FILE}"
     fi
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Reduce the time it takes for the ASIC FW burn as part of the automatic FW upgrade procedure.

**- How I did it**
Add -d option to mlxfwmanager tool to use the faster MST device and not the default one which is not the fastest one.

**- How to verify it**
I manually changed ASIC FW followed by reboot command in order for FW upgrade to take place on deinit.
I manually changed ASIC FW followed by hard reset in order for FW upgrade to take place on init.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [ ] 201811
- [x] 201911
- [ ] 202006
- [x] 202012

