### PR TITLE
[StreamingTelemetry] add noTLS support for debug purpose

### DIFF
--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -23,7 +23,7 @@ if [ -n "$CERTS" ]; then
     SERVER_CRT=$(echo $CERTS | jq -r '.server_crt')
     SERVER_KEY=$(echo $CERTS | jq -r '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
-        TELEMETRY_ARGS+=" --noTLS"
+        TELEMETRY_ARGS+=" --insecure"
     else
         TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
@@ -36,7 +36,7 @@ elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
-        TELEMETRY_ARGS+=" --noTLS"
+        TELEMETRY_ARGS+=" --insecure"
     else
         TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -23,7 +23,7 @@ if [ -n "$CERTS" ]; then
     SERVER_CRT=$(echo $CERTS | jq -r '.server_crt')
     SERVER_KEY=$(echo $CERTS | jq -r '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
-        TELEMETRY_ARGS+=" --insecure"
+        TELEMETRY_ARGS+=" --noTLS"
     else
         TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
@@ -36,7 +36,7 @@ elif [ -n "$X509" ]; then
     SERVER_CRT=$(echo $X509 | jq -r '.server_crt')
     SERVER_KEY=$(echo $X509 | jq -r '.server_key')
     if [ -z $SERVER_CRT  ] || [ -z $SERVER_KEY  ]; then
-        TELEMETRY_ARGS+=" --insecure"
+        TELEMETRY_ARGS+=" --noTLS"
     else
         TELEMETRY_ARGS+=" --server_crt $SERVER_CRT --server_key $SERVER_KEY "
     fi
@@ -46,13 +46,12 @@ elif [ -n "$X509" ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 else
-    TELEMETRY_ARGS+=" --insecure"
+    TELEMETRY_ARGS+=" --noTLS"
 fi
 
 # If no configuration entry exists for TELEMETRY, create one default port
 if [ -z "$GNMI" ]; then
     PORT=8080
-    sonic-db-cli CONFIG_DB hset "TELEMETRY|gnmi" port $PORT
 else
     PORT=$(echo $GNMI | jq -r '.port')
 fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
adding noTLS mode for debugging purpose
Removing config-set for port 8080. It fails to start telemetry if docker restarts in case on noTLS mode because it expects log_level config to be present as well. 
**- How I did it**
Built telemetry standalone with noTLS support.
Replaced binaries on device. 
Updated telemetry.sh script inside docket and ran it

Test results:
**Server on noTLS:**
root@str-s6000-acs-10:/usr/sbin# ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.1  0.2  58964 21304 pts/0    Ss+  Feb05   0:18 /usr/bin/python /usr/bin/supervisord
root         9  0.0  0.1  51908 16088 pts/0    S    Feb05   0:00 python /usr/bin/supervisor-proc-exit-listener --container-name telemetry
root        13  0.0  0.0 262984  3588 pts/0    Sl   Feb05   0:00 /usr/sbin/rsyslogd -n -iNONE
root        53  1.2  0.4 1090896 40228 pts/0   Sl   Feb05   3:25 /usr/sbin/dialout_client_cli -insecure -logtostderr -v 2
root       388  0.0  0.0  18188  3388 pts/1    Ss+  00:40   0:00 bash
root       609  0.0  0.0  18192  3304 pts/2    Ss+  01:06   0:00 bash
root       662  0.0  0.0  18188  3352 pts/3    Ss   04:03   0:00 bash
root       701  0.0  0.0  18192  3412 pts/4    Ss   04:10   0:00 bash
root       762  6.0  0.4 1095332 38300 pts/3   Sl+  04:20   0:01 /usr/sbin/telemetry -logtostderr --noTLS --port 8080 --allow_no_client_auth -v=2
root       797  0.0  0.0  36632  2808 pts/4    R+   04:21   0:00 ps aux

**go Client on noTLS mode:**
root@str-s6000-acs-10:/usr/sbin# ./gnmi_get -xpath_target COUNTERS_DB -xpath COUNTERS/Ethernet0 -target_addr localhost:8080 -notls
== getRequest:
prefix: <
  target: "COUNTERS_DB"
>
path: <
  elem: <
    name: "COUNTERS"
  >
  elem: <
    name: "Ethernet0"
  >
>
encoding: JSON_IETF

== getResponse:
notification: <
  timestamp: 1612585256888042017
  prefix: <
    target: "COUNTERS_DB"
  >
  update: <
    path: <
      elem: <
        name: "COUNTERS"
      >
      elem: <
        name: "Ethernet0"
      >
    >
    val: <
      json_ietf_val: "{\"SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS\":\"0\",\"SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS\":\"0\",\"SAI_PORT_STAT_ETHER_STATS_TX_NO_ERRORS\":\"0\",\"SAI_PORT_STAT_ETHER_TX_OVERSIZE_PKTS\":\"0\",\"SAI_PORT_STAT_IF_IN_BROADCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_IN_DISCARDS\":\"0\",\"SAI_PORT_STAT_IF_IN_ERRORS\":\"0\",\"SAI_PORT_STAT_IF_IN_MULTICAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_IN_OCTETS\":\"0\",\"SAI_PORT_STAT_IF_IN_UCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_IN_UNKNOWN_PROTOS\":\"0\",\"SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_OUT_DISCARDS\":\"0\",\"SAI_PORT_STAT_IF_OUT_ERRORS\":\"0\",\"SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IF_OUT_OCTETS\":\"0\",\"SAI_PORT_STAT_IF_OUT_QLEN\":\"0\",\"SAI_PORT_STAT_IF_OUT_UCAST_PKTS\":\"0\",\"SAI_PORT_STAT_IN_DROPPED_PKTS\":\"0\",\"SAI_PORT_STAT_IP_IN_UCAST_PKTS\":\"0\",\"SAI_PORT_STAT_OUT_DROPPED_PKTS\":\"0\",\"SAI_PORT_STAT_PAUSE_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PAUSE_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_0_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_0_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_1_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_1_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_2_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_2_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_3_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_3_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_4_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_4_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_5_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_5_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_6_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_6_TX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_7_RX_PKTS\":\"0\",\"SAI_PORT_STAT_PFC_7_TX_PKTS\":\"0\"}"
    >
  >
>



**c# client test with Channel.Insecure**
D:\app\GnmiClientTool>GnmiClientTool.exe -d 10.3.147.237 -p 8080 -m false -h 60 -l Paths.txt -r sonic -b COUNTERS_DB -o false -t get
Destination IP: 10.3.147.237
Destination port: 8080
Secure mode: false
File containing list of paths: Paths.txt
Destination host is V4 address
Successfully created GRPC client
Adding path COUNTERS/Ethernet0 to request.
Notification count: 1

Notification no: 1
Notification at 02/06/2021 04:55:39.605 AM
Total updates: 1
COUNTERS/Ethernet0/:
{"SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS":"0","SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS":"0","SAI_PORT_STAT_ETHER_STATS_TX_NO_ERRORS":"0","SAI_PORT_STAT_ETHER_TX_OVERSIZE_PKTS":"0","SAI_PORT_STAT_IF_IN_BROADCAST_PKTS":"0","SAI_PORT_STAT_IF_IN_DISCARDS":"0","SAI_PORT_STAT_IF_IN_ERRORS":"0","SAI_PORT_STAT_IF_IN_MULTICAST_PKTS":"0","SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS":"0","SAI_PORT_STAT_IF_IN_OCTETS":"0","SAI_PORT_STAT_IF_IN_UCAST_PKTS":"0","SAI_PORT_STAT_IF_IN_UNKNOWN_PROTOS":"0","SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS":"0","SAI_PORT_STAT_IF_OUT_DISCARDS":"0","SAI_PORT_STAT_IF_OUT_ERRORS":"0","SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS":"0","SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS":"0","SAI_PORT_STAT_IF_OUT_OCTETS":"0","SAI_PORT_STAT_IF_OUT_QLEN":"0","SAI_PORT_STAT_IF_OUT_UCAST_PKTS":"0","SAI_PORT_STAT_IN_DROPPED_PKTS":"0","SAI_PORT_STAT_IP_IN_UCAST_PKTS":"0","SAI_PORT_STAT_OUT_DROPPED_PKTS":"0","SAI_PORT_STAT_PAUSE_RX_PKTS":"0","SAI_PORT_STAT_PAUSE_TX_PKTS":"0","SAI_PORT_STAT_PFC_0_RX_PKTS":"0","SAI_PORT_STAT_PFC_0_TX_PKTS":"0","SAI_PORT_STAT_PFC_1_RX_PKTS":"0","SAI_PORT_STAT_PFC_1_TX_PKTS":"0","SAI_PORT_STAT_PFC_2_RX_PKTS":"0","SAI_PORT_STAT_PFC_2_TX_PKTS":"0","SAI_PORT_STAT_PFC_3_RX_PKTS":"0","SAI_PORT_STAT_PFC_3_TX_PKTS":"0","SAI_PORT_STAT_PFC_4_RX_PKTS":"0","SAI_PORT_STAT_PFC_4_TX_PKTS":"0","SAI_PORT_STAT_PFC_5_RX_PKTS":"0","SAI_PORT_STAT_PFC_5_TX_PKTS":"0","SAI_PORT_STAT_PFC_6_RX_PKTS":"0","SAI_PORT_STAT_PFC_6_TX_PKTS":"0","SAI_PORT_STAT_PFC_7_RX_PKTS":"0","SAI_PORT_STAT_PFC_7_TX_PKTS":"0"}
[JsonIetfVal]

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [- ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
