### PR TITLE
Allow ability to invoke platform specific hooks in swss

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -149,6 +149,13 @@ start() {
         clean_up_tables STATE_DB "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'LAG_TABLE*', 'LAG_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*', 'FDB_TABLE*', 'FG_ROUTE_TABLE*', 'BUFFER_POOL*', 'BUFFER_PROFILE*', '*MUX_CABLE_TABLE*'"
     fi
 
+    # This is a platform agnostic approach to check if 'platform'
+    # entry exists in the DEVICE_METADATA table. If it exits then
+    # source the script to perform platform specific checks
+    PLATFORM_DIR=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+    F="/usr/share/sonic/device/$PLATFORM_DIR/scripts/swss.sh"
+    [ -e $F ] && source $F start $DEV
+
     # start service docker
     /usr/bin/${SERVICE}.sh start $DEV
     debug "Started ${SERVICE}$DEV service..."

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -149,11 +149,9 @@ start() {
         clean_up_tables STATE_DB "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'LAG_TABLE*', 'LAG_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*', 'FDB_TABLE*', 'FG_ROUTE_TABLE*', 'BUFFER_POOL*', 'BUFFER_PROFILE*', '*MUX_CABLE_TABLE*'"
     fi
 
-    # This is a platform agnostic approach to check if 'platform'
-    # entry exists in the DEVICE_METADATA table. If it exits then
-    # source the script to perform platform specific checks
-    PLATFORM_DIR=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
-    F="/usr/share/sonic/device/$PLATFORM_DIR/scripts/swss.sh"
+    # Run platform specific checks in case one exists
+    # i.e. Source the file under sonic_asic_paltform path
+    F="/usr/share/sonic/device/$sonic_asic_platform/swss.sh"
     [ -e $F ] && source $F start $DEV
 
     # start service docker


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Implement a platform agnostic approach to source a script as desired. 
If it exits it checks if there is a file to source and hence does the needful.

#### How I did it
This is a PR followup from the code-review discussion we had with Guhon/Judy and team. This also addresses the following two comments: 
- Convert to sourcing a file instead of executing the same., so the logic within is run in the same shell.
-  Use sonic_asic_platform instead of PLATFORM_DIR

#### How to verify it
Perform run time check for files sourced via the swss.sh hooks and execute the same.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Simple, platform specific run time checks for swss if desired. 
-->


#### A picture of a cute animal (not mandatory but encouraged)

