### PR TITLE
dhcp for dual tor: include all vlan intf into downstream intf

### DIFF
--- a/src/isc-dhcp/patch/0009-Support-for-dual-tor-scenario.patch
+++ b/src/isc-dhcp/patch/0009-Support-for-dual-tor-scenario.patch
@@ -238,7 +238,7 @@ index e158efe..055d97f 100644
  		  (flags & INTERFACE_UPSTREAM ? 'Y' : 'N'),
  		  (flags & INTERFACE_DOWNSTREAM ? 'Y' : 'N'));
  
-+	if (flags & INTERFACE_DOWNSTREAM) {
++	if (flags & INTERFACE_DOWNSTREAM || flags & INTERFACE_UPSTREAM) {
 +		ci = ((struct downstream_intf_list *)dmalloc(sizeof *ci, MDL));
 +		if (!ci)
 +			log_fatal("no memory for downstream interface pointer.\n");

--- a/src/isc-dhcp/patch/0009-Support-for-dual-tor-scenario.patch
+++ b/src/isc-dhcp/patch/0009-Support-for-dual-tor-scenario.patch
@@ -238,7 +238,7 @@ index e158efe..055d97f 100644
  		  (flags & INTERFACE_UPSTREAM ? 'Y' : 'N'),
  		  (flags & INTERFACE_DOWNSTREAM ? 'Y' : 'N'));
  
-+	if (flags & INTERFACE_DOWNSTREAM || flags & INTERFACE_UPSTREAM) {
++	if (flags & INTERFACE_DOWNSTREAM || flags & INTERFACE_UPSTREAM) { /* include all vlan intf in downstream_intf_list */
 +		ci = ((struct downstream_intf_list *)dmalloc(sizeof *ci, MDL));
 +		if (!ci)
 +			log_fatal("no memory for downstream interface pointer.\n");


### PR DESCRIPTION
Include all vlan interfaces into downstream interface set to allow each dhcp instance to scan over them. Note that with this change, downstream interface set includes not only vlan interfaces but also portchannels. However, this doesn't matter as dhcp uses giaddr or yiaddr to choose out interface.

Tested and verified on a virtual testbed.

