### PR TITLE
[as7726-32x] Support PDDF

### DIFF
--- a/device/accton/x86_64-accton_as7726_32x-r0/pddf/pd-plugin.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pddf/pd-plugin.json
@@ -1,0 +1,67 @@
+{
+    
+    "XCVR":
+    {
+        "xcvr_present":
+        {
+           "i2c":
+           {
+               "valmap-SFP": {"1":true, "0":false },
+               "valmap-SFP28": {"1":true, "0":false },
+               "valmap-QSFP28": {"1":true, "0":false}
+           }
+        }
+    },
+    "PSU":
+    {
+        "psu_present": 
+        {
+            "i2c":
+            {
+                "valmap": { "1":true, "0":false }
+            }
+        },
+
+        "psu_power_good": 
+        {
+            "i2c":
+            {
+                "valmap": { "1": true, "0":false }
+            }
+        },
+
+        "psu_fan_dir":
+        {
+            "i2c":
+            {
+                "valmap": { "F2B":"EXHAUST", "B2F":"INTAKE" } 
+            }
+        },
+
+        "PSU_FAN_MAX_SPEED":"25500"
+    },
+
+    "FAN":
+    {
+        "direction":
+        {
+            "i2c":
+            {
+                "valmap": {"1":"EXHAUST", "0":"INTAKE"} 
+            }
+        },
+
+        "present":
+        {
+            "i2c":
+            {
+                "valmap": {"1":true, "0":false}
+            }
+        },
+		
+        "duty_cycle_to_pwm": "lambda dc: ((dc*100)/625 -1)",
+
+        "pwm_to_duty_cycle": "lambda pwm: (((pwm+1)*625+75)/100)"
+    }
+
+}

