### PR TITLE
[Monit] Restart telemetry container if memory usage is beyond the threshold

### DIFF
--- a/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
+++ b/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
@@ -9,3 +9,6 @@ check program telemetry|telemetry with path "/usr/bin/process_checker telemetry 
 
 check program telemetry|dialout_client with path "/usr/bin/process_checker telemetry /usr/sbin/dialout_client_cli"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
+
+check program container_memory_telemetry with path "/usr/bin/memory_checker telemetry 419430400"
+    if status == 3 for 10 times within 20 cycles then exec "/usr/bin/restart_service telemetry"

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -316,6 +316,10 @@ sudo cp $IMAGE_CONFIGS/monit/process_checker $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/process_checker
 sudo cp $IMAGE_CONFIGS/monit/container_checker $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/container_checker
+sudo cp $IMAGE_CONFIGS/monit/memory_checker $FILESYSTEM_ROOT/usr/bin/
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/memory_checker
+sudo cp $IMAGE_CONFIGS/monit/restart_service $FILESYSTEM_ROOT/usr/bin/
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/restart_service
 
 
 # Install custom-built openssh sshd

--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+import argparse
+import subprocess
+import sys
+import syslog
+import re
+
+
+def get_command_result(command):
+    """Executes the command and return the resulting output.
+
+    Args:
+        command: A string contains the command to be executed.
+
+    Returns:
+        A string which contains the output of command.
+    """
+    command_stdout = ""
+
+    try:
+        proc_instance = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                         shell=True, universal_newlines=True)
+        command_stdout, command_stderr = proc_instance.communicate()
+        if proc_instance.returncode != 0:
+            syslog.syslog(syslog.LOG_ERR, "[memory_checker] Failed to execute the command '{}'. Return code: '{}'"
+                          .format(command, proc_instance.returncode))
+            sys.exit(1)
+    except (OSError, ValueError) as err:
+        syslog.syslog(syslog.LOG_ERR, "[memory_checker] Failed to execute the command '{}'. Error: '{}'"
+                      .format(command, err))
+        sys.exit(2)
+
+    return command_stdout.strip()
+
+
+def check_memory_usage(container_name, threshold_value):
+    """Checks the memory usage of a container and writes an alerting messages into
+    the syslog if the memory usage is larger than the threshold value.
+
+    Args:
+        container_name: A string represtents name of a container
+        threshold_value: An integer indicates the threshold value (Bytes) of memory usage.
+
+    Returns:
+        None.
+    """
+    command = "docker stats --no-stream --format \{{\{{.MemUsage\}}\}} {}".format(container_name)
+    command_stdout = get_command_result(command)
+    mem_usage = command_stdout.split("/")[0].strip()
+    match_obj = re.match(r"\d+\.?\d*", mem_usage)
+    if match_obj:
+        mem_usage_value = float(mem_usage[match_obj.start():match_obj.end()])
+        mem_usage_unit = mem_usage[match_obj.end():]
+
+        mem_usage_bytes = 0.0
+        if mem_usage_unit == "B":
+            mem_usage_bytes = mem_usage_value
+        elif mem_usage_unit == "KiB":
+            mem_usage_bytes = mem_usage_value * 1024
+        elif mem_usage_unit == "MiB":
+            mem_usage_bytes = mem_usage_value * 1024 ** 2
+        elif mem_usage_unit == "GiB":
+            mem_usage_bytes = mem_usage_value * 1024 ** 3
+
+        if mem_usage_bytes > threshold_value:
+            print("[{}]: Memory usage ({} Bytes) is larger than the threshold ({} Bytes)!"
+                  .format(container_name, mem_usage_bytes, threshold_value))
+            sys.exit(3)
+    else:
+        syslog.syslog(syslog.LOG_ERR, "[memory_checker] Failed to retrieve memory value from '{}'"
+                      .format(mem_usage))
+        sys.exit(4)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check memory usage of a container \
+            and an alerting message will be written into syslog if memory usage \
+            is larger than the threshold value", usage="/usr/bin/memory_checker <container_name> <threshold_value_in_bytes>")
+    parser.add_argument("container_name", help="container name")
+    # TODO: Currently the threshold value is hard coded as a command line argument and will
+    # remove this in the new version since we want to read this value from 'CONFIG_DB'.
+    parser.add_argument("threshold_value", type=int, help="threshold value in bytes")
+    args = parser.parse_args()
+
+    check_memory_usage(args.container_name, args.threshold_value)
+
+
+if __name__ == "__main__":
+    main()

