### PR TITLE
[Mellanox] Fixes issue: CLI sfputil does not work based on sonic platform API

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -10,13 +10,14 @@ try:
     import subprocess
     from sonic_platform_base.platform_base import PlatformBase
     from sonic_platform.chassis import Chassis
+    from . import utils
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 class Platform(PlatformBase):
     def __init__(self):
         PlatformBase.__init__(self)
-        if self._is_host():
+        if utils.is_host():
             self._chassis = Chassis()
             self._chassis.initialize_components()
             self._chassis.initizalize_system_led()
@@ -27,26 +28,3 @@ class Platform(PlatformBase):
             self._chassis.initialize_fan()
             self._chassis.initialize_eeprom()
             self._chassis.initialize_thermals()
-
-    def _is_host(self):
-        """
-        Test whether current process is running on the host or an docker
-        return True for host and False for docker
-        """
-        is_host = False
-        try:
-            proc = subprocess.Popen("docker --version 2>/dev/null", 
-                                    stdout=subprocess.PIPE, 
-                                    shell=True, 
-                                    stderr=subprocess.STDOUT, 
-                                    universal_newlines=True)
-            stdout = proc.communicate()[0]
-            proc.wait()
-            result = stdout.rstrip('\n')
-            if result != '':
-                is_host = True
-
-        except OSError as e:
-            pass
-
-        return is_host

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -7,7 +7,6 @@
 #############################################################################
 
 try:
-    import subprocess
     from sonic_platform_base.platform_base import PlatformBase
     from sonic_platform.chassis import Chassis
     from . import utils

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -2047,7 +2047,7 @@ class SFP(SfpBase):
             A boolean, True if lpmode is set successfully, False if not
         """
         if utils.is_host():
-            if lpmode == self.get_lpmode(self.index):
+            if lpmode == self.get_lpmode():
                 return True
 
             # Compose LPM command

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -1,3 +1,9 @@
+import subprocess
+
+# flags to indicate whether this process is running in docker or host
+_is_host = None
+
+
 def read_str_from_file(file_path, default='', raise_exception=False):
     """
     Read string content from file
@@ -55,3 +61,30 @@ def write_file(file_path, content, raise_exception=False):
         else:
             raise e
     return True
+
+
+def is_host():
+    """
+    Test whether current process is running on the host or an docker
+    return True for host and False for docker
+    """
+    if _is_host is not None:
+        return _is_host
+        
+    _is_host = False
+    try:
+        proc = subprocess.Popen("docker --version 2>/dev/null", 
+                                stdout=subprocess.PIPE, 
+                                shell=True, 
+                                stderr=subprocess.STDOUT, 
+                                universal_newlines=True)
+        stdout = proc.communicate()[0]
+        proc.wait()
+        result = stdout.rstrip('\n')
+        if result != '':
+            _is_host = True
+
+    except OSError as e:
+        pass
+
+    return _is_host

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -68,6 +68,7 @@ def is_host():
     Test whether current process is running on the host or an docker
     return True for host and False for docker
     """
+    global _is_host
     if _is_host is not None:
         return _is_host
         


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Recently, CLI sfputil replace the old sonic platform utils with sonic platform API. However, sonic platform API does not suport SFP low power mode and reset related operation. The PR is to fix it.

The change to replace platform utils with sonic platform API was reverted on 202012, once this PR is merged, we can cherry-pick these two PRs to 202012 together.

#### How I did it

In low power mode and reset related operation, use "docker exec" if the command is running on host side.

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

