### PR TITLE
[monit]: fix vnet_route_check path

### DIFF
--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -32,7 +32,7 @@ check program routeCheck with path "/usr/bin/route_check.py"
     if status != 0 for 3 cycle then alert repeat every 1 cycles
 
 # vnet_route_check.py: tool that verifies VNET routes consistancy between SONiC and vendor SDK DBs.
-check program vnetRouteCheck with path "/usr/local/bin/vnet_route_check.py"
+check program vnetRouteCheck with path "/usr/bin/vnet_route_check.py"
     every 5 cycles
         if status != 0 for 3 cycle then alert repeat every 1 cycles
 


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fix vnet_route_check path

#### How I did it

#### How to verify it
tested on 20191130.61 image

```
Program 'vnetRouteCheck'
  status                       Status ok
  monitoring status            Monitored
  monitoring mode              active
  on reboot                    start
  last exit value              0
  last output                  -
  data collected               Sat, 06 Mar 2021 05:56:15
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

