### PR TITLE
[thermalctld] Disable thermalctld on Mellanox simx platforms

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700_simx-r0/pmon_daemon_control.json
@@ -1,5 +1,6 @@
 {
         "skip_ledd": true,
         "skip_xcvrd": true,
-        "skip_psud": true
+        "skip_psud": true,
+        "skip_thermalctld": true
 }

--- a/device/mellanox/x86_64-mlnx_msn3700_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn3700_simx-r0/pmon_daemon_control.json
@@ -1,5 +1,6 @@
 {
         "skip_ledd": true,
         "skip_xcvrd": true,
-        "skip_psud": true
+        "skip_psud": true,
+        "skip_thermalctld": true
 }

--- a/device/mellanox/x86_64-mlnx_msn4700_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4700_simx-r0/pmon_daemon_control.json
@@ -1,5 +1,6 @@
 {
         "skip_ledd": true,
         "skip_xcvrd": true,
-        "skip_psud": true
+        "skip_psud": true,
+        "skip_thermalctld": true
 }


### PR DESCRIPTION
[thermalctld] Disable thermalctld on Mellanox simx platforms.
This commit is targeted to 201911 since master and 202012 already contain this content.

Signed-off-by: liora <liora@nvidia.com>

**- Why I did it**
Service thermalctld should not run on simx systems.

**- How I did it**
Update simx systems pmon_daemon_control.json which is being written to supervisord.conf

**- How to verify it**
Verify supervisord status that thermalctld is not running.

**- Which release branch to backport**
None

