### PR TITLE
update version of ixnetwork client packages

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -39,8 +39,8 @@ RUN pip install cffi==1.10.0 \
                 gitpython \
                 ipaddr \
                 ipython==5.4.1 \
-                ixnetwork-restpy==1.0.52 \
-                ixnetwork-open-traffic-generator==0.0.70 \
+                ixnetwork-restpy==1.0.64 \
+                ixnetwork-open-traffic-generator==0.0.78 \
                 jinja2==2.7.2 \
                 jsonpatch \
                 lxml \


### PR DESCRIPTION
*Why I did it
Upgrade to the latest ixnetwork-restpy and ixnetwork-open-traffic-generator pypi packages

*How I did it
Updated the pip install entries for the packages in the Dockerfile.j2

*How to verify it
pip show ixnetwork-restpy
pip show ixnetwork-open-traffic-generator

*Which release branch to backport (provide reason below if selected)
N/A

*Description for the changelog
Upgrade to the latest ixnetwork-restpy and ixnetwork-open-traffic-generator pypi packages