### PR TITLE
[201911] Fix bgpmon.py syslog exception

### DIFF
--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -153,7 +153,7 @@ def main():
     try:
         bgp_state_get = BgpStateGet()
     except Exception as e:
-        syslog.syslog(syslog.LOG_ERR, "{}: error exit 1, reason {}".format(THIS_MODULE, str(e)))
+        syslog.syslog(syslog.LOG_ERR, "{}: error exit 1, reason {}".format("THIS_MODULE", str(e)))
         exit(1)
 
     # periodically obtain the new neighbor infomraton and update if necessary


### PR DESCRIPTION
Why I did:
Fixes below exception on 201911. Master branch is fine.

```
Mar 11 16:37:09.247008 str2-nxxx-acs-3 INFO bgp3#supervisord: bgpmon Traceback (most recent call last):
Mar 11 16:37:09.247008 str2-nxxxx-acs-3 INFO bgp3#supervisord: bgpmon   File "/usr/local/bin/bgpmon", line 8, in <module>
Mar 11 16:37:09.251225 str2-nxxx-acs-3 INFO bgp3#supervisord: bgpmon
Mar 11 16:37:09.251225 str2-nxxx-acs-3 INFO bgp3#supervisord: bgpmon sys.exit(main())
Mar 11 16:37:09.252281 str2-nxxxx-acs-3 INFO bgp3#supervisord: bgpmon   File "/usr/local/lib/python2.7/dist-packages/bgpmon/bgpmon.py", line 156, in main
Mar 11 16:37:09.252281 str2-nxxxx-acs-3 INFO bgp3#supervisord: bgpmon
Mar 11 16:37:09.253009 str2-nxxxx-acs-3 INFO bgp3#supervisord: bgpmon syslog.syslog(syslog.LOG_ERR, "{}: error exit 1, reason {}".format(THIS_MODULE, str(e)))
Mar 11 16:37:09.253483 str2-nxxxx-acs-3 INFO bgp3#supervisord: bgpmon NameError
Mar 11 16:37:09.254241 str2-nxxxx-acs-3 INFO bgp3#supervisord: bgpmon :
Mar 11 16:37:09.256116 str2-nxxxx-acs-3 INFO bgp3#supervisord: bgpmon global name 'THIS_MODULE' is not defined
Mar 11 16:37:09.256590 str2-nxxx-acs-3 INFO bgp3#supervisord: bgpmon
```

How I verify:

After fix above errors are not seen

`Mar 12 19:09:03.326663 str2-nxxxx-acs-3 ERR bgp0#bgpmon: THIS_MODULE: error exit 1, reason Error 113 connecting to 240.127.1.6:6379. No route to host.
`