### PR TITLE
[ci] Fix the SONiC version starting with HEAD issue

### DIFF
--- a/.azure-pipelines/official-build.yml
+++ b/.azure-pipelines/official-build.yml
@@ -20,6 +20,7 @@ stages:
   pool: sonicbld
   variables:
     CACHE_MODE: wcache
+    BRANCH_NAME: $(Build.SourceBranchName)
     ${{ if eq(variables['Build.SourceBranchName'], '202012') }}:
       VERSION_CONTROL_OPTIONS: 'SONIC_VERSION_CONTROL_COMPONENTS=deb,py2,py3,web'
   jobs:

--- a/functions.sh
+++ b/functions.sh
@@ -54,6 +54,7 @@ sonic_get_version() {
     local describe=$(git describe --tags)
     local latest_tag=$(git describe --tags --abbrev=0)
     local branch_name=$(git rev-parse --abbrev-ref HEAD)
+    [ -n "$BRANCH_NAME" ] && branch_name=$BRANCH_NAME
     if [ -n "$(git status --untracked-files=no -s --ignore-submodules)" ]; then
         local dirty="-dirty-$BUILD_TIMESTAMP"
     fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the SONiC version starting with HEAD issue. For example, sonic-broadcom-HEAD.40620469-1d98d18cf.bin.

#### How I did it
Allow the azure pipelines to input the correct branch name to overwrite the default HEAD value.

#### How to verify it
```
$ git branch 
* (HEAD detached at ca072d2)
$ sonic_get_version
HEAD.0-ca072d2
export BRANCH_NAME=201911
$ sonic_get_version
201911.0-ca072d2
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

