### PR TITLE
[vstest]: add default route vs test

### DIFF
--- a/platform/vs/tests/bgp/files/default_route/bgpd.conf
+++ b/platform/vs/tests/bgp/files/default_route/bgpd.conf
@@ -1,0 +1,4 @@
+router bgp 65501
+  bgp router-id 1.1.1.1
+  no bgp ebgp-requires-policy
+  neighbor 10.10.10.1 remote-as 65502

--- a/platform/vs/tests/bgp/files/default_route/default_route.conf
+++ b/platform/vs/tests/bgp/files/default_route/default_route.conf
@@ -1,0 +1,17 @@
+neighbor 10.10.10.0 {
+    router-id 1.2.3.4;
+    local-address 10.10.10.1;
+    local-as 65502;
+    peer-as 65501;
+    group-updates false;
+
+    family {
+        ipv4 unicast;
+    }
+
+    static {
+        route 0.0.0.0/0 {
+            next-hop 10.10.10.1;
+        }
+    }
+}

--- a/platform/vs/tests/bgp/test_default_route.py
+++ b/platform/vs/tests/bgp/test_default_route.py
@@ -1,0 +1,48 @@
+from swsscommon import swsscommon
+import os
+import re
+import time
+import json
+import pytest
+
+def test_DefaultRoute(dvs, testlog):
+
+    dvs.copy_file("/etc/frr/", "bgp/files/default_route/bgpd.conf")
+    dvs.runcmd("supervisorctl start bgpd")
+    dvs.runcmd("ip addr add 10.10.10.0/31 dev Ethernet0")
+    dvs.runcmd("config interface startup Ethernet0")
+    dvs.runcmd("ip route del 0.0.0.0/0")
+    dvs.runcmd("vtysh -c \"confgure terminal\" -c \"ip route 0.0.0.0/0 via 172.17.0.1 200\"")
+
+    dvs.servers[0].runcmd("ip addr add 10.10.10.1/31 dev eth0")
+    dvs.servers[0].runcmd("ifconfig eth0 up")
+
+    time.sleep(5)
+
+    print(dvs.runcmd("supervisorctl status"))
+
+    p = dvs.servers[0].runcmd_async("exabgp -d bgp/files/default_route/default_route.conf")
+
+    time.sleep(10)
+
+    (exit_code, output) = dvs.runcmd(["redis-cli", "hgetall", "ROUTE_TABLE:0.0.0.0/0"])
+    print(exit_code, output)
+
+    # make sure 10.10.10.1 is the correct next hop for default route
+    assert "10.10.10.1" in output
+
+    # insert default route for table default
+    dvs.runcmd("ip route add default via 172.17.0.1 table default")
+
+    (exit_code, output) = dvs.runcmd(["redis-cli", "hgetall", "ROUTE_TABLE:0.0.0.0/0"])
+    print(exit_code, output)
+
+    time.sleep(10)
+    # make sure 10.10.10.1 is still the correct next hop for default route
+    assert "10.10.10.1" in output
+
+    p.terminate()
+    p = p.wait()
+
+
+


### PR DESCRIPTION
Check #6483

add test to make sure default route change in eth0 does not
affect the default route in the default vrf

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
add regression test for #6483 

**- How I did it**
add vstest

**- How to verify it**
run vstest and failed. will make sure it success after issued fixed.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
