### PR TITLE
[202012][sonic-slave-stretch]: Use pip to install nose package directly

### DIFF
--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -359,6 +359,7 @@ RUN pip3 install redis
 RUN pip2 install pexpect==4.6.0
 
 # For sonic-utilities build
+RUN pip2 install nose==1.3.7
 RUN pip2 install mockredispy==2.9.3
 RUN pip2 install pytest-runner==4.4
 RUN pip2 install setuptools==40.8.0


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Similar issue to #7257 seen in recent 202012 builds ([example](https://dev.azure.com/mssonic/build/_build/results?buildId=10150&view=logs&jobId=5562265b-363f-5c64-5cff-7b508c285721&j=a5b8631f-d2a8-5bf4-c5b7-ed5dd46e146c&t=e747c951-66f6-56b8-ce31-6c6f08969189)). Porting this fix to 202012 to unblock AZP.

#### How I did it
Added another line to the dockerfile to install nose explicitly.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

