### PR TITLE
DellEMC: Z9332f enable mem cache flag

### DIFF
--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
@@ -8,7 +8,7 @@ load_firmware=0x2
 
 ccm_dma_enable=0
 ccmdma_intr_enable=0
-mem_cache_enable=0
+mem_cache_enable=1
 phy_enable=0
 phy_null=1
 

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-32x400G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-32x400G.config.bcm
@@ -8,7 +8,7 @@ load_firmware=0x2
 
 ccm_dma_enable=0
 ccmdma_intr_enable=0
-mem_cache_enable=0
+mem_cache_enable=1
 phy_enable=0
 phy_null=1
 

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
@@ -8,7 +8,7 @@ load_firmware=0x2
 
 ccm_dma_enable=0
 ccmdma_intr_enable=0
-mem_cache_enable=0
+mem_cache_enable=1
 phy_enable=0
 phy_null=1
 


### PR DESCRIPTION

#### Why I did it
SER test script is failing as mem_cache flag is disabled.
#### How I did it
Edit NPU config
#### How to verify it
Check cache command in NPU shell after enabling mem_cache_enable flag
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog


#### A picture of a cute animal (not mandatory but encouraged)

