### PR TITLE
[sonic-yang-models] fix ip_type value in test cases

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
@@ -266,7 +266,7 @@
 					"DST_IP": "10.186.72.0/26",
 					"SRC_IP": "10.176.0.0/15",
 					"PRIORITY": 999980,
-					"IP_TYPE": "IPV4ANY"
+					"IP_TYPE": "IPv4ANY"
 				}]
 			},
 			"sonic-acl:ACL_TABLE": {


### PR DESCRIPTION
* IPV4ANY is not valid value, fix to IPv4ANY
* without this change, test case failed sometimes when the validation on IP_TYPE happens first and then PACKET_ACTION.

```
INFO:YANG-TEST:
------------------- Test 10: Configure undefined packet_action in ACL_RULE table.---------------------
INFO:YANG-TEST:{"sonic-port:sonic-port": {"sonic-port:PORT": {"PORT_LIST": [{"admin_status": "up", "description": "Ethernet0", "mtu": 9000, "alias": "eth0", "speed": 25000, "port_name": "Ethernet0"}, {"admin_status": "up", "description": "Ethernet1", "mtu": 9000, "alias": "eth1", "speed": 25000, "port_name": "Ethernet1"}]}}, "sonic-acl:sonic-acl": {"sonic-acl:ACL_TABLE": {"ACL_TABLE_LIST": [{"stage": "EGRESS", "type": "L3", "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "ports": ["Ethernet0", "Ethernet1"], "policy_desc": "Filter IPv4"}]}, "sonic-acl:ACL_RULE": {"ACL_RULE_LIST": [{"RULE_NAME": "Rule_20", "IP_TYPE": "IPV4ANY", "PRIORITY": 999980, "SRC_IP": "10.176.0.0/15", "ACL_TABLE_NAME": "NO-NSW-PACL-V4", "DST_IP": "10.186.72.0/26", "PACKET_ACTION": "SEND"}]}}}
libyang[0]: Invalid value "IPV4ANY" in "IP_TYPE" element. (path: /sonic-acl:sonic-acl/ACL_RULE/ACL_RULE_LIST[RULE_NAME='Rule_20']/IP_TYPE)
INFO:YANG-TEST:eStr: ['Invalid value', 'PACKET_ACTION']
ERROR:YANG-TEST: Exception >Unknown Error< in /sonic/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py:301
INFO:YANG-TEST:Configure undefined packet_action in ACL_RULE table. Failed 
```

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com