### PR TITLE
Update the netifaces pip3 package version

### DIFF
--- a/files/build/versions/dockers/docker-sonic-vs/versions-py3
+++ b/files/build/versions/dockers/docker-sonic-vs/versions-py3
@@ -5,7 +5,7 @@ deepdiff==5.2.3
 ijson==2.6.1
 jsondiff==1.3.0
 M2Crypto==0.37.1
-netifaces==0.10.7
+netifaces==0.10.9
 ordered-set==4.0.2
 parameterized==0.8.1
 pexpect==4.8.0


### PR DESCRIPTION
#### Why I did it
202012 branch is using reproducible build. The versions-py3 file must contains correct pip3 package version. Otherwise we will get a build error

```
Step 31/74 : RUN pip3 install          scapy==2.4.4          pyroute2==0.5.14          netifaces==0.10.9
 ---> Running in d7a2401dd21d
Collecting scapy==2.4.4
  Downloading scapy-2.4.4.tar.gz (1.0 MB)
Collecting pyroute2==0.5.14
  Downloading pyroute2-0.5.14.tar.gz (873 kB)
ERROR: Cannot install netifaces==0.10.9 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested netifaces==0.10.9
    The user requested (constraint) netifaces==0.10.7

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
The command '/bin/sh -c pip3 install          scapy==2.4.4          pyroute2==0.5.14          netifaces==0.10.9' returned a non-zero code: 1
[  FAIL LOG END  ] [ target/docker-sonic-vs.gz ]
```

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

