### PR TITLE
System Health: Fix ASIC key issue in Dell platform

### DIFF
--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -11,10 +11,13 @@ class HardwareChecker(HealthChecker):
     import sonic_platform.platform
     ASIC_TEMPERATURE_KEY = []
     thermal_list = sonic_platform.platform.Platform().get_chassis().get_all_thermals()
-    for i in range(0, len(thermal_list)):
-         thermal_name = thermal_list[i].get_name()
-         if "ASIC" in thermal_name:
-             ASIC_TEMPERATURE_KEY.append('TEMPERATURE_INFO|' + thermal_name)
+    for sensor in thermal_list:
+        try:
+            thermal_name = sensor.get_name()
+            if "ASIC" in thermal_name:
+                ASIC_TEMPERATURE_KEY.append('TEMPERATURE_INFO|' + thermal_name)
+        except NotImplementedError:
+            print("Thermal sensor get_name() is not implemented")
 
     FAN_TABLE_NAME = 'FAN_INFO'
     PSU_TABLE_NAME = 'PSU_INFO'
@@ -42,12 +45,12 @@ class HardwareChecker(HealthChecker):
         if config.ignore_devices and 'asic' in config.ignore_devices:
             return
 
-        for i in range(0, len(HardwareChecker.ASIC_TEMPERATURE_KEY)):
-            temperature = self._db.get(self._db.STATE_DB, HardwareChecker.ASIC_TEMPERATURE_KEY[i],
+        for asic_key in HardwareChecker.ASIC_TEMPERATURE_KEY:
+            temperature = self._db.get(self._db.STATE_DB, asic_key,
                                                           'temperature')
-            temperature_threshold = self._db.get(self._db.STATE_DB, HardwareChecker.ASIC_TEMPERATURE_KEY[i],
+            temperature_threshold = self._db.get(self._db.STATE_DB, asic_key,
                                                           'high_threshold')
-            asic_name = HardwareChecker.ASIC_TEMPERATURE_KEY[i][17:]
+            asic_name = asic_key.split('|')[1]
             if not temperature:
                 self.set_object_not_ok('ASIC', asic_name,
                         'Failed to get {} temperature'.format(asic_name))

--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -8,16 +8,21 @@ class HardwareChecker(HealthChecker):
     """
     Check system hardware status. For now, it checks ASIC, PSU and fan status.
     """
-    import sonic_platform.platform
+
     ASIC_TEMPERATURE_KEY = []
-    thermal_list = sonic_platform.platform.Platform().get_chassis().get_all_thermals()
-    for sensor in thermal_list:
-        try:
-            thermal_name = sensor.get_name()
-            if "ASIC" in thermal_name:
-                ASIC_TEMPERATURE_KEY.append('TEMPERATURE_INFO|' + thermal_name)
-        except NotImplementedError:
-            print("Thermal sensor get_name() is not implemented")
+    try:
+        import sonic_platform.platform
+        thermal_list = sonic_platform.platform.Platform().get_chassis().get_all_thermals()
+        for sensor in thermal_list:
+            try:
+                thermal_name = sensor.get_name()
+                if "ASIC" in thermal_name:
+                    ASIC_TEMPERATURE_KEY.append('TEMPERATURE_INFO|' + thermal_name)
+            except NotImplementedError:
+                print("Thermal sensor get_name() is not implemented")
+
+    except ImportError as err:
+        print(str(err) + "- required module not found")
 
     FAN_TABLE_NAME = 'FAN_INFO'
     PSU_TABLE_NAME = 'PSU_INFO'

--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -64,13 +64,13 @@ class HardwareChecker(HealthChecker):
                     if temperature > temperature_threshold:
                         self.set_object_not_ok('ASIC', asic_name,
                                                '{} temperature is too hot, temperature={}, threshold={}'.format(
-                                                asic_name,temperature,temperature_threshold))
+                                                asic_name, temperature, temperature_threshold))
                     else:
                         self.set_object_ok('ASIC', asic_name)
                 except ValueError as e:
                     self.set_object_not_ok('ASIC', asic_name,
                                            'Invalid {} temperature data, temperature={}, threshold={}'.format(
-                                            asic_name,temperature,temperature_threshold))
+                                            asic_name, temperature, temperature_threshold))
 
     def _check_fan_status(self, config):
         """

--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -11,10 +11,10 @@ class HardwareChecker(HealthChecker):
     import sonic_platform.platform
     ASIC_TEMPERATURE_KEY = []
     thermal_list = sonic_platform.platform.Platform().get_chassis().get_all_thermals()
-    for i in range(0,len(thermal_list)):
-         thermal_name=thermal_list[i].get_name()
-         if ("ASIC" in thermal_name):
-             ASIC_TEMPERATURE_KEY.append('TEMPERATURE_INFO|'+ thermal_name)
+    for i in range(0, len(thermal_list)):
+         thermal_name = thermal_list[i].get_name()
+         if "ASIC" in thermal_name:
+             ASIC_TEMPERATURE_KEY.append('TEMPERATURE_INFO|' + thermal_name)
 
     FAN_TABLE_NAME = 'FAN_INFO'
     PSU_TABLE_NAME = 'PSU_INFO'
@@ -42,32 +42,32 @@ class HardwareChecker(HealthChecker):
         if config.ignore_devices and 'asic' in config.ignore_devices:
             return
 
-        for i in range(0,len(HardwareChecker.ASIC_TEMPERATURE_KEY)):
+        for i in range(0, len(HardwareChecker.ASIC_TEMPERATURE_KEY)):
             temperature = self._db.get(self._db.STATE_DB, HardwareChecker.ASIC_TEMPERATURE_KEY[i],
                                                           'temperature')
             temperature_threshold = self._db.get(self._db.STATE_DB, HardwareChecker.ASIC_TEMPERATURE_KEY[i],
                                                           'high_threshold')
             asic_name = HardwareChecker.ASIC_TEMPERATURE_KEY[i][17:]
             if not temperature:
-                self.set_object_not_ok('ASIC',asic_name,
-                        ('Failed to get {} temperature').format(asic_name))
+                self.set_object_not_ok('ASIC', asic_name,
+                        'Failed to get {} temperature'.format(asic_name))
             elif not temperature_threshold:
-                self.set_object_not_ok('ASIC',asic_name,
-                        ('Failed to get {} temperature threshold').format(asic_name))
+                self.set_object_not_ok('ASIC', asic_name,
+                        'Failed to get {} temperature threshold'.format(asic_name))
             else:
                 try:
                     temperature = float(temperature)
                     temperature_threshold = float(temperature_threshold)
                     if temperature > temperature_threshold:
                         self.set_object_not_ok('ASIC', asic_name,
-                                               ('{} temperature is too hot, temperature={}, threshold={}'.format(
-                                                asic_name,temperature,temperature_threshold)))
+                                               '{} temperature is too hot, temperature={}, threshold={}'.format(
+                                                asic_name,temperature,temperature_threshold))
                     else:
                         self.set_object_ok('ASIC', asic_name)
                 except ValueError as e:
                     self.set_object_not_ok('ASIC', asic_name,
-                                           ('Invalid {} temperature data, temperature={}, threshold={}'.format(
-                                            asic_name,temperature,temperature_threshold)))
+                                           'Invalid {} temperature data, temperature={}, threshold={}'.format(
+                                            asic_name,temperature,temperature_threshold))
 
     def _check_fan_status(self, config):
         """

