### PR TITLE
Dell S6100: Add dell ich driver

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -28,6 +28,7 @@ if [[ "$1" == "init" ]]; then
     pericom="/sys/bus/pci/devices/0000:08:00.0"
     modprobe i2c-dev
     modprobe i2c-mux-pca954x force_deselect_on_exit=1
+    modprobe dell_ich
     modprobe dell_s6100_iom_cpld
     modprobe dell_s6100_lpc
     modprobe nvram
@@ -59,6 +60,7 @@ elif [[ "$1" == "deinit" ]]; then
     modprobe -r dell_s6100_iom_cpld
     modprobe -r i2c-mux-pca954x
     modprobe -r i2c-dev
+    modprobe -r dell_ich
     modprobe -r nvram
     remove_python_api_package
 else


### PR DESCRIPTION
#### Why I did it
dell_ich driver was removed as part of https://github.com/Azure/sonic-buildimage/pull/7309 and it is needed for watchdog tickle in S6100 platform.
#### How I did it
Modified S6100 platform init to include dell_ich driver 
#### How to verify it
Do modprobe dell_ich/modprobe -r dell_ich or do platform init/deinit and verify the dell_ich sysfs.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
[dell_ich_UT.txt](https://github.com/Azure/sonic-buildimage/files/6316580/dell_ich_UT.txt)


#### A picture of a cute animal (not mandatory but encouraged)

