### PR TITLE
[sonic-config-engine]: Update L2 preset for dualtor

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -1,4 +1,13 @@
+import sys
+
+from ipaddress import ip_interface
 from natsort import natsorted
+
+#TODO: Remove once Python 2 support is removed
+if sys.version_info.major == 3:
+    UNICODE_TYPE = str
+else:
+    UNICODE_TYPE = unicode
 
 def generate_t1_sample_config(data):
     data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
@@ -39,11 +48,44 @@ def generate_empty_config(data):
     return new_data
 
 def generate_l2_config(data):
+    if 'is_dualtor' in data and data['is_dualtor']:
+        is_dualtor = True
+        data.pop('is_dualtor')
+    else:
+        is_dualtor = False
     data['VLAN'] = {'Vlan1000': {'vlanid': '1000'}}
     data['VLAN_MEMBER'] = {}
-    for port in natsorted(data['PORT']):
+    if is_dualtor:
+        data['DEVICE_METADATA']['localhost']['subtype'] = 'DualToR'
+        data['MUX_CABLE'] = {}
+        data['PEER_SWITCH'] = {
+                                "peer_switch_hostname": {
+                                    "address_ipv4": "1.1.1.1"
+                                }
+                              }
+        data['TUNNEL'] = {
+                            "MuxTunnel0": {
+                                "dscp_mode": "uniform",
+                                "dst_ip": "2.2.2.2",
+                                "ecn_mode": "copy_from_outer",
+                                "encap_ecn_mode": "standard",
+                                "ttl_mode": "pipe",
+                                "tunnel_type": "IPINIP"
+                            }
+                         }
+
+        server_ipv4_base = ip_interface(UNICODE_TYPE('192.168.0.1/32'))
+        server_ipv6_base = ip_interface(UNICODE_TYPE('fc02:1000::1/128'))
+    for i, port in enumerate(natsorted(data['PORT'])):
         data['PORT'][port].setdefault('admin_status', 'up')
         data['VLAN_MEMBER']['Vlan1000|{}'.format(port)] = {'tagging_mode': 'untagged'}
