### PR TITLE
DellEMC: Fix Z9332f xcvrd crash

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
@@ -305,6 +305,14 @@ class Sfp(SfpBase):
                 self.dom_tx_power_supported = False
                 self.dom_tx_bias_supported = False
 
+    def _strip_unit_from_str(self, value_str):
+        match = re.match(r'(.*)C$|(.*)Volts$|(.*)mA$|(.*)dBm$', value_str)
+        if match:
+            for value in match.groups():
+                if value is not None:
+                    return float(value)
+        return None
+
     def pci_mem_read(self, mm, offset):
         mm.seek(offset)
         read_data_stream = mm.read(4)
@@ -635,8 +643,8 @@ class Sfp(SfpBase):
                 threshold_dict_keys, 'N/A')
 
         try:
+            module_threshold_data = self._get_eeprom_data('ModuleThreshold')
             if self.sfp_type == 'QSFP_DD':
-                module_threshold_data = self._get_eeprom_data('ModuleThreshold')
                 transceiver_dom_threshold_dict['temphighalarm'] = module_threshold_data['data']['TempHighAlarm']['value']
                 transceiver_dom_threshold_dict['temphighwarning'] = module_threshold_data['data']['TempHighWarning']['value']
                 transceiver_dom_threshold_dict['templowalarm'] = module_threshold_data['data']['TempLowAlarm']['value']
@@ -658,7 +666,6 @@ class Sfp(SfpBase):
                 transceiver_dom_threshold_dict['txpowerlowalarm'] = module_threshold_data['data']['TxPowerLowAlarm']['value']
                 transceiver_dom_threshold_dict['txpowerlowwarning'] = module_threshold_data['data']['TxPowerLowWarning']['value']
             elif self.sfp_type == 'QSFP':
-                module_threshold_data = self._get_eeprom_data('ModuleThreshold')
                 transceiver_dom_threshold_dict['temphighalarm'] = module_threshold_data['data']['TempHighAlarm']['value']
                 transceiver_dom_threshold_dict['temphighwarning'] = module_threshold_data['data']['TempHighWarning']['value']
                 transceiver_dom_threshold_dict['templowalarm'] = module_threshold_data['data']['TempLowAlarm']['value']
@@ -758,12 +765,15 @@ class Sfp(SfpBase):
                 transceiver_dom_dict['tx7bias'] = tx_bias_list[6]
                 transceiver_dom_dict['tx8bias'] = tx_bias_list[7]
 
-        else:
+        elif self.sfp_type == 'QSFP':
             if tx_bias_list is not None:
                 transceiver_dom_dict['tx1bias'] = tx_bias_list[0]
                 transceiver_dom_dict['tx2bias'] = tx_bias_list[1]
                 transceiver_dom_dict['tx3bias'] = tx_bias_list[2]
                 transceiver_dom_dict['tx4bias'] = tx_bias_list[3]
+        else:
+            if tx_bias_list is not None:
+               transceiver_dom_dict['tx1bias'] = tx_bias_list[0]
 
         if self.sfp_type == 'QSFP_DD':
             if rx_power_list is not None:
@@ -776,12 +786,15 @@ class Sfp(SfpBase):
                 transceiver_dom_dict['rx7power'] = rx_power_list[6]
                 transceiver_dom_dict['rx8power'] = rx_power_list[7]
 
-        else:
+        elif self.sfp_type == 'QSFP':
             if rx_power_list is not None:
                 transceiver_dom_dict['rx1power'] = rx_power_list[0]
                 transceiver_dom_dict['rx2power'] = rx_power_list[1]
                 transceiver_dom_dict['rx3power'] = rx_power_list[2]
                 transceiver_dom_dict['rx4power'] = rx_power_list[3]
+        else:
+            if rx_power_list is not None:
+                transceiver_dom_dict['rx1power'] = rx_power_list[0]
 
         if self.sfp_type == 'QSFP_DD':
             if tx_power_list is not None:
@@ -793,13 +806,15 @@ class Sfp(SfpBase):
                 transceiver_dom_dict['tx6power'] = tx_power_list[5]
                 transceiver_dom_dict['tx7power'] = tx_power_list[6]
                 transceiver_dom_dict['tx8power'] = tx_power_list[7]
-        else:
+        elif self.sfp_type == 'QSFP':
             if tx_power_list is not None:
                 transceiver_dom_dict['tx1power'] = tx_power_list[0]
                 transceiver_dom_dict['tx2power'] = tx_power_list[1]
                 transceiver_dom_dict['tx3power'] = tx_power_list[2]
                 transceiver_dom_dict['tx4power'] = tx_power_list[3]
-
+        else:
+             if tx_power_list is not None:
+                 transceiver_dom_dict['tx1power'] = tx_power_list[0]
         transceiver_dom_dict['rx_los'] = rx_los
         transceiver_dom_dict['tx_fault'] = tx_fault
         transceiver_dom_dict['reset_status'] = reset_state
