### PR TITLE
BRCM SAI 4.3.0.13-1 Pick up BRCM Patch to fix bogus interface counters

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_4.3.0.13_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm_4.3.0.13_amd64.deb?sv=2019-12-12&st=2021-02-11T06%3A07%3A09Z&se=2030-02-12T06%3A07%3A00Z&sr=b&sp=r&sig=IlCyw1BGN0Ei56tPPeXJSucFSFj8SSqUGLB2A%2BRZ1w0%3D"
-BRCM_SAI_DEV = libsaibcm-dev_4.3.0.13_amd64.deb
+BRCM_SAI = libsaibcm_4.3.0.13-1_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm_4.3.0.13-1_amd64.deb?sv=2015-04-05&sr=b&sig=e%2BBucofzEwCC%2BclqK1OeCi5YFpQAD4ID4FfODzszsuM%3D&se=2034-10-22T06%3A00%3A14Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_4.3.0.13-1_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm-dev_4.3.0.13_amd64.deb?sv=2019-12-12&st=2021-02-11T06%3A08%3A31Z&se=2030-02-12T06%3A08%3A00Z&sr=b&sp=r&sig=G5mYUa8gCnDNpuadvHEuH%2B4q2MuY0JYspPLt2gaC2NY%3D"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/4.3/master/libsaibcm-dev_4.3.0.13-1_amd64.deb?sv=2015-04-05&sr=b&sig=twfshldM6GQEphfU%2BQ4xmJlGJkv2Sy7KU1F72RYYM0A%3D&se=2034-10-22T06%3A00%3A45Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
#### Why I did it
This PR is needed to fix the show interface counters output issue where the counters are not correct due to an issue introduced in BRCM SAI 4.3.

#### How to verify it
Without the fix if one injects packets, the expected counters for the interfaces involved do not show correct count values. The RX count looks to be TX count while TX count looks to be RX count but even that the values could not be trusted.
After the fix the counters started to look correct.  Here is one sample output taken after the fix is applied where I manually injected 10,000 packets into Ethernet92 to be routed out of the port channel member port Ethernet40. Also injected 10,000 invalid packets into the same Ethernet92  and all 10,000 packets were shown RX_DRP correctly.

```
admin@str-s6000-acs-8:~$ show interface counters
Last cached time was 2021-02-12 03:54:08.960997
      IFACE    STATE    RX_OK      RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK      TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
-----------  -------  -------  ----------  ---------  --------  --------  --------  -------  ----------  ---------  --------  --------  --------
  Ethernet0        U        2    8.26 B/s      0.00%         0         0         0       50  126.89 B/s      0.00%         0         0         0
  Ethernet4        U       50  124.67 B/s      0.00%         0         0         0        2   10.49 B/s      0.00%         0         0         0
  Ethernet8        U       50  124.67 B/s      0.00%         0         0         0        2   10.49 B/s      0.00%         0         0         0
 Ethernet12        U        2    8.26 B/s      0.00%         0         0         0       50  126.92 B/s      0.00%         0         0         0
 Ethernet16        U       50  124.67 B/s      0.00%         0         0         0       38  104.15 B/s      0.00%         0         0         0
 Ethernet20        U        2    8.26 B/s      0.00%         0         0         0        2   10.51 B/s      0.00%         0         0         0
 Ethernet24        U        2    8.26 B/s      0.00%         0         0         0        2   10.51 B/s      0.00%         0         0         0
 Ethernet28        U       50  124.67 B/s      0.00%         0         0         0       50  126.92 B/s      0.00%         0         0         0
 Ethernet32        U        2    8.26 B/s      0.00%         0         0         0       50  126.92 B/s      0.00%         0         0         0
 Ethernet36        U       50  124.67 B/s      0.00%         0         0         0        2   10.51 B/s      0.00%         0         0         0
 Ethernet40        U        2    8.26 B/s      0.00%         0         0         0   10,064  17.51 KB/s      0.00%         0         0         0
 Ethernet44        U       56  142.50 B/s      0.00%         0         0         0        2   10.51 B/s      0.00%         0         0         0
 Ethernet48        U       46  114.97 B/s      0.00%         0         0         0       46  117.21 B/s      0.00%         0         0         0
 Ethernet52        U        2    8.26 B/s      0.00%         0         0         0        2   10.51 B/s      0.00%         0         0         0
 Ethernet56        U        2    8.26 B/s      0.00%         0         0         0       50  126.92 B/s      0.00%         0         0         0
 Ethernet60        U       50  124.67 B/s      0.00%         0         0         0        2   10.51 B/s      0.00%         0         0         0
 Ethernet64        U        4   10.00 B/s      0.00%         0         0         0        4   14.36 B/s      0.00%         0         0         0
 Ethernet68        U        2    9.59 B/s      0.00%         0         0         0       10   24.77 B/s      0.00%         0         0         0
 Ethernet72        U        8   22.11 B/s      0.00%         0         0         0        4   14.36 B/s      0.00%         0         0         0
 Ethernet76        U        1    4.80 B/s      0.00%         0         0         0        4   14.36 B/s      0.00%         0         0         0
 Ethernet80        U        1    4.80 B/s      0.00%         0         0         0       10   24.77 B/s      0.00%         0         0         0
 Ethernet84        U        7   17.31 B/s      0.00%         0         0         0        4   14.36 B/s      0.00%         0         0         0
 Ethernet88        U        1    4.80 B/s      0.00%         0         0         0        4   14.36 B/s      0.00%         0         0         0
 Ethernet92        U   20,001  34.69 KB/s      0.00%         0    10,000         0        4   14.36 B/s      0.00%         0         0         0
 Ethernet96        U        1    4.80 B/s      0.00%         0         0         0        4   14.36 B/s      0.00%         0         0         0
Ethernet100        U        2    9.59 B/s      0.00%         0         0         0        4   14.39 B/s      0.00%         0         0         0
Ethernet104        U        2    9.59 B/s      0.00%         0         0         0        4   14.39 B/s      0.00%         0         0         0
Ethernet108        U        1    4.80 B/s      0.00%         0         0         0        4   14.39 B/s      0.00%         0         0         0
Ethernet112        U        1    4.80 B/s      0.00%         0         0         0        4   14.39 B/s      0.00%         0         0         0
Ethernet116        U        2    9.59 B/s      0.00%         0         0         0        4   14.39 B/s      0.00%         0         0         0
Ethernet120        U        4   12.11 B/s      0.00%         0         0         0        4   14.39 B/s      0.00%         0         0         0
Ethernet124        U        1    4.80 B/s      0.00%         0         0         0        4   14.39 B/s      0.00%         0         0         0
admin@str-s6000-acs-8:~$
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
BRCM SAI 4.3.0.13-1 Pick up BRCM Patch to fix bogus interface counters
