### PR TITLE
[201911] Fix the build failure

### DIFF
--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -350,7 +350,8 @@ RUN apt-get purge -y python-click
 # For sonic utilities testing
 RUN pip install click-default-group click natsort tabulate netifaces==0.10.7 fastentrypoints
 
-# For sonic snmpagent mock testing
+# For sonic snmpagent build and mock testing
+RUN pip3 install -U setuptools
 RUN pip3 install mockredispy==2.9.3
 
 RUN pip3 install "PyYAML>=5.1"


### PR DESCRIPTION
Why I did:

Fix the build failure of asyncsnmp-2.1.0-py3-none-any.whl . 
Looks like a recent update on https://packages.debian.org/stretch/libpython3.5-stdlib
3.5.3-1+deb9u1 -> 3.5.3-1+deb9u3 break the build command `python3 setup.py bdist_wheel`

How I fixed:
Installl setuptool tools explicitly via pip3 install
