### PR TITLE
[baseimage]: add docker ps to the sudoer file

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -25,6 +25,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog*, \
                                  /usr/bin/docker exec bgp cat /etc/quagga/bgpd.conf, \
                                  /usr/bin/docker images *, \
                                  /usr/bin/docker ps *, \
+                                 /usr/bin/docker ps, \
                                  /usr/bin/lldpctl, \
                                  /usr/bin/sensors, \
                                  /usr/bin/tail -F /var/log/syslog, \


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"


Please provide the following information:
-->
fixes https://github.com/Azure/sonic-utilities/issues/1389
**- Why I did it**
With the recent changes in sudoer files. The  show commands fails for the read-only users. 
The problem here is the 'docker ps' is failing in the function [get_routing_stack()](https://github.com/Azure/sonic-utilities/blob/8a1109ed30576f0287fcd98a4349617f7fb55700/show/main.py#L54) therefore all the CLI commands are failing.

**- How I did it**
add `docker ps` to the sudoers file

**- How to verify it**
Verify the show commands works for read-only users
```
user_ro@vlab-01:~$ show vers

SONiC Software Version: SONiC.master.629-10436783
Distribution: Debian 10.7
Kernel: 4.19.0-9-2-amd64
Build commit: 10436783
Build date: Sat Jan 23 07:09:55 UTC 2021
Built by: johnar@jenkins-worker-23

Platform: x86_64-kvm_x86_64-r0
HwSKU: Force10-S6000
ASIC: vs
ASIC Count: 1
Serial Number: 000000
Uptime: 07:08:01 up  4:34,  2 users,  load average: 1.19, 1.44, 1.30

Docker images:
REPOSITORY                    TAG                   IMAGE ID            SIZE
docker-gbsyncd-vs             latest                82e2c12260e6        400MB
docker-gbsyncd-vs             master.629-10436783   82e2c12260e6        400MB
docker-syncd-vs               latest                71207f314ec7        400MB
docker-syncd-vs               master.629-10436783   71207f314ec7        400MB
docker-snmp                   latest                026ea286e9bb        435MB
docker-snmp                   master.629-10436783   026ea286e9bb        435MB
docker-dhcp-relay             latest                84fd5de725f2        401MB
docker-dhcp-relay             master.629-10436783   84fd5de725f2        401MB
docker-orchagent              latest                30e4634953cd        422MB
docker-orchagent              master.629-10436783   30e4634953cd        422MB
docker-teamd                  latest                51d9449a8169        404MB
docker-teamd                  master.629-10436783   51d9449a8169        404MB
docker-nat                    latest                7a6401c73949        407MB
docker-nat                    master.629-10436783   7a6401c73949        407MB
docker-router-advertiser      latest                1fbf3ed29cf4        394MB
docker-router-advertiser      master.629-10436783   1fbf3ed29cf4        394MB
docker-platform-monitor       latest                2aa1e5dd81d9        601MB
docker-platform-monitor       master.629-10436783   2aa1e5dd81d9        601MB
docker-lldp                   latest                384345f22ca3        434MB
docker-lldp                   master.629-10436783   384345f22ca3        434MB
docker-database               latest                2c0056ae1cff        394MB
docker-database               master.629-10436783   2c0056ae1cff        394MB
docker-sonic-telemetry        latest                7489e592890c        468MB
docker-sonic-telemetry        master.629-10436783   7489e592890c        468MB
docker-sonic-mgmt-framework   latest                6b7426569730        610MB
docker-sonic-mgmt-framework   master.629-10436783   6b7426569730        610MB
docker-fpm-frr                latest                44c434320bb0        422MB
docker-fpm-frr                master.629-10436783   44c434320bb0        422MB
docker-macsec                 latest                a1add9c8b374        407MB
docker-macsec                 master.629-10436783   a1add9c8b374        407MB
docker-sflow                  latest                bac784546389        405MB
docker-sflow                  master.629-10436783   bac784546389        405MB

user_ro@vlab-01:~$ show ip bgp summary

IPv4 Unicast Summary:
BGP router identifier 10.1.0.1, local AS number 65100 vrf-id 0
BGP table version 1
RIB entries 1, using 192 bytes of memory
Peers 32, using 698112 KiB of memory
Peer groups 2, using 128 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200          0          0         0      0       0  never      Active          ARISTA01T2
10.0.0.3       4  65200          0          0         0      0       0  never      Active          ARISTA02T2
10.0.0.5       4  65200          0          0         0      0       0  never      Active          ARISTA03T2
10.0.0.7       4  65200          0          0         0      0       0  never      Active          ARISTA04T2
10.0.0.9       4  65200          0          0         0      0       0  never      Active          ARISTA05T2
10.0.0.11      4  65200          0          0         0      0       0  never      Active          ARISTA06T2
10.0.0.13      4  65200          0          0         0      0       0  never      Active          ARISTA07T2
10.0.0.15      4  65200          0          0         0      0       0  never      Active          ARISTA08T2
10.0.0.17      4  65200          0          0         0      0       0  never      Active          ARISTA09T2
10.0.0.19      4  65200          0          0         0      0       0  never      Active          ARISTA10T2
10.0.0.21      4  65200          0          0         0      0       0  never      Active          ARISTA11T2
10.0.0.23      4  65200          0          0         0      0       0  never      Active          ARISTA12T2
10.0.0.25      4  65200          0          0         0      0       0  never      Active          ARISTA13T2
10.0.0.27      4  65200          0          0         0      0       0  never      Active          ARISTA14T2
10.0.0.29      4  65200          0          0         0      0       0  never      Active          ARISTA15T2
10.0.0.31      4  65200          0          0         0      0       0  never      Active          ARISTA16T2
10.0.0.33      4  64001          0          0         0      0       0  never      Active          ARISTA01T0
10.0.0.35      4  64002          0          0         0      0       0  never      Active          ARISTA02T0
10.0.0.37      4  64003          0          0         0      0       0  never      Active          ARISTA03T0
10.0.0.39      4  64004          0          0         0      0       0  never      Active          ARISTA04T0
10.0.0.41      4  64005          0          0         0      0       0  never      Active          ARISTA05T0
10.0.0.43      4  64006          0          0         0      0       0  never      Active          ARISTA06T0
10.0.0.45      4  64007          0          0         0      0       0  never      Active          ARISTA07T0
10.0.0.47      4  64008          0          0         0      0       0  never      Active          ARISTA08T0
10.0.0.49      4  64009          0          0         0      0       0  never      Active          ARISTA09T0
10.0.0.51      4  64010          0          0         0      0       0  never      Active          ARISTA10T0
10.0.0.53      4  64011          0          0         0      0       0  never      Active          ARISTA11T0
10.0.0.55      4  64012          0          0         0      0       0  never      Active          ARISTA12T0
10.0.0.57      4  64013          0          0         0      0       0  never      Active          ARISTA13T0
10.0.0.59      4  64014          0          0         0      0       0  never      Active          ARISTA14T0
10.0.0.61      4  64015          0          0         0      0       0  never      Active          ARISTA15T0
10.0.0.63      4  64016          0          0         0      0       0  never      Active          ARISTA16T0

Total number of neighbors 32
user_ro@vlab-01:~$
```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [x] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
