### PR TITLE
add config-setup.service as dependency for pcie-check.service

### DIFF
--- a/files/image_config/pcie-check/pcie-check.service
+++ b/files/image_config/pcie-check/pcie-check.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Check the PCIe device presence and status
-After=rc.local.service database.service
+After=rc.local.service database.service config-setup.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
start pcie-check.service after config-setup.service since pcie_util depends on device_info which is available with config db metadata.
#### How I did it
Add config-setup.service as a dependency of pcie-check.service
#### How to verify it
Upon reboot, check if the pcie-check.sh throws the platform api error which is dependent on DEVICE_METADATA
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

