### PR TITLE
Refine Azure pipelines for PR/Official/UpgradeVersion builds (Sample code)

### DIFF
--- a/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
+++ b/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
@@ -18,10 +18,25 @@ pool: sonicbld
 
 stages:
 - stage: Build
+  variables:
+    CACHE_MODE: wcache
+    VERSION_CONTROL_OPTIONS: 'SONIC_VERSION_CONTROL_COMPONENTS='
   jobs:
   - template: azure-pipelines-build.yml
     parameters:
-      buildSlave: y
+      buildOptions: '${{ variables.VERSION_CONTROL_OPTIONS }} SONIC_BUILD_JOBS=$(nproc) ENABLE_IMAGE_SIGNATURE=y'
+      preSteps:
+      - script: |
+          containers=$(docker container ls | grep "sonic-slave" | awk '{ print $1 }')
+          if [ ! -z "$containers" ]; then
+            docker container kill $containers || true
+            sleep 5
+          fi
+          images=$(docker images 'sonic-slave-*' -a -q)
+          if [ ! -z "$images" ]; then
+            docker rmi -f $images
+          fi
+        displayName: 'Cleanup sonic slave'
 - stage: UpgradeVersions
   jobs:
   - job: UpgradeVersions
@@ -47,12 +62,16 @@ stages:
         echo "artifacts$artifacts"
         cp -r $(Pipeline.Workspace)/sonic-buildimage.${default_platform}/versions target/
         make freeze FREEZE_VERSION_OPTIONS=-r
-        find files/build/versions 
-        for artifact in $artifacts
+        find files/build/versions
+        ordered_artifacts=$(echo "$artifacts" | grep -v -E "arm64|armhf" && echo "$artifacts" | grep -E "arm64|armhf")
+        for artifact in $ordered_artifacts
         do
+          [[ "$artifact" == *arm64* || "$artifact" == *armhf* ]] && continue
           rm -rf target/versions
           cp -r $artifact/versions target/
-          make freeze FREEZE_VERSION_OPTIONS="-a -d"
+          OPTIONS="-a -d"
+          [[ "$artifact" == *arm64* || "$artifact" == *arm64* ]] && OPTIONS="-d"
+          make freeze FREEZE_VERSION_OPTIONS="$OPTIONS"
         done
         git diff files/build/versions
       displayName: 'Freeze Versions'

--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -1,3 +1,5 @@
+# The azure pipeline template for Official build, and upgrade version build
+
 parameters:
 - name: 'jobFilters'
   type: object
@@ -5,68 +7,50 @@ parameters:
 - name: 'buildOptions'
   type: string
   default: 'SONIC_CONFIG_BUILD_JOBS=1'
-- name: 'buildSlave'
-  type: string
-  default: 'n'
+- name: 'preSteps'
+  type: stepList
+  default: []
 - name: 'postSteps'
   type: stepList
   default: []
 
 jobs:
-- template: azure-pipelines-job-groups.yml
+- template: build-template.yml
   parameters:
     jobFilters: ${{ parameters.jobFilters }}
-    preSteps:
-      - script: |
-          containers=$(docker container ls | grep "sonic-slave" | awk '{ print $1 }')
-          if [ ! -z "$containers" ]; then
-            docker container kill $containers || true
-            sleep 5
-          fi
-          if [ "${{ parameters.buildSlave }}" == "y" ]; then
-            images=$(docker images 'sonic-slave-*' -a -q)
-            [ ! -z "$images" ] && docker rmi -f $images
-          fi
-          sudo rm -rf $(ls -A1)
-        displayName: 'Init'
-      - checkout: self
-        submodules: recursive
-        displayName: 'Checkout code'
-      - script: |
-          make ${{ parameters.buildOptions }} PLATFORM=$GROUP_NAME configure
-        displayName: 'Make configure'
-    postSteps:
-      - ${{ parameters.postSteps }}
-      - publish: $(System.DefaultWorkingDirectory)/target
-        artifact: 'sonic-buildimage.$(GROUP_NAME)$(GROUP_EXTNAME)'
-        displayName: "Archive sonic image"
+    buildOptions: ${{ parameters.buildOptions }}
+    preSteps: ${{ parameters.preSteps }}
+    postSteps: ${{ parameters.postSteps }}
     jobGroups:
       - name: vs
         script: |
