### PR TITLE
Upgrading bcmsai from 4.3.0.10-5 to 4.3.0.13

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_4.3.0.10-5_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm_4.3.0.10-5_amd64.deb?sv=2019-12-12&st=2021-02-08T00%3A20%3A49Z&se=2030-02-09T00%3A20%3A00Z&sr=b&sp=r&sig=rEpcTHNsSr10rKhpr6Cx3EFNa2dRE7VLP7ybZijQKpE%3D"
-BRCM_SAI_DEV = libsaibcm-dev_4.3.0.10-5_amd64.deb
+BRCM_SAI = libsaibcm_4.3.0.13_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm_4.3.0.13_amd64.deb?sv=2019-12-12&st=2021-02-11T06%3A07%3A09Z&se=2030-02-12T06%3A07%3A00Z&sr=b&sp=r&sig=IlCyw1BGN0Ei56tPPeXJSucFSFj8SSqUGLB2A%2BRZ1w0%3D"
+BRCM_SAI_DEV = libsaibcm-dev_4.3.0.13_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm-dev_4.3.0.10-5_amd64.deb?sv=2019-12-12&st=2021-02-08T00%3A21%3A42Z&se=2030-02-09T00%3A21%3A00Z&sr=b&sp=r&sig=gvDnVYkQe%2FA2Yqw9p404Vtmx%2Fo8NwJMFoCn7K4W1k0M%3D"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm-dev_4.3.0.13_amd64.deb?sv=2019-12-12&st=2021-02-11T06%3A08%3A31Z&se=2030-02-12T06%3A08%3A00Z&sr=b&sp=r&sig=G5mYUa8gCnDNpuadvHEuH%2B4q2MuY0JYspPLt2gaC2NY%3D"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Upgrading bcmsai from 4.3.0.10-5 to 4.3.0.13.

**- How I did it**
Merged bcmsai  4.3.0.13 code to top of master bcmsai 4.3.0.10-5.

**- How to verify it**
Ran nightly regression on T0 and T1 topology using bcmsai 4.3.0.13. Test results are better than previous runs.
For T0 -  
      New test passing - CRM, Decap, FDB, platform test, VxLAN
      New test failing – PFC unknown MAC
For T1 – 
      New test passing – Port Channel
      New test failing – platform test
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Upgrading bcmsai from 4.3.0.10-5 to 4.3.0.13.

**- A picture of a cute animal (not mandatory but encouraged)**
