### PR TITLE
[Mellanox] Improve FW upgrade logging: add syslog logger

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -28,6 +28,7 @@ declare -r FW_REQUIRED="{{ MLNX_SPC_FW_VERSION }}"
 
 IMAGE_UPGRADE="${NO_PARAM}"
 CPLD_UPGRADE="${NO_PARAM}"
+SYSLOG_LOGGER="${NO_PARAM}"
 VERBOSE_LEVEL="${VERBOSE_MIN}"
 
 function PrintHelp() {
@@ -37,7 +38,8 @@ function PrintHelp() {
     echo "OPTIONS:"
     echo "  -u, --upgrade  Upgrade firmware using next boot image (useful after SONiC-To-SONiC update)"
     echo "  -c, --cpld     Upgrade CPLD firmware (requires -u|--upgrade)"
-    echo "  -v, --verbose  Verbose mode"
+    echo "  -s, --syslog   Use syslog logger (enabled when -u|--upgrade)"
+    echo "  -v, --verbose  Verbose mode (enabled when -u|--upgrade)"
     echo "  -h, --help     Print help"
     echo
     echo "Examples:"
@@ -53,10 +55,14 @@ function ParseArguments() {
         case "$1" in
             -u|--upgrade)
                 IMAGE_UPGRADE="${YES_PARAM}"
+                SYSLOG_LOGGER="${YES_PARAM}"
                 VERBOSE_LEVEL="${VERBOSE_MAX}"
             ;;
             -c|--cpld)
                 CPLD_UPGRADE="${YES_PARAM}"
+            ;;
+            -s|--syslog)
+                SYSLOG_LOGGER="${YES_PARAM}"
             ;;
             -v|--verbose)
                 VERBOSE_LEVEL="${VERBOSE_MAX}"
@@ -74,11 +80,19 @@ function LogError() {
     if [[ "${VERBOSE_LEVEL}" -ge "${VERBOSE_ERROR}" ]]; then
         echo "ERROR: $*"
     fi
+
+    if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
+        logger -p "ERROR" -t "${SCRIPT_NAME}" "$*"
+    fi
 }
 
 function LogWarning() {
     if [[ "${VERBOSE_LEVEL}" -ge "${VERBOSE_WARNING}" ]]; then
         echo "WARNING: $*"
+    fi
+
+    if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
+        logger -p "WARNING" -t "${SCRIPT_NAME}" "$*"
     fi
 }
 
@@ -86,11 +100,19 @@ function LogNotice() {
     if [[ "${VERBOSE_LEVEL}" -ge "${VERBOSE_NOTICE}" ]]; then
         echo "NOTICE: $*"
     fi
+
+    if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
+        logger -p "NOTICE" -t "${SCRIPT_NAME}" "$*"
+    fi
 }
 
 function LogInfo() {
     if [[ "${VERBOSE_LEVEL}" -ge "${VERBOSE_INFO}" ]]; then
         echo "INFO: $*"
+    fi
+
+    if [[ "${SYSLOG_LOGGER}" = "${YES_PARAM}" ]]; then
+        logger -p "INFO" -t "${SCRIPT_NAME}" "$*"
     fi
 }
 
@@ -219,7 +241,11 @@ function UpgradeASICFW() {
 function UpgradeCPLDFW_Worker() {
     local -r _CPLD_BURN_FILE="${1}"
     local -r _CPLD_REFRESH_FILE="${2}"
-    local -r _ASIC_DEV="$(find /dev/mst -iname '*_pciconf0')"
+    local -r _ASIC_DEV="$(find /dev/mst -iname '*_pci_cr0')"
+
+    # Flush syslog
+    RunCmd "kill -HUP $(cat /var/run/rsyslogd.pid)"
+    RunCmd "sync; sync"
 
     if [[ -f /tmp/cpld_fw_updated ]]; then
         RunCmd "cpldupdate --dev ${_ASIC_DEV} ${_CPLD_REFRESH_FILE}"


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Basically mlnx-fw-upgrade.sh is used in two places:
1. https://github.com/Azure/sonic-buildimage/blob/201811/files/scripts/syncd.sh#L109
```bash
        /usr/bin/mst start
        /usr/bin/mlnx-fw-upgrade.sh
        /etc/init.d/sxdkernel start
        /sbin/modprobe i2c-dev
```
2. https://github.com/Azure/sonic-buildimage/blob/201811/device/mellanox/x86_64-mlnx_msn2700-r0/platform_reboot#L32
```bash
ParseArguments "$@"

${FW_UPGRADE_SCRIPT} --upgrade --verbose
EXIT_CODE="$?"
```

In first case the `stdout` is redirected to `syslog` directly by `systemd`.
Thus, the `syslog` logger is only required in second case.

#### Why I did it
* To improve ASIC/CPLD FW upgrade logging
* To improve CPLD upgrade time

#### How I did it
* Added `syslog` logger support
* Replaced `_pciconf0` -> `_pci_cr0` to reduce CPLD upgrade time

#### How to verify it
1. mlnx-fw-upgrade.sh --upgrade

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```