### PR TITLE
[sonic-py-common] Clear environment variables before running device_info tests

### DIFF
--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -9,6 +9,8 @@ else:
     # https://pypi.python.org/pypi/mock
     import mock
 
+import pytest
+
 from sonic_py_common import device_info
 
 from .mock_swsssdk import SonicV2Connector
@@ -51,9 +53,16 @@ EXPECTED_GET_MACHINE_INFO_RESULT = {
 }
 
 class TestDeviceInfo(object):
-    @classmethod
-    def setup_class(cls):
-        print("SETUP")
+    @pytest.fixture(scope="class", autouse=True)
+    def sanitize_environment(self):
+        # Back up environment variables then clear them, in case an environment
+        # variable is set in the test environment (e.g., PLATFORM) which could
+        # modify the behavior of sonic-py-common
+        env_orig = os.environ.copy()
+        os.environ.clear()
+        yield
+        # Restore original environment variables
+        os.environ.update(env_orig)
 
     def test_get_machine_info(self):
         with mock.patch("os.path.isfile") as mock_isfile:

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -55,14 +55,10 @@ EXPECTED_GET_MACHINE_INFO_RESULT = {
 class TestDeviceInfo(object):
     @pytest.fixture(scope="class", autouse=True)
     def sanitize_environment(self):
-        # Back up environment variables then clear them, in case an environment
-        # variable is set in the test environment (e.g., PLATFORM) which could
-        # modify the behavior of sonic-py-common
-        env_orig = os.environ.copy()
-        os.environ.clear()
-        yield
-        # Restore original environment variables
-        os.environ.update(env_orig)
+        # Clear environment variables, in case a variable is set in the test
+        # environment (e.g., PLATFORM) which could modify the behavior of sonic-py-common
+        with mock.patch.dict(os.environ, {}, clear=True):
+            yield
 
     def test_get_machine_info(self):
         with mock.patch("os.path.isfile") as mock_isfile:

--- a/src/sonic-py-common/tests/interface_test.py
+++ b/src/sonic-py-common/tests/interface_test.py
@@ -4,10 +4,6 @@ import sys
 from sonic_py_common import interface
 
 class TestInterface(object):
-    @classmethod
-    def setup_class(cls):
-        print("SETUP")
-
     def test_get_interface_table_name(self):
         result = interface.get_interface_table_name("Ethernet0")
         assert result == "INTERFACE"
@@ -35,7 +31,3 @@ class TestInterface(object):
         assert result == "VLAN_INTERFACE"
         result = interface.get_port_table_name("Loopback0")
         assert result == "LOOPBACK_INTERFACE"
-
-    @classmethod
-    def teardown_class(cls):
-        print("TEARDOWN")


### PR DESCRIPTION
#### Why I did it

To ensure any environment variables which are configured in the build/test environment do not influence the behavior of sonic-py-common during unit tests. For example, variables which might be set by continuous integration pipelines.

#### How I did it

Add class-scoped pytest fixture to `TestDeviceInfo` class which stashes the current environment variables, clears them and yields. Once all the test cases in the class finish, the fixture will restore the original environment variables.

Also remove unnecessary unittest-style setup and teardown functions from interface_test.py

#### How to verify it

Ensure unit tests pass during package build with the following commands:
```
PLATFORM=not_a_valid_platform_string make target/python-wheels/sonic_py_common-1.0-py2-none-any.whl
PLATFORM=not_a_valid_platform_string make target/python-wheels/sonic_py_common-1.0-py3-none-any.whl
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012