### PR TITLE
Support readonly vtysh for sudoers (#7383)

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/rvtysh
+++ b/dockers/docker-fpm-frr/base_image_files/rvtysh
@@ -9,14 +9,14 @@ if printf -- "$*" | grep -qPz '[\n\r|&$;]'; then
 fi
 
 # The sub commands must start with "show"
-LAST_PARA=
-for para in "$@"
+LAST_PARAM=
+for param in "$@"
 do
-    if [ "$LAST_PARA" == "-c" ] && [[ "$para" != show*  ]]; then
-        echo "Not allow to run the command '$para', please use the comand 'sudo vtysh' instead." 1>&2
+    if [ "$LAST_PARAM" == "-c" ] && [[ "$param" != show*  ]]; then
+        echo "Not allow to run the command '$param', please use the comand 'sudo vtysh' instead." 1>&2
         exit 1
     fi
-    LAST_PARA=$para
+    LAST_PARAM=$param
 done
 
 vtysh "$@"

--- a/dockers/docker-fpm-frr/base_image_files/rvtysh
+++ b/dockers/docker-fpm-frr/base_image_files/rvtysh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# The command rvtysh can be run as root priviledge by any user without password, only allow to execute readonly commands.
+
+# The options in the show command cannot contains any charactors to run multiple sub-commands potentially, such as "\n", "\r", "|", "&", "$" and ";".
+if printf -- "$*" | grep -qPz '[\n\r|&$;]'; then
+    echo "Not allow to run the command, please use the comand 'sudo vtysh' instead." 1>&2
+    exit 1
+fi
+
+# The sub commands must start with "show"
+LAST_PARA=
+for para in "$@"
+do
+    if [ "$LAST_PARA" == "-c" ] && [[ "$para" != show*  ]]; then
+        echo "Not allow to run the command '$para', please use the comand 'sudo vtysh' instead." 1>&2
+        exit 1
+    fi
+    LAST_PARA=$para
+done
+
+vtysh "$@"

--- a/dockers/docker-fpm-quagga/base_image_files/rvtysh
+++ b/dockers/docker-fpm-quagga/base_image_files/rvtysh
@@ -1,0 +1,1 @@
+../../docker-fpm-frr/base_image_files/rvtysh

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -32,6 +32,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /sbin/brctl show, \
                                  /usr/bin/sensors, \
                                  /usr/bin/sfputil show *, \
                                  /usr/bin/teamshow, \
+                                 /usr/bin/rvtysh *, \
                                  /usr/bin/vtysh -c show *, \
                                  /bin/cat /var/log/syslog*, \
                                  /usr/bin/tail -F /var/log/syslog

--- a/rules/docker-fpm-frr.mk
+++ b/rules/docker-fpm-frr.mk
@@ -24,4 +24,5 @@ $(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/sonic/frr:/etc/frr:rw
 
 $(DOCKER_FPM_FRR)_BASE_IMAGE_FILES += vtysh:/usr/bin/vtysh
+$(DOCKER_FPM_FRR)_BASE_IMAGE_FILES += rvtysh:/usr/bin/rvtysh
 $(DOCKER_FPM_FRR)_BASE_IMAGE_FILES += monit_bgp:/etc/monit/conf.d

--- a/rules/docker-fpm-quagga.mk
+++ b/rules/docker-fpm-quagga.mk
@@ -22,3 +22,4 @@ $(DOCKER_FPM_QUAGGA)_RUN_OPT += --net=host --privileged -t
 $(DOCKER_FPM_QUAGGA)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 $(DOCKER_FPM_QUAGGA)_BASE_IMAGE_FILES += vtysh:/usr/bin/vtysh
+$(DOCKER_FPM_QUAGGA)_BASE_IMAGE_FILES += rvtysh:/usr/bin/rvtysh


### PR DESCRIPTION
Why I did it
Support readonly version of the command vtysh

How I did it
Check if the command starting with "show", and verify only contains single command in script.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

