### PR TITLE
[Arista] Update phy-credo gearbox code

### DIFF
--- a/rules/phy-credo.mk
+++ b/rules/phy-credo.mk
@@ -1,3 +1,3 @@
 PHY_CREDO = phy-credo_1.0_amd64.deb
-$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/78a3df2/phy/phy-credo_1.0_amd64.deb"
+$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/6d0d1661d92a342acedb6839dba970ae5778b478/phy/phy-credo_1.0_amd64.deb"
 SONIC_ONLINE_DEBS += $(PHY_CREDO)


### PR DESCRIPTION
#### Why I did it

This package was outdated and did not properly install on buster due to dependency changes.
This version should work on all `DCS-7280CR3*-32[PD]4` platforms.

#### How to verify it

Make sure the phy-credo.service succeeds and that it initialized the phys by looking at the syslog

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012

The version of this package is also outdated on 202012.
202012 currently has the same base image and dependencies that master and should install just fine.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update phy-credo gearbox code

