### PR TITLE
CISCO: Give an opportunity to apply platform specific patches

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -87,8 +87,8 @@ configure :
 	@mkdir -p $(DPKG_ADMINDIR_PATH)
 	@echo $(PLATFORM) > .platform
 	@echo $(PLATFORM_ARCH) > .arch
-	@if [ -x platform/$(PLATFORM)/patches/configure.sh ]; then \
-	    platform/$(PLATFORM)/patches/configure.sh; \
+	@if [ -x platform/$(PLATFORM)/configure.sh ]; then \
+	    platform/$(PLATFORM)/configure.sh; \
 	fi
 
 distclean : .platform clean

--- a/slave.mk
+++ b/slave.mk
@@ -87,6 +87,9 @@ configure :
 	@mkdir -p $(DPKG_ADMINDIR_PATH)
 	@echo $(PLATFORM) > .platform
 	@echo $(PLATFORM_ARCH) > .arch
+	@if [ -x platform/$(PLATFORM)/patches/configure.sh ]; then \
+	    platform/$(PLATFORM)/patches/configure.sh; \
+	fi
 
 distclean : .platform clean
 	@rm -f .platform


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The platform/$PLATFORM/patches/configure.sh will apply patches as desired. 

#### How I did it
Changes to slave.mk file to invoke platform/$PLATFORM/patches/configure.sh. The patches directory, will host all the patches in its path. 

#### How to verify it

A sample bash script that does the following: 

platform/cisco-8000/patches/configure.sh 
```
#!/bin/bash

set -e
ROOT=$(pwd)
PATCHES=${ROOT}/platform/cisco-8000/patches
for path in ${PATCHES}/*; do
    if [ -d ${path} ]; then
        dir=${path##*/}
        (cd ${ROOT} && git submodule update src/${dir})

        (cd src/$dir && git clean -xfd \
                     && git reset --hard \
                     && git apply $(sed -n -e "/^#/n" -e "/^\\S/s@^@${path}/@p" ${path}/series))
    fi
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [X] 201811
- [X ] 201911
- [X] 202006
- [X] 202012

#### Description for the changelog
<!--
configure.sh is bash script to search for any existence of a patch file. If such a file exists then it patches based on their existence in the specified paths.
-->


#### A picture of a cute animal (not mandatory but encouraged)

