### PR TITLE
[202012] Add SOC property to enable AN/LT on some platforms

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
@@ -515,3 +515,5 @@ serdes_preemphasis_123=0x14410a
 serdes_preemphasis_127=0x14410a
 serdes_driver_current_130=0xe
 serdes_preemphasis_130=0x102804
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
@@ -558,3 +558,5 @@ serdes_preemphasis_123=0x85804
 serdes_preemphasis_125=0x85804
 serdes_preemphasis_127=0x85804
 serdes_preemphasis_129=0x85804
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
@@ -444,3 +444,5 @@ serdes_driver_current_109=0xa
 serdes_preemphasis_109=0x284008
 
 mmu_init_config="MSFT-TH-Tier1"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
@@ -545,3 +545,5 @@ serdes_driver_current_115=0xa
 serdes_preemphasis_115=0x284008
 
 mmu_init_config="MSFT-TH-Tier0"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/th-a7060-cx32s-8x100G+24x40G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/th-a7060-cx32s-8x100G+24x40G.config.bcm
@@ -444,3 +444,5 @@ serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier1"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
@@ -442,3 +442,5 @@ serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier0"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
@@ -442,3 +442,5 @@ serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier1"
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/th-a7060-cx32s-8x100G+96x25G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/th-a7060-cx32s-8x100G+96x25G.config.bcm
@@ -778,3 +778,5 @@ serdes_driver_current_126=0xa
 serdes_preemphasis_126=0x284008
 serdes_driver_current_127=0xa
 serdes_preemphasis_127=0x284008
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
@@ -1035,3 +1035,5 @@ serdes_preemphasis_117=0x133c06
 
 {{ mmu_sock }}
 {{ IPinIP_sock }}
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
@@ -946,3 +946,5 @@ serdes_preemphasis_131=0x580c
 
 mmu_init_config="MSFT-TH2-Tier0"
 {{ IPinIP_sock }}
+
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
@@ -1025,3 +1025,5 @@ serdes_preemphasis_117=0x105004
 
 mmu_init_config="MSFT-TH2-Tier0"
 {{ IPinIP_sock }}
+
+phy_an_lt_msft=1

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
@@ -374,3 +374,5 @@ phy_xaui_tx_polarity_flip_130=0x0006
 phy_xaui_rx_polarity_flip_130=0x0000
 
 mmu_init_config="MSFT-TH-Tier0"
+
+phy_an_lt_msft=1

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
@@ -694,3 +694,5 @@ serdes_preemphasis_lane2_130=0x2b4104
 serdes_preemphasis_lane3_130=0x2b4104
 
 mmu_init_config="MSFT-TH-Tier1"
+
+phy_an_lt_msft=1

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
@@ -646,3 +646,4 @@ serdes_preemphasis_lane1_5=0x244a02
 serdes_preemphasis_lane2_5=0x244a02
 serdes_preemphasis_lane3_5=0x254902
 
+phy_an_lt_msft=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -91,6 +91,7 @@ phy_an_allow_pll_change_hg
 phy_an_c37
 phy_an_c73
 phy_an_fec
+phy_an_lt_msft
 phy_automedium
 phy_aux_voltage_enable
 phy_chain_rx_lane_map_physical


### PR DESCRIPTION
#### Why I did it
To enable autonegotiation/link training on some Broadcom-based platforms (Arista 7060CX, 7260CX3, 7050cx3, Celestica DX010)

#### How I did it
- Add 'phy_an_lt_msft' to BCM config file permitted list
- Add appropriate SOC property for enabling the feature to the Broadcom config files of appropriate platforms
- Also convert line endings to UNIX format for one Celestica file