### PR TITLE
[sonic-mgmt docker] pin cryptography version to 3.3.2

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y build-essential \
                                          vim
 
 RUN pip install cffi==1.10.0 \
-                "cryptography>=2.5" \
+                cryptography==3.3.2 \
                 "future>=0.16.0" \
                 gitpython \
                 ipaddr \
@@ -167,10 +167,10 @@ RUN mkdir bin && ln -s /usr/bin/az bin/az
 
 # Install Virtual Environments
 RUN python -m virtualenv --system-site-packages env-201811
-RUN env-201811/bin/pip install ansible==2.0.0.2
+RUN env-201811/bin/pip install cryptography==3.3.2 ansible==2.0.0.2
 
 RUN python3 -m venv env-python3
-RUN env-python3/bin/pip3 install azure-kusto-data azure-kusto-ingest defusedxml pytest
+RUN env-python3/bin/pip3 install cryptography==3.3.2 azure-kusto-data azure-kusto-ingest defusedxml pytest
 
 # NOTE: There is an ordering dependency for pycryptodome. Leaving this at
 #       the end until we figure that out.


### PR DESCRIPTION
#### Why I did it
sonic-mgmt-docker build was failing.

#### How I did it
pin cryptography version to 3.3.2

#### How to verify it
build sonic-mgmt docker.