### PR TITLE
[Celestica] Ensure concrete platform API classes call base class initializer

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/thermal.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/thermal.py
@@ -25,6 +25,8 @@ class Thermal(ThermalBase):
     SS_CONFIG_PATH = "/usr/share/sonic/device/x86_64-cel_e1031-r0/sensors.conf"
 
     def __init__(self, thermal_index):
+        ThermalBase.__init__(self)
+
         self.index = thermal_index
 
         # Add thermal name

--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/watchdog.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/watchdog.py
@@ -53,6 +53,7 @@ WDT_SYSFS_PATH = "/sys/class/watchdog/"
 class Watchdog(WatchdogBase):
 
     def __init__(self):
+        WatchdogBase.__init__(self)
 
         self.watchdog, self.wdt_main_dev_name = self._get_wdt()
         self.status_path = "/sys/class/watchdog/%s/status" % self.wdt_main_dev_name

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/thermal.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/thermal.py
@@ -67,6 +67,7 @@ class Thermal(ThermalBase):
     SS_CONFIG_PATH = "/usr/share/sonic/device/x86_64-cel_seastone-r0/sensors.conf"
 
     def __init__(self, thermal_index, airflow):
+        ThermalBase.__init__(self)
         self.index = thermal_index
         self._api_helper = APIHelper()
         self._airflow = airflow

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/watchdog.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/watchdog.py
@@ -31,6 +31,8 @@ WDT_COMMON_ERROR = -1
 class Watchdog(WatchdogBase):
 
     def __init__(self):
+        WatchdogBase.__init__(self)
+
         # Init helper
         self._api_helper = APIHelper()
 

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/watchdog.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/watchdog.py
@@ -29,6 +29,8 @@ WDT_COMMON_ERROR = -1
 class Watchdog(WatchdogBase):
 
     def __init__(self):
+        WatchdogBase.__init__(self)
+
         self._api_common = Common()
 
         # Init cpld reg path

--- a/device/celestica/x86_64-cel_silverstone-r0/sonic_platform/fan.py
+++ b/device/celestica/x86_64-cel_silverstone-r0/sonic_platform/fan.py
@@ -54,6 +54,7 @@ class Fan(FanBase):
     """Platform-specific Fan class"""
 
     def __init__(self, fan_tray_index, fan_index=0, is_psu_fan=False, psu_index=0):
+        FanBase.__init__(self)
         self.fan_index = fan_index
         self.fan_tray_index = fan_tray_index
         self.is_psu_fan = is_psu_fan


### PR DESCRIPTION
#### Why I did it

In preparation for the merging of https://github.com/Azure/sonic-platform-common/pull/173, which properly defines class and instance members in the Platform API base classes.

It is proper object-oriented methodology to call the base class initializer, even if it is only the default initializer. This also future-proofs the potential addition of custom initializers in the base classes down the road.

#### How I did it

Ensure the base class initializer is called in all concrete initializers

#### How to verify it

Run image on affected Celestica platforms, ensure platform API continues to function properly

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

