### PR TITLE
[build] No longer install scapy Debian package in host

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -302,7 +302,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     ethtool                 \
     screen                  \
     hping3                  \
-    python-scapy            \
     tcptraceroute           \
     mtr-tiny                \
     locales                 \


### PR DESCRIPTION
#### Why I did it

As of the merging of PR https://github.com/Azure/sonic-buildimage/pull/6799, we are now installing a newer version of scapy via pip, therefore there is no longer a need to install the older Debian package.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
