### PR TITLE
[201911][procdockerstatsd] Add missing unit conversion

### DIFF
--- a/files/image_config/procdockerstatsd/procdockerstatsd
+++ b/files/image_config/procdockerstatsd/procdockerstatsd
@@ -69,8 +69,11 @@ class ProcDockerStats(daemon_base.DaemonBase):
         UNITS_B = 'B'
         UNITS_KB = 'KB'
         UNITS_MB = 'MB'
+        UNITS_GB = 'GB'
+        UNITS_GB = 'TB'
         UNITS_MiB = 'MiB'
         UNITS_GiB = 'GiB'
+        UNITS_TiB = 'TiB'
 
         res = re.match(r'(\d+\.?\d*)([a-zA-Z]+)', value)
         value = float(res.groups()[0])
@@ -79,11 +82,17 @@ class ProcDockerStats(daemon_base.DaemonBase):
         if units.lower() == UNITS_KB.lower():
             value *= 1000
         elif units.lower() == UNITS_MB.lower():
-            value *= (1000 * 1000)
+            value *= (1000 ** 2)
+        elif units.lower() == UNITS_GB.lower():
+            value *= (1000 ** 3)
+        elif units.lower() == UNITS_TB.lower():
+            value *= (1000 ** 4)
         elif units.lower() == UNITS_MiB.lower():
-            value *= (1024 * 1024)
+            value *= (1024 ** 2)
         elif units.lower() == UNITS_GiB.lower():
-            value *= (1024 * 1024 * 1024)
+            value *= (1024 ** 3)
+        elif units.lower() == UNITS_TiB.lower():
+            value *= (1024 ** 4)
 
         return int(round(value))
 
@@ -204,4 +213,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixing same issue in 201911 as mention here https://github.com/Azure/sonic-buildimage/pull/7151
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

