### PR TITLE
[ci] Fix the wrong build options issue

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -50,9 +50,9 @@ jobs:
           platform_rpc: centec
       - name: centec-arm64
         pool: sonicbld_8c
+        timeoutInMinutes: 1800
         variables:
-          arch: arm64
-          timeoutInMinutes: 1800
+          PLATFORM_ARCH: arm64
       - name: generic
         variables:
           dbg_image: true
@@ -61,9 +61,9 @@ jobs:
           swi_image: true
       - name: marvell-armhf
         pool: sonicbld_8c
+        timeoutInMinutes: 1800
         variables:
-          arch: armhf
-          timeoutInMinutes: 1800
+          PLATFORM_ARCH: armhf
       - name: mellanox
         variables:
           dbg_image: true
@@ -97,3 +97,4 @@ jobs:
             fi
             make $BUILD_OPTIONS target/sonic-$(GROUP_NAME).bin
           fi
+        displayName: "Build sonic image"

--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -76,6 +76,7 @@ jobs:
           platform_rpc: nephos
     buildSteps:
       - bash: |
+          BUILD_OPTIONS="$BUILD_OPTIONS PLATFORM_ARCH=$(PLATFORM_ARCH)"
           if [ $(GROUP_NAME) == vs ]; then
             if [ $(dbg_image) == true ]; then
               make $BUILD_OPTIONS INSTALL_DEBUG_TOOLS=y target/sonic-vs.img.gz && mv target/sonic-vs.img.gz target/sonic-vs-dbg.img.gz

--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -76,7 +76,6 @@ jobs:
           platform_rpc: nephos
     buildSteps:
       - bash: |
-          BUILD_OPTIONS="$BUILD_OPTIONS PLATFORM_ARCH=$(PLATFORM_ARCH)"
           if [ $(GROUP_NAME) == vs ]; then
             if [ $(dbg_image) == true ]; then
               make $BUILD_OPTIONS INSTALL_DEBUG_TOOLS=y target/sonic-vs.img.gz && mv target/sonic-vs.img.gz target/sonic-vs-dbg.img.gz

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -33,7 +33,7 @@ jobs:
             BUILD_OPTIONS="$(BUILD_OPTIONS) $CACHE_OPTIONS"
             echo "##vso[task.setvariable variable=BUILD_OPTIONS]$BUILD_OPTIONS"
           fi
-        displayName: "Make build options"
+        displayName: "Set cache options"
       - checkout: self
         submodules: recursive
         displayName: 'Checkout code'


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the wrong build options and improve display name for some tasks
1. Fix the wrong build architecture for arm64 and armhf
2. Fix the build timeout parameter

#### How I did it

#### How to verify it
See the build below, arm64/armhf option is correct after applying the fix.
Centec-arm64: https://dev.azure.com/mssonic/build/_build/results?buildId=10483&view=logs&j=88e1b2d1-110a-5bbf-c794-091704096bca&t=41cf5733-fbe6-5db0-23ba-ae081db3aefb
Marvell-armhf: https://dev.azure.com/mssonic/build/_build/results?buildId=10485&view=logs&j=268525a4-f0a8-5106-2898-2602f02ebdb0&t=6a001da7-517d-5aaf-2db9-5992b323c8e5

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

