### PR TITLE
Copy dummy flannel.conf to get around absence of CNI Network

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -404,6 +404,10 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install azure-
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install watchdog==0.10.3
 
 {% if include_kubernetes == "y" %}
+# Copy Flannel conf file into sonic-templates
+#
+sudo cp $BUILD_TEMPLATES/kube_cni.10-flannel.conflist $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
+
 # Install remote Container mgmt package
 # Required even if include_kubernetes != y, as it contains the
 # the container wrapper for docker start/stop/wait commands.

--- a/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
+++ b/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
@@ -201,7 +201,7 @@ class MainServer:
         """ Modify entry for given table|key with given dict type data """
         conn = self.db_connectors[db_name]
         tbl = swsscommon.Table(conn, table_name)
-        print("mod_db_entry: db={} tbl={} key={} data={}".format(db_name, table_name, key, str(data)))
+        log_debug("mod_db_entry: db={} tbl={} key={} data={}".format(db_name, table_name, key, str(data)))
         tbl.set(key, list(data.items()))
 
 
@@ -242,7 +242,7 @@ class MainServer:
                 if not UNIT_TESTING:
                     raise Exception("Received error from select")
                 else:
-                    print("Skipped Exception; Received error from select")
+                    log_debug("Skipped Exception; Received error from select")
                     return
 
             for subscriber in self.subscribers:
@@ -588,7 +588,7 @@ def main():
     FeatureTransitionHandler(server)
     LabelsPendingHandler(server)
     server.run()
-    print("ctrmgrd.py main called")
+    log_debug("ctrmgrd.py main called")
     return 0
 
 

--- a/src/sonic-ctrmgrd/tests/kube_commands_test.py
+++ b/src/sonic-ctrmgrd/tests/kube_commands_test.py
@@ -113,12 +113,11 @@ None".format(KUBE_ADMIN_CONF),
             "rm -rf {}".format(CNI_DIR),
             "systemctl stop kubelet",
             "modprobe br_netfilter",
-            "systemctl start kubelet",
-            "kubeadm join --discovery-file {} --node-name None".format(
-                KUBE_ADMIN_CONF),
             "mkdir -p {}".format(CNI_DIR),
             "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
-            "systemctl restart kubelet"
+            "systemctl start kubelet",
+            "kubeadm join --discovery-file {} --node-name None".format(
+                KUBE_ADMIN_CONF)
         ],
         common_test.PROC_RUN: [True, True]
     },
@@ -137,12 +136,11 @@ None".format(KUBE_ADMIN_CONF),
             "rm -rf {}".format(CNI_DIR),
             "systemctl stop kubelet",
             "modprobe br_netfilter",
-            "systemctl start kubelet",
-            "kubeadm join --discovery-file {} --node-name None".format(
-                KUBE_ADMIN_CONF),
             "mkdir -p {}".format(CNI_DIR),
             "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
-            "systemctl restart kubelet"
+            "systemctl start kubelet",
+            "kubeadm join --discovery-file {} --node-name None".format(
+                KUBE_ADMIN_CONF)
         ],
         common_test.PROC_RUN: [True, True]
     },
@@ -170,12 +168,11 @@ None".format(KUBE_ADMIN_CONF),
             "rm -rf {}".format(CNI_DIR),
             "systemctl stop kubelet",
             "modprobe br_netfilter",
-            "systemctl start kubelet",
-            "kubeadm join --discovery-file {} --node-name None".format(
-                KUBE_ADMIN_CONF),
             "mkdir -p {}".format(CNI_DIR),
             "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
-            "systemctl restart kubelet"
+            "systemctl start kubelet",
+            "kubeadm join --discovery-file {} --node-name None".format(
+                KUBE_ADMIN_CONF)
         ],
         common_test.PROC_RUN: [True, True],
         common_test.PROC_FAIL: [True]
@@ -195,12 +192,11 @@ None".format(KUBE_ADMIN_CONF),
             "rm -rf {}".format(CNI_DIR),
             "systemctl stop kubelet",
             "modprobe br_netfilter",
-            "systemctl start kubelet",
-            "kubeadm join --discovery-file {} --node-name None".format(
-                KUBE_ADMIN_CONF),
             "mkdir -p {}".format(CNI_DIR),
             "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
-            "systemctl restart kubelet"
+            "systemctl start kubelet",
+            "kubeadm join --discovery-file {} --node-name None".format(
+                KUBE_ADMIN_CONF)
         ],
         common_test.PROC_RUN: [True, True],
         common_test.PROC_FAIL: [True],

--- a/src/sonic-ctrmgrd/tests/kube_commands_test.py
+++ b/src/sonic-ctrmgrd/tests/kube_commands_test.py
@@ -13,6 +13,8 @@ import kube_commands
 
 
 KUBE_ADMIN_CONF = "/tmp/kube_admin.conf"
+FLANNEL_CONF_FILE = "/tmp/flannel.conf"
+CNI_DIR = "/tmp/cni/net.d"
 
 # kube_commands test cases
 # NOTE: Ensure state-db entry is complete in PRE as we need to
