### PR TITLE
[7050CX3-32S-C32] Add the 10G ports with updated speed

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/port_config.ini
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/port_config.ini
@@ -31,3 +31,5 @@ Ethernet112     117,118,119,120   Ethernet29/1  29     100000
 Ethernet116     113,114,115,116   Ethernet30/1  30     100000
 Ethernet120     121,122,123,124   Ethernet31/1  31     100000
 Ethernet124     125,126,127,128   Ethernet32/1  32     100000
+Ethernet128     129               Ethernet33    33     10000
+Ethernet132     128               Ethernet34    34     10000


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
https://github.com/Azure/sonic-buildimage/pull/6638 brought in changes which made ProtOrch crash with below error:

```
Feb  5 19:30:55.923878 str2-7050cx3-acs-01 ERR syncd#syncd: [none] SAI_API_PORT:brcm_sai_flex_port_oper:10451 port resource multi set failed with error Invalid parameter (0xfffffffc).
Feb  5 19:30:55.924407 str2-7050cx3-acs-01 INFO syncd#/supervisord: syncd 0:_bcmi_xgs5_port_flexible_validate: FlexPort operation is not enabled on physical port 128#015
Feb  5 19:30:55.924612 str2-7050cx3-acs-01 ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_REMOVE failed in syncd mode: SAI_STATUS_FAILURE
Feb  5 19:30:55.924787 str2-7050cx3-acs-01 ERR swss#orchagent: :- remove: remove status: SAI_STATUS_FAILURE
Feb  5 19:30:55.926302 str2-7050cx3-acs-01 INFO swss#/supervisord: orchagent terminate called after throwing an instance of 'std::runtime_error'
Feb  5 19:30:55.926521 str2-7050cx3-acs-01 INFO swss#/supervisord: orchagent   what():  PortsOrch initialization failure.
Feb  5 19:30:56.119747 str2-7050cx3-acs-01 INFO swss#supervisord 2021-02-05 19:30:56,119 INFO exited: orchagent (terminated by SIGABRT (core dumped); not expected)
```

The reason seems be due to BRCM file still has the port https://github.com/Azure/sonic-buildimage/blob/580666a406fa2ea70972fca6d64e21732095bb38/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm

**- How I did it**
Two ports are added to back with speed 10G. This is so that port_config.ini is in sync with config.bcm file.

Note: the lanes are still looking incorrect. This probably needs a fix from Arista.

**- How to verify it**
Tested warm-reboot, the `PortsOrch initialization failure.` issue is not seen. However, there is another port warm-reboot issue that is seen:
```
Feb  5 22:09:44.804084 str2-7050cx3-acs-01 NOTICE admin: Rebooting with /sbin/kexec -e to SONiC-OS-HEAD.350-ca355037 ...

Feb  5 22:10:28.487262 str2-7050cx3-acs-01 NOTICE swss#orchagent: :- notifySyncd: sending syncd: INIT_VIEW
Feb  5 22:11:28.545452 str2-7050cx3-acs-01 ERR swss#orchagent: :- wait: SELECT operation result: TIMEOUT on notify
Feb  5 22:11:28.545452 str2-7050cx3-acs-01 ERR swss#orchagent: :- wait: failed to get response for notify
Feb  5 22:11:28.545982 str2-7050cx3-acs-01 ERR swss#orchagent: :- initSaiRedis: Failed to notify syncd INIT_VIEW, rv:-1 gSwitchId 0
Feb  5 22:11:28.545982 str2-7050cx3-acs-01 WARNING swss#orchagent: :- meta_sai_on_switch_shutdown_request: switch_id oid:0x0 is of type SAI_OBJECT_TYPE_NULL, but expected SAI_OBJECT_TYPE_SWITCH

Feb  5 22:11:28.546022 str2-7050cx3-acs-01 ERR swss#orchagent: :- operator(): not handled: SAI_OBJECT_TYPE_NULL
Feb  5 22:11:28.546183 str2-7050cx3-acs-01 NOTICE swss#orchagent: :- uninitialize: begin
```
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
