### PR TITLE
[build] Install Python 3 scapy version 2.4.4 in host OS

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -432,6 +432,9 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'wheel
 # docker Python API package is needed by Ansible docker module as well as some SONiC applications
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'docker==4.3.1'
 
+# Install scapy
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'scapy==2.4.4'
+
 ## Note: keep pip installed for maintainance purpose
 
 # Install GCC, needed for building/installing some Python packages


### PR DESCRIPTION
#### Why I did it

As we are currently in the process of removing Python 2 from SONiC, to ensure a seamless transition to Python 3.

#### How I did it

Install Python 3 scapy version 2.4.4 in host OS in build_debian.sh

#### How to verify it

`pip3 show scapy`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
