### PR TITLE
[syncd-rpc] Install Libboost Atomic 1.71, Libqtcore And Libqtnetwork

### DIFF
--- a/platform/barefoot/docker-syncd-bfn-rpc/Dockerfile.j2
+++ b/platform/barefoot/docker-syncd-bfn-rpc/Dockerfile.j2
@@ -11,11 +11,6 @@ debs/
 
 RUN apt-get purge -y syncd
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_bfn_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
 ## Pre-install the fundamental packages
 RUN apt-get update \
  && apt-get -y install  \
@@ -28,8 +23,16 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
-    libpython3.4        \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_bfn_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \
@@ -50,5 +53,5 @@ RUN apt-get update \
  && rm -rf /root/deps
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
- 
+
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
@@ -28,6 +28,7 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
+    libboost-atomic1.71.0 \
  && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \

--- a/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2
@@ -11,11 +11,6 @@ debs/
 
 RUN apt-get purge -y syncd
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_brcm_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
 ## Pre-install the fundamental packages
 RUN apt-get update \
  && apt-get -y install  \
@@ -28,8 +23,16 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
-    libboost-atomic1.71.0 \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_brcm_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \

--- a/platform/cavium/docker-syncd-cavm-rpc/Dockerfile.j2
+++ b/platform/cavium/docker-syncd-cavm-rpc/Dockerfile.j2
@@ -11,11 +11,6 @@ debs/
 
 RUN apt-get purge -y syncd
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_cavm_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
 ## Pre-install the fundamental packages
 RUN apt-get update \
  && apt-get -y install  \
@@ -27,7 +22,16 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_cavm_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \

--- a/platform/centec-arm64/docker-syncd-centec-rpc/Dockerfile.j2
+++ b/platform/centec-arm64/docker-syncd-centec-rpc/Dockerfile.j2
@@ -11,11 +11,6 @@ debs/
 
 RUN apt-get purge -y syncd
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_centec_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
 ## Pre-install the fundamental packages
 RUN apt-get update \
  && apt-get -y install  \
@@ -28,7 +23,16 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_centec_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \
@@ -49,5 +53,5 @@ RUN apt-get update \
  && rm -rf /root/deps
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
- 
+
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/centec/docker-syncd-centec-rpc/Dockerfile.j2
+++ b/platform/centec/docker-syncd-centec-rpc/Dockerfile.j2
@@ -11,11 +11,6 @@ debs/
 
 RUN apt-get purge -y syncd
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_centec_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
 ## Pre-install the fundamental packages
 RUN apt-get update \
  && apt-get -y install  \
@@ -28,7 +23,16 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_centec_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \
@@ -49,5 +53,5 @@ RUN apt-get update \
  && rm -rf /root/deps
 
 COPY ["ptf_nn_agent.conf", "/etc/supervisor/conf.d/"]
- 
+
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/innovium/docker-syncd-invm-rpc/Dockerfile.j2
+++ b/platform/innovium/docker-syncd-invm-rpc/Dockerfile.j2
@@ -11,11 +11,6 @@ debs/
 
 RUN dpkg -P syncd
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_invm_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
 ## Pre-install the fundamental packages
 RUN apt-get update \
  && apt-get -y install  \
@@ -29,7 +24,16 @@ RUN apt-get update \
     libjansson4         \
     wget                \
     cmake               \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_invm_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \

--- a/platform/marvell-arm64/docker-syncd-mrvl-rpc/Dockerfile.j2
+++ b/platform/marvell-arm64/docker-syncd-mrvl-rpc/Dockerfile.j2
@@ -11,11 +11,6 @@ debs/
 
 RUN apt-get purge -y syncd
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_mrvl_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
 ## Pre-install the fundamental packages
 RUN apt-get update \
  && apt-get -y install  \
@@ -27,7 +22,16 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_mrvl_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \

--- a/platform/marvell-armhf/docker-syncd-mrvl-rpc/Dockerfile.j2
+++ b/platform/marvell-armhf/docker-syncd-mrvl-rpc/Dockerfile.j2
@@ -11,11 +11,6 @@ debs/
 
 RUN apt-get purge -y syncd
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_mrvl_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
 ## Pre-install the fundamental packages
 RUN apt-get update \
  && apt-get -y install  \
@@ -27,7 +22,16 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_mrvl_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \

