### PR TITLE
Add 'psample' module to load at boot time on BFN platform

### DIFF
--- a/platform/barefoot/.gitignore
+++ b/platform/barefoot/.gitignore
@@ -1,0 +1,2 @@
+# Overwrite ignore 'platform/**/debian/*' in root directory.
+!**/debian/*

--- a/platform/barefoot/bfn-modules/configs/bfn-modules.conf
+++ b/platform/barefoot/bfn-modules/configs/bfn-modules.conf
@@ -1,0 +1,6 @@
+# /etc/modules: kernel modules to load at boot time.
+#
+# This file contains the names of kernel modules that should be loaded
+# at boot time, one per line. Lines beginning with "#" are ignored.
+
+psample

--- a/platform/barefoot/bfn-modules/debian/install
+++ b/platform/barefoot/bfn-modules/debian/install
@@ -1,0 +1,1 @@
+configs/bfn-modules.conf etc/modules-load.d


### PR DESCRIPTION
* add '.gitignore' to the 'barefoot' subdirectory to overwrite ignore "platform/**/debian/*" in the root directory

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The psample module was not loaded on barefoot platform. The loading of this module is a prerequisite for testing SFlow.

#### How I did it
Update SONiC build/packaging scripts to install 'psample.ko' on BFN platform boot.

#### How to verify it
Do the command after booting SONiC:
`lsmod | grep psam`
psample module must be loaded
`psample                20480  0 `

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

