### PR TITLE
adding snappi to docker

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -41,6 +41,7 @@ RUN pip install cffi==1.10.0 \
                 ipython==5.4.1 \
                 ixnetwork-restpy==1.0.52 \
                 ixnetwork-open-traffic-generator==0.0.70 \
+                snappi[ixnetwork]==0.3.13 \
                 jinja2==2.7.2 \
                 jsonpatch \
                 lxml \


### PR DESCRIPTION
#### Why I did it

For the migration of tests that involves tgen from `abstract` to `snappi`, snappi library is needed

dependent PR: https://github.com/Azure/sonic-mgmt/pull/3298


