### PR TITLE
[201911][monit] Periodically monitor VNET route consistency

### DIFF
--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -31,3 +31,8 @@ check program routeCheck with path "/usr/bin/route_check.py"
     every 5 cycles
     if status != 0 for 3 cycle then alert repeat every 1 cycles
 
+# vnet_route_check.py: tool that verifies VNET routes consistancy between SONiC and vendor SDK DBs.
+check program vnetRouteCheck with path "/usr/local/bin/vnet_route_check.py"
+    every 5 cycles
+        if status != 0 for 3 cycle then alert repeat every 1 cycles
+


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
To run VNET route consistency check periodically.

For any failure, the monit will raise alert based on return code.
The tool will log required details.

**- How I did it**
Added configuration entry to "SONiC monit"

**- How to verify it**
Configure VNET routes then remove some in ASIC_DB or APP_DB and verify logs for error messages.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[monit] Periodically monitor VNET route consistency

