### PR TITLE
Temporarily use mirrors of initramfs/isc-dhcp/python-click/radvd repoes

### DIFF
--- a/src/initramfs-tools/Makefile
+++ b/src/initramfs-tools/Makefile
@@ -10,7 +10,7 @@ INITRAMFS_TOOLS_REVISION = 18fc98e1b63b012f9bcf06ae3f5477872a5880c0
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtaining the initramfs-tools
 	rm -rf ./initramfs-tools
-	git clone --branch v0.130 https://salsa.debian.org/kernel-team/initramfs-tools.git ./initramfs-tools
+	git clone --branch v0.130 https://github.com/qiluo-msft/initramfs-tools.git ./initramfs-tools
 
 	# Patch
 	pushd ./initramfs-tools

--- a/src/isc-dhcp/Makefile
+++ b/src/isc-dhcp/Makefile
@@ -10,7 +10,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf ./isc-dhcp
 
 	# Clone isc-dhcp repo
-	git clone https://salsa.debian.org/dhcp-team/isc-dhcp.git
+	git clone https://github.com/qiluo-msft/isc-dhcp.git
 	pushd ./isc-dhcp
 
 	# Reset HEAD to the commit of the proper tag

--- a/src/python-click/Makefile
+++ b/src/python-click/Makefile
@@ -9,7 +9,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf ./python-click
 
 	# Clone python-click Debian repo
-	git clone https://salsa.debian.org/debian/python-click
+	git clone https://github.com/qiluo-msft/python-click.git
 
 	pushd ./python-click
 

--- a/src/radvd/Makefile
+++ b/src/radvd/Makefile
@@ -10,7 +10,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf ./radvd
 
 	# Clone radvd repo
-	git clone https://salsa.debian.org/debian/radvd.git
+	git clone https://github.com/qiluo-msft/radvd.git
 	pushd ./radvd
 
 	# Reset HEAD to the commit of the proper tag


### PR DESCRIPTION
The official repo is down. So I replaced it with a mirror temporarily.