### PR TITLE
Reduce bgp connect retry timer for general template

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -8,6 +8,7 @@
       or  (bgp_session['holdtime'] is defined  and bgp_session['holdtime']  | int != 180) %}
   neighbor {{ neighbor_addr }} timers {{ bgp_session['keepalive'] | default("60") }} {{ bgp_session['holdtime'] | default("180") }}
 {% endif %}
+  neighbor {{ neighbor_addr }} timers connect 10
 !
 {% if 'admin_status' in bgp_session and bgp_session['admin_status'] == 'down' or 'admin_status' not in bgp_session and 'default_bgp_status' in CONFIG_DB__DEVICE_METADATA['localhost'] and CONFIG_DB__DEVICE_METADATA['localhost']['default_bgp_status'] == 'down' %}
   neighbor {{ neighbor_addr }} shutdown

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_all_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_all_v4.conf
@@ -4,6 +4,7 @@
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
   neighbor 10.10.10.10 timers 5 30
+  neighbor 10.10.10.10 timers connect 10
   neighbor 10.10.10.10 shutdown
   address-family ipv4
     neighbor 10.10.10.10 peer-group PEER_V4

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_all_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_all_v6.conf
@@ -4,6 +4,7 @@
   neighbor fc::10 remote-as 555
   neighbor fc::10 description remote_peer
   neighbor fc::10 timers 5 30
+  neighbor fc::10 timers connect 10
   neighbor fc::10 shutdown
   address-family ipv6
     neighbor fc::10 peer-group PEER_V6

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_base_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_base_v4.conf
@@ -3,6 +3,7 @@
 !
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
+  neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     neighbor 10.10.10.10 peer-group PEER_V4
     neighbor 10.10.10.10 activate

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_base_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_base_v6.conf
@@ -3,6 +3,7 @@
 !
   neighbor fc00::2 remote-as 555
   neighbor fc00::2 description remote_peer
+  neighbor fc00::2 timers connect 10
   address-family ipv6
     neighbor fc00::2 peer-group PEER_V6
     neighbor fc00::2 activate

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_l2vpn.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_l2vpn.conf
@@ -3,6 +3,7 @@
 !
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
+  neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     neighbor 10.10.10.10 peer-group PEER_V4
     neighbor 10.10.10.10 activate

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_shutdown_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_shutdown_1.conf
@@ -3,6 +3,7 @@
 !
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
+  neighbor 10.10.10.10 timers connect 10
   neighbor 10.10.10.10 shutdown
   address-family ipv4
     neighbor 10.10.10.10 peer-group PEER_V4

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_shutdown_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_shutdown_2.conf
@@ -3,6 +3,7 @@
 !
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
+  neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     neighbor 10.10.10.10 peer-group PEER_V4
     neighbor 10.10.10.10 activate

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_timers_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_timers_1.conf
@@ -4,6 +4,7 @@
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
   neighbor 10.10.10.10 timers 5 180
+  neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     neighbor 10.10.10.10 peer-group PEER_V4
     neighbor 10.10.10.10 activate

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_timers_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_timers_2.conf
@@ -4,6 +4,7 @@
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description remote_peer
   neighbor 10.10.10.10 timers 60 240
+  neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     neighbor 10.10.10.10 peer-group PEER_V4
     neighbor 10.10.10.10 activate


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The default bgp connect retry timer is 120 seconds. A reconnection will happen 120 seconds if the initial connection fails. This PR aims to allow a more frequent retry.

#### How I did it
Reduce bgp connect retry timer for general template to 10 seconds.

#### How to verify it
Verify that bgp neighbor has bgp connect retry timer of 10 seconds:
```
BGP Connect Retry Timer in Seconds: 10
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

