### PR TITLE
[pcie-check] Update underlying pcieutil command and add to sudoers file

### DIFF
--- a/files/image_config/pcie-check/pcie-check.sh
+++ b/files/image_config/pcie-check/pcie-check.sh
@@ -16,11 +16,11 @@ function debug()
 
 function check_and_rescan_pcie_devices()
 {
-    PCIE_CHK_CMD='sudo pcieutil pcie-check |grep "$RESULTS"'
+    PCIE_CHK_CMD='sudo pcieutil check | grep "$RESULTS"'
     PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 
     if [ ! -f /usr/share/sonic/device/$PLATFORM/plugins/pcie.yaml ]; then
-        debug "pcie.yaml does not exist! can't check pcie status!"
+        debug "pcie.yaml does not exist! Can't check PCIe status!"
         exit
     fi
 

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -34,6 +34,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog*, \
                                  /usr/local/bin/decode-syseeprom, \
                                  /usr/local/bin/generate_dump, \
                                  /usr/local/bin/lldpshow, \
+                                 /usr/local/bin/pcieutil *, \
                                  /usr/local/bin/psuutil *, \
                                  /usr/local/bin/sonic-installer list, \
                                  /usr/local/bin/sfputil show *, \


### PR DESCRIPTION
**- Why I did it**

As of https://github.com/Azure/sonic-utilities/pull/1297, subcommands of pcieutil have changed to remove the redundant `pcie-` prefix. This PR adapts calling applications (pcie-check) to the new syntax.

Resolves https://github.com/Azure/sonic-buildimage/issues/6676

**- How I did it**

- Remove `pcie-` prefix from pcieutil subcommands in calling applications
- Also add `pcieutil *` to sudoers file, as pcieutil requires elevated permissions

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
