### PR TITLE
[ci] Fix workflow permission issue when merging from the fork repo

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,7 +7,7 @@
 
 name: Labeler
 on:
-  pull_request:
+  pull_request_target:
     types:
     - opened
     - reopened


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the labeler workflow permission issue when merging from fork repo.
It impacts the labeler workflow to support auto-merge for package versions upgrade on 202012 branch. The current workaround is to add the label "automerge" on the PR sent by mssonicbld, then the automerge workflow will merge the PR.

#### How I did it
For adding labels, need to use pull_request_target.
See 
https://docs.github.com/en/actions/reference/authentication-in-a-workflow#example-1-passing-the-github_token-as-an-input


#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

