### PR TITLE
[docker-gbsyncd-vs] Run gbsyncd_startup.py directly

### DIFF
--- a/platform/vs/docker-gbsyncd-vs/supervisord.conf
+++ b/platform/vs/docker-gbsyncd-vs/supervisord.conf
@@ -38,7 +38,7 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
 [program:syncd]
-command=/usr/bin/gbsyncd_start.sh
+command=/usr/bin/gbsyncd_startup.py
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
#### Why I did it

Eliminate the need for `gbsyncd_start.sh`, which simply calls `exec "/usr/bin/gbsyncd_startup.py"`. The shell script is unnecessary.

Once this PR merges, we can remove `gbsyncd_start.sh` from the sonic-sairedis repo.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