--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -8,7 +8,14 @@ class HardwareChecker(HealthChecker):
     """
     Check system hardware status. For now, it checks ASIC, PSU and fan status.
     """
-    ASIC_TEMPERATURE_KEY = 'TEMPERATURE_INFO|ASIC'
+    import sonic_platform.platform
+    ASIC_TEMPERATURE_KEY = []
+    thermal_list = sonic_platform.platform.Platform().get_chassis().get_all_thermals()
+    for i in range(0,len(thermal_list)):
+         thermal_name=thermal_list[i].get_name()
+         if ("ASIC" in thermal_name):
+             ASIC_TEMPERATURE_KEY.append('TEMPERATURE_INFO|'+ thermal_name)
+
     FAN_TABLE_NAME = 'FAN_INFO'
     PSU_TABLE_NAME = 'PSU_INFO'
 
@@ -35,27 +42,32 @@ class HardwareChecker(HealthChecker):
         if config.ignore_devices and 'asic' in config.ignore_devices:
             return
 
-        temperature = self._db.get(self._db.STATE_DB, HardwareChecker.ASIC_TEMPERATURE_KEY, 'temperature')
-        temperature_threshold = self._db.get(self._db.STATE_DB, HardwareChecker.ASIC_TEMPERATURE_KEY, 'high_threshold')
-        if not temperature:
-            self.set_object_not_ok('ASIC', 'ASIC', 'Failed to get ASIC temperature')
-        elif not temperature_threshold:
-            self.set_object_not_ok('ASIC', 'ASIC', 'Failed to get ASIC temperature threshold')
-        else:
-            try:
-                temperature = float(temperature)
-                temperature_threshold = float(temperature_threshold)
-                if temperature > temperature_threshold:
-                    self.set_object_not_ok('ASIC', 'ASIC',
-                                           'ASIC temperature is too hot, temperature={}, threshold={}'.format(
-                                               temperature,
-                                               temperature_threshold))
-                else:
-                    self.set_object_ok('ASIC', 'ASIC')
-            except ValueError as e:
-                self.set_object_not_ok('ASIC', 'ASIC',
-                                       'Invalid ASIC temperature data, temperature={}, threshold={}'.format(temperature,
-                                                                                                            temperature_threshold))
+        for i in range(0,len(HardwareChecker.ASIC_TEMPERATURE_KEY)):
+            temperature = self._db.get(self._db.STATE_DB, HardwareChecker.ASIC_TEMPERATURE_KEY[i],
+                                                          'temperature')
+            temperature_threshold = self._db.get(self._db.STATE_DB, HardwareChecker.ASIC_TEMPERATURE_KEY[i],
+                                                          'high_threshold')
+            asic_name = HardwareChecker.ASIC_TEMPERATURE_KEY[i][17:]
+            if not temperature:
+                self.set_object_not_ok('ASIC',asic_name,
+                        ('Failed to get {} temperature').format(asic_name))
+            elif not temperature_threshold:
+                self.set_object_not_ok('ASIC',asic_name,
+                        ('Failed to get {} temperature threshold').format(asic_name))
+            else:
+                try:
+                    temperature = float(temperature)
+                    temperature_threshold = float(temperature_threshold)
+                    if temperature > temperature_threshold:
+                        self.set_object_not_ok('ASIC', asic_name,
+                                               ('{} temperature is too hot, temperature={}, threshold={}'.format(
+                                                asic_name,temperature,temperature_threshold)))
+                    else:
+                        self.set_object_ok('ASIC', asic_name)
+                except ValueError as e:
+                    self.set_object_not_ok('ASIC', asic_name,
+                                           ('Invalid {} temperature data, temperature={}, threshold={}'.format(
+                                            asic_name,temperature,temperature_threshold)))
 
     def _check_fan_status(self, config):
         """

--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -20,7 +20,6 @@ class HardwareChecker(HealthChecker):
                     ASIC_TEMPERATURE_KEY.append('TEMPERATURE_INFO|' + thermal_name)
             except NotImplementedError:
                 print("Thermal sensor get_name() is not implemented")
-
     except ImportError as err:
         print(str(err) + "- required module not found")
 

--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -9,20 +9,7 @@ class HardwareChecker(HealthChecker):
     Check system hardware status. For now, it checks ASIC, PSU and fan status.
     """
 
