### PR TITLE
Revert "[build] Extend rules/config.user to more Makefiles (#7344)"

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -100,7 +100,6 @@ SLAVE_DIR = sonic-slave-jessie
 endif
 
 include rules/config
--include rules/config.user
 
 ifeq ($(ENABLE_DOCKER_BASE_PULL),)
 	override ENABLE_DOCKER_BASE_PULL = n


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#7344

#7344 causes unnecessary sonic docker slave build with "make init" and/or "make reset"