-          sudo bash -c "echo 1 > /proc/sys/vm/compact_memory"
-          make ${{ parameters.buildOptions }} target/sonic-vs.img.gz
+          make $(BUILD_OPTIONS) target/docker-sonic-vs.gz target/sonic-vs.img.gz target/docker-ptf.gz
       - name: broadcom
         script: |
-          make ${{ parameters.buildOptions }} target/sonic-broadcom.bin target/sonic-aboot-broadcom.swi
+          make $(BUILD_OPTIONS) target/sonic-broadcom.bin target/sonic-aboot-broadcom.swi
+      - name: mellanox
+        script: |
+          make $(BUILD_OPTIONS) ENABLE_SYNCD_RPC=y all
       - name: barefoot
         script: |
-          make ${{ parameters.buildOptions }} target/sonic-barefoot.bin target/sonic-aboot-barefoot.swi
-      - name: centec
-        script: |
-          make ${{ parameters.buildOptions }} INSTALL_DEBUG_TOOLS=y target/sonic-centec.bin
-          mv target/sonic-centec.bin target/sonic-centec-dbg.bin
-          make ${{ parameters.buildOptions }} target/sonic-centec.bin
-          make ${{ parameters.buildOptions }} ENABLE_SYNCD_RPC=y target/docker-syncd-centec-rpc.gz
+          make $(BUILD_OPTIONS) target/sonic-barefoot.bin target/sonic-aboot-barefoot.swi
       - name: innovium
         script: |
-          make ${{ parameters.buildOptions }} SONIC_CONFIG_BUILD_JOBS=1 target/sonic-innovium.bin
-      - name: mellanox
-        script: |
-          make ${{ parameters.buildOptions }} target/sonic-mellanox.bin
-      - name: mellanox
-        extName: _rpc
-        script: |
-          make ${{ parameters.buildOptions }} ENABLE_SYNCD_RPC=y all
+          make $(BUILD_OPTIONS) SONIC_CONFIG_BUILD_JOBS=1 target/sonic-innovium.bin
       - name: nephos
         script: |
-          make ${{ parameters.buildOptions }} target/sonic-nephos.bin
+          make $(BUILD_OPTIONS) target/sonic-nephos.bin
+      - name: marvell-armhf
+        pool: sonicbld_8c
+        timeoutInMinutes: 3600
+        variables:
+          PLATFORM_ARCH: armhf
+        script: |
+          make $(BUILD_OPTIONS) target/sonic-marvell-armhf.bin
+      - name: centec-arm64
+        pool: sonicbld_8c
+        timeoutInMinutes: 3600
+        variables:
+          PLATFORM_ARCH: arm64
+        script: |
+          make $(BUILD_OPTIONS) target/sonic-centec-arm64.bin

--- a/.azure-pipelines/azure-pipelines-job-groups.yml
+++ b/.azure-pipelines/azure-pipelines-job-groups.yml
@@ -23,7 +23,7 @@ parameters:
 
 jobs:
 - ${{ each jobGroup in parameters.jobGroups }}:
-  - ${{ if or(eq(parameters.jobFilters, ''), containsValue(parameters.jobFilters, jobGroup.name)) }}:
+  - ${{ if or(eq(parameters.jobFilters, ''), containsValue(parameters.jobFilters, jobGroup.name), endswith(variables['Build.DefinitionName'], format('.{0}{1}', jobGroup.name, jobGroup.extName))) }}:
     - job: ${{ replace(format('{0}{1}', jobGroup.name, jobGroup.extName), '-', '_') }}
       ${{ each pair in jobGroup }}:
         ${{ if not(in(pair.key, 'job', 'name', 'extName', 'variables', 'steps', 'script', 'scriptEnv')) }}:
@@ -43,6 +43,7 @@ jobs:
       - ${{ parameters.preSteps }}
       - ${{ if ne(jobGroup.script, '') }}:
         - script: |
+            set -e
             ${{ jobGroup.script }}
           env:
             ${{ if ne(parameters.scriptEnv, '') }}:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -1,116 +1,54 @@
+# The azure pipeline template for PR build, Official build, and upgrade version build
+
 parameters:
-- name: platform
+- name: 'jobFilters'
+  type: object
+  default: ''
+- name: 'buildOptions'
   type: string
