### PR TITLE
[DellEMC] Ensure concrete platform API classes call base class initializer

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/component.py
@@ -82,6 +82,7 @@ class Component(ComponentBase):
     ]
 
     def __init__(self, component_index = 0):
+        ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/fan.py
@@ -41,6 +41,7 @@ class Fan(FanBase):
 
     def __init__(self, fantray_index=1, fan_index=1, psu_fan=False,
             dependency=None):
+        FanBase.__init__(self)
         self.is_psu_fan = psu_fan
         if not self.is_psu_fan:
             # API index is starting from 0, DellEMC platform index is

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/watchdog.py
@@ -36,6 +36,7 @@ class Watchdog(WatchdogBase):
     CLOCK_MONOTONIC = 1
 
     def __init__(self):
+        WatchdogBase.__init__(self)
         self._librt = ctypes.CDLL('librt.so.1', use_errno=True)
         self._clock_gettime = self._librt.clock_gettime
         self._clock_gettime.argtypes=[ctypes.c_int, ctypes.POINTER(_timespec)]

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/component.py
@@ -34,6 +34,7 @@ class Component(ComponentBase):
     ]
 
     def __init__(self, component_index):
+        ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/fan.py
@@ -33,6 +33,7 @@ class Fan(FanBase):
 
     def __init__(self, fantray_index=1, fan_index=1,
                  psu_index=1, psu_fan=False, dependency=None):
+        FanBase.__init__(self)
         self.is_psu_fan = psu_fan
         self.is_driver_initialized = True
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/thermal.py
@@ -35,6 +35,7 @@ class Thermal(ThermalBase):
 
     def __init__(self, thermal_index,
                  psu_index=1, psu_thermal=False, dependency=None):
+        ThermalBase.__init__(self)
         self.is_psu_thermal = psu_thermal
         self.dependency = dependency
         self.is_driver_initialized = True

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/component.py
@@ -41,6 +41,7 @@ class Component(ComponentBase):
     def __init__(self, component_index=0,
                  is_module=False, iom_index=0, i2c_line=0, dependency=None):
 
+        ComponentBase.__init__(self)
         self.is_module_component = is_module
         self.dependency = dependency
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan.py
@@ -27,6 +27,7 @@ class Fan(FanBase):
     MAILBOX_DIR = HWMON_DIR + HWMON_NODE
 
     def __init__(self, fantray_index=1, psu_index=1, psu_fan=False, dependency=None):
+        FanBase.__init__(self)
         self.is_psu_fan = psu_fan
         if not self.is_psu_fan:
             self.fantrayindex = fantray_index

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/thermal.py
@@ -26,6 +26,7 @@ class Thermal(ThermalBase):
         )
 
     def __init__(self, thermal_index):
+        ThermalBase.__init__(self)
         self.is_cpu_thermal = False
         self.index = thermal_index + 1
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/watchdog.py
@@ -41,6 +41,7 @@ class Watchdog(WatchdogBase):
     CLOCK_MONOTONIC = 1
 
     def __init__(self):
+        WatchdogBase.__init__(self)
         self._librt = ctypes.CDLL('librt.so.1', use_errno=True)
         self._clock_gettime = self._librt.clock_gettime
         self._clock_gettime.argtypes=[ctypes.c_int, ctypes.POINTER(_timespec)]

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/component.py
@@ -39,6 +39,7 @@ class Component(ComponentBase):
     ]
 
     def __init__(self, component_index=0):
+        ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/fan.py
@@ -27,6 +27,7 @@ class Fan(FanBase):
     MAILBOX_DIR = HWMON_DIR + HWMON_NODE
 
     def __init__(self, fantray_index=1, fan_index=1, psu_fan=False):
+        FanBase.__init__(self)
         self.is_psu_fan = psu_fan
         if not self.is_psu_fan:
             # API index is starting from 0, DellEMC platform index is starting

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/psu.py
@@ -25,6 +25,7 @@ class Psu(PsuBase):
     MAILBOX_DIR = HWMON_DIR + HWMON_NODE
 
     def __init__(self, psu_index):
+        PsuBase.__init__(self)
         # PSU is 1-based in DellEMC platforms
         self.index = psu_index + 1
         self.psu_presence_reg = "psu{}_presence".format(self.index)

--- a/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9100/sonic_platform/thermal.py
@@ -26,6 +26,7 @@ class Thermal(ThermalBase):
         )
 
     def __init__(self, thermal_index):
+        ThermalBase.__init__(self)
         self.is_cpu_thermal = False
         self.index = thermal_index + 1
 

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/component.py
@@ -36,6 +36,7 @@ class Component(ComponentBase):
                                                               "port transceivers (65 and 66)")],
                                                                                         ]
     def __init__(self, component_index=0):
+        ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/fan.py
@@ -43,6 +43,7 @@ class Fan(FanBase):
 
     def __init__(self, fantray_index=1, fan_index=1, psu_fan=False,
             dependency=None):
+        FanBase.__init__(self)
         self.is_psu_fan = psu_fan
         if not self.is_psu_fan:
             # API index is starting from 0, DellEMC platform index is

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/watchdog.py
@@ -38,6 +38,7 @@ class Watchdog(WatchdogBase):
     CLOCK_MONOTONIC = 1
 
     def __init__(self):
+        WatchdogBase.__init__(self)
         self._librt = ctypes.CDLL('librt.so.1', use_errno=True)
         self._clock_gettime = self._librt.clock_gettime
         self._clock_gettime.argtypes=[ctypes.c_int, ctypes.POINTER(_timespec)]

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
@@ -81,6 +81,7 @@ class Component(ComponentBase):
     ]
 
     def __init__(self, component_index = 0):
+        ComponentBase.__init__(self)
         self.index = component_index
         self.name = self.CHASSIS_COMPONENTS[self.index][0]
         self.description = self.CHASSIS_COMPONENTS[self.index][1]

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/fan.py
@@ -38,6 +38,7 @@ class Fan(FanBase):
     PSU_FRU_MAPPING = { 1: 3, 2: 4 }
 
     def __init__(self, fantray_index=1, fan_index=1, psu_fan=False, dependency=None):
+        FanBase.__init__(self)
         self.is_psu_fan = psu_fan
         if not self.is_psu_fan:
             # API index is starting from 0, DellEMC platform index is

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/watchdog.py
@@ -36,6 +36,7 @@ class Watchdog(WatchdogBase):
     CLOCK_MONOTONIC = 1
 
     def __init__(self):
+        WatchdogBase.__init__(self)
         self._librt = ctypes.CDLL('librt.so.1', use_errno=True)
         self._clock_gettime = self._librt.clock_gettime
         self._clock_gettime.argtypes=[ctypes.c_int, ctypes.POINTER(_timespec)]


### PR DESCRIPTION
#### Why I did it

In preparation for the merging of https://github.com/Azure/sonic-platform-common/pull/173, which properly defines class and instance members in the Platform API base classes.

It is proper object-oriented methodology to call the base class initializer, even if it is only the default initializer. This also future-proofs the potential addition of custom initializers in the base classes down the road.

#### How I did it

Ensure the base class initializer is called in all concrete initializers

#### How to verify it

Run image on affected DellEMC platforms, ensure platform API continues to function properly

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