--- a/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
@@ -1,0 +1,1884 @@
+{
+	"PLATFORM":
+	{
+		"num_psus":2,
+		"num_fantrays":6,
+		"num_fans_pertray":2,
+		"num_ports":34,
+		"num_temps":5,
+		"pddf_dev_types":
+		{
+			"description":"AS7726 - Below is the list of supported PDDF device types (chip names) for various components. If any component uses some other driver, we will create the client using 'echo <dev-address> <dev-type> > <path>/new_device' method",
+			"CPLD":
+			[
+				"i2c_cpld"
+			],
+			"PSU":
+			[
+				"psu_eeprom",
+				"psu_pmbus"
+			],
+			"FAN":
+			[
+				"fan_ctrl",
+				"fan_eeprom"
+			],
+            "PORT_MODULE":
+            [
+                "pddf_xcvr"
+			]
+
+		},
+        "std_kos":
+        [
+            "i2c-i801",
+            "i2c_dev",
+            "i2c_mux_pca954x force_deselect_on_exit=1",
+            "optoe"
+        ],
+        "pddf_kos":
+        [
+            "pddf_client_module",
+            "pddf_cpld_module",
+            "pddf_cpld_driver",
+            "pddf_mux_module",
+            "pddf_xcvr_module",
+            "pddf_xcvr_driver_module",
+            "pddf_psu_driver_module",
+            "pddf_psu_module",
+            "pddf_fan_driver_module",
+            "pddf_fan_module",
+            "pddf_led_module",
+            "pddf_sysstatus_module"
+        ]
+	},
+
+	"SYSTEM":
+	{
+		"dev_info": {"device_type":"CPU", "device_name":"ROOT_COMPLEX", "device_parent":null},
+		"i2c":
+		{
+			"CONTROLLERS":
+			[ 
+				{ "dev_name":"i2c-0", "dev":"SMBUS0" }
+			]
+		}
+	},
+
+	"SMBUS0": 
+	{
+		"dev_info": {"device_type": "SMBUS", "device_name": "SMBUS0", "device_parent": "SYSTEM"},
+		"i2c": 
+		{
+			"topo_info": {"dev_addr": "0x0"},
+			"DEVICES": 
+			[
+				{"dev": "EEPROM1"},
+				{"dev": "MUX1"}
+			]
+		}
+	},
+
+	"EEPROM1":
+	{
+		"dev_info": {"device_type": "EEPROM", "device_name": "EEPROM1", "device_parent": "SMBUS0"},
+		"i2c": 
+		{
+			"topo_info": {"parent_bus": "0x0", "dev_addr": "0x56", "dev_type": "24c02"},
+			"dev_attr": {"access_mode": "BLOCK"},
+			"attr_list": [
+				{"attr_name": "eeprom"}
+			]
+		}
+	},
+
+	"MUX1":
+	{
+		"dev_info": { "device_type":"MUX", "device_name":"MUX1", "device_parent":"SMBUS0"},
+		"i2c":
+		{ 
+			"topo_info": { "parent_bus":"0x0", "dev_addr":"0x77", "dev_type":"pca9548"},
+			"dev_attr": { "virt_bus":"0x1"},
+			"channel":
+			[
+				{ "chn":"0", "dev":"MUX2" },
+				{ "chn":"0", "dev":"MUX3" },
+				{ "chn":"0", "dev":"MUX4" },
+				{ "chn":"0", "dev":"MUX5" },
+				{ "chn":"0", "dev":"MUX6" },
+				{ "chn":"1", "dev":"MUX7" }
+			]
+		}
+	},
+
+	"MUX2":
+	{
+		"dev_info": {  "device_type":"MUX", "device_name":"MUX2", "device_parent":"MUX1"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x1", "dev_addr":"0x76", "dev_type":"pca9548"},
+			"dev_attr": { "virt_bus":"0x9"},
+			"channel":
+			[
+				{ "chn":"2", "dev":"CPLD1" },
+				{ "chn":"3", "dev":"CPLD2" },
+				{ "chn":"4", "dev":"CPLD3" },
+				{ "chn":"6", "dev":"PORT33" },
+				{ "chn":"7", "dev":"PORT34" }
+				
+			]
+		}
+	},
+
+	"CPLD1":
+	{
+		"dev_info": { "device_type":"CPLD", "device_name":"CPLD1", "device_parent":"MUX2"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0xb", "dev_addr":"0x60", "dev_type":"i2c_cpld"},
+			"dev_attr":{}
+		}
+	},
+
+    "CPLD2":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD2", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xc", "dev_addr":"0x62", "dev_type":"i2c_cpld"},
+            "dev_attr": { }
+        }
+    },
+
+    "CPLD3":
+    {
+        "dev_info": { "device_type":"CPLD", "device_name":"CPLD3", "device_parent":"MUX1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xd", "dev_addr":"0x64", "dev_type":"i2c_cpld"},
+            "dev_attr": { }
+        }
+    },
+
+	"MUX3":
+	{
+		"dev_info": {  "device_type":"MUX", "device_name":"MUX3", "device_parent":"MUX1"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x1", "dev_addr":"0x72", "dev_type":"pca9548"},
+			"dev_attr": { "virt_bus":"0x11"},
+			"channel":
+			[
+                { "chn":"0", "dev":"PORT9" },
+                { "chn":"1", "dev":"PORT10" },
+                { "chn":"2", "dev":"PORT11" },
+                { "chn":"3", "dev":"PORT12" },
+                { "chn":"4", "dev":"PORT1" },
+                { "chn":"5", "dev":"PORT2" },
+                { "chn":"6", "dev":"PORT3" },
+                { "chn":"7", "dev":"PORT4" }
+			]
+		}
+	},
+
+	"MUX4":
+	{
+		"dev_info": {  "device_type":"MUX", "device_name":"MUX4", "device_parent":"MUX1"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x1", "dev_addr":"0x73", "dev_type":"pca9548"},
+			"dev_attr": { "virt_bus":"0x19"},
+			"channel":
+			[
+                { "chn":"0", "dev":"PORT6" },
+                { "chn":"1", "dev":"PORT5" },
+                { "chn":"2", "dev":"PORT8" },
+                { "chn":"3", "dev":"PORT7" },
+                { "chn":"4", "dev":"PORT13" },
+                { "chn":"5", "dev":"PORT14" },
+                { "chn":"6", "dev":"PORT15" },
+                { "chn":"7", "dev":"PORT16" }
+			]
+		}
+	},
+
+	"MUX5":
+	{
+		"dev_info": {  "device_type":"MUX", "device_name":"MUX5", "device_parent":"MUX1"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x1", "dev_addr":"0x74", "dev_type":"pca9548"},
+			"dev_attr": { "virt_bus":"0x21"},
+			"channel":
+			[
+                { "chn":"0", "dev":"PORT17" },
+                { "chn":"1", "dev":"PORT18" },
+                { "chn":"2", "dev":"PORT19" },
+                { "chn":"3", "dev":"PORT20" },
+                { "chn":"4", "dev":"PORT25" },
+                { "chn":"5", "dev":"PORT26" },
+                { "chn":"6", "dev":"PORT27" },
+                { "chn":"7", "dev":"PORT28" }
+			]
+		}
+	},
+
+	"MUX6":
+	{
+		"dev_info": {  "device_type":"MUX", "device_name":"MUX6", "device_parent":"MUX1"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x1", "dev_addr":"0x75", "dev_type":"pca9548"},
+			"dev_attr": { "virt_bus":"0x29"},
+			"channel":
+			[
+                { "chn":"0", "dev":"PORT29" },
+                { "chn":"1", "dev":"PORT30" },
+                { "chn":"2", "dev":"PORT31" },
+                { "chn":"3", "dev":"PORT32" },
+                { "chn":"4", "dev":"PORT21" },
+                { "chn":"5", "dev":"PORT22" },
+                { "chn":"6", "dev":"PORT23" },
+                { "chn":"7", "dev":"PORT24" }
+			]
+		}
+	},
+	
+    "PORT1":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT1", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"1"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT1-EEPROM" },
+                { "itf":"control", "dev":"PORT1-CTRL" }
+            ]
+        }
+    },
+    "PORT1-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT1-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x15", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	}
+    },
+    "PORT1-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT1-CTRL", "device_parent":"MUX3", "virt_parent":"PORT1"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x15", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x30", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x04", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT2":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT2", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"2"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT2-EEPROM" },
+                { "itf":"control", "dev":"PORT2-CTRL" }
+            ]
+        }
+    },
+    "PORT2-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT2-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x16", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT2-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT2-CTRL", "device_parent":"MUX3", "virt_parent":"PORT2"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x16", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x30", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x04", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT3":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT3", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"3"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT3-EEPROM" },
+                { "itf":"control", "dev":"PORT3-CTRL" }
+            ]
+        }
+    },
+    "PORT3-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT3-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT3"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x17", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT3-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT3-CTRL", "device_parent":"MUX3", "virt_parent":"PORT3"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x17", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x30", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x04", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT4":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT4", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"4"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT4-EEPROM" },
+                { "itf":"control", "dev":"PORT4-CTRL" }
+            ]
+        }
+    },
+    "PORT4-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT4-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x18", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT4-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT4-CTRL", "device_parent":"MUX3", "virt_parent":"PORT4"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x18", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x30", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x04", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT5":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT5", "device_parent":"MUX4"},
+        "dev_attr": { "dev_idx":"5"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT5-EEPROM" },
+                { "itf":"control", "dev":"PORT5-CTRL" }
+            ]
+        }
+    },
+    "PORT5-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT5-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1a", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT5-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT5-CTRL", "device_parent":"MUX4", "virt_parent":"PORT5"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1a", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x30", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x04", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT6":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT6", "device_parent":"MUX4"},
+        "dev_attr": { "dev_idx":"6"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT6-EEPROM" },
+                { "itf":"control", "dev":"PORT6-CTRL" }
+            ]
+        }
+    },
+    "PORT6-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT6-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT6"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x19", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT6-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT6-CTRL", "device_parent":"MUX4", "virt_parent":"PORT6"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x19", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x30", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x04", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT7":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT7", "device_parent":"MUX4"},
+        "dev_attr": { "dev_idx":"7"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT7-EEPROM" },
+                { "itf":"control", "dev":"PORT7-CTRL" }
+            ]
+        }
+    },
+    "PORT7-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT7-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT7"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1c", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT7-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT7-CTRL", "device_parent":"MUX4", "virt_parent":"PORT7"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1c", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x30", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x04", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT8":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT8", "device_parent":"MUX4"},
+        "dev_attr": { "dev_idx":"8"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT8-EEPROM" },
+                { "itf":"control", "dev":"PORT8-CTRL" }
+            ]
+        }
+    },
+    "PORT8-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT8-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT8"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1b", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT8-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT8-CTRL", "device_parent":"MUX4", "virt_parent":"PORT8"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1b", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x30", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x04", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x10", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT9":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT9", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"9"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT9-EEPROM" },
+                { "itf":"control", "dev":"PORT9-CTRL" }
+            ]
+        }
+    },
+    "PORT9-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT9-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT9"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x11", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT9-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT9-CTRL", "device_parent":"MUX3", "virt_parent":"PORT9"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x11", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x31", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x05", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT10":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT10", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"10"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT10-EEPROM" },
+                { "itf":"control", "dev":"PORT10-CTRL" }
+            ]
+        }
+    },
+    "PORT10-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT10-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT10"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x12", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT10-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT10-CTRL", "device_parent":"MUX3", "virt_parent":"PORT10"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x12", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x31", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x05", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT11":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT11", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"11"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT11-EEPROM" },
+                { "itf":"control", "dev":"PORT11-CTRL" }
+            ]
+        }
+    },
+    "PORT11-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT11-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT11"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x13", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT11-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT11-CTRL", "device_parent":"MUX3", "virt_parent":"PORT11"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x13", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x31", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x05", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT12":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT12", "device_parent":"MUX3"},
+        "dev_attr": { "dev_idx":"12"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT12-EEPROM" },
+                { "itf":"control", "dev":"PORT12-CTRL" }
+            ]
+        }
+    },
+    "PORT12-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT12-EEPROM", "device_parent":"MUX3", "virt_parent":"PORT12"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x14", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT12-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT12-CTRL", "device_parent":"MUX3", "virt_parent":"PORT12"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x14", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x31", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x05", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT13":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT13", "device_parent":"MUX4"},
+        "dev_attr": { "dev_idx":"13"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT13-EEPROM" },
+                { "itf":"control", "dev":"PORT13-CTRL" }
+            ]
+        }
+    },
+    "PORT13-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT13-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT13"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1d", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT13-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT13-CTRL", "device_parent":"MUX4", "virt_parent":"PORT13"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1d", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x31", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x05", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT14":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT14", "device_parent":"MUX4"},
+        "dev_attr": { "dev_idx":"14"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT14-EEPROM" },
+                { "itf":"control", "dev":"PORT14-CTRL" }
+            ]
+        }
+    },
+    "PORT14-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT14-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT14"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1e", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT14-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT14-CTRL", "device_parent":"MUX4", "virt_parent":"PORT14"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1e", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x31", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x05", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT15":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT15", "device_parent":"MUX4"},
+        "dev_attr": { "dev_idx":"15"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT15-EEPROM" },
+                { "itf":"control", "dev":"PORT15-CTRL" }
+            ]
+        }
+    },
+    "PORT15-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT15-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT15"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1f", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT15-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT15-CTRL", "device_parent":"MUX4", "virt_parent":"PORT15"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x1f", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x31", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x05", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT16":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT16", "device_parent":"MUX4"},
+        "dev_attr": { "dev_idx":"16"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT16-EEPROM" },
+                { "itf":"control", "dev":"PORT16-CTRL" }
+            ]
+        }
+    },
+    "PORT16-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT16-EEPROM", "device_parent":"MUX4", "virt_parent":"PORT16"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x20", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT16-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT16-CTRL", "device_parent":"MUX4", "virt_parent":"PORT16"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x20", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x31", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x05", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT17":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT17", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"17"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT17-EEPROM" },
+                { "itf":"control", "dev":"PORT17-CTRL" }
+            ]
+        }
+    },
+    "PORT17-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT17-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT17"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x21", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT17-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT17-CTRL", "device_parent":"MUX5", "virt_parent":"PORT17"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x21", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x32", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x06", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT18":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT18", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"18"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT18-EEPROM" },
+                { "itf":"control", "dev":"PORT18-CTRL" }
+            ]
+        }
+    },
+    "PORT18-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT18-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT18"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x22", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT18-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT18-CTRL", "device_parent":"MUX5", "virt_parent":"PORT18"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x22", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x32", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x06", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT19":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT19", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"19"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT19-EEPROM" },
+                { "itf":"control", "dev":"PORT19-CTRL" }
+            ]
+        }
+    },
+    "PORT19-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT19-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT19"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x23", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT19-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT19-CTRL", "device_parent":"MUX5", "virt_parent":"PORT19"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x23", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x32", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x06", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT20":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT20", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"20"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT20-EEPROM" },
+                { "itf":"control", "dev":"PORT20-CTRL" }
+            ]
+        }
+    },
+    "PORT20-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT20-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT20"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x24", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT20-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT20-CTRL", "device_parent":"MUX5", "virt_parent":"PORT20"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x24", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x32", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x06", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT21":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT21", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"21"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT21-EEPROM" },
+                { "itf":"control", "dev":"PORT21-CTRL" }
+            ]
+        }
+    },
+    "PORT21-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT21-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT21"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2d", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT21-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT21-CTRL", "device_parent":"MUX6", "virt_parent":"PORT21"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2d", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x32", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x06", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT22":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT22", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"22"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT22-EEPROM" },
+                { "itf":"control", "dev":"PORT22-CTRL" }
+            ]
+        }
+    },
+    "PORT22-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT22-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT22"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2e", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT22-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT22-CTRL", "device_parent":"MUX6", "virt_parent":"PORT22"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2e", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x32", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x06", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT23":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT23", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"23"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT23-EEPROM" },
+                { "itf":"control", "dev":"PORT23-CTRL" }
+            ]
+        }
+    },
+    "PORT23-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT23-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT23"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2f", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT23-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT23-CTRL", "device_parent":"MUX6", "virt_parent":"PORT23"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2f", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x32", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x06", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT24":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT24", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"24"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT24-EEPROM" },
+                { "itf":"control", "dev":"PORT24-CTRL" }
+            ]
+        }
+    },
+    "PORT24-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT24-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT24"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x30", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT24-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT24-CTRL", "device_parent":"MUX6", "virt_parent":"PORT24"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x30", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x32", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x06", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT25":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT25", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"25"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT25-EEPROM" },
+                { "itf":"control", "dev":"PORT25-CTRL" }
+            ]
+        }
+    },
+    "PORT25-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT25-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT25"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x25", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT25-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT25-CTRL", "device_parent":"MUX5", "virt_parent":"PORT25"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x25", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x33", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x07", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT26":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT26", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"26"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT26-EEPROM" },
+                { "itf":"control", "dev":"PORT26-CTRL" }
+            ]
+        }
+    },
+    "PORT26-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT26-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT26"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x26", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT26-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT26-CTRL", "device_parent":"MUX5", "virt_parent":"PORT26"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x26", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x33", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x07", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT27":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT27", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"27"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT27-EEPROM" },
+                { "itf":"control", "dev":"PORT27-CTRL" }
+            ]
+        }
+    },
+    "PORT27-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT27-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT27"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x27", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT27-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT27-CTRL", "device_parent":"MUX5", "virt_parent":"PORT27"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x27", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x33", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x07", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT28":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT28", "device_parent":"MUX5"},
+        "dev_attr": { "dev_idx":"28"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT28-EEPROM" },
+                { "itf":"control", "dev":"PORT28-CTRL" }
+            ]
+        }
+    },
+    "PORT28-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT28-EEPROM", "device_parent":"MUX5", "virt_parent":"PORT28"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x28", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT28-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT28-CTRL", "device_parent":"MUX5", "virt_parent":"PORT28"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x28", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x33", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x07", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x3", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT29":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT29", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"29"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT29-EEPROM" },
+                { "itf":"control", "dev":"PORT29-CTRL" }
+            ]
+        }
+    },
+    "PORT29-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT29-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT29"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x29", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT29-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT29-CTRL", "device_parent":"MUX6", "virt_parent":"PORT29"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x29", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x33", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x07", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT30":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT30", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"30"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT30-EEPROM" },
+                { "itf":"control", "dev":"PORT30-CTRL" }
+            ]
+        }
+    },
+    "PORT30-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT30-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT30"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2a", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT30-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT30-CTRL", "device_parent":"MUX6", "virt_parent":"PORT30"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2a", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x33", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x07", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT31":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT31", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"31"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT31-EEPROM" },
+                { "itf":"control", "dev":"PORT31-CTRL" }
+            ]
+        }
+    },
+    "PORT31-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT31-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT31"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2b", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT31-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT31-CTRL", "device_parent":"MUX6", "virt_parent":"PORT31"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2b", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x33", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x07", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x6", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+
+    "PORT32":
+    {
+        "dev_info": { "device_type":"QSFP28", "device_name":"PORT32", "device_parent":"MUX6"},
+        "dev_attr": { "dev_idx":"32"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT32-EEPROM" },
+                { "itf":"control", "dev":"PORT32-CTRL" }
+            ]
+        }
+    },
+    "PORT32-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT32-EEPROM", "device_parent":"MUX6", "virt_parent":"PORT32"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2c", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT32-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT32-CTRL", "device_parent":"MUX6", "virt_parent":"PORT32"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x2c", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x33", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_reset", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x07", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x13", "attr_mask":"0x7", "attr_cmpval":"0x0", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT33":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT33", "device_parent":"MUX2"},
+        "dev_attr": { "dev_idx":"33"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT33-EEPROM" },
+                { "itf":"control", "dev":"PORT33-CTRL" }
+            ]
+        }
+    },
+    "PORT33-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT33-EEPROM", "device_parent":"MUX2", "virt_parent":"PORT33"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xf", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT33-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT33-CTRL", "device_parent":"MUX2", "virt_parent":"PORT33"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0xf", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x50", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x50", "attr_mask":"0x2", "attr_cmpval":"0x4", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x49", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+            ]
+        }
+    },
+    "PORT34":
+    {
+        "dev_info": { "device_type":"SFP28", "device_name":"PORT34", "device_parent":"MUX2"},
+        "dev_attr": { "dev_idx":"34"},
+        "i2c":
+        {
+            "interface":
+            [
+                { "itf":"eeprom", "dev":"PORT34-EEPROM" },
+                { "itf":"control", "dev":"PORT34-CTRL" }
+            ]
+        }
+    },
+    "PORT34-EEPROM":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT34-EEPROM", "device_parent":"MUX2", "virt_parent":"PORT34"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x10", "dev_addr":"0x50", "dev_type":"optoe1"},
+            "attr_list":
+            [
+                { "attr_name":"eeprom"}
+            ]
+	    }
+    },
+    "PORT34-CTRL":
+    {
+        "dev_info": { "device_type":"", "device_name":"PORT34-CTRL", "device_parent":"MUX2", "virt_parent":"PORT34"},
+        "i2c":
+        {
+            "topo_info": { "parent_bus":"0x10", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
+            "attr_list":
+            [
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x50", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x50", "attr_mask":"0x3", "attr_cmpval":"0x8", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x49", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+            ]
+        }
+    },
+
+	"MUX7":
+	{
+		"dev_info": {  "device_type":"MUX", "device_name":"MUX7", "device_parent":"MUX1"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x2", "dev_addr":"0x71", "dev_type":"pca9548"},
+			"dev_attr": { "virt_bus":"0x31"},
+			"channel":
+			[
+				{ "chn":"0", "dev":"PSU2" },
+				{ "chn":"1", "dev":"PSU1" },
+				{ "chn":"5", "dev":"FAN-CTRL" },
+				{ "chn":"5", "dev":"TEMP1" },
+				{ "chn":"6", "dev":"TEMP2" },
+				{ "chn":"6", "dev":"TEMP3" },
+				{ "chn":"6", "dev":"TEMP4" },
+				{ "chn":"6", "dev":"TEMP5" }
+			]
+		}
+	},
+
+	"PSU2":
+	{
+		"dev_info": { "device_type":"PSU", "device_name":"PSU2", "device_parent":"MUX7" },
+		"dev_attr": { "dev_idx":"2", "num_psu_fans":"1"},
+		"i2c":
+		{
+			"interface":
+			[
+				{ "itf":"pmbus", "dev":"PSU2-PMBUS"}
+			]
+		}
+	},
+
+	"PSU2-PMBUS":
+	{
+		"dev_info": {"device_type":"PSU-PMBUS", "device_name":"PSU2-PMBUS", "device_parent":"MUX7", "virt_parent":"PSU2"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x31", "dev_addr":"0x58", "dev_type":"psu_pmbus"},
+			"attr_list": 
+			[  
+				{ "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"psu_model_name", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+				{ "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x14", "attr_cmpval":"0x14", "attr_len":"1"},
+				{ "attr_name":"psu_mfr_id", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+				{ "attr_name":"psu_serial_num", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x9e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" },
+				{ "attr_name":"psu_fan_dir", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
+				{ "attr_name":"psu_v_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_i_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_p_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+			]
+		}
+	},
+
+	"PSU1":
+	{
+		"dev_info": { "device_type":"PSU", "device_name":"PSU1", "device_parent":"MUX7"}, 
+		"dev_attr": { "dev_idx":"1", "num_psu_fans": "1"},
+		"i2c":
+		{
+			"interface":
+			[
+				{ "itf":"pmbus", "dev":"PSU1-PMBUS" }
+			]
+		}
+	},
+
+	"PSU1-PMBUS":
+	{
+		"dev_info": { "device_type":"PSU-PMBUS", "device_name":"PSU1-PMBUS", "device_parent":"MUX7", "virt_parent":"PSU1"},
+		"i2c":
+		{
+			"topo_info":{ "parent_bus":"0x32", "dev_addr":"0x5b", "dev_type":"psu_pmbus"}, 
+			"attr_list": 
+			[  
+				{ "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"psu_model_name", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+				{ "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x28", "attr_cmpval":"0x28", "attr_len":"1"},
+				{ "attr_name":"psu_mfr_id", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+				{ "attr_name":"psu_serial_num", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" },
+				{ "attr_name":"psu_fan_dir", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
+				{ "attr_name":"psu_v_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_i_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_p_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+			]
+		}
+	},
+
+	"FAN-CTRL":
+	{
+		"dev_info": { "device_type":"FAN", "device_name":"FAN-CTRL", "device_parent":"MUX7"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x36", "dev_addr":"0x66", "dev_type":"fan_ctrl"},
+			"dev_attr": { "num_fantrays":"6"},
+			"attr_list":
+			[
+				{ "attr_name":"fan1_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan2_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan3_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan4_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan5_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan6_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan7_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x8", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan8_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x8", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan9_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan10_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan11_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x20", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan12_present", "attr_devtype":"FAN-CTRL", "attr_offset":"0x0F", "attr_mask":"0x20", "attr_cmpval":"0x0", "attr_len":"1"},
+				{ "attr_name":"fan1_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x1", "attr_cmpval":"0x1", "attr_len":"1"},
+				{ "attr_name":"fan2_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x1", "attr_cmpval":"0x1", "attr_len":"1"},
+				{ "attr_name":"fan3_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},
+				{ "attr_name":"fan4_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},
+				{ "attr_name":"fan5_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
+				{ "attr_name":"fan6_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
+				{ "attr_name":"fan7_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},
+				{ "attr_name":"fan8_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},
+				{ "attr_name":"fan9_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x10", "attr_cmpval":"0x10", "attr_len":"1"},
+				{ "attr_name":"fan10_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x10", "attr_cmpval":"0x10", "attr_len":"1"},
+				{ "attr_name":"fan11_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x20", "attr_cmpval":"0x20", "attr_len":"1"},
+				{ "attr_name":"fan12_direction", "attr_devtype":"FAN-CTRL", "attr_offset":"0x10", "attr_mask":"0x20", "attr_cmpval":"0x20", "attr_len":"1"},
+				{ "attr_name":"fan1_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x12", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+				{ "attr_name":"fan2_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x22", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+				{ "attr_name":"fan3_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x13", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+				{ "attr_name":"fan4_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x23", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+				{ "attr_name":"fan5_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x14", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+				{ "attr_name":"fan6_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x24", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100", "attr_is_divisor":0},
+				
+				{ "attr_name":"fan7_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x15", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+				{ "attr_name":"fan8_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x25", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+				{ "attr_name":"fan9_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x16", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+				{ "attr_name":"fan10_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x26", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+				{ "attr_name":"fan11_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x17", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+				{ "attr_name":"fan12_input", "attr_devtype":"FAN-CTRL", "attr_offset":"0x27", "attr_mask":"0xFF", "attr_len":"1", "attr_mult":"100" , "attr_is_divisor":0},
+				
+				{ "attr_name":"fan1_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan2_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan3_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan4_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan5_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan6_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan7_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan8_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan9_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan10_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan11_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" },
+				{ "attr_name":"fan12_pwm", "attr_devtype":"FAN-CTRL", "attr_offset":"0x11", "attr_mask":"0x0F", "attr_len":"1" }
+				
+			]
+		}
+	},
+
+	"TEMP1" :
+	{
+		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX7"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x4c", "dev_type":"lm75"},
+			"attr_list":
+			[
+				{ "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+				{ "attr_name": "temp1_max_hyst"},
+				{ "attr_name": "temp1_input"}
+			]
+		}
+	},
+
+	"TEMP2" :
+	{
+		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP2", "device_parent":"MUX7"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x48", "dev_type":"lm75"},
+			"attr_list":
+			[
+				{ "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+				{ "attr_name": "temp1_max_hyst"},
+				{ "attr_name": "temp1_input"}
+			]
+		}
+	},
+
+	"TEMP3" :
+	{
+		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP3", "device_parent":"MUX7"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x49", "dev_type":"lm75"},
+			"attr_list":
+			[
+				{ "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+				{ "attr_name": "temp1_max_hyst"},
+				{ "attr_name": "temp1_input"}
+			]
+		}
+	},
+	
+	"TEMP4" :
+	{
+		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP4", "device_parent":"MUX7"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x4a", "dev_type":"lm75"},
+			"attr_list":
+			[
+				{ "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
+				{ "attr_name": "temp1_max_hyst"},
+				{ "attr_name": "temp1_input"}
+			]
+		}
+	},
+	
+	"TEMP5" :
+	{
+		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP5", "device_parent":"MUX7"},
+		"i2c":
+		{
+			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x4b", "dev_type":"lm75"},
+			"attr_list":
+			[
+				{ "attr_name": "temp1_max"},
+				{ "attr_name": "temp1_max_hyst"},
+				{ "attr_name": "temp1_input"}
+			]
+		}
+	},
+	
+	"SYSSTATUS":
+	{
+		"dev_info":{ "device_type":"SYSSTAT", "device_name":"SYSSTATUS"},
+		"dev_attr":{ },
+		"attr_list":
+		[
+                
+                  { "attr_name":"board_info","attr_devaddr":"0x60", "attr_offset":"0x0","attr_mask":"0xf","attr_len":"0x1"},
+                  { "attr_name":"cpld1_version","attr_devaddr":"0x60","attr_offset":"0x1","attr_mask":"0xff","attr_len":"0x1"},
+                  { "attr_name":"power_module_status","attr_devaddr":"0x60","attr_offset":"0x2","attr_mask":"0x3f","attr_len":"0x1"},
+                  { "attr_name":"system_reset5","attr_devaddr":"0x60","attr_offset":"0x8","attr_mask":"0xff","attr_len":"0x1"},
+                  { "attr_name":"system_reset6","attr_devaddr":"0x60","attr_offset":"0x9","attr_mask":"0xff","attr_len":"0x1"},
+                  { "attr_name":"system_reset7","attr_devaddr":"0x60","attr_offset":"0xa","attr_mask":"0xff","attr_len":"0x1"},
+                  { "attr_name":"misc1","attr_devaddr":"0x60","attr_offset":"0x48","attr_mask":"0xff","attr_len":"0x1"},
+                  { "attr_name":"cpld2_version","attr_devaddr":"0x62","attr_offset":"0x1","attr_mask":"0xff","attr_len":"0x1"},
+                  { "attr_name":"cpld3_version","attr_devaddr":"0x64","attr_offset":"0x1","attr_mask":"0xff","attr_len":"0x1"}
+
+		]
+	},
+
+
+	"LOC_LED":
+	{
+			"dev_info": { "device_type":"LED", "device_name":"LOC_LED"},
+			"dev_attr": { "index":"0"},
+			"i2c" : {
+				"attr_list":
+				[
+					{"attr_name":"blue", "descr" : "Blue", "bits" : "7",  "value" : "0x0", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
+					{"attr_name":"off",  "descr" : "Off", "bits" : "7",  "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"}
+				]
+			}
+	},
+
+	"DIAG_LED":
+	{
+			"dev_info": { "device_type":"LED", "device_name":"DIAG_LED"},
+			"dev_attr": { "index":"0"},
+			"i2c" : {
+				"attr_list":
+				[
+					{"attr_name":"green", "descr" : "Green", "bits" : "1:0", "value" : "0x2", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
+					{"attr_name":"red",   "descr" : "Red" ,"bits" : "1:0", "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
+					{"attr_name":"off",   "descr" : "Off" ,"bits" : "1:0", "value" : "0x3", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"}
+				]
+			}
+
+	}
+	
+}

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/service/as7726-32x-pddf-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/service/as7726-32x-pddf-platform-monitor.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Accton AS7726-32X Platform Monitoring service
+Before=pmon.service
+After=pddf-platform-init.service
+DefaultDependencies=no
+
+[Service]
+ExecStart=/usr/local/bin/accton_as7726_32x_pddf_monitor.py
+KillSignal=SIGKILL
+SuccessExitStatus=SIGKILL
+
+# Resource Limitations
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/service/pddf-platform-init.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/service/pddf-platform-init.service
@@ -1,0 +1,1 @@
+../../../../pddf/i2c/service/pddf-platform-init.service

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/__init__.py
@@ -1,0 +1,3 @@
+# All the derived classes for PDDF
+__all__ = ["platform", "chassis", "sfp", "psu", "thermal", "fan"]
+from . import platform

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+#############################################################################
+# PDDF
+# Module contains an implementation of SONiC Chassis API
+#
+#############################################################################
+
+try:
+    import time
+    from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Chassis(PddfChassis):
+    """
+    PDDF Platform-specific Chassis class
+    """
+
+    def __init__(self, pddf_data=None, pddf_plugin_data=None):
+        PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
+    def get_change_event(self, timeout=2000):
+        now = time.time()
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            timeout = 1000
+        timeout = timeout / float(1000)  # Convert to secs
+
+        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
+            return True, change_dict
+        
+        bitmap = 0
+        for i in range(34):
+            modpres = self.get_sfp(i).get_presence()
+            if modpres:
+                bitmap = bitmap | (1 << i)
+
+        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
+        if changed_ports:
+            for i in range(34):
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update teh cache dict
+            self.sfp_change_event_data['present'] = bitmap
+            self.sfp_change_event_data['last'] = now
+            self.sfp_change_event_data['valid'] = 1
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/eeprom.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+try:
+    from sonic_platform_pddf_base.pddf_eeprom import PddfEeprom
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Eeprom(PddfEeprom):
+
+    def __init__(self, pddf_data=None, pddf_plugin_data=None):
+        PddfEeprom.__init__(self, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/fan.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan import PddfFan
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Fan(PddfFan):
+    """PDDF Platform-Specific Fan class"""
+
+    def __init__(self, tray_idx, fan_idx=0, pddf_data=None, pddf_plugin_data=None, is_psu_fan=False, psu_index=0):
+        # idx is 0-based 
+        PddfFan.__init__(self, tray_idx, fan_idx, pddf_data, pddf_plugin_data, is_psu_fan, psu_index)
+
+    # Provide the functions/variables below for which implementation is to be overwritten
+    # Since AS4630 psu_fan airflow direction cant be read from sysfs, it is fixed as 'F2B' or 'intake'
+

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/platform.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/platform.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+#############################################################################
+# PDDF
+# Module contains an implementation of SONiC Platform Base API and
+# provides the platform information
+#
+#############################################################################
+
+
+try:
+    from sonic_platform_pddf_base.pddf_platform import PddfPlatform
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Platform(PddfPlatform):
+    """
+    PDDF Platform-Specific Platform Class
+    """
+
+    def __init__(self):
+        PddfPlatform.__init__(self)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/psu.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+
+
+try:
+    from sonic_platform_pddf_base.pddf_psu import PddfPsu
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+
+class Psu(PddfPsu):
+    """PDDF Platform-Specific PSU class"""
+    
+    PLATFORM_PSU_CAPACITY = 1200
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        PddfPsu.__init__(self, index, pddf_data, pddf_plugin_data)
+        
+    # Provide the functions/variables below for which implementation is to be overwritten
+    def get_maximum_supplied_power(self):
+        """
+        Retrieves the maximum supplied power by PSU (or PSU capacity)
+        Returns:
+            A float number, the maximum power output in Watts.
+            e.g. 1200.1
+        """
+        return float(self.PLATFORM_PSU_CAPACITY)
+
+    def get_capacity(self):
+        """
+        Gets the capacity (maximum output power) of the PSU in watts
+
+        Returns:
+            An integer, the capacity of PSU
+        """
+        return (self.PLATFORM_PSU_CAPACITY)
+
+    def get_type(self):
+        """
+        Gets the type of the PSU
+        Returns:
+        A string, the type of PSU (AC/DC)
+        """
+        return "AC"

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/sfp.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+try:
+    from sonic_platform_pddf_base.pddf_sfp import PddfSfp
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+
+class Sfp(PddfSfp):
+    """
+    PDDF Platform-Specific Sfp class
+    """
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/thermal.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_thermal import PddfThermal
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+
+class Thermal(PddfThermal):
+    """PDDF Platform-Specific Thermal class"""
+
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
+        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/watchdog.py
@@ -7,8 +7,6 @@
 #############################################################################
 
 try:
-    import os
-    import sys
     from sonic_platform_pddf_base.pddf_watchdog import PddfWatchdog
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/watchdog.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+#############################################################################
+#
+# Module contains an implementation of platform specific watchdog API's
+#
+#############################################################################
+
+try:
+    import os
+    import sys
+    from sonic_platform_pddf_base.pddf_watchdog import PddfWatchdog
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+class Watchdog(PddfWatchdog):
+    """
+    PDDF Platform-specific Chassis class
+    """
+
+    def __init__(self):
+        PddfWatchdog.__init__(self)
+        self.timeout= 180
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform_setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform_setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+setup(
+    name='sonic-platform',
+    version='1.0',
+    description='SONiC platform API implementation on Accton Platforms',
+    license='Apache 2.0',
+    author='SONiC Team',
+    author_email='linuxnetdev@microsoft.com',
+    url='https://github.com/Azure/sonic-buildimage',
+    packages=['sonic_platform'],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Plugins',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 3.7',
+        'Topic :: Utilities',
+    ],
+    keywords='sonic SONiC platform PLATFORM',
+)

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_pddf_monitor.py
@@ -25,25 +25,20 @@
 
 try:
     import os
-    import subprocess
     import sys
     import getopt
     import logging
     import logging.config
     import logging.handlers
     import time
-    import traceback    
-    from tabulate import tabulate
     from sonic_platform import platform
 except ImportError as e:
     raise ImportError('%s - required module not found' % str(e))
 
 # Deafults
 VERSION = '1.0'
-FUNCTION_NAME = '/usr/local/bin/accton_as7726_32x_monitor'
+FUNCTION_NAME = '/usr/local/bin/accton_as7726_32x_pddf_monitor'
 
-global log_file
-global log_level
 platform_chassis = None
  
 #  Air Flow Front to Back :
@@ -115,7 +110,7 @@ class device_monitor(object):
             console.setFormatter(formatter)
             logging.getLogger('').addHandler(console)
 
-        sys_handler = handler = logging.handlers.SysLogHandler(address = '/dev/log')
+        sys_handler = logging.handlers.SysLogHandler(address = '/dev/log')
         sys_handler.setLevel(logging.WARNING)       
         logging.getLogger('').addHandler(sys_handler)
           
@@ -166,7 +161,6 @@ class device_monitor(object):
            LEVEL_TEMP_CRITICAL: [100, 0xE, 59000, 200000],
         }
         
-        fan_policy = fan_policy_f2b
         fan_dir= platform_chassis.get_fan(0).get_direction()
         if fan_dir == 'EXHAUST':
             fan_policy = fan_policy_f2b
@@ -180,9 +174,6 @@ class device_monitor(object):
             temp4 = platform_chassis.get_thermal(3).get_temperature()*1000
             temp5 = platform_chassis.get_thermal(4).get_temperature()*1000
         else:
-            temp1 = test_temp_list[0]
-            temp2 = test_temp_list[1]
-            temp3 = test_temp_list[2]
             temp4 = test_temp_list[3]
             temp5 = test_temp_list[4]            
             fan_fail=0

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_pddf_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_pddf_monitor.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2017 Accton Technology Corporation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# ------------------------------------------------------------------
+# HISTORY:
+#    mm/dd/yyyy (A.D.)#   
+#    4/20/2018: Jostar modify for as7726_32x
+#    12/03/2018:Jostar modify for as7726_32x thermal plan
+#    11/16/2020:Jostar modify for as7726_32x thermal plan based on PDDF
+# ------------------------------------------------------------------
+
+try:
+    import os
+    import subprocess
+    import sys
+    import getopt
+    import logging
+    import logging.config
+    import logging.handlers
+    import time
+    import traceback    
+    from tabulate import tabulate
+    from sonic_platform import platform
+except ImportError as e:
+    raise ImportError('%s - required module not found' % str(e))
+
+# Deafults
+VERSION = '1.0'
+FUNCTION_NAME = '/usr/local/bin/accton_as7726_32x_monitor'
+
+global log_file
+global log_level
+platform_chassis = None
+ 
+#  Air Flow Front to Back :
+#  (Thermal sensor_LM75_4A + Thermal sensor_LM75_CPU) /2 <=38C : Keep 37.5%(0x04) Fan speed
+#  (Thermal sensor_LM75_4A + Thermal sensor_LM75_CPU) /2 > 38C : Change Fan speed from 37.5%(0x04) to 62.5%(0x08)
+#  (Thermal sensor_LM75_4A + Thermal sensor_LM75_CPU) /2 > 46C : Change Fan speed from 62.5%(0x08) to 100%(0x0E)
+#  (Thermal sensor_LM75_4A + Thermal sensor_LM75_CPU) /2 > 58C : Send alarm message
+#  (Thermal sensor_LM75_4A + Thermal sensor_LM75_CPU) /2 > 66C : Shut down system
+#  One Fan fail : Change Fan speed to 100%(0x0E)
+
+
+#  Air Flow Back to Front :
+#  (Thermal sensor_LM75_4A + Thermal sensor_LM75_CPU) /2 <=34C : Keep 37.5%(0x04) Fan speed
+#  (Thermal sensor_LM75_4A + Thermal sensor_LM75_CPU) /2 > 34C : Change Fan speed from 37.5%(0x04) to 62.5%(0x08)
+#  (Thermal sensor_LM75_4A + Thermal sensor_LM75_CPU) /2 > 44C : Change Fan speed from 62.5%(0x08) to 100%(0x0E)
+#  (Thermal sensor_LM75_4A + Thermal sensor_LM75_CPU) /2 > 59C : Send alarm message
+#  (Thermal sensor_LM75_4A + Thermal sensor_LM75_CPU) /2 > 67C : Shut down system
+#  One Fan fail:  Change Fan speed to 100%(0x0E)
+#  sensor_LM75_CPU == sensor_LM75_4B
+ 
+     
+class switch(object):
+    def __init__(self, value):
+        self.value = value
+        self.fall = False
+ 
+    def __iter__(self):
+        """Return the match method once, then stop"""
+        yield self.match
+        raise StopIteration
+     
+    def match(self, *args):
+        """Indicate whether or not to enter a case suite"""
+        if self.fall or not args:
+            return True
+        elif self.value in args: # changed for v1.5, see below
+            self.fall = True
+            return True
+        else:
+            return False
+
+
+fan_policy_state=1
+fan_fail=0
+alarm_state = 0 #0->default or clear, 1-->alarm detect
+test_temp = 0
+test_temp_list = [0, 0, 0, 0, 0, 0]
+temp_test_data=0
+
+
+# Make a class we can use to capture stdout and sterr in the log
+class device_monitor(object):
+        
+    def __init__(self, log_file, log_level):
+        """Needs a logger and a logger level."""
+        # set up logging to file
+        logging.basicConfig(
+            filename=log_file,
+            filemode='w',
+            level=log_level,
+            format= '[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
+            datefmt='%H:%M:%S'
+        )
+        # set up logging to console
+        if log_level == logging.DEBUG:
+            console = logging.StreamHandler()
+            console.setLevel(log_level)
+            formatter = logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+            console.setFormatter(formatter)
+            logging.getLogger('').addHandler(console)
+
+        sys_handler = handler = logging.handlers.SysLogHandler(address = '/dev/log')
+        sys_handler.setLevel(logging.WARNING)       
+        logging.getLogger('').addHandler(sys_handler)
+          
+    def get_state_from_fan_policy(self, temp, policy):
+        state=0
+        
+        logging.debug('temp=%d', temp)
+        for i in range(0, len(policy)):
+            if temp > policy[i][2]:
+                if temp <= policy[i][3]:
+                    state =i
+                    logging.debug ('temp=%d >= policy[%d][2]=%d,  temp=%d < policy[%d][3]=%d' , temp, i, policy[i][2], temp, i, policy[i][3])
+                    logging.debug ('fan_state=%d', state)
+                    break
+        
+        return state
+
+    def manage_fans(self):
+       
+        global fan_policy_state
+        global fan_fail
+        global test_temp
+        global test_temp_list        
+        global alarm_state
+        global temp_test_data
+        global platform_chassis
+        
+        LEVEL_FAN_DEF=0
+        LEVEL_FAN_MID=1       
+        LEVEL_FAN_MAX=2
+        LEVEL_TEMP_HIGH=3
+        LEVEL_TEMP_CRITICAL=4
+        FAN_NUM_MAX = 6
+        FANS_PERTRAY=2
+        
+        fan_policy_f2b = {
+           LEVEL_FAN_DEF:       [38,  0x4, 0,     38000],
+           LEVEL_FAN_MID:       [63,  0x6, 38000, 46000],
+           LEVEL_FAN_MAX:       [100, 0xE, 46000, 58000],
+           LEVEL_TEMP_HIGH:     [100, 0xE, 58000, 66000],
+           LEVEL_TEMP_CRITICAL: [100, 0xE, 58000, 200000],
+        }
+        fan_policy_b2f = {
+           LEVEL_FAN_DEF:       [38,  0x4, 0,     34000],
+           LEVEL_FAN_MID:       [63,  0x8, 34000, 44000],
+           LEVEL_FAN_MAX:       [100, 0xE, 44000, 59000],
+           LEVEL_TEMP_HIGH:     [100, 0xE, 59000, 67000],
+           LEVEL_TEMP_CRITICAL: [100, 0xE, 59000, 200000],
+        }
+        
+        fan_policy = fan_policy_f2b
+        fan_dir= platform_chassis.get_fan(0).get_direction()
+        if fan_dir == 'EXHAUST':
+            fan_policy = fan_policy_f2b
+        else:
+            fan_policy = fan_policy_b2f
+        
+        ori_perc=platform_chassis.get_fan(0).get_speed()
+        #ori_perc=fan.get_fan_duty_cycle()
+        logging.debug('fan_dir=%s, ori_perc=%d, test_temp=%d', fan_dir, ori_perc, test_temp)
+        if test_temp==0:
+            temp4 = platform_chassis.get_thermal(3).get_temperature()*1000
+            temp5 = platform_chassis.get_thermal(4).get_temperature()*1000
+        else:
+            temp1 = test_temp_list[0]
+            temp2 = test_temp_list[1]
+            temp3 = test_temp_list[2]
+            temp4 = test_temp_list[3]
+            temp5 = test_temp_list[4]            
+            fan_fail=0
+        
+        if temp4==0:
+            temp_get=50000  # if one detect sensor is fail or zero, assign temp=50000, let fan to 75% 
+            logging.debug('lm75_4a detect fail, so set temp_get=50000, let fan to 75%')
+        elif temp5==0:        
+            temp_get=50000  # if one detect sensor is fail or zero, assign temp=50000, let fan to 75% 
+            logging.debug('lm75_4b detect fail, so set temp_get=50000, let fan to 75%')
+        else:    
+            temp_get= (temp4 + temp5)/2  # Use (sensor_LM75_4a + sensor_LM75_4b) /2 
+            
+        ori_state=fan_policy_state
+        
+        if test_temp!=0:
+            temp_test_data=temp_test_data+1000
+            temp_get = temp_get + temp_test_data
+            logging.debug('Unit test:temp_get=%d', temp_get)
+        
+        fan_policy_state=self.get_state_from_fan_policy(temp_get, fan_policy)
+                        
+        logging.debug('lm75_4a=%d, lm_4b=%d', temp4,temp5)
+        logging.debug('ori_state=%d, fan_policy_state=%d', ori_state, fan_policy_state)
+        new_perc = fan_policy[fan_policy_state][0]
+        if fan_fail==0:
+            logging.debug('new_fan_cycle=%d', new_perc)
+        
+        if fan_fail==0:
+            if new_perc!=ori_perc:
+                platform_chassis.get_fan(0).set_speed(new_perc)
+                logging.info('Set fan speed from %d to %d', ori_perc, new_perc)
+        
+        #Check Fan status
+        for i in range(FAN_NUM_MAX*FANS_PERTRAY):
+            if not platform_chassis.get_fan(i).get_status() or not platform_chassis.get_fan(i).get_speed_rpm():
+                logging.debug('fan-%d status=%d, rpm=%d', i+1, platform_chassis.get_fan(i).get_status(), platform_chassis.get_fan(i).get_speed_rpm())
+                new_perc=100
+                logging.debug('fan_%d fail, set new_perc to 100',i+1)                
+                if test_temp==0:
+                    fan_fail=1
+                    platform_chassis.get_fan(0).set_speed(new_perc)
+                    break
+            else:
+                fan_fail=0
+      
+        new_state = fan_policy_state
+        
+        if ori_state==LEVEL_FAN_DEF:            
+           if new_state==LEVEL_TEMP_HIGH:
+               if alarm_state==0:
+                   logging.warning('Alarm for temperature high is detected')
+               alarm_state=1
+           if new_state==LEVEL_TEMP_CRITICAL:
+               logging.critical('Alarm for temperature critical is detected, reboot DUT')
+               time.sleep(2)
+               os.system('reboot')           
+        if ori_state==LEVEL_FAN_MID:
+            if new_state==LEVEL_TEMP_HIGH:
+                if alarm_state==0:
+                    logging.warning('Alarm for temperature high is detected')
+                alarm_state=1 
+            if new_state==LEVEL_TEMP_CRITICAL:
+                logging.critical('Alarm for temperature critical is detected')
+                time.sleep(2)
+                os.system('reboot') 
+        if ori_state==LEVEL_FAN_MAX:
+            if new_state==LEVEL_TEMP_HIGH:
+                if alarm_state==0:
+                    logging.warning('Alarm for temperature high is detected') 
+                alarm_state=1
+            if new_state==LEVEL_TEMP_CRITICAL:
+                logging.critical('Alarm for temperature critical is detected')
+                time.sleep(2)
+                os.system('reboot') 
+            if alarm_state==1:
+                if temp_get < (fan_policy[3][0] - 5000):  #below 65 C, clear alarm
+                    logging.warning('Alarm for temperature high is cleared')
+                    alarm_state=0
+        if ori_state==LEVEL_TEMP_HIGH:
+            if new_state==LEVEL_TEMP_CRITICAL:
+                logging.critical('Alarm for temperature critical is detected')
+                time.sleep(2)
+                os.system('reboot')
+            if new_state <= LEVEL_FAN_MID:
+                logging.warning('Alarm for temperature high is cleared')
+                alarm_state=0
+            if new_state <= LEVEL_FAN_MAX:
+                if temp_get < (fan_policy[3][0] - 5000):  #below 65 C, clear alarm
+                    logging.warning('Alarm for temperature high is cleared')
+                    alarm_state=0
+        if ori_state==LEVEL_TEMP_CRITICAL:            
+            if new_state <= LEVEL_FAN_MAX:
+                logging.warning('Alarm for temperature critical is cleared')
+      
+        return True
+
+def main(argv):
+    log_file = '%s.log' % FUNCTION_NAME
+    log_level = logging.INFO
+    global test_temp
+    if len(sys.argv) != 1:
+        try:
+            opts, args = getopt.getopt(argv,'hdlt:',['lfile='])
+        except getopt.GetoptError:
+            print('Usage: %s [-d] [-l <log_file>]' % sys.argv[0])
+            return 0
+        for opt, arg in opts:
+            if opt == '-h':
+                print('Usage: %s [-d] [-l <log_file>]' % sys.argv[0])
+                return 0
+            elif opt in ('-d', '--debug'):
+                log_level = logging.DEBUG
+            elif opt in ('-l', '--lfile'):
+                log_file = arg            
+        
+        if sys.argv[1]== '-t':
+            if len(sys.argv)!=7:
+                print("temp test, need input six temp")
+                return 0
+            
+            i=0
+            for x in range(2, 7):
+               test_temp_list[i]= int(sys.argv[x])*1000
+               i=i+1
+            test_temp = 1   
+            log_level = logging.DEBUG
+            print(test_temp_list)
+    
+    global platform_chassis
+    platform_chassis = platform.Platform().get_chassis()
+    
+    platform_chassis.get_fan(0).set_speed(38)
+  
+    print("set default fan speed to 37.5%")
+    monitor = device_monitor(log_file, log_level)
+    # Loop forever, doing something useful hopefully:
+    while True:
+        monitor.manage_fans()
+        time.sleep(10)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])
+    

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/pddf_post_driver_install.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/pddf_post_driver_install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+dis_i2c_ir3570a()
+{
+    local addr=$1
+
+    i2cset -y 0 $addr 0xE5 0x01 &>/dev/null
+    i2cset -y 0 $addr 0x12 0x02 &>/dev/null
+}
+
+
+ir3570_check()
+{
+    dump=`i2cdump -y 0 0x42 s 0x9a |awk 'END {print $2}'`
+    if [ $dump -eq 24 ]; then
+        echo "Disabling i2c function of ir3570a"
+        dis_i2c_ir3570a 0x4
+    fi
+}
+
+ir3570_check
+
+echo "AS7726 post PDDF driver install completed"

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/pddf_switch_svc.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# Script to stop and start the respective platforms default services. 
+# This will be used while switching the pddf->non-pddf mode and vice versa
+import os
+import sys
+import commands
+
+def check_pddf_support():
+    return True
+
+def stop_platform_svc():
+    status, output = commands.getstatusoutput("systemctl stop as7726-32x-platform-monitor-fan.service")
+    if status:
+        print "Stop as7726-32x-platform-monitor-fan.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl disable as7726-32x-platform-monitor-fan.service")
+    if status:
+        print "Disable as7726-32x-platform-monitor-fan.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl stop as7726-32x-platform-monitor-psu.service")
+    if status:
+        print "Stop as7726-32x-platform-monitor-psu.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl disable as7726-32x-platform-monitor-psu.service")
+    if status:
+        print "Disable as7726-32x-platform-monitor-psu.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl stop as7726-32x-platform-monitor.service")
+    if status:
+        print "Stop as7726-32x-platform-monitor.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl disable as7726-32x-platform-monitor.service")
+    if status:
+        print "Disable as7726-32x-platform-monitor.service failed %d"%status
+        return False
+    
+    status, output = commands.getstatusoutput("/usr/local/bin/accton_as7726_32x_util.py clean")
+    if status:
+        print "accton_as7726_32x_util.py clean command failed %d"%status
+        return False
+
+    # HACK , stop the pddf-platform-init service if it is active
+    status, output = commands.getstatusoutput("systemctl stop pddf-platform-init.service")
+    if status:
+        print "Stop pddf-platform-init.service along with other platform serives failed %d"%status
+        return False
+
+    return True
+    
+def start_platform_svc():
+    status, output = commands.getstatusoutput("/usr/local/bin/accton_as7726_32x_util.py install")
+    if status:
+        print "accton_as7726_32x_util.py install command failed %d"%status
+        return False
+
+    status, output = commands.getstatusoutput("systemctl enable as7726-32x-platform-monitor-fan.service")
+    if status:
+        print "Enable as7726-32x-platform-monitor-fan.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl start as7726-32x-platform-monitor-fan.service")
+    if status:
+        print "Start as7726-32x-platform-monitor-fan.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl enable as7726-32x-platform-monitor-psu.service")
+    if status:
+        print "Enable as7726-32x-platform-monitor-psu.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl start as7726-32x-platform-monitor-psu.service")
+    if status:
+        print "Start as7726-32x-platform-monitor-psu.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl enable as7726-32x-platform-monitor.service")
+    if status:
+        print "Enable as7726-32x-platform-monitor.service failed %d"%status
+        return False
+    status, output = commands.getstatusoutput("systemctl start as7726-32x-platform-monitor.service")
+    if status:
+        print "Start as7726-32x-platform-monitor.service failed %d"%status
+        return False
+
+    return True
+
+def start_platform_pddf():
+    status, output = commands.getstatusoutput("systemctl start pddf-platform-init.service")
+    if status:
+        print "Start pddf-platform-init.service failed %d"%status
+        return False
+    
+    return True
+
+def stop_platform_pddf():
+    status, output = commands.getstatusoutput("systemctl stop pddf-platform-init.service")
+    if status:
+        print "Stop pddf-platform-init.service failed %d"%status
+        return False
+
+    return True
+
+def main():
+    pass
+
+if __name__ == "__main__":
+    main()
+

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/pddf_switch_svc.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/pddf_switch_svc.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # Script to stop and start the respective platforms default services. 
 # This will be used while switching the pddf->non-pddf mode and vice versa
-import os
-import sys
+
 import commands
 
 def check_pddf_support():

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7726-32x.install
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7726-32x.install
@@ -1,0 +1,1 @@
+as7726-32x/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-accton_as7726_32x-r0/pddf

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7726-32x.postinst
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7726-32x.postinst
@@ -1,0 +1,8 @@
+# Special arrangement to make PDDF mode default
+# Disable monitor, monitor-fan, monitor-psu (not enabling them would imply they will be disabled by default)
+# Enable pddf-platform-monitor
+depmod -a
+systemctl enable pddf-platform-init.service
+systemctl start pddf-platform-init.service
+systemctl enable as7726-32x-pddf-platform-monitor.service
+systemctl start as7726-32x-pddf-platform-monitor.service


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support PDDF
#### How I did it
Implement code
#### How to verify it
Test sensors and pddf cmd.
admin@sonic:~$ sensors
ym2651-i2c-50-5b
Adapter: i2c-2-mux (chan_id 1)
fan1:           0 RPM
temp1:         +0.0°C
power1:        0.00 W

lm75-i2c-55-4b
Adapter: i2c-2-mux (chan_id 6)
temp1:        +27.0°C  (high = +80.0°C, hyst = +75.0°C)

lm75-i2c-55-4a
Adapter: i2c-2-mux (chan_id 6)
temp1:        +27.5°C  (high = +80.0°C, hyst = +75.0°C)

as7726_32x_fan-i2c-54-66
Adapter: i2c-2-mux (chan_id 5)
fan1:        9900 RPM
fan2:        9800 RPM
fan3:        9700 RPM
fan4:        9900 RPM
fan5:        10000 RPM
fan6:        10000 RPM
fan11:       8500 RPM
fan12:       8300 RPM
fan13:       8300 RPM
fan14:       8400 RPM
fan15:       8400 RPM
fan16:       8400 RPM

pch_haswell-virtual-0
Adapter: Virtual device
temp1:        +35.0°C

lm75-i2c-55-49
Adapter: i2c-2-mux (chan_id 6)
temp1:        +30.5°C  (high = +80.0°C, hyst = +75.0°C)

ym2651-i2c-49-58
Adapter: i2c-2-mux (chan_id 0)
fan1:        5496 RPM
temp1:        +27.0°C
power1:      124.00 W

lm75-i2c-55-48
Adapter: i2c-2-mux (chan_id 6)
temp1:        +31.5°C  (high = +80.0°C, hyst = +75.0°C)

lm75-i2c-54-4c
Adapter: i2c-2-mux (chan_id 5)
temp1:        +26.5°C  (high = +80.0°C, hyst = +75.0°C)

coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +39.0°C  (high = +82.0°C, crit = +104.0°C)
Core 0:        +39.0°C  (high = +82.0°C, crit = +104.0°C)
Core 1:        +39.0°C  (high = +82.0°C, crit = +104.0°C)
Core 2:        +40.0°C  (high = +82.0°C, crit = +104.0°C)
Core 3:        +40.0°C  (high = +82.0°C, crit = +104.0°C)

root@sonic:~# pddf_psuutil mfrinfo
PSU1 is Not OK

PSU2 is OK
Manufacture Id: 3Y POWER
Model: YM-2651
Serial Number: SA070V581905000055
Fan Direction: Exhaust

root@sonic:~#
root@sonic:~# pddf_psuutil
debug    mfrinfo  numpsus  seninfo  status   version
root@sonic:~# pddf_psuutil status
PSU    Status
-----  --------
PSU1   NOT OK
PSU2   OK
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

