### PR TITLE
[installer] Fix variable inside machine.conf caused install.sh error

### DIFF
--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -24,8 +24,12 @@ read_conf_file() {
     local conf_file=$1
     while IFS='=' read -r var value
     do
-        f_char=$(echo $var | cut -c1)
-        [ "$f_char" = "#" ] && continue
+        # remove comment string
+        var=${var%#*}
+        value=${value%#*}
+        # trim the space
+        var="$(echo $var)"
+        # skip blank line
         [ -z "$var" ] && continue
         # remove double quote in the beginning
         tmp_val=${value#\"}

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -24,6 +24,9 @@ read_conf_file() {
     local conf_file=$1
     while IFS='=' read -r var value
     do
+        f_char=$(echo $var | cut -c1)
+        [ "$f_char" = "#" ] && continue
+        [ -z "$var" ] && continue
         # remove double quote in the beginning
         tmp_val=${value#\"}
         # remove double quote in the end

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -20,6 +20,18 @@ _trap_push() {
 }
 _trap_push true
 
+read_conf_file() {
+    local conf_file=$1
+    while IFS='=' read -r var value
+    do
+        # remove double quote in the beginning
+        tmp_val=${value#\"}
+        # remove double quote in the end
+        value=${tmp_val%\"}
+        eval "$var=\"$value\""
+    done < "$conf_file"
+}
+
 # Main
 set -e
 cd $(dirname $0)
@@ -37,7 +49,7 @@ else
 fi
 
 if [ -r ./machine.conf ]; then
-. ./machine.conf
+    read_conf_file "./machine.conf"
 fi
 
 if [ -r ./onie-image.conf ]; then
@@ -54,9 +66,9 @@ fi
 
 # get running machine from conf file
 if [ -r /etc/machine.conf ]; then
-    . /etc/machine.conf
+    read_conf_file "/etc/machine.conf"
 elif [ -r /host/machine.conf ]; then
-    . /host/machine.conf
+    read_conf_file "/host/machine.conf"
 elif [ "$install_env" != "build" ]; then
     echo "cannot find machine.conf"
     exit 1

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -22,13 +22,14 @@ _trap_push true
 
 read_conf_file() {
     local conf_file=$1
-    while IFS='=' read -r var value
+    while IFS='=' read -r var value || [ -n "$var" ]
     do
+        # remove newline character
+        var=$(echo $var | tr -d '\r\n')
+        value=$(echo $value | tr -d '\r\n')
         # remove comment string
         var=${var%#*}
         value=${value%#*}
-        # trim the space
-        var="$(echo $var)"
         # skip blank line
         [ -z "$var" ] && continue
         # remove double quote in the beginning

--- a/installer/x86_64/tests/sample_machine.conf
+++ b/installer/x86_64/tests/sample_machine.conf
@@ -1,0 +1,16 @@
+# sample_machine.conf for onie
+ # A space in front of comment line
+# One blank line below
+
+onie_machine_rev=0
+onie_arch=x86_64# some comment after declaration
+# no value declaration
+onie_config_version=
+onie_build_date="2021-02-03T01:50+0800"
+onie_partition_type=gpt
+onie_disco_ntpsrv=192.168.0.1 192.168.0.2
+onie_firmware=auto
+# another blank line below
+
+onie_skip_ethmgmt_macs=no
+onie_grub_image_name=grubx64.efi

--- a/installer/x86_64/tests/test_read_conf.sh
+++ b/installer/x86_64/tests/test_read_conf.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# This is a standalone test file to test read_conf_file function for
+# some types of machine.conf file.
+# The read_conf_file function is copy from the install.sh
+
+MACHINE_CONF="sample_machine.conf"
+
+read_conf_file() {
+    local conf_file=$1
+    while IFS='=' read -r var value || [ -n "$var" ]
+    do
+        # remove newline character
+        var=$(echo $var | tr -d '\r\n')
+        value=$(echo $value | tr -d '\r\n')
+        # remove comment string
+        var=${var%#*}
+        value=${value%#*}
+        # skip blank line
+        [ -z "$var" ] && continue
+        # remove double quote in the beginning
+        tmp_val=${value#\"}
+        # remove double quote in the end
+        value=${tmp_val%\"}
+        eval "$var=\"$value\""
+    done < "$conf_file"
+}
+
+TEST_CONF() {
+    input_value=$1
+    exp_value=$2
+    if [ "$input_value" != "$exp_value" ]; then
+        echo "[ERR] Expect value($exp_value) is not equal to input value($input_value)"
+        exit 1
+    fi
+}
+
+# define the expected variable value
+exp_onie_machine_rev="0"
+exp_onie_arch="x86_64"
+exp_onie_build_date="2021-02-03T01:50+0800"
+exp_onie_partition_type="gpt"
+exp_onie_disco_ntpsrv="192.168.0.1 192.168.0.2"
+exp_onie_firmware="auto"
+exp_onie_skip_ethmgmt_macs="no"
+exp_onie_grub_image_name="grubx64.efi"
+
+# read the sample conf file
+read_conf_file $MACHINE_CONF
+
+# check each variable and its expected value
+TEST_CONF "$onie_machine_rev" "$exp_onie_machine_rev"
+TEST_CONF "$onie_arch" "$exp_onie_arch"
+TEST_CONF "$onie_build_date" "$exp_onie_build_date"
+TEST_CONF "$onie_partition_type" "$exp_onie_partition_type"
+TEST_CONF "$onie_disco_ntpsrv" "$exp_onie_disco_ntpsrv"
+TEST_CONF "$onie_firmware" "$exp_onie_firmware"
+TEST_CONF "$onie_skip_ethmgmt_macs" "$exp_onie_skip_ethmgmt_macs"
+TEST_CONF "$onie_grub_image_name" "$exp_onie_grub_image_name"
+
+echo "PASS!!"
+exit 0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Encounter error when install SONiC image if there are some onie_discovery variables assigned with multiple values inside machine.conf

**- How I did it**

Replace original ". /machine.conf" method and add another function to do the same thing.

**- How to verify it**

1. Add a item inside /host/machine.conf like `onie_disco_ntpsrv=10.254.141.10 10.254.141.131`
2. Do `sonic_installer install` to check if any error occurs

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add a new function 'read_conf_file' to read the settings from machine.conf when the value in machine.conf are separated by space without double quotes between them.

**- A picture of a cute animal (not mandatory but encouraged)**