-  values:
-  - broadcom
-  - centec-arm64
-  - marvell-armhf
-  - mellanox
-  - vs
-
-- name: platform_arch
-  type: string
-  values:
-  - amd64
-  - armhf
-  - arm64
-  default: amd64
-
-- name: platform_short
-  type: string
-  values:
-  - brcm
-  - centec-arm64
-  - marvell-armhf
-  - mlnx
-  - vs
-
-- name: cache_mode
-  type: string
-  values:
-  - wcache
-  - rcache
-  - cache
-
-- name: pool
-  type: string
-  values:
-  - sonicbld
-  - sonicbld_8c
-  default: sonicbld
-
-- name: dbg_image
-  type: boolean
-  default: false
-
-- name: swi_image
-  type: boolean
-  default: false
-
-- name: raw_image
-  type: boolean
-  default: false
-
-- name: sync_rpc_image
-  type: boolean
-  default: false
-
-- name: timeout
-  type: number
-  default: 600
+  default: 'SONIC_CONFIG_BUILD_JOBS=1'
+- name: 'preSteps'
+  type: stepList
+  default: []
+- name: 'postSteps'
+  type: stepList
+  default: []
+- name: jobGroups
+  type: object
+  default: []
 
 jobs:
-- job:
-  pool: ${{ parameters.pool }}
-  displayName: ${{ parameters.platform }}
-  timeoutInMinutes: ${{ parameters.timeout }}
-  steps:
-  - template: cleanup.yml
-  - checkout: self
-    clean: true
-    submodules: recursive
-    displayName: 'Checkout code'
-  - script: |
-      git submodule foreach --recursive 'git clean -xfdf || true'
-      git submodule foreach --recursive 'git reset --hard || true'
-      git submodule foreach --recursive 'git remote update || true'
-      git submodule update --init --recursive
-    displayName: 'Reset submodules'
-  - script: |
-      set -e
-      sudo modprobe overlay
-      sudo apt-get install -y acl
-      export DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker
-      CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=${{ parameters.cache_mode }} SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/${{ parameters.platform }}"
-      ENABLE_DOCKER_BASE_PULL=y make configure PLATFORM=${{ parameters.platform }} PLATFORM_ARCH=${{ parameters.platform_arch }}
-      trap "sudo rm -rf fsroot" EXIT
-
-      if [ ${{ parameters.platform }} == vs ]; then
-        if [ ${{ parameters.dbg_image }} == true ]; then
-          make USERNAME=admin $CACHE_OPTIONS SONIC_BUILD_JOBS=$(nproc) INSTALL_DEBUG_TOOLS=y target/sonic-vs.img.gz && \
-            mv target/sonic-vs.img.gz target/sonic-vs-dbg.img.gz
-        fi
-
-        make USERNAME=admin $CACHE_OPTIONS SONIC_BUILD_JOBS=$(nproc) target/docker-sonic-vs.gz target/sonic-vs.img.gz target/docker-ptf.gz
-      else
-        if [ ${{ parameters.dbg_image }} == true ]; then
-          make USERNAME=admin $CACHE_OPTIONS SONIC_BUILD_JOBS=$(nproc) INSTALL_DEBUG_TOOLS=y target/sonic-${{ parameters.platform }}.bin && \
-            mv target/sonic-${{ parameters.platform }}.bin target/sonic-${{ parameters.platform }}-dbg.bin
-        fi
-        if [ ${{ parameters.swi_image }} == true ]; then
-          make USERNAME=admin $CACHE_OPTIONS SONIC_BUILD_JOBS=$(nproc) ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-${{ parameters.platform }}.swi
-        fi
-        if [ ${{ parameters.raw_image }} == true ]; then
-          make USERNAME=admin $CACHE_OPTIONS SONIC_BUILD_JOBS=$(nproc) target/sonic-${{ parameters.platform }}.raw
-        fi
-        if [ ${{ parameters.sync_rpc_image }} == true ]; then
-          make USERNAME=admin $CACHE_OPTIONS SONIC_BUILD_JOBS=$(nproc) ENABLE_SYNCD_RPC=y target/docker-syncd-${{ parameters.platform_short }}-rpc.gz
-        fi
-
-        make USERNAME=admin $CACHE_OPTIONS SONIC_BUILD_JOBS=$(nproc) target/sonic-${{ parameters.platform }}.bin
-      fi
-    displayName: 'Build sonic image'
-  - template: cleanup.yml
-  - publish: $(System.DefaultWorkingDirectory)/
-    artifact: sonic-buildimage.${{ parameters.platform }}
-    displayName: "Archive sonic image"
+- template: azure-pipelines-job-groups.yml
+  parameters:
+    jobFilters: ${{ parameters.jobFilters }}
+    jobVariables:
+      PLATFORM: $(GROUP_NAME)
+      PLATFORM_ARCH: amd64
+      BUILD_OPTIONS: ${{ parameters.buildOptions }}
+    preSteps:
+      - template: cleanup.yml
+      - ${{ parameters. preSteps }}
+      - script: |
+          if [ -n "$(CACHE_MODE)" ] && echo $(PLATFORM) | grep -E -q "^(vs|broadcom|mellanox)$"; then
+            CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=$(CACHE_MODE) SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/$(PLATFORM)"
+            BUILD_OPTIONS="$(BUILD_OPTIONS) $CACHE_OPTIONS"
+            echo "##vso[task.setvariable variable=BUILD_OPTIONS]$BUILD_OPTIONS"
+          fi
+        displayName: "Make build options"
+      - checkout: self
+        submodules: recursive
+        displayName: 'Checkout code'
+      - script: |
+          sudo modprobe overlay
+          sudo apt-get install -y acl
+          export DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker
+          sudo bash -c "echo 1 > /proc/sys/vm/compact_memory"
+          make $BUILD_OPTIONS PLATFORM=$(PLATFORM) PLATFORM_ARCH=$(PLATFORM_ARCH) configure
+        displayName: 'Make configure'
+    postSteps:
+      - publish: $(System.DefaultWorkingDirectory)/target
+        artifact: 'sonic-buildimage.$(GROUP_NAME)$(GROUP_EXTNAME)'
+        displayName: "Archive sonic image"
+      - ${{ parameters.postSteps }}
+      - template: cleanup.yml
+    jobGroups: ${{ parameters.jobGroups }}

