### PR TITLE
Fix get-pip 2.7 url according to upstream announcement

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -78,7 +78,7 @@ RUN rm -rf /debs \
     && apt-get -y autoclean \
     && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --https-only https://bootstrap.pypa.io/2.7/get-pip.py \
+    && wget --https-only https://bootstrap.pypa.io/pip/2.7/get-pip.py \
     && python get-pip.py \
     && rm -f get-pip.py \
     && pip install setuptools \


### PR DESCRIPTION
#### Why I did it

ref: https://bootstrap.pypa.io/2.7/get-pip.py

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/2.7/get-pip.py


#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

- [x] 201811
- [x] 201911
- [x] 202006
- [x] 202012
