### PR TITLE
[dockers][platform-monitor] Add chassis_db_init to platform monitor tasks

### DIFF
--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -41,7 +41,7 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}
 
-[program:chassisd]
+[program:chassisshow]
 command=/usr/local/bin/chassisshow
 priority=3
 autostart=false

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -41,6 +41,17 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}
 
+[program:chassisd]
+command=/usr/local/bin/chassisshow
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+startsecs=0
+dependent_startup=true
+dependent_startup_wait_for=rsyslogd:running
+
 {% if not skip_sensors and HAVE_SENSORS_CONF == 1 %}
 [program:lm-sensors]
 command=/usr/bin/lm-sensors.sh

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -41,8 +41,8 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}
 
-[program:chassisshow]
-command=/usr/local/bin/chassisshow
+[program:chassis_db_init]
+command=/usr/local/bin/chassis_db_init
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
#### Why I did it
I added `chassis_db_init` to the startup tasks for the `docker-platform-monitor` docker so that the script is run on startup of the switch and the chassis info is correctly provisioned to STATE_DB.

**NOTE: THIS DEPENDS ON https://github.com/Azure/sonic-platform-daemons/pull/183 DO NOT MERGE**

#### How I did it
I modified the supervisord template in order to define the new task to be started. 

#### How to verify it

Run `sudo redis-cli -n 6 hgetall "CHASSIS_INFO|chassis 1"`

Expected output (exact values will differ per platform)

```
1) "serial"
2) "MT1822K07815"
3) "model"
4) "MSN2700-CS2FO"
5) "revision"
6) "A1"
7) "psu_num"
8) "2"
```

#### Description for the changelog
[dockers][platform-monitor] Add chassis_db_init to platform monitor tasks

#### A picture of a cute animal (not mandatory but encouraged)
![babycow](https://user-images.githubusercontent.com/5898707/116715018-51f9fb00-a9a4-11eb-841d-d5a2b4f84d83.jpg)

