### PR TITLE
[Mellanox] Ensure concrete platform API classes call base class initializer

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -323,6 +323,7 @@ class ONIEUpdater(object):
 
 class Component(ComponentBase):
     def __init__(self):
+        super(Component, self).__init__()
         self.name = None
         self.description = None
         self.image_ext_name = None

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -373,6 +373,7 @@ class Thermal(ThermalBase):
         """
         index should be a string for category ambient and int for other categories
         """
+        super(Thermal, self).__init__()
         if category == THERMAL_DEV_CATEGORY_AMBIENT:
             self.name = thermal_ambient_name[index]
             self.index = index

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
@@ -63,6 +63,7 @@ class WatchdogImplBase(WatchdogBase):
         Open a watchdog handle
         @param wd_device_path Path to watchdog device
         """
+        super(WatchdogImplBase, self).__init__()
 
         self.watchdog_path = wd_device_path
         self.watchdog = os.open(self.watchdog_path, os.O_WRONLY)


### PR DESCRIPTION
#### Why I did it

In preparation for the merging of https://github.com/Azure/sonic-platform-common/pull/173, which properly defines class and instance members in the Platform API base classes.

It is proper object-oriented methodology to call the base class initializer, even if it is only the default initializer. This also future-proofs the potential addition of custom initializers in the base classes down the road.

#### How I did it

Ensure the base class initializer is called in all concrete initializers

#### How to verify it

Run image on affected Mellanox platforms, ensure platform API continues to function properly

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

