### PR TITLE
BGP TSA/B/C : Handler error message seen with TSB command.

### DIFF
--- a/dockers/docker-fpm-frr/TS
+++ b/dockers/docker-fpm-frr/TS
@@ -10,7 +10,7 @@ function check_not_installed()
 {
   c=0
   config=$(vtysh -c "show run")
-  for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | egrep 'V4|V6');
+  for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | egrep 'V4|V6' | uniq);
   do
     is_internal_route_map $route_map_name && continue
     echo "$config" | egrep -q "^route-map $route_map_name permit 20$"
@@ -26,7 +26,7 @@ function check_installed()
   c=0
   e=0
   config=$(vtysh -c "show run")
-  for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | egrep 'V4|V6');
+  for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | egrep 'V4|V6' | uniq);
   do
     is_internal_route_map $route_map_name && continue
     echo "$config" | egrep -q "^route-map $route_map_name permit 20$"
@@ -37,4 +37,16 @@ function check_installed()
     e=$((e+1))
   done
   return $((e-c))
+}
+
+function find_num_routemap()
+{
+  c=0
+  config=$(vtysh -c "show run")
+  for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | egrep 'V4|V6' | uniq);
+  do
+    is_internal_route_map $route_map_name && continue
+    c=$((c+1))
+  done
+  return $c
 }

--- a/dockers/docker-fpm-frr/TSA
+++ b/dockers/docker-fpm-frr/TSA
@@ -3,12 +3,18 @@
 # Load the common functions
 source /usr/bin/TS
 
+find_num_routemap
+routemap_count=$?
 check_not_installed
 not_installed=$?
-if [[ $not_installed -ne 0 ]];
+
+if [[ $routemap_count -eq 0 ]];
+then
+  echo "System Mode: No external neighbors"
+elif [[ $not_installed -ne 0 ]];
 then
   TSA_FILE=$(mktemp)
-  for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p');
+  for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | uniq);
   do
     is_internal_route_map $route_map_name && continue
     case "$route_map_name" in

--- a/dockers/docker-fpm-frr/TSB
+++ b/dockers/docker-fpm-frr/TSB
@@ -3,12 +3,18 @@
 # Load the common functions
 source /usr/bin/TS
 
+find_num_routemap
+routemap_count=$?
 check_installed
 installed=$?
-if [[ $installed -ne 0 ]];
+
+if [[ $routemap_count -eq 0 ]];
+then
+  echo "System Mode: No external neighbors"
+elif [[ $installed -ne 0 ]]; 
 then
   TSB_FILE=$(mktemp)
-  for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p');
+  for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | uniq);
   do
     is_internal_route_map $route_map_name && continue
     case "$route_map_name" in

--- a/dockers/docker-fpm-frr/TSC
+++ b/dockers/docker-fpm-frr/TSC
@@ -3,13 +3,18 @@
 # Load the common functions
 source /usr/bin/TS
 
+find_num_routemap
+routemap_count=$?
 check_not_installed
 not_installed=$?
 
 check_installed
 installed=$?
 
-if [[ $installed -eq 0 ]];
+if [[ $routemap_count -eq 0 ]];
+then 
+  echo "System Mode: No external neighbors"
+elif [[ $installed -eq 0 ]];
 then
   echo "System Mode: Normal"
 elif [[ $not_installed -eq 0 ]];


### PR DESCRIPTION
#### Why I did it

With the latest 201911 image, the following error was seen on staging devices with TSB command ( for both single asic, multi asic ). Though this err message doesn't affect the TSB functionality, it is good to fix.

```
admin@STG01-0101-0102-01T1:~$ TSB
BGP0 : % Could not find route-map entry TO_TIER0_V4 20
line 1: Failure to communicate[13] to zebra, line: no route-map TO_TIER0_V4 permit 20

% Could not find route-map entry TO_TIER0_V4 30
line 2: Failure to communicate[13] to zebra, line: no route-map TO_TIER0_V4 deny 30
```

