### PR TITLE
Increase min-links limit for portchannel from 128 to 1024.

### DIFF
--- a/src/libteam/patch/0012-Increase-min_ports-upper-limit-to-1024.patch
+++ b/src/libteam/patch/0012-Increase-min_ports-upper-limit-to-1024.patch
@@ -1,0 +1,34 @@
+diff --git a/man/teamd.conf.5 b/man/teamd.conf.5
+index 350ffc9..dc913cd 100644
+--- a/man/teamd.conf.5
++++ b/man/teamd.conf.5
+@@ -248,7 +248,7 @@ Default:
+ .RE
+ .TP
+ .BR "runner.min_ports " (int)
+-Specifies the minimum number of ports that must be active before asserting carrier in the master interface, value can be 1 \(en 255.
++Specifies the minimum number of ports that must be active before asserting carrier in the master interface, value can be 1 \(en 1024.
+ .RS 7
+ .PP
+ Default:
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 9354ebb..a901398 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -151,6 +151,7 @@ struct lacp {
+ #define		LACP_CFG_DFLT_FALLBACK false
+ 		int min_ports;
+ #define		LACP_CFG_DFLT_MIN_PORTS 1
++#define		LACP_CFG_DFLT_MIN_PORTS_MAX 1024
+ 		enum lacp_agg_select_policy agg_select_policy;
+ #define		LACP_CFG_DFLT_AGG_SELECT_POLICY LACP_AGG_SELECT_LACP_PRIO
+ 	} cfg;
+@@ -493,7 +494,7 @@ static int lacp_load_config(struct teamd_context *ctx, struct lacp *lacp)
+ 	err = teamd_config_int_get(ctx, &tmp, "$.runner.min_ports");
+ 	if (err) {
+ 		lacp->cfg.min_ports = LACP_CFG_DFLT_MIN_PORTS;
+-	} else if (tmp < 1 || tmp > UCHAR_MAX) {
++	} else if (tmp < 1 || tmp > LACP_CFG_DFLT_MIN_PORTS_MAX) {
+ 		teamd_log_err("\"min_ports\" value is out of its limits.");
+ 		return -EINVAL;
+ 	} else {

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -9,3 +9,4 @@
 0009-Fix-ifinfo_link_with_port-race-condition-with-newlink.patch
 0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch
 0011-Remove-extensive-debug-output.patch
+0012-Increase-min_ports-upper-limit-to-1024.patch

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -2,6 +2,13 @@
     "PORT_CHANNEL_TEST": {
         "desc": "Configure a member port in PORT_CHANNEL table."
     },
+    "PORT_CHANNEL_MAX_VALID_MIN_LINKS": {
+        "desc": "Configure PortChannel with maximum valid value of min-links."
+    },
+    "PORT_CHANNEL_OUT_OF_RANGE_MIN_LINKS": {
+        "desc": "Configure PortChannel with greater than maximum valid value of min-links.",
+        "eStr": ["Value", "does not satisfy the constraint"]
+    },
     "PORT_CHANNEL_WRONG_PATTERN": {
         "desc": "INCORRECT PORTCHANNEL_NAME IN PORT_CHANNEL TABLE.",
         "eStrKey" : "Pattern",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -28,6 +28,70 @@
                         "mtu": "9100",
                         "tpid": "0x8100",
                         "lacp_key": "auto",
+			"name": "PortChannel0001"
+                    }
+                ]
+            }
+        }
+    },
+    "PORT_CHANNEL_MAX_VALID_MIN_LINKS": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "members": [
+                            "Ethernet0"
+                        ],
+                        "min_links": "1024",
+                        "mtu": "9100",
+                        "name": "PortChannel0001"
+                    }
+                ]
+            }
+        }
+    },
+    "PORT_CHANNEL_OUT_OF_RANGE_MIN_LINKS": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "members": [
+                            "Ethernet0"
+                        ],
+                        "min_links": "1025",
+                        "mtu": "9100",
                         "name": "PortChannel0001"
                     }
                 ]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -28,7 +28,7 @@
                         "mtu": "9100",
                         "tpid": "0x8100",
                         "lacp_key": "auto",
-			"name": "PortChannel0001"
+                        "name": "PortChannel0001"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -26,6 +26,10 @@ module sonic-portchannel {
 
     description "PORTCHANNEL yang Module for SONiC OS";
 
+    revision 2021-05-13 {
+        description "Change min-links valid range from 1-128 to 0-1024";
+    }
+
     revision 2021-03-31 {
         description "Add PortChannel Interface List with VRF attribute";
     }
@@ -75,9 +79,7 @@ module sonic-portchannel {
 
                 leaf min_links {
                     type uint16 {
-                        range 1..1024;
-                    type uint8 {
-                        range 1..128;
+                        range 0..1024;
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -26,8 +26,8 @@ module sonic-portchannel {
 
     description "PORTCHANNEL yang Module for SONiC OS";
 
-    revision 2021-05-13 {
-        description "Change min-links valid range from 1-128 to 0-1024";
+    revision 2021-06-13 {
+        description "Change min-links valid range from 1-128 to 1-1024";
     }
 
     revision 2021-03-31 {
@@ -79,7 +79,7 @@ module sonic-portchannel {
 
                 leaf min_links {
                     type uint16 {
-                        range 0..1024;
+                        range 1..1024;
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -74,6 +74,8 @@ module sonic-portchannel {
                 }
 
                 leaf min_links {
+                    type uint16 {
+                        range 1..1024;
                     type uint8 {
                         range 1..128;
                     }


### PR DESCRIPTION
Signed-off-by: Raphael Tryster <raphaelt@nvidia.com>


#### Why I did it

Restrict the min-links parameter in "config portchannel" to the range 1-1024.
Fixes Azure/sonic-buildimage#6781 in conjunction with https://github.com/Azure/sonic-buildimage/pull/1630.
Align YANG model with limits in libteam and sonic-utilties.

#### How I did it

PR 1630 in sonic-utilities prevents CLI user from entering a value outside the allowed range.  This PR does the following:

- Increases the maximum value of min-links from 128 to 1024.
- Provides validation in libteam, incorporating as a patch the code in https://git.kernel.org/pub/scm/linux/kernel/git/jpirko/libteam.git/commit/?id=69a7494bb77dc10bb27076add07b380dbd778592.
- Updates the Yang model upper limit from 128 to 1024 (was inconsistent with libteam value).
- Updates the Yang model lower limit from 1 to 0, since 0 is set as default in sonic-utilities which would fail its new range check otherwise.
- Added Yang tests for valid and invalid value.

#### How to verify it

config portchannel add PortChannel0004 --min-links 1024

Command should be accepted.

show interfaces portchannel

Output should show PortChannel0004, no errors on CLI.

config portchannel add PortChannel0005 --min-links 1025

Command should be rejected

show interfaces portchannel

Output should not show PortChannel0005 , no errors on CLI.

#### Which release branch to backport (provide reason below if selected)


#### Description for the changelog

Updates YANG model to allow up to 1024 min_links for portchannel.  Fixes Azure/sonic-buildimage#6781 in conjunction with https://github.com/Azure/sonic-buildimage/pull/1630.

#### A picture of a cute animal (not mandatory but encouraged)

