### PR TITLE
[radv] fix bug for radv can't startup if DEVICE_METADATA.localhost.type not exist

### DIFF
--- a/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
+++ b/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
@@ -44,14 +44,16 @@ dependent_startup_wait_for=rsyslogd:running
 {# But not for specific deployment_id #}
 {%- set vlan_v6 = namespace(count=0) -%}
 {%- if DEVICE_METADATA.localhost.deployment_id != "8" -%}
-  {%- if "ToRRouter" in DEVICE_METADATA.localhost.type and DEVICE_METADATA.localhost.type != "MgmtToRRouter" -%}
-    {%- if VLAN_INTERFACE -%}
-      {%- for (name, prefix) in VLAN_INTERFACE|pfx_filter -%}
-        {# If this VLAN has an IPv6 address... #}
-        {%- if prefix | ipv6 -%}
-          {%- set vlan_v6.count = vlan_v6.count + 1 -%}
-        {%- endif -%}
-      {%- endfor -%}
+  {%- if DEVICE_METADATA.localhost.type -%}
+    {%- if "ToRRouter" in DEVICE_METADATA.localhost.type and DEVICE_METADATA.localhost.type != "MgmtToRRouter" -%}
+      {%- if VLAN_INTERFACE -%}
+        {%- for (name, prefix) in VLAN_INTERFACE|pfx_filter -%}
+          {# If this VLAN has an IPv6 address... #}
+          {%- if prefix | ipv6 -%}
+            {%- set vlan_v6.count = vlan_v6.count + 1 -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
     {%- endif -%}
   {%- endif -%}
 {%- endif -%}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
docker radv can't startup if DEVICE_METADATA.localhost.type not exist

#### How I did it
add check for DEVICE_METADATA.localhost.type exist

#### How to verify it
build the sonic image, run on board, and radv can startup

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

