### PR TITLE
Start DHCP Relay When Helpers IPs Are Available (#6961)

### DIFF
--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -43,7 +43,7 @@ dependent_startup_wait_for=rsyslogd:running
 {# Count how many VLANs require a DHCP relay agent... #}
 {% set num_relays = { 'count': 0 } %}
 {% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and VLAN[vlan_name]['dhcp_servers'] %}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
 {% set _dummy = num_relays.update({'count': num_relays.count + 1}) %}
 {% endif %}
 {% endfor %}
@@ -53,7 +53,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=
 {%- set add_preceding_comma = { 'flag': False } %}
 {% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and VLAN[vlan_name]['dhcp_servers'] %}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
 {% if add_preceding_comma.flag %},{% endif %}
 {% set _dummy = add_preceding_comma.update({'flag': True}) %}
 isc-dhcp-relay-{{ vlan_name }}
@@ -64,7 +64,7 @@ isc-dhcp-relay-{{ vlan_name }}
 {# Create a program entry for each DHCP relay agent instance #}
 {% set relay_for_ipv4 = { 'flag': False } %}
 {% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and VLAN[vlan_name]['dhcp_servers'] %}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
 {% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
 {% if dhcp_server | ipv4 %}
 {% set _dummy = relay_for_ipv4.update({'flag': True}) %}
@@ -105,7 +105,7 @@ dependent_startup_wait_for=start:exited
 programs=
 {%- set add_preceding_comma = { 'flag': False } %}
 {% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and VLAN[vlan_name]['dhcp_servers'] %}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
 {% if add_preceding_comma.flag %},{% endif %}
 {% set _dummy = add_preceding_comma.update({'flag': True}) %}
 dhcpmon-{{ vlan_name }}
@@ -116,7 +116,7 @@ dhcpmon-{{ vlan_name }}
 {# Create a program entry for each DHCP MONitor instance #}
 {% set relay_for_ipv4 = { 'flag': False } %}
 {% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and VLAN[vlan_name]['dhcp_servers'] %}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
 {% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
 {% if dhcp_server | ipv4 %}
 {% set _dummy = relay_for_ipv4.update({'flag': True}) %}

--- a/src/sonic-config-engine/tests/sample_output/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/bgpd_frr.conf
@@ -33,7 +33,9 @@ ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.1/27
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.200.1/27
+!
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.0.1/27
 !
 !
 !
@@ -56,6 +58,7 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
 !
+  network 192.168.200.1/27
   network 192.168.0.1/27
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/bgpd_quagga.conf
+++ b/src/sonic-config-engine/tests/sample_output/bgpd_quagga.conf
@@ -27,6 +27,7 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
   network 10.1.0.32/32
+  network 192.168.200.1/27
   network 192.168.0.1/27
   neighbor 10.0.0.59 remote-as 64600
   neighbor 10.0.0.59 description ARISTA02T1

--- a/src/sonic-config-engine/tests/sample_output/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/docker-dhcp-relay.supervisord.conf
@@ -42,7 +42,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=isc-dhcp-relay-Vlan1000
 
 [program:isc-dhcp-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false
@@ -56,7 +56,7 @@ dependent_startup_wait_for=start:exited
 programs=dhcpmon-Vlan1000
 
 [program:dhcpmon-Vlan1000]
-command=/usr/sbin/dhcpmon -id Vlan1000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
+command=/usr/sbin/dhcpmon -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
 priority=4
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/frr.conf
@@ -51,7 +51,9 @@ ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.1/27
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.200.1/27
+!
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.0.1/27
 !
 !
 !
@@ -74,6 +76,7 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
 !
+  network 192.168.200.1/27
   network 192.168.0.1/27
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/ipinip.json
@@ -2,7 +2,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"10.1.0.32,10.0.0.58,10.0.0.60,10.0.0.62,10.0.0.56,192.168.0.1",
+            "dst_ip":"10.1.0.32,10.0.0.58,10.0.0.60,10.0.0.62,10.0.0.56,192.168.200.1,192.168.0.1",
             "dscp_mode":"pipe",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"

--- a/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/wait_for_intf.sh
@@ -23,6 +23,7 @@ function wait_until_iface_ready
 
 
 # Wait for all interfaces with IPv4 addresses to be up and ready
+wait_until_iface_ready Vlan2000 192.168.200.1/27
 wait_until_iface_ready Vlan1000 192.168.0.1/27
 wait_until_iface_ready PortChannel02 10.0.0.58/31
 wait_until_iface_ready PortChannel03 10.0.0.60/31

--- a/src/sonic-config-engine/tests/t0-sample-graph.xml
+++ b/src/sonic-config-engine/tests/t0-sample-graph.xml
@@ -247,6 +247,20 @@
           <SecondarySubnets/>
         </VlanInterface>
         <VlanInterface>
+          <Name>Vlan2000</Name>
+          <AttachTo>fortyGigE0/112;fortyGigE0/116;fortyGigE0/120</AttachTo>
+          <NoDhcpRelay>False</NoDhcpRelay>
+          <StaticDHCPRelay>0.0.0.0/0</StaticDHCPRelay>
+          <FhrpProtoType i:nil="true"/>
+          <Type i:nil="true"/>
+          <DhcpRelays></DhcpRelays>
+          <VlanID>2000</VlanID>
+          <Tag>2000</Tag>
+          <Subnets>192.168.200.0/27</Subnets>
+          <MacAddress i:nil="true"/>
+          <SecondarySubnets/>
+        </VlanInterface>
+        <VlanInterface>
           <Name>Vlan99</Name>
           <AttachTo>fortyGigE0/100</AttachTo>
           <NoDhcpRelay>False</NoDhcpRelay>
@@ -320,6 +334,11 @@
           <Name i:nil="true"/>
           <AttachTo>Vlan1000</AttachTo>
           <Prefix>192.168.0.1/27</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Vlan2000</AttachTo>
+          <Prefix>192.168.200.1/27</Prefix>
         </IPInterface>
       </IPInterfaces>
       <DataAcls/>


### PR DESCRIPTION
It is possible to have DHCP relay configuration with no servers/
helpers which result in DHCP container to crash. This PR fixes this
issue by not starting DHCP relay for vlans with no DHCP helpers.

resolves: #6931
closes: #6931
Do not add program group for dhcp relay with not dhcp helpers

Unit test

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

