### PR TITLE
Update versions_manager.py to make versions map key unique

### DIFF
--- a/scripts/versions_manager.py
+++ b/scripts/versions_manager.py
@@ -22,7 +22,7 @@ class Component:
     ctype -- Component Type, such as deb, py2, etc
     dist  -- Distribution, such as stretch, buster, etc
     arch  -- Architectrue, such as amd64, arm64, etc
-    
+
     '''
     def __init__(self, versions, ctype, dist=ALL_DIST, arch=ALL_ARCH):
         self.versions = versions
@@ -44,6 +44,8 @@ class Component:
                 offset = line.rfind('==')
                 if offset > 0:
                     package = line[:offset].strip()
+                    if not package.startswith('http://') and not package.startswith('https://'):
+                        package = package.lower()
                     version = line[offset+2:].strip()
                     result[package] = version
         return result
@@ -86,7 +88,7 @@ class Component:
         if config and self.ctype == 'deb':
             none_config_file_path = os.path.join(file_path, filename)
             self.dump_to_file(none_config_file_path, False, priority)
-            filename = VERSION_DEB_PREFERENCE 
+            filename = VERSION_DEB_PREFERENCE
         file_path = os.path.join(file_path, filename)
         self.dump_to_file(file_path, config, priority)
 

--- a/scripts/versions_manager.py
+++ b/scripts/versions_manager.py
@@ -44,7 +44,7 @@ class Component:
                 offset = line.rfind('==')
                 if offset > 0:
                     package = line[:offset].strip()
-                    if not package.startswith('http://') and not package.startswith('https://'):
+                    if 'py2' in version_file.lower() or 'py3' in version_file.lower():
                         package = package.lower()
                     version = line[offset+2:].strip()
                     result[package] = version


### PR DESCRIPTION
py2/py3 packages names are case insensitive, and the versions map
key should be the same for packages whose name can have different cases.

For example, in files/build/versions/default/versions-py3, package
"click==7.1.2" is pinned; and in
files/build/versions/dockers/docker-sonic-vs/versions-py3, package
"Click==7.0" is pinned.
Without this fix, the aggregated versions-py3 file used for building
docker-sonic-vs looks like below:
...
click==7.1.2
Click==7.0
...
However, we actually want "click==7.0" to overwrite "click==7.1.2" for
docker-sonic-vs build.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

