### PR TITLE
[docker-sonic-vs] Install sonic-platform-common package

### DIFF
--- a/platform/vs/docker-sonic-vs.mk
+++ b/platform/vs/docker-sonic-vs.mk
@@ -18,10 +18,9 @@ $(DOCKER_SONIC_VS)_DEPENDS += $(SWSS) \
 
 # swsssdk is a dependency of sonic-py-common
 # TODO: sonic-py-common should depend on swsscommon instead
-$(DOCKER_SONIC_VS)_PYTHON_WHEELS += $(SWSSSDK_PY2) \
-                                    $(SWSSSDK_PY3) \
-                                    $(SONIC_PY_COMMON_PY2) \
+$(DOCKER_SONIC_VS)_PYTHON_WHEELS += $(SWSSSDK_PY3) \
                                     $(SONIC_PY_COMMON_PY3) \
+                                    $(SONIC_PLATFORM_COMMON_PY3) \
                                     $(SONIC_YANG_MODELS_PY3) \
                                     $(SONIC_YANG_MGMT_PY3) \
                                     $(SONIC_UTILITIES_PY3) \


### PR DESCRIPTION
**- Why I did it**

sonic-utilities will become dependent upon sonic-platform-common as of https://github.com/Azure/sonic-utilities/pull/1386.

**- How I did it**

- Add sonic-platform-common as a dependency in docker-sonic-vs.mk
- Additionally, no longer install Python 2 packages of swsssdk and sonic-py-common, as they should no longer be needed.

**- How to verify it**

Build docker-sonic-vs and ensure sonic-platform-common package is installed (e.g., `pip list | grep sonic-platform-common`)

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