--- a/.azure-pipelines/official-build.yml
+++ b/.azure-pipelines/official-build.yml
@@ -9,6 +9,7 @@ schedules:
   branches:
     include:
     - master
+    - '202012'
   always: true
 
 trigger: none
@@ -16,47 +17,21 @@ pr: none
 
 stages:
 - stage: Build
+  pool: sonicbld
+  variables:
+    CACHE_MODE: wcache
+    ${{ if eq(variables['Build.SourceBranchName'], '202012') }}:
+      VERSION_CONTROL_OPTIONS: 'SONIC_VERSION_CONTROL_COMPONENTS=deb,py2,py3,web'
 
   jobs:
-  - template: build-template.yml
+  - template: azure-pipelines-build.yml
     parameters:
-      platform: broadcom
-      platform_short: brcm
-      cache_mode: wcache
-      dbg_image: true
-      swi_image: true
-      raw_image: true
-      sync_rpc_image: true
-
-  - template: build-template.yml
-    parameters:
-      platform: mellanox
-      platform_short: mlnx
-      cache_mode: wcache
-      dbg_image: true
-      sync_rpc_image: true
-
-  - template: build-template.yml
-    parameters:
-      platform: vs
-      platform_short: vs
-      dbg_image: true
-      cache_mode: wcache
-
-  - template: build-template.yml
-    parameters:
-      timeout: 3600
-      platform: marvell-armhf
-      platform_arch: armhf
-      platform_short: marvell-armhf
-      cache_mode: wcache
-      pool: sonicbld_8c
-
-  - template: build-template.yml
-    parameters:
-      timeout: 3600
-      platform: centec-arm64
-      platform_arch: arm64
-      platform_short: centec-arm64
-      cache_mode: wcache
-      pool: sonicbld_8c
+      buildOptions: '${{ variables.VERSION_CONTROL_OPTIONS }} SONIC_BUILD_JOBS=$(nproc) ENABLE_IMAGE_SIGNATURE=y ENABLE_DOCKER_BASE_PULL=y'
+      jobFilters: none
+      postSteps:
+      - script: |
+          make freeze
+          git status files/build/versions
+          git add files/build/versions
+          git diff HEAD files/build/versions
+        displayName: "Show git diff"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Refine the azure pipeline scripts, make to use the same script for different azure pipeline definitions.
Support to create one official build azure pipeline for multiple platforms or create multiple official build azure pipelines for each of the platform using the same pipeline definition.

#### How I did it
azure-pipelines-job-groups.yml: 
The template is a common azure pipeline template for build, it supports to create multiple jobs sharing same steps.
build-template.yml:
The template is an implementation of the azure-pipelines-job-groups.yml, it is specified  for SONiC build initialization, cleanup, etc. It can be used by PR build, official build, and upgrade version build, but it is not relative to specified platform.
azure-pipelines-build.yml:
The template is an implementation of build-template.yml, it is for official build and upgrade version build.


#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

