### PR TITLE
[Mellanox] [201911] Fix for all SPC1 devices sai profile speed configurations

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/ACS-MSN2010/sai_2010.xml
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/ACS-MSN2010/sai_2010.xml
@@ -21,7 +21,7 @@
 				<!-- 0 none, 1=2, 2=4, 3=2,4 -->
 				<breakout-modes>0</breakout-modes>
 
-				<!-- (BITMASK) 4096 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221225472 - 50Gb , 11534336 - 100Gb-->
+				<!-- (BITMASK) 28700 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221487616 - 50Gb , 11534336 - 100Gb-->
 				<port-speed>939524096</port-speed>
 			</port-info>
 			<port-info>

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/sai_2100.xml
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/sai_2100.xml
@@ -18,7 +18,7 @@
 				<!-- 0 none, 1=2, 2=4, 3=2,4 -->
 				<breakout-modes>3</breakout-modes>
 
-				<!-- (BITMASK) 4096 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221225472 - 50Gb , 11534336 - 100Gb-->
+				<!-- (BITMASK) 28700 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221487616 - 50Gb , 11534336 - 100Gb-->
 				<port-speed>98368</port-speed>
 			</port-info>
 			<port-info>

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/sai_2410.xml
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/sai_2410.xml
@@ -21,7 +21,7 @@
 				<!-- 0 none, 1=2, 2=4, 3=2,4 -->
 				<breakout-modes>0</breakout-modes>
 
-				<!-- (BITMASK) 4096 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221225472 - 50Gb , 11534336 - 100Gb-->
+				<!-- (BITMASK) 28700 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221487616 - 50Gb , 11534336 - 100Gb-->
 				<port-speed>939524096</port-speed>
 			</port-info>
 			<port-info>

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/sai_2700.xml
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/sai_2700.xml
@@ -21,7 +21,7 @@
 				<!-- 0 none, 1=2, 2=4, 3=2,4 -->
 				<breakout-modes>3</breakout-modes>
 
-				<!-- (BITMASK) 4096 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221225472 - 50Gb , 11534336 - 100Gb-->
+				<!-- (BITMASK) 28700 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221487616 - 50Gb , 11534336 - 100Gb-->
 				<port-speed>98368</port-speed>
 			</port-info>
 			<port-info>

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-C28D8/sai_2700_8x50g_28x100g.xml
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-C28D8/sai_2700_8x50g_28x100g.xml
@@ -21,7 +21,7 @@
 				<!-- 0 none, 1=2, 2=4, 3=2,4 -->
 				<breakout-modes>3</breakout-modes>
 
-				<!-- (BITMASK) 4096 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221225472 - 50Gb , 11534336 - 100Gb-->
+				<!-- (BITMASK) 28700 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221487616 - 50Gb , 11534336 - 100Gb-->
 				<port-speed>11534336</port-speed>
 			</port-info>
 			<port-info>
@@ -106,7 +106,7 @@
 				<width>4</width>
 				<module>28</module>
 				<breakout-modes>3</breakout-modes>
-				<port-speed>3221225472</port-speed>
+				<port-speed>3221487616</port-speed>
 				<split>2</split>
 			</port-info>
 			<port-info>
@@ -114,7 +114,7 @@
 				<width>4</width>
 				<module>29</module>
 				<breakout-modes>1</breakout-modes>
-				<port-speed>3221225472</port-speed>
+				<port-speed>3221487616</port-speed>
 				<split>2</split>
 			</port-info>
 			<port-info>
@@ -122,7 +122,7 @@
 				<width>4</width>
 				<module>30</module>
 				<breakout-modes>3</breakout-modes>
-				<port-speed>3221225472</port-speed>
+				<port-speed>3221487616</port-speed>
 				<split>2</split>
 			</port-info>
 			<port-info>
@@ -130,7 +130,7 @@
 				<width>4</width>
 				<module>31</module>
 				<breakout-modes>1</breakout-modes>
-				<port-speed>3221225472</port-speed>
+				<port-speed>3221487616</port-speed>
 				<split>2</split>
 			</port-info>
 			<port-info>

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/sai_2700_8x100g_40x50g_8x10g.xml
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/sai_2700_8x100g_40x50g_8x10g.xml
@@ -22,8 +22,8 @@
                 <!-- 0 none, 1=2, 2=4, 3=2,4 -->
                 <breakout-modes>3</breakout-modes>
 
-                <!-- (BITMASK) 4096 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221225472 - 50Gb , 11534336 - 100Gb-->
-                <port-speed>3221225472</port-speed>
+                <!-- (BITMASK) 28700 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221487616 - 50Gb , 11534336 - 100Gb-->
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>3</local-port>
@@ -31,7 +31,7 @@
                 <width>4</width>
                 <module>17</module>
                 <breakout-modes>1</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>5</local-port>
@@ -39,7 +39,7 @@
                 <width>4</width>
                 <module>18</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>7</local-port>
@@ -47,7 +47,7 @@
                 <width>4</width>
                 <module>19</module>
                 <breakout-modes>1</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>9</local-port>
@@ -55,7 +55,7 @@
                 <width>4</width>
                 <module>20</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>11</local-port>
@@ -63,7 +63,7 @@
                 <width>4</width>
                 <module>21</module>
                 <breakout-modes>1</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>13</local-port>
@@ -99,7 +99,7 @@
                 <width>4</width>
                 <module>26</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>23</local-port>
@@ -107,7 +107,7 @@
                 <width>4</width>
                 <module>27</module>
                 <breakout-modes>1</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>25</local-port>
@@ -115,7 +115,7 @@
                 <width>4</width>
                 <module>28</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>27</local-port>