--- a/platform/marvell/docker-syncd-mrvl-rpc/Dockerfile.j2
+++ b/platform/marvell/docker-syncd-mrvl-rpc/Dockerfile.j2
@@ -11,11 +11,6 @@ debs/
 
 RUN apt-get purge -y syncd
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_mrvl_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
 ## Pre-install the fundamental packages
 RUN apt-get update \
  && apt-get -y install  \
@@ -27,7 +22,16 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_mrvl_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \

--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -11,17 +11,11 @@ RUN apt-get purge -y syncd
 {% if docker_syncd_mlnx_rpc_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("debs/", docker_syncd_mlnx_rpc_debs.split(' '), "/debs/") }}
-
-# Install locally-built Debian packages and implicitly install their dependencies
-{{ install_debian_packages(docker_syncd_mlnx_rpc_debs.split(' ')) }}
 {% endif %}
 
 {% if docker_syncd_mlnx_rpc_pydebs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("python-debs/", docker_syncd_mlnx_rpc_pydebs.split(' '), "/debs/") }}
-
-# Install locally-built Debian packages and implicitly install their dependencies
-{{ install_debian_packages(docker_syncd_mlnx_rpc_pydebs.split(' ')) }}
 {% endif %}
 
 ## Pre-install the fundamental packages
@@ -36,7 +30,22 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+{% if docker_syncd_mlnx_rpc_debs.strip() -%}
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_mlnx_rpc_debs.split(' ')) }}
+{% endif %}
+
+{% if docker_syncd_mlnx_rpc_pydebs.strip() -%}
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_syncd_mlnx_rpc_pydebs.split(' ')) }}
+{% endif %}
+
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \

--- a/platform/nephos/docker-syncd-nephos-rpc/Dockerfile.j2
+++ b/platform/nephos/docker-syncd-nephos-rpc/Dockerfile.j2
@@ -11,11 +11,6 @@ debs/
 
 RUN apt-get purge -y syncd
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_syncd_nephos_rpc_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
-
 ## Pre-install the fundamental packages
 RUN apt-get update \
  && apt-get -y install  \
@@ -27,7 +22,16 @@ RUN apt-get update \
     python-dev          \
     wget                \
     cmake               \
- && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
+    libqt5core5a        \
+    libqt5network5      \
+    libboost-atomic1.71.0
+
+RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
+{% for deb in docker_syncd_nephos_rpc_debs.split(' ') -%}
+dpkg_apt debs/{{ deb }}{{'; '}}
+{%- endfor %}
+
+RUN wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
  && tar xvfz 1.0.0.tar.gz \
  && cd nanomsg-1.0.0    \
  && mkdir -p build      \


### PR DESCRIPTION
When Building syncd-rpc, libthrift has dependency on libboost-atomic1.71.0, libqt5core5a, 
and libqt5network5 however debian packager fails to resolve the dependencies. It instead
installs libthrift from debian along with its dependencies which result in symbols not found.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

closes #6622 
resolves #6622

Please provide the following information:
-->

**- Why I did it**
resolve issue loading sync-rpc

**- How I did it**
ensured dependecies are installed before installing libthrift

**- How to verify it**
load docker sync-rpc on target and there should not be errors find symbol thrift server symbol

```
Preparing to unpack .../libthrift-0.11.0_0.11.0-4_amd64.deb ...
Unpacking libthrift-0.11.0 (0.11.0-4) ...
[91mdpkg: dependency problems prevent configuration of libthrift-0.11.0:
 libthrift-0.11.0 depends on libboost-atomic1.71.0; however:
  Package libboost-atomic1.71.0 is not installed.
 libthrift-0.11.0 depends on libqt5core5a (>= 5.11.0~rc1); however:
  Package libqt5core5a is not installed.
 libthrift-0.11.0 depends on libqt5network5 (>= 5.0.2); however:
  Package libqt5network5 is not installed.

dpkg: error processing package libthrift-0.11.0 (--install):
 dependency problems - leaving unconfigured
[0mProcessing triggers for libc-bin (2.28-10) ...
[91mErrors were encountered while processing:
 libthrift-0.11.0
[0mReading package lists...
Building dependency tree...
Reading state information...
Correcting dependencies... Done
The following additional packages will be installed:
  libboost-atomic1.67.0 libdouble-conversion1 libglib2.0-0 libicu63
  libpcre2-16-0 libqt5core5a libqt5dbus5 libqt5network5 libthrift-0.11.0
```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
