### PR TITLE
DellEMC: <202012 branch> Z9332f PSU data is not updated in state DB.

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/psu.py
@@ -113,7 +113,7 @@ class Psu(PsuBase):
         if not is_valid:
             return None
 
-        return "{:.1f}".format(voltage)
+        return float(voltage)
 
     def get_voltage_low_threshold(self):
         """
@@ -159,7 +159,7 @@ class Psu(PsuBase):
         if not is_valid:
             return None
 
-        return "{:.1f}".format(current)
+        return float(current)
 
     def get_power(self):
         """
@@ -173,7 +173,7 @@ class Psu(PsuBase):
         if not is_valid:
             return None
 
-        return "{:.1f}".format(power)
+        return float(power)
 
     def get_powergood_status(self):
         """


### PR DESCRIPTION

#### Why I did it

- PSU data is loaded into state DB.
   Following errors are seen in syslogs:
  "Failed to update PSU data - '<=' not supported between instances of 'float' and 'str'"

#### How I did it

- Changed the return type in PSU API's.

#### How to verify it

- Check state DB, syslogs.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
[psu_UT.txt](https://github.com/Azure/sonic-buildimage/files/6434517/psu_UT.txt)


#### A picture of a cute animal (not mandatory but encouraged)

