### PR TITLE
DHCP Relay: add -si support in dhcp docker template

### DIFF
--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -77,6 +77,8 @@ isc-dhcp-relay-{{ vlan_name }}
 command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}
 {#- Dual ToR Option #}
 {% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -U Loopback0 -dt{% endif -%}
+{#- si option to use intf addr in relay #}
+{% if DEVICE_METADATA['localhost']['deployment_id'] == '8' %} -si{% endif -%}
 {#- We treat all other interfaces as upstream interfaces (-iu), as we only want to listen for replies #}
 {% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 and name != vlan_name %} -iu {{ name }}{% endif -%}


### PR DESCRIPTION
Add -si support in dhcp docker template

Tested and verified on a vs testbed.