### PR TITLE
[system-health] Check fan speed before check fan status

### DIFF
--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -89,11 +89,6 @@ class HardwareChecker(HealthChecker):
                 self.set_object_not_ok('Fan', name, '{} is missing'.format(name))
                 continue
 
-            status = data_dict.get('status', 'false')
-            if status.lower() != 'true':
-                self.set_object_not_ok('Fan', name, '{} is broken'.format(name))
-                continue
-
             if not self._ignore_check(config.ignore_devices, 'fan', name, 'speed'):
                 speed = data_dict.get('speed', None)
                 speed_target = data_dict.get('speed_target', None)
@@ -129,6 +124,11 @@ class HardwareChecker(HealthChecker):
                                                    speed_target,
                                                    speed_tolerance))
                         continue
+
+            status = data_dict.get('status', 'false')
+            if status.lower() != 'true':
+                self.set_object_not_ok('Fan', name, '{} is broken'.format(name))
+                continue
 
             self.set_object_ok('Fan', name)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

In thermalctd, when speed of fan exceeds threashold, the fan status will be saved as "bad". So in system health, it is better to check fan speed before fan status. In this case, if fan speed exceeds threashold, we get more deatil information.

**- How I did it**

Move fan speed check logic before fan status check

**- How to verify it**

Manual test

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
