### PR TITLE
[config-setup]: Fix a bug of checking if updategraph is enabled

### DIFF
--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -158,7 +158,7 @@ updategraph_is_enabled()
     rv=1
     if [ -e ${UPDATEGRAPH_CONF} ]; then
         updategraph_mode=$(grep enabled ${UPDATEGRAPH_CONF} | head -n 1 | cut -f2 -d=)
-        [ "${updategraph_mode}" = "true" ] && rv = 0
+        [ "${updategraph_mode}" = "true" ] && rv=0
     fi
     return $rv
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Encounter error during "config-setup boot" if the updategraph is enabled.

#### How I did it

Correct the code inside the config-setup script.
Remove the space between the assignment operator.

#### How to verify it

Remove the /etc/sonic/config_db.json and reboot the device.
Originally, it will return following error after boot up.
`rv: command not found`
After modification, it can correctly parse the status of updategraph without error.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix a bug of checking if updategraph is enabled in config-setup script.

#### A picture of a cute animal (not mandatory but encouraged)

