### PR TITLE
[201811] Add SOC property to enable AN/LT on some platforms (A7060, A7260, DX010)

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
@@ -444,3 +444,5 @@ serdes_driver_current_109=0xa
 serdes_preemphasis_109=0x284008
 
 mmu_init_config="MSFT-TH-Tier1"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
@@ -545,3 +545,5 @@ serdes_driver_current_115=0xa
 serdes_preemphasis_115=0x284008
 
 mmu_init_config="MSFT-TH-Tier0"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
@@ -442,3 +442,5 @@ serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier0"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
@@ -442,3 +442,5 @@ serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier1"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/th2-a7260cx3-64-64x100G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/th2-a7260cx3-64-64x100G-t0.config.bcm
@@ -1013,3 +1013,5 @@ serdes_preemphasis_116=0x103706
 serdes_preemphasis_117=0x133c06
 
 mmu_init_config="MSFT-TH2-Tier0"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/th2-a7260cx3-64-64x100G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/th2-a7260cx3-64-64x100G-t1.config.bcm
@@ -1013,3 +1013,5 @@ serdes_preemphasis_116=0x103706
 serdes_preemphasis_117=0x133c06
 
 mmu_init_config="MSFT-TH2-Tier1"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/th2-a7260cx3-64-112x50G+8x100G.config.bcm
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/th2-a7260cx3-64-112x50G+8x100G.config.bcm
@@ -934,3 +934,5 @@ serdes_preemphasis_130=0x580c
 serdes_preemphasis_131=0x580c
 
 mmu_init_config="MSFT-TH2-Tier0"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/th2-a7260cx3-64-64x40G.config.bcm
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/th2-a7260cx3-64-64x40G.config.bcm
@@ -1013,3 +1013,5 @@ serdes_preemphasis_116=0x105004
 serdes_preemphasis_117=0x105004
 
 mmu_init_config="MSFT-TH2-Tier0"
+
+phy_an_lt_msft=1

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
@@ -374,3 +374,5 @@ phy_xaui_tx_polarity_flip_130=0x0006
 phy_xaui_rx_polarity_flip_130=0x0000
 
 mmu_init_config="MSFT-TH-Tier0"
+
+phy_an_lt_msft=1

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
@@ -694,3 +694,5 @@ serdes_preemphasis_lane2_130=0x2b4104
 serdes_preemphasis_lane3_130=0x2b4104
 
 mmu_init_config="MSFT-TH-Tier1"
+
+phy_an_lt_msft=1

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
@@ -646,3 +646,4 @@ serdes_preemphasis_lane1_5=0x244a02
 serdes_preemphasis_lane2_5=0x244a02
 serdes_preemphasis_lane3_5=0x254902
 
+phy_an_lt_msft=1


### PR DESCRIPTION
#### Why I did it

To enable autonegotiation/link training on some Broadcom-based platforms (Arista 7060 and 7260, Celestica DX010)

#### How I did it

- Add appropriate SOC property for enabling the feature to the Broadcom config files of appropriate platforms
- Also convert line endings to UNIX format for one Celestica file
