### PR TITLE
[as7326-56x] Add to support PDDF

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/pddf/pd-plugin.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/pddf/pd-plugin.json
@@ -1,0 +1,67 @@
+{
+    
+    "XCVR":
+    {
+        "xcvr_present":
+        {
+           "i2c":
+           {
+               "valmap-SFP": {"1":true, "0":false },
+               "valmap-SFP28": {"1":true, "0":false },
+               "valmap-QSFP28": {"1":true, "0":false}
+           }
+        }
+    },
+    "PSU":
+    {
+        "psu_present": 
+        {
+            "i2c":
+            {
+                "valmap": { "1":true, "0":false }
+            }
+        },
+
+        "psu_power_good": 
+        {
+            "i2c":
+            {
+                "valmap": { "1": true, "0":false }
+            }
+        },
+
+        "psu_fan_dir":
+        {
+            "i2c":
+            {
+                "valmap": { "F2B":"EXHAUST", "B2F":"INTAKE" }
+            }
+        },
+
+        "PSU_FAN_MAX_SPEED":"18000"
+    },
+
+    "FAN":
+    {
+        "direction":
+        {
+            "i2c":
+            {
+                "valmap": {"1":"INTAKE", "0":"EXHAUST"}
+            }
+        },
+
+        "present":
+        {
+            "i2c":
+            {
+                "valmap": {"1":true, "0":false}
+            }
+        },
+
+        "duty_cycle_to_pwm": "lambda dc: ((dc*100)/625 -1)",
+
+        "pwm_to_duty_cycle": "lambda pwm: (((pwm+1)*625+75)/100)"
+    }
+
+}

