### PR TITLE
[BCM Config] Update BCM config with parameters to update firmware on TD3 platforms

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/td3-as7326-48x25G+8x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/td3-as7326-48x25G+8x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 #polarity/lanemap is using TH2 style.
 core_clock_frequency=1525
 dpp_clock_ratio=2:3

--- a/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/td3-as7726-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/td3-as7726-32x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 #polarity/lanemap is using TH2 style.
 core_clock_frequency=1525
 dpp_clock_ratio=2:3

--- a/device/celestica/x86_64-cel_seastone_2-r0/Seastone_2/td3-seastone_2-32x100G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone_2-r0/Seastone_2/td3-seastone_2-32x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 help_cli_enable=1
 ifp_inports_support_enable=1
 ipv6_lpm_128b_enable=0x1

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/td3-s5232f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/td3-s5232f-32x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 os=unix
 
 core_clock_frequency=1525

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/td3-s5232f-8x100G+48x50G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/td3-s5232f-8x100G+48x50G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 os=unix
 
 core_clock_frequency=1525

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/td3-s5232f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/td3-s5232f-32x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 os=unix
 
 core_clock_frequency=1525

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/td3-s5232f-96x10G+8x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/td3-s5232f-96x10G+8x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 os=unix
 
 core_clock_frequency=1525

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/td3-s5232f-96x25G+8x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/td3-s5232f-96x25G+8x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 os=unix
 
 core_clock_frequency=1525

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-10G/td3-s5248f-10g.config.bcm
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-10G/td3-s5248f-10g.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 os=unix
 dpp_clock_ratio=2:3
 oversubscribe_mode=1

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/td3-s5248f-25g.config.bcm
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/td3-s5248f-25g.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 os=unix
 
 dpp_clock_ratio=2:3

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-10G/td3-s5296f-10g.config.bcm
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-10G/td3-s5296f-10g.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 os=unix
 portmap_5.0=5:10
 portmap_6.0=6:10

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-25G/td3-s5296f-25g.config.bcm
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-25G/td3-s5296f-25g.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 os=unix
 portmap_5.0=5:25
 portmap_6.0=6:25

--- a/device/delta/x86_64-delta_ag9032v2a-r0/Delta-ag9032v2a/td3-ag9032v2a-32x100G+1x10G.config.bcm
+++ b/device/delta/x86_64-delta_ag9032v2a-r0/Delta-ag9032v2a/td3-ag9032v2a-32x100G+1x10G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 pbmp_oversubscribe=0x00003fc000000ff0000003fc000001fe
 pbmp_xport_xe=0xffffffffffffffffffffffffffffffffffff
 core_clock_frequency=1525

--- a/device/inventec/x86_64-inventec_d6332-r0/INVENTEC-D6332/td3-d6332-32x100G-SR4.config.bcm
+++ b/device/inventec/x86_64-inventec_d6332-r0/INVENTEC-D6332/td3-d6332-32x100G-SR4.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 ### fix for sonic
 ptp_ts_pll_fref=50000000
 ptp_bs_fref_0=50000000

--- a/device/inventec/x86_64-inventec_d6356-r0/INVENTEC-D6356/td3-d6356-48x25G-8x100G.config.bcm
+++ b/device/inventec/x86_64-inventec_d6356-r0/INVENTEC-D6356/td3-d6356-48x25G-8x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 ### fix for sonic
 ptp_ts_pll_fref=50000000
 ptp_bs_fref_0=50000000

--- a/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/td3-ix7-32x100G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/td3-ix7-32x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 bcm_tunnel_term_compatible_mode=1
 core_clock_frequency=1525
 dpp_clock_ratio=2:3

--- a/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/td3-ix8-48x25G+8x100G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/td3-ix8-48x25G+8x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 bcm_tunnel_term_compatible_mode=1
 core_clock_frequency=1525
 dpp_clock_ratio=2:3

--- a/device/quanta/x86_64-quanta_ix8c_bwde-r0/Quanta-IX8C-56X/td3-ix8c-48x25G+8x100G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix8c_bwde-r0/Quanta-IX8C-56X/td3-ix8c-48x25G+8x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 bcm_tunnel_term_compatible_mode=1
 core_clock_frequency=1525
 dpp_clock_ratio=2:3


### PR DESCRIPTION
**- Why I did it**

BRCM SDK 6.5.21 includes firmware updates (premier cancun) for TD3 platforms. The firmware update is required on TD3 platforms, which is packaged with BCMSAI 4.3.0.10.

**- How I did it**

Updated BCM config with a new variable that specifies the firmware package path. SDK uses this path to locate firmware packages and load during cold boot.

**- How to verify it**

```
 
bsv
BRCM SAI ver: [4.3.0.10], OCP SAI ver: [1.7.1], SDK ver: [sdk-6.5.21] CANCUN ver: [5.3.3]
drivshell>
admin@str2-7050cx3-acs-02:~$ bcmsh
Press Enter to show prompt.
Press Ctrl+C to exit.
NOTICE: Only one bcmsh or bcmcmd can connect to the shell at same time.
 
 
 
drivshell>cancun stat
cancun stat
UNIT0 CANCUN:
        CIH: LOADED
        Ver: 06.06.01
 
        CMH: LOADED
        Ver: 06.06.01
        SDK Ver: 06.05.21
 
        CCH: LOADED
       Ver: 06.06.01
        SDK Ver: 06.05.21
 
        CEH: LOADED
        Ver: 06.06.01
        SDK Ver: 06.05.21
 
drivshell>
```

**- Which release branch to backport (provide reason below if selected)**


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
Update BCM config for TD3 platforms.

**- A picture of a cute animal (not mandatory but encouraged)**
