### PR TITLE
[ci]: archive kvmtest artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,19 +163,19 @@ stages:
         pwd
         username=$(id -un)
 
+        rm -rf $(Build.ArtifactStagingDirectory)/*
         docker exec sonic-mgmt bash -c "/data/sonic-mgmt/tests/kvmtest.sh -en $(tbname) $(dut)"
 
         # save dut state if test fails
         if [ $? != 0 ]; then
             virsh_version=$(virsh --version)
             if [ $virsh_version == "6.0.0" ]; then
-                rm -rf kvmdump
-                mkdir -p kvmdump
+                mkdir -p $(Build.ArtifactStagingDirectory)/kvmdump
                 virsh -c qemu:///system list
-                virsh -c qemu:///system save $(dut) kvmdump/$(dut).memdmp
-                virsh -c qemu:///system dumpxml $(dut) > kvmdump/$(dut).xml
+                virsh -c qemu:///system save $(dut) $(Build.ArtifactStagingDirectory)/kvmdump/$(dut).memdmp
+                virsh -c qemu:///system dumpxml $(dut) > $(Build.ArtifactStagingDirectory)/kvmdump/$(dut).xml
                 img=$(virsh -c qemu:///system domblklist $(dut) | grep vda | awk '{print $2}')
-                cp $img kvmdump/$(dut).img
+                cp $img $(Build.ArtifactStagingDirectory)/kvmdump/$(dut).img
                 sudo chown -R $username.$username kvmdump
                 virsh -c qemu:///system undefine $(dut)
             fi
@@ -183,11 +183,28 @@ stages:
             rm -rf ptfdump
             mkdir -p ptfdump
             docker commit $(ptf_name) docker-ptf:$(Build.BuildNumber)
-            docker save docker-ptf:$(Build.BuildNumber) | gzip -c > ptfdump/docker-ptf-dump.gz
+            docker save docker-ptf:$(Build.BuildNumber) | gzip -c > $(Build.ArtifactStagingDirectory)/kvmdump/docker-ptf-dump.gz
             docker rmi docker-ptf:$(Build.BuildNumber)
+
+            cp -r /data/sonic-mgmt/tests/logs $(Build.ArtifactStagingDirectory)/
 
             exit 2
         else
             sudo rm /nfs/azpl/kvmimage/sonic-vs.$(Build.BuildNumber).img.gz
+
+            cp -r /data/sonic-mgmt/tests/logs $(Build.ArtifactStagingDirectory)/
         fi
       displayName: "Run T0 tests"
+    - publish: $(Build.ArtifactStagingDirectory)/kvmdump
+      artifact: sonic-buildimage.kvmtest.memdump
+      displayName: "Archive sonic kvm memdump"
+      condition: failed()
+    - publish: $(Build.ArtifactStagingDirectory)/logs
+      artifact: sonic-buildimage.kvmtest.log
+      displayName: "Archive sonic kvm logs"
+      condition: succeededOrFailed()
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: '$(Build.ArtifactStagingDirectory)/logs/**/*.yml'
+        testRunTitle: kvmtest
+      condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -205,6 +205,6 @@ stages:
       condition: succeededOrFailed()
     - task: PublishTestResults@2
       inputs:
-        testResultsFiles: '$(Build.ArtifactStagingDirectory)/logs/**/*.yml'
+        testResultsFiles: '$(Build.ArtifactStagingDirectory)/logs/**/*.xml'
         testRunTitle: kvmtest
       condition: succeededOrFailed()


### PR DESCRIPTION
- archive logs
- archive kvm memdump when failed
- publish kvm test results

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
- archive logs
- archive kvm memdump when failed
- publish kvm test results

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
