### PR TITLE
Reduce route selection deferral timer for bgp graceful restart

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -57,7 +57,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp graceful-restart restart-time {{ constants.bgp.graceful_restart.restart_time | default(240) }}
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time {{ constants.bgp.graceful_restart.select_defer_time | default(0) }}
+  bgp graceful-restart select-defer-time {{ constants.bgp.graceful_restart.select_defer_time | default(15) }}
 {% endif %}
 !
 {# set router-id #}

--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -57,7 +57,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp graceful-restart restart-time {{ constants.bgp.graceful_restart.restart_time | default(240) }}
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time {{ constants.bgp.graceful_restart.select_defer_time | default(15) }}
+  bgp graceful-restart select-defer-time {{ constants.bgp.graceful_restart.select_defer_time | default(25) }}
 {% endif %}
 !
 {# set router-id #}

--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -57,6 +57,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp graceful-restart restart-time {{ constants.bgp.graceful_restart.restart_time | default(240) }}
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time {{ constants.bgp.graceful_restart.select_defer_time | default(0) }}
 {% endif %}
 !
 {# set router-id #}

--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -57,7 +57,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp graceful-restart restart-time {{ constants.bgp.graceful_restart.restart_time | default(240) }}
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time {{ constants.bgp.graceful_restart.select_defer_time | default(25) }}
+  bgp graceful-restart select-defer-time {{ constants.bgp.graceful_restart.select_defer_time | default(45) }}
 {% endif %}
 !
 {# set router-id #}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -51,6 +51,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -51,7 +51,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -51,7 +51,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -51,7 +51,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
@@ -30,6 +30,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
@@ -30,7 +30,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
@@ -30,7 +30,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
@@ -30,7 +30,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
@@ -30,6 +30,7 @@ router bgp 55555
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
@@ -30,7 +30,7 @@ router bgp 55555
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
@@ -30,7 +30,7 @@ router bgp 55555
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
@@ -30,7 +30,7 @@ router bgp 55555
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -70,7 +70,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -70,7 +70,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -70,6 +70,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -70,7 +70,7 @@ router bgp 55555
   bgp graceful-restart restart-time 480
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 55.55.55.55
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -50,6 +50,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -50,7 +50,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -50,7 +50,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -50,7 +50,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 8.0.0.5
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -49,6 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 8.0.0.5
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 8.0.0.5
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 8.0.0.5
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -49,6 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -73,7 +73,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -73,7 +73,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -73,6 +73,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -73,7 +73,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
@@ -66,7 +66,7 @@ router bgp 4000
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 4.0.0.0
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
@@ -66,6 +66,7 @@ router bgp 4000
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 4.0.0.0
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
@@ -66,7 +66,7 @@ router bgp 4000
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 4.0.0.0
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-bgpd.conf
@@ -66,7 +66,7 @@ router bgp 4000
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 4.0.0.0
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -50,6 +50,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -50,7 +50,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -50,7 +50,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -50,7 +50,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 8.0.0.5
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -49,6 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 8.0.0.5
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 8.0.0.5
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 8.0.0.5
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -49,6 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -49,7 +49,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -73,7 +73,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -73,7 +73,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -73,6 +73,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -73,7 +73,7 @@ router bgp 65100
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 10.1.0.32
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
@@ -66,7 +66,7 @@ router bgp 4000
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 0
+  bgp graceful-restart select-defer-time 15
 !
   bgp router-id 4.0.0.0
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
@@ -66,6 +66,7 @@ router bgp 4000
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 0
 !
   bgp router-id 4.0.0.0
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
@@ -66,7 +66,7 @@ router bgp 4000
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 15
+  bgp graceful-restart select-defer-time 25
 !
   bgp router-id 4.0.0.0
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-bgpd.conf
@@ -66,7 +66,7 @@ router bgp 4000
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
-  bgp graceful-restart select-defer-time 25
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 4.0.0.0
 !


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
There are scenarios that End-of-RIB comes from a part of the peers arrives after reconciliation. In such scenarios, if the route selection deferral timer has the default value of 360 seconds, FRR would not set up routes and all routes would be removed after reconciliation. This PR reduces the route selection deferral timer so that at least routes to parts of the peers get restored at the point of reconciliation.

Fix https://github.com/Azure/sonic-buildimage/issues/7488

#### How I did it
Reduce route selection deferral timer for bgp graceful restart to 15 seconds.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