In addition, in this PR I am fixing the message displayed to user when there are no BGP neighbors configured on that BGP instance. In multi-asic device there could be case where there are **no BGP neighbors** configured on a particular ASIC **(in BGP2 in below example)**. The message displayed to user don't convey the correct action
```
admin@STG01-0101-0102-01T1:~$ TSA
BGP0 : System Mode: Normal -> Maintenance
BGP1 : System Mode: Normal -> Maintenance
BGP2 : System is already in Maintenance mode      ---- this message don't seem to convey correct action.
BGP3 : System Mode: Normal -> Maintenance
admin@STG01-0101-0102-01T1:~$ TSC
BGP0 : System Mode: Maintenance
BGP1 : System Mode: Maintenance
BGP2 : System Mode: Normal                         ---- this message don't seem to convey correct action.
BGP3 : System Mode: Maintenance
admin@STG01-0101-0102-01T1:~$ TSB
BGP0 : System Mode: Maintenance -> Normal
BGP1 : System Mode: Maintenance -> Normal
BGP2 : System is already in Normal mode           ---- this message don't seem to convey correct action.
BGP3 : System Mode: Maintenance -> Normal

```


#### How I did it
The error message started coming with the use of multiple Deployment ID's and all use the same **route-map TO_TIER0_V4 out** as shown below. The way TSA/B works is by checking for routemaps configured in **out** direction - and hence there is a duplicate here. To fix add **uniq** check to make sure we are working with unique route-map names.

```
  neighbor TIER0_V4_DEPLOYMENT_ID_19 activate
  neighbor TIER0_V4_DEPLOYMENT_ID_19 soft-reconfiguration inbound
  neighbor TIER0_V4_DEPLOYMENT_ID_19 maximum-prefix 12000 90 warning-only
  neighbor TIER0_V4_DEPLOYMENT_ID_19 route-map FROM_TIER0_V4_DEPLOYMENT_ID_19 in
  neighbor TIER0_V4_DEPLOYMENT_ID_19 route-map TO_TIER0_V4 out             <<<<<<<<<<<<<<<<<
  neighbor TIER0_V4_DEPLOYMENT_ID_4 activate
  neighbor TIER0_V4_DEPLOYMENT_ID_4 soft-reconfiguration inbound
  neighbor TIER0_V4_DEPLOYMENT_ID_4 maximum-prefix 12000 90 warning-only
  neighbor TIER0_V4_DEPLOYMENT_ID_4 route-map FROM_TIER0_V4_DEPLOYMENT_ID_4 in
  neighbor TIER0_V4_DEPLOYMENT_ID_4 route-map TO_TIER0_V4 out             <<<<<<<<<<<<<<<<<
```

To fix the message displayed to user when there are no BGP neighbors configured on that BGP instance, a new message **"BGP2 : System Mode: No external neighbors"** is introduced to let users know of this scenario.

Plan to update the sonic-mgmt tests to cover this case as well.

#### How to verify it

1. The error message is no more seen with TSB
2. The new message "System Mode: No external neighbors" is shown as the BGP2 instance don't have any external BGP neighbors present.

```
admin@STG01-0101-0102-01T1:~$ TSA
BGP0 : System Mode: Normal -> Maintenance
BGP1 : System Mode: Normal -> Maintenance
BGP2 : System Mode: No external neighbors
BGP3 : System Mode: Normal -> Maintenance
admin@STG01-0101-0102-01T1:~$ TSC
BGP0 : System Mode: Maintenance
BGP1 : System Mode: Maintenance
BGP2 : System Mode: No external neighbors
BGP3 : System Mode: Maintenance
admin@STG01-0101-0102-01T1:~$ TSB
BGP0 : System Mode: Maintenance -> Normal
BGP1 : System Mode: Maintenance -> Normal
BGP2 : System Mode: No external neighbors
BGP3 : System Mode: Maintenance -> Normal
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

