### PR TITLE
Update minigraph.py to parse kubernetes config from minigraph.xml

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -815,7 +815,7 @@ def parse_meta(meta, hname):
                 elif name == "ResourceType":
                     resource_type = value
                 elif name == "KubernetesEnabled":
-                    kube_data["disable"] = value
+                    kube_data["enable"] = value
                 elif name == "KubernetesServerIp":
                     kube_data["ip"] = value
     return syslog_servers, dhcp_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, kube_data
@@ -1191,7 +1191,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
 
     if kube_data:
         results['KUBERNETES_MASTER'] = { 'SERVER': {
-            'disable': 'True' if kube_data.get('disable', '0') == '0' else 'False',
+            'disable': 'True' if kube_data.get('enable', '0') == '0' else 'False',
             'ip': kube_data.get('ip', '')
             }
         }

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1190,9 +1190,10 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         results['DEVICE_METADATA']['localhost']['cluster'] = cluster
 
     if kube_data:
-        results['KUBERNETES_MASTER'] = { 'SERVER': {
-            'disable': str(kube_data.get('enable', '0') == '0'),
-            'ip': kube_data.get('ip', '')
+        results['KUBERNETES_MASTER'] = {
+            'SERVER': {
+                'disable': str(kube_data.get('enable', '0') == '0'),
+                'ip': kube_data.get('ip', '')
             }
         }
 

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1191,7 +1191,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
 
     if kube_data:
         results['KUBERNETES_MASTER'] = { 'SERVER': {
-            'disable': 'True' if kube_data.get('enable', '0') == '0' else 'False',
+            'disable': str(kube_data.get('enable', '0') == '0'),
             'ip': kube_data.get('ip', '')
             }
         }

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -390,6 +390,16 @@
      <a:Reference i:nil="true"/>
      <a:Value>10.0.10.7;10.0.10.8</a:Value>
     </a:DeviceProperty>
+    <a:DeviceProperty>
+     <a:Name>KubernetesEnabled</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>0</a:Value>
+    </a:DeviceProperty>
+    <a:DeviceProperty>
+     <a:Name>KubernetesServerIp</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>10.10.10.10</a:Value>
+    </a:DeviceProperty>
   </a:Properties>
   </a:DeviceMetadata>
  </Devices>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -146,6 +146,11 @@ class TestCfgGenCaseInsensitive(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "1")
 
+    def test_minigraph_cluster(self):
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "DEVICE_METADATA[\'localhost\'][\'cluster\']"'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), "AAA00PrdStr00")
+
     def test_minigraph_neighbor_metadata(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "DEVICE_NEIGHBOR_METADATA"'
 

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 
@@ -194,6 +195,12 @@ class TestCfgGenCaseInsensitive(TestCase):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "TACPLUS_SERVER"'
         output = self.run_script(argument)
         self.assertEqual(output.strip(), "{'10.0.10.7': {'priority': '1', 'tcp_port': '49'}, '10.0.10.8': {'priority': '1', 'tcp_port': '49'}}")
+
+    def test_metadata_kube(self):
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "KUBERNETES_MASTER[\'SERVER\']"'
+        output = self.run_script(argument)
+        self.assertEqual(json.loads(output.strip().replace("'", "\"")),
+                json.loads('{"ip": "10.10.10.10", "disable": "True"}'))
 
     def test_minigraph_mgmt_port(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "MGMT_PORT"'

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -301,4 +301,3 @@ class TestCfgGenCaseInsensitive(TestCase):
             utils.to_dict(output.strip()),
             expected_table
         )
-        


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
To make  the kubernetes server IP & enabled/disabled status configurable through minigraph.
Saved cluster name into "DEVICE_METADATA|localhost" , so this can be available for kubernetes use.

**- How I did it**
Updated the parser (minigraph.py) to get it from MetadataDeclaration/Devices/DeviceMetadata section for this device.
Add to "DEVICE_METADATA|localhost" , if ClusterName is available in PngDec/Devices/Device for localhost

**- How to verify it**
Unit test is added to parse & test out.
For manual test add the following to MetadataDeclaration/Devices/DeviceMetadata section. call "config load_minigraph" and verify through "show kube server config"

Look for "DEVICE_METADATA": { "localhost": { ... "cluster": "<this device cluster name", ...}}, if minigraph.xml does carry it in JSON dump or /etc/sonic/config_db.json

```
<a:DeviceProperty>
<a:Name>KubernetesEnabled</a:Name>
<a:Reference i:nil="true"/>
<a:Value>0</a:Value>
</a:DeviceProperty>
<a:DeviceProperty>
<a:Name>KubernetesServerIp</a:Name>
<a:Reference i:nil="true"/>
<a:Value>10.10.10.10</a:Value>
</a:DeviceProperty>
```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
