### PR TITLE
[sonic-mgmt] Install aiohttp package to sonic-mgmt docker

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -171,7 +171,7 @@ RUN python -m virtualenv --system-site-packages env-201811
 RUN env-201811/bin/pip install cryptography==3.3.2 ansible==2.0.0.2
 
 RUN python3 -m venv env-python3
-RUN env-python3/bin/pip3 install cryptography==3.3.2 azure-kusto-data azure-kusto-ingest defusedxml pytest
+RUN env-python3/bin/pip3 install cryptography==3.3.2 azure-kusto-data azure-kusto-ingest defusedxml pytest aiohttp
 
 # NOTE: There is an ordering dependency for pycryptodome. Leaving this at
 #       the end until we figure that out.


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The aiohttp package is required by azure.kusto.data which is used by  sonic-mgmt/test_reporting.
Older version of azure.kusto.data does not need this package. Newer version of azure.kusto.data
requires this 'aiohttp' package.

This change is to ensure that the dependent package is installed in the sonic-mgmt docker.

#### How I did it
Update the sonic-mgmt Dockerfile to ensure that the aiohttp python package is installed during build.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

