### PR TITLE
[device] Modify as4630_54pe configuration for stable size

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hx5-as4630-48x1G+4x25G+2x100G.bcm
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hx5-as4630-48x1G+4x25G+2x100G.bcm
@@ -1,4 +1,4 @@
-stable_size=71303168
+stable_size=76303168
 
 #polarity/lanemap is using TH2 style.
 core_clock_frequency=893


### PR DESCRIPTION
Signed-off-by: derek_sun <ecsonic@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Warm-Boot feature needs more resource for stable-size parameter.
#### How I did it
- Modify configuration file.
#### How to verify it
- Platform test and test log.
 
[sonic_test_2021_0407.log](https://github.com/Azure/sonic-buildimage/files/6270273/sonic_test_2021_0407.log)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Modify configuration parameter of stable-size for Warm-Boot feature 

#### A picture of a cute animal (not mandatory but encouraged)

