### PR TITLE
SONiC QoS DSCP-TO-TC-MAP Yang

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -55,6 +55,7 @@ setup(
                          './yang-models/sonic-types.yang',
                          './yang-models/sonic-versions.yang',
                          './yang-models/sonic-vlan.yang',
+                         './yang-models/sonic-dscp-tc-map.yang',
                          './yang-models/sonic_yang_tree']),
     ],
     zip_safe=False,

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -686,8 +686,16 @@
                 "nexthop_group_threshold_type": "percentage",
                 "polling_interval": "0"
             }
+        },
+
+        "DSCP_TO_TC_MAP": {
+	        "Dscp_to_tc_map1": { 
+		        "24": "3", 
+		        "10": "1"
+            }	
         }
     },
+
 
     "SAMPLE_CONFIG_DB_UNKNOWN": {
         "UNKNOWN_TABLE": {

--- a/src/sonic-yang-models/yang-models/sonic-dscp-tc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dscp-tc-map.yang
@@ -1,0 +1,65 @@
+module sonic-dscp-tc-map {
+
+	yang-version 1.1;
+
+	namespace "http://github.com/Azure/sonic-dscp-tc-map";
+
+	prefix dtm;
+
+	import sonic-extension {
+		prefix sonic-ext;
+	}
+
+	organization
+		"SONiC";
+
+	contact
+		"SONiC";
+
+	description
+		"SONIC DSCP_TO_TC_MAP";
+
+	revision 2021-04-15 {
+		description
+			"Initial revision.";
+	}
+
+	container sonic-dscp-tc-map {	
+
+		container DSCP_TO_TC_MAP {
+
+			list DSCP_TO_TC_MAP_LIST {
+				key "name";
+				//sonic-ext:map-list true; //special conversion for map tables
+				//sonic-ext:map-leaf "dscp tc_num"; //every key:value pair is mapped to list keys, e.g. "1":"7" ==> dscp=1, tc_num=7
+
+				leaf name {
+                    type string {
+                        pattern '[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,31})';
+                        length 1..32;
+                    }
+				}
+
+				list DSCP_TO_TC_MAP { //this is list inside list for storing mapping between two fields
+					key "dscp tc_num";
+
+					leaf tc_num {
+						type string {
+							pattern "[0-9]?"{
+								error-message "Invalid Traffic Class number";
+								error-app-tag tc-num-invalid;
+							}
+						}
+					}
+
+					leaf dscp {
+						type string {
+							pattern "[1-9][0-9]?|[0-9]?";
+						}
+					}
+				}
+
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Created SONiC Yang model for QOS DSCP_TO_TC_MAP
Tables: DSCP_TO_TC_MAP table.

#### How I did it
Defined Yang models for QOS DSCP_TO_TC_MAP based on Guideline doc:
https://github.com/Azure/SONiC/blob/master/doc/mgmt/SONiC_YANG_Model_Guidelines.md
and
https://github.com/Azure/sonic-utilities/blob/master/doc/Command-Reference.md



#### How to verify it
sonic_yang_models package build
(The build fails at present. It looks like the nested list involved in the DSCP_TO_TC_MAP may not be supported  yet. The testcase reports the following error message:

YANG-TEST: Invalid JSON data (missing top level begin-object). 


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
comments

-->



