### PR TITLE
[docker-gbsyncd-vs] Run new gbsyncdmgrd in lieu of deprecated gbsyncd_startup.py

### DIFF
--- a/platform/vs/docker-gbsyncd-vs/critical_processes
+++ b/platform/vs/docker-gbsyncd-vs/critical_processes
@@ -1,1 +1,1 @@
-program:syncd
+program:gbsyncdmgrd

--- a/platform/vs/docker-gbsyncd-vs/supervisord.conf
+++ b/platform/vs/docker-gbsyncd-vs/supervisord.conf
@@ -37,8 +37,8 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
-[program:syncd]
-command=/usr/bin/gbsyncd_startup.py
+[program:gbsyncdmgrd]
+command=/usr/bin/gbsyncdmgrd
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
#### Why I did it

To improve management of docker-gbsyncd-vs. `gbsyncd_startup.py` simply spawned syncd processes and then exited. In that case, supervisord would no longer manage any processes in the container, and thus there was no way to know if a critical process had exited.

I recently created `gbsyncdmgrd` to be a more complete, robust replacement for `gbsyncd_startup.py`.

NOTE: This PR is dependent on the inclusion of `gbsyncdmgrd` in the sonic-sairedis repo. A submodule update is pending at 
https://github.com/Azure/sonic-buildimage/pull/7089

#### How I did it

Replace references to `gbsyncd_startup.py` with `gbsyncdmgrd`.

#### How to verify it

Ensure gbsyncdmgrd spawns all applicable syncd processes, and that it will exit if any of the syncd subprocesses exits.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
