### PR TITLE
Fix E1031 udev rules not work for sonic os first boot after be installed

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.postinst
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.postinst
@@ -1,4 +1,7 @@
 depmod -a
+sudo chmod +x /usr/local/bin/udev_prefix.sh
+sudo chmod +x /usr/local/bin/popmsg.sh
+sudo chmod +x /usr/local/bin/reload_udev.sh
 systemctl enable platform-modules-haliburton.service
 systemctl enable fancontrol.service
 
@@ -6,5 +9,4 @@ systemctl start platform-modules-haliburton.service
 systemctl start fancontrol.service
 
 /usr/local/bin/platform_api_mgnt.sh install
-sudo chmod +x /usr/local/bin/udev_prefix.sh
-sudo chmod +x /usr/local/bin/popmsg.sh
+/usr/local/bin/reload_udev.sh

--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/script/reload_udev.sh
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/script/reload_udev.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+UDEV_DIR=/etc/udev/rules.d/50-ttyUSB-C0.rules
+TTYUSB_DIR=/dev/ttyUSB
+
+if [ -f "$UDEV_DIR" ]; then
+        for i in {0..95}
+        do
+                ttydev=$TTYUSB_DIR$i
+                if [ -c "$ttydev" ]; then
+                        echo "$ttydev"
+                        udevadm trigger -c add $ttydev
+                fi
+        done
+fi

--- a/platform/broadcom/sonic-platform-modules-cel/haliburton/script/reload_udev.sh
+++ b/platform/broadcom/sonic-platform-modules-cel/haliburton/script/reload_udev.sh
@@ -8,7 +8,6 @@ if [ -f "$UDEV_DIR" ]; then
         do
                 ttydev=$TTYUSB_DIR$i
                 if [ -c "$ttydev" ]; then
-                        echo "$ttydev"
                         udevadm trigger -c add $ttydev
                 fi
         done


### PR DESCRIPTION
#### Why I did it
The udev rules does not work for sonic first boot.

#### How I did it
Use udevadm to trigger the udev rules on the first boot

#### How to verify it
1. Connect C0 with E1031;
2. Install or upgrade the sonic os to 202012 branch;
3. When access to sonic  check if /dev/C0-1 to /dev/C0-48 are existed.

#### Which release branch to backport (provide reason below if selected)
- [x] 202012

