### PR TITLE
[201811][build] install python-arptable and psutil in sonic slave docker

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -293,7 +293,7 @@ RUN pip install Pympler==0.8
 RUN pip2 install redis==2.10.6
 RUN pip3 install redis==2.10.6
 
-# For snmpagent buld
+# For snmpagent build
 RUN pip3 install python-arptable>=0.0.1 psutil==5.7.0
 
 # Install dependencies for isc-dhcp-relay build

--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -293,6 +293,9 @@ RUN pip install Pympler==0.8
 RUN pip2 install redis==2.10.6
 RUN pip3 install redis==2.10.6
 
+# For snmpagent buld
+RUN pip3 install python-arptable>=0.0.1 psutil==5.7.0
+
 # Install dependencies for isc-dhcp-relay build
 RUN apt-get -y build-dep isc-dhcp
 


### PR DESCRIPTION
#### Why I did it
sonic snmp subagent build was failing recently.

#### How I did it
install python-arptable and psutil in sonic slave docker to address sonic snmp subagent build issue.

#### How to verify it
build 201811 image locally.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
