### PR TITLE
Replace swsssdk.ConfigDBConnector and SonicDBConfig with swsscommon implementation in sonic-py-common

### DIFF
--- a/rules/sonic-py-common.mk
+++ b/rules/sonic-py-common.mk
@@ -4,7 +4,7 @@ SONIC_PY_COMMON_PY2 = sonic_py_common-1.0-py2-none-any.whl
 $(SONIC_PY_COMMON_PY2)_SRC_PATH = $(SRC_PATH)/sonic-py-common
 $(SONIC_PY_COMMON_PY2)_DEPENDS += $(SWSSSDK_PY2)
 $(SONIC_PY_COMMON_PY2)_DEBS_DEPENDS = $(LIBSWSSCOMMON) \
-                                      $(PYTHON2_SWSSCOMMON)
+                                      $(PYTHON_SWSSCOMMON)
 $(SONIC_PY_COMMON_PY2)_PYTHON_VERSION = 2
 SONIC_PYTHON_WHEELS += $(SONIC_PY_COMMON_PY2)
 

--- a/rules/sonic-py-common.mk
+++ b/rules/sonic-py-common.mk
@@ -3,6 +3,8 @@
 SONIC_PY_COMMON_PY2 = sonic_py_common-1.0-py2-none-any.whl
 $(SONIC_PY_COMMON_PY2)_SRC_PATH = $(SRC_PATH)/sonic-py-common
 $(SONIC_PY_COMMON_PY2)_DEPENDS += $(SWSSSDK_PY2)
+$(SONIC_PY_COMMON_PY2)_DEBS_DEPENDS = $(LIBSWSSCOMMON) \
+                                      $(PYTHON2_SWSSCOMMON)
 $(SONIC_PY_COMMON_PY2)_PYTHON_VERSION = 2
 SONIC_PYTHON_WHEELS += $(SONIC_PY_COMMON_PY2)
 
@@ -11,6 +13,8 @@ SONIC_PYTHON_WHEELS += $(SONIC_PY_COMMON_PY2)
 SONIC_PY_COMMON_PY3 = sonic_py_common-1.0-py3-none-any.whl
 $(SONIC_PY_COMMON_PY3)_SRC_PATH = $(SRC_PATH)/sonic-py-common
 $(SONIC_PY_COMMON_PY3)_DEPENDS += $(SWSSSDK_PY3)
+$(SONIC_PY_COMMON_PY3)_DEBS_DEPENDS = $(LIBSWSSCOMMON) \
+                                      $(PYTHON3_SWSSCOMMON)
 # Synthetic dependency to avoid building the Python 2 and 3 packages
 # simultaneously and any potential conflicts which may arise
 $(SONIC_PY_COMMON_PY3)_DEPENDS += $(SONIC_PY_COMMON_PY2)

--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -2,12 +2,7 @@ from setuptools import setup
 
 dependencies = [
     'natsort==6.2.1', # 6.2.1 is the last version which supports Python 2
-    'pyyaml',
-    'swsssdk>=2.0.1',
-]
-
-high_performance_deps = [
-    'swsssdk[high_perf]>=2.0.1',
+    'pyyaml'
 ]
 
 setup(
@@ -21,9 +16,6 @@ setup(
     maintainer='Joe LeVeque',
     maintainer_email='jolevequ@microsoft.com',
     install_requires=dependencies,
-    extras_require={
-        'high_perf': high_performance_deps,
-    },
     packages=[
         'sonic_py_common',
     ],

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -8,7 +8,7 @@ import yaml
 from natsort import natsorted
 
 # TODO: Replace with swsscommon
-from swsssdk import ConfigDBConnector, SonicDBConfig, SonicV2Connector
+from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig, SonicV2Connector
 
 USR_SHARE_SONIC_PATH = "/usr/share/sonic"
 HOST_DEVICE_PATH = USR_SHARE_SONIC_PATH + "/device"

--- a/src/system-health/setup.py
+++ b/src/system-health/setup.py
@@ -27,6 +27,7 @@ setup(
         'pytest-runner'
     ],
     tests_require=[
+        'swsssdk>=2.0.1',
         'pytest',
         'mock>=2.0.0'
     ],


### PR DESCRIPTION
#### Why I did it
swsssdk will be deprecated. Use swsscommon instead.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

