### PR TITLE
[port_config.ini] 7050CX3-32S-C32: Remove unused 10G ports and update speed

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/port_config.ini
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/port_config.ini
@@ -1,35 +1,33 @@
-# name          lanes             alias         index
-Ethernet0       1,2,3,4           Ethernet1/1    1
-Ethernet4       5,6,7,8           Ethernet2/1    2
-Ethernet8       9,10,11,12        Ethernet3/1    3
-Ethernet12      13,14,15,16       Ethernet4/1    4
-Ethernet16      21,22,23,24       Ethernet5/1    5
-Ethernet20      17,18,19,20       Ethernet6/1    6
-Ethernet24      25,26,27,28       Ethernet7/1    7
-Ethernet28      29,30,31,32       Ethernet8/1    8
-Ethernet32      37,38,39,40       Ethernet9/1    9
-Ethernet36      33,34,35,36       Ethernet10/1  10
-Ethernet40      41,42,43,44       Ethernet11/1  11
-Ethernet44      45,46,47,48       Ethernet12/1  12
-Ethernet48      53,54,55,56       Ethernet13/1  13
-Ethernet52      49,50,51,52       Ethernet14/1  14
-Ethernet56      57,58,59,60       Ethernet15/1  15
-Ethernet60      61,62,63,64       Ethernet16/1  16
-Ethernet64      69,70,71,72       Ethernet17/1  17
-Ethernet68      65,66,67,68       Ethernet18/1  18
-Ethernet72      73,74,75,76       Ethernet19/1  19
-Ethernet76      77,78,79,80       Ethernet20/1  20
-Ethernet80      85,86,87,88       Ethernet21/1  21
-Ethernet84      81,82,83,84       Ethernet22/1  22
-Ethernet88      89,90,91,92       Ethernet23/1  23
-Ethernet92      93,94,95,96       Ethernet24/1  24
-Ethernet96      101,102,103,104   Ethernet25/1  25
-Ethernet100     97,98,99,100      Ethernet26/1  26
-Ethernet104     105,106,107,108   Ethernet27/1  27
-Ethernet108     109,110,111,112   Ethernet28/1  28
-Ethernet112     117,118,119,120   Ethernet29/1  29
-Ethernet116     113,114,115,116   Ethernet30/1  30
-Ethernet120     121,122,123,124   Ethernet31/1  31
-Ethernet124     125,126,127,128   Ethernet32/1  32
-Ethernet128     129               Ethernet33    33
-Ethernet132     128               Ethernet34    34
+# name          lanes             alias         index  speed
+Ethernet0       1,2,3,4           Ethernet1/1    1     100000 
+Ethernet4       5,6,7,8           Ethernet2/1    2     100000
+Ethernet8       9,10,11,12        Ethernet3/1    3     100000
+Ethernet12      13,14,15,16       Ethernet4/1    4     100000
+Ethernet16      21,22,23,24       Ethernet5/1    5     100000
+Ethernet20      17,18,19,20       Ethernet6/1    6     100000
+Ethernet24      25,26,27,28       Ethernet7/1    7     100000
+Ethernet28      29,30,31,32       Ethernet8/1    8     100000
+Ethernet32      37,38,39,40       Ethernet9/1    9     100000
+Ethernet36      33,34,35,36       Ethernet10/1  10     100000
+Ethernet40      41,42,43,44       Ethernet11/1  11     100000
+Ethernet44      45,46,47,48       Ethernet12/1  12     100000
+Ethernet48      53,54,55,56       Ethernet13/1  13     100000
+Ethernet52      49,50,51,52       Ethernet14/1  14     100000
+Ethernet56      57,58,59,60       Ethernet15/1  15     100000
+Ethernet60      61,62,63,64       Ethernet16/1  16     100000
+Ethernet64      69,70,71,72       Ethernet17/1  17     100000
+Ethernet68      65,66,67,68       Ethernet18/1  18     100000
+Ethernet72      73,74,75,76       Ethernet19/1  19     100000
+Ethernet76      77,78,79,80       Ethernet20/1  20     100000
+Ethernet80      85,86,87,88       Ethernet21/1  21     100000
+Ethernet84      81,82,83,84       Ethernet22/1  22     100000
+Ethernet88      89,90,91,92       Ethernet23/1  23     100000
+Ethernet92      93,94,95,96       Ethernet24/1  24     100000
+Ethernet96      101,102,103,104   Ethernet25/1  25     100000
+Ethernet100     97,98,99,100      Ethernet26/1  26     100000
+Ethernet104     105,106,107,108   Ethernet27/1  27     100000
+Ethernet108     109,110,111,112   Ethernet28/1  28     100000
+Ethernet112     117,118,119,120   Ethernet29/1  29     100000
+Ethernet116     113,114,115,116   Ethernet30/1  30     100000
+Ethernet120     121,122,123,124   Ethernet31/1  31     100000
+Ethernet124     125,126,127,128   Ethernet32/1  32     100000


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->
`port_config.ini` for HWSKU `Arista-7050CX3-32S-C32` has missing speed column and duplicated lanes.
The incorrect speed causes issues in Orchagent RESTARTCHECK as the below task remains as the remaining item during swss shutdown.

**- Why I did it**
Fixes: https://github.com/Azure/sonic-buildimage/issues/6569

**- How I did it**
Updated port_config.ini file with speed, and removed duplicated lanes.

**- How to verify it**
Generated new minigraph, and installed it on a 7050CX3 device, the RESTARTCHECK passes and warm-reboot proceeds.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
