### PR TITLE
Add fabric lane mapping to vs (sai.profile) and HWSKU Force10-S6000

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/fabriclanemap.ini
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/fabriclanemap.ini
@@ -1,0 +1,16 @@
+fabric1:1
+fabric2:2
+fabric3:3
+fabric4:4
+fabric5:5
+fabric6:6
+fabric7:7
+fabric8:8
+fabric9:9
+fabric10:10
+fabric11:11
+fabric12:12
+fabric13:13
+fabric14:14
+fabric15:15
+fabric16:16

--- a/src/sonic-device-data/src/sai.vs_profile
+++ b/src/sonic-device-data/src/sai.vs_profile
@@ -2,3 +2,4 @@ SAI_VS_SWITCH_TYPE=SAI_VS_SWITCH_TYPE_BCM56850
 SAI_VS_HOSTIF_USE_TAP_DEVICE=true
 SAI_VS_INTERFACE_LANE_MAP_FILE=/usr/share/sonic/hwsku/lanemap.ini
 SAI_VS_CORE_PORT_INDEX_MAP_FILE=/usr/share/sonic/hwsku/coreportindexmap.ini
+SAI_VS_INTERFACE_FABRIC_LANE_MAP_FILE=/usr/share/sonic/hwsku/fabriclanemap.ini


### PR DESCRIPTION
This PR is actually https://github.com/Azure/sonic-buildimage/pull/6185 that was merged and then reverted to avoid test failure in swss. 

Now https://github.com/Azure/sonic-swss/pull/1459/ merged, and so this PR could merge to enable fabric test in swss.

Signed-off-by: ngocdo <ngocdo@arista.com>

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

