### PR TITLE
[bgpcfgd] Enable BGP sessions over subinterfaces

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -44,6 +44,7 @@ def do_work():
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_VLAN_INTF_TABLE_NAME),
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_LAG_INTF_TABLE_NAME),
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_VOQ_INBAND_INTERFACE_TABLE_NAME),
+        InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_VLAN_SUB_INTF_TABLE_NAME)
         # State DB managers
         ZebraSetSrc(common_objs, "STATE_DB", swsscommon.STATE_INTERFACE_TABLE_NAME),
         # Peer Managers

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -44,7 +44,7 @@ def do_work():
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_VLAN_INTF_TABLE_NAME),
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_LAG_INTF_TABLE_NAME),
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_VOQ_INBAND_INTERFACE_TABLE_NAME),
-        InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_VLAN_SUB_INTF_TABLE_NAME)
+        InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_VLAN_SUB_INTF_TABLE_NAME),
         # State DB managers
         ZebraSetSrc(common_objs, "STATE_DB", swsscommon.STATE_INTERFACE_TABLE_NAME),
         # Peer Managers


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Fixes #7531
 
#### Why I did it
To enable bgp sessions to be established over subinterfaces

#### How I did it
Listen to VLAN_SUB_INTERFACE table in config db

#### How to verify it
Bgp sessions were established successfully
```
admin@str-s6000-on-5:~$ show ip bgp summary

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 12806
RIB entries 12807, using 2458944 bytes of memory
Peers 4, using 87264 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600       6454      12859         0      0       0  00:40:20             6400  ARISTA01T1
10.0.0.59      4  64600       3337      20604         0      0       0  02:12:36             6400  ARISTA02T1
10.0.0.61      4  64600       3296      17204         0      0       0  01:31:26             6400  ARISTA03T1
10.0.0.63      4  64600       3270      13641         0      0       0  01:05:17             6400  ARISTA04T1

Total number of neighbors 4
admin@str-s6000-on-5:~$ show ip int
Interface       Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
--------------  --------  -------------------  ------------  --------------  -------------
Ethernet112.10            10.0.0.56/31         up/up         ARISTA01T1      10.0.0.57
Ethernet116.10            10.0.0.58/31         up/up         ARISTA02T1      10.0.0.59
Ethernet120.10            10.0.0.60/31         up/up         ARISTA03T1      10.0.0.61
Ethernet124.10            10.0.0.62/31         up/up         ARISTA04T1      10.0.0.63
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
