### PR TITLE
BRCM SAI 3.7.5.2-2 Pick up fix CS00011729558 SAI_STATUS_INSUFFICIENT_RESOURCE wit attr SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_3.7.5.2-1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.5.2-1_amd64.deb?sv=2015-04-05&sr=b&sig=9nPXIgFsF3GsypmaSUV2cZ1t2FQbInjfahVLX64%2BinQ%3D&se=2034-09-15T20%3A34%3A43Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_3.7.5.2-1_amd64.deb
+BRCM_SAI = libsaibcm_3.7.5.2-2_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.5.2-2_amd64.deb?sv=2015-04-05&sr=b&sig=iHtJX8UWU8HmkijkYsuw3X7j6Tyoe5swaDv07nz%2BVEc%3D&se=2034-11-05T00%3A18%3A35Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_3.7.5.2-2_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.5.2-1_amd64.deb?sv=2015-04-05&sr=b&sig=SCd4ZhnKQX3SGFIpClVMWp5%2FgJtAXFtDXzUClMV3AOA%3D&se=2034-09-15T20%3A35%3A22Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.5.2-2_amd64.deb?sv=2015-04-05&sr=b&sig=UPlGJmD1PXGArUgvB84%2BU807HeJt1J5YTWaS%2Fq2%2FfGQ%3D&se=2034-11-05T00%3A19%3A05Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
#### Why I did it
This is to address the issue when "mmuconfig -p egress_lossy_profile" is executed which causes SYNCd failure with SAI_STATUS_INSUFFICIENT_RESOURCE for attr SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE.
This change also requires the change from (https://github.com/Azure/sonic-swss/pull/1649)
This SAI change was already tested as part of the (https://github.com/Azure/sonic-swss/pull/1649) PR.

#### How to verify it
Please refer to (https://github.com/Azure/sonic-swss/pull/1649) for details on the verification performed.

#### Which release branch to backport (provide reason below if selected)
None.

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
Pick up fix for "mmuconfig -p egress_lossy_profile" causing SYNCd error SAI_STATUS_INSUFFICIENT_RESOURCE wit attr SAI_BUFFER_PROFILE_ATTR_RESERVED_BUFFER_SIZE (CS00011729558)
