### PR TITLE
[Minipack] Modify fbfpgaiomodule.c to support both python2 and python3

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/minipack/lib/fbfpgaiomodule.c
+++ b/platform/broadcom/sonic-platform-modules-accton/minipack/lib/fbfpgaiomodule.c
@@ -109,10 +109,7 @@ static PyMethodDef FbfpgaMethods[] = {
   { NULL, NULL, 0, NULL },
 };
 
-PyMODINIT_FUNC
-initfbfpgaio(void)
-{
-  char docstr[] = "\
+static char docstr[] = "\
 1. hw_init():\n\
    return value: True/False\n\
 2. hw_release():\n\
@@ -122,5 +119,26 @@ initfbfpgaio(void)
      In reading operation: data which is read from FPGA\n\
      In writing operation: None\n";
 
+#if PY_MAJOR_VERSION < 3
+PyMODINIT_FUNC
+initfbfpgaio(void)
+{
   (void) Py_InitModule3("fbfpgaio", FbfpgaMethods, docstr);
 }
+#else
+static struct PyModuleDef FbfpgaModule =
+{
+    PyModuleDef_HEAD_INIT,
+    "fbfpgaio", /* name of module */
+    docstr,
+    -1,   /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
+    FbfpgaMethods
+};
+
+PyMODINIT_FUNC
+PyInit_fbfpgaio(void)
+{
+  return PyModule_Create(&FbfpgaModule);
+}
+#endif
+


### PR DESCRIPTION
Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

