### PR TITLE
Support for updating tmpfs size according to Image size

### DIFF
--- a/installer/sharch_body.sh
+++ b/installer/sharch_body.sh
@@ -25,7 +25,7 @@ fi
 
 echo " OK."
 
-image_size=$(du "$0" | awk '{print $1}')
+image_size=$(( $(sed -e '1,/^exit_marker$/d' "$0"  | tar --to-stdout -xf - | wc -c) / 1024))
 # Untar and launch install script in a tmpfs
 cur_wd=$(pwd)
 export cur_wd

--- a/installer/sharch_body.sh
+++ b/installer/sharch_body.sh
@@ -34,8 +34,10 @@ tmp_dir=$(mktemp -d)
 if [ "$(id -u)" = "0" ] ; then
     mount -t tmpfs tmpfs-installer $tmp_dir || exit 1
     mount_size=$(df $tmp_dir | tail -1 | tr -s ' ' | cut -d' ' -f4)
-    if [ "$mount_size" -lt "$((image_size*3))" ]; then
-        mount_size=$((((image_size*3)/1024/1024)+1))
+    #checking extra 100KB space in tmp_dir, after image extraction
+    padding=102400
+    if [ "$mount_size" -le "$((image_size + padding))" ]; then
+        mount_size=$(((image_size/1024/1024)+1))
         mount -o remount,size="${mount_size}G" -t tmpfs tmpfs-installer $tmp_dir || exit 1
     fi
 fi

--- a/installer/sharch_body.sh
+++ b/installer/sharch_body.sh
@@ -25,6 +25,7 @@ fi
 
 echo " OK."
 
+image_size=$(du "$0" | awk '{print $1}')
 # Untar and launch install script in a tmpfs
 cur_wd=$(pwd)
 export cur_wd
@@ -32,6 +33,11 @@ archive_path=$(realpath "$0")
 tmp_dir=$(mktemp -d)
 if [ "$(id -u)" = "0" ] ; then
     mount -t tmpfs tmpfs-installer $tmp_dir || exit 1
+    mount_size=$(df $tmp_dir | tail -1 | tr -s ' ' | cut -d' ' -f4)
+    if [ "$mount_size" -lt "$((image_size*3))" ]; then
+        mount_size=$((((image_size*3)/1024/1024)+1))
+        mount -o remount,size="${mount_size}G" -t tmpfs tmpfs-installer $tmp_dir || exit 1
+    fi
 fi
 cd $tmp_dir
 echo -n "Preparing image archive ..."

--- a/installer/sharch_body.sh
+++ b/installer/sharch_body.sh
@@ -25,7 +25,7 @@ fi
 
 echo " OK."
 
-image_size=$(( $(sed -e '1,/^exit_marker$/d' "$0"  | tar --to-stdout -xf - | wc -c) / 1024))
+image_size_in_kb=$((($(sed -e '1,/^exit_marker$/d' "$0"  | tar --to-stdout -xf - | wc -c) + 1023 ) / 1024))
 # Untar and launch install script in a tmpfs
 cur_wd=$(pwd)
 export cur_wd
@@ -33,12 +33,14 @@ archive_path=$(realpath "$0")
 tmp_dir=$(mktemp -d)
 if [ "$(id -u)" = "0" ] ; then
     mount -t tmpfs tmpfs-installer $tmp_dir || exit 1
-    mount_size=$(df $tmp_dir | tail -1 | tr -s ' ' | cut -d' ' -f4)
+    mount_size_in_kb=$(df $tmp_dir | tail -1 | tr -s ' ' | cut -d' ' -f4)
     #checking extra 100KB space in tmp_dir, after image extraction
     padding=102400
-    if [ "$mount_size" -le "$((image_size + padding))" ]; then
-        mount_size=$(((image_size/1024/1024)+1))
-        mount -o remount,size="${mount_size}G" -t tmpfs tmpfs-installer $tmp_dir || exit 1
+    if [ "$mount_size_in_kb" -le "$((image_size_in_kb + padding))" ]; then
+        image_size_in_mb=$(((image_size_in_kb + 1023) / 1024))
+        #Adding extra 32MB free space for image extraction.
+        mount_size_in_mb=$((((image_size_in_mb + 31) / 32) * 32))
+        mount -o remount,size="${mount_size_in_mb}M" -t tmpfs tmpfs-installer $tmp_dir || exit 1
     fi
 fi
 cd $tmp_dir


### PR DESCRIPTION

#### Why I did it
while sonic upgrade, Image will be extracted to tmpfs for installation so tmpfs size should be larger than image size. Image installation will fail if image size is larger than tmpfs size.

we are facing below error while installing debug image with size greater than tmpfs which is 1.5g in marvell armhf platform.

sonic-installer install <url>
New image will be installed, continue? [y/N]: y
Downloading image...
...99%, 1744 MB, 708 KB/s, 0 seconds left...
Installing image SONiC-OS-202012.0-dirty-20210311.224845 and setting it as default...
Command: bash /tmp/sonic_image
tar: installer/fs.zip: Wrote only 7680 of 10240 bytes
tar: installer/onie-image-arm64.conf: Cannot write: No space left on device
tar: Exiting with failure status due to previous errors
Verifying image checksum ... OK.
Preparing image archive ...



#### How I did it
compare downloaded image size with tmpfs size, if size less than image size update the tmpfs size according to image size.

#### How to verify it
Install an Image with size larger than tmpfs. we verified by installing debug image with size 1.9gb which is larger than tmpfs size 1.5gb.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

