### PR TITLE
Fix systemd backport dependency issue

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -324,8 +324,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \
-    flashrom                \
-    rasdaemon
+    flashrom
 fi
 
 ## Set /etc/shadow permissions to -rw-------.
@@ -356,6 +355,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y -t
     systemd-sysv
 
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
+    sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install rasdaemon
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
         grub-pc-bin
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Build broken when reproducible build enabled, relative to backport package systemd.

See https://dev.azure.com/mssonic/build/_build/results?buildId=14292&view=logs&j=88ce9a53-729c-5fa9-7b6e-3d98f2488e3f&t=8d99be27-49d0-54d0-99b1-cfc0d47f0318

Issue Analysis:
The package rasdaemon has dependency on systemd, the systemd is installed twice in build_debian.sh.
The first one is the package from main, the second one is the package from backport.
When reproducible build enabled, it will only install the backport one.

Logs:
2021-05-09T14:32:42.3205320Z dpkg: error processing package systemd (--configure):
2021-05-09T14:32:42.3206017Z  installed systemd package post-installation script subprocess returned error exit status 73
2021-05-09T14:32:42.3206740Z dpkg: dependency problems prevent configuration of systemd-timesyncd:
2021-05-09T14:32:42.3207431Z  systemd-timesyncd depends on systemd (= 247.3-3~bpo10+1); however:
2021-05-09T14:32:42.3207870Z   Package systemd is not configured yet.
2021-05-09T14:32:42.3208036Z 
2021-05-09T14:32:42.3208573Z dpkg: error processing package systemd-timesyncd (--configure):
2021-05-09T14:32:42.3209163Z  dependency problems - leaving unconfigured
2021-05-09T14:32:42.3209572Z dpkg: dependency problems prevent configuration of rasdaemon:
2021-05-09T14:32:42.3210004Z  rasdaemon depends on systemd; however:
2021-05-09T14:32:42.3210352Z   Package systemd is not configured yet.



#### How I did it
The rasdaemon has dependency on systemd, so install systemd, then install rasdaemon.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

