### PR TITLE
[201811] Fix swsssdk build by installing redis explicitly

### DIFF
--- a/sonic-slave-stretch/Dockerfile
+++ b/sonic-slave-stretch/Dockerfile
@@ -230,6 +230,10 @@ RUN pip install pyangbind==0.5.10
 # For supervisor build
 RUN pip install meld3 mock
 
+# For swsssdk build
+RUN pip2 install redis==2.10.6
+RUN pip3 install redis==2.10.6
+
 # Install dependencies for isc-dhcp-relay build
 RUN apt-get -y build-dep isc-dhcp
 

--- a/sonic-slave-stretch/Dockerfile
+++ b/sonic-slave-stretch/Dockerfile
@@ -230,10 +230,6 @@ RUN pip install pyangbind==0.5.10
 # For supervisor build
 RUN pip install meld3 mock
 
-# For swsssdk build
-RUN pip2 install redis==2.10.6
-RUN pip3 install redis==2.10.6
-
 # Install dependencies for isc-dhcp-relay build
 RUN apt-get -y build-dep isc-dhcp
 

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -281,6 +281,7 @@ RUN pip install meld3 mock
 RUN pip install pexpect==4.6.0
 
 # For sonic-utilities build
+RUN pip install nose==1.3.7
 RUN pip install mockredispy==2.9.3
 RUN pip install pytest-runner==4.4
 RUN pip install setuptools==40.8.0

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -288,6 +288,10 @@ RUN pip install setuptools==40.8.0
 # For sonic-swss-common testing
 RUN pip install Pympler==0.8
 
+# For swsssdk build
+RUN pip2 install redis==2.10.6
+RUN pip3 install redis==2.10.6
+
 # Install dependencies for isc-dhcp-relay build
 RUN apt-get -y build-dep isc-dhcp
 


### PR DESCRIPTION
Signed-off-by: Sangita Maity <samaity@linkedin.com>

#### Why I did it
for 201811 build image, swsssdk wheel package is not getting build due to `redis==2.10.6` requirement issue. Notied that after upgrading pip to 20.3.3, we are experiencling this issue.

**the issue**
```
21:10:41  /sonic/src/sonic-py-swsssdk /sonic
21:10:41  running test
21:10:41  Searching for redis==2.10.6
21:10:41  Reading https://pypi.python.org/simple/redis/
21:10:41  Couldn't find index page for 'redis' (maybe misspelled?)
21:10:41  Scanning index of all packages (this may take a while)
21:10:41  Reading https://pypi.python.org/simple/
21:10:41  No local packages or download links found for redis==2.10.6
21:10:41  error: Could not find suitable distribution for Requirement.parse('redis==2.10.6')
21:10:41  [  FAIL LOG END  ] [ target/python-wheels/swsssdk-2.0.1-py3-none-any.whl ]
21:10:41  slave.mk:422: recipe for target 'target/python-wheels/swsssdk-2.0.1-py3-none-any.whl' failed
21:10:41  make: *** [target/python-wheels/swsssdk-2.0.1-py3-none-any.whl] Error 1
21:10:43  Makefile.work:132: recipe for target 'target/sonic-aboot-broadcom.swi' failed
21:10:43  make[1]: *** [target/sonic-aboot-broadcom.swi] Error 2
21:10:43  make[1]: Leaving directory '/data/johnar/workspace/broadcom/buildimage-brcm-201811'
21:10:43  Makefile:6: recipe for target 'target/sonic-aboot-broadcom.swi' failed
```

So, what I have understood till now, if pip v20.3.3 is able to produce a wheel that is not installable because it raises pip._vendor.packaging.version.InvalidVersion or some error like that (resource- > https://github.com/pypa/pip/issues/9206), it just raises an exception when building the wheel.

SO, this issue occurs when we pinned down pip to 20.3.3 in short.

As of now, there are two solutions mentioned below.
1. pin down pip to 20.3.3(which it is) and explicitly install packages.
2. pin down pip to 20.3.4(pip wheel now verifies the built wheel contains valid metadata, and can be installed by a subsequent pip install.)(resource-> https://pip.pypa.io/en/stable/news/) -- didn't try yet

#### How I did it
- Install nose explicitly for mockredispy
- Install redis==2.10.6 for swsssdk tests.

#### How to verify it
Build got successful.
