### PR TITLE
[202012][sonic-platform-common] Track 202012 branch of submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,6 +41,7 @@
 [submodule "src/sonic-platform-common"]
 	path = src/sonic-platform-common
 	url = https://github.com/Azure/sonic-platform-common
+	branch = 202012
 [submodule "src/sonic-platform-daemons"]
 	path = src/sonic-platform-daemons
 	url = https://github.com/Azure/sonic-platform-daemons


### PR DESCRIPTION
#### Why I did it

Recently created a 202012 branch of sonic-platform common. Update .gitmodules to track that branch of the submodule in the 202012 branch of sonic-buildimage.