### PR TITLE
[syncd-vs]: remove pindown version for iproute2 and libcap2-bin

### DIFF
--- a/platform/vs/docker-gbsyncd-vs/Dockerfile.j2
+++ b/platform/vs/docker-gbsyncd-vs/Dockerfile.j2
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-RUN apt-get install -f -y iproute2=4.20.0-2 libcap2-bin=1:2.25-2
+RUN apt-get install -f -y iproute2 libcap2-bin
 
 COPY \
 {% for deb in docker_gbsyncd_vs_debs.split(' ') -%}

--- a/platform/vs/docker-syncd-vs/Dockerfile.j2
+++ b/platform/vs/docker-syncd-vs/Dockerfile.j2
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-RUN apt-get install -f -y iproute2=4.20.0-2 libcap2-bin=1:2.25-2
+RUN apt-get install -f -y iproute2 libcap2-bin
 
 COPY \
 {% for deb in docker_syncd_vs_debs.split(' ') -%}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fix #6711 

the requirement was introduced in commit 75104bb35d86e3ec5565abe1cb49809e7790a155
to support sflow in stretch build. in buster build, the requirement
is met, no need to pin down the version.

Signed-off-by: Guohan Lu <lguohan@gmail.com>

**- How I did it**
remove pindown version for iproute2

**- How to verify it**
check pr build

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
