### PR TITLE
Provide curl options in curl command

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -332,7 +332,7 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_ONLINE_DEBS)) : $(DEBS_PATH)/% : .platform \
 	if [ -z '$($*_CACHE_LOADED)' ] ; then
 
 		$(foreach deb,$* $($*_DERIVED_DEBS), \
-			{ curl -L -f -o $(DEBS_PATH)/$(deb) $($(deb)_URL) $(LOG) || { exit 1 ; } } ; )
+			{ curl -L -f -o $(DEBS_PATH)/$(deb) $($(deb)_CURL_OPTIONS) $($(deb)_URL) $(LOG) || { exit 1 ; } } ; )
 
 		# Save the target deb into DPKG cache
 		$(call SAVE_CACHE,$*,$@)
@@ -349,7 +349,7 @@ SONIC_TARGET_LIST += $(addprefix $(DEBS_PATH)/, $(SONIC_ONLINE_DEBS))
 #     SONIC_ONLINE_FILES += $(SOME_NEW_FILE)
 $(addprefix $(FILES_PATH)/, $(SONIC_ONLINE_FILES)) : $(FILES_PATH)/% : .platform
 	$(HEADER)
-	curl -L -f -o $@ $($*_URL) $(LOG)
+	curl -L -f -o $@ $($*_CURL_OPTIONS) $($*_URL) $(LOG)
 	$(FOOTER)
 
 SONIC_TARGET_LIST += $(addprefix $(FILES_PATH)/, $(SONIC_ONLINE_FILES))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Provide possibility to specify curl options as the present curl support provided in Azure/sonic does not extend capability for options like --user which some of the cisco artifacts are requiring. 

#### How I did it
Add extensions to the slave.mk file to include curl options as follows: 

$($*_CURL_OPTIONS)


#### How to verify it

Option 1) use curl -u, and environment variables

 it with --user <user:password> curl_options. Ex: --user foo:'bar!'

curl -u ${BASIC_AUTH_HEADER} https://foo.bar

This works to obscure password/credential in a terminal session that someone else might see directly or via screen share. 


Option 2)  Option 1: use curl -n

 If you run linux, create a ~/.netrc file and insert your creds there, and use curl -n. 

chmod the file to 400. curl knows how to extract your creds from the file silently. You never have to type creds on the command line again.

If you run Windows, and use curl, you must name the file _netrc . As on *nix, the file should be in your home directory, and should have appropriate permissions.

For Administrative APIs , my .netrc file looks like this:

machine foobar-linux 
  login foo
  password bar
	

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [] 201811
- [] 201911
- [] 202006
- [x] 202012

#### Description for the changelog
<!--
Provide support for curl options in curl command 
-->


#### A picture of a cute animal (not mandatory but encouraged)

