### PR TITLE
[platform] Update path to udevprefix.conf file

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/script/udev_prefix.sh
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/script/udev_prefix.sh
@@ -3,21 +3,21 @@
 PREV_REBOOT_CAUSE="/host/reboot-cause/"
 DEVICE="/usr/share/sonic/device"
 PLATFORM=$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
-FILES=$DEVICE/$PLATFORM/plugins
+PLATFORM_PATH=$DEVICE/$PLATFORM
 FILENAME="udevprefix.conf"
 
 if [ "$1" = "clear" ]
 then
-	if [ -e $FILES/$FILENAME ]; then
-		rm $FILES/$FILENAME
+	if [ -e $PLATFORM_PATH/$FILENAME ]; then
+		rm $PLATFORM_PATH/$FILENAME
 	fi
 else
-	if [ -e $FILES/$FILENAME ]; then
-		: > $FILES/$FILENAME 
-		echo -n "$1" > $FILES/$FILENAME
+	if [ -e $PLATFORM_PATH/$FILENAME ]; then
+		: > $PLATFORM_PATH/$FILENAME
+		echo -n "$1" > $PLATFORM_PATH/$FILENAME
 	else
-		touch $FILES/$FILENMAE
-		echo -n "$1" > $FILES/$FILENAME 
+		touch $PLATFORM_PATH/$FILENMAE
+		echo -n "$1" > $PLATFORM_PATH/$FILENAME
 	fi
 fi
 


### PR DESCRIPTION
#### Why I did it

https://github.com/Azure/sonic-utilities/pull/1431 changes the path to the `udevprefix.conf` file. The file previously inappropriately resided in the `<platform>/plugins/` directory. That directory is reserved for now-deprecated Python platform plugins, and will be removed in the near future.

#### How I did it

Update all references to udevprefix.conf to reflect the new path, directly under the `<platform>/` directory

Note that this PR requires https://github.com/Azure/sonic-utilities/pull/1431. For the master branch, this means that this PR should be merged at the same time as the sonic-utilities submodule update here: https://github.com/Azure/sonic-buildimage/pull/6777. For the 202012 branch, this change should be cherry-picked along with an updated 202012 branch of sonic-utilities which includes the respective commit there.

#### How to verify it

Ensure the udevprefix.conf is now found under the `<platform>/` directory

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