@@ -924,10 +939,10 @@ class Sfp(SfpBase):
         tx_fault_list = []
         try:
             if self.sfp_type == 'QSFP_DD':
-                tx_fault_list = False
+                tx_fault_list.append(False)
             elif self.sfp_type == 'QSFP':
                 tx_fault_data = self._get_eeprom_data('tx_fault')
-                for tx_fault_id in ('Tx1Fault', 'Tx2Fault', 'Tx3Fault', 'Tx4Fault') : 
+                for tx_fault_id in ('Tx1Fault', 'Tx2Fault', 'Tx3Fault', 'Tx4Fault') :
                     tx_fault_list.append(tx_fault_data['data'][tx_fault_id]['value'] == 'On')
             else:
                 tx_fault_data = self._read_eeprom_bytes(self.eeprom_path, SFP_STATUS_CONTROL_OFFSET, SFP_STATUS_CONTROL_WIDTH)
@@ -1014,7 +1029,7 @@ class Sfp(SfpBase):
         """
         Retrieves the temperature of this SFP
         """
-        temperature = None
+        temperature = 0.0
         try:
             if self.sfp_type == 'QSFP_DD':
                 if self.qsfp_dd_DomInfo is None:
@@ -1024,10 +1039,10 @@ class Sfp(SfpBase):
                     return None
                 temperature_data = self.qsfp_dd_DomInfo.parse_temperature(dom_data_raw, 0)
 
-            elif self.sfp_type == 'QSFP':
+            else:
                 temperature_data = self._get_eeprom_data('Temperature')
-
-            temperature = temperature_data['data']['Temperature']['value']
+            if temperature_data is not None:
+                temperature = self._strip_unit_from_str(temperature_data['data']['Temperature']['value'])
         except (TypeError, ValueError):
             return None
         return temperature
@@ -1036,7 +1051,7 @@ class Sfp(SfpBase):
         """
         Retrieves the supply voltage of this SFP
         """
-        voltage = None
+        voltage = 0.0
         try:
             if self.sfp_type == 'QSFP_DD':
                 if self.qsfp_dd_DomInfo is None:
@@ -1046,11 +1061,10 @@ class Sfp(SfpBase):
                     return None
                 voltage_data = self.qsfp_dd_DomInfo.parse_voltage(dom_data_raw, 0)
 
-            elif self.sfp_type == 'QSFP':
+            else:
                 voltage_data = self._get_eeprom_data('Voltage')
-
-            voltage = voltage_data['data']['Vcc']['value']
-
+            if voltage_data is not None:
+                voltage = self._strip_unit_from_str(voltage_data['data']['Vcc']['value'])
         except (TypeError, ValueError):
             return None
         return voltage
@@ -1072,17 +1086,21 @@ class Sfp(SfpBase):
 
                 for tx_bias_id in ('TX1Bias', 'TX2Bias', 'TX3Bias', 'TX4Bias',
                                    'TX5Bias', 'TX6Bias', 'TX7Bias', 'TX8Bias'):
-                    tx_bias = tx_bias_data['data'][tx_bias_id]['value']
+                    tx_bias = self._strip_unit_from_str(tx_bias_data['data'][tx_bias_id]['value'])
                     tx_bias_list.append(tx_bias)
 
             elif self.sfp_type == 'QSFP':
                 tx_bias_data = self._get_eeprom_data('ChannelMonitor')
                 for tx_bias_id in ('TX1Bias', 'TX2Bias', 'TX3Bias', 'TX4Bias'):
-                    tx_bias = tx_bias_data['data'][tx_bias_id]['value']
+                    tx_bias = self._strip_unit_from_str(tx_bias_data['data'][tx_bias_id]['value'])
                     tx_bias_list.append(tx_bias)
             else:
-                tx1_bias = tx_bias_data['data']['TXBias']['value']
-                tx_bias_list.append(tx1_bias)
+                tx_bias_data = self._get_eeprom_data('ChannelMonitor')
+                if tx_bias_data is not None:
+                    tx1_bias = self._strip_unit_from_str(tx_bias_data['data']['TXBias']['value'])
+                    tx_bias_list.append(tx1_bias)
+                else:
+                    tx_bias_list.append(0.0)
 
         except (TypeError, ValueError):
             return None
