### PR TITLE
[201811][bcm sai] ugprade Broadcom SAI to 3.5.3.7-2

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.5.3.6-2_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm_3.5.3.6-2_amd64.deb?sv=2019-10-10&st=2021-01-07T19%3A44%3A15Z&se=2036-01-08T19%3A44%3A00Z&sr=b&sp=r&sig=VgJZNnPYfITkP1pLhisBdNmWKKRuaLCVNWVGgUnUW3Q%3D"
+BRCM_SAI = libsaibcm_3.5.3.7-2_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm_3.5.3.7-2_amd64.deb?sv=2019-10-10&st=2021-04-14T19%3A58%3A40Z&se=2036-04-15T19%3A58%3A00Z&sr=b&sp=r&sig=vfB9GZxdlHrJv1bhwCkADDIXe%2FO12dWZYf9i9ya7CGk%3D"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.5.3.6-2_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.5.3.7-2_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm-dev_3.5.3.6-2_amd64.deb?sv=2019-10-10&st=2021-01-07T19%3A42%3A40Z&se=2036-01-08T19%3A42%3A00Z&sr=b&sp=r&sig=V18w8%2BSnrhUXEOJhcyaYXiagBolg0f0Dr0TqsO7YJ9A%3D"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm-dev_3.5.3.7-2_amd64.deb?sv=2019-10-10&st=2021-04-14T19%3A57%3A29Z&se=2036-04-15T19%3A57%3A00Z&sr=b&sp=r&sig=DSH1o6MduwF2ZyJRxHdYAQkjBDFWiQx84PKyi6JtmlM%3D"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
* 1d588e38 2021-03-25 | Pending changes for CS00011808451 (bcm_sai/REL_3.5.3, INT_3.5) [BrcmSAI]
* 53efbe91 2021-03-18 | Fix for CS00011810218 [BRCM-DevOps]
* ca0dc86c 2021-03-11 | Fix for CS00011808451 (msazure/INT_3.5, bcm_sai/REL_3.5.3, INT_3.5) [BrcmSAI]
* 208ea62e 2021-01-08 | Update changelog [BRCM-DevOps]
* 3961673c 2021-01-08 | Update version after sdk patch and egress obj leak fixes. [BRCM-DevOps]
* ce3818ad 2021-01-08 | Fix for CS00011581499 [BrcmSAI]
* 1e06157f 2021-01-08 | Merged SDk patch for CS00011651922 [BrcmSAI]
* 4d0c2c86 2021-04-06 | Merged PR 4328641: Add support for AN/LT (HEAD -> 3.5-201811, msazure/3.5-201811) [Joe LeVeque]

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

