### PR TITLE
[kvm]: increase the pexpect timeout from 30 to 60 seconds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,7 @@ stages:
     timeoutInMinutes: 600
     steps:
     - checkout: self
+      clean: true
       submodules: recursive
       displayName: 'Checkout code'
     - script: |
@@ -55,6 +56,7 @@ stages:
     timeoutInMinutes: 600
     steps:
     - checkout: self
+      clean: true
       submodules: recursive
       displayName: 'Checkout code'
 
@@ -80,6 +82,7 @@ stages:
     timeoutInMinutes: 600
     steps:
     - checkout: self
+      clean: true
       submodules: recursive
       displayName: 'Checkout code'
 

--- a/check_install.py
+++ b/check_install.py
@@ -58,6 +58,8 @@ def main():
 
     # check version
     time.sleep(5)
+    p.sendline('uptime')
+    p.expect([cmd_prompt])
     p.sendline('show version')
     p.expect([cmd_prompt])
     p.sendline('show ip bgp sum')

--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -48,6 +48,7 @@ prepare_installer_disk()
     umount $tmpdir
 }
 
+apt-get install -y net-tools
 create_disk
 prepare_installer_disk
 


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
increase the pexpect timeout from 30 to 60 seconds

**- How I did it**
follow three commits:
* 006764bb 2021-01-30 | [ci]: cleanup source directory upon checkout (HEAD -> kvm, lgh/kvm) [Guohan Lu]
* 6481c225 2021-01-30 | [kvm]: install net-tools package for debug [Guohan Lu]
* 3ffa352a 2021-01-29 | [ci]: reset the repo (origin/master, origin/HEAD, master) [Guohan Lu]

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
