### PR TITLE
[multi-asic] BBR support on internal-peers for multi-asic platfroms.

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/peer-group.conf.j2
@@ -8,6 +8,7 @@
     neighbor INTERNAL_PEER_V4 route-reflector-client
 {% endif %}
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
+    neighbor INTERNAL_PEER_V4 allowas-in 1
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
   exit-address-family
@@ -16,6 +17,7 @@
     neighbor INTERNAL_PEER_V6 route-reflector-client
 {% endif %}
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound
+    neighbor INTERNAL_PEER_V6 allowas-in 1
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
   exit-address-family

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_back.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_back.conf
@@ -1,20 +1,22 @@
 !
-! template: bgpd/templates/internal/peer-group.conf.j2
+! template: bgpd/templates/general/peer-group.conf.j2
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
   address-family ipv4
     neighbor INTERNAL_PEER_V4 route-reflector-client
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
+    neighbor INTERNAL_PEER_V4 allowas-in 1
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor INTERNAL_PEER_V6 route-reflector-client
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound
+    neighbor INTERNAL_PEER_V6 allowas-in 1
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
   exit-address-family
 !
-! end of template: bgpd/templates/internal/peer-group.conf.j2
+! end of template: bgpd/templates/general/peer-group.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_back.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_back.conf
@@ -1,5 +1,5 @@
 !
-! template: bgpd/templates/general/peer-group.conf.j2
+! template: bgpd/templates/internal/peer-group.conf.j2
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
@@ -18,5 +18,5 @@
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
   exit-address-family
 !
-! end of template: bgpd/templates/general/peer-group.conf.j2
+! end of template: bgpd/templates/internal/peer-group.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_front.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_front.conf
@@ -1,5 +1,5 @@
 !
-! template: bgpd/templates/general/peer-group.conf.j2
+! template: bgpd/templates/internal/peer-group.conf.j2
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
@@ -16,5 +16,5 @@
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
   exit-address-family
 !
-! end of template: bgpd/templates/general/peer-group.conf.j2
+! end of template: bgpd/templates/internal/peer-group.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_front.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/peer-group.conf/result_front.conf
@@ -1,18 +1,20 @@
 !
-! template: bgpd/templates/internal/peer-group.conf.j2
+! template: bgpd/templates/general/peer-group.conf.j2
 !
   neighbor INTERNAL_PEER_V4 peer-group
   neighbor INTERNAL_PEER_V6 peer-group
   address-family ipv4
     neighbor INTERNAL_PEER_V4 soft-reconfiguration inbound
+    neighbor INTERNAL_PEER_V4 allowas-in 1
     neighbor INTERNAL_PEER_V4 route-map FROM_BGP_INTERNAL_PEER_V4 in
     neighbor INTERNAL_PEER_V4 route-map TO_BGP_INTERNAL_PEER_V4 out
   exit-address-family
   address-family ipv6
     neighbor INTERNAL_PEER_V6 soft-reconfiguration inbound
+    neighbor INTERNAL_PEER_V6 allowas-in 1
     neighbor INTERNAL_PEER_V6 route-map FROM_BGP_INTERNAL_PEER_V6 in
     neighbor INTERNAL_PEER_V6 route-map TO_BGP_INTERNAL_PEER_V6 out
   exit-address-family
 !
-! end of template: bgpd/templates/internal/peer-group.conf.j2
+! end of template: bgpd/templates/general/peer-group.conf.j2
 !


### PR DESCRIPTION
What I did:
Enable BBR config `allowas-in 1` for internal peers 

Why I did:
To advertise BBR routes learnt via e-BGP peer in one asic/namespace to another iBGP asic/namespace via Route Reflector.

How I Verify:
- Verify manually route advertisement.

- https://github.com/Azure/sonic-mgmt/pull/3022

