### PR TITLE
[platform] Add serial number and model number to Mellanox PSU platform implementation

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -52,14 +52,14 @@ psu_profile_list = [
     {
         PSU_CURRENT : "power/psu{}_curr",
         PSU_VOLTAGE : "power/psu{}_volt_out2",
-        PSU_POWER : "power/psu{}_power"
+        PSU_POWER : "power/psu{}_power",
         PSU_VPD : "eeprom/psu{}_vpd"
     },
     # for fixed platforms 2100, 2010
     {
         PSU_CURRENT : "power/psu{}_curr",
         PSU_VOLTAGE : "power/psu{}_volt_out2",
-        PSU_POWER : "power/psu{}_power"
+        PSU_POWER : "power/psu{}_power",
         PSU_VPD : None
     }
 ]

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -87,10 +87,10 @@ class Psu(PsuBase):
             filemap = psu_profile_list[0]
 
         self.psu_data = DEVICE_DATA[platform]['psus']
-        psu_path = filemap[PSU_VPD].format(self.index)
+        psu_vpd = filemap[PSU_VPD]
 
-        if psu_path is not None:
-            self.psu_vpd = os.path.join(self.psu_path, psu_vpd)
+        if psu_vpd is not None:
+            self.psu_vpd = os.path.join(self.psu_path, psu_vpd.format(self.index))
             self.vpd_data = self._read_vpd_file(self.psu_vpd)
 
             if PN_VPD_FIELD in self.vpd_data:
@@ -169,7 +169,7 @@ class Psu(PsuBase):
             with open(filename, 'r') as fileobj:
                 for line in fileobj.readlines():
                     key, val = line.split(":")
-                    result[key] = val
+                    result[key.strip()] = val.strip()
         except Exception as e:
             logger.log_error("Fail to read VPD file {} due to {}".format(filename, repr(e)))
         return result

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -79,6 +79,9 @@ class Psu(PsuBase):
 
         self.psu_data = DEVICE_DATA[platform]['psus']
 
+        self.model = self._read_vpd_file(self.psu_vpd).get(PN_VPD_FIELD, "")
+        self.serial = self._read_vpd_file(self.psu_vpd).get(SN_VPD_FIELD, "")
+
         if not self.psu_data['hot_swappable']:
             self.always_present = True
             self.psu_voltage = None
@@ -138,8 +141,7 @@ class Psu(PsuBase):
                 return result
             with open(filename, 'r') as fileobj:
                 for line in fileobj.readlines():
-                    key = line.split(":")[0].strip()
-                    val = line.split(":")[1].strip()
+                    key, val = line.split(":")
                     result[key] = val
         except Exception as e:
             logger.log_info("Fail to read file {} due to {}".format(filename, repr(e)))
@@ -166,9 +168,9 @@ class Psu(PsuBase):
         Retrieves the model number (or part number) of the device
 
         Returns:
-            string: Model/part number of devic
+            string: Model/part number of device
         """
-        return self._read_vpd_file(self.psu_vpd)[PN_VPD_FIELD]
+        return self.model
 
 
     def get_serial(self):
@@ -178,7 +180,7 @@ class Psu(PsuBase):
         Returns:
             string: Serial number of device
         """
-        return self._read_vpd_file(self.psu_vpd)[SN_VPD_FIELD]
+        return self.serial
 
 
     def get_powergood_status(self):


### PR DESCRIPTION
#### Why I did it

We want to add the ability for the command `show platform psustatus` to show the serial number and part number of the PSU devices on Mellanox platforms. This will be useful for data-center management of field replaceable units (FRUs) on switches.

#### How I did it

I implemented the platform 2.0 functions `get_model()` and `get_serial()` for the PSU in the mellanox platform API by referencing the sysfs nodes provided by the [hw-management](https://github.com/Azure/sonic-buildimage/tree/master/platform/mellanox/hw-management) module.

#### How to verify it

I ran `show platform psustatus` and verified that the serial number and model number were present on platforms where the information was accessible through sysfs. (Currently functioning on all mellanox platforms other than MSN2100 and MSN2010)

#### Which release branch to backport (provide reason below if selected)

None

#### Description for the changelog

[platform] Add serial number and model number to Mellanox PSU platform implementation

#### A picture of a cute animal (not mandatory but encouraged)

![97f64614927328325cf385c8be8aa80b](https://user-images.githubusercontent.com/5898707/113910020-5caae100-97a6-11eb-83dd-44bffa45958b.jpg)