### PR TITLE
Use 'importlib' module in lieu of deprecated 'imp' module

### DIFF
--- a/src/sonic-host-services/scripts/procdockerstatsd
+++ b/src/sonic-host-services/scripts/procdockerstatsd
@@ -72,7 +72,7 @@ class ProcDockerStats(daemon_base.DaemonBase):
         UNITS_MiB = 'MiB'
         UNITS_GiB = 'GiB'
 
-        res = re.match('(\d+\.?\d*)([a-zA-Z]+)', value)
+        res = re.match(r'(\d+\.?\d*)([a-zA-Z]+)', value)
         value = float(res.groups()[0])
         units = res.groups()[1]
         if units.lower() == UNITS_KB.lower():

--- a/src/sonic-host-services/tests/procdockerstatsd_test.py
+++ b/src/sonic-host-services/tests/procdockerstatsd_test.py
@@ -1,4 +1,4 @@
-import imp
+import importlib
 import sys
 import os
 import pytest
@@ -14,8 +14,13 @@ modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")
 sys.path.insert(0, modules_path)
 
-imp.load_source('procdockerstatsd', scripts_path + '/procdockerstatsd')
-from procdockerstatsd import *
+# Load the file under test
+procdockerstatsd_path = os.path.join(scripts_path, 'procdockerstatsd')
+loader = importlib.machinery.SourceFileLoader('procdockerstatsd', procdockerstatsd_path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+procdockerstatsd = importlib.util.module_from_spec(spec)
+loader.exec_module(procdockerstatsd)
+sys.modules['procdockerstatsd'] = procdockerstatsd
 
 class TestProcDockerStatsDaemon(object):
     def test_convert_to_bytes(self):
@@ -35,7 +40,7 @@ class TestProcDockerStatsDaemon(object):
             ('7.751GiB', 8322572878)
         ]
 
-        pdstatsd = ProcDockerStats(SYSLOG_IDENTIFIER)
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
 
         for test_input, expected_output in test_data:
             res = pdstatsd.convert_to_bytes(test_input)


### PR DESCRIPTION
#### What I did

Migrate from using the `imp` module to using the `importlib` module. As of Python 3, the `imp` module has been deprecated in favor of the `importlib` module.

#### How I did it

Eliminate all importing of the `imp` module, and replace all which were actually used with imports of the `importlib` module, and modify all affected code appropriately.

#### How to verify it

- Ensure determine-reboot-cause_test.py unit tests pass
- Ensure procdockerstatsd_test.py unit tests pass
- Ensure sonic_py_common.DaemonBase.load_platform_util() still functions correctly with old plugins (which are deprecated and will be removed soon anyway)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012