### PR TITLE
[StreamingTelemetry] add 'runInHttpMode' flag in telemetry config

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1454,7 +1454,8 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             'server_crt': '/etc/sonic/telemetry/streamingtelemetryserver.cer',
             'server_key': '/etc/sonic/telemetry/streamingtelemetryserver.key',
             'ca_crt': '/etc/sonic/telemetry/dsmsroot.cer'
-        }
+        },
+        'runInHttpMode': 'false'
     }
     results['RESTAPI'] = {
         'config': {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
This is to support BSL scenario using streaming telemetry. In case of BSL this flag will be set to true and streamingtelemetry c# client inside ANPLean package can get device information over http.
Next task will be to change telemetry docker script to start in http mode when this flag is true
**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [- ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
