### PR TITLE
Makefile: Optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ NOSTRETCH ?= 0
 	@echo "+++ --- Making $@ --- +++"
 ifeq ($(NOJESSIE), 0)
 	EXTRA_DOCKER_TARGETS=$(notdir $@) make -f Makefile.work jessie
-endif
-ifeq ($(NOSTRETCH), 0)
+else ifeq ($(NOSTRETCH), 0)
 	EXTRA_DOCKER_TARGETS=$(notdir $@) BLDENV=stretch make -f Makefile.work stretch
-endif
+else
 	BLDENV=buster make -f Makefile.work $@
+endif
 
 jessie:
 	@echo "+++ Making $@ +++"
@@ -33,11 +33,11 @@ clean configure reset showtag sonic-slave-build sonic-slave-bash :
 	@echo "+++ Making $@ +++"
 ifeq ($(NOJESSIE), 0)
 	make -f Makefile.work $@
-endif
-ifeq ($(NOSTRETCH), 0)
+else ifeq ($(NOSTRETCH), 0)
 	BLDENV=stretch make -f Makefile.work $@
-endif
+else
 	BLDENV=buster make -f Makefile.work $@
+endif
 
 # Freeze the versions, see more detail options: scripts/versions_manager.py freeze -h
 freeze:


### PR DESCRIPTION
* Fix if/else/endif logic
* To only target a single build environment

Signed-off-by: Don Newton don@opennetworking.org

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To speed up new build environment setup / save disk space
To speed up builds

Currently if **NOJESSIE** and **NOSTRETCH** are unset `make configure` will build 3 separate build images 
#### How I did it
Arranged `if`, `else` and `endif` statement such that only one will be entered per invocation
#### How to verify it
On a clean environment with **NOJESSIE** and **NOSTRETCH** unset execute 
`make configure PLATFORM=$platform_of_choice` - only the jessie build environment will be created

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
ONF is currently using the 202012 branch as our base for our p4 project
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Only build / use one of **jessie**, **stretch** or **buster**

#### A picture of a cute animal (not mandatory but encouraged)

