### PR TITLE
Update Media settings test case

### DIFF
--- a/src/sonic-device-data/tests/media_checker
+++ b/src/sonic-device-data/tests/media_checker
@@ -6,7 +6,10 @@ import re
 import sys
 
 level1_keys = ["GLOBAL_MEDIA_SETTINGS","PORT_MEDIA_SETTINGS"]
-setting_keys = ["preemphasis","idriver","ipredriver"]
+
+setting_keys = ["preemphasis","idriver","ipredriver",\
+                "main","pre1","pre2","pre3",\
+                "post1","post2","post3","attn"]
 lane_prefix = "lane"
 comma_separator = ","
 range_separator = "-"


### PR DESCRIPTION

#### Why I did it

- Build failure were seen in https://github.com/Azure/sonic-buildimage/pull/6984 as media settings test case is not updated and resulting in unknown fields error.

#### How I did it

- Added the media settings fields in device data test case. 

#### How to verify it

- Verify whether sonic-device deb is built.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog


#### A picture of a cute animal (not mandatory but encouraged)

