### PR TITLE
[Dependencies] Pin pip3 version

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -426,7 +426,7 @@ sudo augtool --autosave "$sysctl_net_cmd_string" -r $FILESYSTEM_ROOT
 
 # Upgrade pip via PyPI and uninstall the Debian version
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install --upgrade 'pip<21'
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install --upgrade pip
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install --upgrade 'pip==21.0.1'
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get purge -y python-pip python3-pip
 
 # For building Python packages

--- a/dockers/docker-base-buster/Dockerfile.j2
+++ b/dockers/docker-base-buster/Dockerfile.j2
@@ -83,7 +83,7 @@ RUN rm redis-tools_6.0.6-1~bpo10+1_amd64.deb
 {% endif %}
 
 # Upgrade pip via PyPI and uninstall the Debian version
-RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade 'pip==21.0.1'
 RUN apt-get purge -y python3-pip
 
 # setuptools and wheel are necessary for installing some Python wheel packages

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -395,7 +395,7 @@ RUN export VERSION=1.14.2 \
  && echo 'export PATH=$PATH:$GOROOT/bin' >> /etc/bash.bashrc \
  && rm go$VERSION.linux-*.tar.gz
 
-RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade 'pip==21.0.1'
 RUN pip2 install --upgrade 'pip<21'
 RUN apt-get purge -y python-pip python3-pip python3-yaml
 

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -321,7 +321,7 @@ RUN export VERSION=1.14.2 \
  && echo 'export PATH=$PATH:$GOROOT/bin' >> /etc/bash.bashrc \
  && rm go$VERSION.linux-*.tar.gz
 
-RUN pip3 install --upgrade 'pip==21.0.1'
+RUN pip3 install --upgrade 'pip==20.3.4'
 RUN pip2 install --upgrade 'pip<21'
 RUN apt-get purge -y python-pip python3-pip
 

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -321,7 +321,7 @@ RUN export VERSION=1.14.2 \
  && echo 'export PATH=$PATH:$GOROOT/bin' >> /etc/bash.bashrc \
  && rm go$VERSION.linux-*.tar.gz
 
-RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade 'pip==21.0.1'
 RUN pip2 install --upgrade 'pip<21'
 RUN apt-get purge -y python-pip python3-pip
 


### PR DESCRIPTION
#### Why I did it

A new version of pip (21.1) was released on 4/24, and it appears to have introduced new behavior which is causing the build to break. New log messages such as the following are seen in the build log:

```
WARNING: Value for scheme.platlib does not match. Please report this to <https://github.com/pypa/pip/issues/9617> 
WARNING: Value for scheme.headers does not match. Please report this to <https://github.com/pypa/pip/issues/9617> 
WARNING: Value for scheme.scripts does not match. Please report this to <https://github.com/pypa/pip/issues/9617> 
WARNING: Value for scheme.data does not match. Please report this to <https://github.com/pypa/pip/issues/9617> 
```

And the build is failing with errors like:

```
Requirement already satisfied: sonic-yang-mgmt in /usr/local/lib/python3.7/dist-packages (from sonic-utilities==1.2) (1.0) 
Collecting pexpect==4.8.0 
Downloading pexpect-4.8.0-py2.py3-none-any.whl (59 kB) 
ERROR: Cannot install sonic-utilities==1.2 because these package versions have conflicting dependencies. 
The conflict is caused by: 
sonic-utilities 1.2 depends on netifaces==0.10.7 
The user requested (constraint) netifaces==0.10.9 
To fix this you could try to: 
1. loosen the range of package versions you've specified 
2. remove package versions to allow pip attempt to solve the dependency conflict 
```


Until we can resolve these issues, pin the version to the last known good version, 21.0.1 in Buster environments, and 20.3.4 in Stretch environments.

---

Update: This appears to be due to netifaces version 0.10.9 being [installed](https://github.com/Azure/sonic-buildimage/blob/master/platform/vs/docker-sonic-vs/Dockerfile.j2#L113) in docker-sonic-vs, whereas sonic-utilities explicitly requires 0.10.7 in its setup.py file. Older versions of pip did not error out here, but 21.1 does.

https://github.com/Azure/sonic-utilities/pull/1530 may solve this issue by relaxing the dependencies, therefore this PR may not be necessary.

