### PR TITLE
[docker-fpm-frr]: fix proc-exit-listener crash

### DIFF
--- a/dockers/docker-fpm-frr/frr/supervisord/critical_processes.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/critical_processes.j2
@@ -7,6 +7,6 @@ program:bfdd
 program:ospfd
 program:pimd
 program:frrcfgd
-{% else %}
+{%- else %}
 program:bgpcfgd
-{% endif %}
+{%- endif %}

--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -2,6 +2,7 @@
 
 import getopt
 import os
+import re
 import select
 import signal
 import sys
@@ -40,6 +41,9 @@ def get_critical_group_and_process_list():
 
     with open(CRITICAL_PROCESSES_FILE, 'r') as file:
         for line in file:
+            # ignore blank lines
+            if re.match(r"^\s*$", line)
+                continue
             line_info = line.strip(' \n').split(':')
             if len(line_info) != 2:
                 syslog.syslog(syslog.LOG_ERR,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
remove blank lines in criticial_process
make proc-exit-listener more robust to handle blank lines

**- How I did it**
see the pr

**- How to verify it**
tested on kvm.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
