### PR TITLE
[container_checker] Exclude the 'always_disabled' container from expected running container list

### DIFF
--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -48,11 +48,11 @@ def get_command_result(command):
 def get_expected_running_containers():
     """
     @summary: This function will get the expected running containers by following the rule:
-              The 'state' field of container in 'FEATURE' table should not be 'disabled'. Then
-              if the device has Multi-ASIC, this function will get container list by determining the
+              The 'state' field of container in 'FEATURE' table should not be 'disabled' or 'always_disabled'.
+              If the device has Multi-ASIC, this function will get container list by determining the
               value of field 'has_global_scope', the number of ASICs and the value of field
-              'has_per_asic_scope'. If the device has single ASIC, the container name was put into
-              the list.
+              'has_per_asic_scope'.
+              If the device has single ASIC, the container name was put into the list.
     @return:  A set which contains the expected running containers.
     """
     config_db = swsssdk.ConfigDBConnector()
@@ -62,7 +62,8 @@ def get_expected_running_containers():
     expected_running_containers = set()
 
     for container_name in feature_table.keys():
-        if feature_table[container_name]["state"] != "disabled":
+        if (feature_table[container_name]["state"] != "disabled" and
+                feature_table[container_name]["state"] != "always_disabled"):
             if multi_asic.is_multi_asic():
                 if feature_table[container_name]["has_global_scope"] == "True":
                     expected_running_containers.add(container_name)

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -62,8 +62,7 @@ def get_expected_running_containers():
     expected_running_containers = set()
 
     for container_name in feature_table.keys():
-        if (feature_table[container_name]["state"] != "disabled" and
-                feature_table[container_name]["state"] != "always_disabled"):
+        if feature_table[container_name]["state"] not in ["disabled", "always_disabled"]:
             if multi_asic.is_multi_asic():
                 if feature_table[container_name]["has_global_scope"] == "True":
                     expected_running_containers.add(container_name)


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Since we introduced a new value `always_disabled` for the `state` field in `FEATURE` table, the `expected` running container list
should exclude the `always_diabled` containers. This bug was found by nightly test and posted at here: [issue](https://github.com/Azure/sonic-buildimage/issues/7210). This PR fixes #7210.

#### How I did it
I added a logic condition to decide whether the value of `state` field of a container was `always_disabled` or not. 

#### How to verify it
I verified this on the device `str-dx010-acs-1`.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

