### PR TITLE
[platform] Update QSFP method name 'parse_qsfp_dom_capability' -> 'parse_dom_capability'

### DIFF
--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/sfp.py
@@ -698,7 +698,7 @@ class Sfp(SfpBase):
         qsfp_dom_capability_raw = self.__read_eeprom_specific_bytes(
             (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
         if qsfp_dom_capability_raw is not None:
-            qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(
+            qspf_dom_capability_data = sfpi_obj.parse_dom_capability(
                 qsfp_dom_capability_raw, 0)
         else:
             return None

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
@@ -279,7 +279,7 @@ class Sfp(SfpBase):
                     QSFP_VERSION_COMPLIANCE_OFFSET, QSFP_VERSION_COMPLIANCE_WIDTH)
                 qsfp_version_compliance = int(
                     qsfp_version_compliance_raw[0], 16)
-                dom_capability = sfpi_obj.parse_qsfp_dom_capability(
+                dom_capability = sfpi_obj.parse_dom_capability(
                     qsfp_dom_capability_raw, 0)
                 if qsfp_version_compliance >= 0x08:
                     self.dom_temp_supported = dom_capability['data']['Temp_support']['value'] == 'On'

--- a/device/celestica/x86_64-cel_silverstone-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_silverstone-r0/sonic_platform/sfp.py
@@ -328,7 +328,7 @@ class Sfp(SfpBase):
                     QSFP_VERSION_COMPLIANCE_OFFSET, QSFP_VERSION_COMPLIANCE_WIDTH)
                 qsfp_version_compliance = int(
                     qsfp_version_compliance_raw[0], 16)
-                dom_capability = sfpi_obj.parse_qsfp_dom_capability(
+                dom_capability = sfpi_obj.parse_dom_capability(
                     qsfp_dom_capability_raw, 0)
                 if qsfp_version_compliance >= 0x08:
                     self.dom_temp_supported = dom_capability['data']['Temp_support']['value'] == 'On'

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/plugins/sfputil.py
@@ -311,7 +311,7 @@ class SfpUtil(SfpUtilBase):
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes(
                 sysfsfile_eeprom, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
-                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(
+                qspf_dom_capability_data = sfpi_obj.parse_dom_capability(
                     qsfp_dom_capability_raw, 0)
             else:
                 return transceiver_dom_info_dict

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/plugins/sfputil.py
@@ -358,7 +358,7 @@ class SfpUtil(SfpUtilBase):
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes(
                 sysfsfile_eeprom, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
-                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(
+                qspf_dom_capability_data = sfpi_obj.parse_dom_capability(
                     qsfp_dom_capability_raw, 0)
             else:
                 return transceiver_dom_info_dict

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/plugins/sfputil.py
@@ -305,7 +305,7 @@ class SfpUtil(SfpUtilBase):
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes(
                 sysfsfile_eeprom, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
-                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+                qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
             else:
                 return transceiver_dom_info_dict
 

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/plugins/sfputil.py
@@ -378,7 +378,7 @@ class SfpUtil(SfpUtilBase):
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes(
                 sysfsfile_eeprom, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
-                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+                qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
             else:
                 return transceiver_dom_info_dict
 

--- a/device/juniper/x86_64-juniper_qfx5200-r0/plugins/sfputil.py
+++ b/device/juniper/x86_64-juniper_qfx5200-r0/plugins/sfputil.py
@@ -870,7 +870,7 @@ class SfpUtil(SfpUtilBase):
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes(
                 sysfsfile_eeprom, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
-                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+                qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
             else:
                 return None
 

--- a/device/juniper/x86_64-juniper_qfx5210-r0/plugins/sfputil.py
+++ b/device/juniper/x86_64-juniper_qfx5210-r0/plugins/sfputil.py
@@ -583,7 +583,7 @@ class SfpUtil(SfpUtilBase):
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes(
                 sysfsfile_eeprom, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
-                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+                qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
             else:
                 return None
 

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -513,7 +513,7 @@ class SfpUtil(SfpUtilBase):
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes_via_ethtool(
                 port_num, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
-                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+                qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
             else:
                 return transceiver_dom_info_dict
 

--- a/device/mellanox/x86_64-mlnx_msn4410-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/plugins/sfputil.py
@@ -488,7 +488,7 @@ class SfpUtil(SfpUtilBase):
             # in SFF-8636 dom capability definitions evolving with the versions.
             qsfp_dom_capability_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
-                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+                qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
             else:
                 return transceiver_dom_info_dict
 

--- a/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/sfp.py
@@ -358,7 +358,7 @@ class Sfp(SfpBase):
                     QSFP_VERSION_COMPLIANCE_OFFSET, QSFP_VERSION_COMPLIANCE_WIDTH)
                 qsfp_version_compliance = int(
                     qsfp_version_compliance_raw[0], 16)
-                dom_capability = sfpi_obj.parse_qsfp_dom_capability(
+                dom_capability = sfpi_obj.parse_dom_capability(
                     qsfp_dom_capability_raw, 0)
                 if qsfp_version_compliance >= 0x08:
                     self.dom_temp_supported = dom_capability['data']['Temp_support']['value'] == 'On'

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/sfp.py
@@ -118,7 +118,7 @@ sff8436_parser = {
      'hardware_rev': [QSFP_INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
            'serial': [QSFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
       'vendor_date': [QSFP_INFO_OFFSET, 84,  8, 'parse_vendor_date'],
-   'dom_capability': [QSFP_INFO_OFFSET, 92,  1, 'parse_qsfp_dom_capability'],
+   'dom_capability': [QSFP_INFO_OFFSET, 92,  1, 'parse_dom_capability'],
           'dom_rev': [QSFP_DOM_OFFSET,   1,  1, 'parse_sfp_dom_rev'],
   'ModuleThreshold': [QSFP_DOM_OFFSET1, 128, 24, 'parse_module_threshold_values'],
  'ChannelThreshold': [QSFP_DOM_OFFSET1, 176, 16, 'parse_channel_threshold_values'],

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/sfp.py
@@ -122,7 +122,7 @@ sff8436_parser = {
      'hardware_rev': [QSFP_INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
            'serial': [QSFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
       'vendor_date': [QSFP_INFO_OFFSET, 84,  8, 'parse_vendor_date'],
-   'dom_capability': [QSFP_INFO_OFFSET, 92,  1, 'parse_qsfp_dom_capability'],
+   'dom_capability': [QSFP_INFO_OFFSET, 92,  1, 'parse_dom_capability'],
           'dom_rev': [QSFP_DOM_OFFSET,   1,  1, 'parse_sfp_dom_rev'],
   'ModuleThreshold': [QSFP_DOM_OFFSET1, 128, 24, 'parse_module_threshold_values'],
  'ChannelThreshold': [QSFP_DOM_OFFSET1, 176, 16, 'parse_channel_threshold_values'],

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
@@ -127,7 +127,7 @@ sff8436_parser = {
       'hardware_rev': [QSFP_INFO_OFFSET, 56,  2, 'parse_vendor_rev'],
         'serial': [QSFP_INFO_OFFSET, 68, 16, 'parse_vendor_sn'],
       'vendor_date': [QSFP_INFO_OFFSET, 84,  8, 'parse_vendor_date'],
-   'dom_capability': [QSFP_INFO_OFFSET, 92,  1, 'parse_qsfp_dom_capability'],
+   'dom_capability': [QSFP_INFO_OFFSET, 92,  1, 'parse_dom_capability'],
           'dom_rev': [QSFP_DOM_OFFSET,   1,  1, 'parse_sfp_dom_rev'],
   'ModuleThreshold': [QSFP_DOM_OFFSET1, 128, 24, 'parse_module_threshold_values'],
  'ChannelThreshold': [QSFP_DOM_OFFSET1, 176, 16, 'parse_channel_threshold_values'],

--- a/platform/broadcom/sonic-platform-modules-inventec/d6332/sonic_platform/qsfp.py
+++ b/platform/broadcom/sonic-platform-modules-inventec/d6332/sonic_platform/qsfp.py
@@ -436,7 +436,7 @@ class QSfp(SfpBase):
         # in SFF-8636 dom capability definitions evolving with the versions.
         qsfp_dom_capability_raw = self.__read_eeprom_specific_bytes((offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
         if qsfp_dom_capability_raw is not None:
-            qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+            qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
         else:
             return None
 
@@ -793,7 +793,7 @@ class QSfp(SfpBase):
 
         qsfp_dom_capability_raw = self.__read_eeprom_specific_bytes((offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
         if qsfp_dom_capability_raw is not None:
-            qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+            qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
         else:
             return None
 
@@ -844,7 +844,7 @@ class QSfp(SfpBase):
 
         qsfp_dom_capability_raw = self.__read_eeprom_specific_bytes((offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
         if qsfp_dom_capability_raw is not None:
-            qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+            qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
         else:
             return None
 
@@ -895,7 +895,7 @@ class QSfp(SfpBase):
 
         qsfp_dom_capability_raw = self.__read_eeprom_specific_bytes((offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
         if qsfp_dom_capability_raw is not None:
-            qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+            qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
         else:
             return None
 

--- a/platform/broadcom/sonic-platform-modules-inventec/d6356/sonic_platform/qsfp.py
+++ b/platform/broadcom/sonic-platform-modules-inventec/d6356/sonic_platform/qsfp.py
@@ -388,7 +388,7 @@ class QSfp(SfpBase):
         # in SFF-8636 dom capability definitions evolving with the versions.
         qsfp_dom_capability_raw = self.__read_eeprom_specific_bytes((offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
         if qsfp_dom_capability_raw is not None:
-            qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+            qspf_dom_capability_data = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
         else:
             return None
 

--- a/platform/broadcom/sonic-platform-modules-inventec/d7054q28b/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-inventec/d7054q28b/sonic_platform/sfp.py
@@ -636,7 +636,7 @@ class Sfp(SfpBase):
         qsfp_dom_capability_raw = self.__read_eeprom_specific_bytes(
             (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
         if qsfp_dom_capability_raw is not None:
-            qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(
+            qspf_dom_capability_data = sfpi_obj.parse_dom_capability(
                 qsfp_dom_capability_raw, 0)
         else:
             return None

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -440,7 +440,7 @@ class SFP(SfpBase):
             if qsfp_dom_capability_raw is not None:
                 qsfp_version_compliance_raw = self._read_eeprom_specific_bytes(QSFP_VERSION_COMPLIANCE_OFFSET, QSFP_VERSION_COMPLIANCE_WIDTH)
                 qsfp_version_compliance = int(qsfp_version_compliance_raw[0], 16)
-                dom_capability = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+                dom_capability = sfpi_obj.parse_dom_capability(qsfp_dom_capability_raw, 0)
                 if qsfp_version_compliance >= 0x08:
                     self.dom_temp_supported = dom_capability['data']['Temp_support']['value'] == 'On'
                     self.dom_volt_supported = dom_capability['data']['Voltage_support']['value'] == 'On'

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
@@ -418,7 +418,7 @@ class PddfSfp(SfpBase):
             qsfp_dom_capability_raw = self.__read_eeprom_specific_bytes(
                 (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
             if qsfp_dom_capability_raw is not None:
-                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(
+                qspf_dom_capability_data = sfpi_obj.parse_dom_capability(
                     qsfp_dom_capability_raw, 0)
             else:
                 return None


### PR DESCRIPTION
**- Why I did it**
PR https://github.com/Azure/sonic-platform-common/pull/102 modified the name of the SFF-8436 (QSFP) method to align the method name between all drivers, renaming it from `parse_qsfp_dom_capability` to `parse_dom_capability`. Once the submodule was updated, the callers using the old nomenclature broke. This PR updates all callers to use the new naming convention.

**- How I did it**

Update the name of the function globally for all calls into the SFF-8436 driver.

Note that the QSFP-DD driver still uses the old nomenclature and should be modified similarly. I will open a PR to handle this separately.

**- How to verify it**

Ensure method is called properly and callers no longer crash.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
