### PR TITLE
[build] Extend rules/config.user to more Makefiles

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -91,6 +91,7 @@ SLAVE_DIR = sonic-slave-jessie
 endif
 
 include rules/config
+-include rules/config.user
 
 ifeq ($(ENABLE_DOCKER_BASE_PULL),)
 	override ENABLE_DOCKER_BASE_PULL = n


### PR DESCRIPTION
rules/config.user allows overriding default properties without
touching tracked files. This change makes sure all properties
can be set and not just the ones used in slave.mk.

#### Why I did it

I want to set `SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD` which is read by `Makefile.work`.

#### How I did it

I extended the existing functionality introduced in https://github.com/Azure/sonic-buildimage/pull/5325.

#### How to verify it

```
echo 'SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD = y` > rules/config.user
make [some target]
ps ax | grep 'docker.sock' --color
# Verify that the docker container running has  -v /var/run/docker.sock:/var/run/docker.sock set.
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog

Extending functionality of `rules/config.user` to include all build options.

#### A picture of a cute animal (not mandatory but encouraged)
![image](https://user-images.githubusercontent.com/149442/114947833-1c0a3200-9e4e-11eb-8dce-b6f592771c0c.png)