-    ASIC_TEMPERATURE_KEY = []
-    try:
-        import sonic_platform.platform
-        thermal_list = sonic_platform.platform.Platform().get_chassis().get_all_thermals()
-        for sensor in thermal_list:
-            try:
-                thermal_name = sensor.get_name()
-                if "ASIC" in thermal_name:
-                    ASIC_TEMPERATURE_KEY.append('TEMPERATURE_INFO|' + thermal_name)
-            except NotImplementedError:
-                print("Thermal sensor get_name() is not implemented")
-    except ImportError as err:
-        print(str(err) + "- required module not found")
-
+    ASIC_TEMPERATURE_KEY = 'TEMPERATURE_INFO|ASIC'
     FAN_TABLE_NAME = 'FAN_INFO'
     PSU_TABLE_NAME = 'PSU_INFO'
 
@@ -49,7 +36,9 @@ class HardwareChecker(HealthChecker):
         if config.ignore_devices and 'asic' in config.ignore_devices:
             return
 
-        for asic_key in HardwareChecker.ASIC_TEMPERATURE_KEY:
+        ASIC_TEMPERATURE_KEY_LIST = self._db.keys(self._db.STATE_DB,
+                                                  HardwareChecker.ASIC_TEMPERATURE_KEY + '*')
+        for asic_key in ASIC_TEMPERATURE_KEY_LIST:
             temperature = self._db.get(self._db.STATE_DB, asic_key,
                                                           'temperature')
             temperature_threshold = self._db.get(self._db.STATE_DB, asic_key,


### PR DESCRIPTION

**- Why I did it**
ASIC key used in system health daemon is not present in Dell platforms.
Fixes https://github.com/Azure/sonic-buildimage/issues/6343 
**- How I did it**
Got the thermal sensor list using 2.0 API and retrieved the ASIC keys.
**- How to verify it**
Check "show system-health summary/detail/monitor-list" 
**- Which release branch to backport (provide reason below if selected)**


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
Get the platform based ASIC keys used in thermal sensor list.
UT logs:
[system_health_UT.txt](https://github.com/Azure/sonic-buildimage/files/5867573/system_health_UT.txt)

**- A picture of a cute animal (not mandatory but encouraged)**
