### PR TITLE
[ruijie] Fix show version error info

### DIFF
--- a/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_platform/__init__.py
@@ -1,1 +1,2 @@
 __all__ = ["platform", "chassis", "fan", "psu", "sfp", "thermal", "common"]
+from sonic_platform import platform

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/Makefile
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/Makefile
@@ -9,6 +9,7 @@ SUB_BUILD_DIR = $(PWD)/build
 DIR_KERNEL_SRC = $(PWD)/modules
 SCRIPT_DIR = $(PWD)/script
 SERVICE_DIR = $(PWD)/service
+DEPMOD_CONF_DIR = $(PWD)/depmod_conf
 
 KBUILD_EXTRA_SYMBOLS += $(DIR_KERNEL_SRC)/Module.symvers
 export KBUILD_EXTRA_SYMBOLS
@@ -17,6 +18,7 @@ INSTALL_MODULE_DIR = $(SUB_BUILD_DIR)/$(KERNEL_SRC)/$(INSTALL_MOD_DIR)
 INSTALL_SCRIPT_DIR = $(SUB_BUILD_DIR)/usr/local/bin
 INSTALL_SERVICE_DIR = $(SUB_BUILD_DIR)/lib/systemd/system
 INSTALL_LIB_DIR = $(SUB_BUILD_DIR)/usr/lib/python3.7/dist-packages
+INSTALL_DEPMOD_CONF  = $(SUB_BUILD_DIR)/etc/depmod.d
 
 all:
 	$(MAKE) -C $(KERNEL_SRC)/build M=$(DIR_KERNEL_SRC) modules
@@ -27,6 +29,8 @@ all:
 	@if [ -d $(PWD)/lib/ ]; then cp -r $(PWD)/lib/* ${INSTALL_LIB_DIR} ;fi
 	@if [ -d $(PWD)/lib/ ]; then cp -r $(PWD)/lib/* ${INSTALL_LIB_DIR2} ;fi
 	cp -r $(DIR_KERNEL_SRC)/*.ko $(INSTALL_MODULE_DIR)
+	@if [ ! -d ${INSTALL_DEPMOD_CONF} ]; then mkdir -p ${INSTALL_DEPMOD_CONF} ;fi
+	cp -r  $(DEPMOD_CONF_DIR)/*  $(INSTALL_DEPMOD_CONF)
 	cp -r $(SCRIPT_DIR)/*  $(INSTALL_SCRIPT_DIR)
 	cp -r $(SERVICE_DIR)/*  $(INSTALL_SERVICE_DIR)
 	@if [ -d $(INSTALL_SCRIPT_DIR) ]; then chmod +x $(INSTALL_SCRIPT_DIR)/* ;fi

--- a/platform/broadcom/sonic-platform-modules-ruijie/common/depmod_conf/distsearch.conf
+++ b/platform/broadcom/sonic-platform-modules-ruijie/common/depmod_conf/distsearch.conf
@@ -1,0 +1,4 @@
+# depmod.conf
+#
+# override default search ordering for kmod packaging
+search updates extra external built-in weak-updates


### PR DESCRIPTION
Signed-off-by: pettershao-ragilenetworks <pettershao@ragilenetworks.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fix below issue:
```
root@sonic:/home/admin# show version

SONiC Software Version: SONiC.master.13806-15be1539
Distribution: Debian 10.9
Kernel: 4.19.0-12-2-amd64
Build commit: 15be1539
Build date: Wed May  5 23:33:22 UTC 2021
Built by: AzDevOps@sonic-build-workers-0008G2

Platform: x86_64-ruijie_b6510-48vs8cq-r0
HwSKU: B6510-48VS8CQ
ASIC: broadcom
ASIC Count: 1
Traceback (most recent call last):
  File "/usr/local/bin/decode-syseeprom", line 32, in instantiate_eeprom_object
    eeprom = sonic_platform.platform.Platform().get_chassis().get_eeprom()
AttributeError: module 'sonic_platform' has no attribute 'platform'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/decode-syseeprom", line 262, in <module>
    sys.exit(main())
  File "/usr/local/bin/decode-syseeprom", line 244, in main
    print_serial(use_db)
  File "/usr/local/bin/decode-syseeprom", line 169, in print_serial
    eeprom = instantiate_eeprom_object()
  File "/usr/local/bin/decode-syseeprom", line 34, in instantiate_eeprom_object
    log.log_error('Failed to obtain EEPROM object due to {}'.format(repr(e)))
NameError: name 'log' is not defined
Serial Number:
Uptime: 09:54:54 up  1:05,  2 users,  load average: 0.33, 0.68, 0.83


```

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

