### PR TITLE
Add DPB Support for Liger SN4600

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4600-r0/ACS-MSN4600/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4600-r0/ACS-MSN4600/hwsku.json
@@ -1,0 +1,196 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet8": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet16": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet24": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet32": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet40": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet48": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet56": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet64": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet72": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet80": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet88": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet96": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet104": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet112": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet120": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet128": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet136": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet144": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet152": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet160": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet168": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet176": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet184": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet192": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet200": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet208": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet216": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet224": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet232": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet240": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet248": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet256": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet264": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet272": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet280": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet288": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet296": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet304": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet312": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet320": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet328": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet336": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet344": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet352": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet360": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet368": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet376": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet384": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet392": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet400": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet408": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet416": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet424": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet432": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet440": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet448": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet456": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet464": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet472": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet480": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet488": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet496": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet504": {
+            "default_brkout_mode": "1x200G[100G,50G,40G,25G,10G,1G]"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn4600-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4600-r0/platform.json
@@ -1,0 +1,388 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "index": "1,1,1,1", 
+            "lanes": "0,1,2,3", 
+            "alias_at_lanes": "etp1a, etp1b, etp1c, etp1d",
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet8": {
+            "index": "2,2,2,2", 
+            "lanes": "8,9,10,11", 
+            "alias_at_lanes": "etp2a, etp2b, etp2c, etp2d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet16": {
+            "index": "3,3,3,3", 
+            "lanes": "16,17,18,19", 
+            "alias_at_lanes": "etp3a, etp3b, etp3c, etp3d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet24": {
+            "index": "4,4,4,4", 
+            "lanes": "24,25,26,27", 
+            "alias_at_lanes": "etp4a, etp4b, etp4c, etp4d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet32": {
+            "index": "5,5,5,5", 
+            "lanes": "32,33,34,35", 
+            "alias_at_lanes": "etp5a, etp5b, etp5c, etp5d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet40": {
+            "index": "6,6,6,6", 
+            "lanes": "40,41,42,43", 
+            "alias_at_lanes": "etp6a, etp6b, etp6c, etp6d",  
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet48": {
+            "index": "7,7,7,7", 
+            "lanes": "48,49,50,51", 
+            "alias_at_lanes": "etp7a, etp7b, etp7c, etp7d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet56": {
+            "index": "8,8,8,8", 
+            "lanes": "56,57,58,59", 
+            "alias_at_lanes": "etp8a, etp8b, etp8c, etp8d",
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet64": {
+            "index": "9,9,9,9", 
+            "lanes": "64,65,66,67", 
+            "alias_at_lanes": "etp9a, etp9b, etp9c, etp9d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet72": {
+            "index": "10,10,10,10", 
+            "lanes": "72,73,74,75", 
+            "alias_at_lanes": "etp10a, etp10b, etp10c, etp10d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet80": {
+            "index": "11,11,11,11", 
+            "lanes": "80,81,82,83", 
+            "alias_at_lanes": "etp11a, etp11b, etp11c, etp11d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet88": {
+            "index": "12,12,12,12", 
+            "lanes": "88,89,90,91", 
+            "alias_at_lanes": "etp12a, etp12b, etp12c, etp12d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet96": {
+            "index": "13,13,13,13", 
+            "lanes": "96,97,98,99", 
+            "alias_at_lanes": "etp13a, etp13b, etp13c, etp13d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet104": {
+            "index": "14,14,14,14", 
+            "lanes": "104,105,106,107", 
+            "alias_at_lanes": "etp14a, etp14b, etp14c, etp14d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet112": {
+            "index": "15,15,15,15", 
+            "lanes": "112,113,114,115", 
+            "alias_at_lanes": "etp15a, etp15b, etp15c, etp15d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet120": {
+            "index": "16,16,16,16", 
+            "lanes": "120,121,122,123", 
+            "alias_at_lanes": "etp16a, etp16b, etp16c, etp16d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet128": {
+            "index": "17,17,17,17", 
+            "lanes": "128,129,130,131", 
+            "alias_at_lanes": "etp17a, etp17b, etp17c, etp17d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet136": {
+            "index": "18,18,18,18", 
+            "lanes": "136,137,138,139", 
+            "alias_at_lanes": "etp18a, etp18b, etp18c, etp18d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet144": {
+            "index": "19,19,19,19", 
+            "lanes": "144,145,146,147", 
+            "alias_at_lanes": "etp19a, etp19b, etp19c, etp19d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet152": {
+            "index": "20,20,20,20", 
+            "lanes": "152,153,154,155", 
+            "alias_at_lanes": "etp20a, etp20b, etp20c, etp20d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet160": {
+            "index": "21,21,21,21", 
+            "lanes": "160,161,162,163", 
+            "alias_at_lanes": "etp21a, etp21b, etp21c, etp21d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet168": {
+            "index": "22,22,22,22", 
+            "lanes": "168,169,170,171", 
+            "alias_at_lanes": "etp22a, etp22b, etp22c, etp22d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet176": {
+            "index": "23,23,23,23", 
+            "lanes": "176,177,178,179", 
+            "alias_at_lanes": "etp23a, etp23b, etp23c, etp23d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet184": {
+            "index": "24,24,24,24", 
+            "lanes": "184,185,186,187", 
+            "alias_at_lanes": "etp24a, etp24b, etp24c, etp24d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet192": {
+            "index": "25,25,25,25", 
+            "lanes": "192,193,194,195", 
+            "alias_at_lanes": "etp25a, etp25b, etp25c, etp25d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet200": {
+            "index": "26,26,26,26", 
+            "lanes": "200,201,202,203", 
+            "alias_at_lanes": "etp26a, etp26b, etp26c, etp26d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet208": {
+            "index": "27,27,27,27", 
+            "lanes": "208,209,210,211", 
+            "alias_at_lanes": "etp27a, etp27b, etp27c, etp27d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet216": {
+            "index": "28,28,28,28", 
+            "lanes": "216,217,218,219", 
+            "alias_at_lanes": "etp28a, etp28b, etp28c, etp28d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet224": {
+            "index": "29,29,29,29", 
+            "lanes": "224,225,226,227", 
+            "alias_at_lanes": "etp29a, etp29b, etp29c, etp29d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet232": {
+            "index": "30,30,30,30", 
+            "lanes": "232,233,234,235", 
+            "alias_at_lanes": "etp30a, etp30b, etp30c, etp30d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet240": {
+            "index": "31,31,31,31", 
+            "lanes": "240,241,242,243", 
+            "alias_at_lanes": "etp31a, etp31b, etp31c, etp31d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet248": {
+            "index": "32,32,32,32", 
+            "lanes": "248,249,250,251", 
+            "alias_at_lanes": "etp32a, etp32b, etp32c, etp32d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet256": {
+            "index": "33,33,33,33", 
+            "lanes": "256,257,258,259", 
+            "alias_at_lanes": "etp33a, etp33b, etp33c, etp33d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet264": {
+            "index": "34,34,34,34", 
+            "lanes": "264,265,266,267", 
+            "alias_at_lanes": "etp34a, etp34b, etp34c, etp34d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet272": {
+            "index": "35,35,35,35", 
+            "lanes": "272,273,274,275", 
+            "alias_at_lanes": "etp35a, etp35b, etp35c, etp35d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet280": {
+            "index": "36,36,36,36", 
+            "lanes": "280,281,282,283", 
+            "alias_at_lanes": "etp36a, etp36b, etp36c, etp36d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet288": {
+            "index": "37,37,37,37", 
+            "lanes": "288,289,290,291", 
+            "alias_at_lanes": "etp37a, etp37b, etp37c, etp37d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet296": {
+            "index": "38,38,38,38", 
+            "lanes": "296,297,298,299", 
+            "alias_at_lanes": "etp38a, etp38b, etp38c, etp38d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet304": {
+            "index": "39,39,39,39", 
+            "lanes": "304,305,306,307", 
+            "alias_at_lanes": "etp39a, etp39b, etp39c, etp39d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet312": {
+            "index": "40,40,40,40", 
+            "lanes": "312,313,314,315", 
+            "alias_at_lanes": "etp40a, etp40b, etp40c, etp40d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet320": {
+            "index": "41,41,41,41", 
+            "lanes": "320,321,322,323", 
+            "alias_at_lanes": "etp41a, etp41b, etp41c, etp41d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet328": {
+            "index": "42,42,42,42", 
+            "lanes": "328,329,330,331", 
+            "alias_at_lanes": "etp42a, etp42b, etp42c, etp42d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet336": {
+            "index": "43,43,43,43", 
+            "lanes": "336,337,338,339", 
+            "alias_at_lanes": "etp43a, etp43b, etp43c, etp43d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet344": {
+            "index": "44,44,44,44", 
+            "lanes": "344,345,346,347", 
+            "alias_at_lanes": "etp44a, etp44b, etp44c, etp44d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet352": {
+            "index": "45,45,45,45", 
+            "lanes": "352,353,354,355", 
+            "alias_at_lanes": "etp45a, etp45b, etp45c, etp45d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet360": {
+            "index": "46,46,46,46", 
+            "lanes": "360,361,362,363", 
+            "alias_at_lanes": "etp46a, etp46b, etp46c, etp46d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet368": {
+            "index": "47,47,47,47", 
+            "lanes": "368,369,370,371", 
+            "alias_at_lanes": "etp47a, etp47b, etp47c, etp47d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet376": {
+            "index": "48,48,48,48", 
+            "lanes": "376,377,378,379", 
+            "alias_at_lanes": "etp48a, etp48b, etp48c, etp48d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet384": {
+            "index": "49,49,49,49", 
+            "lanes": "384,385,386,387", 
+            "alias_at_lanes": "etp49a, etp49b, etp49c, etp49d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet392": {
+            "index": "50,50,50,50", 
+            "lanes": "392,393,394,395", 
+            "alias_at_lanes": "etp50a, etp50b, etp50c, etp50d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet400": {
+            "index": "51,51,51,51", 
+            "lanes": "400,401,402,403", 
+            "alias_at_lanes": "etp51a, etp51b, etp51c, etp51d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet408": {
+            "index": "52,52,52,52", 
+            "lanes": "408,409,410,411", 
+            "alias_at_lanes": "etp52a, etp52b, etp52c, etp52d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet416": {
+            "index": "53,53,53,53", 
+            "lanes": "416,417,418,419", 
+            "alias_at_lanes": "etp53a, etp53b, etp53c, etp53d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet424": {
+            "index": "54,54,54,54", 
+            "lanes": "424,425,426,427", 
+            "alias_at_lanes": "etp54a, etp54b, etp54c, etp54d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet432": {
+            "index": "55,55,55,55", 
+            "lanes": "432,433,434,435", 
+            "alias_at_lanes": "etp55a, etp55b, etp55c, etp55d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet440": {
+            "index": "56,56,56,56", 
+            "lanes": "440,441,442,443", 
+            "alias_at_lanes": "etp56a, etp56b, etp56c, etp56d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet448": {
+            "index": "57,57,57,57", 
+            "lanes": "448,449,450,451", 
+            "alias_at_lanes": "etp57a, etp57b, etp57c, etp57d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet456": {
+            "index": "58,58,58,58", 
+            "lanes": "456,457,458,459", 
+            "alias_at_lanes": "etp58a, etp58b, etp58c, etp58d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet464": {
+            "index": "59,59,59,59", 
+            "lanes": "464,465,466,467", 
+            "alias_at_lanes": "etp59a, etp59b, etp59c, etp59d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet472": {
+            "index": "60,60,60,60", 
+            "lanes": "472,473,474,475", 
+            "alias_at_lanes": "etp60a, etp60b, etp60c, etp60d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet480": {
+            "index": "61,61,61,61", 
+            "lanes": "480,481,482,483", 
+            "alias_at_lanes": "etp61a, etp61b, etp61c, etp61d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet488": {
+            "index": "62,62,62,62", 
+            "lanes": "488,489,490,491", 
+            "alias_at_lanes": "etp62a, etp62b, etp62c, etp62d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet496": {
+            "index": "63,63,63,63", 
+            "lanes": "496,497,498,499", 
+            "alias_at_lanes": "etp63a, etp63b, etp63c, etp63d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }, 
+        "Ethernet504": {
+            "index": "64,64,64,64", 
+            "lanes": "504,505,506,507", 
+            "alias_at_lanes": "etp64a, etp64b, etp64c, etp64d", 
+            "breakout_modes": "1x200G[100G,50G,40G,25G,10G,1G],2x100G[50G,40G,25G,10G,1G],4x50G[40G,25G,10G,1G]"
+        }
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To add support for the dynamic breakout on Mellanox platform x86_64-mlnx_msn4600

#### How I did it
Add the relevant files describing Mellanox platform x86_64-mlnx_msn4600 breakout modes to a new device folder.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

