### PR TITLE
[201911] DellEMC S6100 SSD Monitor additional changes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -10,6 +10,7 @@ s6100/scripts/platform_reboot_override usr/share/sonic/device/x86_64-dell_s6100_
 s6100/scripts/fast-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/track_reboot_reason.sh usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/warm-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
+s6100/scripts/soft-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/override.conf /etc/systemd/system/systemd-reboot.service.d
 common/dell_lpc_mon.sh usr/local/bin
 s6100/scripts/s6100_ssd_mon.sh usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_reboot_pre_check
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_reboot_pre_check
@@ -1,10 +1,16 @@
 #!/bin/bash
 SSD_FW_UPGRADE="/host/ssd_fw_upgrade"
 
+_error_msg(){
+    echo "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
+    echo "soft-/fast-/warm-reboot is allowed."
+    logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
+    logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
+}
+
 # Check SSD Status
-if [ -e $SSD_FW_UPGRADE/GPIO7_low ] || [ -e $SSD_FW_UPGRADE/GPIO7_error ] || [ -e $SSD_FW_UPGRADE/GPIO_pending_upgrade ]; then
-    logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty and does not support cold reboot."
-    logger -p user.crit -t DELL_S6100_SSD_MON "Please perform a soft-/fast-/warm-reboot instead"
+if [ -e $SSD_FW_UPGRADE/GPIO7_low ] || [ -e $SSD_FW_UPGRADE/GPIO7_error ] || [ -e $SSD_FW_UPGRADE/GPIO7_pending_upgrade ]; then
+    _error_msg
     exit 1
 fi
 
@@ -19,8 +25,7 @@ if [ -e $SSD_FW_UPGRADE/GPIO7_high ]; then
     if [ $GPIO_STATUS == "0x01" ];then
 	exit 0
     else
-        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty and does not support cold reboot."
-        logger -p user.crit -t DELL_S6100_SSD_MON "Please perform a soft-/fast-/warm-reboot instead"
+        _error_msg
         exit 1
     fi
 fi

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_mon.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_mon.sh
@@ -10,8 +10,8 @@ if [ -e $SSD_FW_UPGRADE/GPIO7_high ]; then
     GPIO_STATUS=$(echo "$iSMART_CMD" | grep GPIO | awk '{print $NF}')
 
     if [ $GPIO_STATUS != "0x01" ];then
-        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty and does not support cold reboot."
-        logger -p user.crit -t DELL_S6100_SSD_MON "If a reboot is required, please perform a soft-/fast-/warm-reboot."
+        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
+        logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
         rm -rf $SSD_FW_UPGRADE/GPIO7_*
         touch $SSD_FW_UPGRADE/GPIO7_low
         systemctl stop s6100-ssd-monitor.timer

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_upgrade_status.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_upgrade_status.sh
@@ -69,20 +69,24 @@ elif [ $SSD_FW_VERSION == "s141002g" ] || [ $SSD_FW_VERSION == "s16425cg" ]; the
         echo "$0 `date` soft-/fast-/warm-reboot is allowed." >> $SSD_UPGRADE_LOG
 
     else
-        rm -rf $SSD_FW_UPGRADE/GPIO7_*
-        touch $SSD_FW_UPGRADE/GPIO7_high
-    fi
+        if [ $SSD_UPGRADE_STATUS1 == "0" ]; then
+            rm -rf $SSD_FW_UPGRADE/GPIO7_*
+            touch $SSD_FW_UPGRADE/GPIO7_high
+            systemctl start --no-block s6100-ssd-monitor.timer
 
-    systemctl start --no-block s6100-ssd-monitor.timer
+            if [ $SSD_MODEL  == "3IE" ];then
+                echo "$0 `date` SSD FW upgraded from S141002C to S141002G in first mp_64." >> $SSD_UPGRADE_LOG
+            else
+                echo "$0 `date` SSD FW upgraded from S16425c1 to S16425cG in first mp_64." >> $SSD_UPGRADE_LOG
+            fi
+        elif [ $SSD_UPGRADE_STATUS2 == "1" ]; then
+            rm -rf $SSD_FW_UPGRADE/GPIO7_*
+            touch $SSD_FW_UPGRADE/GPIO7_low
+            logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
+            logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
 
-    if [ $SSD_UPGRADE_STATUS1 == "0" ]; then
-        if [ $SSD_MODEL  == "3IE" ];then
-            echo "$0 `date` SSD FW upgraded from S141002C to S141002G in first mp_64." >> $SSD_UPGRADE_LOG
-        else
-            echo "$0 `date` SSD FW upgraded from S16425c1 to S16425cG in first mp_64." >> $SSD_UPGRADE_LOG
+            echo "$0 `date` SSD entered loader mode in first mp_64 and upgraded to latest version after second mp_64." >> $SSD_UPGRADE_LOG
         fi
