### PR TITLE
[as4630-54pe] Fixes qfp_ports to port53 and 54

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/plugins/sfputil.py
@@ -50,7 +50,11 @@ class SfpUtil(SfpUtilBase):
 
     @property
     def qsfp_ports(self):
-        return list(range(self.PORT_START, self.PORTS_IN_BLOCK + 1))
+        return list(range(self.QSFP_START, self.PORTS_IN_BLOCK + 1))
+    
+    @property
+    def sfp_ports(self):
+        return list(range(self.PORT_START, 4))
 
     @property
     def port_to_eeprom_mapping(self):

--- a/device/accton/x86_64-accton_as4630_54pe-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/plugins/sfputil.py
@@ -53,10 +53,6 @@ class SfpUtil(SfpUtilBase):
         return list(range(self.QSFP_START, self.PORTS_IN_BLOCK + 1))
     
     @property
-    def sfp_ports(self):
-        return list(range(self.PORT_START, 4))
-
-    @property
     def port_to_eeprom_mapping(self):
         return self._port_to_eeprom_mapping
 


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This DUT from port49 to 52 are sfp. Port53 and port54 are QSFP ports.
Old code define 6 ports to QSFP, and it will let sonic_sfp dom parse to incorrect offset.
#### How I did it
Add to define sfp_ports for port49 to 52.
Fixes to define qsfp port from 6 ports to only port53 and port54 
#### How to verify it
Test sfpuutil show and insert the cable that not support dom cable to Thernet48.
Insert the cable support dom to Ethernet49.
Ethernet48: SFP EEPROM detected
        Connector: LC
        EncodingCodes: 8B/10B
        ExtIdentOfTypeOfTransceiver: GBIC/SFP defined by twowire interface ID
       ...........
        MonitorData:
                RXPower: Unknown
                TXBias: Unknown
                TXPower: Unknown
                Temperature: Unknown
                Vcc: Unknown

Ethernet49: SFP EEPROM detected
        CalibrationType: Internally Calibrated
        Connector: LC
        EncodingCodes: 64B/66B
        ExtIdentOfTypeOfTransceiver: GBIC/SFP defined by twowire interface ID
.............
      MonitorData:
                RXPower: 2.4202dBm
                TXBias: 25.1920mA
                TXPower: 1.5011dBm
                Temperature: 70.3281C
                Vcc: 1.9544Volts
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

