### PR TITLE
[201811][pip2]: pin down pip to 20.3.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,11 @@ stages:
     - checkout: self
       submodules: recursive
       displayName: 'Checkout code'
-
+    - script: |
+         git submodule foreach --recursive git clean -xfdf
+         git submodule foreach --recursive git reset --hard
+         git submodule update --init --recursive
+      displayName: 'reset submodules'
     - script: |
         sudo modprobe overlay
         CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=rcache SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/broadcom"
@@ -48,6 +52,11 @@ stages:
       displayName: 'Checkout code'
 
     - script: |
+         git submodule foreach --recursive git clean -xfdf
+         git submodule foreach --recursive git reset --hard
+         git submodule update --init --recursive
+      displayName: 'reset submodules'
+    - script: |
         sudo modprobe overlay
         CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=rcache SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/mellanox"
         make configure PLATFORM=mellanox
@@ -66,6 +75,11 @@ stages:
       submodules: recursive
       displayName: 'Checkout code'
 
+    - script: |
+         git submodule foreach --recursive git clean -xfdf
+         git submodule foreach --recursive git reset --hard
+         git submodule update --init --recursive
+      displayName: 'reset submodules'
     - script: |
         echo $(Build.BuildNumber)
         sudo modprobe overlay

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -365,7 +365,7 @@ set /files/etc/sysctl.conf/net.core.wmem_max 2097152
 sudo sed -i 's/^#syslog = yes/syslog = yes/' $FILESYSTEM_ROOT/etc/mcelog/mcelog.conf
 
 ## docker-py is needed by Ansible docker module
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT easy_install pip
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT easy_install 'pip==20.3.3'
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'docker-py==1.6.0'
 ## Note: keep pip installed for maintainance purpose
 

--- a/dockers/docker-config-engine/Dockerfile.j2
+++ b/dockers/docker-config-engine/Dockerfile.j2
@@ -8,7 +8,7 @@ RUN apt-get update
 # Dependencies for sonic-cfggen
 RUN apt-get install -y python-lxml python-yaml python-bitarray python-pip python-dev python-natsort
 
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip==20.3.3
 
 RUN pip install netaddr==0.7.19 ipaddr==2.2.0 jinja2==2.11.2 pyangbind==0.5.10
 


### PR DESCRIPTION
With the release of pip21.0 (https://pypi.org/project/pip/#history) on branch
201811 stretch build is failing with below error logs:

As per https://pypi.org/project/pip/ pip21.0 does not not support python2
from Jan 2021. To fix this tag the pip to 20.3.3 version which was being used last
and is working fine.

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
With the release of pip21.0 (https://pypi.org/project/pip/#history) on branch
201811 stretch build is failing with below error logs:

As per https://pypi.org/project/pip/ pip21.0 does not not support python2
from Jan 2021. To fix this tag the pip to 20.3.3 version which was being used last
and is working fine.


**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
