### PR TITLE
To follow consistent naming-conventions for key-attributes of all different types of interfaces in sonic-yang-models

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
+++ b/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
@@ -172,7 +172,7 @@ class Test_yang_models:
             'PORT_TEST': {
                 'desc': 'LOAD PORT TABLE WITH FEC AND PFC_ASYM SUCCESSFULLY. VERIFY PFC_ASYM.',
                 'eStr': self.defaultYANGFailure['Verify'],
-                'verify': {'xpath': "/sonic-port:sonic-port/PORT/PORT_LIST[port_name='Ethernet8']/port_name",
+                'verify': {'xpath': "/sonic-port:sonic-port/PORT/PORT_LIST[name='Ethernet8']/name",
                     'key': 'sonic-port:pfc_asym',
                     'value': 'on'
                 }
@@ -465,7 +465,7 @@ class Test_yang_models:
             for i in range(4095):
                 vlan = 'Vlan'+str(i)
                 jInput["sonic-vlan:sonic-vlan"]["sonic-vlan:VLAN"]["VLAN_LIST"]\
-                      [0]["vlan_name"] = vlan
+                      [0]["name"] = vlan
                 log.debug(jInput)
                 s = self.loadConfigData(json.dumps(jInput))
                 if s!="":

--- a/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
@@ -3,10 +3,10 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN_INTERFACE": {
 				"VLAN_INTERFACE_LIST": [{
-					"vlan_name": "Vlan100"
+					"name": "Vlan100"
 				}],
 				"VLAN_INTERFACE_IPPREFIX_LIST": [{
-					"vlan_name": "Vlan100",
+					"name": "Vlan100",
 					"ip-prefix": "2a04:5555:66:7777::1/64",
 					"scope": "global",
 					"family": "IPv4"
@@ -14,7 +14,7 @@
 			},
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlan_name": "Vlan100",
+					"name": "Vlan100",
 					"description": "server_vlan"
 				}]
 			}
@@ -25,7 +25,7 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlan_name": "Vlan100",
+					"name": "Vlan100",
 					"description": "server_vlan",
 					"dhcp_servers": [
 						"10.186.72.566"
@@ -41,7 +41,7 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlan_name": "Vlan1-4094",
+					"name": "Vlan1-4094",
 					"description": "server_vlan",
 					"dhcp_servers": [
 						"10.186.72.56"
@@ -57,7 +57,7 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlan_name": "Vlan8090",
+					"name": "Vlan8090",
 					"description": "server_vlan",
 					"dhcp_servers": [
 						"10.186.72.56"
@@ -73,14 +73,14 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN_MEMBER": {
 				"VLAN_MEMBER_LIST": [{
-					"vlan_name": "Vlan100",
+					"name": "Vlan100",
 					"port": "Ethernet156",
 					"tagging_mode": "tagged"
 				}]
 			},
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlan_name": "Vlan100",
+					"name": "Vlan100",
 					"description": "server_vlan"
 				}]
 			}
@@ -88,7 +88,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-						"port_name": "Ethernet0",
+						"name": "Ethernet0",
 						"alias": "eth0",
 						"description": "Ethernet0",
 						"speed": 25000,
