### PR TITLE
Add PG_DROP yang model

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -28,6 +28,9 @@
                 },
                 "QUEUE_WATERMARK": {
                     "FLEX_COUNTER_STATUS": "enable"
+                },
+                "PG_DROP": {
+                    "FLEX_COUNTER_STATUS": "enable"
                 }
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -11,6 +11,9 @@
                 "PFCWD": {
                     "FLEX_COUNTER_STATUS": "enable"
                 },
+                "PG_DROP": {
+                    "FLEX_COUNTER_STATUS": "enable"
+                },
                 "PG_WATERMARK": {
                     "FLEX_COUNTER_STATUS": "enable"
                 },
@@ -27,9 +30,6 @@
                     "FLEX_COUNTER_STATUS": "enable"
                 },
                 "QUEUE_WATERMARK": {
-                    "FLEX_COUNTER_STATUS": "enable"
-                },
-                "PG_DROP": {
                     "FLEX_COUNTER_STATUS": "enable"
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -104,6 +104,13 @@ module sonic-flex_counter {
                 }
             }
 
+            container PG_DROP {
+                /* PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+            }
+
         }
         /* end of container FLEX_COUNTER_TABLE */
     }

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -48,6 +48,13 @@ module sonic-flex_counter {
                 }
             }
 
+            container PG_DROP {
+                /* PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+            }
+
             container PG_WATERMARK {
                 /* PG_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
@@ -99,13 +106,6 @@ module sonic-flex_counter {
 
             container RIF_RATES {
                 /* RIF_RATE_COUNTER_FLEX_COUNTER_GROUP */
-                leaf FLEX_COUNTER_STATUS {
-                    type flex_status;
-                }
-            }
-
-            container PG_DROP {
-                /* PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
                 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Dynamic Port Breakout falls cause of PG_DROP yang model missing

#### How I did it
Add PG_DROP yang model and add check this field in unit test for yang model

#### How to verify it
Firstly try to do DPB (2x50G) for Ethernet0 port:
`sudo config interface breakout Ethernet0 2x50G -f`
After that try to do DPB (1x100G[40G]) for Ethernet0 port:
`sudo config interface breakout Ethernet0 1x100G[40G] -f`
Both commands should work correctly.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

