### PR TITLE
[Mellanox] Adopt single way to get fan direction for all ASIC types

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -10,7 +10,7 @@ DEVICE_DATA = {
             'drawer_num': 4,
             'drawer_type': 'real',
             'fan_num_per_drawer': 2,
-            'support_fan_direction': False,
+            'support_fan_direction': True,
             'hot_swappable': True
         },
         'psus': {
@@ -31,7 +31,7 @@ DEVICE_DATA = {
             'drawer_num': 4,
             'drawer_type': 'real',
             'fan_num_per_drawer': 1,
-            'support_fan_direction': False,
+            'support_fan_direction': True,
             'hot_swappable': True
         },
         'psus': {
@@ -73,7 +73,7 @@ DEVICE_DATA = {
             'drawer_num': 4,
             'drawer_type': 'real',
             'fan_num_per_drawer': 2,
-            'support_fan_direction': False,
+            'support_fan_direction': True,
             'hot_swappable': True
         },
         'psus': {

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -52,7 +52,7 @@ DEVICE_DATA = {
             'drawer_num': 1,
             'drawer_type': 'virtual',
             'fan_num_per_drawer': 4,
-            'support_fan_direction': False,
+            'support_fan_direction': True,
             'hot_swappable': False
         },
         'psus': {
@@ -94,7 +94,7 @@ DEVICE_DATA = {
             'drawer_num': 1,
             'drawer_type': 'virtual',
             'fan_num_per_drawer': 4,
-            'support_fan_direction': False,
+            'support_fan_direction': True,
             'hot_swappable': False
         },
         'psus': {

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -22,8 +22,10 @@ PWM_MAX = 255
 
 FAN_PATH = "/var/run/hw-management/thermal/"
 CONFIG_PATH = "/var/run/hw-management/config"
-# fan_dir isn't supported on Spectrum 1. It is supported on Spectrum 2 and later switches
-FAN_DIR = "/var/run/hw-management/system/fan_dir"
+
+FAN_DIR = "/var/run/hw-management/thermal/fan{}_dir"
+FAN_DIR_VALUE_EXHAUST = 0
+FAN_DIR_VALUE_INTAKE = 1
 COOLING_STATE_PATH = "/var/run/hw-management/thermal/cooling_cur_state"
 
 class Fan(FanBase):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan_drawer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan_drawer.py
@@ -51,14 +51,15 @@ class MellanoxFanDrawer(FanDrawerBase):
             return FanBase.FAN_DIRECTION_NOT_APPLICABLE
         
         try:
-            from .fan import FAN_DIR
-            with open(FAN_DIR, 'r') as fan_dir:
-                fan_dir_bits = int(fan_dir.read())
-                fan_mask = 1 << self._index - 1
-                if fan_dir_bits & fan_mask:
+            from .fan import FAN_DIR, FAN_DIR_VALUE_INTAKE, FAN_DIR_VALUE_EXHAUST
+            with open(FAN_DIR.format(self._index), 'r') as fan_dir:
+                fan_dir_value = int(fan_dir.read())
+                if fan_dir_value == FAN_DIR_VALUE_INTAKE:
                     return FanBase.FAN_DIRECTION_INTAKE
-                else:
+                elif fan_dir_value == FAN_DIR_VALUE_EXHAUST:
                     return FanBase.FAN_DIRECTION_EXHAUST
+                else:
+                    raise RuntimeError("Got wrong value {} for fan direction {}".format(fan_dir_value, self._index))
         except (ValueError, IOError) as e:
             raise RuntimeError("Failed to read fan direction status to {}".format(repr(e)))
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan_drawer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan_drawer.py
@@ -14,6 +14,7 @@ try:
     from sonic_platform_base.fan_drawer_base import FanDrawerBase
     from sonic_platform_base.fan_base import FanBase
     from .led import FanLed, SharedLed
+    from .utils import read_int_from_file
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -52,14 +53,13 @@ class MellanoxFanDrawer(FanDrawerBase):
         
         try:
             from .fan import FAN_DIR, FAN_DIR_VALUE_INTAKE, FAN_DIR_VALUE_EXHAUST
-            with open(FAN_DIR.format(self._index), 'r') as fan_dir:
-                fan_dir_value = int(fan_dir.read())
-                if fan_dir_value == FAN_DIR_VALUE_INTAKE:
-                    return FanBase.FAN_DIRECTION_INTAKE
-                elif fan_dir_value == FAN_DIR_VALUE_EXHAUST:
-                    return FanBase.FAN_DIRECTION_EXHAUST
-                else:
-                    raise RuntimeError("Got wrong value {} for fan direction {}".format(fan_dir_value, self._index))
+            fan_dir = read_int_from_file(FAN_DIR.format(self._index), raise_exception=True)
+            if fan_dir == FAN_DIR_VALUE_INTAKE:
+                return FanBase.FAN_DIRECTION_INTAKE
+            elif fan_dir == FAN_DIR_VALUE_EXHAUST:
+                return FanBase.FAN_DIRECTION_EXHAUST
+            else:
+                raise RuntimeError("Got wrong value {} for fan direction {}".format(fan_dir, self._index))
         except (ValueError, IOError) as e:
             raise RuntimeError("Failed to read fan direction status to {}".format(repr(e)))
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Adopt a single way to get fan direction for all ASIC types.
It depends on hw-mgmt V.7.0010.2000.2303. Depends on https://github.com/Azure/sonic-buildimage/pull/7419

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it
Originally, the get_direction was implemented by fetching and parsing `/var/run/hw-management/system/fan_dir` on the Spectrum-2 and the Spectrum-3 systems. It isn't supported on the Spectrum system.
Now, it is implemented by fetching `/var/run/hw-management/thermal/fanX_dir` for all the platforms.

#### How to verify it
1. Regression test.
  - Mock random legal value: 0 - intake or 1 - exhaust
  - Mock an invalid value: values other than 0 or 1
  - Mock the case that file doesn't exist
2. Manually test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

