### PR TITLE
[bgpmon]: Fix exception in bgpmon caused by duplicate bgp neighbor ID

### DIFF
--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -145,7 +145,7 @@ class BgpStateGet:
         # If anything in the pipeline not yet flushed, flush them now
         if len(data) > 0:
             self.flush_pipe(data)
-        # Save the new dict
+        # Save the new set
         self.peer_l = self.new_peer_l.copy()
 
 def main():


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
It is possible that BGP neighbors in IPv4 and IPv6 address families share the same name. 
For example, if belowing config is applied to creare a bgp monitor:
```
{
    "BGP_MONITORS": {
        "11.0.0.1": {
            "admin_status": "up",
                "asn": "4200065100",
                "holdtime": "10",
                "keepalive": "3",
                "local_addr": "10.1.0.32",
                "name": "bgp_monitor",
                "nhopself": "0",
                "rrclient": "0"
        }
    }
}
```
Then a bgp neighbor named ```11.0.0.1``` will exist in both ipv4 and ipv6 neighbors.
```
root@str-7260cx3-acs-2:/var/log# show ip bgp sum

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 4200065100 vrf-id 0
BGP table version 45133
RIB entries 12807, using 2458944 bytes of memory
Peers 5, using 109080 KiB of memory
Peer groups 5, using 320 bytes of memory


Neighbhor      V          AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  ----------  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.33      4  4200064600       9616      18386         0      0       0  02:33:56   6400            ARISTA01T1
10.0.0.35      4  4200064600       9616      19205         0      0       0  02:33:56   6400            ARISTA02T1
10.0.0.37      4  4200064600       9618      20598         0      0       0  02:33:55   6400            ARISTA03T1
10.0.0.39      4  4200064600       9616      17468         0      0       0  02:33:55   6400            ARISTA04T1
11.0.0.1       4  4200065100          0          0         0      0       0  never      Active          bgp_monitor

Total number of neighbors 5
root@str-7260cx3-acs-2:/var/log# show ipv6 bgp sum

IPv6 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 4200065100 vrf-id 0
BGP table version 36748
RIB entries 12807, using 2458944 bytes of memory
Peers 5, using 109080 KiB of memory
Peer groups 5, using 320 bytes of memory


Neighbhor      V          AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  ----------  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
11.0.0.1       4  4200065100          0          0         0      0       0  never      Active          bgp_monitor
fc00::2a       4  4200064600       9617      21462         0      0       0  02:33:59   6400            ARISTA03T1
fc00::2e       4  4200064600       9618      20863         0      0       0  02:33:59   6400            ARISTA04T1
fc00::22       4  4200064600       9615      19880         0      0       0  02:34:00   6400            ARISTA01T1
fc00::26       4  4200064600       9616      20582         0      0       0  02:34:00   6400            ARISTA02T1

Total number of neighbors 5
```
However, such case is not handled in ```bgpmon.py```, and an Exception will be raised because the same key is deleted twice. 
```
Jan 25 06:40:56.540613 str-7260cx3-acs-2 INFO bgp#/supervisord: bgpmon Traceback (most recent call last):
Jan 25 06:40:56.540971 str-7260cx3-acs-2 INFO bgp#/supervisord: bgpmon   File "/usr/local/bin/bgpmon", line 8, in <module>
Jan 25 06:40:56.540971 str-7260cx3-acs-2 INFO bgp#/supervisord: bgpmon     sys.exit(main())
Jan 25 06:40:56.540971 str-7260cx3-acs-2 INFO bgp#/supervisord: bgpmon   File "/usr/local/lib/python3.7/dist-packages/bgpmon/bgpmon.py", line 167, in main
Jan 25 06:40:56.540971 str-7260cx3-acs-2 INFO bgp#/supervisord: bgpmon     bgp_state_get.update_neigh_states()
Jan 25 06:40:56.540971 str-7260cx3-acs-2 INFO bgp#/supervisord: bgpmon   File "/usr/local/lib/python3.7/dist-packages/bgpmon/bgpmon.py", line 143, in update_neigh_states
Jan 25 06:40:56.540971 str-7260cx3-acs-2 INFO bgp#/supervisord: bgpmon     del self.peer_state[peer]
Jan 25 06:40:56.540971 str-7260cx3-acs-2 INFO bgp#/supervisord: bgpmon KeyError: '11.0.0.1'
```
This commit will address the issue.

**- How I did it**
Use ```set``` instead of ```list``` to store neighbors' ID to avoid duplicate keys.

**Please be noted that this PR only fix exception in ```bgpmon.py```. Similar issue exists in ```STATE_DB``` because ```NEIGH_STATE_TABLE|x.x.x.x``` is used as keys in ```STATE_DB```. If neighbors have duplicated keys, the value will be overwriten.** 

**- How to verify it**
Verified on A7260. No exception is observed after update.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
No.

**- A picture of a cute animal (not mandatory but encouraged)**
