### PR TITLE
[ci] Disable the reproducible build for arm64 and armhf temporarily

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -61,6 +61,7 @@ jobs:
           timeoutInMinutes: 1800
           variables:
             PLATFORM_ARCH: arm64
+            BUILD_OPTIONS: ${{ parameters.buildOptions }} SONIC_VERSION_CONTROL_COMPONENTS=
         - name: generic
           variables:
             dbg_image: yes
@@ -72,6 +73,7 @@ jobs:
           timeoutInMinutes: 1800
           variables:
             PLATFORM_ARCH: armhf
+            BUILD_OPTIONS: ${{ parameters.buildOptions }} SONIC_VERSION_CONTROL_COMPONENTS=
         - name: mellanox
           variables:
             dbg_image: yes


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Disable the reproducible build for arm64 and armhf temporarily.
The package version upgrade has been disabled for armhf and armhf for long run time, so disable the reproducible build for the official builds as well. we will enable it when arm64 azure agent ready.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

