### PR TITLE
[PMON] syseepromd simx fix - expose pmon docker to relevant folders and avoi…

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/eeprom.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/eeprom.py
@@ -30,6 +30,7 @@ except ImportError as e:
 
 SYSLOG_IDENTIFIER = "eeprom.py"
 EEPROM_SYMLINK = "/var/run/hw-management/eeprom/vpd_info"
+CACHE_ROOT = "/var/cache/sonic/decode-syseeprom"
 CACHE_FILE = "/var/cache/sonic/decode-syseeprom/syseeprom_cache"
 
 
@@ -43,9 +44,11 @@ machine_info = get_machine_info()
 onie_platform = machine_info['onie_platform']
 if 'simx' in onie_platform:
     platform_path = os.path.join('/usr/share/sonic/device', onie_platform)
-    subprocess.check_call(['/usr/bin/xxd', '-r', '-p', 'syseeprom.hex', 'syseeprom.bin'], cwd=platform_path)
-    CACHE_FILE = os.path.join(platform_path, 'syseeprom.bin')
-
+    if not os.path.exists(platform_path):
+        platform_path = '/usr/share/sonic/platform'
+    if not os.path.exists(CACHE_ROOT):
+        os.makedirs(CACHE_ROOT)
+    subprocess.check_call(['/usr/bin/xxd', '-r', '-p', 'syseeprom.hex', CACHE_FILE], cwd=platform_path)
 
 class board(eeprom_tlvinfo.TlvInfoDecoder):
 

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -393,6 +393,8 @@ start() {
         -v mlnx_sdk_ready:/tmp \
         -e SX_API_SOCKET_FILE=/var/run/sx_sdk/sx_api.sock \
         -v /dev/shm:/dev/shm:rw \
+        -v /usr/share/sonic/device/$PLATFORM:/usr/share/sonic/device/$PLATFORM:ro \
+        -v /host/machine.conf:/host/machine.conf:ro \
 {%- else %}
 {%- if mount_default_tmpfs|default("n") == "y" %}
         --tmpfs /tmp \

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -13,6 +13,7 @@ try:
     from sonic_platform_base.component_base import ComponentBase
     from sonic_py_common import device_info
     from sonic_py_common.logger import Logger
+    from sonic_py_common.device_info import get_machine_info
     from os import listdir
     from os.path import isfile, join
     import sys
@@ -86,6 +87,10 @@ class Chassis(ChassisBase):
 
 
     def initialize_psu(self):
+        onie_platform = get_machine_info()['onie_platform']
+        if 'simx'  in onie_platform:
+            return
+            
         from sonic_platform.psu import Psu
         # Initialize PSU list
         self.psu_module = Psu
@@ -95,6 +100,10 @@ class Chassis(ChassisBase):
 
 
     def initialize_fan(self):
+        onie_platform = get_machine_info()['onie_platform']
+        if 'simx'  in onie_platform:
+            return
+        
         from .device_data import DEVICE_DATA
         from sonic_platform.fan import Fan
         from .fan_drawer import RealDrawer, VirtualDrawer
@@ -116,6 +125,9 @@ class Chassis(ChassisBase):
 
 
     def initialize_sfp(self):
+        onie_platform = get_machine_info()['onie_platform']
+        if 'simx'  in onie_platform:
+            return
         from sonic_platform.sfp import SFP
 
         self.sfp_module = SFP
@@ -148,6 +160,9 @@ class Chassis(ChassisBase):
 
 
     def initialize_thermals(self):
+        onie_platform = get_machine_info()['onie_platform']
+        if 'simx'  in onie_platform:
+            return
         from sonic_platform.thermal import initialize_chassis_thermals
         # Initialize thermals
         initialize_chassis_thermals(self.platform_name, self._thermal_list)
@@ -163,6 +178,9 @@ class Chassis(ChassisBase):
 
 
     def initialize_components(self):
+        onie_platform = get_machine_info()['onie_platform']
+        if 'simx'  in onie_platform:
+            return
         # Initialize component list
         from sonic_platform.component import ComponentONIE, ComponentSSD, ComponentBIOS, ComponentCPLD
         self._component_list.append(ComponentONIE())
@@ -171,6 +189,9 @@ class Chassis(ChassisBase):
         self._component_list.extend(ComponentCPLD.get_component_list())
 
     def initizalize_system_led(self):
+        onie_platform = get_machine_info()['onie_platform']
+        if 'simx'  in onie_platform:
+            return
         from .led import SystemLed
         Chassis._led = SystemLed()
 


### PR DESCRIPTION
[PMON] syseepromd simx fix - expose pmon docker to relevant folders and avoid initializing sfp/thermal/components/fan/psu/leds on simx

Signed-off-by: tomeri <tomeri@nvidia.com>

#### Why I did it
this is a fix for issue in mellanox simx platforms. the syseepromd failed on the pmon docker.
- the pmon was trying to check the content of the files on /host/machine.conf
- avoid initializing sfp/thermal/components/fan/psu/leds on simx
- create cache folder if not exist 
- avoid check EEPROM_SYMLINK if we are running on simx
#### How I did it
- i added to docker create script the "-v <folder> " attribute to open this folder for read or write from the pmon docker
- before initializing sfp/thermal/components/fan/psu/leds --> check if we are running on simx
#### How to verify it
- syseepromd didnt failed on simx - without any unknown errors/warnings on log 
- the mounts for the pmon docker is using and the new added folders (using "docker inspect -f '{{ .Mounts }}' <contasiner id>")
- decode-syseepromd is working well without errors

#### Which release branch to backport (provide reason below if selected)
master

#### Description for the changelog
- change the docker create script - added folders to be exposed to the pmon docker
- change to chassis.py - initialize sfp/thermal/components/fan/psu/leds only on non simx systems
- change the eeprom script - location of syseeprom.bin was changed to CACHE folder



