### PR TITLE
[ci]: reset the owner for all files under working directory

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,7 +131,7 @@ stages:
               docker rmi docker-sonic-vs:$(Build.BuildNumber); \
               ip netns list | grep -E [-]srv[0-9]+ | awk '{print $1}' | xargs -I {} sudo ip netns delete {}; \
               sudo chown -R ${username}.${username} .; \
-              sudo chown -R ${usernaem}.${username} $(System.DefaultWorkingDirectory)" EXIT
+              sudo chown -R ${username}.${username} $(System.DefaultWorkingDirectory)" EXIT
         pushd platform/vs/tests
         sudo py.test -v --junitxml=tr.xml --imgname=docker-sonic-vs:$(Build.BuildNumber) && \
             sudo rm /nfs/azpl/kvmimage/docker-sonic-vs.$(Build.BuildNumber).gz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,11 +125,13 @@ stages:
         sudo docker load -i /nfs/azpl/kvmimage/docker-sonic-vs.$(Build.BuildNumber).gz
         docker tag docker-sonic-vs:latest docker-sonic-vs:$(Build.BuildNumber)
         username=$(id -un)
+        set -x
 
         trap "docker ps; docker images; ip netns list; \
               docker rmi docker-sonic-vs:$(Build.BuildNumber); \
               ip netns list | grep -E [-]srv[0-9]+ | awk '{print $1}' | xargs -I {} sudo ip netns delete {}; \
-              sudo chown -R ${username}.${username} ." EXIT
+              sudo chown -R ${username}.${username} .; \
+              sudo chown -R ${usernaem}.${username} $($System.DefaultWorkingDirectory)" EXIT
         pushd platform/vs/tests
         sudo py.test -v --junitxml=tr.xml --imgname=docker-sonic-vs:$(Build.BuildNumber) && \
             sudo rm /nfs/azpl/kvmimage/docker-sonic-vs.$(Build.BuildNumber).gz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,7 +131,7 @@ stages:
               docker rmi docker-sonic-vs:$(Build.BuildNumber); \
               ip netns list | grep -E [-]srv[0-9]+ | awk '{print $1}' | xargs -I {} sudo ip netns delete {}; \
               sudo chown -R ${username}.${username} .; \
-              sudo chown -R ${usernaem}.${username} $($System.DefaultWorkingDirectory)" EXIT
+              sudo chown -R ${usernaem}.${username} $(System.DefaultWorkingDirectory)" EXIT
         pushd platform/vs/tests
         sudo py.test -v --junitxml=tr.xml --imgname=docker-sonic-vs:$(Build.BuildNumber) && \
             sudo rm /nfs/azpl/kvmimage/docker-sonic-vs.$(Build.BuildNumber).gz


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
reset the owner for all files under working directory. some files were owned by root after build, which cause
next build to fail since directory cannot be cleanned.

**- How I did it**
reset the owner for all files under working directory after build.

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