+        if is_dualtor:
+            mux_cable_entry = {
+                'server_ipv4': str(server_ipv4_base + i),
+                'server_ipv6': str(server_ipv6_base + i),
+                'state': 'auto'
+            }
+            data['MUX_CABLE'][port] = mux_cable_entry
     return data
 
 _sample_generators = {

--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -57,6 +57,10 @@ def generate_l2_config(data):
     data['VLAN_MEMBER'] = {}
     if is_dualtor:
         data['DEVICE_METADATA']['localhost']['subtype'] = 'DualToR'
+        data['LOOPBACK_INTERFACE'] = {
+                                        'Loopback2': {},
+                                        'Loopback2|3.3.3.3': {}
+                                     }
         data['MUX_CABLE'] = {}
         data['PEER_SWITCH'] = {
                                 "peer_switch_hostname": {

--- a/src/sonic-config-engine/tests/sample_output/py2/l2switch_dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/l2switch_dualtor.json
@@ -1,0 +1,450 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "hwsku": "Mellanox-SN2700",
+            "subtype": "DualToR"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "alias": "fortyGigE0/0",
+            "lanes": "29,30,31,32",
+            "admin_status": "up"
+        },
+        "Ethernet4": {
+            "alias": "fortyGigE0/4",
+            "lanes": "25,26,27,28",
+            "admin_status": "up"
+        },
+        "Ethernet8": {
+            "alias": "fortyGigE0/8",
+            "lanes": "37,38,39,40",
+            "admin_status": "up"
+        },
+        "Ethernet12": {
+            "alias": "fortyGigE0/12",
+            "lanes": "33,34,35,36",
+            "admin_status": "up"
+        },
+        "Ethernet16": {
+            "alias": "fortyGigE0/16",
+            "lanes": "41,42,43,44",
+            "admin_status": "up"
+        },
+        "Ethernet20": {
+            "alias": "fortyGigE0/20",
+            "lanes": "45,46,47,48",
+            "admin_status": "up"
+        },
+        "Ethernet24": {
+            "alias": "fortyGigE0/24",
+            "lanes": "5,6,7,8",
+            "admin_status": "up"
+        },
+        "Ethernet28": {
+            "alias": "fortyGigE0/28",
+            "lanes": "1,2,3,4",
+            "admin_status": "up"
+        },
+        "Ethernet32": {
+            "alias": "fortyGigE0/32",
+            "lanes": "9,10,11,12",
+            "admin_status": "up"
+        },
+        "Ethernet36": {
+            "alias": "fortyGigE0/36",
+            "lanes": "13,14,15,16",
+            "admin_status": "up"
+        },
+        "Ethernet40": {
+            "alias": "fortyGigE0/40",
+            "lanes": "21,22,23,24",
+            "admin_status": "up"
+        },
+        "Ethernet44": {
+            "alias": "fortyGigE0/44",
+            "lanes": "17,18,19,20",
+            "admin_status": "up"
+        },
+        "Ethernet48": {
+            "alias": "fortyGigE0/48",
+            "lanes": "49,50,51,52",
+            "admin_status": "up"
+        },
+        "Ethernet52": {
+            "alias": "fortyGigE0/52",
+            "lanes": "53,54,55,56",
+            "admin_status": "up"
+        },
+        "Ethernet56": {
+            "alias": "fortyGigE0/56",
+            "lanes": "61,62,63,64",
+            "admin_status": "up"
+        },
+        "Ethernet60": {
+            "alias": "fortyGigE0/60",
+            "lanes": "57,58,59,60",
+            "admin_status": "up"
+        },
+        "Ethernet64": {
+            "alias": "fortyGigE0/64",
+            "lanes": "65,66,67,68",
+            "admin_status": "up"
+        },
+        "Ethernet68": {
+            "alias": "fortyGigE0/68",
+            "lanes": "69,70,71,72",
+            "admin_status": "up"
+        },
+        "Ethernet72": {
+            "alias": "fortyGigE0/72",
+            "lanes": "77,78,79,80",
+            "admin_status": "up"
+        },
+        "Ethernet76": {
+            "alias": "fortyGigE0/76",
+            "lanes": "73,74,75,76",
+            "admin_status": "up"
+        },
+        "Ethernet80": {
+            "alias": "fortyGigE0/80",
+            "lanes": "105,106,107,108",
+            "admin_status": "up"
+        },
+        "Ethernet84": {
+            "alias": "fortyGigE0/84",
+            "lanes": "109,110,111,112",
+            "admin_status": "up"
+        },
+        "Ethernet88": {
+            "alias": "fortyGigE0/88",
+            "lanes": "117,118,119,120",
+            "admin_status": "up"
+        },
+        "Ethernet92": {
+            "alias": "fortyGigE0/92",
+            "lanes": "113,114,115,116",
+            "admin_status": "up"
+        },
+        "Ethernet96": {
+            "alias": "fortyGigE0/96",
+            "lanes": "121,122,123,124",
+            "admin_status": "up"
+        },
+        "Ethernet100": {
+            "alias": "fortyGigE0/100",
+            "lanes": "125,126,127,128",
+            "admin_status": "up"
+        },
+        "Ethernet104": {
+            "alias": "fortyGigE0/104",
+            "lanes": "85,86,87,88",
+            "admin_status": "up"
+        },
+        "Ethernet108": {
+            "alias": "fortyGigE0/108",
+            "lanes": "81,82,83,84",
+            "admin_status": "up"
+        },
+        "Ethernet112": {
+            "alias": "fortyGigE0/112",
+            "lanes": "89,90,91,92",
+            "admin_status": "up"
+        },
+        "Ethernet116": {
+            "alias": "fortyGigE0/116",
+            "lanes": "93,94,95,96",
+            "admin_status": "up"
+        },
+        "Ethernet120": {
+            "alias": "fortyGigE0/120",
+            "lanes": "97,98,99,100",
+            "admin_status": "up"
+        },
+        "Ethernet124": {
+            "alias": "fortyGigE0/124",
+            "lanes": "101,102,103,104",
+            "admin_status": "up"
+        }
+    },
+    "VLAN": {
+        "Vlan1000": {
+            "vlanid": "1000"
+        }
+    },
+    "VLAN_MEMBER": {
+        "Vlan1000|Ethernet0": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet4": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet8": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet12": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet16": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet20": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet24": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet28": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet32": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet36": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet40": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet44": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet48": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet52": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet56": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet60": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet64": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet68": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet72": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet76": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet80": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet84": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet88": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet92": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet96": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet100": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet104": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet108": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet112": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet116": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet120": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet124": {
+            "tagging_mode": "untagged"
+        }
+    },
+    "TUNNEL": {
+        "MuxTunnel0": {
+            "dscp_mode": "uniform",
+            "dst_ip": "2.2.2.2",
+            "ecn_mode": "copy_from_outer",
+            "encap_ecn_mode": "standard",
+            "ttl_mode": "pipe",
+            "tunnel_type": "IPINIP"
+        }
+    },
+    "PEER_SWITCH": {
+        "peer_switch_hostname": {
+            "address_ipv4": "1.1.1.1"
+        }
+    },
+    "MUX_CABLE":{
+        "Ethernet0": {
+            "server_ipv4": "192.168.0.1/32",
+            "server_ipv6": "fc02:1000::1/128",
+            "state": "auto"
+        },
+        "Ethernet4": {
+            "server_ipv4": "192.168.0.2/32",
+            "server_ipv6": "fc02:1000::2/128",
+            "state": "auto"
+        },
+        "Ethernet8": {
+            "server_ipv4": "192.168.0.3/32",
+            "server_ipv6": "fc02:1000::3/128",
+            "state": "auto"
+        },
+        "Ethernet12": {
+            "server_ipv4": "192.168.0.4/32",
+            "server_ipv6": "fc02:1000::4/128",
+            "state": "auto"
+        },
+        "Ethernet16": {
+            "server_ipv4": "192.168.0.5/32",
+            "server_ipv6": "fc02:1000::5/128",
+            "state": "auto"
+        },
+        "Ethernet20": {
+            "server_ipv4": "192.168.0.6/32",
+            "server_ipv6": "fc02:1000::6/128",
+            "state": "auto"
+        },
+        "Ethernet24": {
+            "server_ipv4": "192.168.0.7/32",
+            "server_ipv6": "fc02:1000::7/128",
+            "state": "auto"
+        },
+        "Ethernet28": {
+            "server_ipv4": "192.168.0.8/32",
+            "server_ipv6": "fc02:1000::8/128",
+            "state": "auto"
+        },
+        "Ethernet32": {
+            "server_ipv4": "192.168.0.9/32",
+            "server_ipv6": "fc02:1000::9/128",
+            "state": "auto"
+        },
+        "Ethernet36": {
+            "server_ipv4": "192.168.0.10/32",
+            "server_ipv6": "fc02:1000::a/128",
+            "state": "auto"
+        },
+        "Ethernet40": {
+            "server_ipv4": "192.168.0.11/32",
+            "server_ipv6": "fc02:1000::b/128",
+            "state": "auto"
+        },
+        "Ethernet44": {
+            "server_ipv4": "192.168.0.12/32",
+            "server_ipv6": "fc02:1000::c/128",
+            "state": "auto"
+        },
+        "Ethernet48": {
+            "server_ipv4": "192.168.0.13/32",
+            "server_ipv6": "fc02:1000::d/128",
+            "state": "auto"
+        },
+        "Ethernet52": {
+            "server_ipv4": "192.168.0.14/32",
+            "server_ipv6": "fc02:1000::e/128",
+            "state": "auto"
+        },
+        "Ethernet56": {
+            "server_ipv4": "192.168.0.15/32",
+            "server_ipv6": "fc02:1000::f/128",
+            "state": "auto"
+        },
+        "Ethernet60": {
+            "server_ipv4": "192.168.0.16/32",
+            "server_ipv6": "fc02:1000::10/128",
+            "state": "auto"
+        },
+        "Ethernet64": {
+            "server_ipv4": "192.168.0.17/32",
+            "server_ipv6": "fc02:1000::11/128",
+            "state": "auto"
+        },
+        "Ethernet68": {
+            "server_ipv4": "192.168.0.18/32",
+            "server_ipv6": "fc02:1000::12/128",
+            "state": "auto"
+        },
+        "Ethernet72": {
+            "server_ipv4": "192.168.0.19/32",
+            "server_ipv6": "fc02:1000::13/128",
+            "state": "auto"
+        },
+        "Ethernet76": {
+            "server_ipv4": "192.168.0.20/32",
+            "server_ipv6": "fc02:1000::14/128",
+            "state": "auto"
+        },
+        "Ethernet80": {
+            "server_ipv4": "192.168.0.21/32",
+            "server_ipv6": "fc02:1000::15/128",
+            "state": "auto"
+        },
+        "Ethernet84": {
+            "server_ipv4": "192.168.0.22/32",
+            "server_ipv6": "fc02:1000::16/128",
+            "state": "auto"
+        },
+        "Ethernet88": {
+            "server_ipv4": "192.168.0.23/32",
+            "server_ipv6": "fc02:1000::17/128",
+            "state": "auto"
+        },
+        "Ethernet92": {
+            "server_ipv4": "192.168.0.24/32",
+            "server_ipv6": "fc02:1000::18/128",
+            "state": "auto"
+        },
+        "Ethernet96": {
+            "server_ipv4": "192.168.0.25/32",
+            "server_ipv6": "fc02:1000::19/128",
+            "state": "auto"
+        },
+        "Ethernet100": {
+            "server_ipv4": "192.168.0.26/32",
+            "server_ipv6": "fc02:1000::1a/128",
+            "state": "auto"
+        },
+        "Ethernet104": {
+            "server_ipv4": "192.168.0.27/32",
+            "server_ipv6": "fc02:1000::1b/128",
+            "state": "auto"
+        },
+        "Ethernet108": {
+            "server_ipv4": "192.168.0.28/32",
+            "server_ipv6": "fc02:1000::1c/128",
+            "state": "auto"
+        },
+        "Ethernet112": {
+            "server_ipv4": "192.168.0.29/32",
+            "server_ipv6": "fc02:1000::1d/128",
+            "state": "auto"
+        },
+        "Ethernet116": {
+            "server_ipv4": "192.168.0.30/32",
+            "server_ipv6": "fc02:1000::1e/128",
+            "state": "auto"
+        },
+        "Ethernet120": {
+            "server_ipv4": "192.168.0.31/32",
+            "server_ipv6": "fc02:1000::1f/128",
+            "state": "auto"
+        },
+        "Ethernet124": {
+            "server_ipv4": "192.168.0.32/32",
+            "server_ipv6": "fc02:1000::20/128",
+            "state": "auto"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/sample_output/py2/l2switch_dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/l2switch_dualtor.json
@@ -285,6 +285,10 @@
             "address_ipv4": "1.1.1.1"
         }
     },
