### PR TITLE
[slave.mk] Remove PYTHON_CLICK target

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -842,7 +842,6 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
         $(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$(INITRAMFS_TOOLS) \
                 $(LINUX_KERNEL) \
                 $(SONIC_DEVICE_DATA) \
-                $(PYTHON_CLICK) \
                 $(IFUPDOWN2) \
                 $(KDUMP_TOOLS) \
                 $(NTP) \


### PR DESCRIPTION
**- Why I did it**

We stopped building our own custom python-click package via https://github.com/Azure/sonic-buildimage/pull/5549. This target should have been removed at that time but was missed.

**- How I did it**

Remove PYTHON_CLICK target from slave.mk

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
