### PR TITLE
Fix Python 3 'importlib' bug; Add support for Python 2 back in sonic-py-common

### DIFF
--- a/src/sonic-ctrmgrd/tests/common_test.py
+++ b/src/sonic-ctrmgrd/tests/common_test.py
@@ -1,5 +1,6 @@
 import copy
-import importlib
+import importlib.machinery
+import importlib.util
 import json
 import os
 import subprocess

--- a/src/sonic-host-services/tests/determine-reboot-cause_test.py
+++ b/src/sonic-host-services/tests/determine-reboot-cause_test.py
@@ -1,4 +1,5 @@
-import importlib
+import importlib.machinery
+import importlib.util
 import sys
 import os
 import pytest

--- a/src/sonic-host-services/tests/procdockerstatsd_test.py
+++ b/src/sonic-host-services/tests/procdockerstatsd_test.py
@@ -1,4 +1,5 @@
-import importlib
+import importlib.machinery
+import importlib.util
 import sys
 import os
 import pytest

--- a/src/sonic-py-common/sonic_py_common/daemon_base.py
+++ b/src/sonic-py-common/sonic_py_common/daemon_base.py
@@ -30,10 +30,11 @@ def _load_module_from_file(module_name, file_path):
 
     # TODO: Remove this check once we no longer support Python 2
     if sys.version_info.major == 3:
-        from importlib import machinery, util
-        loader = machinery.SourceFileLoader(module_name, file_path)
-        spec = util.spec_from_loader(loader.name, loader)
-        module = util.module_from_spec(spec)
+        import importlib.machinery
+        import importlib.util
+        loader = importlib.machinery.SourceFileLoader(module_name, file_path)
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        module = importlib.util.module_from_spec(spec)
         loader.exec_module(module)
     else:
         import imp

--- a/src/sonic-py-common/sonic_py_common/daemon_base.py
+++ b/src/sonic-py-common/sonic_py_common/daemon_base.py
@@ -25,6 +25,9 @@ def db_connect(db_name, namespace=EMPTY_NAMESPACE):
     return swsscommon.DBConnector(db_name, REDIS_TIMEOUT_MSECS, True, namespace)
 
 
+# TODO: Consider moving this logic out of daemon_base and into antoher file
+# so that it can be used by non-daemons. We can simply call that function here
+# to retain backward compatibility.
 def _load_module_from_file(module_name, file_path):
     module = None
 

--- a/src/sonic-py-common/sonic_py_common/daemon_base.py
+++ b/src/sonic-py-common/sonic_py_common/daemon_base.py
@@ -1,4 +1,3 @@
-import importlib
 import signal
 import sys
 
@@ -27,11 +26,21 @@ def db_connect(db_name, namespace=EMPTY_NAMESPACE):
 
 
 def _load_module_from_file(module_name, file_path):
-    loader = importlib.machinery.SourceFileLoader(module_name, file_path)
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    module = importlib.util.module_from_spec(spec)
-    loader.exec_module(module)
+    module = None
+
+    # TODO: Remove this check once we no longer support Python 2
+    if sys.version_info.major == 3:
+        from importlib import machinery, util
+        loader = machinery.SourceFileLoader(module_name, file_path)
+        spec = util.spec_from_loader(loader.name, loader)
+        module = util.module_from_spec(spec)
+        loader.exec_module(module)
+    else:
+        import imp
+        module = imp.load_source(module_name, file_path)
+
     sys.modules[module_name] = module
+
     return module
 
 


### PR DESCRIPTION
#### Why I did it

Fix a strange bug introduced by https://github.com/Azure/sonic-buildimage/pull/6832 which would only occur in environments with both Python 2 and Python 3 installed (e.g., the PMon container). Error messages such as the following would be seen:

```
ERR pmon#ledd[29]: Failed to load ledutil: module 'importlib' has no attribute 'machinery'
```

This is very odd, and it seems like the Python 2 version of importlib, which is basically just a stub, is taking precedence over the Python 3 version. I found that this occurs when calling `import importlib`. However, calling `import importlib.machinery` and `import importlib.util` causes the proper package to be referenced, and the `machinery` and `util` modules are loaded successfully. This is how it is specified in the official documentation, however there is nothing mentioned regarding that it *should* be done this way or that `import importlib` is unreliable.

Also, since sonic-py-common is still used in environments with Python 2 installed we should maintain support for both Python 2 and 3 until we completely deprecate Python 2, so I have added this back in.

#### How I did it
- Call `import importlib.machinery` and `import importlib.util` explicitly
- Re-introduce Python 2 support in `_load_module_from_file()` method. If Python 2, load source via the `imp` module, if Python 3, use the `importlib` module.

#### How to verify it

Ensure `ledd` daemon starts properly with both Python 2 and Python 3

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