@@ -1093,19 +1111,20 @@ class Sfp(SfpBase):
         Retrieves the received optical power for this SFP
         """
         rx_power_list = []
-        offset = 128
         try:
             if self.sfp_type == 'QSFP_DD':
                 if self.qsfp_dd_DomInfo is None:
                     return None
                 if not self.dom_rx_power_supported:
                     return None
+
+                offset = 128
                 rx_power_data_raw = self._read_eeprom_bytes(self.eeprom_path, offset + QSFP_DD_RXPOWER_OFFSET, QSFP_DD_TXPOWER_WIDTH)
                 rx_power_data = self.qsfp_dd_DomInfo.parse_dom_rx_power(rx_power_data_raw, 0)
 
                 for rx_power_id in ('RX1Power', 'RX2Power', 'RX3Power', 'RX4Power',
                                      'RX5Power', 'RX6Power', 'RX7Power', 'RX8Power'):
-                    rx_power = rx_power_data['data'][rx_power_id]['value']
+                    rx_power = self._strip_unit_from_str(rx_power_data['data'][rx_power_id]['value'])
                     rx_power_list.append(rx_power)
 
             elif self.sfp_type == 'QSFP':
@@ -1114,7 +1133,11 @@ class Sfp(SfpBase):
                     rx_power = rx_power_data['data'][rx_power_id]['value']
                     rx_power_list.append(rx_power)
             else:
-                rx1_pw = rx_power_data['data']['RXPower']['value']
+                rx_power_data = self._get_eeprom_data('ChannelMonitor')
+                if rx_power_data is not None:
+                     rx1_pw = self._strip_unit_from_str(rx_power_data['data']['RXPower']['value'])
+                else:
+                     rx1_pw = 0.0
                 rx_power_list.append(rx1_pw)
         except (TypeError, ValueError):
             return None
@@ -1140,7 +1163,7 @@ class Sfp(SfpBase):
 
                 for tx_power_id in ('TX1Power', 'TX2Power', 'TX3Power', 'TX4Power',
                                      'TX5Power', 'TX6Power', 'TX7Power', 'TX8Power'):
-                    tx_pw = tx_power_data['data'][tx_power_id]['value']
+                    tx_pw = self._strip_unit_from_str(tx_power_data['data'][tx_power_id]['value'])
                     tx_power_list.append(tx_pw)
 
             elif self.sfp_type == 'QSFP':
@@ -1159,11 +1182,14 @@ class Sfp(SfpBase):
                     return None
                 channel_monitor_data = self._get_eeprom_data('ChannelMonitor_TxPower')
                 for tx_power_id in ('TX1Power', 'TX2Power', 'TX3Power', 'TX4Power'):
-                    tx_pw = channel_monitor_data['data'][tx_power_id]['value']
+                    tx_pw = self._strip_unit_from_str(channel_monitor_data['data'][tx_power_id]['value'])
                     tx_power_list.append(tx_pw)
             else:
                 channel_monitor_data = self._get_eeprom_data('ChannelMonitor')
-                tx1_pw = channel_monitor_data['data']['TXPower']['value']
+                if channel_monitor_data is not None:
+                    tx1_pw = self._strip_unit_from_str(channel_monitor_data['data']['TXPower']['value'])
+                else:
+                    tx1_pw = 0.0
                 tx_power_list.append(tx1_pw)
         except (TypeError, ValueError):
             return None
@@ -1282,7 +1308,6 @@ class Sfp(SfpBase):
     def get_max_port_power(self):
         """
         Retrieves the maximum power allowed on the port in watts
-
         ***
         This method of fetching power values is not ideal.
         TODO: enhance by placing power limits in config file

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
@@ -305,14 +305,6 @@ class Sfp(SfpBase):
                 self.dom_tx_power_supported = False
                 self.dom_tx_bias_supported = False
 
-    def _strip_unit_from_str(self, value_str):
-        match = re.match(r'(.*)C$|(.*)Volts$|(.*)mA$|(.*)dBm$', value_str)
-        if match:
-            for value in match.groups():
-                if value is not None:
-                    return float(value)
-        return None
-
     def pci_mem_read(self, mm, offset):
         mm.seek(offset)
         read_data_stream = mm.read(4)
@@ -499,7 +491,7 @@ class Sfp(SfpBase):
             transceiver_info_dict['ext_identifier'] = ext_id
             transceiver_info_dict['ext_rateselect_compliance'] = rate_identifier
             transceiver_info_dict['cable_type'] = cable_type
-            transceiver_info_dict['cable_length'] = cable_length
+            transceiver_info_dict['cable_length'] = str(float(cable_length))
             transceiver_info_dict['nominal_bit_rate'] = bit_rate
             transceiver_info_dict['specification_compliance'] = str(compliance_code_dict)
 
@@ -1035,7 +1027,7 @@ class Sfp(SfpBase):
             elif self.sfp_type == 'QSFP':
                 temperature_data = self._get_eeprom_data('Temperature')
 
-            temperature = self._strip_unit_from_str(temperature_data['data']['Temperature']['value'])
+            temperature = temperature_data['data']['Temperature']['value']
         except (TypeError, ValueError):
             return None
         return temperature
