### PR TITLE
fix restapi startup

### DIFF
--- a/dockers/docker-sonic-restapi/supervisord.conf
+++ b/dockers/docker-sonic-restapi/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python3 -m supervisord_dependent_startup
+command=python -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

`go-server-server` doesn't start in `restapi` container.  
`restapi` is `docker-config-engine-stretch` base container, and it has no `Python3` but only `Python2`.

#### How I did it

I changed from `python3` to `python` in `supervisord.conf`.

#### How to verify it

`go-server-server` starts in `restapi` container, if specified `RESTAPI` configs in `/etc/sonic/config_db.json`.

```
$ show services
...<snip>

restapi docker
---------------------------
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.1  59276 21512 pts/0    Ss+  Mar12   1:05 /usr/bin/python /usr/local/bin/supervisord
root        12  0.0  0.0 262988  3592 pts/0    Sl   Mar12   0:00 /usr/sbin/rsyslogd -n -iNONE
root        24  0.0  0.1 1010616 19320 pts/0   Sl   Mar12   0:03 /usr/sbin/go-server-server -enablehttp=true -enablehttps=true -servercert=/etc/sonic/credentials/server_selfsigned.crt -serverkey=/etc/sonic/credentials/server_selfsigned.key -clientcert=/etc/sonic/credentials/client_selfsigned.crt -clientcertcommonname=SonicCLient -loglevel=trace


$ show run all | jq .RESTAPI
{
  "certs": {
    "ca_crt": "/etc/sonic/credentials/client_selfsigned.crt",
    "client_crt_cname": "SonicCLient",
    "server_crt": "/etc/sonic/credentials/server_selfsigned.crt",
    "server_key": "/etc/sonic/credentials/server_selfsigned.key"
  },
  "config": {
    "allow_insecure": "true",
    "client_auth": "true",
    "log_level": "trace"
  }
}
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)
