### PR TITLE
[Mellanox] Align PSU fan name in platform.json with latest change in PR #7490

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2410-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/platform.json
@@ -73,7 +73,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -86,7 +86,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform.json
@@ -73,7 +73,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -86,7 +86,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/platform.json
@@ -58,7 +58,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -71,7 +71,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [

--- a/device/mellanox/x86_64-mlnx_msn3420-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn3420-r0/platform.json
@@ -84,7 +84,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -97,7 +97,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/platform.json
@@ -95,7 +95,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -108,7 +108,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/platform.json
@@ -73,7 +73,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -86,7 +86,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/platform.json
@@ -56,7 +56,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -69,7 +69,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [

--- a/device/mellanox/x86_64-mlnx_msn4410-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/platform.json
@@ -95,7 +95,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -108,7 +108,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [

--- a/device/mellanox/x86_64-mlnx_msn4600-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4600-r0/platform.json
@@ -53,7 +53,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -66,7 +66,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/platform.json
@@ -53,7 +53,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -66,7 +66,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/platform.json
@@ -95,7 +95,7 @@
                 "name": "PSU 1",
                 "fans": [
                     {
-                        "name": "psu_1_fan_1"
+                        "name": "psu1_fan1"
                     }
                 ],
                 "thermals": [
@@ -108,7 +108,7 @@
                 "name": "PSU 2",
                 "fans": [
                     {
-                        "name": "psu_2_fan_1"
+                        "name": "psu2_fan1"
                     }
                 ],
                 "thermals": [


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 The PSU fan name convention was changed from "psu_{}\_fan_{}" to "psu{}_fan{}" in PR https://github.com/Azure/sonic-buildimage/pull/7490, platform.json need to be changed and aligned.

#### How I did it

change PSU fan name in platform.json

#### How to verify it

run related platform API community test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

