### PR TITLE
[Arista] Fix dockerd issue on Arista platforms

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -615,6 +615,9 @@ write_image_specific_cmdline() {
     # disable deterministic interface naming
     cmdline_add net.ifnames=0
 
+    # disable unified cgroup hierarchy to workaround dockerd limitation
+    cmdline_add systemd.unified_cgroup_hierarchy=0
+
     # verbosity
     cmdline_add quiet
     # Start showing systemd information from the first failing unit if any.


### PR DESCRIPTION
#### Why I did it

Recent systemd upgrade from #7228 requires an extra cmdline parameter for dockerd to start properly.
Updating boot0 was missed as part of the systemd upgrade change.

#### How I did it

Just added the missing cmdline parameter in files/Aboot/boot0.j2
This change fixes #7372

#### How to verify it

Boot the image and dockerd should start normally.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

I'm not sure if systemd will be upgraded in 202012.
If it is, this change will have to be cherry-picked.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix dockerd issue on Arista platforms due to missing cmdline parameter

