### PR TITLE
[ci] Archive compiled Debian packages and Python wheels

### DIFF
--- a/.artifactignore
+++ b/.artifactignore
@@ -5,4 +5,8 @@
 !target/docker-sonic-vs.gz
 !target/docker-ptf.gz
 !target/debs/**/*.deb
+!target/debs/**/*.deb.log
+!target/debs/**/*.deb-install.log
 !target/python-wheels/*.whl
+!target/python-wheels/*.whl.log
+!target/python-wheels/*.whl-install.log

--- a/.artifactignore
+++ b/.artifactignore
@@ -4,3 +4,5 @@
 !target/*.img.gz
 !target/docker-sonic-vs.gz
 !target/docker-ptf.gz
+!target/debs/**/*.deb
+!target/python-wheels/*.whl


### PR DESCRIPTION
Archive compiled Debian packages and Python wheels so that the artifacts can be downloaded and used by other pipelines.
Also archive related log files.