### PR TITLE
[caclmgrd] Remove sleep which allowed threads to progress

### DIFF
--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -646,11 +646,6 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         while True:
             ctrl_plane_acl_notification = set()
 
-            # A brief sleep appears necessary in this loop or any spawned
-            # update threads will get stuck. Appears to be due to the sel.select() call.
-            # TODO: Eliminate the need for this sleep.
-            time.sleep(0.1)
-
             (state, selectableObj) = sel.select(SELECT_TIMEOUT_MS)
             # Continue if select is timeout or selectable object is not return
             if state != swsscommon.Select.OBJECT:


### PR DESCRIPTION
#### Why I did it

Previously, a brief sleep was necessary in order to get Python threads to progress. The root cause of this has since been found and fixed in sonic-swss-common: https://github.com/Azure/sonic-swss-common/pull/477. The submodule was updated [here](https://github.com/Azure/sonic-buildimage/pull/7467), so we can now safely remove this sleep.

This PR should also be cherry-picked to the 202012 branch once the submodule is updated there to also include the fix.

#### How to verify it

Ensure the update threads progress in caclmgrd

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
