### PR TITLE
Change the order of stopping dependent services of SWSS on 201911

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -101,14 +101,6 @@ start_peer_and_dependent_services() {
 stop_peer_and_dependent_services() {
     # if warm start enabled or peer lock exists, don't stop peer service docker
     if [[ x"$WARM_BOOT" != x"true" ]]; then
-        if [[ ! -z $DEV ]]; then
-            /bin/systemctl stop ${PEER}@$DEV
-        else
-            /bin/systemctl stop ${PEER}
-        fi
-        for dep in ${DEPENDENT}; do
-            /bin/systemctl stop ${dep}
-        done
         for dep in ${MULTI_INST_DEPENDENT}; do
             if [[ ! -z $DEV ]]; then
                 /bin/systemctl stop ${dep}@$DEV
@@ -116,7 +108,14 @@ stop_peer_and_dependent_services() {
                 /bin/systemctl stop ${dep}
             fi
         done
-
+        for dep in ${DEPENDENT}; do
+            /bin/systemctl stop ${dep}
+        done
+        if [[ ! -z $DEV ]]; then
+            /bin/systemctl stop ${PEER}@$DEV
+        else
+            /bin/systemctl stop ${PEER}
+        fi
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- Why I did it**
When large number of port channels (more than 64) is configured, a config reload command might ends with not all port channel configured and up. Further debug shows that unloading the port channels on the ASIC driver take a lot of time.
With the change, deleting all port channels before the syncd restart will free resources better and the ASIC driver will unload all netdev fast and the operation will execute properly.

**- How I did it**
Change the order of dependent services of SWSS.

**- How to verify it**
Before the fix: 
- Configure more than 80 port channel each with IP address.
- Run 'config reload' command. ASIC driver failure observed and not all port channels are configured properly and up. 

After the fix:
- Configure more than 80 port channel each with IP address.
- Run 'config reload' command. No errors on ASIC driver, all port channel configured and up.

**Which release branch to backport (provide reason below if selected)**
[ ] 201811
[ ] 201911
[ ] 202006
[ ] 202012

**Description for the changelog** 

**A picture of a cute animal (not mandatory but encouraged)**

