### PR TITLE
[makefile] define a do-nothing target for config.user

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -100,7 +100,10 @@ SLAVE_DIR = sonic-slave-jessie
 endif
 
 include rules/config
--include rules/config.user
+
+ifeq (rules/config.user, $(wildcard rules/config.user))
+    include rules/config.user
+endif
 
 ifeq ($(ENABLE_DOCKER_BASE_PULL),)
 	override ENABLE_DOCKER_BASE_PULL = n

--- a/Makefile.work
+++ b/Makefile.work
@@ -99,8 +99,8 @@ else
 SLAVE_DIR = sonic-slave-jessie
 endif
 
-# Define an empty target for rules/config.user so that when
-# the file is missng, make won't try to rebuld everything.
+# Define a do-nothing target for rules/config.user so that when
+# the file is missing, make won't try to rebuld everything.
 rules/config.user:
 	@echo -n ""
 

--- a/Makefile.work
+++ b/Makefile.work
@@ -99,11 +99,13 @@ else
 SLAVE_DIR = sonic-slave-jessie
 endif
 
-include rules/config
+# Define an empty target for rules/config.user so that when
+# the file is missng, make won't try to rebuld everything.
+rules/config.user:
+	@echo -n ""
 
-ifeq (rules/config.user, $(wildcard rules/config.user))
-    include rules/config.user
-endif
+include rules/config
+-include rules/config.user
 
 ifeq ($(ENABLE_DOCKER_BASE_PULL),)
 	override ENABLE_DOCKER_BASE_PULL = n


### PR DESCRIPTION
#### Why I did it
After PR #7344, 'make init' and/or 'make reset' will also build sonic slave dockers.

'-include rules/config.user' is supposed to be fine when the file is missing.  However, when the file is missing, it generates a delayed error which later causes make init and make reset trying to build the sonic slave dockers.
    
#### How I did it
Define a do-nothing target for config.user to catch config.user build therefore preventing other builds to be triggered unexpectedly.

#### How to verify it
did make init and it is now only doing submodule init.