### PR TITLE
[service]: Bind macsec service to sonic.target

### DIFF
--- a/files/build_templates/macsec.service.j2
+++ b/files/build_templates/macsec.service.j2
@@ -2,6 +2,8 @@
 Description=MACsec container
 Requires=swss.service
 After=swss.service syncd.service
+BindsTo=sonic.target
+After=sonic.target
 StartLimitIntervalSec=1200
 StartLimitBurst=3
 
@@ -14,4 +16,4 @@ Restart=always
 RestartSec=30
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sonic.target


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
MACsec service cannot be enabled by "sudo config feature state macsec enabled"

#### How I did it
Bind MACsec service to sonic.target
Refer to this PR: https://github.com/Azure/sonic-buildimage/pull/5705

#### How to verify it
```
sudo config feature state macsec enabled
```
We should see the macsec container was enabiled
```
admin@sonic:~$ docker ps -a
CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS              PORTS               NAMES
83e7bea5e130        docker-macsec:latest                 "/usr/local/bin/supe…"   33 seconds ago      Up 31 seconds                           macsec

```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

