### PR TITLE
[sonic-utilities] Depend on sonic-platform-common

### DIFF
--- a/rules/sonic-utilities.mk
+++ b/rules/sonic-utilities.mk
@@ -6,6 +6,7 @@ $(SONIC_UTILITIES_PY3)_PYTHON_VERSION = 3
 $(SONIC_UTILITIES_PY3)_DEPENDS += $(SONIC_PY_COMMON_PY3) \
                                   $(SWSSSDK_PY3) \
                                   $(SONIC_CONFIG_ENGINE_PY3) \
+                                  $(SONIC_PLATFORM_COMMON_PY3) \
                                   $(SONIC_YANG_MGMT_PY3) \
                                   $(SONIC_YANG_MODELS_PY3)
 $(SONIC_UTILITIES_PY3)_DEBS_DEPENDS = $(LIBYANG) \


### PR DESCRIPTION
**- Why I did it**

sonic-utilities will become dependent upon sonic-platform-common as of https://github.com/Azure/sonic-utilities/pull/1386.

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
