### PR TITLE
[minigraph] Support tagged VlanInterface if attached to multiple vlans

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -526,16 +526,13 @@ def parse_dpg(dpg, hname):
         vlans = {}
         vlan_members = {}
         vlantype_name = ""
-        intf_vlan_mbr = {}
+        intf_vlan_mbr = defaultdict(list)
         for vintf in vlanintfs.findall(str(QName(ns, "VlanInterface"))):
             vlanid = vintf.find(str(QName(ns, "VlanID"))).text
             vintfmbr = vintf.find(str(QName(ns, "AttachTo"))).text
             vmbr_list = vintfmbr.split(';')
             for i, member in enumerate(vmbr_list):
-                try:
-                    intf_vlan_mbr[member].append(vlanid)
-                except:
-                    intf_vlan_mbr[member] = [vlanid]
+                intf_vlan_mbr[member].append(vlanid)
         for vintf in vlanintfs.findall(str(QName(ns, "VlanInterface"))):
             vintfname = vintf.find(str(QName(ns, "Name"))).text
             vlanid = vintf.find(str(QName(ns, "VlanID"))).text

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -526,6 +526,16 @@ def parse_dpg(dpg, hname):
         vlans = {}
         vlan_members = {}
         vlantype_name = ""
+        intf_vlan_mbr = {}
+        for vintf in vlanintfs.findall(str(QName(ns, "VlanInterface"))):
+            vlanid = vintf.find(str(QName(ns, "VlanID"))).text
+            vintfmbr = vintf.find(str(QName(ns, "AttachTo"))).text
+            vmbr_list = vintfmbr.split(';')
+            for i, member in enumerate(vmbr_list):
+                try:
+                    intf_vlan_mbr[member].append(vlanid)
+                except:
+                    intf_vlan_mbr[member] = [vlanid]
         for vintf in vlanintfs.findall(str(QName(ns, "VlanInterface"))):
             vintfname = vintf.find(str(QName(ns, "Name"))).text
             vlanid = vintf.find(str(QName(ns, "VlanID"))).text
@@ -538,6 +548,8 @@ def parse_dpg(dpg, hname):
                 vmbr_list[i] = port_alias_map.get(member, member)
                 sonic_vlan_member_name = "Vlan%s" % (vlanid)
                 if vlantype_name == "Tagged":
+                    vlan_members[(sonic_vlan_member_name, vmbr_list[i])] = {'tagging_mode': 'tagged'}
+                elif len(intf_vlan_mbr[member]) > 1:
                     vlan_members[(sonic_vlan_member_name, vmbr_list[i])] = {'tagging_mode': 'tagged'}
                 else:
                     vlan_members[(sonic_vlan_member_name, vmbr_list[i])] = {'tagging_mode': 'untagged'}

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -173,6 +173,22 @@
           <Type>Tagged</Type>
           <Subnets>192.168.0.0/28</Subnets>
         </VlanInterface>
+        <VlanInterface>
+          <Name>ab2</Name>
+          <AttachTo>fortyGigE0/12</AttachTo>
+          <DhcpRelays>192.0.0.1;192.0.0.2</DhcpRelays>
+          <VlanID>2000</VlanID>
+          <Tag>2000</Tag>
+          <Subnets>192.168.0.240/27</Subnets>
+        </VlanInterface>
+        <VlanInterface>
+          <Name>ab3</Name>
+          <AttachTo>fortyGigE0/12</AttachTo>
+          <DhcpRelays>192.0.0.1;192.0.0.2</DhcpRelays>
+          <VlanID>2001</VlanID>
+          <Tag>2001</Tag>
+          <Subnets>192.168.0.240/27</Subnets>
+        </VlanInterface>
       </VlanInterfaces>
       <IPInterfaces>
         <IPInterface>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -121,6 +121,8 @@ class TestCfgGen(TestCase):
             utils.to_dict(output.strip()),
             utils.to_dict(
                 '{\n    "Vlan1000|Ethernet8": {\n        "tagging_mode": "untagged"\n    },'
+                ' \n    "Vlan2000|Ethernet12": {\n        "tagging_mode": "tagged"\n    },'
+                ' \n    "Vlan2001|Ethernet12": {\n        "tagging_mode": "tagged"\n    },'
                 ' \n    "Vlan2020|Ethernet12": {\n        "tagging_mode": "tagged"\n    }\n}'
             )
         )
@@ -206,6 +208,8 @@ class TestCfgGen(TestCase):
             utils.to_dict(output.strip()),
             utils.to_dict(
                 "{'Vlan1000': {'alias': 'ab1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '1000'}, "
+                "'Vlan2001': {'alias': 'ab3', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2001'},"
+                "'Vlan2000': {'alias': 'ab2', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2000'},"
                 "'Vlan2020': {'alias': 'kk1', 'dhcp_servers': ['192.0.0.1', '192.0.0.2'], 'vlanid': '2020'}}"
             )
         )
@@ -214,9 +218,13 @@ class TestCfgGen(TestCase):
         argument = '-m "' + self.sample_graph_simple + '" -p "' + self.port_config + '" -v VLAN_MEMBER'
         output = self.run_script(argument)
         self.assertEqual(
-            output.strip(),
-            "{('Vlan1000', 'Ethernet8'): {'tagging_mode': 'untagged'}, "
-            "('Vlan2020', 'Ethernet12'): {'tagging_mode': 'tagged'}}"
+            utils.to_dict(output.strip()),
+            utils.to_dict(
+                "{('Vlan2000', 'Ethernet12'): {'tagging_mode': 'tagged'}, "
+                "('Vlan1000', 'Ethernet8'): {'tagging_mode': 'untagged'}, "
+                "('Vlan2020', 'Ethernet12'): {'tagging_mode': 'tagged'}, "
+                "('Vlan2001', 'Ethernet12'): {'tagging_mode': 'tagged'}}"
+            )
         )
 
     def test_minigraph_vlan_interfaces(self):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It is possible that one interface attaches multiple vlans. The VlanInterface should be in tagged mode.

#### How I did it

#### How to verify it
Unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

