### PR TITLE
[ci]: get build logs when build fails

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -114,3 +114,12 @@ jobs:
   - publish: $(System.DefaultWorkingDirectory)/
     artifact: sonic-buildimage.${{ parameters.platform }}
     displayName: "Archive sonic image"
+  - script: |
+      set -x
+      find target -name "*.log" | xargs -I{} cp {} $(Build.ArtifactStagingDirectory)/
+    condition: failed()
+    displayName: "Copy build logs"
+  - publish: $(Build.ArtifactStagingDirectory)/
+    artifact: sonic-buildimage.${{ parameters.platform}}.logs@$(System.JobAttempt)
+    displayName: "Archive build logs"
+    condition: failed()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
get build logs when build fails for debugging

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

