### PR TITLE
[platform][barefoot] Lazy initialize fans and thermals list

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
@@ -28,8 +28,28 @@ class Chassis(ChassisBase):
             psu = Psu(i)
             self._psu_list.append(psu)
 
-        self._fan_drawer_list = fan_drawer_list_get()
-        self._thermal_list = thermal_list_get()
+        self.__fan_drawers = None
+        self.__thermals = None
+
+    @property
+    def _fan_drawer_list(self):
+        if self.__fan_drawers is None:
+            self.__fan_drawers = fan_drawer_list_get()
+        return self.__fan_drawers
+
+    @_fan_drawer_list.setter
+    def _fan_drawer_list(self, value):
+        pass
+
+    @property
+    def _thermal_list(self):
+        if self.__thermals is None:
+            self.__thermals = thermal_list_get()
+        return self.__thermals
+
+    @_thermal_list.setter
+    def _thermal_list(self, value):
+        pass
 
     def get_name(self):
         """


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to reduce Chassis object initialization time

#### How I did it
Initialize fans and thermals lists on demand; make them properties

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Initialize fans and thermals lists on demand to reduce Chassis object initialization time

#### A picture of a cute animal (not mandatory but encouraged)

