### PR TITLE
[pcie-check] Fix incorrect subcommand of pcieutil in pcie-check.sh

### DIFF
--- a/files/image_config/pcie-check/pcie-check.sh
+++ b/files/image_config/pcie-check/pcie-check.sh
@@ -16,7 +16,7 @@ function debug()
 
 function check_and_rescan_pcie_devices()
 {
-    PCIE_CHK_CMD='sudo pcieutil pcie-check |grep "$RESULTS"'
+    PCIE_CHK_CMD='sudo pcieutil check |grep "$RESULTS"'
     PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 
     if [ ! -f /usr/share/sonic/device/$PLATFORM/plugins/pcie.yaml ]; then


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fix #6676 
PR #1297 removes redundant 'pcie-' prefix from subcommands. However, ```pcie-check.sh``` script is not updated yet. So errors are reported.
```
 3253 Feb  3 23:07:17.736780 str-7260cx3-acs-2 INFO pcie-check.sh[1001]: Usage: pcieutil [OPTIONS] COMMAND [ARGS]...                                                                                   
 3254 Feb  3 23:07:17.736922 str-7260cx3-acs-2 INFO pcie-check.sh[1001]: Try "pcieutil --help" for help.
 3255 Feb  3 23:07:17.737276 str-7260cx3-acs-2 INFO pcie-check.sh[1001]: Error: No such command "pcie-check".
```

**- How I did it**
Fix incorrect subcommand. ```pcie-check``` -> ```check```.

**- How to verify it**
Verified on A7260. No errors are seen, and pcie-check passed.
```
Feb  4 02:33:43.626555 str-7260cx3-acs-2 NOTICE admin: /usr/bin/pcie-check.sh : PCIe check passed
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix incorrect subcommand of pcieutil in pcie-check.sh

**- A picture of a cute animal (not mandatory but encouraged)**
