### PR TITLE
[201911][procdockerstatsd] Fix unit conversion for docker stats

### DIFF
--- a/files/image_config/procdockerstatsd/procdockerstatsd
+++ b/files/image_config/procdockerstatsd/procdockerstatsd
@@ -66,28 +66,26 @@ class ProcDockerStats(daemon_base.DaemonBase):
         return process_data_list
 
     def convert_to_bytes(self, value):
-        unit_value = re.search('[a-zA-Z]+', value)
-        value_to_convert = float(filter(str.isdigit, value))
-        unit = unit_value.group(0)
         UNITS_B = 'B'
         UNITS_KB = 'KB'
         UNITS_MB = 'MB'
         UNITS_MiB = 'MiB'
         UNITS_GiB = 'GiB'
-        if unit.lower() == UNITS_B.lower():
-            return int(round(value_to_convert))
-        elif unit.lower() == UNITS_KB.lower():
-            value_converted = value_to_convert * 1000
-            return int(round(value_converted))
+
+        res = re.match(r'(\d+\.?\d*)([a-zA-Z]+)', value)
+        value = float(res.groups()[0])
+        units = res.groups()[1]
+
+        if unit.lower() == UNITS_KB.lower():
+            value *= 1000
         elif unit.lower() == UNITS_MB.lower():
-            value_converted = value_to_convert * 1000 * 1000
-            return int(round(value_converted))
+            value *= (1000 * 1000)
         elif unit.lower() == UNITS_MiB.lower():
-            value_converted = value_to_convert * 1024 * 1024
-            return int(round(value_converted))
+            value *= (1024 * 1024)
         elif unit.lower() == UNITS_GiB.lower():
-            value_converted = value_to_convert * 1024 * 1024 * 1024
-            return int(round(value_converted))
+            value *= (1024 * 1024 * 1024)
+
+        return int(round(value))
 
     def create_docker_dict(self, dict_list):
         dockerdict = {}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Bug exists in 201911 branch where unit conversion for docker stats is incorrect. Both MiB/GiB to byes conversion is incorrect
Example: 
`admin@str-s6000-acs-10:/usr/bin$ docker stats --no-stream -a`
CONTAINER ID        NAME                CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
e958c81d27a8        mgmt-framework      0.00%               0B / 0B               0.00%               0B / 0B             0B / 0B             0
9b6b7b4361d5        telemetry           3.13%               86.31MiB / 7.785GiB   1.08%               0B / 0B             0B / 106kB          30
e7fee0b617fe        snmp                70.28%              57.03MiB / 7.785GiB   0.72%               0B / 0B             0B / 102kB          9

admin@str-s6000-acs-10:/usr/bin$ redis-cli -n 6 hgetall "DOCKER_STATS|e7fee0b617fe"
 1) "MEM%"
 2) "0.72"
 3) "MEM_LIMIT_BYTES"
 4) "8359080099840"
 5) "NAME"
 6) "snmp"
 7) "NET_OUT_BYTES"
 8) "0"
 9) "MEM_BYTES"
10) "5980028928"
11) "BLOCK_OUT_BYTES"
12) "102000"
13) "NET_IN_BYTES"
14) "0"
15) "BLOCK_IN_BYTES"
16) "0"
17) "PIDS"
18) "9"
19) "CPU%"
20) "5.96"
#### How I did it
Installed 2019 image and verified values
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

This has been fixed as part 0f 202006 and 202012 image, along with some other changes which are not supposed to be backported.
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

