### PR TITLE
Fix the SONiC version starting with HEAD issue

### DIFF
--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -38,6 +38,7 @@ jobs:
         submodules: recursive
         displayName: 'Checkout code'
       - script: |
+          git checkout -b $(Build.SourceBranchName)
           sudo modprobe overlay
           sudo apt-get install -y acl
           export DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the SONiC version starting with HEAD issue. For example, sonic-broadcom-HEAD.40620469-1d98d18cf.bin.

#### How I did it
Set the correct branch name after the code checked out.

#### How to verify it
After applied the change "git checkout -b 201911", the version is good.
```
$ git branch
* (HEAD detached at cf54cbc5)
$ sonic_get_version
HEAD.0-cf54cbc5
$ git checkout -b 201911
Switched to a new branch '201911'
$ sonic_get_version     
201911.0-cf54cbc5
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

