### PR TITLE
[Mellanox] [202012] Initialize PSU API on both host and docker side

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -16,16 +16,14 @@ except ImportError as e:
 class Platform(PlatformBase):
     def __init__(self):
         PlatformBase.__init__(self)
-        if self._is_host():
-            self._chassis = Chassis()
+        self._chassis = Chassis()
+        self._chassis.initialize_psu()
+        self._chassis.initialize_eeprom()
+        if self._is_host():  
             self._chassis.initialize_components()
-            self._chassis.initizalize_system_led()
-            self._chassis.initialize_eeprom()
-        else:
-            self._chassis = Chassis()
-            self._chassis.initialize_psu()
+            self._chassis.initizalize_system_led()  
+        else:    
             self._chassis.initialize_fan()
-            self._chassis.initialize_eeprom()
             self._chassis.initialize_thermals()
 
     def _is_host(self):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

There was a change to replace platform utils with sonic platform API in psuutil. However, psu API is not initialized on host side. The PR is to fix it.

Backport of https://github.com/Azure/sonic-buildimage/pull/7016 to the 202012 branch.

#### How I did it

Initialize PSU API on both host and non-host side

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

