### PR TITLE
[201911][docker-teamd]: Increase teammgrd timeout to allow graceful shutdown

### DIFF
--- a/dockers/docker-teamd/supervisord.conf
+++ b/dockers/docker-teamd/supervisord.conf
@@ -44,6 +44,7 @@ command=/usr/bin/teammgrd
 priority=3
 autostart=false
 autorestart=false
+stopwaitsecs=60
 stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Adding a missing part of https://github.com/Azure/sonic-buildimage/pull/6537

Resolves  #7591 

#### Why I did it
* To fix LAG IP configuration race

#### How I did it
* Extended timeout for teammgrd

#### How to verify it
1. Add >80 router LAGs
2. Do config reload

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [X] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```