### PR TITLE
[baseimage]: specify gid for redis group.

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -584,12 +584,10 @@ if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
     DOCKERFS_PATH=../dockerfs/
 fi
 
-# Ensure admin gid 1000 is available
-gid_1000=$(sudo LANG=C grep -e ":1000:" $FILESYSTEM_ROOT/etc/group)
-if [ -n "${gid_1000}" ]; then
-    if [ "${gid_1000}" != "admin:x:1000:" ]; then
-        die "gid 1000 is in use. Expect: Reserve it for admin group. use:${gid_1000}"
-    fi
+# Ensure admin gid is 1000
+gid_user=$(sudo LANG=C chroot $FILESYSTEM_ROOT id -g $USERNAME) || gid_user="none"
+if [ "${gid_user}" != "1000" ]; then
+    die "expect gid 1000. current:${gid_user}"
 fi
 
 ## Compress docker files

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -244,14 +244,15 @@ sudo cp files/docker/docker.service.conf $_
 ## Fix systemd race between docker and containerd
 sudo sed -i '/After=/s/$/ containerd.service/' $FILESYSTEM_ROOT/lib/systemd/system/docker.service
 
-## Create redis group
-sudo LANG=C chroot $FILESYSTEM_ROOT groupadd -f -g 1001 redis
-
 ## Create default user
 ## Note: user should be in the group with the same name, and also in sudo/docker/redis groups
-sudo LANG=C chroot $FILESYSTEM_ROOT useradd -G sudo,docker,redis $USERNAME -c "$DEFAULT_USERINFO" -m -s /bin/bash
+sudo LANG=C chroot $FILESYSTEM_ROOT useradd -G sudo,docker $USERNAME -c "$DEFAULT_USERINFO" -m -s /bin/bash
 ## Create password for the default user
 echo "$USERNAME:$PASSWORD" | sudo LANG=C chroot $FILESYSTEM_ROOT chpasswd
+
+## Create redis group
+sudo LANG=C chroot $FILESYSTEM_ROOT groupadd -f redis
+sudo LANG=C chroot $FILESYSTEM_ROOT usermod -aG redis $USERNAME
 
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
     ## Pre-install hardware drivers

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -245,7 +245,7 @@ sudo cp files/docker/docker.service.conf $_
 sudo sed -i '/After=/s/$/ containerd.service/' $FILESYSTEM_ROOT/lib/systemd/system/docker.service
 
 ## Create redis group
-sudo LANG=C chroot $FILESYSTEM_ROOT groupadd -f redis
+sudo LANG=C chroot $FILESYSTEM_ROOT groupadd -f -g 1001 redis
 
 ## Create default user
 ## Note: user should be in the group with the same name, and also in sudo/docker/redis groups

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -583,6 +583,14 @@ if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
     DOCKERFS_PATH=../dockerfs/
 fi
 
+# Ensure admin gid 1000 is available
+gid_1000=$(sudo LANG=C grep -e ":1000:" $FILESYSTEM_ROOT/etc/group)
+if [ -n "${gid_1000}" ]; then
+    if [ "${gid_1000}" != "admin:x:1000:" ]; then
+        die "gid 1000 is in use. Expect: Reserve it for admin group. use:${gid_1000}"
+    fi
+fi
+
 ## Compress docker files
 pushd $FILESYSTEM_ROOT && sudo tar czf $OLDPWD/$FILESYSTEM_DOCKERFS -C ${DOCKERFS_PATH}var/lib/docker .; popd
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Default  groupadd for redis, takes 1000 by default. This forces, subsequently created admin group to get 1001.
As all TACACS users are created with 1000 as their gid, they end up in redis group.

#### How I did it
Explicitly provide the gid for redis group.

### How to verify it
Check /etc/group & group of RW users via TACACS

```
   admin@str-s6000-acs-9:~$ cat /etc/group | grep -e "admin\|redis"
    sudo:x:27:admin,user_rw
    docker:x:999:admin,user_rw
    redis:x:1001:admin               --- takes 1001
    admin:x:1000:                       --- retains 1000
    admin@str-s6000-acs-9:~$

    admin@str-s6000-acs-9:~$ ls -l /home
    total 4
    drwxr-xr-x 2 admin   admin   66 Apr  7 14:53 admin
    drwxr-xr-x 2 user_rw admin 4096 Apr  7 15:47 user_rw  -- RW user get admin group
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x ] 201911
- [x ] 202006
- [x ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

