### PR TITLE
[201911][Monit] Use VLAN name to differentiate each Monit service of dhcp_relay

### DIFF
--- a/dockers/docker-dhcp-relay/base_image_files/monit_dhcp_relay.j2
+++ b/dockers/docker-dhcp-relay/base_image_files/monit_dhcp_relay.j2
@@ -27,7 +27,7 @@
         {%- if relay_for_ipv4.flag -%}
           {%- set relay_for_ipv4 = False -%}
           {# Check the running status of each DHCP relay agent instance #}
-check program dhcp_relay|dhcrelay with path "/usr/bin/process_checker dhcp_relay /usr/sbin/dhcrelay -d -m discard -a %h:%p %P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}"
+check program dhcp_relay|dhcrelay_{{ vlan_name }} with path "/usr/bin/process_checker dhcp_relay /usr/sbin/dhcrelay -d -m discard -a %h:%p %P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
         {%- endif -%}
       {%- endif -%}


### PR DESCRIPTION

Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Since we will have multiple `dhcrelay` processes if there exists different VLANs in the table `VLAN_INTERFACE` of `CONIFG_DB`, 
we should use unique service name for each `dhcrelay` process in Monit configuration file. Otherwise, Monit service will fail to work.

#### How I did it
I append the VLAN name to the end of each service name such that they are unique.

#### How to verify it
I verified this on a virtual testbed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