@@ -108,12 +110,15 @@ join_test_data = {
             "kubectl --kubeconfig {} --request-timeout 20s delete node \
 None".format(KUBE_ADMIN_CONF),
             "kubeadm reset -f",
-            "rm -rf /etc/cni/net.d",
+            "rm -rf {}".format(CNI_DIR),
             "systemctl stop kubelet",
             "modprobe br_netfilter",
             "systemctl start kubelet",
             "kubeadm join --discovery-file {} --node-name None".format(
-                KUBE_ADMIN_CONF)
+                KUBE_ADMIN_CONF),
+            "mkdir -p {}".format(CNI_DIR),
+            "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
+            "systemctl restart kubelet"
         ],
         common_test.PROC_RUN: [True, True]
     },
@@ -129,12 +134,15 @@ None".format(KUBE_ADMIN_CONF),
             "kubectl --kubeconfig {} --request-timeout 20s delete node \
 None".format(KUBE_ADMIN_CONF),
             "kubeadm reset -f",
-            "rm -rf /etc/cni/net.d",
+            "rm -rf {}".format(CNI_DIR),
             "systemctl stop kubelet",
             "modprobe br_netfilter",
             "systemctl start kubelet",
             "kubeadm join --discovery-file {} --node-name None".format(
-                KUBE_ADMIN_CONF)
+                KUBE_ADMIN_CONF),
+            "mkdir -p {}".format(CNI_DIR),
+            "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
+            "systemctl restart kubelet"
         ],
         common_test.PROC_RUN: [True, True]
     },
@@ -159,12 +167,15 @@ None".format(KUBE_ADMIN_CONF),
             "kubectl --kubeconfig {} --request-timeout 20s delete node \
 None".format(KUBE_ADMIN_CONF),
             "kubeadm reset -f",
-            "rm -rf /etc/cni/net.d",
+            "rm -rf {}".format(CNI_DIR),
             "systemctl stop kubelet",
             "modprobe br_netfilter",
             "systemctl start kubelet",
             "kubeadm join --discovery-file {} --node-name None".format(
-                KUBE_ADMIN_CONF)
+                KUBE_ADMIN_CONF),
+            "mkdir -p {}".format(CNI_DIR),
+            "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
+            "systemctl restart kubelet"
         ],
         common_test.PROC_RUN: [True, True],
         common_test.PROC_FAIL: [True]
@@ -181,12 +192,15 @@ None".format(KUBE_ADMIN_CONF),
             "kubectl --kubeconfig {} --request-timeout 20s delete node \
 None".format(KUBE_ADMIN_CONF),
             "kubeadm reset -f",
-            "rm -rf /etc/cni/net.d",
+            "rm -rf {}".format(CNI_DIR),
             "systemctl stop kubelet",
             "modprobe br_netfilter",
             "systemctl start kubelet",
             "kubeadm join --discovery-file {} --node-name None".format(
-                KUBE_ADMIN_CONF)
+                KUBE_ADMIN_CONF),
+            "mkdir -p {}".format(CNI_DIR),
+            "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
+            "systemctl restart kubelet"
         ],
         common_test.PROC_RUN: [True, True],
         common_test.PROC_FAIL: [True],
@@ -213,7 +227,7 @@ reset_test_data = {
             "kubectl --kubeconfig {} --request-timeout 20s delete node \
 None".format(KUBE_ADMIN_CONF),
             "kubeadm reset -f",
-            "rm -rf /etc/cni/net.d",
+            "rm -rf {}".format(CNI_DIR),
             "rm -f {}".format(KUBE_ADMIN_CONF),
             "systemctl stop kubelet"
         ]
@@ -228,7 +242,7 @@ None".format(KUBE_ADMIN_CONF),
             "kubectl --kubeconfig {} --request-timeout 20s delete node \
 None".format(KUBE_ADMIN_CONF),
             "kubeadm reset -f",
-            "rm -rf /etc/cni/net.d",
+            "rm -rf {}".format(CNI_DIR),
             "rm -f {}".format(KUBE_ADMIN_CONF),
             "systemctl stop kubelet"
         ]
@@ -239,7 +253,7 @@ None".format(KUBE_ADMIN_CONF),
         common_test.ARGS: [True],
         common_test.PROC_CMD: [
             "kubeadm reset -f",
-            "rm -rf /etc/cni/net.d",
+            "rm -rf {}".format(CNI_DIR),
             "rm -f {}".format(KUBE_ADMIN_CONF),
             "systemctl stop kubelet"
         ]
@@ -269,7 +283,11 @@ clusters:\n\
         kubelet_yaml = "/tmp/kubelet_config.yaml"
         with open(kubelet_yaml, "w") as s:
             s.close()
+        with open(FLANNEL_CONF_FILE, "w") as s:
+            s.close()
         kube_commands.KUBELET_YAML = kubelet_yaml
+        kube_commands.CNI_DIR = CNI_DIR
+        kube_commands.FLANNEL_CONF_FILE = FLANNEL_CONF_FILE
         kube_commands.SERVER_ADMIN_URL = "file://{}".format(self.admin_conf_file)
         kube_commands.KUBE_ADMIN_CONF = KUBE_ADMIN_CONF
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We skip install of CNI plugin, as we don't need. But this leaves node in "not ready" state, upon joining master. 
To fix, we copy this dummy .conf file in /etc/cni/net.d

#### How I did it
Keep this file in /usr/share/sonic/templates and copy to /etc/cni/net.d upon joining k8s master.

#### How to verify it
Upon configuring master-IP and enable join, watch node join and move to ready state.
You may verify using `kubectl get nodes` command
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

