### PR TITLE
[ci] Fix no enough space issue in docker root in multi arch build

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -24,6 +24,7 @@ jobs:
       PLATFORM_AZP: $(GROUP_NAME)
       PLATFORM_ARCH: amd64
       BUILD_OPTIONS: ${{ parameters.buildOptions }}
+      DOCKER_DATA_ROOT_FOR_MULTIARCH: /data/multiarch/docker
       dbg_image: false
       swi_image: false
       raw_image: false

--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -24,7 +24,7 @@ jobs:
       PLATFORM_AZP: $(GROUP_NAME)
       PLATFORM_ARCH: amd64
       BUILD_OPTIONS: ${{ parameters.buildOptions }}
-      DOCKER_DATA_ROOT_FOR_MULTIARCH: /data/multiarch/docker
+      DOCKER_DATA_ROOT_FOR_MULTIARCH: /data/march/docker
       dbg_image: false
       swi_image: false
       raw_image: false

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -40,7 +40,6 @@ jobs:
       - script: |
           sudo modprobe overlay
           sudo apt-get install -y acl
-          export DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker
           sudo bash -c "echo 1 > /proc/sys/vm/compact_memory"
           ENABLE_DOCKER_BASE_PULL=y make PLATFORM=$(PLATFORM_AZP) PLATFORM_ARCH=$(PLATFORM_ARCH) configure
         displayName: 'Make configure'


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Failed to build the centec-arm64 for no space in docker data root.

#### How I did it
Change to use the data root to the folder under /data.
See detail info about DOCKER_DATA_ROOT_FOR_MULTIARCH in the file Makefile.work.

#### How to verify it
Set the environment variable, then the /data used as docker root.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

