### PR TITLE
[installer]: Prevent filesystem corruption

### DIFF
--- a/installer/arm64/install.sh
+++ b/installer/arm64/install.sh
@@ -99,6 +99,12 @@ if [ "$install_env" = "onie" ]; then
 elif [ "$install_env" = "sonic" ]; then
     demo_mnt="/host"
     eval running_sonic_revision=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
+    # Verify SONiC image exists
+    if [ ! -d "$demo_mnt/image-$running_sonic_revision" ]; then
+        echo "ERROR: SONiC installation is corrupted: path $demo_mnt/image-$running_sonic_revision doesn't exist"
+        echo "Please check /etc/sonic/sonic_version.yml"
+        exit 1
+    fi
     # Prevent installing existing SONiC if it is running
     if [ "$image_dir" = "image-$running_sonic_revision" ]; then
         echo "Not installing SONiC version $running_sonic_revision, as current running SONiC has the same version"

--- a/installer/arm64/install.sh
+++ b/installer/arm64/install.sh
@@ -98,11 +98,11 @@ if [ "$install_env" = "onie" ]; then
     mount_partition
 elif [ "$install_env" = "sonic" ]; then
     demo_mnt="/host"
-    eval running_sonic_revision=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
+    # Get current SONiC image (grub/aboot/uboot)
+    eval running_sonic_revision="$(cat /proc/cmdline | sed -n 's/^.*loop=\/*image-\(\S\+\)\/.*$/\1/p')"
     # Verify SONiC image exists
     if [ ! -d "$demo_mnt/image-$running_sonic_revision" ]; then
         echo "ERROR: SONiC installation is corrupted: path $demo_mnt/image-$running_sonic_revision doesn't exist"
-        echo "Please check /etc/sonic/sonic_version.yml"
         exit 1
     fi
     # Prevent installing existing SONiC if it is running

--- a/installer/armhf/install.sh
+++ b/installer/armhf/install.sh
@@ -99,6 +99,12 @@ if [ "$install_env" = "onie" ]; then
 elif [ "$install_env" = "sonic" ]; then
     demo_mnt="/host"
     eval running_sonic_revision=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
+    # Verify SONiC image exists
+    if [ ! -d "$demo_mnt/image-$running_sonic_revision" ]; then
+        echo "ERROR: SONiC installation is corrupted: path $demo_mnt/image-$running_sonic_revision doesn't exist"
+        echo "Please check /etc/sonic/sonic_version.yml"
+        exit 1
+    fi
     # Prevent installing existing SONiC if it is running
     if [ "$image_dir" = "image-$running_sonic_revision" ]; then
         echo "Not installing SONiC version $running_sonic_revision, as current running SONiC has the same version"

--- a/installer/armhf/install.sh
+++ b/installer/armhf/install.sh
@@ -98,11 +98,11 @@ if [ "$install_env" = "onie" ]; then
     mount_partition
 elif [ "$install_env" = "sonic" ]; then
     demo_mnt="/host"
-    eval running_sonic_revision=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
+    # Get current SONiC image (grub/aboot/uboot)
+    eval running_sonic_revision="$(cat /proc/cmdline | sed -n 's/^.*loop=\/*image-\(\S\+\)\/.*$/\1/p')"
     # Verify SONiC image exists
     if [ ! -d "$demo_mnt/image-$running_sonic_revision" ]; then
         echo "ERROR: SONiC installation is corrupted: path $demo_mnt/image-$running_sonic_revision doesn't exist"
-        echo "Please check /etc/sonic/sonic_version.yml"
         exit 1
     fi
     # Prevent installing existing SONiC if it is running

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -468,6 +468,12 @@ if [ "$install_env" = "onie" ]; then
 elif [ "$install_env" = "sonic" ]; then
     demo_mnt="/host"
     eval running_sonic_revision=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
+    # Verify SONiC image exists
+    if [ ! -d "$demo_mnt/image-$running_sonic_revision" ]; then
+        echo "ERROR: SONiC installation is corrupted: path $demo_mnt/image-$running_sonic_revision doesn't exist"
+        echo "Please check /etc/sonic/sonic_version.yml"
+        exit 1
+    fi
     # Prevent installing existing SONiC if it is running
     if [ "$image_dir" = "image-$running_sonic_revision" ]; then
         echo "Not installing SONiC version $running_sonic_revision, as current running SONiC has the same version"

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -467,11 +467,11 @@ if [ "$install_env" = "onie" ]; then
 
 elif [ "$install_env" = "sonic" ]; then
     demo_mnt="/host"
-    eval running_sonic_revision=$(cat /etc/sonic/sonic_version.yml | grep build_version | cut -f2 -d" ")
+    # Get current SONiC image (grub/aboot/uboot)
+    eval running_sonic_revision="$(cat /proc/cmdline | sed -n 's/^.*loop=\/*image-\(\S\+\)\/.*$/\1/p')"
     # Verify SONiC image exists
     if [ ! -d "$demo_mnt/image-$running_sonic_revision" ]; then
         echo "ERROR: SONiC installation is corrupted: path $demo_mnt/image-$running_sonic_revision doesn't exist"
-        echo "Please check /etc/sonic/sonic_version.yml"
         exit 1
     fi
     # Prevent installing existing SONiC if it is running


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
This improvement reads current SONiC version directly from `/proc/cmdline`.
it supports `grub/aboot/uboot` bootloaders.

**Code snippet**:
```bash
cat /proc/cmdline | sed -n 's/^.*loop=\/*image-\(\S\+\)\/.*$/\1/p'
```

**Description**:
```
-n         don't print lines
s          substitute
^.*        matches anything before the <image_version>
loop=      matches <loop> kernel parameter
\/*image-  matches <image_version> prefix
\(\S\+\)   matches <image_version> group and assigns it to \1
\/.*$      matches anything after the <image_version>
\1         replace everything with <image_version>
p          print it
```


closes #6267

#### Why I did it
* To fix #6267

#### How I did it
* Fixed installer scripts

#### How to verify it
1. Write invalid SONiC version to sonic_version.yml
2. Run SONiC-To-SONiC update

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [X] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```