### PR TITLE
[docker-orchagent]: Increase ndppd kernel poll interval

### DIFF
--- a/dockers/docker-orchagent/ndppd.conf.j2
+++ b/dockers/docker-orchagent/ndppd.conf.j2
@@ -21,7 +21,7 @@
 {%              set _x = proxy_interfaces[intf].append(prefix) %}
 {%          endif %}
 {%      endfor -%}
-
+route-ttl 2147483647
 {%      for intf, prefix_list in proxy_interfaces.items() %}
 {%          if prefix_list %}
 

--- a/src/sonic-config-engine/tests/sample_output/py2/ndppd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/ndppd.conf
@@ -4,6 +4,7 @@
 #
 # Config file for ndppd, the NDP Proxy Daemon
 # See man page for ndppd.conf.5 for descriptions of all available options
+route-ttl 2147483647
 
 proxy Vlan1000 {
     rule fc02:1000::/64 {

--- a/src/sonic-config-engine/tests/sample_output/py3/ndppd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/ndppd.conf
@@ -4,6 +4,7 @@
 #
 # Config file for ndppd, the NDP Proxy Daemon
 # See man page for ndppd.conf.5 for descriptions of all available options
+route-ttl 2147483647
 
 proxy Vlan1000 {
     rule fc01:1000::/64 {


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Fixes #6823 

#### Why I did it
`ndppd` by default reads `/proc/net/ipv6_route` ever 30 seconds. Since T1s advertise so many routes to ToRs, this file is extremely large, and reading it causes `ndppd`'s CPU usage to spike every 30 seconds

#### How I did it
Increase the delay for reading this file to the maximum possible value (max integer value), which will result in CPU spikes every ~24 days instead of every 30 seconds

#### How to verify it
Start `ndppd` with the new config file, confirm that no CPU spikes are seen except at startup

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)
![image](https://user-images.githubusercontent.com/6006991/116341270-70d67280-a795-11eb-8731-8bb6d7563293.png)
