### PR TITLE
Support pytest-timeut to terminate tests

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -59,6 +59,7 @@ RUN pip install cffi==1.10.0 \
                 pysnmp==4.2.5 \
                 pytest-repeat \
                 pytest-html \
+                pytest-timeout \
                 pytest-xdist==1.28.0 \
                 pytest==4.6.5 \
                 redis \


### PR DESCRIPTION
Signed-off-by: Yuliia Bashko <yuliiax.bashko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To limit TC execution time in case of issues by adding `--timeout=1000` to test execution command. For that pytest-timeout should be installed in sonic-mgmt-container.
#### How I did it
Added pytest-timeout plugin to sonic-mgmt Dockerfile
#### How to verify it
Check if plugin is installed in container with `pip show pytest-timeout`
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

