### PR TITLE
[CI] enable official build in release branch

### DIFF
--- a/.azure-pipelines/official-build.yml
+++ b/.azure-pipelines/official-build.yml
@@ -11,6 +11,12 @@ schedules:
     - master
     - 202012
   always: true
+- cron: "0 4 * * *"
+  displayName: nightly build for release
+  branches:
+    include:
+    - 201911
+    - 201811
 
 trigger: none
 pr: none


### PR DESCRIPTION
Signed-off-by: Shilong Liu <shilongliu@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
enable official build of sonic image in azure pipeline on 201911 branch.
#### How I did it
change azure pipeline file
#### How to verify it
check it in azure pipeline
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

