### PR TITLE
[Mellanox] [syncd] Added support for python2

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -11,7 +11,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
-        libxml2
+        libxml2     \
+        python-pip  \
+        python-dev \
+        python-setuptools
+
+RUN pip2 install --upgrade pip
+RUN apt-get purge -y python-pip
 
 {% if docker_syncd_mlnx_debs.strip() -%}
 # Copy locally-built Debian package dependencies


### PR DESCRIPTION
Signed-off-by: allas <allas@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Mellanox SDK APIs support python 2 at the moment.

**- How I did it**
Mellanox SDK APIs support python 2 at the moment.

**- How to verify it**
Add python 2 to Mellanox syncd only.

**- Which release branch to backport (provide reason below if selected)**
docker exec -t syncd /bin/bash -c "sx_api_dbg_generate_dump.py /home/sx_api_dbg_dump"
You can see that it will work and generate /home/sx_api_dbg_dump

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
