### PR TITLE
[dockers][supervisor] Increase event buffer size for process exit listener; Set all event buffer sizes to 1024

### DIFF
--- a/dockers/docker-database/supervisord.conf.j2
+++ b/dockers/docker-database/supervisord.conf.j2
@@ -8,6 +8,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name database
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name dhcp_relay
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=50
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=50
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name dhcp_relay
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=50
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name bgp
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=50
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=50
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name bgp
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=50
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-fpm-gobgp/supervisord.conf
+++ b/dockers/docker-fpm-gobgp/supervisord.conf
@@ -8,6 +8,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name bgp
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=1024
 
 [program:start.sh]
 command=/usr/bin/start.sh

--- a/dockers/docker-fpm-quagga/supervisord.conf
+++ b/dockers/docker-fpm-quagga/supervisord.conf
@@ -8,6 +8,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name bgp
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=1024
 
 [program:start.sh]
 command=/usr/bin/start.sh

--- a/dockers/docker-iccpd/supervisord.conf
+++ b/dockers/docker-iccpd/supervisord.conf
@@ -10,6 +10,7 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-lldp/supervisord.conf.j2
+++ b/dockers/docker-lldp/supervisord.conf.j2
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name lldp
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-lldp/supervisord.conf.j2
+++ b/dockers/docker-lldp/supervisord.conf.j2
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name lldp
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-macsec/supervisord.conf
+++ b/dockers/docker-macsec/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name macsec
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-macsec/supervisord.conf
+++ b/dockers/docker-macsec/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name macsec
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-nat/supervisord.conf
+++ b/dockers/docker-nat/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name nat
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-nat/supervisord.conf
+++ b/dockers/docker-nat/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name nat
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name swss
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=100
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-orchagent/supervisord.conf
+++ b/dockers/docker-orchagent/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=100
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name swss
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=100
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name pmon
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=100
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=100
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name pmon
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=100
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
+++ b/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-script]
 command=/usr/bin/supervisor-proc-exit-listener --container-name radv
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
+++ b/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name radv
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-sflow/supervisord.conf
+++ b/dockers/docker-sflow/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name sflow
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-sflow/supervisord.conf
+++ b/dockers/docker-sflow/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name sflow
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-snmp/supervisord.conf
+++ b/dockers/docker-snmp/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=50
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name snmp
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=50
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-snmp/supervisord.conf
+++ b/dockers/docker-snmp/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name snmp
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=50
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-sonic-mgmt-framework/supervisord.conf
+++ b/dockers/docker-sonic-mgmt-framework/supervisord.conf
@@ -10,7 +10,7 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-sonic-restapi/supervisord.conf
+++ b/dockers/docker-sonic-restapi/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name restapi
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=false
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-sonic-restapi/supervisord.conf
+++ b/dockers/docker-sonic-restapi/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name restapi
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=false
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-sonic-telemetry/supervisord.conf
+++ b/dockers/docker-sonic-telemetry/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=50
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name telemetry
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=false
-buffer_size=50
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-sonic-telemetry/supervisord.conf
+++ b/dockers/docker-sonic-telemetry/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name telemetry
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=false
+buffer_size=50
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-teamd/supervisord.conf
+++ b/dockers/docker-teamd/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name teamd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=50
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/dockers/docker-teamd/supervisord.conf
+++ b/dockers/docker-teamd/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=50
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name teamd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=50
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/barefoot/docker-syncd-bfn/supervisord.conf
+++ b/platform/barefoot/docker-syncd-bfn/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/barefoot/docker-syncd-bfn/supervisord.conf
+++ b/platform/barefoot/docker-syncd-bfn/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/broadcom/docker-syncd-brcm/supervisord.conf
+++ b/platform/broadcom/docker-syncd-brcm/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/broadcom/docker-syncd-brcm/supervisord.conf
+++ b/platform/broadcom/docker-syncd-brcm/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/cavium/docker-syncd-cavm/supervisord.conf
+++ b/platform/cavium/docker-syncd-cavm/supervisord.conf
@@ -8,6 +8,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=1024
 
 [program:start.sh]
 command=/usr/bin/start.sh

