### PR TITLE
libnl3 updates for MPLS

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -11,7 +11,8 @@
             "polling_interval": "300",
 {%- for crm_res in ["ipv4_route", "ipv6_route", "ipv4_nexthop", "ipv6_nexthop", "ipv4_neighbor",
                     "ipv6_neighbor", "nexthop_group_member", "nexthop_group", "acl_table",
-                    "acl_group", "acl_entry", "acl_counter", "fdb_entry", "snat_entry", "dnat_entry", "ipmc_entry"] %}
+                    "acl_group", "acl_entry", "acl_counter", "fdb_entry", "snat_entry", "dnat_entry",
+                    "ipmc_entry", "mpls_inseg", "mpls_nexthop"] %}
             "{{crm_res}}_threshold_type": "percentage",
             "{{crm_res}}_low_threshold": "70",
             "{{crm_res}}_high_threshold": "85"{% if not loop.last %},{% endif -%}

--- a/src/libnl3/.gitignore
+++ b/src/libnl3/.gitignore
@@ -3,3 +3,4 @@
 !debian/
 debian/libnl-*/
 !Makefile
+!patch

--- a/src/libnl3/Makefile
+++ b/src/libnl3/Makefile
@@ -20,6 +20,10 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	pushd libnl3-$(LIBNL3_VERSION_BASE)
 	git checkout tags/libnl$(subst .,_,$(LIBNL3_VERSION_BASE))
 
+	git checkout -b sonic
+	stg init
+	stg import -s ../patch/series
+
 	ln -s ../debian debian
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 	popd

--- a/src/libnl3/patch/0001-mpls-encap-accessors.patch
+++ b/src/libnl3/patch/0001-mpls-encap-accessors.patch
@@ -1,0 +1,77 @@
+From 701122c539d6da3fbd3367be6e62141328ebeb07 Mon Sep 17 00:00:00 2001
+From: Ann Pokora <apokora@juniper.net>
+Date: Tue, 25 May 2021 18:07:37 -0700
+Subject: [PATCH 1/2] mpls encap accessors
+
+Signed-off-by: Ann Pokora <apokora@juniper.net>
+---
+ include/netlink/route/nexthop.h |  2 ++
+ lib/route/nh_encap_mpls.c       | 28 ++++++++++++++++++++++++++++
+ libnl-route-3.sym               |  2 ++
+ 3 files changed, 32 insertions(+)
+
+diff --git a/include/netlink/route/nexthop.h b/include/netlink/route/nexthop.h
+index 5b422dd..a502005 100644
+--- a/include/netlink/route/nexthop.h
++++ b/include/netlink/route/nexthop.h
+@@ -70,6 +70,8 @@ extern int		rtnl_route_nh_str2flags(const char *);
+ extern int		rtnl_route_nh_encap_mpls(struct rtnl_nexthop *nh,
+ 						 struct nl_addr *addr,
+ 						 uint8_t ttl);
++extern struct nl_addr *	rtnl_route_nh_get_encap_mpls_dst(struct rtnl_nexthop *);
++extern uint8_t		rtnl_route_nh_get_encap_mpls_ttl(struct rtnl_nexthop *);
+ #ifdef __cplusplus
+ }
+ #endif
+diff --git a/lib/route/nh_encap_mpls.c b/lib/route/nh_encap_mpls.c
+index 081661e..18336ac 100644
+--- a/lib/route/nh_encap_mpls.c
++++ b/lib/route/nh_encap_mpls.c
+@@ -133,3 +133,31 @@ int rtnl_route_nh_encap_mpls(struct rtnl_nexthop *nh,
+ 
+ 	return 0;
+ }
++
++struct nl_addr *rtnl_route_nh_get_encap_mpls_dst(struct rtnl_nexthop *nh)
++{
++	struct mpls_iptunnel_encap *mpls_encap;
++
++	if (!nh->rtnh_encap || nh->rtnh_encap->ops->encap_type != LWTUNNEL_ENCAP_MPLS)
++		return NULL;
++
++	mpls_encap = (struct mpls_iptunnel_encap *)nh->rtnh_encap->priv;
++	if (!mpls_encap)
++		return NULL;
++
++	return mpls_encap->dst;
++}
++
++uint8_t rtnl_route_nh_get_encap_mpls_ttl(struct rtnl_nexthop *nh)
++{
++	struct mpls_iptunnel_encap *mpls_encap;
++
++	if (!nh->rtnh_encap || nh->rtnh_encap->ops->encap_type != LWTUNNEL_ENCAP_MPLS)
++		return 0;
++
++	mpls_encap = (struct mpls_iptunnel_encap *)nh->rtnh_encap->priv;
++	if (!mpls_encap)
++		return 0;
++
++	return mpls_encap->ttl;
++}
+diff --git a/libnl-route-3.sym b/libnl-route-3.sym
+index 4a65503..ce6d714 100644
+--- a/libnl-route-3.sym
++++ b/libnl-route-3.sym
+@@ -1127,6 +1127,8 @@ global:
+ 	rtnl_qdisc_mqprio_set_priomap;
+ 	rtnl_qdisc_mqprio_set_queue;
+ 	rtnl_qdisc_mqprio_set_shaper;
++	rtnl_route_nh_get_encap_mpls_dst;
++	rtnl_route_nh_get_encap_mpls_ttl;
+ 	rtnl_rule_get_dport;
+ 	rtnl_rule_get_ipproto;
+ 	rtnl_rule_get_protocol;
+-- 
+2.7.4
+

