### PR TITLE
[Monit] Monitor critical processes in radv container

### DIFF
--- a/dockers/docker-router-advertiser/base_image_files/monit_radv.j2
+++ b/dockers/docker-router-advertiser/base_image_files/monit_radv.j2
@@ -1,0 +1,30 @@
+{# Router advertiser should only run on ToR (T0) devices which have #}
+{# at least one VLAN interface which has an IPv6 address asigned #}
+{# But not for specific deployment_id #}
+{%- set vlan_v6 = namespace(count=0) -%}
+{%- if DEVICE_METADATA is defined and DEVICE_METADATA.localhost is defined -%}
+  {%- if DEVICE_METADATA.localhost.deployment_id is defined and DEVICE_METADATA.localhost.type is defined -%}
+    {%- if DEVICE_METADATA.localhost.deployment_id != "8" -%}
+      {%- if "ToRRouter" in DEVICE_METADATA.localhost.type and DEVICE_METADATA.localhost.type != "MgmtToRRouter" -%}
+        {%- if VLAN_INTERFACE -%}
+          {%- for (name, prefix) in VLAN_INTERFACE|pfx_filter -%}
+            {# If this VLAN has an IPv6 address... #}
+            {%- if prefix | ipv6 -%}
+              {%- set vlan_v6.count = vlan_v6.count + 1 -%}
+            {%- endif -%}
+          {%- endfor -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endif -%}
+
+{%- if vlan_v6.count > 0 %}
+###############################################################################
+## Monit configuration for radv container
+## process list:
+##  radvd
+###############################################################################
+check program radv|radvd with path "/usr/bin/process_checker radv /usr/sbin/radvd -n"
+    if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+{% endif -%}

--- a/dockers/docker-router-advertiser/base_image_files/monit_radv.j2
+++ b/dockers/docker-router-advertiser/base_image_files/monit_radv.j2
@@ -1,3 +1,5 @@
+{# This template file is used to generate Monit configuration file of router advertiser container. -#}
+
 {# Router advertiser should only run on ToR (T0) devices which have #}
 {# at least one VLAN interface which has an IPv6 address asigned #}
 {# But not for specific deployment_id #}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -319,7 +319,6 @@ sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/container_checker
 sudo cp $IMAGE_CONFIGS/monit/generate_monit_config.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 sudo cp $IMAGE_CONFIGS/monit/generate_monit_config $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/generate_monit_config
-s
 
 # Install custom-built openssh sshd
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/openssh-server_*.deb

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -316,7 +316,10 @@ sudo cp $IMAGE_CONFIGS/monit/process_checker $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/process_checker
 sudo cp $IMAGE_CONFIGS/monit/container_checker $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/container_checker
-
+sudo cp $IMAGE_CONFIGS/monit/generate_monit_config.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+sudo cp $IMAGE_CONFIGS/monit/generate_monit_config $FILESYSTEM_ROOT/usr/bin/
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/generate_monit_config
+s
 
 # Install custom-built openssh sshd
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/openssh-server_*.deb

--- a/files/image_config/monit/generate_monit_config
+++ b/files/image_config/monit/generate_monit_config
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+CFGGEN_PARAMS=" \
+    -d -t /usr/share/sonic/templates/monit_radv.j2,/etc/monit/conf.d/monit_radv \
+"
+sonic-cfggen $CFGGEN_PARAMS

--- a/files/image_config/monit/generate_monit_config.service
+++ b/files/image_config/monit/generate_monit_config.service
@@ -6,7 +6,8 @@ Before=monit.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/generate_monit_config.sh
+RemainAfterExit=yes
+ExecStart=/usr/bin/generate_monit_config
 
 [Install]
 WantedBy=multi-user.target

--- a/files/image_config/monit/generate_monit_config.service
+++ b/files/image_config/monit/generate_monit_config.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Generate Monit configuration file from template
+Requires=updategraph.service
+After=updategraph.service
+Before=monit.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/generate_monit_config.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/rules/docker-router-advertiser.mk
+++ b/rules/docker-router-advertiser.mk
@@ -24,3 +24,4 @@ $(DOCKER_ROUTER_ADVERTISER)_RUN_OPT += --privileged -t
 $(DOCKER_ROUTER_ADVERTISER)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_ROUTER_ADVERTISER)_RUN_OPT += -v /usr/share/sonic/scripts:/usr/share/sonic/scripts:ro
 $(DOCKER_ROUTER_ADVERTISER)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)
+$(DOCKER_ROUTER_ADVERTISER)_BASE_IMAGE_FILES += monit_radv.j2:/usr/share/sonic/tempaltes


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR aims to monitor critical processes in router advertiser container by Monit.

#### How I did it
Router advertiser container only ran on T0 device and the T0 device should have at least one VLAN interface
which was configured an IPv6 address. At the same time, router advertiser container will not run on devices of which
the deployment type is 8.

As such, I created a service which will dynamically generate Monit configuration file of router advertiser from a
template.

#### How to verify it
I verified this implementation on a DuT.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