--- a/platform/centec-arm64/docker-syncd-centec/supervisord.conf
+++ b/platform/centec-arm64/docker-syncd-centec/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/centec-arm64/docker-syncd-centec/supervisord.conf
+++ b/platform/centec-arm64/docker-syncd-centec/supervisord.conf
@@ -17,6 +17,7 @@ command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/centec/docker-syncd-centec/supervisord.conf
+++ b/platform/centec/docker-syncd-centec/supervisord.conf
@@ -10,12 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/innovium/docker-syncd-invm/supervisord.conf
+++ b/platform/innovium/docker-syncd-invm/supervisord.conf
@@ -10,7 +10,7 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/marvell-arm64/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell-arm64/docker-syncd-mrvl/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/marvell-arm64/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell-arm64/docker-syncd-mrvl/supervisord.conf
@@ -17,6 +17,7 @@ command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/marvell-armhf/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell-armhf/docker-syncd-mrvl/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/marvell-armhf/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell-armhf/docker-syncd-mrvl/supervisord.conf
@@ -17,6 +17,7 @@ command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/marvell/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell/docker-syncd-mrvl/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/marvell/docker-syncd-mrvl/supervisord.conf
+++ b/platform/marvell/docker-syncd-mrvl/supervisord.conf
@@ -17,6 +17,7 @@ command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/mellanox/docker-syncd-mlnx/supervisord.conf
+++ b/platform/mellanox/docker-syncd-mlnx/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/mellanox/docker-syncd-mlnx/supervisord.conf
+++ b/platform/mellanox/docker-syncd-mlnx/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/nephos/docker-syncd-nephos/supervisord.conf
+++ b/platform/nephos/docker-syncd-nephos/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/nephos/docker-syncd-nephos/supervisord.conf
+++ b/platform/nephos/docker-syncd-nephos/supervisord.conf
@@ -17,6 +17,7 @@ command=python2 /usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/vs/docker-gbsyncd-vs/supervisord.conf
+++ b/platform/vs/docker-gbsyncd-vs/supervisord.conf
@@ -10,12 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name gbsyncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/vs/docker-syncd-vs/supervisord.conf
+++ b/platform/vs/docker-syncd-vs/supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=25
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=25
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/vs/docker-syncd-vs/supervisord.conf
+++ b/platform/vs/docker-syncd-vs/supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=25
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name dhcp_relay
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=50
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=50
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name dhcp_relay
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=50
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -17,6 +17,7 @@ command=/usr/bin/supervisor-proc-exit-listener --container-name dhcp_relay
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=50
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -10,14 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
-buffer_size=50
+buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name dhcp_relay
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
-buffer_size=50
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE


### PR DESCRIPTION
#### Why I did it

To prevent error [messages](https://dev.azure.com/mssonic/build/_build/results?buildId=2254&view=logs&j=9a13fbcd-e92d-583c-2f89-d81f90cac1fd&t=739db6ba-1b35-5485-5697-de102068d650&l=802) like the following from being logged:

```
Mar 17 02:33:48.523153 vlab-01 INFO swss#supervisord 2021-03-17 02:33:48,518 ERRO pool supervisor-proc-exit-listener event buffer overflowed, discarding event 46
```

This is basically an addendum to https://github.com/Azure/sonic-buildimage/pull/5247, which increased the event buffer size for dependent-startup. While supervisor-proc-exit-listener doesn't subscribe to as many events as dependent-startup, there is still a chance some containers (like swss, as in the example above) have enough processes running to cause an overflow of the default buffer size of 10.

This is especially important for preventing erroneous log_analyzer failures in the sonic-mgmt repo regression tests, which have started occasionally causing PR check builds to fail. Example [here](https://dev.azure.com/mssonic/build/_build/results?buildId=2254&view=logs&j=9a13fbcd-e92d-583c-2f89-d81f90cac1fd&t=739db6ba-1b35-5485-5697-de102068d650&l=802).

I set all supervisor-proc-exit-listener event buffer sizes to 1024, and also updated all dependent-startup event buffer sizes to 1024, as well, to keep things simple, unified, and allow headroom so that we will not need to adjust these values frequently, if at all.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012
