### PR TITLE
CISCO: Provide support for platform hooks in syncd.sh

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -28,6 +28,10 @@ function startplatform() {
         debug "Firmware update procedure ended"
     fi
 
+    # This is a platform agnostic approach to check if 'platform'
+    # entry exists in the DEVICE_METADATA table. If it exits then
+    # source the script to perform platform specific checks
+
     PLATFORM_DIR=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
     F="/usr/share/sonic/device/$PLATFORM_DIR/scripts/syncd.sh"
     [ -e $F ] && source $F start $DEV

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -28,6 +28,10 @@ function startplatform() {
         debug "Firmware update procedure ended"
     fi
 
+    PLATFORM_DIR=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+    F="/usr/share/sonic/device/$PLATFORM_DIR/scripts/syncd.sh"
+    [ -e $F ] && source $F start $DEV
+
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         if [ x$sonic_asic_platform == x'cavium' ]; then
             /etc/init.d/xpnet.sh start


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is a platform agnostic & vendor agnostic change to files/scripts/syncd.sh to check if 'platform' entry exists in the DEVICE_METADATA table. If it exits it checks if there is a file to source and hence does the needful. 

#### How to verify it
This is a PR followup from the code-review discussion we had with Guhon/Rita and team. This also addresses one of the comment that was raised to convert to sourcing a file instead of executing the same., so the logic within is run in the same shell. 

#### How I did it#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x ] 201811
- [x ] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
This extends the capability to run certain platform specific plugin once a given platform is initialized. Such plugins can range from detecting # of asic for a distributed system, discovering PCiE entries etc. 
-->


#### A picture of a cute animal (not mandatory but encouraged)

