### PR TITLE
[201911][baseimage] add ipintutil in sudoer file

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -27,6 +27,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /sbin/brctl show, \
                                  /usr/bin/docker exec * ps aux, \
                                  /usr/bin/docker ps*, \
                                  /usr/bin/generate_dump, \
+                                 /usr/bin/ipintutil, \
                                  /usr/bin/lldpctl, \
                                  /usr/bin/lldpshow, \
                                  /usr/bin/psuutil *, \


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is port of https://github.com/Azure/sonic-buildimage/pull/6845 for `201911`

`show ip interfaces` is enhanced recently to support multi ASIC platforms in this https://github.com/Azure/sonic-utilities/pull/1437. The `ipintutil` script as to run as `sudo`  user, to get the ip interface from each namespace.
Add this script to the sudoer file so that `show ip interface` command is available for user with read-only permissions
 
#### How I did it
Add script `ipintutil` to the read-only allowed commands list.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

