### PR TITLE
[201911] Fix easy_install error when installing pip

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -401,7 +401,7 @@ if [[ $CONFIGURED_ARCH == amd64 ]]; then
 fi
 
 ## docker-py is needed by Ansible docker module
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install --upgrade 'pip<21'
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install --upgrade 'pip==20.3.3'
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'docker-py==1.6.0'
 ## Note: keep pip installed for maintainance purpose
 

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -302,6 +302,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     ndisc6                  \
     makedumpfile            \
     conntrack               \
+    python-pip              \
     jq
 
 
@@ -400,7 +401,7 @@ if [[ $CONFIGURED_ARCH == amd64 ]]; then
 fi
 
 ## docker-py is needed by Ansible docker module
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT easy_install 'pip==20.3.3'
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install --upgrade 'pip<21'
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install 'docker-py==1.6.0'
 ## Note: keep pip installed for maintainance purpose
 


### PR DESCRIPTION
What/Why I did:
Seeing this error intermittently:
```
+ sudo https_proxy= LANG=C chroot ./fsroot easy_install pip==20.3.3
Searching for pip==20.3.3
Reading https://pypi.python.org/simple/pip/
Couldn't find index page for 'pip' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading https://pypi.python.org/simple/
No local packages or working download links found for pip==20.3.3
error: Could not find suitable distribution for Requirement.parse('pip==20.3.3')
```
How I fix:
- Install `python-pip` via apt-get
- Pin the version to 20.3.3
- Master has same changes.

How I verify:
- Build is sucessfull
```
admin@str-sxxxx-xx-2:~$ pip --version
pip 20.3.3 from /usr/local/lib/python2.7/dist-packages/pip (python 2.7)

```

