### PR TITLE
 .gitmodules: Fix make init

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -59,7 +59,7 @@
 	url = https://github.com/aristanetworks/sonic
 [submodule "platform/mellanox/hw-management/hw-mgmt"]
 	path = platform/mellanox/hw-management/hw-mgmt
-	url = https://github.com/Mellanox/hw-mgmt/
+	url = https://github.com/Mellanox/hw-mgmt
 [submodule "src/redis-dump-load"]
 	path = src/redis-dump-load
 	url = https://github.com/p/redis-dump-load.git


### PR DESCRIPTION
* fix url for
* submodule "platform/mellanox/hw-management/hw-mgmt"
* remove trailing / from url

Signed-off-by: Don Newton don@opennetworking.org

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
During make init submodule`` "platform/mellanox/hw-management/hw-mgmt" fails to clone due to trailing / on the url

#### How I did it
Removed the trailing /
#### How to verify it
`make init` and look for errors
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x ] 202012
ONF is using the 202012 branch as the base for our effort
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Correct the url line for submodule "platform/mellanox/hw-management/hw-mgmt"

#### A picture of a cute animal (not mandatory but encouraged)