--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -1,4 +1,23 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+"""
+memory_checker
+
+This script is part of the feature which will restart the container if memory
+usage of it is larger than the threshold value.
+
+This script is used to check the memory usage of specified cotnainer and
+is intended to be run by Monit. It will write an alerting message into
+syslog if memory usage of the container is larger than the threshold value for X
+times within Y cycles/minutes. Note that if print(...) statement in this script
+was executed, the string in it will be appended to Monit syslog messages.
+
+The following is an example in Monit configuration file to show how Monit will run
+this script:
+
+check program container_memory_<container_name> with path "/usr/bin/memory_checker <container_name> <threshold_value>"
+    if status == 3 for X times within Y cycles exec "/usr/bin/restart_service <container_name>"
+"""
 
 import argparse
 import subprocess

--- a/files/image_config/monit/restart_service
+++ b/files/image_config/monit/restart_service
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+import syslog
+import subprocess
+
+
+def get_command_result(command):
+    """Executes command and return the exit code, stdout and stderr.
+
+    Args:
+        command: A string contains the command to be executed.
+
+    Returns:
+        An integer contains the exit code.
+        A string contains the output of stdout.
+        A string contains the output of stderr.
+    """
+    command_stdout = ""
+    command_stderr = ""
+
+    try:
+        proc_instance = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                         shell=True, universal_newlines=True)
+        command_stdout, command_stderr = proc_instance.communicate()
+        if proc_instance.returncode != 0:
+            return 1, command_stdout.strip(), command_stderr.strip()
+    except (OSError, ValueError) as err:
+        return 2, command_stdout.strip(), err
+
+    return 0, command_stdout.strip(), command_stderr.strip()
+
+
+def reset_failed_flag(service_name):
+    """Reset the failed status of a service.
+
+    Args:
+        service_name: Name of the service.
+
+    Returns:
+        None
+    """
+    reset_failed_command = "sudo systemctl reset-failed {}.service".format(service_name)
+
+    syslog.syslog(syslog.LOG_INFO, "Resetting failed status of service '{}' ..."
+                  .format(service_name))
+
+    exit_code, command_stdout, command_stderr = get_command_result(reset_failed_command)
+    if exit_code == 0:
+        syslog.syslog(syslog.LOG_INFO, "Succeeded to reset failed status of service '{}.service'."
+                      .format(service_name))
+    else:
+        syslog.syslog(syslog.LOG_ERR, "Failed to reset failed status of service '{}'. Error: {}"
+                      .format(service_name, command_stderr))
+
+
+def restart_service(service_name):
+    """Reset the failed status of a service and then restart it.
+
+    Args:
+        service_name: Name of specified service.
+
+    Returns:
+        None.
+    """
+    restart_command = "sudo systemctl restart {}.service".format(service_name)
+
+    reset_failed_flag(service_name)
+
+    syslog.syslog(syslog.LOG_INFO, "Restarting service '{}' ...".format(service_name))
+    exit_code, command_stdout, command_stderr = get_command_result(restart_command)
+    if exit_code != 0:
+        syslog.syslog(syslog.LOG_ERR, "Failed to restart the service '{}'. Error: {}"
+                      .format(service_name, command_stderr))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Restart a specific service",
+                                     usage="/usr/bin/restart_service <service_name>")
+    parser.add_argument("service_name", help="service name")
+    args = parser.parse_args()
+
+    restart_service(args.service_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/files/image_config/monit/restart_service
+++ b/files/image_config/monit/restart_service
@@ -1,4 +1,21 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+"""
+restart_service
+
+This script is part of the feature which will restart the container if memory
+usage of it is larger than the threshold value.
+
+This script is intended to be run by Monit and is used to restart the specified
+container if the memory usage of it is larger than the threshold value for X
+times within Y cycles/minutes.
+
+The following is an example in Monit configuration file to show how Monit will run
+this script:
+
+check program container_memory_<container_name> with path "/usr/bin/memory_checker <container_name> <threshold_value>"
+    if status == 3 for X times within Y cycles exec "/usr/bin/restart_service <container_name>"
+"""
 
 import argparse
 import sys


### PR DESCRIPTION

Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR aims to monitor the memory usage of streaming telemetry container and restart streaming telemetry container if memory usage is larger than the pre-defined threshold.

#### How I did it
I borrowed the system tool Monit to run a script `memory_checker` which will periodically check the memory usage of streaming telemetry container. If the memory usage of telemetry container is larger than the pre-defined threshold for 10 times during 20 cycles, then an alerting message will be written into syslog and at the same time Monit will run the script `restart_service` to restart the streaming telemetry container.

#### How to verify it
I verified this implementation on device `str-7260cx3-acs-1`.

    May 14 21:40:44.944347 str-7260cx3-acs-1 INFO systemd[1]: Starting LSB: service and resource monitoring daemon...
    May 14 21:40:44.956604 str-7260cx3-acs-1 INFO monit[15268]: Starting Monit 5.20.0 daemon with http interface at /var/run/monit.sock
    May 14 21:40:44.957122 str-7260cx3-acs-1 INFO monit[15268]: Monit start delay set to 300s
    May 14 21:40:44.957308 str-7260cx3-acs-1 INFO monit[15264]: Starting daemon monitor: monit.
    May 14 21:40:44.957823 str-7260cx3-acs-1 INFO systemd[1]: Started LSB: service and resource monitoring daemon.
    May 14 21:45:44.958178 str-7260cx3-acs-1 INFO monit[15270]: 'str-7260cx3-acs-1' Monit 5.20.0 started
    
    May 14 21:55:54.783286 str-7260cx3-acs-1 ERR monit[15270]: 'container_memory_telemetry' status failed (3) -- [telemetry]: Memory usage (600204902.4 Bytes) is larger than the threshold (419430400 Bytes)!
    May 14 21:55:54.783790 str-7260cx3-acs-1 INFO monit[15270]: 'container_memory_telemetry' exec: '/usr/bin/restart_container telemetry'
    May 14 21:55:54.995415 str-7260cx3-acs-1 INFO restart_container: Issue command 'sudo systemctl reset-failed telemetry.service' to reset failed status of service 'telemetry' ...
    May 14 21:55:55.171162 str-7260cx3-acs-1 INFO restart_container: Succeeded to reset failed status of service 'telemetry.service'.
    May 14 21:55:55.171756 str-7260cx3-acs-1 INFO restart_container: Issues command 'sudo systemctl restart telemetry.service' to restart container 'telemetry' ...
    May 14 21:55:55.556005 str-7260cx3-acs-1 INFO telemetry#supervisord 2021-05-14 21:55:55,555 WARN received SIGTERM indicating exit request
    May 14 21:55:55.562252 str-7260cx3-acs-1 INFO telemetry#supervisord 2021-05-14 21:55:55,559 INFO waiting for dialout, supervisor-proc-exit-listener, rsyslogd to die
    May 14 21:55:55.603269 str-7260cx3-acs-1 INFO telemetry#supervisord 2021-05-14 21:55:55,596 INFO stopped: dialout (terminated by SIGTERM)
    May 14 21:55:58.255612 str-7260cx3-acs-1 INFO telemetry.sh[8335]: 0
    May 14 21:55:58.528473 str-7260cx3-acs-1 INFO telemetry.sh[18723]: Starting existing telemetry container with HWSKU Arista-7260CX3-D108C8
    May 14 21:55:58.996912 str-7260cx3-acs-1 INFO restart_container: Issues command 'docker inspect -f \{\{.State.Running\}\} telemetry' to check running status of container 'telemetry' ...
    May 14 21:55:59.803825 str-7260cx3-acs-1 INFO restart_container: Container 'telemetry' is restarted successfully and is in the running state.



#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

