### PR TITLE
Control usage of unix socket on DB read.

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -350,10 +350,11 @@ def main():
         deep_update(data, json.loads(args.additional_data))
 
     if args.from_db:
+        use_unix_sock = True if os.getuid() == 0 else False
         if args.namespace is None:
-            configdb = ConfigDBPipeConnector(use_unix_socket_path=True, **db_kwargs)
+            configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, **db_kwargs)
         else:
-            configdb = ConfigDBPipeConnector(use_unix_socket_path=True, namespace=args.namespace, **db_kwargs)
+            configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, namespace=args.namespace, **db_kwargs)
 
         configdb.connect()
         deep_update(data, FormatConverter.db_to_output(configdb.get_config()))


### PR DESCRIPTION
#### Why I did it
Closes issue https://github.com/Azure/sonic-buildimage/issues/6982.
The issue was root caused as we were using the unix_socket for reading from DB as a default mechanism (https://github.com/Azure/sonic-buildimage/pull/5250). The redis unix socket is created as follows. 
```
admin@str--acs-1:~$ ls -lrt /var/run/redis/redis.sock 
srwxrw---- 1 root redis 0 Mar  6 01:57 /var/run/redis/redis.sock
```
So it used to work fine for the user "root" or if user is part of redis group ( admin was made part of redis group by default )

#### How I did it
Check if the user is with sudo permissions then use the redis unix socket, else fallback to tcp socket. 

#### How to verify it
Checked "show running all" command from a user which is not part of redis group.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ x] 201911
- [ x] 202006
- [x ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

