### PR TITLE
[DPB][YANG-models] Update portchannel yang model to have lacp_key

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -11,7 +11,8 @@
                 "members": [
                     "Ethernet1"
                 ],
-                "mtu": "9100"
+                "mtu": "9100",
+                "lacp_key": "auto"
             },
             "PortChannel0004": {
                 "admin_status": "up",
@@ -19,7 +20,8 @@
                 "members": [
                     "Ethernet2"
                 ],
-                "mtu": "9100"
+                "mtu": "9100",
+                "lacp_key": "auto"
             }
         },
         "PORTCHANNEL_INTERFACE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -25,6 +25,7 @@
                         ],
                         "min_links": "1",
                         "mtu": "9100",
+                        "lacp_key": "auto",
                         "name": "PortChannel0001"
                     }
                 ]

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -95,7 +95,21 @@ module sonic-portchannel {
                     mandatory true;
                     type stypes:admin_status;
                 }
-            } /* end of list PORTCHANNEL_LIST */
+
+                leaf lacp_key {
+                    /* lacp key should be either auto or a integer in the range of 1 to 65535 */
+                    /* When lacp_key is set to 'auto' the lacp key would be set to be the number */
+                    /* on the end of the PortChannel name with a prefix of 1 */
+                    type union {
+                        type string {
+                            pattern "auto";
+                        }
+                        type uint16 {
+                            range 1..65535;
+                        }
+                    }
+                }
+			} /* end of list PORTCHANNEL_LIST */
 
         } /* end of container PORTCHANNEL */
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
This PR depends on https://github.com/Azure/sonic-swss/pull/1660

#### Why I did it
To update the yang model to support the new key interduced in https://github.com/Azure/sonic-swss/pull/1660
#### How I did it
Add to the portchanels yang file an definition for the lacp_key

#### How to verify it
Run the command `config interface breakout <interface> <breakout_mode>`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)