### PR TITLE
[reboot] Retrieve and store the reboot reason if kernel was panicked. 

### DIFF
--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -127,7 +127,15 @@ def find_hardware_reboot_cause():
 
 
 def get_reboot_cause_dict(previous_reboot_cause, comment, gen_time):
-    # resultant dictionary
+    """Store the key infomation of reboot into a dictionary by parsing the string
+    `previous_reboot_cause`.
+
+    If user issused a command to reboot device, then user, command and time will be
+    stored into a dictionary.
+
+    If device was rebooted due to the kernel panic, then the string `Kernel Panic` 
+    and time will be stored into a dictionary.
+    """
     reboot_cause_dict = {}
     reboot_cause_dict['gen_time'] = gen_time
     reboot_cause_dict['cause'] = previous_reboot_cause
@@ -142,7 +150,12 @@ def get_reboot_cause_dict(previous_reboot_cause, comment, gen_time):
             reboot_cause_dict['cause'] = match.group(1)
             reboot_cause_dict['user'] = match.group(2)
             reboot_cause_dict['time'] = match.group(3)
-
+    elif re.search(r'Kernel Panic', previous_reboot_cause):
+        match = re.search(r'Kernel Panic \(Time: (.*)\)', previous_reboot_cause)
+        if match is not None:
+            reboot_cause_dict['cause'] = "Kernel Panic"
+            reboot_cause_dict['time'] = match.group(1)
+ 
     return reboot_cause_dict
 
 

--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -127,8 +127,8 @@ def find_hardware_reboot_cause():
 
 
 def get_reboot_cause_dict(previous_reboot_cause, comment, gen_time):
-    """Store the key infomation of reboot into a dictionary by parsing the string
-    `previous_reboot_cause`.
+    """Store the key infomation of reboot into a dictionary by parsing the string in the
+    previous_reboot_cause.
 
     If user issused a command to reboot device, then user, command and time will be
     stored into a dictionary.


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

#### Why I did it
If device reboot was caused by kernel panic, then we need retrieve and store the key information into the symbol file `previous-reboot-cause.json`. The CLI `show reboot-cause` will read this file to get the reason of previous reboot.

This PR is related to PR in sonic-utilities repo: https://github.com/Azure/sonic-utilities/pull/1486

#### How I did it
The string variable `previous_reboot_cause` will be parsed to check whether it contains the keyword `Kernel Panic`. If it did, then store the keyword and time information into a dictionary.

#### How to verify it
I verified this change on a virtual testbed.

    admin@vlab-01:/host/reboot-cause$ more previous-reboot-cause.json
    {"gen_time": "2021_03_24_23_22_35", "cause": "Kernel Panic", "user": "N/A", "time": "Wed 24 Mar 2021 11:22:03 PM UTC", "comment": "N/A"}

    admin@vlab-01:/host/reboot-cause$ show reboot-cause
    Kernel Panic (Time: Wed 24 Mar 2021 11:22:03 PM UTC)
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

