### PR TITLE
Update hostcfgd to disable unused services for fabric asics

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -437,10 +437,15 @@ class HostConfigDaemon:
         has_global_scope = ast.literal_eval(feature_table[feature_name].get('has_global_scope', 'True'))
         has_per_asic_scope = ast.literal_eval(feature_table[feature_name].get('has_per_asic_scope', 'False'))
 
+        # This feature may be disabled on some asics (but may not be on all)
+        always_disabled_on_asics = ast.literal_eval(feature_table[feature_name].get('always_disabled_on_asics', '()'))
+        disabled_feature_name_suffix_list = ([(feature_name + '@' + str(asic_inst)) for asic_inst in range(device_info.get_num_npus())
+                                             if has_per_asic_scope and self.is_multi_npu and asic_inst in always_disabled_on_asics])
+
         # Create feature name suffix depending feature is running in host or namespace or in both 
         feature_name_suffix_list = (([feature_name] if has_global_scope or not self.is_multi_npu else []) +
                                    ([(feature_name + '@' + str(asic_inst)) for asic_inst in range(device_info.get_num_npus()) 
-                                    if has_per_asic_scope and self.is_multi_npu]))
+                                    if has_per_asic_scope and self.is_multi_npu and asic_inst not in always_disabled_on_asics]))
 
         if not feature_name_suffix_list:
             syslog.syslog(syslog.LOG_ERR, "Feature '{}' service not available"
@@ -448,9 +453,9 @@ class HostConfigDaemon:
 
         feature_suffixes = ["service"] + (["timer"] if has_timer else [])
 
-        if state == "enabled":
+        def _enableServices(feature_name_suffix_list_):
             start_cmds = []
-            for feature_name_suffix in feature_name_suffix_list:
+            for feature_name_suffix in feature_name_suffix_list_:
                 for suffix in feature_suffixes:
                     start_cmds.append("sudo systemctl unmask {}.{}".format(feature_name_suffix, suffix))
                 # If feature has timer associated with it, start/enable corresponding systemd .timer unit
@@ -469,9 +474,10 @@ class HostConfigDaemon:
                         return
             syslog.syslog(syslog.LOG_INFO, "Feature '{}.{}' is enabled and started"
                           .format(feature_name, feature_suffixes[-1]))
-        elif state == "disabled":
+
+        def _disableServices(feature_name_suffix_list_):
             stop_cmds = []
-            for feature_name_suffix in feature_name_suffix_list:
+            for feature_name_suffix in feature_name_suffix_list_:
                 for suffix in reversed(feature_suffixes):
                     stop_cmds.append("sudo systemctl stop {}.{}".format(feature_name_suffix, suffix))
                     stop_cmds.append("sudo systemctl disable {}.{}".format(feature_name_suffix, suffix))
@@ -490,6 +496,16 @@ class HostConfigDaemon:
             syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}'"
                           .format(state, feature_name))
 
+        if state == "enabled":
+            _enableServices(feature_name_suffix_list)
+        elif state == "disabled":
+            _disableServices(feature_name_suffix_list)
+        else:
+            syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature '{}'"
+                          .format(state, feature_name))
+
+        # Keep services in disabled_feature_name_suffix_list disabled.
+        _disableServices(disabled_feature_name_suffix_list)
 
     def update_all_feature_states(self):
         feature_table = self.config_db.get_table('FEATURE')


### PR DESCRIPTION
Some services are unnecessary for fabric asics like bgp, lldp, teamd.
We so disable them. But it could be that there are some mixed asics
NPU and fabric in the same system, so we should just disable only
for fabric asics.

This commit is to disable those services only fabric asics. It works together
with https://github.com/Azure/sonic-utilities/pull/1493.

Signed-off-by: ngocdo <ngocdo@arista.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fabric asics do not need some services like bgp, lldp, teamd.
They just need database, swss, and syncd running.

#### How I did it

I disable them with `FEATURE` flag configured in `CONFIG_DB`, which is listened and reacted by hostcfgd. 

This PR will update `CONFIG_DB's FEATURE` for fabric asics. The update is executed in load_minigraph, and saved to config_db.json. So the update will run only once.

If a system has both NPU and fabric, only services running on fabric are disabled. NPU's services are not affected.

One field, `always_disabled_on_asics` is added to `FEATURE`'s services that we want to disable for fabric asics. For example, `bgp@4.service` and `bgp@5.service` will be disabled.
```
    "FEATURE": {
        "bgp": {
            "state": "enabled",
            "has_timer": "False",
            "has_global_scope": "False",
            "has_per_asic_scope": "True",
            "auto_restart": "enabled",
            "high_mem_alert": "disabled",
            "always_disabled_on_asics": "4,5"
        },
   }
```

The above setup is at https://github.com/Azure/sonic-utilities/pull/1493.

hostcfg will act on the setup, and disable the services.

#### How to verify it

Tested on systems with VOQ and fabric asics.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

