### PR TITLE
[Mellanox] Use a service to clear EEPROM cache

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -393,6 +393,7 @@ start() {
         -v mlnx_sdk_ready:/tmp \
         -e SX_API_SOCKET_FILE=/var/run/sx_sdk/sx_api.sock \
         -v /dev/shm:/dev/shm:rw \
+        -v /var/cache/sonic/decode-syseeprom:/var/cache/sonic/decode-syseeprom:rw \
 {%- else %}
 {%- if mount_default_tmpfs|default("n") == "y" %}
         --tmpfs /tmp \

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -544,6 +544,12 @@ sudo cp $IMAGE_CONFIGS/pcie-check/pcie-check.service $FILESYSTEM_ROOT_USR_LIB_SY
 echo "pcie-check.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo cp $IMAGE_CONFIGS/pcie-check/pcie-check.sh $FILESYSTEM_ROOT/usr/bin/
 
+{% if sonic_asic_platform == "mellanox" %}
+sudo cp $IMAGE_CONFIGS/eeprom-cache-clear/eeprom-cache-clear.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+echo "eeprom-cache-clear.service" | sudo tee -a $GENERATED_SERVICE_FILE
+sudo cp $IMAGE_CONFIGS/eeprom-cache-clear/eeprom-cache-clear.sh $FILESYSTEM_ROOT/usr/bin/
+{% endif %}
+
 ## Install package without starting service
 ## ref: https://wiki.debian.org/chroot
 sudo tee -a $FILESYSTEM_ROOT/usr/sbin/policy-rc.d > /dev/null <<EOF

--- a/files/image_config/eeprom-cache-clear/eeprom-cache-clear.service
+++ b/files/image_config/eeprom-cache-clear/eeprom-cache-clear.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Clear EEPROM cache file
+After=rc.local.service database.service
+Before=pmon.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/eeprom-cache-clear.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/files/image_config/eeprom-cache-clear/eeprom-cache-clear.sh
+++ b/files/image_config/eeprom-cache-clear/eeprom-cache-clear.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+## Clear EEPROM cache
+
+CACHE_ROOT="/var/cache/sonic/decode-syseeprom"
+CACHE_FILE="syseeprom_cache"
+
+mkdir -p ${CACHE_ROOT}
+rm -f ${CACHE_ROOT}/${CACHE_FILE}

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
@@ -55,7 +55,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
 
         if not (os.path.exists(EEPROM_SYMLINK) \
                 or os.path.isfile(os.path.join(CACHE_ROOT, CACHE_FILE))):
-            log_error("Nowhere to read syseeprom from! No symlink or cache file found")
+            logger.log_error("Nowhere to read syseeprom from! No symlink or cache file found")
             raise RuntimeError("No syseeprom symlink or cache file found")
 
         self.eeprom_path = EEPROM_SYMLINK
@@ -66,18 +66,6 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
 
     def _load_eeprom(self):
         cache_file = os.path.join(CACHE_ROOT, CACHE_FILE)
-        if not os.path.exists(CACHE_ROOT):
-            try:
-                os.makedirs(CACHE_ROOT)
-            except:
-                pass
-        else:
-            try:
-                # Make sure first time always read eeprom data from hardware
-                if os.path.exists(cache_file):
-                    os.remove(cache_file)
-            except Exception as e:
-                logger.log_error('Failed to remove cache file {} - {}'.format(cache_file, repr(e)))
 
         try:
             self.set_cache_name(cache_file)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Use a service to clear eeprom cache during boot up so that CLI does not have to remove and update cache everytime.

#### How I did it

Use a service to clear eeprom. It is a one shot which runs before PMON service.

#### How to verify it

Manual test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

