### PR TITLE
[201911][radv] Fix Script Name Change

### DIFF
--- a/dockers/docker-router-advertiser/docker-init.sh
+++ b/dockers/docker-router-advertiser/docker-init.sh
@@ -8,10 +8,10 @@ CFGGEN_PARAMS=" \
     -d \
     -t /usr/share/sonic/templates/docker-router-advertiser.supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf \
     -t /usr/share/sonic/templates/radvd.conf.j2,/etc/radvd.conf \
-    -t /usr/share/sonic/templates/wait_for_intf.sh.j2,/usr/bin/wait_for_intf.sh \
+    -t /usr/share/sonic/templates/wait_for_link.sh.j2,/usr/bin/wait_for_link.sh \
 "
 sonic-cfggen $CFGGEN_PARAMS
 
-chmod +x /usr/bin/wait_for_intf.sh
+chmod +x /usr/bin/wait_for_link.sh
 
 exec /usr/bin/supervisord


### PR DESCRIPTION
#### Why I did it

[PR:4599](https://github.com/Azure/sonic-buildimage/pull/4599) changed startup
script name from wait_for_intf.sh.j2 to wait_for_link.sh.j2, however
when [PR:5178](https://github.com/Azure/sonic-buildimage/pull/5178) was cherry-
picked, the script name was not changed to wait_for_link.sh.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>


#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

