### PR TITLE
[sonic-slave-buster]: upgrade pyang version to 2.4.0 and install only…

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -455,8 +455,7 @@ RUN pip2 install Pympler==0.8
 RUN pip3 install Pympler==0.8
 
 # For sonic_yang_model build
-RUN pip2 install pyang==2.1.1
-RUN pip3 install pyang==2.1.1
+RUN pip3 install pyang==2.4.0
 
 # For mgmt-framework build
 RUN pip2 install mmh3==2.5.1

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -370,7 +370,7 @@ RUN pip2 install setuptools==40.8.0
 RUN pip2 install Pympler==0.8
 
 # For sonic_yang_model build
-RUN pip2 install pyang==2.1.1
+RUN pip3 install pyang==2.4.0
 
 # For mgmt-framework build
 RUN pip2 install mmh3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
[sonic-slave-buster]: upgrade pyang version to 2.4.0 and install only using pip3.
    
[sonic-slave-stretch]: upgrade pyang version to 2.4.0.

**- How I did it**

Change in docker file for Buster and stretch

**- How to verify it**

Sonic Yang models test uses pyang. They should built fine.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
