### PR TITLE
[baseimage] add ipintutil in sudoer file

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -20,6 +20,7 @@ Defaults        lecture_file = /etc/sudoers.lecture
 # Cmnd alias specification
 # Note: bcmcmd is dangerous for users in read only netgroups because it may operate ASIC
 Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog*, \
+                                 /bin/ip netns identify [0-9]*, \
                                  /sbin/brctl show, \
                                  /usr/bin/docker exec snmp cat /etc/snmp/snmpd.conf, \
                                  /usr/bin/docker exec bgp cat /etc/quagga/bgpd.conf, \
@@ -33,14 +34,13 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog*, \
                                  /usr/bin/vtysh -n [0-9] -c show *, \
                                  /usr/local/bin/decode-syseeprom, \
                                  /usr/local/bin/generate_dump, \
+                                 /usr/local/bin/ipintutil, \
                                  /usr/local/bin/lldpshow, \
                                  /usr/local/bin/pcieutil *, \
                                  /usr/local/bin/psuutil *, \
                                  /usr/local/bin/sonic-installer list, \
-                                 /usr/local/bin/sfputil show *, \
-                                 /bin/ip netns identify [0-9]*, \
-                                 /usr/local/bin/ipintutil
-                                 
+                                 /usr/local/bin/sfputil show *
+
 
 Cmnd_Alias      PASSWD_CMDS = /usr/local/bin/config tacacs passkey *, \
                               /usr/sbin/chpasswd *

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -38,7 +38,8 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog*, \
                                  /usr/local/bin/psuutil *, \
                                  /usr/local/bin/sonic-installer list, \
                                  /usr/local/bin/sfputil show *, \
-                                 /bin/ip netns identify [0-9]*
+                                 /bin/ip netns identify [0-9]*, \
+                                 /usr/local/bin/ipintutil
                                  
 
 Cmnd_Alias      PASSWD_CMDS = /usr/local/bin/config tacacs passkey *, \


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`show ip interfaces` is enhanced recently to support multi ASIC platforms in this [PR ](https://github.com/Azure/sonic-utilities/pull/1396). The `ipintutil` script as to run as `sudo`  user, to get the ip interface from each namespace.
Add this script to the sudoer file so that `show ip interface` command is available for user with read-only permissions
 
#### How I did it
Add script `ipintutil` to the read-only allowed commands list.

#### How to verify it
**- Before the change**
```
user_ro@vlab-01:~$ id
uid=1002(user_ro) gid=1002(user_ro) groups=1002(user_ro)
user_ro@vlab-01:~$ show ip int

Make sure your account has RW permission to current device.
Otherwise sudo requests will be rejected.

[sudo] password for user_ro:

Aborted!
user_ro@vlab-01:~$
```

**- After the change**
```
user_ro@vlab-01:~$ id
uid=1002(user_ro) gid=1002(user_ro) groups=1002(user_ro)
user_ro@vlab-01:~$ show ip int
Interface    Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
-----------  --------  -------------------  ------------  --------------  -------------
Ethernet0              10.0.0.0/31          up/up         ARISTA01T2      10.0.0.1
Ethernet4              10.0.0.2/31          up/up         ARISTA02T2      10.0.0.3
Ethernet8              10.0.0.4/31          up/up         ARISTA03T2      10.0.0.5
Ethernet12             10.0.0.6/31          up/up         ARISTA04T2      10.0.0.7
Ethernet16             10.0.0.8/31          up/up         ARISTA05T2      10.0.0.9
Ethernet20             10.0.0.10/31         up/up         ARISTA06T2      10.0.0.11
Ethernet24             10.0.0.12/31         up/up         ARISTA07T2      10.0.0.13
Ethernet28             10.0.0.14/31         up/up         ARISTA08T2      10.0.0.15
Ethernet32             10.0.0.16/31         up/up         ARISTA09T2      10.0.0.17
Ethernet36             10.0.0.18/31         up/up         ARISTA10T2      10.0.0.19
Ethernet40             10.0.0.20/31         up/up         ARISTA11T2      10.0.0.21
Ethernet44             10.0.0.22/31         up/up         ARISTA12T2      10.0.0.23
Ethernet48             10.0.0.24/31         up/up         ARISTA13T2      10.0.0.25
Ethernet52             10.0.0.26/31         up/up         ARISTA14T2      10.0.0.27
Ethernet56             10.0.0.28/31         up/up         ARISTA15T2      10.0.0.29
Ethernet60             10.0.0.30/31         up/up         ARISTA16T2      10.0.0.31
Ethernet64             10.0.0.32/31         up/up         ARISTA01T0      10.0.0.33
Ethernet68             10.0.0.34/31         up/up         ARISTA02T0      10.0.0.35
Ethernet72             10.0.0.36/31         up/up         ARISTA03T0      10.0.0.37
Ethernet76             10.0.0.38/31         up/up         ARISTA04T0      10.0.0.39
Ethernet80             10.0.0.40/31         up/up         ARISTA05T0      10.0.0.41
Ethernet84             10.0.0.42/31         up/up         ARISTA06T0      10.0.0.43
Ethernet88             10.0.0.44/31         up/up         ARISTA07T0      10.0.0.45
Ethernet92             10.0.0.46/31         up/up         ARISTA08T0      10.0.0.47
Ethernet96             10.0.0.48/31         up/up         ARISTA09T0      10.0.0.49
Ethernet100            10.0.0.50/31         up/up         ARISTA10T0      10.0.0.51
Ethernet104            10.0.0.52/31         up/up         ARISTA11T0      10.0.0.53
Ethernet108            10.0.0.54/31         up/up         ARISTA12T0      10.0.0.55
Ethernet112            10.0.0.56/31         up/up         ARISTA13T0      10.0.0.57
Ethernet116            10.0.0.58/31         up/up         ARISTA14T0      10.0.0.59
Ethernet120            10.0.0.60/31         up/up         ARISTA15T0      10.0.0.61
Ethernet124            10.0.0.62/31         up/up         ARISTA16T0      10.0.0.63
Loopback0              10.1.0.1/32          up/up         N/A             N/A
docker0                240.127.1.1/24       up/down       N/A             N/A
eth0                   10.250.0.101/24      up/up         N/A             N/A
lo                     127.0.0.1/16         up/up         N/A             N/A
user_ro@vlab-01:~$
```

The `sonic-mgmt` tests `test_ro_user_allowed_command` and `test_ro_user_banned_command` is enhanced to check `show ip interfaces` and other common SONiC CLI commands in this PR https://github.com/Azure/sonic-mgmt/pull/3016



#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ X] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

