### PR TITLE
[DPB] [Mellanox] added capability files for SN2700-D40C8S8 SKU

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/hwsku.json
@@ -1,0 +1,184 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x10G"
+        }, 
+        "Ethernet1": {
+            "default_brkout_mode": "1x10G"
+        }, 
+        "Ethernet2": {
+            "default_brkout_mode": "1x10G"
+        }, 
+        "Ethernet3": {
+            "default_brkout_mode": "1x10G"
+        }, 
+        "Ethernet4": {
+            "default_brkout_mode": "1x10G"
+        }, 
+        "Ethernet5": {
+            "default_brkout_mode": "1x10G"
+        }, 
+        "Ethernet6": {
+            "default_brkout_mode": "1x10G"
+        }, 
+        "Ethernet7": {
+            "default_brkout_mode": "1x10G"
+        }, 
+        "Ethernet8": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet10": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet12": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet14": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet16": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet18": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet20": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet22": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet24": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
+        }, 
+        "Ethernet28": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
+        }, 
+        "Ethernet32": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
+        }, 
+        "Ethernet36": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
+        }, 
+        "Ethernet40": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet42": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet44": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet46": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet48": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet50": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet52": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet54": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet56": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet58": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet60": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet62": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet64": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet66": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet68": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet70": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet72": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet74": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet76": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet78": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet80": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet82": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet84": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet86": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet88": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
+        }, 
+        "Ethernet92": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
+        }, 
+        "Ethernet96": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
+        }, 
+        "Ethernet100": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
+        }, 
+        "Ethernet104": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet106": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet108": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet110": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet112": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet114": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet116": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet118": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet120": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet122": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet124": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }, 
+        "Ethernet126": {
+            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/hwsku.json
@@ -12,29 +12,17 @@
         "Ethernet3": {
             "default_brkout_mode": "1x10G"
         }, 
-        "Ethernet4": {
-            "default_brkout_mode": "1x10G"
-        }, 
-        "Ethernet5": {
-            "default_brkout_mode": "1x10G"
-        }, 
-        "Ethernet6": {
-            "default_brkout_mode": "1x10G"
-        }, 
-        "Ethernet7": {
-            "default_brkout_mode": "1x10G"
-        }, 
         "Ethernet8": {
-            "default_brkout_mode": "2x50G[40G,25G,10G]"
+            "default_brkout_mode": "1x10G"
+        }, 
+        "Ethernet9": {
+            "default_brkout_mode": "1x10G"
         }, 
         "Ethernet10": {
-            "default_brkout_mode": "2x50G[40G,25G,10G]"
+            "default_brkout_mode": "1x10G"
         }, 
-        "Ethernet12": {
-            "default_brkout_mode": "2x50G[40G,25G,10G]"
-        }, 
-        "Ethernet14": {
-            "default_brkout_mode": "2x50G[40G,25G,10G]"
+        "Ethernet11": {
+            "default_brkout_mode": "1x10G"
         }, 
         "Ethernet16": {
             "default_brkout_mode": "2x50G[40G,25G,10G]"

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/hwsku.json
@@ -12,6 +12,9 @@
         "Ethernet3": {
             "default_brkout_mode": "1x10G"
         }, 
+        "Ethernet4": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
+        }, 
         "Ethernet8": {
             "default_brkout_mode": "1x10G"
         }, 
@@ -23,6 +26,9 @@
         }, 
         "Ethernet11": {
             "default_brkout_mode": "1x10G"
+        }, 
+        "Ethernet12": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G]"
         }, 
         "Ethernet16": {
             "default_brkout_mode": "2x50G[40G,25G,10G]"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Additional file for DPB in order to support SKU SN2700-D40C8S8 on master

#### How I did it

Add hwsku.json file

#### How to verify it

Enforce  "Mellanox-SN2700-D40C8S8 SKU on Master and see it works as expected, meaning:

Port 1/3 will be used as 4x10G
Port 2/4 - Not exist (blocked since 1 and 3 split to 4)
Port 7/8/9/10/23/24/25/26 will used as 100G
All other ports will be used as 2x50G

This PR should be added on top of PR:
https://github.com/Azure/sonic-buildimage/pull/6876

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Adding hwsku.json file to SN2700-D40C8S8 SKU

#### A picture of a cute animal (not mandatory but encouraged)

