### PR TITLE
[HLX] Fix issue where HLX module failed to do postinit

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.install
@@ -8,4 +8,5 @@ haliburton/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x8
 services/platform_api/platform_api_mgnt.sh usr/local/bin
 haliburton/script/popmsg.sh usr/local/bin
 haliburton/script/udev_prefix.sh usr/local/bin
+haliburton/script/reload_udev.sh usr/local/bin
 haliburton/script/50-ttyUSB-C0.rules etc/udev/rules.d


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

There is an issue where HLX module failed to do postinit script.
The issue were introduced in this PR: https://github.com/Azure/sonic-buildimage/pull/7043

Basically, this is a low impact issue because the postinit script failed at last line and all required module service has started before the script crash.

#### How I did it

Copy the required script file before postinit run

#### How to verify it

No this kind of log raise again
```
[   27.556949] rc.local[384]: /var/lib/dpkg/info/platform-modules-haliburton.postinst: 12: /var/lib/dpkg/info/platform-modules-haliburton.postinst: /usr/local/bin/reload_udev.sh: not found
[   27.761279] rc.local[384]: dpkg: error processing package platform-modules-haliburton (--install):
[   27.869157] rc.local[384]:  installed platform-modules-haliburton package post-installation script subprocess returned error exit status 127
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
Fix issue where HLX module failed to do postinit


#### A picture of a cute animal (not mandatory but encouraged)

