### PR TITLE
[Mellanox] Adjust PSU fan name to align with sysfs file name

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -64,7 +64,7 @@ class Fan(FanBase):
         else:
             self.fan_speed_get_path = "psu{}_fan1_speed_get".format(self.index)
             self.fan_presence_path = "psu{}_fan1_speed_get".format(self.index)
-            self._name = 'psu_{}_fan_{}'.format(self.index, 1)
+            self._name = 'psu{}_fan{}'.format(self.index, 1)
             self.fan_max_speed_path = os.path.join(CONFIG_PATH, "psu_fan_max")
             self.fan_min_speed_path = os.path.join(CONFIG_PATH, "psu_fan_min")
             self.psu_i2c_bus_path = os.path.join(CONFIG_PATH, 'psu{0}_i2c_bus'.format(self.index))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Adjust PSU fan name to align with sysfs file name

#### How I did it

Change PSU fan name from psu_{psu_index}_fan_{fan_index} to psu{psu_index}_fan{fan_index}

#### How to verify it

Manually test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