#### Description for the changelog
<!--
[   10.031055] rc.local[402]: + grep build_version
[   10.100384] rc.local[402]: + sed -e s/build_version: //g;s/'//g
[   10.184642] rc.local[402]: + SONIC_VERSION=master.0-dirty-20210309.090106
[   10.284599] rc.local[402]: + FIRST_BOOT_FILE=/host/image-master.0-dirty-20210309.090106/platform/firsttime
[   10.404711] rc.local[402]: + SONIC_CONFIG_DIR=/host/image-master.0-dirty-20210309.090106/sonic-config
[   10.549293] rc.local[402]: + SONIC_ENV_FILE=/host/image-master.0-dirty-20210309.090106/sonic-config/sonic-environment
[   10.694770] rc.local[402]: + [ -d /host/image-master.0-dirty-20210309.090106/sonic-config -a -f /host/image-master.0-dirty-20210309.090106/sonic-config/sonic-environment ]
[   10.883837] rc.local[402]: + logger SONiC version master.0-dirty-20210309.090106 starting up...
[   10.993835] rc.local[402]: + grub_installation_needed=
[   11.064267] rc.local[402]: + [ ! -e /host/machine.conf ]
[   11.129238] rc.local[402]: + migrate_nos_configuration
[   11.196565] rc.local[402]: + rm -rf /host/migration
[   11.256649] rc.local[402]: + mkdir -p /host/migration
[   11.384179] kdump-tools[401]: /etc/init.d/kdump-tools: 117: /etc/default/kdump-tools: KDUMP_CMDLINE_APPEND+= panic=10 debug hpet=disable pcie_port=compat pci=nommconf sonic_platform=__PLATFORM__: not found
[   11.623611] rc.local[402]: + cat /proc/cmdline
[   11.686343] rc.local[402]: + set -- BOOT_IMAGE=/image-master.0-dirty-20210309.090106/boot/vmlinuz-4.19.0-12-2-amd64 root=UUID=689eaf9b-fdc1-484b-88a6-c116de04f8d5 rw console=tty0 console=ttyS1,9600n8 quiet intel_idle.max_cstate=0 net.ifnames=0 biosdevname=0 loop=image-master.0-dirty-20210309.090106/fs.squashfs loopfstype=squashfs apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 module_blacklist=gpio_ich
[   12.142438] rc.local[402]: + [ -n  ]
[   12.196536] rc.local[402]: + . /host/machine.conf
[   12.256564] rc.local[402]: + onie_version=2015.05.0.0.3
[   12.328538] rc.local[402]: + onie_vendor_id=12244
[   12.388599] rc.local[402]: + onie_platform=x86_64-cel_e1031-r0
[   12.464583] rc.local[402]: + onie_machine=cel_e1031
[   12.524507] rc.local[402]: + onie_machine_rev=0
[   12.585316] rc.local[402]: + onie_arch=x86_64
[   12.648607] rc.local[402]: + onie_config_version=1
[   12.708589] rc.local[402]: + onie_build_date=2018-05-14T19:01-0400
[   12.785379] rc.local[402]: + onie_partition_type=gpt
[   12.845867] rc.local[402]: + onie_kernel_version=3.2.35
[   12.916594] rc.local[402]: + program_console_speed
[   12.983411] rc.local[402]: + grep -Eo console=ttyS[0-9]+,[0-9]+
[   13.062521] rc.local[402]: + cat /proc/cmdline
[   13.125523] kdump-tools[401]: Starting kdump-tools: no crashkernel= parameter in the kernel cmdline ... failed!
[   13.261278] rc.local[402]: + cut -d , -f2
[   13.320802] rc.local[402]: + speed=9600
[   13.376586] rc.local[402]: + [ -z 9600 ]
[   13.432575] rc.local[402]: + CONSOLE_SPEED=9600
[   13.492571] rc.local[402]: + sed -i s|\-\-keep\-baud .* %I| 9600 %I|g /lib/systemd/system/serial-getty@.service
[   13.616473] rc.local[402]: + systemctl daemon-reload
[   13.676568] rc.local[402]: + [ -f /host/image-master.0-dirty-20210309.090106/platform/firsttime ]
[   13.784548] rc.local[402]: + echo First boot detected. Performing first boot tasks...
[   13.888587] rc.local[402]: First boot detected. Performing first boot tasks...
[   13.980957] rc.local[402]: + [ -n  ]
[   14.026866] rc.local[402]: + [ -n x86_64-cel_e1031-r0 ]
[   14.096562] rc.local[402]: + platform=x86_64-cel_e1031-r0
[   14.168670] rc.local[402]: + [ -d /host/old_config ]
[   14.240823] rc.local[402]: + [ -f /host/minigraph.xml ]
[   14.317798] rc.local[402]: + [ -n  ]
[   14.373001] rc.local[402]: + touch /tmp/pending_config_initialization
[   14.460464] rc.local[402]: + touch /tmp/notify_firstboot_to_platform
[   14.548489] rc.local[402]: + [ ! -d /host/reboot-cause/platform ]
[   14.624509] rc.local[402]: + mkdir -p /host/reboot-cause/platform
[   14.700499] rc.local[402]: + [ -d /host/image-master.0-dirty-20210309.090106/platform/x86_64-cel_e1031-r0 ]
[   14.820615] rc.local[402]: + dpkg -i /host/image-master.0-dirty-20210309.090106/platform/x86_64-cel_e1031-r0/platform-modules-haliburton_0.9_amd64.deb
[   15.007007] rc.local[402]: Selecting previously unselected package platform-modules-haliburton.
[   15.117102] rc.local[402]: (Reading database ... 29726 files and directories currently installed.)
[   15.236626] rc.local[402]: Preparing to unpack .../platform-modules-haliburton_0.9_amd64.deb ...
[   15.345543] rc.local[402]: Unpacking platform-modules-haliburton (0.9) ...
[   15.432575] rc.local[402]: Setting up platform-modules-haliburton (0.9) ...
[   21.093551] rc.local[402]: Synchronizing state of platform-modules-haliburton.service with SysV service script with /lib/systemd/systemd-sysv-install.
[   21.264786] rc.local[402]: Executing: /lib/systemd/systemd-sysv-install enable platform-modules-haliburton
[   32.806301] rc.local[402]: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
[   33.248723] rc.local[402]: Processing /usr/share/sonic/device/x86_64-cel_e1031-r0/sonic_platform-1.0-py2-none-any.whl
[   33.581101] rc.local[402]: Installing collected packages: sonic-platform
[   33.716700] rc.local[402]: Successfully installed sonic-platform-1.0
[   36.514391] rc.local[402]: Processing triggers for systemd (241-7~deb10u6) ...
[   36.606286] rc.local[402]: + sync
[   36.648617] rc.local[402]: + [ -n x86_64-cel_e1031-r0 ]
[   36.720593] rc.local[402]: + [ -n  ]
[   36.764636] rc.local[402]: + mkdir -p /var/platform
[   36.824609] rc.local[402]: + sed -i -e s/__PLATFORM__/x86_64-cel_e1031-r0/g /etc/default/kdump-tools
[   36.944596] rc.local[402]: + firsttime_exit
[   37.005107] rc.local[402]: + rm -rf /host/image-master.0-dirty-20210309.090106/platform/firsttime
[   37.112623] rc.local[402]: + exit 0

Debian GNU/Linux 10 sonic ttyS1

sonic login: admin
Password: 
Linux sonic 4.19.0-12-2-amd64 #1 SMP Debian 4.19.152-1 (2020-10-18) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:    http://azure.github.io/SONiC/

admin@sonic:~$ sudo -i
root@sonic:~# ls /dev//C0*
/dev/C0-1   /dev/C0-17	/dev/C0-24  /dev/C0-31	/dev/C0-39  /dev/C0-46
/dev/C0-10  /dev/C0-18	/dev/C0-25  /dev/C0-32	/dev/C0-4   /dev/C0-47
/dev/C0-11  /dev/C0-19	/dev/C0-26  /dev/C0-33	/dev/C0-40  /dev/C0-48
/dev/C0-12  /dev/C0-2	/dev/C0-27  /dev/C0-34	/dev/C0-41  /dev/C0-5
/dev/C0-13  /dev/C0-20	/dev/C0-28  /dev/C0-35	/dev/C0-42  /dev/C0-6
/dev/C0-14  /dev/C0-21	/dev/C0-29  /dev/C0-36	/dev/C0-43  /dev/C0-7
/dev/C0-15  /dev/C0-22	/dev/C0-3   /dev/C0-37	/dev/C0-44  /dev/C0-8
/dev/C0-16  /dev/C0-23	/dev/C0-30  /dev/C0-38	/dev/C0-45  /dev/C0-9
root@sonic:~#
-->


#### A picture of a cute animal (not mandatory but encouraged)