@@ -1057,7 +1049,7 @@ class Sfp(SfpBase):
             elif self.sfp_type == 'QSFP':
                 voltage_data = self._get_eeprom_data('Voltage')
 
-            voltage = self._strip_unit_from_str(voltage_data['data']['Vcc']['value'])
+            voltage = voltage_data['data']['Vcc']['value']
 
         except (TypeError, ValueError):
             return None
@@ -1080,16 +1072,16 @@ class Sfp(SfpBase):
 
                 for tx_bias_id in ('TX1Bias', 'TX2Bias', 'TX3Bias', 'TX4Bias',
                                    'TX5Bias', 'TX6Bias', 'TX7Bias', 'TX8Bias'):
-                    tx_bias = self._strip_unit_from_str(tx_bias_data['data'][tx_bias_id]['value'])
+                    tx_bias = tx_bias_data['data'][tx_bias_id]['value']
                     tx_bias_list.append(tx_bias)
 
             elif self.sfp_type == 'QSFP':
                 tx_bias_data = self._get_eeprom_data('ChannelMonitor')
                 for tx_bias_id in ('TX1Bias', 'TX2Bias', 'TX3Bias', 'TX4Bias'):
-                    tx_bias = self._strip_unit_from_str(tx_bias_data['data'][tx_bias_id]['value'])
+                    tx_bias = tx_bias_data['data'][tx_bias_id]['value']
                     tx_bias_list.append(tx_bias)
             else:
-                tx1_bias = self._strip_unit_from_str(tx_bias_data['data']['TXBias']['value'])
+                tx1_bias = tx_bias_data['data']['TXBias']['value']
                 tx_bias_list.append(tx1_bias)
 
         except (TypeError, ValueError):
@@ -1113,7 +1105,7 @@ class Sfp(SfpBase):
 
                 for rx_power_id in ('RX1Power', 'RX2Power', 'RX3Power', 'RX4Power',
                                      'RX5Power', 'RX6Power', 'RX7Power', 'RX8Power'):
-                    rx_power = self._strip_unit_from_str(rx_power_data['data'][rx_power_id]['value'])
+                    rx_power = rx_power_data['data'][rx_power_id]['value']
                     rx_power_list.append(rx_power)
 
             elif self.sfp_type == 'QSFP':
@@ -1122,7 +1114,7 @@ class Sfp(SfpBase):
                     rx_power = rx_power_data['data'][rx_power_id]['value']
                     rx_power_list.append(rx_power)
             else:
-                rx1_pw = self._strip_unit_from_str(rx_power_data['data']['RXPower']['value'])
+                rx1_pw = rx_power_data['data']['RXPower']['value']
                 rx_power_list.append(rx1_pw)
         except (TypeError, ValueError):
             return None
@@ -1148,7 +1140,7 @@ class Sfp(SfpBase):
 
                 for tx_power_id in ('TX1Power', 'TX2Power', 'TX3Power', 'TX4Power',
                                      'TX5Power', 'TX6Power', 'TX7Power', 'TX8Power'):
-                    tx_pw = self._strip_unit_from_str(tx_power_data['data'][tx_power_id]['value'])
+                    tx_pw = tx_power_data['data'][tx_power_id]['value']
                     tx_power_list.append(tx_pw)
 
             elif self.sfp_type == 'QSFP':
@@ -1167,11 +1159,11 @@ class Sfp(SfpBase):
                     return None
                 channel_monitor_data = self._get_eeprom_data('ChannelMonitor_TxPower')
                 for tx_power_id in ('TX1Power', 'TX2Power', 'TX3Power', 'TX4Power'):
-                    tx_pw = self._strip_unit_from_str(channel_monitor_data['data'][tx_power_id]['value'])
+                    tx_pw = channel_monitor_data['data'][tx_power_id]['value']
                     tx_power_list.append(tx_pw)
             else:
                 channel_monitor_data = self._get_eeprom_data('ChannelMonitor')
-                tx1_pw = self._strip_unit_from_str(channel_monitor_data['data']['TXPower']['value'])
+                tx1_pw = channel_monitor_data['data']['TXPower']['value']
                 tx_power_list.append(tx1_pw)
         except (TypeError, ValueError):
             return None


### PR DESCRIPTION
#### Why I did it

- Xcvrd crashes with the below message in Z9332f platform.
    “May  6 05:12:37.446235 S1G2 ERR pmon#xcvrd[5292]: This functionality is currently not implemented for this platform”

#### How I did it

- Changed the return type in SFP API's.

#### How to verify it

- Check whether xcvrd is running properly. 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
[xcvrd_UT.txt](https://github.com/Azure/sonic-buildimage/files/6435262/xcvrd_UT.txt)


#### A picture of a cute animal (not mandatory but encouraged)