+    "LOOPBACK_INTERFACE": {
+        "Loopback2": {},
+        "Loopback2|3.3.3.3": {}
+    },
     "MUX_CABLE":{
         "Ethernet0": {
             "server_ipv4": "192.168.0.1/32",

--- a/src/sonic-config-engine/tests/sample_output/py3/l2switch_dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l2switch_dualtor.json
@@ -1,0 +1,450 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "hwsku": "Mellanox-SN2700",
+            "subtype": "DualToR"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "alias": "fortyGigE0/0",
+            "lanes": "29,30,31,32",
+            "admin_status": "up"
+        },
+        "Ethernet4": {
+            "alias": "fortyGigE0/4",
+            "lanes": "25,26,27,28",
+            "admin_status": "up"
+        },
+        "Ethernet8": {
+            "alias": "fortyGigE0/8",
+            "lanes": "37,38,39,40",
+            "admin_status": "up"
+        },
+        "Ethernet12": {
+            "alias": "fortyGigE0/12",
+            "lanes": "33,34,35,36",
+            "admin_status": "up"
+        },
+        "Ethernet16": {
+            "alias": "fortyGigE0/16",
+            "lanes": "41,42,43,44",
+            "admin_status": "up"
+        },
+        "Ethernet20": {
+            "alias": "fortyGigE0/20",
+            "lanes": "45,46,47,48",
+            "admin_status": "up"
+        },
+        "Ethernet24": {
+            "alias": "fortyGigE0/24",
+            "lanes": "5,6,7,8",
+            "admin_status": "up"
+        },
+        "Ethernet28": {
+            "alias": "fortyGigE0/28",
+            "lanes": "1,2,3,4",
+            "admin_status": "up"
+        },
+        "Ethernet32": {
+            "alias": "fortyGigE0/32",
+            "lanes": "9,10,11,12",
+            "admin_status": "up"
+        },
+        "Ethernet36": {
+            "alias": "fortyGigE0/36",
+            "lanes": "13,14,15,16",
+            "admin_status": "up"
+        },
+        "Ethernet40": {
+            "alias": "fortyGigE0/40",
+            "lanes": "21,22,23,24",
+            "admin_status": "up"
+        },
+        "Ethernet44": {
+            "alias": "fortyGigE0/44",
+            "lanes": "17,18,19,20",
+            "admin_status": "up"
+        },
+        "Ethernet48": {
+            "alias": "fortyGigE0/48",
+            "lanes": "49,50,51,52",
+            "admin_status": "up"
+        },
+        "Ethernet52": {
+            "alias": "fortyGigE0/52",
+            "lanes": "53,54,55,56",
+            "admin_status": "up"
+        },
+        "Ethernet56": {
+            "alias": "fortyGigE0/56",
+            "lanes": "61,62,63,64",
+            "admin_status": "up"
+        },
+        "Ethernet60": {
+            "alias": "fortyGigE0/60",
+            "lanes": "57,58,59,60",
+            "admin_status": "up"
+        },
+        "Ethernet64": {
+            "alias": "fortyGigE0/64",
+            "lanes": "65,66,67,68",
+            "admin_status": "up"
+        },
+        "Ethernet68": {
+            "alias": "fortyGigE0/68",
+            "lanes": "69,70,71,72",
+            "admin_status": "up"
+        },
+        "Ethernet72": {
+            "alias": "fortyGigE0/72",
+            "lanes": "77,78,79,80",
+            "admin_status": "up"
+        },
+        "Ethernet76": {
+            "alias": "fortyGigE0/76",
+            "lanes": "73,74,75,76",
+            "admin_status": "up"
+        },
+        "Ethernet80": {
+            "alias": "fortyGigE0/80",
+            "lanes": "105,106,107,108",
+            "admin_status": "up"
+        },
+        "Ethernet84": {
+            "alias": "fortyGigE0/84",
+            "lanes": "109,110,111,112",
+            "admin_status": "up"
+        },
+        "Ethernet88": {
+            "alias": "fortyGigE0/88",
+            "lanes": "117,118,119,120",
+            "admin_status": "up"
+        },
+        "Ethernet92": {
+            "alias": "fortyGigE0/92",
+            "lanes": "113,114,115,116",
+            "admin_status": "up"
+        },
+        "Ethernet96": {
+            "alias": "fortyGigE0/96",
+            "lanes": "121,122,123,124",
+            "admin_status": "up"
+        },
+        "Ethernet100": {
+            "alias": "fortyGigE0/100",
+            "lanes": "125,126,127,128",
+            "admin_status": "up"
+        },
+        "Ethernet104": {
+            "alias": "fortyGigE0/104",
+            "lanes": "85,86,87,88",
+            "admin_status": "up"
+        },
+        "Ethernet108": {
+            "alias": "fortyGigE0/108",
+            "lanes": "81,82,83,84",
+            "admin_status": "up"
+        },
+        "Ethernet112": {
+            "alias": "fortyGigE0/112",
+            "lanes": "89,90,91,92",
+            "admin_status": "up"
+        },
+        "Ethernet116": {
+            "alias": "fortyGigE0/116",
+            "lanes": "93,94,95,96",
+            "admin_status": "up"
+        },
+        "Ethernet120": {
+            "alias": "fortyGigE0/120",
+            "lanes": "97,98,99,100",
+            "admin_status": "up"
+        },
+        "Ethernet124": {
+            "alias": "fortyGigE0/124",
+            "lanes": "101,102,103,104",
+            "admin_status": "up"
+        }
+    },
+    "VLAN": {
+        "Vlan1000": {
+            "vlanid": "1000"
+        }
+    },
+    "VLAN_MEMBER": {
+        "Vlan1000|Ethernet0": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet4": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet8": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet12": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet16": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet20": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet24": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet28": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet32": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet36": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet40": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet44": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet48": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet52": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet56": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet60": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet64": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet68": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet72": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet76": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet80": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet84": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet88": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet92": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet96": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet100": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet104": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet108": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet112": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet116": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet120": {
+            "tagging_mode": "untagged"
+        },
+        "Vlan1000|Ethernet124": {
+            "tagging_mode": "untagged"
+        }
+    },
+    "TUNNEL": {
+        "MuxTunnel0": {
+            "dscp_mode": "uniform",
+            "dst_ip": "2.2.2.2",
+            "ecn_mode": "copy_from_outer",
+            "encap_ecn_mode": "standard",
+            "ttl_mode": "pipe",
+            "tunnel_type": "IPINIP"
+        }
+    },
+    "PEER_SWITCH": {
+        "peer_switch_hostname": {
+            "address_ipv4": "1.1.1.1"
+        }
+    },
+    "MUX_CABLE":{
+        "Ethernet0": {
+            "server_ipv4": "192.168.0.1/32",
+            "server_ipv6": "fc02:1000::1/128",
+            "state": "auto"
+        },
+        "Ethernet4": {
+            "server_ipv4": "192.168.0.2/32",
+            "server_ipv6": "fc02:1000::2/128",
+            "state": "auto"
+        },
+        "Ethernet8": {
+            "server_ipv4": "192.168.0.3/32",
+            "server_ipv6": "fc02:1000::3/128",
+            "state": "auto"
+        },
+        "Ethernet12": {
+            "server_ipv4": "192.168.0.4/32",
+            "server_ipv6": "fc02:1000::4/128",
+            "state": "auto"
+        },
+        "Ethernet16": {
+            "server_ipv4": "192.168.0.5/32",
+            "server_ipv6": "fc02:1000::5/128",
+            "state": "auto"
+        },
+        "Ethernet20": {
+            "server_ipv4": "192.168.0.6/32",
+            "server_ipv6": "fc02:1000::6/128",
+            "state": "auto"
+        },
+        "Ethernet24": {
+            "server_ipv4": "192.168.0.7/32",
+            "server_ipv6": "fc02:1000::7/128",
+            "state": "auto"
+        },
+        "Ethernet28": {
+            "server_ipv4": "192.168.0.8/32",
+            "server_ipv6": "fc02:1000::8/128",
+            "state": "auto"
+        },
+        "Ethernet32": {
+            "server_ipv4": "192.168.0.9/32",
+            "server_ipv6": "fc02:1000::9/128",
+            "state": "auto"
+        },
+        "Ethernet36": {
+            "server_ipv4": "192.168.0.10/32",
+            "server_ipv6": "fc02:1000::a/128",
+            "state": "auto"
+        },
+        "Ethernet40": {
+            "server_ipv4": "192.168.0.11/32",
+            "server_ipv6": "fc02:1000::b/128",
+            "state": "auto"
+        },
+        "Ethernet44": {
+            "server_ipv4": "192.168.0.12/32",
+            "server_ipv6": "fc02:1000::c/128",
+            "state": "auto"
+        },
+        "Ethernet48": {
+            "server_ipv4": "192.168.0.13/32",
+            "server_ipv6": "fc02:1000::d/128",
+            "state": "auto"
+        },
+        "Ethernet52": {
+            "server_ipv4": "192.168.0.14/32",
+            "server_ipv6": "fc02:1000::e/128",
+            "state": "auto"
+        },
+        "Ethernet56": {
+            "server_ipv4": "192.168.0.15/32",
+            "server_ipv6": "fc02:1000::f/128",
+            "state": "auto"
+        },
+        "Ethernet60": {
+            "server_ipv4": "192.168.0.16/32",
+            "server_ipv6": "fc02:1000::10/128",
+            "state": "auto"
+        },
+        "Ethernet64": {
+            "server_ipv4": "192.168.0.17/32",
+            "server_ipv6": "fc02:1000::11/128",
+            "state": "auto"
+        },
+        "Ethernet68": {
+            "server_ipv4": "192.168.0.18/32",
+            "server_ipv6": "fc02:1000::12/128",
+            "state": "auto"
+        },
+        "Ethernet72": {
+            "server_ipv4": "192.168.0.19/32",
+            "server_ipv6": "fc02:1000::13/128",
+            "state": "auto"
+        },
+        "Ethernet76": {
+            "server_ipv4": "192.168.0.20/32",
+            "server_ipv6": "fc02:1000::14/128",
+            "state": "auto"
+        },
+        "Ethernet80": {
+            "server_ipv4": "192.168.0.21/32",
+            "server_ipv6": "fc02:1000::15/128",
+            "state": "auto"
+        },
+        "Ethernet84": {
+            "server_ipv4": "192.168.0.22/32",
+            "server_ipv6": "fc02:1000::16/128",
+            "state": "auto"
+        },
+        "Ethernet88": {
+            "server_ipv4": "192.168.0.23/32",
+            "server_ipv6": "fc02:1000::17/128",
+            "state": "auto"
+        },
+        "Ethernet92": {
+            "server_ipv4": "192.168.0.24/32",
+            "server_ipv6": "fc02:1000::18/128",
+            "state": "auto"
+        },
+        "Ethernet96": {
+            "server_ipv4": "192.168.0.25/32",
+            "server_ipv6": "fc02:1000::19/128",
+            "state": "auto"
+        },
+        "Ethernet100": {
+            "server_ipv4": "192.168.0.26/32",
+            "server_ipv6": "fc02:1000::1a/128",
+            "state": "auto"
+        },
+        "Ethernet104": {
+            "server_ipv4": "192.168.0.27/32",
+            "server_ipv6": "fc02:1000::1b/128",
+            "state": "auto"
+        },
+        "Ethernet108": {
+            "server_ipv4": "192.168.0.28/32",
+            "server_ipv6": "fc02:1000::1c/128",
+            "state": "auto"
+        },
+        "Ethernet112": {
+            "server_ipv4": "192.168.0.29/32",
+            "server_ipv6": "fc02:1000::1d/128",
+            "state": "auto"
+        },
+        "Ethernet116": {
+            "server_ipv4": "192.168.0.30/32",
+            "server_ipv6": "fc02:1000::1e/128",
+            "state": "auto"
+        },
+        "Ethernet120": {
+            "server_ipv4": "192.168.0.31/32",
+            "server_ipv6": "fc02:1000::1f/128",
+            "state": "auto"
+        },
+        "Ethernet124": {
+            "server_ipv4": "192.168.0.32/32",
+            "server_ipv6": "fc02:1000::20/128",
+            "state": "auto"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/sample_output/py3/l2switch_dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l2switch_dualtor.json
@@ -285,6 +285,10 @@
             "address_ipv4": "1.1.1.1"
         }
     },