-    elif [ $SSD_UPGRADE_STATUS2 == "1" ]; then
-        echo "$0 `date` SSD entered loader mode in first mp_64 and upgraded to latest version after second mp_64." >> $SSD_UPGRADE_LOG
     fi
 
 else

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_upgrade_status.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_ssd_upgrade_status.sh
@@ -18,10 +18,15 @@ SSD_UPGRADE_LOG="$SSD_FW_UPGRADE/upgrade.log"
 SMART_CMD=`smartctl -a /dev/sda`
 
 SSD_FW_VERSION=$(echo "$SMART_CMD" | grep "Firmware Version" | awk '{print $NF}')
+SSD_FW_VERSION=${SSD_FW_VERSION,,}
 SSD_MODEL=$(echo "$SMART_CMD" | grep "Device Model" | awk '{print $NF}')
 
 if [ -e $SSD_FW_UPGRADE/GPIO7_pending_upgrade ]; then
-    if [ $SSD_FW_VERSION == "S141002C" ] || [ $SSD_FW_VERSION == "S16425c1" ]; then
+    if [ $SSD_MODEL == "3IE" ] && [ $SSD_FW_VERSION == "s141002c" ]; then
+        # If SSD Firmware is not upgraded
+        exit 0
+    fi
+    if [ $SSD_FW_VERSION == "s16425c1" ] || [ $SSD_FW_VERSION == "s16425cq" ]; then
         # If SSD Firmware is not upgraded
         exit 0
     fi
@@ -51,17 +56,17 @@ elif [ $SSD_UPGRADE_STATUS2 == "2" ];then
 
     echo "$0 `date` Upgraded to unknown version after second mp_64 upgrade." >> $SSD_UPGRADE_LOG
 
-elif [ $SSD_FW_VERSION == "S141002G" ] || [ $SSD_FW_VERSION == "S16425cG" ]; then
+elif [ $SSD_FW_VERSION == "s141002g" ] || [ $SSD_FW_VERSION == "s16425cg" ]; then
     # If SSD Firmware is upgraded
     GPIO_STATUS=$(echo "$iSMART_CMD" | grep GPIO | awk '{print $NF}')
 
     if [ $GPIO_STATUS != "0x01" ];then
-        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty and does not support reboot."
-        logger -p user.crit -t DELL_S6100_SSD_MON "If a reboot is required, please perform a soft-/fast-/warm-reboot."
+        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
+        logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
         rm -rf $SSD_FW_UPGRADE/GPIO7_*
         touch $SSD_FW_UPGRADE/GPIO7_low
-        echo "$0 `date` The SSD on this unit is faulty and does not support cold reboot." >> $SSD_UPGRADE_LOG
-        echo "$0 `date` If a reboot is required, please perform a soft-/fast-/warm-reboot." >> $SSD_UPGRADE_LOG
+        echo "$0 `date` The SSD on this unit is faulty. Do not power-cycle/reboot this unit!" >> $SSD_UPGRADE_LOG
+        echo "$0 `date` soft-/fast-/warm-reboot is allowed." >> $SSD_UPGRADE_LOG
 
     else
         rm -rf $SSD_FW_UPGRADE/GPIO7_*
@@ -85,13 +90,13 @@ else
         rm -rf $SSD_FW_UPGRADE/GPIO7_*
         touch $SSD_FW_UPGRADE/GPIO7_pending_upgrade
 
-        echo "$0 `date` SSD upgrade didn’t happened." >> $SSD_UPGRADE_LOG
+        echo "$0 `date` SSD upgrade didn’t happen." >> $SSD_UPGRADE_LOG
 
     elif [ $SSD_UPGRADE_STATUS1 == "1" ]; then
         rm -rf $SSD_FW_UPGRADE/GPIO7_*
         touch $SSD_FW_UPGRADE/GPIO7_low
-        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty and does not support reboot."
-        logger -p user.crit -t DELL_S6100_SSD_MON "If a reboot is required, please perform a soft-/fast-/warm-reboot."
+        logger -p user.crit -t DELL_S6100_SSD_MON "The SSD on this unit is faulty. Do not power-cycle/reboot this unit!"
+        logger -p user.crit -t DELL_S6100_SSD_MON "soft-/fast-/warm-reboot is allowed."
 
         echo "$0 `date` SSD entered loader mode in first mp_64 upgrade." >> $SSD_UPGRADE_LOG
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/soft-reboot_plugin
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/soft-reboot_plugin
@@ -1,0 +1,1 @@
+fast-reboot_plugin


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Added soft-reboot plugin support.
- Added SSD version s16425cq check
- Added error message to display in console/SSH in case reboot is called in faulty/non-upgraded devices.

#### How I did it
On branch 201911_ssd_plugin
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        modified:   ../../debian/platform-modules-s6100.install
        modified:   platform_reboot_pre_check
        modified:   s6100_ssd_mon.sh
        modified:   s6100_ssd_upgrade_status.sh
        new file:   soft-reboot_plugin


#### How to verify it
Attached logs for reference.
[test-3IE3-2018-2019.txt](https://github.com/Azure/sonic-buildimage/files/6294065/test-3IE3-2018-2019.txt)
[test-3IE-2018-2019.txt](https://github.com/Azure/sonic-buildimage/files/6294066/test-3IE-2018-2019.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

