### PR TITLE
[platform/cel]: fix modprobe order conflict in Seastone-DX010

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -33,7 +33,11 @@ case "$1" in
 start)
         echo -n "Setting up board... "
 
+        rmmod i2c-i801
+        rmmod i2c-ismt
         modprobe i2c-dev
+        modprobe i2c-i801
+        modprobe i2c-ismt
         modprobe i2c-mux-pca954x
         modprobe dx010_wdt
         modprobe leds-dx010


### PR DESCRIPTION
#### Why I did it
- The iSMT SMBUS I2c bus number conflicts in different kernel versions.

#### How I did it
- Unload the default drivers and reload them manually to avoid bus number sequence conflicts.

#### How to verify it
- iSMT SMBUS I2c bus must be i2c-1.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

