### PR TITLE
[Supervisord] Deduplicate the alerting messages of critical processes from Supervisord.

### DIFF
--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -65,7 +65,7 @@ def get_critical_group_and_process_list():
     return critical_group_list, critical_process_list
 
 
-def generate_alerting_message(process_name, num_minutes):
+def generate_alerting_message(process_name, dead_minutes):
     """
     @summary: If a critical process was not running, this function will determine it resides in host
               or in a specific namespace. Then an alerting message will be written into syslog.
@@ -78,8 +78,8 @@ def generate_alerting_message(process_name, num_minutes):
     else:
         namespace = namespace_prefix + namespace_id
 
-    syslog.syslog(syslog.LOG_ERR, "Process '{}' is not running in namespace '{}'({} minutes)."
-                  .format(process_name, namespace, num_minutes))
+    syslog.syslog(syslog.LOG_ERR, "Process '{}' is not running in namespace '{}' ({} minutes)."
+                  .format(process_name, namespace, dead_minutes))
 
 
 def get_autorestart_state(container_name):
@@ -120,7 +120,7 @@ def main(argv):
 
     critical_group_list, critical_process_list = get_critical_group_and_process_list()
 
-    process_under_alerting = defaultdict(list)
+    process_under_alerting = defaultdict(dict)
     # Transition from ACKNOWLEDGED to READY
     childutils.listener.ready()
 
@@ -147,8 +147,8 @@ def main(argv):
                         syslog.syslog(syslog.LOG_INFO, msg)
                         os.kill(os.getppid(), signal.SIGTERM)
                     else:
-                        process_under_alerting[process_name].append(time.time())
-                        process_under_alerting[process_name].append(0)
+                        process_under_alerting[process_name]["last_alerted"] = time.time()
+                        process_under_alerting[process_name]["dead_minutes"] = 0
 
             # Handle the PROCESS_STATE_RUNNING event
             elif headers['eventname'] == 'PROCESS_STATE_RUNNING':
@@ -165,12 +165,14 @@ def main(argv):
             childutils.listener.ready()
 
         # Check whether we need write alerting messages into syslog
-        for process in process_under_alerting.keys():
+        for process_name in process_under_alerting.keys():
             epoch_time = time.time()
-            if epoch_time - process_under_alerting[process][0] >= ALERTING_INTERVAL_SECS:
-                process_under_alerting[process][0] = epoch_time
-                process_under_alerting[process][1] += 1
-                generate_alerting_message(process, process_under_alerting[process][1])
+            elapsed_secs = epoch_time - process_under_alerting[process_name]["last_alerted"]
+            if elapsed_secs >= ALERTING_INTERVAL_SECS:
+                elapsed_mins = int(elapsed_secs / 60)
+                process_under_alerting[process_name]["last_alerted"] = epoch_time
+                process_under_alerting[process_name]["dead_minutes"] += elapsed_mins
+                generate_alerting_message(process_name, process_under_alerting[process_name]["dead_minutes"])
 
 
 if __name__ == "__main__":

--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -169,7 +169,7 @@ def main(argv):
             epoch_time = time.time()
             elapsed_secs = epoch_time - process_under_alerting[process_name]["last_alerted"]
             if elapsed_secs >= ALERTING_INTERVAL_SECS:
-                elapsed_mins = int(elapsed_secs / 60)
+                elapsed_mins = elapsed_secs // 60
                 process_under_alerting[process_name]["last_alerted"] = epoch_time
                 process_under_alerting[process_name]["dead_minutes"] += elapsed_mins
                 generate_alerting_message(process_name, process_under_alerting[process_name]["dead_minutes"])

--- a/files/scripts/supervisor-proc-exit-listener
+++ b/files/scripts/supervisor-proc-exit-listener
@@ -8,6 +8,7 @@ import signal
 import sys
 import syslog
 import time
+from collections import defaultdict
 
 import swsssdk
 
@@ -64,7 +65,7 @@ def get_critical_group_and_process_list():
     return critical_group_list, critical_process_list
 
 
-def generate_alerting_message(process_name):
+def generate_alerting_message(process_name, num_minutes):
     """
     @summary: If a critical process was not running, this function will determine it resides in host
               or in a specific namespace. Then an alerting message will be written into syslog.
@@ -77,7 +78,8 @@ def generate_alerting_message(process_name):
     else:
         namespace = namespace_prefix + namespace_id
 
