### PR TITLE
[CI] Fix the wrong environment variable PLATFORM passing into the slave container issue

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -21,7 +21,7 @@ jobs:
     preSteps: ${{ parameters.preSteps }}
     postSteps: ${{ parameters.postSteps }}
     jobVariables:
-      PLATFORM: $(GROUP_NAME)
+      PLATFORM_FULL: $(GROUP_NAME)
       PLATFORM_ARCH: amd64
       BUILD_OPTIONS: ${{ parameters.buildOptions }}
       dbg_image: false

--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -21,7 +21,7 @@ jobs:
     preSteps: ${{ parameters.preSteps }}
     postSteps: ${{ parameters.postSteps }}
     jobVariables:
-      PLATFORM_FULL: $(GROUP_NAME)
+      PLATFORM_AZP: $(GROUP_NAME)
       PLATFORM_ARCH: amd64
       BUILD_OPTIONS: ${{ parameters.buildOptions }}
       dbg_image: false

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -28,8 +28,8 @@ jobs:
       - template: cleanup.yml
       - ${{ parameters. preSteps }}
       - script: |
-          if [ -n "$(CACHE_MODE)" ] && echo $(PLATFORM) | grep -E -q "^(vs|broadcom|mellanox)$"; then
-            CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=$(CACHE_MODE) SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/$(PLATFORM)"
+          if [ -n "$(CACHE_MODE)" ] && echo $(PLATFORM_FULL) | grep -E -q "^(vs|broadcom|mellanox)$"; then
+            CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=$(CACHE_MODE) SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/$(PLATFORM_FULL)"
             BUILD_OPTIONS="$(BUILD_OPTIONS) $CACHE_OPTIONS"
             echo "##vso[task.setvariable variable=BUILD_OPTIONS]$BUILD_OPTIONS"
           fi
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install -y acl
           export DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker
           sudo bash -c "echo 1 > /proc/sys/vm/compact_memory"
-          ENABLE_DOCKER_BASE_PULL=y make PLATFORM=$(PLATFORM) PLATFORM_ARCH=$(PLATFORM_ARCH) configure
+          ENABLE_DOCKER_BASE_PULL=y make PLATFORM=$(PLATFORM_FULL) PLATFORM_ARCH=$(PLATFORM_ARCH) configure
         displayName: 'Make configure'
     postSteps:
       - publish: $(System.DefaultWorkingDirectory)/target

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -28,8 +28,8 @@ jobs:
       - template: cleanup.yml
       - ${{ parameters. preSteps }}
       - script: |
-          if [ -n "$(CACHE_MODE)" ] && echo $(PLATFORM_FULL) | grep -E -q "^(vs|broadcom|mellanox)$"; then
-            CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=$(CACHE_MODE) SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/$(PLATFORM_FULL)"
+          if [ -n "$(CACHE_MODE)" ] && echo $(PLATFORM_AZP) | grep -E -q "^(vs|broadcom|mellanox)$"; then
+            CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=$(CACHE_MODE) SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/$(PLATFORM_AZP)"
             BUILD_OPTIONS="$(BUILD_OPTIONS) $CACHE_OPTIONS"
             echo "##vso[task.setvariable variable=BUILD_OPTIONS]$BUILD_OPTIONS"
           fi
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install -y acl
           export DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker
           sudo bash -c "echo 1 > /proc/sys/vm/compact_memory"
-          ENABLE_DOCKER_BASE_PULL=y make PLATFORM=$(PLATFORM_FULL) PLATFORM_ARCH=$(PLATFORM_ARCH) configure
+          ENABLE_DOCKER_BASE_PULL=y make PLATFORM=$(PLATFORM_AZP) PLATFORM_ARCH=$(PLATFORM_ARCH) configure
         displayName: 'Make configure'
     postSteps:
       - publish: $(System.DefaultWorkingDirectory)/target


### PR DESCRIPTION
#### Why I did it
It is to fix the wrong usage of the build parameter in the azure pipelines' template. The build parameter PLATFORM=XXX can only be set when making configure (by command make configuration). To build platform images, we should avoid to set the value.
make PLATFORM=vs configuration
Bad usage:
make PLATFORM=vs  target/sonic-vs.img.gz
Good usage:
make target/sonic-vs.img.gz

#### How I did it
Change the environment PLATFORM to PLATFORM_AZP to avoid to pass the parameter.

#### How to verify it


