### PR TITLE
[minigraph] Add downstreamsubrole parsing to minigraph.py

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -787,6 +787,7 @@ def parse_meta(meta, hname):
     region = None
     cloudtype = None
     resource_type = None
+    downstream_subrole = None
     kube_data = {}
     device_metas = meta.find(str(QName(ns, "Devices")))
     for device in device_metas.findall(str(QName(ns1, "DeviceMetadata"))):
@@ -816,11 +817,13 @@ def parse_meta(meta, hname):
                     cloudtype = value
                 elif name == "ResourceType":
                     resource_type = value
+                elif name == "DownStreamSubRole":
+                    downstream_subrole = value
                 elif name == "KubernetesEnabled":
                     kube_data["enable"] = value
                 elif name == "KubernetesServerIp":
                     kube_data["ip"] = value
-    return syslog_servers, dhcp_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, kube_data
+    return syslog_servers, dhcp_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, downstream_subrole, kube_data
 
 
 def parse_linkmeta(meta, hname):
@@ -1093,6 +1096,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     devices = None
     sub_role = None
     resource_type = None
+    downstream_subrole = None
     docker_routing_config_mode = "separated"
     port_speeds_default = {}
     port_speed_png = {}
@@ -1151,7 +1155,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             elif child.tag == str(QName(ns, "UngDec")):
                 (u_neighbors, u_devices, _, _, _, _, _, _) = parse_png(child, hostname, None)
             elif child.tag == str(QName(ns, "MetadataDeclaration")):
-                (syslog_servers, dhcp_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, kube_data) = parse_meta(child, hostname)
+                (syslog_servers, dhcp_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, downstream_subrole, kube_data) = parse_meta(child, hostname)
             elif child.tag == str(QName(ns, "LinkMetadataDeclaration")):
                 linkmetas = parse_linkmeta(child, hostname)
             elif child.tag == str(QName(ns, "DeviceInfos")):
@@ -1225,6 +1229,9 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
 
     if resource_type is not None:
         results['DEVICE_METADATA']['localhost']['resource_type'] = resource_type
+
+    if downstream_subrole is not None:
+        results['DEVICE_METADATA']['localhost']['downstream_subrole'] = downstream_subrole
 
     results['BGP_NEIGHBOR'] = bgp_sessions
     results['BGP_MONITORS'] = bgp_monitors

--- a/src/sonic-config-engine/tests/simple-sample-graph-metadata.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-metadata.xml
@@ -258,6 +258,11 @@
      <a:Reference i:nil="true"/>
      <a:Value>resource_type_x</a:Value>
     </a:DeviceProperty>
+    <a:DeviceProperty>
+     <a:Name>DownStreamSubRole</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>downstream_subrole_y</a:Value>
+    </a:DeviceProperty>
   </a:Properties>
   </a:DeviceMetadata>
  </Devices>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -88,6 +88,11 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'resource_type_x')
 
+    def test_minigraph_downstream_subrole(self):
+        argument = '-v "DEVICE_METADATA[\'localhost\'][\'downstream_subrole\']" -m "' + self.sample_graph_metadata + '"'
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), 'downstream_subrole_y')
+
     def test_print_data(self):
         argument = '-m "' + self.sample_graph + '" --print-data'
         output = self.run_script(argument)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
So that downstreamsubrole values can be used for policies

#### How I did it
Added downstream_subrole to DEVICE_METADATA section of config_db

#### How to verify it
Unit testing in sonic-config-engine

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

