### PR TITLE
[Celestica][haliburton][cp210x] modprobe cp210x to ensure the driver can be load properly

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.init
@@ -18,6 +18,7 @@ start)
         modprobe smc
         modprobe hlx_gpio_ich
         modprobe dps200
+        modprobe cp210x
 
         found=0
         for devnum in 0 1; do


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

This PR is to fix issue: https://github.com/Azure/sonic-buildimage/issues/6603
The CP210x driver not attached properly after first login (cold-plug), `lsusb` and `dmesg` shown that the usb devices has been recognized but driver is missing.

The CP210x driver is embedded in Kernel, so we don't need install it manually.

**- How I did it**

Add `modprode cp210x` to haliburton service initialization stage.

**- How to verify it**

- [x] Build image without any change and reproduce the issue
- [x] Build image with current change and see if the issue fixed

After this change, all driver are attached and udev rule is working well
```
Debian GNU/Linux 10 sonic ttyS1

sonic login: admin
Password: 
Linux sonic 4.19.0-9-2-amd64 #1 SMP Debian 4.19.118-2+deb10u1 (2020-06-07) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:    http://azure.github.io/SONiC/

admin@sonic:~$ ls /dev/tty*
/dev/tty    /dev/tty26  /dev/tty44  /dev/tty62     /dev/ttyUSB19  /dev/ttyUSB37
/dev/tty0   /dev/tty27  /dev/tty45  /dev/tty63     /dev/ttyUSB2   /dev/ttyUSB38
/dev/tty1   /dev/tty28  /dev/tty46  /dev/tty7      /dev/ttyUSB20  /dev/ttyUSB39
/dev/tty10  /dev/tty29  /dev/tty47  /dev/tty8      /dev/ttyUSB21  /dev/ttyUSB4
/dev/tty11  /dev/tty3   /dev/tty48  /dev/tty9      /dev/ttyUSB22  /dev/ttyUSB40
/dev/tty12  /dev/tty30  /dev/tty49  /dev/ttyS0     /dev/ttyUSB23  /dev/ttyUSB41
/dev/tty13  /dev/tty31  /dev/tty5   /dev/ttyS1     /dev/ttyUSB24  /dev/ttyUSB42
/dev/tty14  /dev/tty32  /dev/tty50  /dev/ttyS2     /dev/ttyUSB25  /dev/ttyUSB43
/dev/tty15  /dev/tty33  /dev/tty51  /dev/ttyS3     /dev/ttyUSB26  /dev/ttyUSB44
/dev/tty16  /dev/tty34  /dev/tty52  /dev/ttyUSB0   /dev/ttyUSB27  /dev/ttyUSB45
/dev/tty17  /dev/tty35  /dev/tty53  /dev/ttyUSB1   /dev/ttyUSB28  /dev/ttyUSB46
/dev/tty18  /dev/tty36  /dev/tty54  /dev/ttyUSB10  /dev/ttyUSB29  /dev/ttyUSB47
/dev/tty19  /dev/tty37  /dev/tty55  /dev/ttyUSB11  /dev/ttyUSB3   /dev/ttyUSB5
/dev/tty2   /dev/tty38  /dev/tty56  /dev/ttyUSB12  /dev/ttyUSB30  /dev/ttyUSB6
/dev/tty20  /dev/tty39  /dev/tty57  /dev/ttyUSB13  /dev/ttyUSB31  /dev/ttyUSB7
/dev/tty21  /dev/tty4   /dev/tty58  /dev/ttyUSB14  /dev/ttyUSB32  /dev/ttyUSB8
/dev/tty22  /dev/tty40  /dev/tty59  /dev/ttyUSB15  /dev/ttyUSB33  /dev/ttyUSB9
/dev/tty23  /dev/tty41  /dev/tty6   /dev/ttyUSB16  /dev/ttyUSB34
/dev/tty24  /dev/tty42  /dev/tty60  /dev/ttyUSB17  /dev/ttyUSB35
/dev/tty25  /dev/tty43  /dev/tty61  /dev/ttyUSB18  /dev/ttyUSB36
admin@sonic:~$ ls /dev/C0*
/dev/C0-1   /dev/C0-17  /dev/C0-24  /dev/C0-31  /dev/C0-39  /dev/C0-46
/dev/C0-10  /dev/C0-18  /dev/C0-25  /dev/C0-32  /dev/C0-4   /dev/C0-47
/dev/C0-11  /dev/C0-19  /dev/C0-26  /dev/C0-33  /dev/C0-40  /dev/C0-48
/dev/C0-12  /dev/C0-2   /dev/C0-27  /dev/C0-34  /dev/C0-41  /dev/C0-5
/dev/C0-13  /dev/C0-20  /dev/C0-28  /dev/C0-35  /dev/C0-42  /dev/C0-6
/dev/C0-14  /dev/C0-21  /dev/C0-29  /dev/C0-36  /dev/C0-43  /dev/C0-7
/dev/C0-15  /dev/C0-22  /dev/C0-3   /dev/C0-37  /dev/C0-44  /dev/C0-8
/dev/C0-16  /dev/C0-23  /dev/C0-30  /dev/C0-38  /dev/C0-45  /dev/C0-9
```

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

This is a system regression fix for console switch. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
