### PR TITLE
[docker-sonic-mgmt]: add snappi[ixnetwork]==0.3.4

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -66,6 +66,7 @@ RUN pip install cffi==1.10.0 \
                 requests \
                 rpyc \
                 six \
+                statistics \
                 tabulate \
                 textfsm \
                 virtualenv \

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -41,6 +41,7 @@ RUN pip install cffi==1.10.0 \
                 ipython==5.4.1 \
                 ixnetwork-restpy==1.0.52 \
                 ixnetwork-open-traffic-generator==0.0.70 \
+                snappi[ixnetwork]==0.3.4 \
                 jinja2==2.7.2 \
                 jsonpatch \
                 lxml \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to support Pull Request: BGP Convergence Testplan for Benchmark Performance #3164
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--

-->
The PR has snappi[ixnetwork]==0.3.4 module support

#### A picture of a cute animal (not mandatory but encouraged)

