### PR TITLE
[build] Add versions for bfnplatform and bfnsdk downloads

### DIFF
--- a/files/build/versions/default/versions-web
+++ b/files/build/versions/default/versions-web
@@ -16,6 +16,8 @@ https://bootstrap.pypa.io/pip/2.7/get-pip.py==60e8267eb1b7bc71dc4843eb7bd294d3
 https://chrome-infra-packages.appspot.com/client?platform=linux-amd64&version=git_revision:e75c9bf286fbb31347379cb478df2a556ab185b1==9df7a96a4a4fb6e484027d80b3ee821c
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
 https://github.com/aristanetworks/sonic-firmware/raw/6d0d1661d92a342acedb6839dba970ae5778b478/phy/phy-credo_1.0_amd64.deb==dd74acbb7bf979b01c1a89e2a628aaf3
+https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnplatform_20210324_deb10.deb==b1f3087f05b82504130c5a7d428b9ef5
+https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnsdk_20210324_deb10.deb==40a5468c7b7a003df6f4e6c2f9f98817
 https://github.com/CentecNetworks/sonic-binaries/raw/master/amd64/libsai_1.6.3-1_amd64.deb==e7a41e5cf06b44ae3ed615d553de40d3
 https://github.com/CumulusNetworks/ifupdown2/archive/1.2.8-1.tar.gz==12f45e90d23178e96cf70f68dc9455e6
 https://github.com/Innovium/SONiC/raw/master/debian/master/ipd.deb==a0f512aba05180b15c2f6b5809b9d5c1


### PR DESCRIPTION
#### Why I did it

[Build failed with error "Failed to verify the package"](https://dev.azure.com/mssonic/build/_build/results?buildId=13879&view=logs&j=993d6e22-aeec-5c03-fa19-35ecba587dd9&t=d0538dec-1681-5ff8-bd45-c0de13be9706&l=694)

[The reason of the fail is version verification](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/src/sonic-build-hooks/scripts/buildinfo_base.sh#L79)

[Version verification is controled with var "ENABLE_VERSION_CONTROL_WEB"](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/src/sonic-build-hooks/scripts/buildinfo_base.sh#L74)

[This var is set using check_version_control function ](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/src/sonic-build-hooks/scripts/buildinfo_base.sh#L159)

[So, var "ENABLE_VERSION_CONTROL_WEB" is set depending on env var "SONIC_VERSION_CONTROL_COMPONENTS"](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/src/sonic-build-hooks/scripts/buildinfo_base.sh#L39)

[Env var "SONIC_VERSION_CONTROL_COMPONENTS" is set to "deb,py2,py3,web" for the branch 202012](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/azure-pipelines.yml#L38)


Both bfnplatform_20210324_deb10.deb and bfnsdk_20210324_deb10.deb are required targets, so neither of them can be removed.
* [rules are required by slave](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/slave.mk#L157)
* [bfnsdk is required by rules](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/platform/barefoot/rules.mk#L7)
* [bfnplatformand is required by ruels](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/platform/barefoot/rules.mk#L13)
* [bfnsdk source](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/platform/barefoot/bfn-sai.mk#L1)
* [bfnplatformand  source](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/platform/barefoot/bfn-platform.mk#L1)

#### How I did it

Added md5 hashes for bfnplatform_20210324_deb10.deb and /bfnsdk_20210324_deb10.deb