### PR TITLE
Allow ability to invoke platform specific hooks in syncd.sh

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -28,6 +28,10 @@ function startplatform() {
         debug "Firmware update procedure ended"
     fi
 
+    # This is a platform agnostic approach to check if 'platform'
+    # entry exists in the DEVICE_METADATA table. If it exits then
+    # source the script to perform platform specific checks
+
     PLATFORM_DIR=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
     F="/usr/share/sonic/device/$PLATFORM_DIR/scripts/syncd.sh"
     [ -e $F ] && source $F start $DEV

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -28,12 +28,9 @@ function startplatform() {
         debug "Firmware update procedure ended"
     fi
 
-    # This is a platform agnostic approach to check if 'platform'
-    # entry exists in the DEVICE_METADATA table. If it exits then
-    # source the script to perform platform specific checks
-
-    PLATFORM_DIR=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
-    F="/usr/share/sonic/device/$PLATFORM_DIR/scripts/syncd.sh"
+    # Run platform specific checks in case one exists
+    # i.e. Source the file under sonic_asic_paltform path
+    F="/usr/share/sonic/device/$sonic_asic_platform/swss.sh"
     [ -e $F ] && source $F start $DEV
 
     if [[ x"$WARM_BOOT" != x"true" ]]; then

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -30,7 +30,7 @@ function startplatform() {
 
     # Run platform specific checks in case one exists
     # i.e. Source the file under sonic_asic_paltform path
-    F="/usr/share/sonic/device/$sonic_asic_platform/swss.sh"
+    F="/usr/share/sonic/device/$sonic_asic_platform/syncd.sh"
     [ -e $F ] && source $F start $DEV
 
     if [[ x"$WARM_BOOT" != x"true" ]]; then

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -28,6 +28,10 @@ function startplatform() {
         debug "Firmware update procedure ended"
     fi
 
+    PLATFORM_DIR=`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`
+    F="/usr/share/sonic/device/$PLATFORM_DIR/scripts/syncd.sh"
+    [ -e $F ] && source $F start $DEV
+
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         if [ x$sonic_asic_platform == x'cavium' ]; then
             /etc/init.d/xpnet.sh start


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is a platform agnostic & vendor agnostic change to files/scripts/syncd.sh to check if 'sonic_asic_platform' entry exists and sources syncd specific hooks

#### How I did it
Source syncd specific hooks from within platform/<>/ code 

#### How to verify it 
These are run time checks for vendor/platforms 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

