### PR TITLE
[frr] protect template if deployment_id is missing in map when generating dynamic bgp neighbor

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/instance.conf.j2
@@ -12,7 +12,7 @@
 !
 {% if bgp_session['peer_asn'] is defined %}
   neighbor {{ bgp_session['name'] }} remote-as {{ bgp_session['peer_asn'] }}
-{% else %}
+{% elif CONFIG_DB__DEVICE_METADATA['localhost']['deployment_id'] in constants.deployment_id_asn_map %}
   neighbor {{ bgp_session['name'] }} remote-as {{ constants.deployment_id_asn_map[CONFIG_DB__DEVICE_METADATA['localhost']['deployment_id']] }}
 {% endif %}
 !


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is to protect a corner case: if deployment_id is missing in map when generating dynamic bgp neighbor, the template will generate an incomplete line.

```
neighbor dyn_name remote-as
```

#### How I did it
Remove the whole line in the case.

#### How to verify it
Pass the sonic-bgpcfgd unit test. Tested the corner case manually

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