@@ -96,7 +96,7 @@
 						"admin_status": "up"
 					},
 					{
-						"port_name": "Ethernet1",
+						"name": "Ethernet1",
 						"alias": "eth1",
 						"description": "Ethernet1",
 						"speed": 25000,
@@ -112,7 +112,7 @@
 		"sonic-portchannel:sonic-portchannel": {
 			"sonic-portchannel:PORTCHANNEL": {
 				"PORTCHANNEL_LIST": [{
-					"portchannel_name": "PortChannel0001",
+					"name": "PortChannel0001",
 					"admin_status": "up",
 					"members": [
 						"Ethernet0"
@@ -125,7 +125,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-						"port_name": "Ethernet0",
+						"name": "Ethernet0",
 						"alias": "eth0",
 						"description": "Ethernet0",
 						"speed": 25000,
@@ -141,7 +141,7 @@
 		"sonic-portchannel:sonic-portchannel": {
 			"sonic-portchannel:PORTCHANNEL": {
 				"PORTCHANNEL_LIST": [{
-					"portchannel_name": "PortChannel11001",
+					"name": "PortChannel11001",
 					"admin_status": "up",
 					"mtu": "9100"
 				}]
@@ -153,18 +153,18 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN_MEMBER": {
 				"VLAN_MEMBER_LIST": [{
-					"vlan_name": "Vlan200",
+					"name": "Vlan200",
 					"port": "Ethernet0",
 					"tagging_mode": "tagged"
 				}]
 			},
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-						"vlan_name": "Vlan100",
+						"name": "Vlan100",
 						"description": "server_vlan"
 					},
 					{
-						"vlan_name": "Vlan300",
+						"name": "Vlan300",
 						"description": "ipmi_vlan"
 					}
 				]
@@ -173,7 +173,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-					"port_name": "Ethernet0",
+					"name": "Ethernet0",
 					"alias": "eth0",
 					"description": "Ethernet0",
 					"speed": 25000,
@@ -188,14 +188,14 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN_MEMBER": {
 				"VLAN_MEMBER_LIST": [{
-					"vlan_name": "Vlan100",
+					"name": "Vlan100",
 					"port": "Ethernet0",
 					"tagging_mode": "non-tagged"
 				}]
 			},
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlan_name": "Vlan100",
+					"name": "Vlan100",
 					"description": "server_vlan"
 				}]
 			}
@@ -203,7 +203,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-					"port_name": "Ethernet0",
+					"name": "Ethernet0",
 					"alias": "eth0",
 					"description": "Ethernet0",
 					"speed": 25000,
@@ -218,10 +218,10 @@
 		"sonic-interface:sonic-interface": {
 			"sonic-interface:INTERFACE": {
 				"INTERFACE_LIST": [{
-					"port_name": "Ethernet8"
+					"name": "Ethernet8"
 				}],
 				"INTERFACE_IPPREFIX_LIST": [{
-					"port_name": "Ethernet8",
+					"name": "Ethernet8",
 					"ip-prefix": "",
 					"scope": "global",
 					"family": "IPv4"
@@ -231,7 +231,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-					"port_name": "Ethernet8",
+					"name": "Ethernet8",
 					"alias": "eth8",
 					"description": "Ethernet8",
 					"speed": 25000,
@@ -282,7 +282,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-						"port_name": "Ethernet0",
+						"name": "Ethernet0",
 						"alias": "eth0",
 						"description": "Ethernet0",
 						"speed": 25000,
@@ -290,7 +290,7 @@
 						"admin_status": "up"
 					},
 					{
-						"port_name": "Ethernet1",
+						"name": "Ethernet1",
 						"alias": "eth1",
 						"description": "Ethernet1",
 						"speed": 25000,
@@ -317,7 +317,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-						"port_name": "Ethernet0",
+						"name": "Ethernet0",
 						"alias": "eth0",
 						"description": "Ethernet0",
 						"speed": 25000,
@@ -325,7 +325,7 @@
 						"admin_status": "up"
 					},
 					{
-						"port_name": "Ethernet1",
+						"name": "Ethernet1",
 						"alias": "eth1",
 						"description": "Ethernet1",
 						"speed": 25000,
@@ -363,7 +363,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-						"port_name": "Ethernet0",
+						"name": "Ethernet0",
 						"alias": "eth0",
 						"description": "Ethernet0",
 						"speed": 25000,
@@ -371,7 +371,7 @@
 						"admin_status": "up"
 					},
 					{
-						"port_name": "Ethernet1",
+						"name": "Ethernet1",
 						"alias": "eth1",
 						"description": "Ethernet1",
 						"speed": 25000,
@@ -408,7 +408,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-						"port_name": "Ethernet0",
+						"name": "Ethernet0",
 						"alias": "eth0",
 						"description": "Ethernet0",
 						"speed": 25000,
@@ -416,7 +416,7 @@
 						"admin_status": "up"
 					},
 					{
-						"port_name": "Ethernet1",
+						"name": "Ethernet1",
 						"alias": "eth1",
 						"description": "Ethernet1",
 						"speed": 25000,
@@ -453,7 +453,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-						"port_name": "Ethernet0",
+						"name": "Ethernet0",
 						"alias": "eth0",
 						"description": "Ethernet0",
 						"speed": 25000,
@@ -461,7 +461,7 @@
 						"admin_status": "up"
 					},
 					{
-						"port_name": "Ethernet1",
+						"name": "Ethernet1",
 						"alias": "eth1",
 						"description": "Ethernet1",
 						"speed": 25000,
@@ -500,7 +500,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-						"port_name": "Ethernet0",
+						"name": "Ethernet0",
 						"alias": "eth0",
 						"description": "Ethernet0",
 						"speed": 25000,
@@ -508,7 +508,7 @@
 						"admin_status": "up"
 					},
 					{
-						"port_name": "Ethernet1",
+						"name": "Ethernet1",
 						"alias": "eth1",
 						"description": "Ethernet1",
 						"speed": 25000,
@@ -524,7 +524,7 @@
 		"sonic-vlan:sonic-vlan": {
 			"sonic-vlan:VLAN_INTERFACE": {
 				"VLAN_INTERFACE_IPPREFIX_LIST": [{
-					"vlan_name": "Vlan100",
+					"name": "Vlan100",
 					"ip-prefix": "2a04:5555:66:7777::1/64",
 					"scope": "global",
 					"family": "IPv6"
@@ -532,7 +532,7 @@
 			},
 			"sonic-vlan:VLAN": {
 				"VLAN_LIST": [{
-					"vlan_name": "Vlan100",
+					"name": "Vlan100",
 					"description": "server_vlan"
 				}]
 			}
@@ -543,7 +543,7 @@
 		"sonic-loopback-interface:sonic-loopback-interface": {
 			"sonic-loopback-interface:LOOPBACK_INTERFACE": {
 				"LOOPBACK_INTERFACE_IPPREFIX_LIST": [{
-					"loopback_interface_name": "lo1",
+					"name": "lo1",
 					"ip-prefix": "2a04:5555:66:7777::1/64",
 					"scope": "global",
 					"family": "IPv6"
@@ -556,10 +556,10 @@
 		"sonic-interface:sonic-interface": {
 			"sonic-interface:INTERFACE": {
 				"INTERFACE_LIST": [{
-					"port_name": "Ethernet9"
+					"name": "Ethernet9"
 				}],
 				"INTERFACE_IPPREFIX_LIST": [{
-					"port_name": "Ethernet8",
+					"name": "Ethernet8",
 					"ip-prefix": "10.0.0.1/30",
 					"scope": "global",
 					"family": "IPv4"
@@ -569,7 +569,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-					"port_name": "Ethernet8",
+					"name": "Ethernet8",
 					"alias": "eth8",
 					"lanes": "65",
 					"description": "Ethernet8",
@@ -578,7 +578,7 @@
 					"admin_status": "up"
 				},
 				{
-					"port_name": "Ethernet9",
+					"name": "Ethernet9",
 					"alias": "eth9",
 					"lanes": "71",
 					"description": "Ethernet9",
@@ -594,10 +594,10 @@
 		"sonic-interface:sonic-interface": {
 			"sonic-interface:INTERFACE": {
 				"INTERFACE_LIST": [{
-					"port_name": "Ethernet8"
+					"name": "Ethernet8"
 				}],
 				"INTERFACE_IPPREFIX_LIST": [{
-					"port_name": "Ethernet8",
+					"name": "Ethernet8",
 					"ip-prefix": "10.0.0.1/30",
 					"scope": "global",
 					"family": "IPv4"
@@ -607,7 +607,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-					"port_name": "Ethernet8",
+					"name": "Ethernet8",
 					"alias": "eth8",
 					"lanes": "65",
 					"description": "Ethernet8",
@@ -624,7 +624,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-					"port_name": "Ethernet8",
+					"name": "Ethernet8",
 					"alias": "eth8",
 					"lanes": "65",
 					"description": "Ethernet8",
@@ -642,7 +642,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-					"port_name": "Ethernet8",
+					"name": "Ethernet8",
 					"alias": "eth8",
 					"lanes": "65",
 					"description": "Ethernet8",
@@ -684,7 +684,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-						"port_name": "Ethernet0",
+						"name": "Ethernet0",
 						"alias": "eth0",
 						"description": "Ethernet0",
 						"speed": 25000,
@@ -692,7 +692,7 @@
 						"admin_status": "up"
 					},
 					{
-						"port_name": "Ethernet1",
+						"name": "Ethernet1",
 						"alias": "eth1",
 						"description": "Ethernet1",
 						"speed": 25000,
@@ -1243,7 +1243,7 @@
 		"sonic-port:sonic-port": {
 			"sonic-port:PORT": {
 				"PORT_LIST": [{
-						"port_name": "Ethernet0",
+						"name": "Ethernet0",
 						"alias": "eth0",
 						"description": "Ethernet0",
 						"speed": 25000,
@@ -1251,7 +1251,7 @@
 						"admin_status": "up"
 					},
 					{
-						"port_name": "Ethernet1",
+						"name": "Ethernet1",
 						"alias": "eth1",
 						"description": "Ethernet1",
 						"speed": 25000,

--- a/src/sonic-yang-models/yang-models/sonic-acl.yang
+++ b/src/sonic-yang-models/yang-models/sonic-acl.yang
@@ -267,10 +267,10 @@ module sonic-acl {
 					/* union of leafref is allowed in YANG 1.1 */
 					type union {
 						type leafref {
-							path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
+							path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
 						}
 						type leafref {
-							path /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:portchannel_name;
+							path /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name;
 						}
 						type string {
 							pattern "";

--- a/src/sonic-yang-models/yang-models/sonic-device_neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_neighbor.yang
@@ -57,7 +57,7 @@ module sonic-device_neighbor {
 
                 leaf local_port {
                     type leafref {
-                        path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
+                        path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-interface.yang
@@ -36,15 +36,15 @@ module sonic-interface {
 
 				description "INTERFACE part of config_db.json with vrf";
 
-				key "port_name";
+				key "name";
 
 				ext:key-regex-configdb-to-yang "^(Ethernet[0-9]+)$";
 
-				ext:key-regex-yang-to-configdb "<port_name>";
+				ext:key-regex-yang-to-configdb "<name>";
 
-				leaf port_name {
+				leaf name {
 					type leafref {
-						path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
+						path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
 					}
 				}
 
@@ -61,21 +61,21 @@ module sonic-interface {
 
 				description "INTERFACE part of config_db.json with ip-prefix";
 
-				key "port_name ip-prefix";
+				key "name ip-prefix";
 
 				ext:key-regex-configdb-to-yang "^(Ethernet[0-9]+)|([a-fA-F0-9:./]+)$";
 
-				ext:key-regex-yang-to-configdb "<port_name>|<ip-prefix>";
+				ext:key-regex-yang-to-configdb "<name>|<ip-prefix>";
 
-				leaf port_name {
+				leaf name {
 					/* This node must be present in INTERFACE_LIST */
-					must "(current() = ../../INTERFACE_LIST[port_name=current()]/port_name)"
+					must "(current() = ../../INTERFACE_LIST[name=current()]/name)"
 					{
 						error-message "Must condition not satisfied, Try adding PORT: {}, Example: 'Ethernet0': {}";
 					}
 
 					type leafref {
-						path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
+						path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
 					}
 				}
 

--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -27,13 +27,13 @@ module sonic-loopback-interface {
         container LOOPBACK_INTERFACE {
 
             list LOOPBACK_INTERFACE_LIST {
-                key "loopback_interface_name";
+                key "name";
 
                 ext:key-regex-configdb-to-yang "^([a-zA-Z0-9-_]+)$";
 
-                ext:key-regex-yang-to-configdb "<loopback_interface_name>";
+                ext:key-regex-yang-to-configdb "<name>";
 
-                leaf loopback_interface_name{
+                leaf name{
                     type string;
                 }
 
@@ -48,15 +48,15 @@ module sonic-loopback-interface {
 
             list LOOPBACK_INTERFACE_IPPREFIX_LIST {
 
-                key "loopback_interface_name ip-prefix";
+                key "name ip-prefix";
 
                 ext:key-regex-configdb-to-yang "^([a-zA-Z0-9-_]+)|([a-fA-F0-9:./]+$)";
 
-                ext:key-regex-yang-to-configdb "<loopback_interface_name>|<ip-prefix>";
+                ext:key-regex-yang-to-configdb "<name>|<ip-prefix>";
 
-                leaf loopback_interface_name{
+                leaf name{
                     /* This node must be present in LOOPBACK_INTERFACE_LIST */
-                    must "(current() = ../../LOOPBACK_INTERFACE_LIST[loopback_interface_name=current()]/loopback_interface_name)"
+                    must "(current() = ../../LOOPBACK_INTERFACE_LIST[name=current()]/name)"
                     {
                         error-message "Must condition not satisfied, Try adding lo<>: {}, Example: 'lo1': {}";
                     }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -29,13 +29,13 @@ module sonic-port{
 
 			list PORT_LIST {
 
-				key "port_name";
+				key "name";
 
 				ext:key-regex-configdb-to-yang "^(Ethernet[0-9]+)$";
 
-				ext:key-regex-yang-to-configdb "<port_name>";
+				ext:key-regex-yang-to-configdb "<name>";
 
-				leaf port_name {
+				leaf name {
 					type string {
 						length 1..128;
 					}

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -33,13 +33,13 @@ module sonic-portchannel {
 
 			list PORTCHANNEL_LIST {
 
-				key "portchannel_name";
+				key "name";
 
 				ext:key-regex-configdb-to-yang "^(PortChannel[0-9]{1,4})$";
 
-				ext:key-regex-yang-to-configdb "<portchannel_name>";
+				ext:key-regex-yang-to-configdb "<name>";
 
-				leaf portchannel_name {
+				leaf name {
 					type string {
 						length 1..128;
 						pattern 'PortChannel[0-9]{1,4}';
@@ -50,7 +50,7 @@ module sonic-portchannel {
 					/* leaf-list members are unique by default */
 					type union {
 						type leafref {
-							path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
+							path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
 						}
 						type string {
 							pattern "";

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -40,15 +40,15 @@ module sonic-vlan {
 
 				description "VLAN INTERFACE part of config_db.json with vrf";
 
-				key "vlan_name";
+				key "name";
 
 				ext:key-regex-configdb-to-yang "^(Vlan[a-zA-Z0-9_-]+)$";
 
-				ext:key-regex-yang-to-configdb "<vlan_name>";
+				ext:key-regex-yang-to-configdb "<name>";
 
-				leaf vlan_name {
+				leaf name {
 					type leafref {
-						path /vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:vlan_name;
+						path /vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name;
 					}
 				}
 
@@ -63,21 +63,21 @@ module sonic-vlan {
 
 			list VLAN_INTERFACE_IPPREFIX_LIST {
 
-				key "vlan_name ip-prefix";
+				key "name ip-prefix";
 
 				ext:key-regex-configdb-to-yang "^(Vlan[a-zA-Z0-9_-]+)|([a-fA-F0-9:./]+$)";
 
-				ext:key-regex-yang-to-configdb "<vlan_name>|<ip-prefix>";
+				ext:key-regex-yang-to-configdb "<name>|<ip-prefix>";
 
-				leaf vlan_name {
+				leaf name {
 					/* This node must be present in VLAN_INTERFACE_LIST */
-					must "(current() = ../../VLAN_INTERFACE_LIST[vlan_name=current()]/vlan_name)"
+					must "(current() = ../../VLAN_INTERFACE_LIST[name=current()]/name)"
 					{
 						error-message "Must condition not satisfied, Try adding Vlan<vlanid>: {}, Example: 'Vlan100': {}";
 					}
 
 					type leafref {
-						path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:vlan_name";
+						path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name";
 					}
 				}
 
@@ -118,13 +118,13 @@ module sonic-vlan {
 
 			list VLAN_LIST {
 
-				key "vlan_name";
+				key "name";
 
 				ext:key-regex-configdb-to-yang "^(Vlan[a-zA-Z0-9_-]+)$";
 
-				ext:key-regex-yang-to-configdb "<vlan_name>";
+				ext:key-regex-yang-to-configdb "<name>";
 
-				leaf vlan_name {
+				leaf name {
 					type string {
 						pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
 					}
@@ -166,22 +166,22 @@ module sonic-vlan {
 
 			list VLAN_MEMBER_LIST {
 
-				key "vlan_name port";
+				key "name port";
 
 				ext:key-regex-configdb-to-yang "^(Vlan[a-zA-Z0-9-_]+)|(Ethernet[0-9]+)$";
 
-				ext:key-regex-yang-to-configdb "<vlan_name>|<port>";
+				ext:key-regex-yang-to-configdb "<name>|<port>";
 
-				leaf vlan_name {
+				leaf name {
 					type leafref {
-						path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:vlan_name";
+						path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name";
 					}
 				}
 
 				leaf port {
 					/* key elements are mandatory by default */
 					type leafref {
-						path /port:sonic-port/port:PORT/port:PORT_LIST/port:port_name;
+						path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
 					}
 				}
 


### PR DESCRIPTION
To follow consistent naming-conventions for key-attributes of all different types of interfaces in sonic-yang-models

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
As discussed in the yang subgroup community meeting, this change is bring consistent naming-conventions for all different type  of interfaces in sonic-yang-model. Particularly the key-attribute name. Since the relevant interface container does have a context about that interface, having a simple & clear key-attribute name will be sufficient. For e.g. PORT/PORT_LIST/port_name has been renamed as PORT/PORT_LIST/name. Similar changes are done for portchannel, VLAN & loopback interfaces as well.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

