### PR TITLE
[ci]: gzip the vm image disk and memdmp

### DIFF
--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -50,7 +50,7 @@ steps:
         img=$(virsh -c qemu:///system domblklist ${{ parameters.dut }} | grep vda | awk '{print $2}')
         cp $img $(Build.ArtifactStagingDirectory)/kvmdump/${{ parameters.dut }}.img
         gzip $(Build.ArtifactStagingDirectory)/kvmdump/${{ parameters.dut }}.img
-        gzip $(Build.ArtifactStagingDirectory)/kvmdump/${{ parameters.dut }}.memdmp
+        sudo gzip $(Build.ArtifactStagingDirectory)/kvmdump/${{ parameters.dut }}.memdmp
         virsh -c qemu:///system undefine ${{ parameters.dut }}
     fi
 

--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -49,6 +49,8 @@ steps:
         virsh -c qemu:///system dumpxml ${{ parameters.dut }} > $(Build.ArtifactStagingDirectory)/kvmdump/${{ parameters.dut }}.xml
         img=$(virsh -c qemu:///system domblklist ${{ parameters.dut }} | grep vda | awk '{print $2}')
         cp $img $(Build.ArtifactStagingDirectory)/kvmdump/${{ parameters.dut }}.img
+        gzip $(Build.ArtifactStagingDirectory)/kvmdump/${{ parameters.dut }}.img
+        gzip $(Build.ArtifactStagingDirectory)/kvmdump/${{ parameters.dut }}.memdmp
         virsh -c qemu:///system undefine ${{ parameters.dut }}
     fi
 


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
gzip vm image disk and memdmp to save download time

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

