### PR TITLE
[gcov] install lcov for gcov in docker-soniv-vs.gz

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -66,7 +66,8 @@ RUN apt-get install -y net-tools \
                        gir1.2-glib-2.0 \
                        libdbus-1-3 \
                        libgirepository-1.0-1 \
-                       libsystemd0
+                       libsystemd0 \
+                       lcov
 
 # Install redis-server
 {% if CONFIGURED_ARCH == "armhf" %}


### PR DESCRIPTION
This is for gcov swss repo, need be merge before gcov swss repo.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This lcov tool need install first for html report generation before gcov repo pr be submitted.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

