### PR TITLE
BRCM SAI 4.3.0.10-4 Fix _brcm_sai_indexed_data_get () with unexpected  queue causing _brcm_sai_switch_assert () after warm reboot

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_4.3.0.10-3_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm_4.3.0.10-3_amd64.deb?sv=2015-04-05&sr=b&sig=snXITt%2BRq2cKD7I%2Bqr2WCbj1Ly%2FB2NM8EW3R7wc%2B1ME%3D&se=2034-10-10T06%3A30%3A07Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_4.3.0.10-3_amd64.deb
+BRCM_SAI = libsaibcm_4.3.0.10-4_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm_4.3.0.10-4_amd64.deb?sv=2015-04-05&sr=b&sig=nfseU56PACVqklQ4MC0HvZ7qt7Ou4loQMBA7jx8CSOY%3D&se=2034-10-13T16%3A31%3A22Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_4.3.0.10-4_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm-dev_4.3.0.10-3_amd64.deb?sv=2015-04-05&sr=b&sig=%2BfGcnKeMApru1b8aebMHT68zEc%2BCn%2BTcC27izdHNrlA%3D&se=2034-10-10T06%3A30%3A44Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm-dev_4.3.0.10-4_amd64.deb?sv=2015-04-05&sr=b&sig=4tF26GxI6jmrcvRyCezQ7RL6qMjzip7SFf61eqy%2Bvf4%3D&se=2034-10-13T16%3A31%3A53Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
**- Why I did it**
Porting the same workaround frix from BRCM SAI 4.2.1.5-9 to SAI 4.3.0.10-4 to address the same WARM Reboot SYNCd crash issue.
See (https://github.com/Azure/sonic-buildimage/pull/6374)

A case has filed with BRCM. We are porting this change in master branch that has moved on to SAI 4.3.0.10 release so that it will allow further feature validation/testing especially in the warm reboot area.
Once an official fix is provided by BRCM, we will then remove this in house fix and apply the official fix.

This PR fixes (https://github.com/Azure/sonic-buildimage/issues/6655)

**- How to verify it**
Just perform warm reboot with any master code prior to this PR you should see SYNCd crash issue with something as the following in the syslog:
```
Feb 2 19:56:56.585774 str-s6100-acs-2 CRIT syncd#syncd: [none] SAI_API_SWITCH:_brcm_sai_switch_assert:558 ERROR: Assertion failed: (index[1] < __brcm_sai_index2_max[type].max2) at /__w/1/s/src/arch/brcm_sai_data_mgr.c:16869
```

**- Which release branch to backport (provide reason below if selected)**

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012

**- Description for the changelog**
BRCM SAI 4.3.0.10-4 Fix _brcm_sai_indexed_data_get () with unexpected  queue causing _brcm_sai_switch_assert () after warm reboot
