### PR TITLE
[platform][barefoot] Fix sonic_platform for x86_64-accton_wedge100bf_65x-r0

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn/debian/rules
+++ b/platform/barefoot/sonic-platform-modules-bfn/debian/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 
+PLATFORM_NAME := x86_64-accton_wedge100bf_65x-r0
 PACKAGE_NAME := sonic-platform-modules-bfn
 SCRIPT_SRC := $(shell pwd)/scripts
 CONFIGS_SRC := $(shell pwd)/configs
@@ -20,6 +21,8 @@ override_dh_auto_install:
 	cp -r $(SCRIPT_SRC)/* debian/$(PACKAGE_NAME)/usr/local/bin
 	dh_installdirs -p$(PACKAGE_NAME) etc/network/interfaces.d/
 	cp -r $(CONFIGS_SRC)/network/interfaces.d/* debian/$(PACKAGE_NAME)/etc/network/interfaces.d/
+	dh_installdirs -p$(PACKAGE_NAME) usr/share/sonic/device/$(PLATFORM_NAME)/
+	cp -r $(WHEEL_BUILD_DIR)/*  debian/$(PACKAGE_NAME)/usr/share/sonic/device/$(PLATFORM_NAME)/
 
 override_dh_usrlocal:
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
platform modules' deb package rules for x86_64-accton_wedge100bf_65x-r0 was missing the code that installs the sonic_platform wheel package file under device directory on host (which is checked by pmon deamon on start)
**- How I did it**
Added the required code
**- How to verify it**
install the package
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