-    syslog.syslog(syslog.LOG_ERR, "Process '{}' is not running in namespace '{}'.".format(process_name, namespace))
+    syslog.syslog(syslog.LOG_ERR, "Process '{}' is not running in namespace '{}'({} minutes)."
+                  .format(process_name, namespace, num_minutes))
 
 
 def get_autorestart_state(container_name):
@@ -118,7 +120,7 @@ def main(argv):
 
     critical_group_list, critical_process_list = get_critical_group_and_process_list()
 
-    process_under_alerting = {}
+    process_under_alerting = defaultdict(list)
     # Transition from ACKNOWLEDGED to READY
     childutils.listener.ready()
 
@@ -145,7 +147,8 @@ def main(argv):
                         syslog.syslog(syslog.LOG_INFO, msg)
                         os.kill(os.getppid(), signal.SIGTERM)
                     else:
-                        process_under_alerting[process_name] = time.time()
+                        process_under_alerting[process_name].append(time.time())
+                        process_under_alerting[process_name].append(0)
 
             # Handle the PROCESS_STATE_RUNNING event
             elif headers['eventname'] == 'PROCESS_STATE_RUNNING':
@@ -164,9 +167,10 @@ def main(argv):
         # Check whether we need write alerting messages into syslog
         for process in process_under_alerting.keys():
             epoch_time = time.time()
-            if epoch_time - process_under_alerting[process] >= ALERTING_INTERVAL_SECS:
-                process_under_alerting[process] = epoch_time
-                generate_alerting_message(process)
+            if epoch_time - process_under_alerting[process][0] >= ALERTING_INTERVAL_SECS:
+                process_under_alerting[process][0] = epoch_time
+                process_under_alerting[process][1] += 1
+                generate_alerting_message(process, process_under_alerting[process][1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In the configuration of `rsyslog`, duplicate messages will be suppressed and reported in the format of `message repeated n times`.
Due to this behavior, if a critical process in a container exited unexpectedly, the alerting message will be written into syslog once
and not be written into syslog anymore until the second critical process exited. This PR aims to differentiate these alerting messages such that they will not be suppressed by `rsyslogd` and can appear in the syslog periodically.
 
#### How I did it
This PR adds a counter into the alerting message and shows how many minutes a critical process was not running.

#### How to verify it
I verified and test this implementation on a physical DUT.

    Feb 23 01:24:36.541111 str-dx010-acs-1 INFO lldp#supervisord 2021-02-23 01:24:36,540 INFO exited: lldp-syncd (terminated by SIGKILL; not expected)
    Feb 23 01:24:36.543880 str-dx010-acs-1 INFO lldp#supervisord 2021-02-23 01:24:36,543 INFO exited: lldpmgrd (terminated by SIGKILL; not expected)
    Feb 23 01:25:36.616111 str-dx010-acs-1 ERR lldp#supervisor-proc-exit-listener: Process 'lldp-syncd' is not running in namespace 'host'(1 minutes).
    Feb 23 01:25:36.616207 str-dx010-acs-1 ERR lldp#supervisor-proc-exit-listener: Process 'lldpmgrd' is not running in namespace 'host'(1 minutes).
    Feb 23 01:26:36.673000 str-dx010-acs-1 ERR lldp#supervisor-proc-exit-listener: Process 'lldp-syncd' is not running in namespace 'host'(2 minutes).
    Feb 23 01:26:36.673443 str-dx010-acs-1 ERR lldp#supervisor-proc-exit-listener: Process 'lldpmgrd' is not running in namespace 'host'(2 minutes).
    Feb 23 01:27:36.730690 str-dx010-acs-1 ERR lldp#supervisor-proc-exit-listener: Process 'lldp-syncd' is not running in namespace 'host'(3 minutes).
    Feb 23 01:27:36.730817 str-dx010-acs-1 ERR lldp#supervisor-proc-exit-listener: Process 'lldpmgrd' is not running in namespace 'host'(3 minutes).
    Feb 23 01:28:36.782367 str-dx010-acs-1 ERR lldp#supervisor-proc-exit-listener: Process 'lldp-syncd' is not running in namespace 'host'(4 minutes).
    Feb 23 01:28:36.782818 str-dx010-acs-1 ERR lldp#supervisor-proc-exit-listener: Process 'lldpmgrd' is not running in namespace 'host'(4 minutes).
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

