### PR TITLE
[ci] Add the platform filter to ignore some platforms not ready to use

### DIFF
--- a/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
+++ b/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
@@ -17,7 +17,7 @@ schedules:
 pool: sonicbld
 
 parameters:
-  - name: jobFilters:
+  - name: jobFilters
     type: object
     default:
     - vs

--- a/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
+++ b/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
@@ -16,6 +16,18 @@ schedules:
 
 pool: sonicbld
 
+parameters:
+  - name: jobFilters:
+    type: object
+    default:
+    - vs
+    - broadcom
+    - centec
+    - generic
+    - innovium
+    - mellanox
+    - nephos
+
 stages:
 - stage: Build
   variables:
@@ -25,6 +37,7 @@ stages:
   - template: azure-pipelines-build.yml
     parameters:
       buildOptions: '${{ variables.VERSION_CONTROL_OPTIONS }} SONIC_BUILD_JOBS=$(nproc) ENABLE_IMAGE_SIGNATURE=y'
+      jobFilters: ${{ parameters.jobFilters }}
       preSteps:
       - script: |
           containers=$(docker container ls | grep "sonic-slave" | awk '{ print $1 }')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add the platform filter to ignore some platforms not ready to use
The platform centos-arm64 and the platform marvell-armhf are not ready to use now. We will add it when it is available.

#### How I did it

#### How to verify it
Create a new azure pipeline to test it, see https://dev.azure.com/mssonic/build/_build/results?buildId=12804&view=results

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

