### PR TITLE
[multi asic] add ip netns identify command to sudoer

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -36,7 +36,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog*, \
                                  /usr/local/bin/psuutil *, \
                                  /usr/local/bin/sonic-installer list, \
                                  /usr/local/bin/sfputil show *, \
-                                 /bin/ip netns identify * 
+                                 /bin/ip netns identify [0-9]*
                                  
 
 Cmnd_Alias      PASSWD_CMDS = /usr/local/bin/config tacacs passkey *, \

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -35,7 +35,9 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog*, \
                                  /usr/local/bin/lldpshow, \
                                  /usr/local/bin/psuutil *, \
                                  /usr/local/bin/sonic-installer list, \
-                                 /usr/local/bin/sfputil show *
+                                 /usr/local/bin/sfputil show *, \
+                                 /bin/ip netns identify * 
+                                 
 
 Cmnd_Alias      PASSWD_CMDS = /usr/local/bin/config tacacs passkey *, \
                               /usr/sbin/chpasswd *


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The command `sudo ip netns identify <pid>` is used  in function  [ get_current_namespace](https://github.com/Azure/sonic-buildimage/blob/0e7287856cf2873b1f130063e04cb44d7ecd3c98/src/sonic-py-common/sonic_py_common/multi_asic.py#L141)
 to check in the cli command is running in host context or within a namespace.

This function is used for every CLI command and command `sudo ip netns identify <pid>` needs to be added in sudoer files to allow users with `RO` access to run show cli commands

This problem is not there on single asic platforms.

**- How I did it**
Add `ip netns identify *` to sudoers file.

**- How to verify it**
Verify on multi asic platforms
 - before the change
```
 user_ro@sonic~$ show vers
[sudo] password for user_ro: 
^CTraceback (most recent call last):
  File "/usr/bin/show", line 8, in <module>
    from show.main import cli
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 12, in <module>
    import bgp_common
  File "/usr/lib/python2.7/dist-packages/show/bgp_common.py", line 5, in <module>
    import utilities_common.multi_asic as multi_asic_util
  File "/usr/lib/python2.7/dist-packages/utilities_common/multi_asic.py", line 97, in <module>
    type=click.Choice(multi_asic_ns_choices()),
  File "/usr/lib/python2.7/dist-packages/utilities_common/multi_asic.py", line 69, in multi_asic_ns_choices
    choices = multi_asic.get_namespace_list()
  File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/multi_asic.py", line 254, in get_namespace_list
    ns_list = get_namespaces_from_linux()
  File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/multi_asic.py", line 210, in get_namespaces_from_linux
    current_ns = get_current_namespace()
  File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/multi_asic.py", line 182, in get_current_namespace
    stdout, stderr = proc.communicate()
  File "/usr/lib/python2.7/subprocess.py", line 471, in communicate
    stdout = _eintr_retry_call(self.stdout.read)
  File "/usr/lib/python2.7/subprocess.py", line 121, in _eintr_retry_call
    return func(*args)
KeyboardInterrupt
user_ro@sonic~$ 
user_ro@sonic
user_ro@sonic~$ show ip bgp summary
[sudo] password for user_ro: 
^CTraceback (most recent call last):
  File "/usr/bin/show", line 8, in <module>
    from show.main import cli
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 12, in <module>
    import bgp_common
  File "/usr/lib/python2.7/dist-packages/show/bgp_common.py", line 5, in <module>
    import utilities_common.multi_asic as multi_asic_util
  File "/usr/lib/python2.7/dist-packages/utilities_common/multi_asic.py", line 97, in <module>
    type=click.Choice(multi_asic_ns_choices()),
  File "/usr/lib/python2.7/dist-packages/utilities_common/multi_asic.py", line 69, in multi_asic_ns_choices
    choices = multi_asic.get_namespace_list()
  File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/multi_asic.py", line 254, in get_namespace_list
    ns_list = get_namespaces_from_linux()
  File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/multi_asic.py", line 210, in get_namespaces_from_linux
    current_ns = get_current_namespace()
  File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/multi_asic.py", line 182, in get_current_namespace
    stdout, stderr = proc.communicate()
  File "/usr/lib/python2.7/subprocess.py", line 471, in communicate
    stdout = _eintr_retry_call(self.stdout.read)
  File "/usr/lib/python2.7/subprocess.py", line 121, in _eintr_retry_call
    return func(*args)
KeyboardInterrupt
user_ro@sonic~$ 
user_ro@sonic~$ show interface status
[sudo] password for user_ro: 
^CTraceback (most recent call last):
  File "/usr/bin/show", line 8, in <module>
    from show.main import cli
  File "/usr/lib/python2.7/dist-packages/show/main.py", line 12, in <module>
    import bgp_common
  File "/usr/lib/python2.7/dist-packages/show/bgp_common.py", line 5, in <module>
    import utilities_common.multi_asic as multi_asic_util
  File "/usr/lib/python2.7/dist-packages/utilities_common/multi_asic.py", line 97, in <module>
    type=click.Choice(multi_asic_ns_choices()),
  File "/usr/lib/python2.7/dist-packages/utilities_common/multi_asic.py", line 69, in multi_asic_ns_choices
    choices = multi_asic.get_namespace_list()
  File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/multi_asic.py", line 254, in get_namespace_list
    ns_list = get_namespaces_from_linux()
  File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/multi_asic.py", line 210, in get_namespaces_from_linux
    current_ns = get_current_namespace()
  File "/usr/local/lib/python2.7/dist-packages/sonic_py_common/multi_asic.py", line 182, in get_current_namespace
    stdout, stderr = proc.communicate()
  File "/usr/lib/python2.7/subprocess.py", line 471, in communicate
    stdout = _eintr_retry_call(self.stdout.read)
  File "/usr/lib/python2.7/subprocess.py", line 121, in _eintr_retry_call
    return func(*args)
KeyboardInterrupt
user_ro@sonic~$ 
```
- after the change

```
user_ro@sonic~$ show vers

SONiC Software Version: SONiC.20191130.58
Distribution: Debian 9.13
Kernel: 4.9.0-11-2-amd64
Build commit: 089214873
Build date: Thu Jan  7 10:12:05 UTC 2021
Built by: sonicbld@jenkins-slave-phx-2

Platform: x86_64-n3164-r0
HwSKU: Nexus-3164
ASIC: broadcom
Serial Number: FDO215109NN
Uptime: 15:37:58 up 12:45,  2 users,  load average: 1.54, 1.89, 2.17

Docker images:
REPOSITORY                 TAG                 IMAGE ID            SIZE
docker-snmp-sv2            20191130.58         46de4ef67f1f        348MB
docker-snmp-sv2            latest              46de4ef67f1f        348MB
docker-fpm-frr             20191130.58         21296f4b1f64        326MB
docker-fpm-frr             latest              21296f4b1f64        326MB
docker-acms                20191130.58         89991569477f        194MB
docker-acms                latest              89991569477f        194MB
docker-lldp-sv2            20191130.58         04a96b151640        312MB
docker-lldp-sv2            latest              04a96b151640        312MB
docker-orchagent           20191130.58         810135ffcf83        333MB
docker-orchagent           latest              810135ffcf83        333MB
docker-syncd-brcm          20191130.58         2a961a57ee57        437MB
docker-syncd-brcm          latest              2a961a57ee57        437MB
docker-teamd               20191130.58         748227bc0de0        315MB
docker-teamd               latest              748227bc0de0        315MB
docker-platform-monitor    20191130.58         548e262b3f7e        358MB
docker-platform-monitor    latest              548e262b3f7e        358MB
docker-sonic-telemetry     20191130.58         4deeec7b321a        353MB
docker-sonic-telemetry     latest              4deeec7b321a        353MB
docker-database            20191130.58         c19667071be6        290MB
docker-database            latest              c19667071be6        290MB
docker-router-advertiser   20191130.58         642b7f38f1b4        290MB
docker-router-advertiser   latest              642b7f38f1b4        290MB
docker-dhcp-relay          20191130.58         442975d2e863        300MB
docker-dhcp-relay          latest              442975d2e863        300MB
k8s.gcr.io/pause           3.2                 80d28bedfe5d        683kB



user_ro@sonic~$ show ip bgp summary

IPv4 Unicast Summary:
asic0: BGP router identifier 8.0.0.0, local AS number 65100 vrf-id 0
BGP table version 12532
asic1: BGP router identifier 8.0.0.1, local AS number 65100 vrf-id 0
BGP table version 7591
asic2: BGP router identifier 8.0.0.2, local AS number 65100 vrf-id 0
BGP table version 12904
asic3: BGP router identifier 8.0.0.3, local AS number 65100 vrf-id 0
BGP table version 8703
RIB entries 51708, using 9514272 bytes of memory
Peers 32, using 669440 KiB of memory
Peer groups 16, using 1024 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200       3955        793         0      0       0  12:45:55             6370  ARISTA01T2
10.0.0.5       4  65200       3955        793         0      0       0  12:45:55             6370  ARISTA03T2
10.0.0.9       4  65200       3954        793         0      0       0  12:45:57             6368  ARISTA05T2
10.0.0.13      4  65200       3956        793         0      0       0  12:45:57             6370  ARISTA07T2
10.0.0.33      4  64001        771       7175         0      0       0  12:45:58               33  ARISTA01T0
10.0.0.35      4  64002        772       7175         0      0       0  12:45:58               33  ARISTA02T0
10.0.0.37      4  64003        772       7175         0      0       0  12:45:58               34  ARISTA03T0
10.0.0.39      4  64004        771       7175         0      0       0  12:45:58               33  ARISTA04T0
10.0.0.41      4  64005        772       7175         0      0       0  12:45:58               34  ARISTA05T0
10.0.0.43      4  64006        771       7175         0      0       0  12:45:57               33  ARISTA06T0
10.0.0.45      4  64007        771       7175         0      0       0  12:45:58               33  ARISTA07T0
10.0.0.47      4  64008        771       7175         0      0       0  12:45:58               33  ARISTA08T0
10.0.0.49      4  64009        771       7175         0      0       0  12:45:58               33  ARISTA09T0
10.0.0.51      4  64010        771       7175         0      0       0  12:45:58               33  ARISTA10T0
10.0.0.53      4  64011        771       4093         0      0       0  12:46:02               33  ARISTA11T0
10.0.0.55      4  64012        772       4093         0      0       0  12:46:01               33  ARISTA12T0
10.0.0.57      4  64013        772       4093         0      0       0  12:46:01               33  ARISTA13T0
10.0.0.59      4  64014        772       4093         0      0       0  12:46:01               33  ARISTA14T0
10.0.0.61      4  64015        772       4093         0      0       0  12:46:01               33  ARISTA15T0
10.0.0.63      4  64016        772       4093         0      0       0  12:46:01               33  ARISTA16T0
10.0.0.65      4  64017        771       4093         0      0       0  12:46:01               33  ARISTA17T0
10.0.0.67      4  64018        772       4093         0      0       0  12:46:01               33  ARISTA18T0
10.0.0.69      4  64019        772       4093         0      0       0  12:46:02               33  ARISTA19T0
10.0.0.71      4  64020        772       4090         0      0       0  12:46:02               33  ARISTA20T0
```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ x] 201911
- [ x] 202006
- [ x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
