### PR TITLE
[docker-syncd-brcm] Fix and simplify start_led.sh

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/start_led.sh
+++ b/platform/broadcom/docker-syncd-brcm/start_led.sh
@@ -4,11 +4,6 @@ PLATFORM_DIR=/usr/share/sonic/platform
 SYNCD_SOCKET_FILE=/var/run/sswsyncd/sswsyncd.socket
 LED_PROC_INIT_SOC=${PLATFORM_DIR}/led_proc_init.soc
 
-if [ ! -f "$LED_PROC_INIT_SOC" ]; then
-   echo "No soc led configuration found under $LED_SOC_INIT_SOC"
-   exit 0
-fi
-
 # Function: wait until syncd has created the socket for bcmcmd to connect to
 wait_syncd() {
     while true; do
@@ -38,6 +33,6 @@ wait_syncd() {
 # If this platform has an initialization file for the Broadcom LED microprocessor, load it
 if [[ -r "$LED_PROC_INIT_SOC" && ! -f /var/warmboot/warm-starting ]]; then
     wait_syncd
+    /usr/bin/bcmcmd -t 60 "rcload $LED_PROC_INIT_SOC"
 fi
 
-/usr/bin/bcmcmd -t 60 "rcload $LED_PROC_INIT_SOC"


### PR DESCRIPTION
#### Why I did it

`LED_PROC_INIT_SOC` variable was incorrectly referenced as `LED_SOC_INIT_SOC`. Introduced in https://github.com/Azure/sonic-buildimage/pull/5483

#### How I did it

Rather than fixing the typo, I decided to simplify the script, removing the need for the conditional altogether by moving the bcmcmd call inside the conditional which checks for the presence of `LED_SOC_INIT_SOC`.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [x] 202012

