### PR TITLE
[Mellanox] No need enable thermal zones in thermal_manager.deinitialize since they are enabled by default

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_manager.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_manager.py
@@ -17,15 +17,6 @@ class ThermalManager(ThermalManagerBase):
         cls._add_private_thermal_policy()
 
     @classmethod
-    def deinitialize(cls):
-        """
-        Destroy thermal manager, including any vendor specific cleanup. The default behavior of this function
-        is a no-op.
-        :return:
-        """
-        cls.start_thermal_control_algorithm()
-
-    @classmethod
     def start_thermal_control_algorithm(cls):
         """
         Start thermal control algorithm


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

No need enable thermal zones in thermal_manager.deinitialize since they are enabled by default. And removing this will faster thermalctld exit speed

#### How I did it

Remove thermal_manager.deinitialize and it will use default implementation which is a no-op.

#### How to verify it

Manual test and run platform related regression

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