--- a/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
@@ -1,0 +1,2916 @@
+{
+    "PLATFORM":
+    {
+        "num_psus":2,
+        "num_fantrays":6,
+        "num_fans_pertray":2,
+        "num_ports":58,
+        "num_temps": 4,
+        "pddf_dev_types":
+        {
+            "description":"AS7326-56X - Below is the list of supported PDDF device types (chip names) for various components. If any component uses some other driver, we will create the client using 'echo <dev-address> <dev-type> > <path>/new_device' method",
+            "CPLD":
+            [
+                "i2c_cpld"
+            ],
+            "PSU":
+            [
+                "psu_eeprom",
+                "psu_pmbus"
+            ],
+            "FAN":
+            [
+                "fan_ctrl",
+                "fan_eeprom"
+            ],
+            "PORT_MODULE":
+            [
+                "pddf_xcvr"
+            ]            
+        },
+        "std_kos":
+        [
+            "i2c-i801",
+            "i2c_dev",
+            "i2c_mux_pca954x force_deselect_on_exit=1",
+            "optoe"
+        ],
+        "pddf_kos":
+        [
+            "pddf_client_module",
+            "pddf_cpld_module",
+            "pddf_cpld_driver",
+            "pddf_mux_module",
+            "pddf_xcvr_module",
+            "pddf_xcvr_driver_module",
+            "pddf_psu_driver_module",
+            "pddf_psu_module",
+            "pddf_fan_driver_module",
+            "pddf_fan_module",
+            "pddf_led_module",
+            "pddf_sysstatus_module"
+        ]
+    },
+
+    "SYSTEM":
+    {
+        "dev_info": {"device_type":"CPU", "device_name":"ROOT_COMPLEX", "device_parent":null},
+        "i2c":
+        {
+            "CONTROLLERS":
+            [ 
+                { "dev_name":"i2c-0", "dev":"SMBUS0" }
+            ]
+        }
+    },
+    
+    "SMBUS0": 
+    {
+        "dev_info": {"device_type": "SMBUS", "device_name": "SMBUS0", "device_parent": "SYSTEM"},
+        "i2c": 
+        {
+            "topo_info": {"dev_addr": "0x0"},
+            "DEVICES": 
+            [
+                {"dev": "EEPROM1"},
+                {"dev": "CPU_CPLD"},
+                {"dev": "MUX1"}
+            ]
+        }
+    },
+  
+    "EEPROM1": 
+    {
+        "dev_info": {"device_type": "EEPROM", "device_name": "EEPROM1", "device_parent": "SMBUS0"},
+        "i2c": 
+        {
+            "topo_info": {"parent_bus": "0x0", "dev_addr": "0x56", "dev_type": "24c04"},
+            "dev_attr": {"access_mode": "BLOCK"},
+            "attr_list": [
+                {"attr_name": "eeprom"}
+            ]
+        }
+    },
+    
+    "CPU_CPLD":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPU_CPLD", "device_parent":"SMBUS0"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x0", "dev_addr":"0x65", "dev_type":"i2c_cpld"},
+            "dev_attr": { }
+        }
+    },
+    
+    "MUX1":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX1", "device_parent":"SMBUS0"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x0", "dev_addr":"0x77", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x1"},
+             "channel":
+            [
+                { "chn":"0", "dev":"MUX2" },
+                { "chn":"0", "dev":"MUX3" },
+                { "chn":"1", "dev":"MUX4" }
+                
+            ]            
+        }
+    },
+    "MUX2":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX2", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1", "dev_addr":"0x70", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x9"},
+            "channel":
+            [         
+                { "chn":"2", "dev":"FAN-CTRL" },       
+                { "chn":"3", "dev":"CPLD2" },
+                { "chn":"4", "dev":"PSU2" } ,
+                { "chn":"6", "dev":"TEMP1" },
+                { "chn":"6", "dev":"TEMP2" },
+                { "chn":"6", "dev":"TEMP3" },
+                { "chn":"6", "dev":"TEMP4" }
+            ]
+        }
+    },
+    "MUX3":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX3", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1", "dev_addr":"0x71", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x11"},
+            "channel":
+            [                
+                { "chn":"0", "dev":"PSU1" },
+                { "chn":"1", "dev":"CPLD1" },
+                { "chn":"2", "dev":"CPLD3" },
+                { "chn":"5", "dev":"PORT57" },
+                { "chn":"6", "dev":"PORT58" },
+                { "chn":"7", "dev":"MUX11" }
+            ]
+        }
+    },
+    "MUX4":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX4", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2", "dev_addr":"0x70", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x21"},
+            "channel":
+            [                
+                { "chn":"0", "dev":"MUX5" },
+                { "chn":"1", "dev":"MUX6" },
+                { "chn":"2", "dev":"MUX7" },
+                { "chn":"3", "dev":"MUX8" },
+                { "chn":"4", "dev":"MUX9" },
+                { "chn":"5", "dev":"MUX10" }
+            ]
+        }
+    },
+    "PSU2":
+    {
+        "dev_info": { "device_type":"PSU", "device_name":"PSU2", "device_parent":"MUX2" },
+        "dev_attr": { "dev_idx":"2", "num_psu_fans":"1"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"pmbus", "dev":"PSU2-PMBUS"}
+            ]
+        }
+    },
+
+    "PSU2-PMBUS":
+    {
+        "dev_info": {"device_type":"PSU-PMBUS", "device_name":"PSU2-PMBUS", "device_parent":"MUX2", "virt_parent":"PSU2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xd", "dev_addr":"0x5b", "dev_type":"psu_pmbus"},
+            "attr_list": 
+            [  
+                { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"psu_mfr_id", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" },
+                { "attr_name":"psu_fan_dir", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
+                { "attr_name":"psu_v_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_i_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_p_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_temp1_input", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+            ]
+        }
+    },
+    
+    "PSU1":
+    {
+        "dev_info": { "device_type":"PSU", "device_name":"PSU1", "device_parent":"MUX3" },
+        "dev_attr": { "dev_idx":"1", "num_psu_fans":"1"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"pmbus", "dev":"PSU1-PMBUS"}
+            ]
+        }
+    },
+
+    "PSU1-PMBUS":
+    {
+        "dev_info": {"device_type":"PSU-PMBUS", "device_name":"PSU1-PMBUS", "device_parent":"MUX3", "virt_parent":"PSU1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x11", "dev_addr":"0x59", "dev_type":"psu_pmbus"},
+            "attr_list": 
+            [  
+                { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"psu_mfr_id", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x9e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" },
+                { "attr_name":"psu_fan_dir", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
+                { "attr_name":"psu_v_out", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_i_out", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_p_out", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+                { "attr_name":"psu_temp1_input", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+            ]
+        }
+    },
+    
+    "CPLD1":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD1", "device_parent":"MUX3"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x12", "dev_addr":"0x60", "dev_type":"i2c_cpld"},
+            "dev_attr":{}
+        }
+    },
+     "CPLD2":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD2", "device_parent":"MUX2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xc", "dev_addr":"0x62", "dev_type":"i2c_cpld"},
+            "dev_attr":{}
+        }
+    },
+    "CPLD3":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD3", "device_parent":"MUX3"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x13", "dev_addr":"0x64", "dev_type":"i2c_cpld"},
+            "dev_attr":{}
+        }
+    },
+     "TEMP1" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xf", "dev_addr":"0x48", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+     "TEMP2" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xf", "dev_addr":"0x49", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+     "TEMP3" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xf", "dev_addr":"0x4A", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+    "TEMP4" :
+    {
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xf", "dev_addr":"0x4B", "dev_type":"lm75"},
+            "attr_list":
+            [
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+                { "attr_name": "temp1_max_hyst"},
+                { "attr_name": "temp1_input"}
+            ]
+        }
+    },
+    "FAN-CTRL":
+    {
+        "dev_info": { "device_type":"FAN", "device_name":"FAN-CTRL", "device_parent":"MUX2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xb", "dev_addr":"0x66", "dev_type":"fan_ctrl"},
+            "dev_attr": { "num_fantrays":"5"},
+            "attr_list":
+            [
+                { "attr_name":"fan1_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan2_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan3_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan4_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan5_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan6_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan7_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x8", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan8_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x8", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan9_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan10_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan11_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x20", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan12_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0f", "attr_mask":"0x20", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"fan1_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x1", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"fan2_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x1", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"fan3_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"fan4_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"fan5_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"fan6_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"fan7_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"fan8_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"fan9_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x10", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"fan10_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x10", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"fan11_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x20", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"fan12_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x20", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"fan1_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x12", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+                { "attr_name":"fan2_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x22", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+                { "attr_name":"fan3_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x13", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+                { "attr_name":"fan4_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x23", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+                { "attr_name":"fan5_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x14", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+                { "attr_name":"fan6_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x24", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+                { "attr_name":"fan7_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x15", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+                { "attr_name":"fan8_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x25", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+                { "attr_name":"fan9_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x16", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+                { "attr_name":"fan10_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x26", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+                { "attr_name":"fan11_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x17", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+                { "attr_name":"fan12_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x27", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+                { "attr_name":"fan1_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan2_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan3_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan4_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan5_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan6_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan7_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan8_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan9_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan10_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan11_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" },
+                { "attr_name":"fan12_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0xF", "attr_len":"1" }
+            ]
+        }
+    },
+    "PORT57":
+    {
+        "dev_info": { "device_type":"SFP", "device_name":"PORT57", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"57"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT57-EEPROM" },
+                { "itf":"control", "dev":"PORT57-CTRL" }
+            ]
+        }
+    },
+    "PORT57-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT57-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT57"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x16", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT57-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT57-CTRL", "device_parent":"MUX3", "virt_parent":"PORT57"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x16", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1c", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x16", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x19", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+     "PORT58":
+    {
+        "dev_info": { "device_type":"SFP", "device_name":"PORT58", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"58"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT58-EEPROM" },
+                { "itf":"control", "dev":"PORT58-CTRL" }
+            ]
+        }
+    },
+    "PORT58-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT58-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT58"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x17", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT58-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT58-CTRL", "device_parent":"MUX3", "virt_parent":"PORT58"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x17", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1c", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x16", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x19", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    "MUX5":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX5", "device_parent":"MUX4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x21", "dev_addr":"0x71", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x29"},
+            "channel":
+            [                
+                { "chn":"0", "dev":"PORT2" },
+                { "chn":"1", "dev":"PORT1" },
+                { "chn":"2", "dev":"PORT4" },
+                { "chn":"3", "dev":"PORT3" },
+                { "chn":"4", "dev":"PORT6" },
+                { "chn":"5", "dev":"PORT7" },
+                { "chn":"6", "dev":"PORT5" },
+                { "chn":"7", "dev":"PORT9" }
+            ]
+        }
+    },
+    "MUX6":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX6", "device_parent":"MUX4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x22", "dev_addr":"0x72", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x31"},
+            "channel":
+            [                
+                { "chn":"0", "dev":"PORT10" },
+                { "chn":"1", "dev":"PORT8"  },
+                { "chn":"2", "dev":"PORT12" },
+                { "chn":"3", "dev":"PORT11" },
+                { "chn":"4", "dev":"PORT13" },
+                { "chn":"5", "dev":"PORT16" },
+                { "chn":"6", "dev":"PORT15" },
+                { "chn":"7", "dev":"PORT14" }
+            ]
+        }
+    },
+    "MUX7":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX7", "device_parent":"MUX4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x23", "dev_addr":"0x73", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x39"},
+            "channel":
+            [                
+                { "chn":"0", "dev":"PORT18" },
+                { "chn":"1", "dev":"PORT17" },
+                { "chn":"2", "dev":"PORT20" },
+                { "chn":"3", "dev":"PORT19" },
+                { "chn":"4", "dev":"PORT21" },
+                { "chn":"5", "dev":"PORT23" },
+                { "chn":"6", "dev":"PORT22" },
+                { "chn":"7", "dev":"PORT24" }
+            ]
+        }
+    },
+    "MUX8":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX8", "device_parent":"MUX4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x24", "dev_addr":"0x74", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x41"},
+            "channel":
+            [                
+                { "chn":"0", "dev":"PORT27" },
+                { "chn":"1", "dev":"PORT25"  },
+                { "chn":"2", "dev":"PORT28" },
+                { "chn":"3", "dev":"PORT26" },
+                { "chn":"4", "dev":"PORT29" },
+                { "chn":"5", "dev":"PORT32" },
+                { "chn":"6", "dev":"PORT30" },
+                { "chn":"7", "dev":"PORT31" }
+            ]
+        }
+    },
+    "MUX9":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX9", "device_parent":"MUX4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x25", "dev_addr":"0x75", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x49"},
+            "channel":
+            [                
+                { "chn":"0", "dev":"PORT34" },
+                { "chn":"1", "dev":"PORT33"  },
+                { "chn":"2", "dev":"PORT36" },
+                { "chn":"3", "dev":"PORT35" },
+                { "chn":"4", "dev":"PORT37" },
+                { "chn":"5", "dev":"PORT39" },
+                { "chn":"6", "dev":"PORT38" },
+                { "chn":"7", "dev":"PORT40" }
+            ]
+        }
+    },   
+    "MUX10":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX10", "device_parent":"MUX4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x26", "dev_addr":"0x76", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x51"},
+            "channel":
+            [                
+                { "chn":"0", "dev":"PORT41" },
+                { "chn":"1", "dev":"PORT42"  },
+                { "chn":"2", "dev":"PORT45" },
+                { "chn":"3", "dev":"PORT43" },
+                { "chn":"4", "dev":"PORT44" },
+                { "chn":"5", "dev":"PORT48" },
+                { "chn":"6", "dev":"PORT46" },
+                { "chn":"7", "dev":"PORT47" }
+            ]
+        }
+    },    
+    "MUX11":
+    {
+        "dev_info": {  "device_type":"MUX", "device_name":"MUX11", "device_parent":"MUX3"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x18", "dev_addr":"0x72", "dev_type":"pca9548"},
+            "dev_attr": { "virt_bus":"0x19"},
+            "channel":
+            [                
+                { "chn":"0", "dev":"PORT49" },
+                { "chn":"1", "dev":"PORT50"  },
+                { "chn":"2", "dev":"PORT51" },
+                { "chn":"3", "dev":"PORT52" },
+                { "chn":"4", "dev":"PORT53" },
+                { "chn":"5", "dev":"PORT54" },
+                { "chn":"6", "dev":"PORT55" },
+                { "chn":"7", "dev":"PORT56" }
+            ]
+        }
+    },    
+    
+     
+    
+    "PORT2":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT2", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"2"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT2-EEPROM" },
+                { "itf":"control", "dev":"PORT2-CTRL" }
+            ]
+        }
+    },
+    "PORT2-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT2-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x29", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT2-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT2-CTRL", "device_parent":"MUX5", "virt_parent":"PORT2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x29", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xF", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x3", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld","attr_devname":"CPLD2",  "attr_offset":"0x7", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xb", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT1":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT1", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"1"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT1-EEPROM" },
+                { "itf":"control", "dev":"PORT1-CTRL" }
+            ]
+        }
+    },
+    "PORT1-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT1-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2a", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT1-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT1-CTRL", "device_parent":"MUX5", "virt_parent":"PORT1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2a", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xF", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x3", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x7", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xb", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT4":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT4", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"4"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT4-EEPROM" },
+                { "itf":"control", "dev":"PORT4-CTRL" }
+            ]
+        }
+    },
+    "PORT4-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT4-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2b", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT4-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT4-CTRL", "device_parent":"MUX5", "virt_parent":"PORT4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2b", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xF", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x3", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x7", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xB", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT3":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT3", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"3"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT3-EEPROM" },
+                { "itf":"control", "dev":"PORT3-CTRL" }
+            ]
+        }
+    },
+    "PORT3-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT3-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT3"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2c", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT3-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT3-CTRL", "device_parent":"MUX5", "virt_parent":"PORT3"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2c", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xF", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x3", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x7", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xB", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT6":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT6", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"6"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT6-EEPROM" },
+                { "itf":"control", "dev":"PORT6-CTRL" }
+            ]
+        }
+    },
+    "PORT6-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT6-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT6"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2d", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT6-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT6-CTRL", "device_parent":"MUX5", "virt_parent":"PORT6"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2d", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xF", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x3", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld","attr_devname":"CPLD2", "attr_offset":"0x7", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xB", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT7":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT7", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"7"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT7-EEPROM" },
+                { "itf":"control", "dev":"PORT7-CTRL" }
+            ]
+        }
+    },
+    "PORT7-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT7-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT7"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2e", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT7-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT7-CTRL", "device_parent":"MUX5", "virt_parent":"PORT7"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2e", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xF", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x3", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld","attr_devname":"CPLD2",  "attr_offset":"0x7", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xB", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT5":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT5", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"5"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT5-EEPROM" },
+                { "itf":"control", "dev":"PORT5-CTRL" }
+            ]
+        }
+    },
+    "PORT5-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT5-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2f", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT5-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT5-CTRL", "device_parent":"MUX5", "virt_parent":"PORT5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2f", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xF", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x3", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x7", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_offset":"0xB", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT9":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT9", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"9"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT9-EEPROM" },
+                { "itf":"control", "dev":"PORT9-CTRL" }
+            ]
+        }
+    },
+    "PORT9-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT9-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT9"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x30", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT9-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT9-CTRL", "device_parent":"MUX5", "virt_parent":"PORT9"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x30", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x4", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld","attr_devname":"CPLD2",  "attr_offset":"0x8", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_offset":"0xC", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT10":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT10", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"10"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT10-EEPROM" },
+                { "itf":"control", "dev":"PORT10-CTRL" }
+            ]
+        }
+    },
+    "PORT10-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT10-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT10"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x31", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT10-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT10-CTRL", "device_parent":"MUX6", "virt_parent":"PORT10"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x31", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x4", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld","attr_devname":"CPLD2",  "attr_offset":"0x8", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xC", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT8":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT8", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"8"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT8-EEPROM" },
+                { "itf":"control", "dev":"PORT8-CTRL" }
+            ]
+        }
+    },
+    "PORT8-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT8-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT8"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x32", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT8-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT8-CTRL", "device_parent":"MUX6", "virt_parent":"PORT8"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x32", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xF", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x3", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x7", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xB", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"}
+            ]
+        }
+    },    
+    "PORT12":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT12", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"12"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT12-EEPROM" },
+                { "itf":"control", "dev":"PORT12-CTRL" }
+            ]
+        }
+    },
+    "PORT12-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT12-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT12"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x33", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT12-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT12-CTRL", "device_parent":"MUX6", "virt_parent":"PORT12"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x33", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x4", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xC", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT11":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT11", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"11"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT11-EEPROM" },
+                { "itf":"control", "dev":"PORT11-CTRL" }
+            ]
+        }
+    },
+    "PORT11-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT11-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT11"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x34", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT11-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT11-CTRL", "device_parent":"MUX6", "virt_parent":"PORT11"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x34", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x4", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xC", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT13":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT13", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"13"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT13-EEPROM" },
+                { "itf":"control", "dev":"PORT13-CTRL" }
+            ]
+        }
+    },
+    "PORT13-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT13-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT13"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x35", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT13-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT13-CTRL", "device_parent":"MUX6", "virt_parent":"PORT13"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x35", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x4", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xC", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT16":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT16", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"16"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT16-EEPROM" },
+                { "itf":"control", "dev":"PORT16-CTRL" }
+            ]
+        }
+    },
+    "PORT16-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT16-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT16"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x36", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT16-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT16-CTRL", "device_parent":"MUX6", "virt_parent":"PORT16"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x36", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x4", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xC", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT15":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT15", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"15"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT15-EEPROM" },
+                { "itf":"control", "dev":"PORT15-CTRL" }
+            ]
+        }
+    },
+    "PORT15-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT15-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT15"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x37", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT15-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT15-CTRL", "device_parent":"MUX6", "virt_parent":"PORT15"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x37", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x4", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xC", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"}
+            ]
+        }
+    },
+     "PORT14":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT14", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"14"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT14-EEPROM" },
+                { "itf":"control", "dev":"PORT14-CTRL" }
+            ]
+        }
+    },
+    "PORT14-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT14-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT14"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x38", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT14-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT14-CTRL", "device_parent":"MUX6", "virt_parent":"PORT14"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x38", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x4", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x8", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xC", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT18":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT18", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"18"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT18-EEPROM" },
+                { "itf":"control", "dev":"PORT18-CTRL" }
+            ]
+        }
+    },
+    "PORT18-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT18-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT18"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x39", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT18-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT18-CTRL", "device_parent":"MUX7", "virt_parent":"PORT18"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x39", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x5", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x9", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xD", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT17":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT17", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"17"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT17-EEPROM" },
+                { "itf":"control", "dev":"PORT17-CTRL" }
+            ]
+        }
+    },
+    "PORT17-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT17-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT17"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3a", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT17-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT17-CTRL", "device_parent":"MUX7", "virt_parent":"PORT17"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3a", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x5", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x9", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xD", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT20":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT20", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"20"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT20-EEPROM" },
+                { "itf":"control", "dev":"PORT20-CTRL" }
+            ]
+        }
+    },
+    "PORT20-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT20-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT20"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3b", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT20-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT20-CTRL", "device_parent":"MUX7", "virt_parent":"PORT20"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3b", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x5", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x9", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xD", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT19":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT19", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"19"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT19-EEPROM" },
+                { "itf":"control", "dev":"PORT19-CTRL" }
+            ]
+        }
+    },
+    "PORT19-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT19-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT19"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3c", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT19-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT19-CTRL", "device_parent":"MUX7", "virt_parent":"PORT19"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3c", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x5", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x9", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xD", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT21":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT21", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"21"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT21-EEPROM" },
+                { "itf":"control", "dev":"PORT21-CTRL" }
+            ]
+        }
+    },
+    "PORT21-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT21-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT21"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3d", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT21-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT21-CTRL", "device_parent":"MUX7", "virt_parent":"PORT21"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3d", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x5", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x9", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xD", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    
+     "PORT23":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT23", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"23"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT23-EEPROM" },
+                { "itf":"control", "dev":"PORT23-CTRL" }
+            ]
+        }
+    },
+    "PORT23-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT23-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT23"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3e", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT23-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT23-CTRL", "device_parent":"MUX7", "virt_parent":"PORT23"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3e", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x5", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x9", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xD", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"}
+            ]
+        }
+    },
+    
+     "PORT22":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT22", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"22"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT22-EEPROM" },
+                { "itf":"control", "dev":"PORT22-CTRL" }
+            ]
+        }
+    },
+    "PORT22-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT22-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT22"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3f", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT22-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT22-CTRL", "device_parent":"MUX7", "virt_parent":"PORT22"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x3f", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x5", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x9", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xD", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT24":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT24", "device_parent":"MUX7"},
+        "dev_attr": { "dev_idx":"24"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT24-EEPROM" },
+                { "itf":"control", "dev":"PORT24-CTRL" }
+            ]
+        }
+    },
+    "PORT24-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT24-EEPROM", "device_parent":"MUX7", "virt_parent":"PORT24"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x40", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT24-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT24-CTRL", "device_parent":"MUX7", "virt_parent":"PORT24"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x40", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x11", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x5", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x9", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xD", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT27":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT27", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"27"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT27-EEPROM" },
+                { "itf":"control", "dev":"PORT27-CTRL" }
+            ]
+        }
+    },
+    "PORT27-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT27-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT27"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x41", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT27-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT27-CTRL", "device_parent":"MUX8", "virt_parent":"PORT27"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x41", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x6", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xA", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xE", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT25":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT25", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"25"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT25-EEPROM" },
+                { "itf":"control", "dev":"PORT25-CTRL" }
+            ]
+        }
+    },
+    "PORT25-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT25-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT25"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x42", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT25-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT25-CTRL", "device_parent":"MUX8", "virt_parent":"PORT25"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x42", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x6", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xA", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xE", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+   
+    "PORT28":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT28", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"28"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT28-EEPROM" },
+                { "itf":"control", "dev":"PORT28-CTRL" }
+            ]
+        }
+    },
+    "PORT28-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT28-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT28"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x43", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT28-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT28-CTRL", "device_parent":"MUX8", "virt_parent":"PORT28"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x43", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x6", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xA", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xE", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT26":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT26", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"26"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT26-EEPROM" },
+                { "itf":"control", "dev":"PORT26-CTRL" }
+            ]
+        }
+    },
+    "PORT26-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT26-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT26"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x44", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT26-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT26-CTRL", "device_parent":"MUX8", "virt_parent":"PORT26"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x44", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x6", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xA", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xE", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT29":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT29", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"29"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT29-EEPROM" },
+                { "itf":"control", "dev":"PORT29-CTRL" }
+            ]
+        }
+    },
+    "PORT29-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT29-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT29"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x45", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT29-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT29-CTRL", "device_parent":"MUX8", "virt_parent":"PORT29"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x45", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x6", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xA", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xE", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT32":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT32", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"32"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT32-EEPROM" },
+                { "itf":"control", "dev":"PORT32-CTRL" }
+            ]
+        }
+    },
+    "PORT32-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT32-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT32"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x46", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT32-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT32-CTRL", "device_parent":"MUX8", "virt_parent":"PORT32"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x46", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1A", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x14", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x17", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT30":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT30", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"30"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT30-EEPROM" },
+                { "itf":"control", "dev":"PORT30-CTRL" }
+            ]
+        }
+    },
+    "PORT30-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT30-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT30"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x47", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT30-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT30-CTRL", "device_parent":"MUX8", "virt_parent":"PORT30"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x47", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x12", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x6", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xA", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xE", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },    
+    
+    "PORT31":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT31", "device_parent":"MUX8"},
+        "dev_attr": { "dev_idx":"31"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT31-EEPROM" },
+                { "itf":"control", "dev":"PORT31-CTRL" }
+            ]
+        }
+    },
+    "PORT31-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT31-EEPROM", "device_parent":"MUX8", "virt_parent":"PORT31"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x48", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT31-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT31-CTRL", "device_parent":"MUX8", "virt_parent":"PORT31"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x48", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1A", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x14", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x17", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT34":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT34", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"34"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT34-EEPROM" },
+                { "itf":"control", "dev":"PORT34-CTRL" }
+            ]
+        }
+    },
+    "PORT34-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT34-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT34"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x49", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT34-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT34-CTRL", "device_parent":"MUX9", "virt_parent":"PORT34"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x49", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1A", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x14", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x17", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT33":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT33", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"33"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT33-EEPROM" },
+                { "itf":"control", "dev":"PORT33-CTRL" }
+            ]
+        }
+    },
+    "PORT33-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT33-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT33"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4a", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT33-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT33-CTRL", "device_parent":"MUX9", "virt_parent":"PORT33"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4a", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1A", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x14", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x17", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT36":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT36", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"36"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT36-EEPROM" },
+                { "itf":"control", "dev":"PORT36-CTRL" }
+            ]
+        }
+    },
+    "PORT36-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT36-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT36"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4b", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT36-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT36-CTRL", "device_parent":"MUX9", "virt_parent":"PORT36"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4b", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1A", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x14", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x17", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT35":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT35", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"35"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT35-EEPROM" },
+                { "itf":"control", "dev":"PORT35-CTRL" }
+            ]
+        }
+    },
+    "PORT35-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT35-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT35"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4c", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT35-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT35-CTRL", "device_parent":"MUX9", "virt_parent":"PORT35"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4c", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1A", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x14", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x17", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT37":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT37", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"37"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT37-EEPROM" },
+                { "itf":"control", "dev":"PORT37-CTRL" }
+            ]
+        }
+    },
+    "PORT37-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT37-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT37"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4d", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT37-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT37-CTRL", "device_parent":"MUX9", "virt_parent":"PORT37"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4d", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1A", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x14", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x17", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT39":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT39", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"39"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT39-EEPROM" },
+                { "itf":"control", "dev":"PORT39-CTRL" }
+            ]
+        }
+    },
+    "PORT39-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT39-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT39"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4e", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT39-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT39-CTRL", "device_parent":"MUX9", "virt_parent":"PORT39"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4e", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1B", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x15", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x18", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT38":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT38", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"38"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT38-EEPROM" },
+                { "itf":"control", "dev":"PORT38-CTRL" }
+            ]
+        }
+    },
+    "PORT38-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT38-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT38"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4f", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT38-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT38-CTRL", "device_parent":"MUX9", "virt_parent":"PORT38"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x4f", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1A", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x14", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x17", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT40":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT40", "device_parent":"MUX9"},
+        "dev_attr": { "dev_idx":"40"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT40-EEPROM" },
+                { "itf":"control", "dev":"PORT40-CTRL" }
+            ]
+        }
+    },
+    "PORT40-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT40-EEPROM", "device_parent":"MUX9", "virt_parent":"PORT40"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x50", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT40-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT40-CTRL", "device_parent":"MUX9", "virt_parent":"PORT40"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x50", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1B", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x15", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x18", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT41":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT41", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"41"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT41-EEPROM" },
+                { "itf":"control", "dev":"PORT41-CTRL" }
+            ]
+        }
+    },
+    "PORT41-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT41-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT41"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x51", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT41-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT41-CTRL", "device_parent":"MUX10", "virt_parent":"PORT41"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x51", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1B", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x15", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x18", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT42":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT42", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"42"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT42-EEPROM" },
+                { "itf":"control", "dev":"PORT42-CTRL" }
+            ]
+        }
+    },
+    "PORT42-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT42-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT42"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x52", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT42-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT42-CTRL", "device_parent":"MUX10", "virt_parent":"PORT42"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x52", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1B", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x15", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x18", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT45":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT45", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"45"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT45-EEPROM" },
+                { "itf":"control", "dev":"PORT45-CTRL" }
+            ]
+        }
+    },
+    "PORT45-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT45-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT45"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x53", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT45-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT45-CTRL", "device_parent":"MUX10", "virt_parent":"PORT45"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x53", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1B", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x15", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x18", "attr_mask":"0x6", "attr_cmpval":"0x40", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT43":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT43", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"43"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT43-EEPROM" },
+                { "itf":"control", "dev":"PORT43-CTRL" }
+            ]
+        }
+    },
+    "PORT43-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT43-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT43"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x54", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT43-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT43-CTRL", "device_parent":"MUX10", "virt_parent":"PORT43"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x54", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_devname":"CPLD1", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1B","attr_devname":"CPLD1",  "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x15", "attr_devname":"CPLD1", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x18", "attr_devname":"CPLD1","attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT44":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT44", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"44"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT44-EEPROM" },
+                { "itf":"control", "dev":"PORT44-CTRL" }
+            ]
+        }
+    },
+    "PORT44-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT44-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT44"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x55", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT44-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT44-CTRL", "device_parent":"MUX10", "virt_parent":"PORT44"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x55", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x1B", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x15", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x18", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+            ]
+        }
+    },    
+    "PORT48":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT48", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"48"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT48-EEPROM" },
+                { "itf":"control", "dev":"PORT48-CTRL" }
+            ]
+        }
+    },
+    "PORT48-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT48-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT48"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x56", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT48-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT48-CTRL", "device_parent":"MUX10", "virt_parent":"PORT48"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x56", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_devname":"CPLD1","attr_offset":"0x1C", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x16", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x19", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT46":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT46", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"46"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT46-EEPROM" },
+                { "itf":"control", "dev":"PORT46-CTRL" }
+            ]
+        }
+    },
+    "PORT46-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT46-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT46"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x57", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT46-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT46-CTRL", "device_parent":"MUX10", "virt_parent":"PORT46"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x57", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1","attr_offset":"0x1B", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0x15", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1","attr_offset":"0x18", "attr_mask":"0x7", "attr_cmpval":"0x80", "attr_len":"1"}
+            ]
+        }
+    },    
+    "PORT47":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT47", "device_parent":"MUX10"},
+        "dev_attr": { "dev_idx":"47"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT47-EEPROM" },
+                { "itf":"control", "dev":"PORT47-CTRL" }
+            ]
+        }
+    },
+    "PORT47-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT47-EEPROM", "device_parent":"MUX10", "virt_parent":"PORT47"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x58", "dev_addr":"0x50", "dev_type":"optoe2"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT47-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT47-CTRL", "device_parent":"MUX10", "virt_parent":"PORT47"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x58", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1C", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x16", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x19", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    
+    "PORT49":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT49", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"49"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT49-EEPROM" },
+                { "itf":"control", "dev":"PORT49-CTRL" }
+            ]
+        }
+    },
+    "PORT49-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT49-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT49"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x19", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT49-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT49-CTRL", "device_parent":"MUX11", "virt_parent":"PORT49"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x19", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x4", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0xA", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"}
+                
+            ]
+        }
+    },
+    
+    "PORT50":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT50", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"50"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT50-EEPROM" },
+                { "itf":"control", "dev":"PORT50-CTRL" }
+            ]
+        }
+    },
+    "PORT50-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT50-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT50"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1a", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT50-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT50-CTRL", "device_parent":"MUX11", "virt_parent":"PORT50"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1a", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x4", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0xA", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"}
+                
+            ]
+        }
+    },
+    
+    "PORT51":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT51", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"51"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT51-EEPROM" },
+                { "itf":"control", "dev":"PORT51-CTRL" }
+            ]
+        }
+    },
+    "PORT51-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT51-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT51"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1b", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT51-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT51-CTRL", "device_parent":"MUX11", "virt_parent":"PORT51"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1b", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x4", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0xA", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"}
+                
+            ]
+        }
+    },
+    
+    "PORT52":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT52", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"52"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT52-EEPROM" },
+                { "itf":"control", "dev":"PORT52-CTRL" }
+            ]
+        }
+    },
+    "PORT52-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT52-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT52"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1c", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT52-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT52-CTRL", "device_parent":"MUX11", "virt_parent":"PORT52"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1c", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x4", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0xA", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"}
+                
+            ]
+        }
+    },
+    
+    "PORT53":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT53", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"53"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT53-EEPROM" },
+                { "itf":"control", "dev":"PORT53-CTRL" }
+            ]
+        }
+    },
+    "PORT53-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT53-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT53"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1d", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT53-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT53-CTRL", "device_parent":"MUX11", "virt_parent":"PORT53"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1d", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x4", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0xA", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"}
+                
+            ]
+        }
+    },
+    
+    "PORT54":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT54", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"54"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT54-EEPROM" },
+                { "itf":"control", "dev":"PORT54-CTRL" }
+            ]
+        }
+    },
+    "PORT54-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT54-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT54"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1e", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT54-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT54-CTRL", "device_parent":"MUX11", "virt_parent":"PORT54"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1e", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x4", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0xA", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"}
+                
+            ]
+        }
+    },
+    
+    "PORT55":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT55", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"55"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT55-EEPROM" },
+                { "itf":"control", "dev":"PORT55-CTRL" }
+            ]
+        }
+    },
+    "PORT55-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT55-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT55"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1f", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT55-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT55-CTRL", "device_parent":"MUX11", "virt_parent":"PORT55"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1f", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x4", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0xA", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"}
+                
+            ]
+        }
+    },
+    
+    "PORT56":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT56", "device_parent":"MUX11"},
+        "dev_attr": { "dev_idx":"56"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT56-EEPROM" },
+                { "itf":"control", "dev":"PORT56-CTRL" }
+            ]
+        }
+    },
+    "PORT56-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT56-EEPROM", "device_parent":"MUX11", "virt_parent":"PORT56"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x20", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+        }
+    },    
+    "PORT56-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT56-CTRL", "device_parent":"MUX11", "virt_parent":"PORT56"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x20", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x4", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0xA", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"}
+                
+            ]
+        }
+    },
+    "LOC_LED":
+    {
+        "dev_info": { "device_type":"LED", "device_name":"LOC_LED"},
+        "dev_attr": { "index":"0"},
+        "i2c" :
+        {
+            "attr_list":
+            [
+                {"attr_name":"STATUS_LED_COLOR_BLUE_BLINK", "descr": "" , "bits" : "5:0",  "value" : "0x27", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x25"},
+                {"attr_name":"STATUS_LED_COLOR_GREEN_BLINK", "descr": "" , "bits" : "5:0",  "value" : "0x17", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x25"},
+                {"attr_name":"STATUS_LED_COLOR_AMBER_BLINK", "descr": "" , "bits" : "5:0",  "value" : "0xf", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x25"},
+                {"attr_name":"STATUS_LED_COLOR_BLUE", "descr": "" , "bits" : "5:0",  "value" : "0x3", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x25"},
+                {"attr_name":"STATUS_LED_COLOR_GREEN", "descr": "" , "bits" : "5:0",  "value" : "0x5", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x25"},
+                {"attr_name":"STATUS_LED_COLOR_AMBER", "descr": "" , "bits" : "5:0",  "value" : "0x6", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x25"},
+                {"attr_name":"STATUS_LED_COLOR_OFF", "descr": "" , "bits" : "5:0",  "value" : "0xf", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x25"}
+            ]
+        }
+    },
+    "DIAG_LED":
+    {
+        "dev_info": { "device_type":"LED", "device_name":"DIAG_LED"},
+         "dev_attr": { "index":"0"},
+         "i2c" :
+         {
+             "attr_list":
+             [
+                {"attr_name":"STATUS_LED_COLOR_BLUE_BLINK", "descr": "" , "bits" : "5:0",  "value" : "0x27", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
+                {"attr_name":"STATUS_LED_COLOR_GREEN_BLINK", "descr": "" , "bits" : "5:0",  "value" : "0x17", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
+                {"attr_name":"STATUS_LED_COLOR_AMBER_BLINK", "descr": "" , "bits" : "5:0",  "value" : "0xf", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
+                {"attr_name":"STATUS_LED_COLOR_BLUE", "descr": "" , "bits" : "5:0",  "value" : "0x3", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
+                {"attr_name":"STATUS_LED_COLOR_GREEN", "descr": "" , "bits" : "5:0",  "value" : "0x5", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
+                {"attr_name":"STATUS_LED_COLOR_AMBER", "descr": "" , "bits" : "5:0",  "value" : "0x6", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
+                {"attr_name":"STATUS_LED_COLOR_OFF", "descr": "" , "bits" : "5:0",  "value" : "0x7", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"}
+                
+             ]
+        }
+    }
+}

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-56x-pddf-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-56x-pddf-platform-monitor.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Accton AS7326-56X Platform Monitoring service
+Before=pmon.service
+After=pddf-platform-init.service
+DefaultDependencies=no
+
+[Service]
+ExecStart=/usr/local/bin/accton_as7326_pddf_monitor.py
+KillSignal=SIGKILL
+SuccessExitStatus=SIGKILL
+
+# Resource Limitations
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-platform-handle_mac.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-platform-handle_mac.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7326-56X Platform MAC handle service
-Before=opennsl-modules.service
+Before=opennsl-modules.service pddf-platform-init.service
 After=local-fs.target
 
 [Service]

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/pddf-platform-init.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/pddf-platform-init.service
@@ -1,0 +1,1 @@
+../../../../pddf/i2c/service/pddf-platform-init.service

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/__init__.py
@@ -1,0 +1,3 @@
+# All the derived classes for PDDF
+__all__ = ["platform", "chassis", "sfp", "psu", "thermal"]
+from . import platform

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+#############################################################################
+# PDDF
+# Module contains an implementation of SONiC Chassis API
+#
+#############################################################################
+
+try:
+    import time
+    from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Chassis(PddfChassis):
+    """
+    PDDF Platform-specific Chassis class
+    """
+
+    def __init__(self, pddf_data=None, pddf_plugin_data=None):
+        PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
+    def get_change_event(self, timeout=2000):
+        now = time.time()
+        port_dict = {}
+        port = 0
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            timeout = 1000
+        timeout = timeout / float(1000)  # Convert to secs
+
+        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
+            return True, change_dict
+
+        bitmap = 0
+        for i in range(58):
+            modpres = self.get_sfp(i).get_presence()
+            if modpres:
+                bitmap = bitmap | (1 << i)
+
+        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
+        if changed_ports:
+            for i in range(58):
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update teh cache dict
+            self.sfp_change_event_data['present'] = bitmap
+            self.sfp_change_event_data['last'] = now
+            self.sfp_change_event_data['valid'] = 1
+            return True, change_dict
+        else:
+            return True, change_dict
+
+        print("get_change_event: Control should not reach here")
+        return False, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
@@ -26,7 +26,6 @@ class Chassis(PddfChassis):
     def get_change_event(self, timeout=2000):
         now = time.time()
         port_dict = {}
-        port = 0
         change_dict = {}
         change_dict['sfp'] = port_dict
 
@@ -60,6 +59,3 @@ class Chassis(PddfChassis):
             return True, change_dict
         else:
             return True, change_dict
-
-        print("get_change_event: Control should not reach here")
-        return False, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/eeprom.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+try:
+    from sonic_platform_pddf_base.pddf_eeprom import PddfEeprom
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Eeprom(PddfEeprom):
+
+    def __init__(self, pddf_data=None, pddf_plugin_data=None):
+        PddfEeprom.__init__(self, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/fan.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan import PddfFan
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Fan(PddfFan):
+    """PDDF Platform-Specific Fan class"""
+
+    def __init__(self, tray_idx, fan_idx=0, pddf_data=None, pddf_plugin_data=None, is_psu_fan=False, psu_index=0):
+        # idx is 0-based 
+        PddfFan.__init__(self, tray_idx, fan_idx, pddf_data, pddf_plugin_data, is_psu_fan, psu_index)
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    # Since AS4630 psu_fan airflow direction cant be read from sysfs, it is fixed as 'F2B' or 'intake'
+

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/platform.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/platform.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+#############################################################################
+# PDDF
+# Module contains an implementation of SONiC Platform Base API and
+# provides the platform information
+#
+#############################################################################
+
+
+try:
+    from sonic_platform_pddf_base.pddf_platform import PddfPlatform
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Platform(PddfPlatform):
+    """
+    PDDF Platform-Specific Platform Class
+    """
+
+    def __init__(self):
+        PddfPlatform.__init__(self)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/psu.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#
+
+
+try:
+    from sonic_platform_pddf_base.pddf_psu import PddfPsu
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+
+class Psu(PddfPsu):
+    """PDDF Platform-Specific PSU class"""
+    
+    PLATFORM_PSU_CAPACITY = 1200
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        PddfPsu.__init__(self, index, pddf_data, pddf_plugin_data)
+        
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_maximum_supplied_power(self):
+        """
+        Retrieves the maximum supplied power by PSU (or PSU capacity)
+        Returns:
+            A float number, the maximum power output in Watts.
+            e.g. 1200.1
+        """
+        return float(self.PLATFORM_PSU_CAPACITY)
+
+    def get_type(self):
+        """
+        Gets the type of the PSU
+        Returns:
+        A string, the type of PSU (AC/DC)
+        """
+        return "DC"

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/sfp.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+try:
+    from sonic_platform_pddf_base.pddf_sfp import PddfSfp
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+
+class Sfp(PddfSfp):
+    """
+    PDDF Platform-Specific Sfp class
+    """
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/thermal.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_thermal import PddfThermal
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+
+class Thermal(PddfThermal):
+    """PDDF Platform-Specific Thermal class"""
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform_setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform_setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+setup(
+    name='sonic-platform',
+    version='1.0',
+    description='SONiC platform API implementation on Accton Platforms',
+    license='Apache 2.0',
+    author='SONiC Team',
+    author_email='linuxnetdev@microsoft.com',
+    url='https://github.com/Azure/sonic-buildimage',
+    packages=['sonic_platform'],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Plugins',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Utilities',
+    ],
+    keywords='sonic SONiC platform PLATFORM',
+)

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform_setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform_setup.py
@@ -18,7 +18,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Utilities',
     ],
     keywords='sonic SONiC platform PLATFORM',

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_pddf_monitor.py
@@ -28,9 +28,7 @@ try:
     import logging
     import logging.config
     import logging.handlers
-    import time  # this is only being used as part of the example
-    import traceback
-    from tabulate import tabulate
+    import time
     from sonic_platform import platform
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
@@ -39,8 +37,6 @@ except ImportError as e:
 VERSION = '1.0'
 FUNCTION_NAME = 'accton_as7326_56x_monitor'
 
-global log_file
-global log_level
 platform_chassis = None
 
 # Default FAN speed: 37.5%(0x05)
@@ -147,10 +143,8 @@ class device_monitor(object):
             3: [61000, 66000,   LEVEL_TEMP_HIGH],
             4: [66000, 200000,  LEVEL_TEMP_CRITICAL],
         }
-
-        fan_dir = platform_chassis.get_fan(0).get_direction()
+        
         ori_perc = platform_chassis.get_fan(0).get_speed()
-        #logging.debug('fan_dir=%s, ori_perc=%f', fan_dir, ori_perc)
         #logging.debug('test_temp=%d', test_temp)
         if test_temp == 0:
             temp2 = platform_chassis.get_thermal(1).get_temperature()*1000
@@ -167,7 +161,7 @@ class device_monitor(object):
         if temp2 == 0:
             temp_get = 50000  # if one detect sensor is fail or zero, assign temp=50000, let fan to 75%
             logging.debug('lm75_49 detect fail, so set temp_get=50000, let fan to 75%')
-        elif temp2 == 0:
+        elif temp4 == 0:
             temp_get = 50000  # if one detect sensor is fail or zero, assign temp=50000, let fan to 75%
             logging.debug('lm75_4b detect fail, so set temp_get=50000, let fan to 75%')
         else:

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/accton_as7326_pddf_monitor.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# ------------------------------------------------------------------
+# HISTORY:
+#    mm/dd/yyyy (A.D.)
+#    3/23/2018: Roy Lee modify for as7326_56x
+#    6/26/2018: Jostar implement by new thermal policy from HW RD
+#    09/18/2020: Jostar Yang, change to call PDDF API .
+# ------------------------------------------------------------------
+
+try:
+    import os
+    import sys
+    import getopt
+    import logging
+    import logging.config
+    import logging.handlers
+    import time  # this is only being used as part of the example
+    import traceback
+    from tabulate import tabulate
+    from sonic_platform import platform
+except ImportError as e:
+    raise ImportError('%s - required module not found' % str(e))
+
+# Deafults
+VERSION = '1.0'
+FUNCTION_NAME = 'accton_as7326_56x_monitor'
+
+global log_file
+global log_level
+platform_chassis = None
+
+# Default FAN speed: 37.5%(0x05)
+# Ori is that detect: (U45_BCM56873 + Thermal sensor_LM75_CPU:0x4B) /2
+# New Detect: (sensor_LM75_49 + Thermal sensor_LM75_CPU_4B) /2
+# Thermal policy: Both F2B and B2F
+# 1.    (sensor_LM75_49 + Thermal sensor_LM75_CPU) /2 =< 39C   , Keep 37.5%(0x05) Fan speed
+# 2.    (sensor_LM75_49 + Thermal sensor_LM75_CPU) /2 > 39C   , Change Fan speed from 37.5%(0x05) to % 75%(0x0B)
+# 3.    (sensor_LM75_49 + Thermal sensor_LM75_CPU) /2 > 45C   , Change Fan speed from 75%(0x0B) to 100%(0x0F)
+# 4.    (sensor_LM75_49 + Thermal sensor_LM75_CPU) /2 > 61C   , Send alarm message
+# 5.    (sensor_LM75_49 + Thermal sensor_LM75_CPU) /2 > 66C   , Shutdown system
+# 6.    One Fan fail      , Change Fan speed to 100%(0x0F)
+
+# fan-dev 0-11 speed 0x05     Setup fan speed 37.50%
+# fan-dev 0-11 speed 0xB      Setup fan speed 75%
+# fan-dev 0-11 speed 0xF      Setup fan speed 100.00%
+
+fan_policy_state = 1
+fan_fail = 0
+alarm_state = 0  # 0->default or clear, 1-->alarm detect
+test_temp = 0
+test_temp_list = [0, 0]
+temp_test_data = 0
+test_temp_revert = 0
+
+# Make a class we can use to capture stdout and sterr in the log
+
+
+class device_monitor(object):
+    # static temp var
+    temp = 0
+    new_pwm = 0
+    pwm = 0
+    ori_pwm = 0
+    default_pwm = 0x4
+
+    def __init__(self, log_file, log_level):
+        """Needs a logger and a logger level."""
+        # set up logging to file
+        logging.basicConfig(
+            filename=log_file,
+            filemode='w',
+            level=log_level,
+            format='[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
+            datefmt='%H:%M:%S'
+        )
+        # set up logging to console
+        if log_level == logging.DEBUG:
+            console = logging.StreamHandler()
+            console.setLevel(log_level)
+            formatter = logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+            console.setFormatter(formatter)
+            logging.getLogger('').addHandler(console)
+
+        sys_handler = logging.handlers.SysLogHandler(address='/dev/log')
+        sys_handler.setLevel(logging.WARNING)
+        logging.getLogger('').addHandler(sys_handler)
+
+    def get_state_from_fan_policy(self, temp, policy):
+        state = 0
+        logging.debug('temp=%d', temp)
+        for i in range(0, len(policy)):
+            #logging.debug('policy[%d][0]=%d, policy[%d][1]=%d', i,policy[i][0],i, policy[i][1])
+            if temp > policy[i][0]:
+                if temp <= policy[i][1]:
+                    state = policy[i][2]
+                    logging.debug('temp=%d >= policy[%d][0]=%d,  temp=%d < policy[%d][1]=%d',
+                                  temp, i, policy[i][0], temp, i, policy[i][1])
+                    logging.debug('fan_state=%d', state)
+        if state == 0:
+            state = policy[0][2]  # below fan_min, set to default pwm
+            logging.debug('set default state')
+        return state
+
+    def manage_fans(self):
+        LEVEL_FAN_DEF = 1
+        LEVEL_FAN_MID = 2
+        LEVEL_FAN_MAX = 3
+        LEVEL_TEMP_HIGH = 4
+        LEVEL_TEMP_CRITICAL = 5
+
+        FAN_NUM = 2
+        FAN_TRAY_NUM = 6
+
+        fan_policy_state_pwm_tlb = {
+            LEVEL_FAN_DEF:          [38,  0x4],
+            LEVEL_FAN_MID:          [75,  0xB],
+            LEVEL_FAN_MAX:          [100, 0xE],
+            LEVEL_TEMP_HIGH:        [100, 0xE],
+            LEVEL_TEMP_CRITICAL:    [100, 0xE],
+        }
+        global platform_chassis
+        global fan_policy_state
+        global fan_fail
+        global test_temp
+        global test_temp_list
+        global temp_test_data
+        global test_temp_revert
+        global alarm_state
+        fan_policy = {
+            0: [0,     39000,   LEVEL_FAN_DEF],  # F2B_policy, B2F_plicy, PWM, reg_val
+            1: [39000, 45000,   LEVEL_FAN_MID],
+            2: [45000, 61000,   LEVEL_FAN_MAX],
+            3: [61000, 66000,   LEVEL_TEMP_HIGH],
+            4: [66000, 200000,  LEVEL_TEMP_CRITICAL],
+        }
+
+        fan_dir = platform_chassis.get_fan(0).get_direction()
+        ori_perc = platform_chassis.get_fan(0).get_speed()
+        #logging.debug('fan_dir=%s, ori_perc=%f', fan_dir, ori_perc)
+        #logging.debug('test_temp=%d', test_temp)
+        if test_temp == 0:
+            temp2 = platform_chassis.get_thermal(1).get_temperature()*1000
+            temp4 = platform_chassis.get_thermal(3).get_temperature()*1000
+        else:
+            temp2 = test_temp_list[0]
+            temp4 = test_temp_list[1]
+            # fan_fail=0 # When test no-fan DUT. Need to use this.
+            if test_temp_revert == 0:
+                temp_test_data = temp_test_data+2000
+            else:
+                temp_test_data = temp_test_data-2000
+
+        if temp2 == 0:
+            temp_get = 50000  # if one detect sensor is fail or zero, assign temp=50000, let fan to 75%
+            logging.debug('lm75_49 detect fail, so set temp_get=50000, let fan to 75%')
+        elif temp2 == 0:
+            temp_get = 50000  # if one detect sensor is fail or zero, assign temp=50000, let fan to 75%
+            logging.debug('lm75_4b detect fail, so set temp_get=50000, let fan to 75%')
+        else:
+            temp_get = (temp2 + temp4)/2  # Use (sensor_LM75_49 + Thermal sensor_LM75_CPU_4B) /2
+        logging.debug('Begeinning ,fan_policy_state=%d', fan_policy_state)
+        if test_temp == 1:
+            temp_get = temp_get+temp_test_data
+
+        ori_state = fan_policy_state
+        fan_policy_state = self.get_state_from_fan_policy(temp_get, fan_policy)
+        #logging.debug("temp2=" + str(temp2))
+        #logging.debug("temp4=" + str(temp4))
+        #logging.debug("temp_get=" + str(temp_get))
+        logging.debug('temp2=lm75_49=%d,temp4=lm_4b=%d, temp_get=%d, ori_state=%d', temp2, temp4, temp_get, ori_state)
+        if fan_policy_state > ori_state:
+            logging.debug('ori_state=%d, fan_policy_state=%d', ori_state, fan_policy_state)
+        new_perc = fan_policy_state_pwm_tlb[fan_policy_state][0]
+
+        if fan_fail == 0:
+            if new_perc != ori_perc:
+                # fan.set_fan_duty_cycle(new_perc)
+                platform_chassis.get_fan(0).set_speed(new_perc)
+                logging.info('Set fan speed from %d to %d', ori_perc, new_perc)
+
+        # for i in range (fan.FAN_NUM_1_IDX, fan.FAN_NUM_ON_MAIN_BROAD+1):
+        for i in range(FAN_TRAY_NUM * FAN_NUM):
+            if not platform_chassis.get_fan(i).get_status() or not platform_chassis.get_fan(i).get_speed_rpm():
+                new_perc = 100
+                logging.debug('fan_%d fail, set new_perc to 100', i+1)
+                # if test_temp==0:# When test no-fan DUT. Need to use this.
+                fan_fail = 1
+                if ori_state < LEVEL_FAN_MAX:
+                    fan_policy_state = new_state = LEVEL_FAN_MAX
+                    logging.debug('fan_policy_state=%d', fan_policy_state)
+                    logging.warning('fan_policy_state is LEVEL_FAN_MAX')
+                platform_chassis.get_fan(0).set_speed(new_perc)
+                break
+            else:
+                fan_fail = 0
+
+        if fan_fail == 0:
+            new_state = fan_policy_state
+        else:
+            if fan_policy_state > ori_state:
+                new_state = fan_policy_state
+            else:
+                fan_policy_state = new_state = LEVEL_FAN_MAX
+
+        if ori_state == LEVEL_FAN_DEF:
+            if new_state == LEVEL_TEMP_HIGH:
+                if alarm_state == 0:
+                    logging.warning('Alarm for temperature high is detected')
+                alarm_state = 1
+            if new_state == LEVEL_TEMP_CRITICAL:
+                logging.critical('Alarm for temperature critical is detected, reboot DUT')
+                time.sleep(2)
+                os.system('reboot')
+        if ori_state == LEVEL_FAN_MID:
+            if new_state == LEVEL_TEMP_HIGH:
+                if alarm_state == 0:
+                    logging.warning('Alarm for temperature high is detected')
+                alarm_state = 1
+            if new_state == LEVEL_TEMP_CRITICAL:
+                logging.critical('Alarm for temperature critical is detected')
+                time.sleep(2)
+                os.system('reboot')
+        if ori_state == LEVEL_FAN_MAX:
+            if new_state == LEVEL_TEMP_HIGH:
+                if alarm_state == 0:
+                    logging.warning('Alarm for temperature high is detected')
+                alarm_state = 1
+            if new_state == LEVEL_TEMP_CRITICAL:
+                logging.critical('Alarm for temperature critical is detected')
+                time.sleep(2)
+                os.system('reboot')
+            if alarm_state == 1:
+                if temp_get < (fan_policy[3][0] - 5000):  # below 65 C, clear alarm
+                    logging.warning('Alarm for temperature high is cleared')
+                    alarm_state = 0
+        if ori_state == LEVEL_TEMP_HIGH:
+            if new_state == LEVEL_TEMP_CRITICAL:
+                logging.critical('Alarm for temperature critical is detected')
+                time.sleep(2)
+                os.system('reboot')
+            if new_state <= LEVEL_FAN_MID:
+                logging.warning('Alarm for temperature high is cleared')
+                alarm_state = 0
+            if new_state <= LEVEL_FAN_MAX:
+                if temp_get < (fan_policy[3][0] - 5000):  # below 65 C, clear alarm
+                    logging.warning('Alarm for temperature high is cleared')
+                    alarm_state = 0
+        if ori_state == LEVEL_TEMP_CRITICAL:
+            if new_state <= LEVEL_FAN_MAX:
+                logging.warning('Alarm for temperature critical is cleared')
+
+        return True
+
+
+def main(argv):
+    log_file = '%s.log' % FUNCTION_NAME
+    log_level = logging.INFO
+    global test_temp
+    if len(sys.argv) != 1:
+        try:
+            opts, args = getopt.getopt(argv, 'hdlt:', ['lfile='])
+        except getopt.GetoptError:
+            print('Usage: %s [-d] [-l <log_file>]' % sys.argv[0])
+            return 0
+        for opt, arg in opts:
+            if opt == '-h':
+                print('Usage: %s [-d] [-l <log_file>]' % sys.argv[0])
+                return 0
+            elif opt in ('-d', '--debug'):
+                log_level = logging.DEBUG
+            elif opt in ('-l', '--lfile'):
+                log_file = arg
+
+        if sys.argv[1] == '-t':
+            if len(sys.argv) != 4:
+                print("temp test, need input four temp")
+                return 0
+
+            i = 0
+            for x in range(2, 4):
+                test_temp_list[i] = int(sys.argv[x])*1000
+                i = i+1
+            test_temp = 1
+            log_level = logging.DEBUG
+            print(test_temp_list)
+
+    global platform_chassis
+    platform_chassis = platform.Platform().get_chassis()
+
+    platform_chassis.get_fan(0).set_speed(38)
+
+    print("set default fan speed to 37.5%")
+    monitor = device_monitor(log_file, log_level)
+
+    while True:
+        monitor.manage_fans()
+        time.sleep(5)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pddf_switch_svc.py
@@ -81,15 +81,7 @@ def stop_platform_pddf():
     return True
 
 def main():
-    print"stop_platform_svc"
-    stop_platform_svc()
-    #print"start_platform_svc"
-    #start_platform_svc()
-    #print"start_platform_pddf"
-    #start_platform_pddf()
-    print"stop_platform_pddf"
-    stop_platform_pddf()
-    #pass
+    pass
 
 if __name__ == "__main__":
     main()

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pddf_switch_svc.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # Script to stop and start the respective platforms default services. 
 # This will be used while switching the pddf->non-pddf mode and vice versa
-import os
-import sys
+
 import commands
 
 def check_pddf_support():
@@ -81,7 +80,15 @@ def stop_platform_pddf():
     return True
 
 def main():
-    pass
+    print"stop_platform_svc"
+    stop_platform_svc()
+    #print"start_platform_svc"
+    #start_platform_svc()
+    #print"start_platform_pddf"
+    #start_platform_pddf()
+    print"stop_platform_pddf"
+    stop_platform_pddf()
+    #pass
 
 if __name__ == "__main__":
     main()

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pddf_switch_svc.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# Script to stop and start the respective platforms default services. 
+# This will be used while switching the pddf->non-pddf mode and vice versa
+import os
+import sys
+import commands
+
+def check_pddf_support():
+    return True
+
+def stop_platform_svc():
+    
+    status, output = commands.getstatusoutput("systemctl stop as7326-platform-monitor-fan.service")
+    if status:
+        print "Stop as7326-platform-fan.service failed %d"%status
+        return False
+    
+    status, output = commands.getstatusoutput("systemctl stop as7326-platform-monitor-psu.service")
+    if status:
+        print "Stop as7326-platform-psu.service failed %d"%status
+        return False
+    
+    status, output = commands.getstatusoutput("systemctl stop as7326-platform-monitor.service")
+    if status:
+        print "Stop as7326-platform-init.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl disable as7326-platform-monitor.service")
+    if status:
+        print "Disable as7326-platform-monitor.service failed %d"%status
+        return False
+    
+    status, output = commands.getstatusoutput("/usr/local/bin/accton_as7326_util.py clean")
+    if status:
+        print "accton_as7326_util.py clean command failed %d"%status
+        return False
+
+    # HACK , stop the pddf-platform-init service if it is active
+    status, output = commands.getstatusoutput("systemctl stop pddf-platform-init.service")
+    if status:
+        print "Stop pddf-platform-init.service along with other platform serives failed %d"%status
+        return False
+
+    return True
+    
+def start_platform_svc():
+    status, output = commands.getstatusoutput("/usr/local/bin/accton_as7326_util.py install")
+    if status:
+        print "accton_as7326_util.py install command failed %d"%status
+        return False
+
+    status, output = commands.getstatusoutput("systemctl enable as7326-platform-monitor.service")
+    if status:
+        print "Enable as7326-platform-monitor.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl start as7326-platform-monitor-fan.service")
+    if status:
+        print "Start as7326-platform-monitor-fan.service failed %d"%status
+        return False
+        
+    status, output = commands.getstatusoutput("systemctl start as7326-platform-monitor-psu.service")
+    if status:
+        print "Start as7326-platform-monitor-psu.service failed %d"%status
+        return False
+
+    return True
+
+def start_platform_pddf():
+    status, output = commands.getstatusoutput("systemctl start pddf-platform-init.service")
+    if status:
+        print "Start pddf-platform-init.service failed %d"%status
+        return False
+    
+    return True
+
+def stop_platform_pddf():
+    status, output = commands.getstatusoutput("systemctl stop pddf-platform-init.service")
+    if status:
+        print "Stop pddf-platform-init.service failed %d"%status
+        return False
+
+    return True
+
+def main():
+    print"stop_platform_svc"
+    stop_platform_svc()
+    #print"start_platform_svc"
+    #start_platform_svc()
+    #print"start_platform_pddf"
+    #start_platform_pddf()
+    print"stop_platform_pddf"
+    stop_platform_pddf()
+    #pass
+
+if __name__ == "__main__":
+    main()
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.install
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.install
@@ -1,0 +1,1 @@
+as7326-56x/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-accton_as7326_56x-r0/pddf

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.postinst
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.postinst
@@ -1,6 +1,25 @@
 # Special arrangement to make PDDF mode default
 # Disable monitor, monitor-fan, monitor-psu (not enabling them would imply they will be disabled by default)
 # Enable pddf-platform-monitor
+
+# Steps to check syseeprom i2c address
+modprobe i2c-i801
+modprobe i2c-dev
+use_57_eeprom=true
+(i2cget -y -f 0 0x56 0x0) > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    use_57_eeprom=false
+fi
+
+if $use_57_eeprom ; then
+    echo "The board has system EEPROM at I2C address 0x57"
+    # syseeprom is at the i2c address 0x57. Change the PDDF JSON file
+    sed -i 's@"topo_info": {"parent_bus": "0x0", "dev_addr": "0x56", "dev_type": "24c04"},@\
+        "topo_info": {"parent_bus": "0x0", "dev_addr": "0x57", "dev_type": "24c02"},@g' \
+        /usr/share/sonic/device/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
+    sync
+fi
+
 depmod -a
 systemctl enable as7326-platform-handle_mac.service
 systemctl start as7326-platform-handle_mac.service

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.postinst
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.postinst
@@ -1,0 +1,10 @@
+# Special arrangement to make PDDF mode default
+# Disable monitor, monitor-fan, monitor-psu (not enabling them would imply they will be disabled by default)
+# Enable pddf-platform-monitor
+depmod -a
+systemctl enable as7326-platform-handle_mac.service
+systemctl start as7326-platform-handle_mac.service
+systemctl enable pddf-platform-init.service
+systemctl start pddf-platform-init.service
+systemctl enable as7326-56x-pddf-platform-monitor.service
+systemctl start as7326-56x-pddf-platform-monitor.service


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add to support PDDF.
#### How I did it
Implement pddff related code.
#### How to verify it
Test pddf cmd, sfputil , sensors.
root@sonic:~# pddf_psuutil seninfo
PSU1 is Not OK

PSU2 is OK
Output Voltage: 12062.0 mv
Output Current: 17000.0 ma
Output Power: 206000.0 mw
Fan1 Speed: 6144 rpm

root@sonic:~#
root@sonic:~# pddf_psuutil mfrinfo
PSU1 is Not OK

PSU2 is OK
Manufacture Id: ACBEL
Model: FSF019
Serial Number: FSF0191813105530
Fan Direction: Exhaust

root@sonic:~#
root@sonic:~# pddf_psuutil status
PSU    Status
-----  --------
PSU1   NOT OK
PSU2   OK
root@sonic:~# sensors

fan_ctrl-i2c-11-66
Adapter: i2c-1-mux (chan_id 2)
fan1:        23200 RPM
fan2:        19200 RPM
fan3:        23400 RPM
fan4:        19500 RPM
fan5:        24000 RPM
fan6:        19600 RPM
fan7:           0 RPM
fan8:           0 RPM
fan9:        22500 RPM
fan10:       19600 RPM
fan11:       23300 RPM
fan12:       19300 RPM

pch_haswell-virtual-0
Adapter: Virtual device
temp1:        +36.5 C

psu_pmbus-i2c-17-59
Adapter: i2c-1-mux (chan_id 0)
in3:          +0.00 V
fan1:           0 RPM
power2:        0.00 W
curr2:        +0.00 A

lm75-i2c-15-4a
Adapter: i2c-1-mux (chan_id 6)
temp1:        +26.0 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-15-48
Adapter: i2c-1-mux (chan_id 6)
temp1:        +31.0 C  (high = +80.0 C, hyst = +75.0 C)

psu_pmbus-i2c-13-5b
Adapter: i2c-1-mux (chan_id 4)
in3:         +12.06 V
fan1:        6144 RPM
power2:      241.00 W
curr2:       +21.00 A

coretemp-isa-0000
Adapter: ISA adapter
Physical id 0:  +40.0 C  (high = +82.0 C, crit = +104.0 C)
Core 0:         +40.0 C  (high = +82.0 C, crit = +104.0 C)
Core 1:         +40.0 C  (high = +82.0 C, crit = +104.0 C)
Core 2:         +40.0 C  (high = +82.0 C, crit = +104.0 C)
Core 3:         +40.0 C  (high = +82.0 C, crit = +104.0 C)

lm75-i2c-15-4b
Adapter: i2c-1-mux (chan_id 6)
temp1:        +26.0 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-15-49
Adapter: i2c-1-mux (chan_id 6)
temp1:        +29.5 C  (high = +80.0 C, hyst = +75.0 C)


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

