### PR TITLE
Fix the /var wrong permission issue

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -80,7 +80,6 @@ TARGET_PATH=$TARGET_PATH scripts/build_debian_base_system.sh $CONFIGURED_ARCH $I
 sudo scripts/prepare_debian_image_buildinfo.sh $CONFIGURED_ARCH $IMAGE_DISTRO $FILESYSTEM_ROOT $http_proxy
 
 sudo chown root:root $FILESYSTEM_ROOT
-sudo chown -R root:root $FILESYSTEM_ROOT/var
 
 ## Config hostname and hosts, otherwise 'sudo ...' will complain 'sudo: unable to resolve host ...'
 sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "echo '$HOSTNAME' > /etc/hostname"

--- a/scripts/build_debian_base_system.sh
+++ b/scripts/build_debian_base_system.sh
@@ -78,7 +78,7 @@ do
 done
 touch $APTDEBIAN
 touch $DEBOOTSTRAP_BASE
-(cd $BASEIMAGE_TARBALLPATH && tar -zcf $BASEIMAGE_TARBALL .)
+(cd $BASEIMAGE_TARBALLPATH && fakeroot tar -zcf $BASEIMAGE_TARBALL .)
 
 sudo debootstrap --verbose --variant=minbase --arch $CONFIGURED_ARCH --unpack-tarball=$BASEIMAGE_TARBALL $IMAGE_DISTRO $FILESYSTEM_ROOT
 RET=$?


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Build broken when reproducible build enabled, relative to backport package systemd.
The root cause is the bad permission of /var.

See https://dev.azure.com/mssonic/build/_build/results?buildId=14292&view=logs&j=88ce9a53-729c-5fa9-7b6e-3d98f2488e3f&t=8d99be27-49d0-54d0-99b1-cfc0d47f0318

Issue Analysis:
The owner of the folder /var is not correct, should be root:root, not 1001:redis.
See similar issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=950684
```
xumia@f1b0c55f162c:/sonic$ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot ./fsroot ls -ld /var /var/log
drwxr-xr-x 11 1001 redis 4096 May 10 06:40 /var
drwxr-xr-x  4 root root  4096 May 10 06:45 /var/log
```

The package rasdaemon has dependency on systemd, the systemd is installed twice in build_debian.sh.
The first one is the package from main, the second one is the package from backport.
When reproducible build enabled, it will only install the backport one. The backport systemd was installed in the PR: https://github.com/Azure/sonic-buildimage/pull/7322

Logs:

The error is "Detected unsafe path transition /var -> /var/log during canonicalization of /var/log/journal.", see more logs as below:
```
Created symlink /etc/systemd/system/getty.target.wants/getty@tty1.service -> /lib/systemd/system/getty@.service.
Created symlink /etc/systemd/system/multi-user.target.wants/remote-fs.target -> /lib/systemd/system/remote-fs.target.
Created symlink /etc/systemd/system/sysinit.target.wants/systemd-pstore.service -> /lib/systemd/system/systemd-pstore.service.
Initializing machine ID from D-Bus machine ID.
Detected unsafe path transition /var -> /var/log during canonicalization of /var/log/journal.
Detected unsafe path transition /var -> /var/log during canonicalization of /var/log/journal.
Detected unsafe path transition /var -> /var/log during canonicalization of /var/log/journal.
dpkg: error processing package systemd (--configure):
 installed systemd package post-installation script subprocess returned error exit status 73
dpkg: dependency problems prevent configuration of systemd-timesyncd:
 systemd-timesyncd depends on systemd (= 247.3-3~bpo10+1); however:
  Package systemd is not configured yet.

dpkg: error processing package systemd-timesyncd (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of rasdaemon:
 rasdaemon depends on systemd; however:
  Package systemd is not configured yet.

dpkg: error processing package rasdaemon (--configure):
 dependency problems - leaving unconfigured
Processing triggers for libc-bin (2.28-10) ...
Processing triggers for dbus (1.12.20-0+deb10u1) ...
Errors were encountered while processing:
 systemd
 systemd-timesyncd
 rasdaemon
```

#### How I did it
Change the right ownership to root:root for /var.

#### How to verify it
The issue can be reproduced by following command, no issue after fixed.
```
make SONIC_CONFIG_BUILD_JOBS=1 SONIC_VERSION_CONTROL_COMPONENTS=all target/sonic-broadcom.bin
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