@@ -123,7 +123,7 @@
                 <width>4</width>
                 <module>29</module>
                 <breakout-modes>1</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>29</local-port>
@@ -131,7 +131,7 @@
                 <width>4</width>
                 <module>30</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>31</local-port>
@@ -139,7 +139,7 @@
                 <width>4</width>
                 <module>31</module>
                 <breakout-modes>1</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>33</local-port>
@@ -147,7 +147,7 @@
                 <width>4</width>
                 <module>14</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>35</local-port>
@@ -155,7 +155,7 @@
                 <width>4</width>
                 <module>15</module>
                 <breakout-modes>1</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>37</local-port>
@@ -163,7 +163,7 @@
                 <width>4</width>
                 <module>12</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>39</local-port>
@@ -171,7 +171,7 @@
                 <width>4</width>
                 <module>13</module>
                 <breakout-modes>1</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>41</local-port>
@@ -179,7 +179,7 @@
                 <width>4</width>
                 <module>10</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>43</local-port>
@@ -187,7 +187,7 @@
                 <width>4</width>
                 <module>11</module>
                 <breakout-modes>1</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>45</local-port>
@@ -209,7 +209,7 @@
                 <width>4</width>
                 <module>6</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>51</local-port>
@@ -224,7 +224,7 @@
                 <width>4</width>
                 <module>4</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>55</local-port>
@@ -232,7 +232,7 @@
                 <width>4</width>
                 <module>5</module>
                 <breakout-modes>1</breakout-modes>
-                <port-speed>3221225472</port-speed>
+                <port-speed>3221487616</port-speed>
             </port-info>
             <port-info>
                 <local-port>57</local-port>
@@ -240,7 +240,7 @@
                 <width>4</width>
                 <module>2</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>4096</port-speed>
+                <port-speed>28700</port-speed>
             </port-info>
             <port-info>
                 <local-port>59</local-port>
@@ -255,7 +255,7 @@
                 <width>4</width>
                 <module>0</module>
                 <breakout-modes>3</breakout-modes>
-                <port-speed>4096</port-speed>
+                <port-speed>28700</port-speed>
             </port-info>
             <port-info>
                 <local-port>63</local-port>

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/sai_2700_48x50g_8x100g.xml
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/sai_2700_48x50g_8x100g.xml
@@ -21,8 +21,8 @@
 				<!-- 0 none, 1=2, 2=4, 3=2,4 -->
 				<breakout-modes>3</breakout-modes>
 
-				<!-- (BITMASK) 4096 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221225472 - 50Gb , 11534336 - 100Gb-->
-				<port-speed>3221225472</port-speed>
+				<!-- (BITMASK) 28700 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221487616 - 50Gb , 11534336 - 100Gb-->
+				<port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -30,7 +30,7 @@
 				<width>4</width>
 				<module>17</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -38,7 +38,7 @@
 				<width>4</width>
 				<module>18</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -46,7 +46,7 @@
 				<width>4</width>
 				<module>19</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -54,7 +54,7 @@
 				<width>4</width>
 				<module>20</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -62,7 +62,7 @@
 				<width>4</width>
 				<module>21</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -98,7 +98,7 @@
 				<width>4</width>
 				<module>26</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -106,7 +106,7 @@
 				<width>4</width>
 				<module>27</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>>
 			</port-info>
 			<port-info>
@@ -114,7 +114,7 @@
 				<width>4</width>
 				<module>28</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -122,7 +122,7 @@
 				<width>4</width>
 				<module>29</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -130,7 +130,7 @@
 				<width>4</width>
 				<module>30</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -138,7 +138,7 @@
 				<width>4</width>
 				<module>31</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -146,7 +146,7 @@
 				<width>4</width>
 				<module>14</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -154,7 +154,7 @@
 				<width>4</width>
 				<module>15</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -162,7 +162,7 @@
 				<width>4</width>
 				<module>12</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -170,7 +170,7 @@
 				<width>4</width>
 				<module>13</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -178,7 +178,7 @@
 				<width>4</width>
 				<module>10</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -186,7 +186,7 @@
 				<width>4</width>
 				<module>11</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -222,7 +222,7 @@
 				<width>4</width>
 				<module>4</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -230,7 +230,7 @@
 				<width>4</width>
 				<module>5</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -238,7 +238,7 @@
 				<width>4</width>
 				<module>2</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -246,7 +246,7 @@
 				<width>4</width>
 				<module>3</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -254,7 +254,7 @@
 				<width>4</width>
 				<module>0</module>
 				<breakout-modes>3</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 			<port-info>
@@ -262,7 +262,7 @@
 				<width>4</width>
 				<module>1</module>
 				<breakout-modes>1</breakout-modes>
-        <port-speed>3221225472</port-speed>
+        <port-speed>3221487616</port-speed>
         <split>2</split>
 			</port-info>
 		</ports-list>

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/ACS-MSN2740/sai_2740.xml
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/ACS-MSN2740/sai_2740.xml
@@ -18,7 +18,7 @@
 				<!-- 0 none, 1=2, 2=4, 3=2,4 -->
 				<breakout-modes>3</breakout-modes>
 
-				<!-- (BITMASK) 4096 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221225472 - 50Gb , 11534336 - 100Gb-->
+				<!-- (BITMASK) 28700 - 10Gb , 939524096 - 25Gb , 98368 - 40Gb , 3221487616 - 50Gb , 11534336 - 100Gb-->
 				<port-speed>98368</port-speed>
 			</port-info>
 			<port-info>


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SAI profile files speed configuration have wrong bitmap value for 10/50G speed option.

#### How I did it
Fix to the correct value for all SPC1 devices.

#### How to verify it
Configure on these platforms ports with 10/50G speed using this fix.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

