### PR TITLE
Ensure platform has a chance to override defaults

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -92,6 +92,13 @@ endif
 
 include rules/config
 
+# Ensure platform has a chance to override defaults
+CONFIGURED_PLATFORM := $(shell [ -f .platform ] && cat .platform || echo generic)
+PLATFORM_CONFIG := platform/$(if $(PLATFORM),$(PLATFORM),$(CONFIGURED_PLATFORM))/rules/config
+ifneq (,$(wildcard $(PLATFORM_CONFIG)))
+include $(PLATFORM_CONFIG)
+endif
+
 ifeq ($(ENABLE_DOCKER_BASE_PULL),)
 	override ENABLE_DOCKER_BASE_PULL = n
 endif

--- a/Makefile.work
+++ b/Makefile.work
@@ -92,13 +92,6 @@ endif
 
 include rules/config
 
-# Ensure platform has a chance to override defaults
-CONFIGURED_PLATFORM := $(shell [ -f .platform ] && cat .platform || echo generic)
-PLATFORM_CONFIG := platform/$(if $(PLATFORM),$(PLATFORM),$(CONFIGURED_PLATFORM))/rules/config
-ifneq (,$(wildcard $(PLATFORM_CONFIG)))
-include $(PLATFORM_CONFIG)
-endif
-
 ifeq ($(ENABLE_DOCKER_BASE_PULL),)
 	override ENABLE_DOCKER_BASE_PULL = n
 endif

--- a/slave.mk
+++ b/slave.mk
@@ -110,6 +110,12 @@ export PACKAGE_URL_PREFIX
 export TRUSTED_GPG_URLS
 export SONIC_VERSION_CONTROL_COMPONENTS
 
+# Ensure platform has a chance to override defaults
+PLATFORM_CONFIG := platform/$(if $(PLATFORM),$(PLATFORM),$(CONFIGURED_PLATFORM))/rules/config
+ifneq (,$(wildcard $(PLATFORM_CONFIG)))
+include $(PLATFORM_CONFIG)
+endif
+
 ifeq ($(SONIC_ENABLE_PFCWD_ON_START),y)
 ENABLE_PFCWD_ON_START = y
 endif


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This provides ability for Platform to override certain defaults specified in the SONiC's rules/config file or via the environment variables. This gives build time & run time flexibility for a vendor platform to scale over build and run time issues 

#### How I did it
Check if platform/<vendor>/rules/config file exists and if so then source it 

#### How to verify it
Two such examples are as follows: 

example1: 
For instance, certain build time docker mounts issues in internal servers can be overcome: 
DOCKER_BUILDER_MOUNTS := \
    $(if $(BUILD_DOCKER_CONFIG),$(BUILD_DOCKER_CONFIG),/etc/docker/interior.daemon.json):/etc/docker/daemon.json:ro


example 2: 
DEFAULT_USERNAME := foo
DEFAULT_PASSWORD := bar

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
Extend SONiC builid env to provide ability for platforms to use their defaults instead of SONiC specified defaults 
-->


#### A picture of a cute animal (not mandatory but encouraged)

