### PR TITLE
[teamd] Increase wait timeout for teamd docker stop to clean Port channels

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -366,7 +366,12 @@ wait() {
 }
 
 stop() {
+{%- if docker_container_name == "teamd" %}
+    # Longer timeout of 60 sec to wait for Portchannels to be cleaned.
+    docker stop -t 60 {{docker_container_name}}$DEV
+{%- else %}
     docker stop {{docker_container_name}}$DEV
+{%- endif %}
 {%- if docker_container_name == "database" %}
     if [ "$DEV" ]; then 
         ip netns delete "$NET_NS"


### PR DESCRIPTION
**- Why I did it**
Put the fix https://github.com/Azure/sonic-buildimage/pull/6537 in 201911.

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
