### PR TITLE
Fix syncd dpkg cache dependency issue

### DIFF
--- a/platform/broadcom/docker-syncd-brcm.dep
+++ b/platform/broadcom/docker-syncd-brcm.dep
@@ -1,6 +1,6 @@
 #DPKG FRK
 DPATH       := $($(DOCKER_SYNCD_BASE)_PATH)
-DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/broadcom/docker-syncd-brcm.mk platform/broadcom/docker-syncd-brcm.dep   
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/broadcom/docker-syncd-brcm.mk platform/broadcom/docker-syncd-brcm.dep platform/broadcom/sai.mk 
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/mellanox/docker-syncd-mlnx.dep
+++ b/platform/mellanox/docker-syncd-mlnx.dep
@@ -1,7 +1,7 @@
 # DPKG FRK
 
 DPATH := $($(DOCKER_SYNCD_BASE)_PATH)
-DEP_FILES := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/docker-syncd-mlnx.mk $(PLATFORM_PATH)/docker-syncd-mlnx.dep
+DEP_FILES := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/docker-syncd-mlnx.mk $(PLATFORM_PATH)/docker-syncd-mlnx.dep platform/mellanox/mlnx-sai.mk
 DEP_FILES += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES += $(shell git ls-files -- $(DPATH))
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
The docker image docker-syncd-brcm.gz not use the right libsai.

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
