### PR TITLE
[BCM Config] Update TD3 bcm.config files to use ISSU capable premium CANCUN 6.4.1

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/td3-as7326-48x25G+8x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/td3-as7326-48x25G+8x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 #polarity/lanemap is using TH2 style.
 core_clock_frequency=1525
 dpp_clock_ratio=2:3

--- a/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/td3-as7726-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/td3-as7726-32x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 #polarity/lanemap is using TH2 style.
 core_clock_frequency=1525
 dpp_clock_ratio=2:3

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 host_as_route_disable=1
 use_all_splithorizon_groups=1
 riot_enable=1
@@ -7,7 +8,6 @@ riot_overlay_l3_egress_mem_size=32768
 l3_ecmp_levels=3
 riot_overlay_ecmp_resilient_hash_size=16384
 flow_init_mode=1
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2
 bcm_num_cos=10

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 host_as_route_disable=1
 use_all_splithorizon_groups=1
 riot_enable=1
@@ -7,7 +8,6 @@ riot_overlay_l3_egress_mem_size=32768
 l3_ecmp_levels=3
 riot_overlay_ecmp_resilient_hash_size=16384
 flow_init_mode=1
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2
 bcm_num_cos=8

--- a/device/celestica/x86_64-cel_seastone_2-r0/Seastone_2/td3-seastone_2-32x100G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone_2-r0/Seastone_2/td3-seastone_2-32x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 help_cli_enable=1
 ifp_inports_support_enable=1
 ipv6_lpm_128b_enable=0x1

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/td3-s5232f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/td3-s5232f-32x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 os=unix
 
 core_clock_frequency=1525

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/td3-s5232f-8x100G+48x50G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/td3-s5232f-8x100G+48x50G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 os=unix
 
 core_clock_frequency=1525

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/td3-s5232f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/td3-s5232f-32x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 os=unix
 
 core_clock_frequency=1525

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/td3-s5232f-96x10G+8x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/td3-s5232f-96x10G+8x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 os=unix
 
 core_clock_frequency=1525

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/td3-s5232f-96x25G+8x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/td3-s5232f-96x25G+8x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 os=unix
 
 core_clock_frequency=1525

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-10G/td3-s5248f-10g.config.bcm
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-10G/td3-s5248f-10g.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 os=unix
 dpp_clock_ratio=2:3
 oversubscribe_mode=1

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/td3-s5248f-25g.config.bcm
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/td3-s5248f-25g.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 os=unix
 
 dpp_clock_ratio=2:3

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-10G/td3-s5296f-10g.config.bcm
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-10G/td3-s5296f-10g.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 os=unix
 portmap_5.0=5:10
 portmap_6.0=6:10

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-25G/td3-s5296f-25g.config.bcm
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-25G/td3-s5296f-25g.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 os=unix
 portmap_5.0=5:25
 portmap_6.0=6:25

--- a/device/delta/x86_64-delta_ag9032v2a-r0/Delta-ag9032v2a/td3-ag9032v2a-32x100G+1x10G.config.bcm
+++ b/device/delta/x86_64-delta_ag9032v2a-r0/Delta-ag9032v2a/td3-ag9032v2a-32x100G+1x10G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 pbmp_oversubscribe=0x00003fc000000ff0000003fc000001fe
 pbmp_xport_xe=0xffffffffffffffffffffffffffffffffffff
 core_clock_frequency=1525

--- a/device/inventec/x86_64-inventec_d6332-r0/INVENTEC-D6332/td3-d6332-32x100G-SR4.config.bcm
+++ b/device/inventec/x86_64-inventec_d6332-r0/INVENTEC-D6332/td3-d6332-32x100G-SR4.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 ### fix for sonic
 ptp_ts_pll_fref=50000000
 ptp_bs_fref_0=50000000

--- a/device/inventec/x86_64-inventec_d6356-r0/INVENTEC-D6356/td3-d6356-48x25G-8x100G.config.bcm
+++ b/device/inventec/x86_64-inventec_d6356-r0/INVENTEC-D6356/td3-d6356-48x25G-8x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 ### fix for sonic
 ptp_ts_pll_fref=50000000
 ptp_bs_fref_0=50000000

--- a/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/td3-ix7-32x100G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/td3-ix7-32x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 bcm_tunnel_term_compatible_mode=1
 core_clock_frequency=1525
 dpp_clock_ratio=2:3

--- a/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/td3-ix8-48x25G+8x100G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/td3-ix8-48x25G+8x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 bcm_tunnel_term_compatible_mode=1
 core_clock_frequency=1525
 dpp_clock_ratio=2:3

--- a/device/quanta/x86_64-quanta_ix8c_bwde-r0/Quanta-IX8C-56X/td3-ix8c-48x25G+8x100G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix8c_bwde-r0/Quanta-IX8C-56X/td3-ix8c-48x25G+8x100G.config.bcm
@@ -1,4 +1,4 @@
-sai_load_hw_config=/etc/bcm/flex/bcm56870_a0/b870.6.6.1/
+sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 bcm_tunnel_term_compatible_mode=1
 core_clock_frequency=1525
 dpp_clock_ratio=2:3


### PR DESCRIPTION
**- Why I did it**
BRCM SDK 6.5.21 includes firmware updates (premier cancun ISSU capable version 6.4.1) for TD3 platforms. The firmware update is required on TD3 platforms, which is packaged with BCMSAI 4.3.0.10.  

**- How I did it**
Update all TD3 based bcm.config files to use the ISSU capable Premium Cancun version 6.4.1

**- How to verify it**
```
drivshell>cancun stat
cancun stat
UNIT0 CANCUN:
        CIH: LOADED
        Ver: 06.04.01

        CMH: LOADED
        Ver: 06.04.01
        SDK Ver: 06.05.21

        CCH: LOADED
        Ver: 06.04.01
        SDK Ver: 06.05.21

        CEH: LOADED
        Ver: 06.04.01
        SDK Ver: 06.05.21

        CFH: LOADED
        Ver: 06.04.01
```

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
[BCM Config] Update TD3 bcm.config files to use ISSU capable premium CANCUN 6.4.1
