### PR TITLE
Revert "[201911][monit] Periodically monitor VNET route consistency"

### DIFF
--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -31,8 +31,3 @@ check program routeCheck with path "/usr/bin/route_check.py"
     every 5 cycles
     if status != 0 for 3 cycle then alert repeat every 1 cycles
 
-# vnet_route_check.py: tool that verifies VNET routes consistancy between SONiC and vendor SDK DBs.
-check program vnetRouteCheck with path "/usr/local/bin/vnet_route_check.py"
-    every 5 cycles
-        if status != 0 for 3 cycle then alert repeat every 1 cycles
-


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#6819

This commit broke 201911 image. We need revert if non-critical.
```
$ which vnet_route_check.py
/usr/bin/vnet_route_check.py

$ sudo config load_minigraph
Reload config from minigraph? [y/N]: y
Executing stop of service telemetry...
Warning: Stopping telemetry.service, but it can still be activated by:
  telemetry.timer
Executing stop of service restapi...
Executing stop of service swss...
Executing stop of service lldp...
Executing stop of service bgp...
Executing stop of service hostcfgd...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json   --write-to-db
Running command: pfcwd start_default
Running command: config qos reload
Running command: /usr/local/bin/sonic-cfggen  -d -t /usr/share/sonic/device/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers.json.j2 > /tmp/buffers.json
Running command: /usr/local/bin/sonic-cfggen  -d -t /usr/share/sonic/device/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/qos.json.j2 -y /etc/sonic/sonic_version.yml > /tmp/qos.json
Running command: /usr/local/bin/sonic-cfggen  -j /tmp/buffers.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen  -j /tmp/qos.json --write-to-db

Executing reset-failed of service bgp...
Executing reset-failed of service dhcp_relay...
Executing reset-failed of service hostcfgd...
Executing reset-failed of service hostname-config...
Executing reset-failed of service interfaces-config...
Executing reset-failed of service lldp...
Executing reset-failed of service ntp-config...
Executing reset-failed of service pmon...
Executing reset-failed of service radv...
Executing reset-failed of service restapi...
Executing reset-failed of service rsyslog-config...
Executing reset-failed of service snmp...
Executing reset-failed of service swss...
Executing reset-failed of service syncd...
Executing reset-failed of service teamd...
Executing reset-failed of service telemetry...
Executing restart of service hostname-config...
Executing restart of service interfaces-config...
Executing restart of service ntp-config...
Executing restart of service rsyslog-config...
Executing restart of service swss...
Executing restart of service bgp...
Executing restart of service lldp...
Executing restart of service hostcfgd...
Executing restart of service restapi...
Executing restart of service telemetry...
Reloading Monit configuration ...
/etc/monit/conf.d/sonic-host:35: Program does not exist: '/usr/local/bin/vnet_route_check.py'
/etc/monit/conf.d/sonic-host:35: Program does not exist: '/usr/local/bin/vnet_route_check.py'
AssertException: File '/usr/local/bin/vnet_route_check.py' does not exist
 raised in Command_new at src/system/Command.c:357
$ echo $?
1
```