### PR TITLE
[build] Pass number of CPUs as jobs parameter to make command for SONIC_MAKE_DEBS

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -427,7 +427,7 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_MAKE_DEBS)) : $(DEBS_PATH)/% : .platform $$(a
 		if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; popd; fi
 		# Build project and take package
 		$(SETUP_OVERLAYFS_FOR_DPKG_ADMINDIR)
-		DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC}" make DEST=$(shell pwd)/$(DEBS_PATH) -C $($*_SRC_PATH) $(shell pwd)/$(DEBS_PATH)/$* $(LOG)
+		DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC}" make -j$(SONIC_CONFIG_MAKE_JOBS) DEST=$(shell pwd)/$(DEBS_PATH) -C $($*_SRC_PATH) $(shell pwd)/$(DEBS_PATH)/$* $(LOG)
 		# Clean up
 		if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && quilt pop -a -f; [ -d .pc ] && rm -rf .pc; popd; fi
 


### PR DESCRIPTION
#### Why I did it
There was an existing omission in the build jobs that SONIC_CONFIG_MAKE_JOBS wasn't being passed through to the underlying make command in SONIC_MAKE_DEBS, meaning we weren't fully utilizing all of the CPUs during builds.

#### How I did it
Added "-j$(SONIC_CONFIG_MAKE_JOBS)" to the make command
