### PR TITLE
[sonic-yang-models]: fix unit test failure

### DIFF
--- a/src/sonic-yang-models/tests/test_sonic_yang_models.py
+++ b/src/sonic-yang-models/tests/test_sonic_yang_models.py
@@ -24,9 +24,12 @@ def test_content(response):
 def test_generate_yang_tree():
 
     # Generate YANG Tree, see no error in it.
-    pyang_tree_cmd = "pyang -f tree ./yang-models/*.yang > ./yang-models/sonic_yang_tree"
+    pyang_tree_cmd = "pyang -Vf tree -p /usr/local/share/yang/modules/ietf ./yang-models/*.yang > ./yang-models/sonic_yang_tree"
     if (system(pyang_tree_cmd)):
         print("Failed: {}".format(pyang_tree_cmd))
+        system("pyang --version")
+        system("env")
+        system("ls -l /usr/local/share/yang/modules/ietf/")
         exit(1)
     else:
         print("Passed: {}".format(pyang_tree_cmd))


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
    [sonic-yang-models]: fix unit test failure
    
    it is not quite understood why the unit test suddenly failed as below.
    but add ietf yang model explicitly to the build process fix the test
    failure.
    
    tests/test_sonic_yang_models.py .F [ 66%]
    tests/yang_model_tests/test_yang_model.py . [100%]
    Failed: pyang -f tree ./yang-models/*.yang > ./yang-models/sonic_yang_tree
    ----------------------------- Captured stderr call -----------------------------
    ./yang-models/sonic-acl.yang:8: error: module "ietf-inet-types" not found in search path
    ./yang-models/sonic-device_metadata.yang:8: error: module "ietf-yang-types" not found in search path

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

