### PR TITLE
[PMON] docker create of pmon change, expose pmon docker to a file fro…

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -365,6 +365,8 @@ start() {
         -v mlnx_sdk_ready:/tmp \
         -e SX_API_SOCKET_FILE=/var/run/sx_sdk/sx_api.sock \
         -v /dev/shm:/dev/shm:rw \
+        -v /usr/share/sonic/device/$PLATFORM:/usr/share/sonic/device/$PLATFORM:ro \
+        -v /host/machine.conf:/host/machine.conf:ro \
 {%- else %}
         --tmpfs /tmp \
 {%- endif %}


### PR DESCRIPTION
[PMON] docker create of pmon change, expose pmon docker to a file from outside the docker
redmine ticket:
https://redmine.mellanox.com/issues/2566693

#### Why I did it
this is a fix for issue in mellanox simx platforms. the syseepromd failed on the pmon docker.
the pmon was trying to check the content of the files on /host/machine.conf and add a file to: /usr/share/sonic/device/$PLATFORM

#### How I did it
i added to docker create script the "-v " attribute to open this folder for read or write from the pmon docker


#### How to verify it
I ran the simx and the syseepromd didnt failed, I also checked the mounts for the pmon docker using and the new added folders were displayed there:
"docker inspect -f '{{ .Mounts }}' <container_id>"

#### Which release branch to backport (provide reason below if selected)


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
change the docker create script - added folders to be exposed to the pmon docker

