### PR TITLE
[sonic-slave-stretch]: use pip to install nose package directly

### DIFF
--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -366,6 +366,7 @@ RUN pip install meld3 mock
 RUN pip install pexpect==4.6.0
 
 # For sonic-utilities build
+RUN pip install nose==1.3.7
 RUN pip install mockredispy==2.9.3
 RUN pip install pytest-runner==4.4
 RUN pip install setuptools==40.8.0


### PR DESCRIPTION
Fix #7248 

Issue is similiar to martinblech/xmltodict#47

The correct solution is to change mockredispy to move 
nose from setup_requirement to test_requirement.

The quick workaround is to install nose explicitly.

fix build issue:

05:09:37    Downloading mockredispy-2.9.3.tar.gz (17 kB)
05:09:39  ?[91m    ERROR: Command errored out with exit status 1:
05:09:39       command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-sypos2ry/mockredispy_ab86cd14995544df90f78a63ab7041a3/setup.py'"'"'; __file__='"'"'/tmp/pip-install-sypos2ry/mockredispy_ab86cd14995544df90f78a63ab7041a3/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-ymhn19ne
05:09:39           cwd: /tmp/pip-install-sypos2ry/mockredispy_ab86cd14995544df90f78a63ab7041a3/
05:09:39      Complete output (23 lines):
05:09:39      Couldn't find index page for 'nose' (maybe misspelled?)
05:09:39      No local packages or working download links found for nose
05:09:39      Traceback (most recent call last):
05:09:39        File "<string>", line 1, in <module>
05:09:39        File "/tmp/pip-install-sypos2ry/mockredispy_ab86cd14995544df90f78a63ab7041a3/setup.py", line 29, in <module>
05:09:39          'with_redis = mockredis.noseplugin:WithRedis'
05:09:39        File "/usr/lib/python3.5/distutils/core.py", line 108, in setup
05:09:39          _setup_distribution = dist = klass(attrs)
05:09:39        File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 317, in __init__
05:09:39          self.fetch_build_eggs(attrs['setup_requires'])
05:09:39        File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 372, in fetch_build_eggs
05:09:39          replace_conflicting=True,
05:09:39        File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 846, in resolve
05:09:39          dist = best[req.key] = env.best_match(req, ws, installer)
05:09:39        File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1118, in best_match
05:09:39          return self.obtain(req, installer)
05:09:39        File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1130, in obtain
05:09:39          return installer(requirement)
05:09:39        File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 440, in fetch_build_egg
05:09:39          return cmd.easy_install(req)
05:09:39        File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 693, in easy_install
05:09:39          raise DistutilsError(msg)
05:09:39      distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('nose')
05:09:39      ----------------------------------------

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

