### PR TITLE
[multi-asic] Port the fix to get the PCI_id from asic.conf from 201911 --> master

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -41,7 +41,7 @@ from functools import partial
 from minigraph import minigraph_encoder, parse_xml, parse_device_desc_xml, parse_asic_sub_role
 from portconfig import get_port_config, get_breakout_mode
 from redis_bcc import RedisBytecodeCache
-from sonic_py_common.multi_asic import get_asic_id_from_name
+from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id
 from sonic_py_common import device_info
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig, ConfigDBPipeConnector
 
@@ -380,7 +380,12 @@ def main():
             }}}
         # The ID needs to be passed to the SAI to identify the asic.
         if asic_name is not None:
-            hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=asic_id)
+            device_id = get_asic_device_id(asic_id)
+            # if the device_id obtained is None, exit with error
+            if device_id is None:
+                print('Failed to get device ID for', asic_name, file=sys.stderr)
+                sys.exit(1)
+            hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
         deep_update(data, hardware_data)
 
     paths = ['/', '/usr/share/sonic/templates']

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -137,6 +137,29 @@ def get_asic_id_from_name(asic_name):
     else:
         raise ValueError('Unknown asic namespace name {}'.format(asic_name))
 
+def get_asic_device_id(asic_id):
+    # Get asic.conf file
+    asic_conf_file_path = get_asic_conf_file_path()
+
+    if asic_conf_file_path is None:
+        return None
+
+    # In a multi-asic device we need to have the file "asic.conf" updated with the asic instance
+    # and the corresponding device id which could be pci_id. Below is an eg: for a 2 ASIC platform/sku.
+    # DEV_ID_ASIC_0=03:00.0
+    # DEV_ID_ASIC_1=04:00.0
+    device_str = "DEV_ID_ASIC_{}".format(asic_id)
+
+    with open(asic_conf_file_path) as asic_conf_file:
+        for line in asic_conf_file:
+            tokens = line.split('=')
+            if len(tokens) < 2:
+               continue
+            if tokens[0] == device_str:
+                device_id = tokens[1].strip()
+                return device_id
+
+    return None
 
 def get_current_namespace(pid=None):
     """


### PR DESCRIPTION
#### Why I did it

Port the fix to get the pci_device ID from asic.conf file and update the "asic_id" field in DEVICE_METADATA with the pci_device_Id

#### How I did it
#### How to verify it
PR ref: https://github.com/Azure/sonic-buildimage/pull/4705

eg: 
```
admin@str2--acs-1:~$ cat /usr/share/sonic/device/x86-r0/asic.conf 
NUM_ASIC=3
DEV_ID_ASIC_0=03:00.0
DEV_ID_ASIC_1=04:00.0
DEV_ID_ASIC_2=05:00.0
```

In the config db.json file 
```
    "DEVICE_METADATA": {
        "localhost": {
  ....
            "asic_id": "03:00.0",
            "bgp_asn": "65100",
            "sub_role": "FrontEnd",
            "cloudtype": "None",
            "asic_name": "asic0",
            "type": "LeafRouter",
            "deployment_id": "None"
...
        }
    },
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

