### PR TITLE
add psmisc to bring fuser that identifies processes that are using files or sockets

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -23,7 +23,8 @@ RUN apt-get update &&   \
         python-smbus    \
         python3-smbus   \
         dmidecode       \
-        i2c-tools
+        i2c-tools       \
+        psmisc
 
 # TODO: Remove these lines once we no longer need Python 2
 RUN apt-get install -f -y python-dev python-pip


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 fuser support is required since new cisco hardware watchdog plugin uses them to check anyone else use's /dev/watchdogX resource. The actual validation happens in the platform code, but the package is required for pmon container. Currently the /dev/watchdogX  is being used by cisco platform-monitor service. Cisco chassis level watchdog plugin uses "fuser" to claim the watchdog release from platform-monitor service.

#### How I did it
Extend  dockers/docker-platform-monitor/Dockerfile.j2 to bring in psmisc package

#### How to verify it

cmd = "fuser {}".format(device)
    while True:
        return_code = runcommand(cmd)
        if return_code == 1:
            break#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Add psmisc to bring in fuser functionality.  When sonic test-mgmt runs the PMON container plugin checks if any process owns /dev/watchdogX the it requests release and sonic-mgmt test takes up /dev/watchdog
-->


#### A picture of a cute animal (not mandatory but encouraged)

