### PR TITLE
[201811][device] add phy_an_lt_msft to permitted list

### DIFF
--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -74,6 +74,7 @@ phy_an_allow_pll_change_hg
 phy_an_c37
 phy_an_c73
 phy_an_fec
+phy_an_lt_msft 
 phy_automedium
 phy_aux_voltage_enable
 phy_chain_rx_lane_map_physical


### PR DESCRIPTION
#### Why I did it
201811 build was failing due to the newly added bcm config file key word was not on the permitted list

#### How I did it
add phy_an_lt_msft to permitted list.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### How to verify it
Build device package.
