### PR TITLE
Revert "[Telemetry docker] add memory and memory swap limits"

### DIFF
--- a/rules/docker-telemetry.mk
+++ b/rules/docker-telemetry.mk
@@ -29,7 +29,6 @@ endif
 
 $(DOCKER_TELEMETRY)_CONTAINER_NAME = telemetry
 $(DOCKER_TELEMETRY)_RUN_OPT += --privileged -t
-$(DOCKER_TELEMETRY)_RUN_OPT += --memory 500m
 $(DOCKER_TELEMETRY)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_TELEMETRY)_RUN_OPT += -v /usr/share/sonic/scripts:/usr/share/sonic/scripts:ro
 $(DOCKER_TELEMETRY)_RUN_OPT += -v /var/run/dbus:/var/run/dbus:rw


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#7062