+    "LOOPBACK_INTERFACE": {
+        "Loopback2": {},
+        "Loopback2|3.3.3.3": {}
+    },
     "MUX_CABLE":{
         "Ethernet0": {
             "server_ipv4": "192.168.0.1/32",

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -132,6 +132,17 @@ class TestJ2Files(TestCase):
 
         self.assertTrue(json.dumps(sample_output_json, sort_keys=True) == json.dumps(output_json, sort_keys=True))
 
+    def test_l2switch_template_dualtor(self):
+        argument = '-a \'{"is_dualtor": true}\' -k Mellanox-SN2700 --preset l2 -p ' + self.t0_port_config
+        output = self.run_script(argument)
+        output_json = json.loads(output)
+
+        sample_output_file = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'l2switch_dualtor.json')
+        with open(sample_output_file) as sample_output_fd:
+            sample_output_json = json.load(sample_output_fd)
+        self.maxDiff = None
+        self.assertEqual(sample_output_json, output_json)
+
     def test_qos_arista7050_render_template(self):
         arista_dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', 'arista', 'x86_64-arista_7050_qx32s', 'Arista-7050-QX-32S')
         qos_file = os.path.join(arista_dir_path, 'qos.json.j2')


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
* L2 switch mode support is needed for dual ToR devices

#### How I did it
* When generating L2 preset, check for dual ToR setting from CLI option
     * `-a '{"is_dualtor": true}'`
* When dual ToR is specified, add `subtype` field to `DEVICE_METADATA` table
* When dual ToR is specified, add `MUX_CABLE`, `TUNNEL`, and `PEER_SWITCH` tables

#### How to verify it
Run the sonic-config-engine tests

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)
![image](https://user-images.githubusercontent.com/6006991/113365011-cdb34a00-9309-11eb-87aa-db57ac896c78.png)
