### PR TITLE
CISCO: Enhance sonic-config-engine to support L1 & L3 configurations

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -9,6 +9,39 @@ if sys.version_info.major == 3:
 else:
     UNICODE_TYPE = unicode
 
+
+# The new enhancements to this file provides capabilities to generate l1 & l3
+# configuration in addition the existing l2, t1 and empty configurations
+# So the following capabilities exits now:
+#    't1': generate_t1_sample_config,
+#    'l2': generate_l2_config,
+#    'empty': generate_empty_config,
+#    'l1': generate_l1_config,
+#    'l3': generate_l3_config
+
+def generate_l1_config(data):
+    data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
+    data['DEVICE_METADATA']['localhost']['type'] = 'LeafRouter'
+    for port in natsorted(data['PORT']):
+        data['PORT'][port]['admin_status'] = 'up'
+        data['PORT'][port]['mtu'] = '9100'
+    return data;
+
+def generate_l3_config(data):
+    data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
+    data['DEVICE_METADATA']['localhost']['type'] = 'LeafRouter'
+    data['DEVICE_METADATA']['localhost']['bgp_asn'] = '65100'
+    data['LOOPBACK_INTERFACE'] = {"Loopback0": {},
+                                  "Loopback0|10.1.0.1/32": {}}
+    data['BGP_NEIGHBOR'] = {}
+    data['DEVICE_NEIGHBOR'] = {}
+    data['INTERFACE'] = {}
+    for port in natsorted(data['PORT']):
+        data['PORT'][port]['admin_status'] = 'up'
+        data['PORT'][port]['mtu'] = '9100'
+        data['INTERFACE']['{}'.format(port)] = {}
+    return data;
+
 def generate_t1_sample_config(data):
     data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
     data['DEVICE_METADATA']['localhost']['type'] = 'LeafRouter'
@@ -95,7 +128,9 @@ def generate_l2_config(data):
 _sample_generators = {
         't1': generate_t1_sample_config,
         'l2': generate_l2_config,
-        'empty': generate_empty_config
+        'empty': generate_empty_config,
+        'l1': generate_l1_config,
+        'l3': generate_l3_config
         }
 
 def get_available_config():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This provides support for: https://github.com/Azure/sonic-buildimage/issues/7074. 


#### How I did it
Extend sonic-config-engine/config_samples.py to provide support for l1 & l3 

#### How to verify it
Verify system bring up with L1 & L3 configuration 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
Provide support for L1 & L3 configuration for sonic-config-engine 

-->


#### A picture of a cute animal (not mandatory but encouraged)

