### PR TITLE
[platform][barefoot] Install sonic_platform to host

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/debian/postinst
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/debian/postinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+PLATFORM_NAME=x86_64-accton_wedge100bf_32x-r0
+SONIC_PLATFORM_WHEEL_PY2="/usr/share/sonic/device/${PLATFORM_NAME}/sonic_platform-1.0-py2-none-any.whl"
+python2 -m pip install ${SONIC_PLATFORM_WHEEL_PY2}
+SONIC_PLATFORM_WHEEL_PY3="/usr/share/sonic/device/${PLATFORM_NAME}/sonic_platform-1.0-py3-none-any.whl"
+python3 -m pip install ${SONIC_PLATFORM_WHEEL_PY3}
+
+#DEBHELPER#

--- a/platform/barefoot/sonic-platform-modules-bfn-newport/debian/postinst
+++ b/platform/barefoot/sonic-platform-modules-bfn-newport/debian/postinst
@@ -1,6 +1,27 @@
 #!/bin/sh
 set -e
-depmod -a 
+depmod -a
 systemctl enable bfn-newport.service
 systemctl start bfn-newport.service
+
+PLATFORM_NAME=x86_64-accton_as9516bf_32d-r0
+SONIC_PLATFORM_WHEEL_PY2="/usr/share/sonic/device/${PLATFORM_NAME}/sonic_platform-1.0-py2-none-any.whl"
+if [ -e ${SONIC_PLATFORM_WHEEL_PY2} ]; then
+    python2 -m pip install ${SONIC_PLATFORM_WHEEL_PY2}
+fi
+SONIC_PLATFORM_WHEEL_PY3="/usr/share/sonic/device/${PLATFORM_NAME}/sonic_platform-1.0-py3-none-any.whl"
+if [ -e ${SONIC_PLATFORM_WHEEL_PY3} ]; then
+    python3 -m pip install ${SONIC_PLATFORM_WHEEL_PY3}
+fi
+
+PLATFORM_NAME=x86_64-accton_as9516_32d-r0
+SONIC_PLATFORM_WHEEL_PY2="/usr/share/sonic/device/${PLATFORM_NAME}/sonic_platform-1.0-py2-none-any.whl"
+if [ -e ${SONIC_PLATFORM_WHEEL_PY2} ]; then
+    python2 -m pip install ${SONIC_PLATFORM_WHEEL_PY2}
+fi
+SONIC_PLATFORM_WHEEL_PY3="/usr/share/sonic/device/${PLATFORM_NAME}/sonic_platform-1.0-py3-none-any.whl"
+if [ -e ${SONIC_PLATFORM_WHEEL_PY3} ]; then
+    python3 -m pip install ${SONIC_PLATFORM_WHEEL_PY3}
+fi
+
 #DEBHELPER#

--- a/platform/barefoot/sonic-platform-modules-bfn/debian/postinst
+++ b/platform/barefoot/sonic-platform-modules-bfn/debian/postinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+PLATFORM_NAME=x86_64-accton_wedge100bf_65x-r0
+SONIC_PLATFORM_WHEEL_PY2="/usr/share/sonic/device/${PLATFORM_NAME}/sonic_platform-1.0-py2-none-any.whl"
+python2 -m pip install ${SONIC_PLATFORM_WHEEL_PY2}
+SONIC_PLATFORM_WHEEL_PY3="/usr/share/sonic/device/${PLATFORM_NAME}/sonic_platform-1.0-py3-none-any.whl"
+python3 -m pip install ${SONIC_PLATFORM_WHEEL_PY3}
+
+#DEBHELPER#


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
SONiC design requires sonic_platform package to be installed in SONiC host environment, not only in docker containers.
**- How I did it**
For now, sonic_platform python wheel package, that is used by pmon, is provided via device-specific platform modules deb packages that unpacks the wheel package file into specific device's directory on lazy-install.
The PR makes deb packages' postinst script also install these unpacked wheel packages to host.
**- How to verify it**
python3 -c "import sonic_platform" should succeed when running on host.
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