--- a/src/libnl3/patch/0002-mpls-remove-nl_addr_valid.patch
+++ b/src/libnl3/patch/0002-mpls-remove-nl_addr_valid.patch
@@ -1,0 +1,63 @@
+From c89d1a129f71d3d2f76e6cbadb11ef41d8941a73 Mon Sep 17 00:00:00 2001
+From: Ann Pokora <apokora@juniper.net>
+Date: Tue, 25 May 2021 18:10:04 -0700
+Subject: [PATCH 2/2] mpls remove nl_addr_valid
+
+The removed calls to nl_addr_valid() are passing in a pointer to a binary address
+and the length of the binary address, which does not match expected arguments for
+nl_addr_valid().
+nl_addr_valid() expects a pointer to an ASCII string and the address family of
+the string format.
+The incorrect arguments cause unexpected failures and the expected arguments are
+not available in the context.
+
+Signed-off-by: Ann Pokora <apokora@juniper.net>
+---
+ lib/route/nexthop.c       | 8 --------
+ lib/route/nh_encap_mpls.c | 4 ----
+ 2 files changed, 12 deletions(-)
+
+diff --git a/lib/route/nexthop.c b/lib/route/nexthop.c
+index 7a9904c..ac0095e 100644
+--- a/lib/route/nexthop.c
++++ b/lib/route/nexthop.c
+@@ -351,10 +351,6 @@ int rtnl_route_nh_set_newdst(struct rtnl_nexthop *nh, struct nl_addr *addr)
+ {
+ 	struct nl_addr *old = nh->rtnh_newdst;
+ 
+-	if (!nl_addr_valid(nl_addr_get_binary_addr(addr),
+-			   nl_addr_get_len(addr)))
+-		return -NLE_INVAL;
+-
+ 	if (addr) {
+ 		nh->rtnh_newdst = nl_addr_get(addr);
+ 		nh->ce_mask |= NH_ATTR_NEWDST;
+@@ -378,10 +374,6 @@ int rtnl_route_nh_set_via(struct rtnl_nexthop *nh, struct nl_addr *addr)
+ {
+ 	struct nl_addr *old = nh->rtnh_via;
+ 
+-	if (!nl_addr_valid(nl_addr_get_binary_addr(addr),
+-			   nl_addr_get_len(addr)))
+-		return -NLE_INVAL;
+-
+ 	if (addr) {
+ 		nh->rtnh_via = nl_addr_get(addr);
+ 		nh->ce_mask |= NH_ATTR_VIA;
+diff --git a/lib/route/nh_encap_mpls.c b/lib/route/nh_encap_mpls.c
+index 18336ac..6c5a3c7 100644
+--- a/lib/route/nh_encap_mpls.c
++++ b/lib/route/nh_encap_mpls.c
+@@ -109,10 +109,6 @@ int rtnl_route_nh_encap_mpls(struct rtnl_nexthop *nh,
+ 	if (!addr)
+ 		return -NLE_INVAL;
+ 
+-	if (!nl_addr_valid(nl_addr_get_binary_addr(addr),
+-			   nl_addr_get_len(addr)))
+-		return -NLE_INVAL;
+-
+ 	rtnh_encap = calloc(1, sizeof(*rtnh_encap));
+ 	if (!rtnh_encap)
+ 		return -NLE_NOMEM;
+-- 
+2.7.4
+

--- a/src/libnl3/patch/series
+++ b/src/libnl3/patch/series
@@ -1,0 +1,2 @@
+0001-mpls-encap-accessors.patch
+0002-mpls-remove-nl_addr_valid.patch


### PR DESCRIPTION
What I did
SONiC buildimage support for MPLS:
1) New accessors in libnl3 for MPLS attributes
2) bug fixes in libnl3 for MPLS attribute parsing

Why I did it
SONiC libnl3 support for MPLS

How I verified it
Unit-tests in sonic-swss/tests/test_mpls.py and sonic-utilities/tests
System tests in sonic-mgmt

Details if related
Refer to HLD: Azure/SONiC#706