### PR TITLE
[sonic-mgmt docker]: Added allure-pytest library to sonic-mgmt docker container

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -176,3 +176,7 @@ RUN env-python3/bin/pip3 install cryptography==3.3.2 azure-kusto-data azure-kust
 # NOTE: There is an ordering dependency for pycryptodome. Leaving this at
 #       the end until we figure that out.
 RUN pip install pycryptodome==3.9.8
+
+# Install allure-pytest library
+RUN pip install --upgrade setuptools \
+    && pip install allure-pytest==2.8.22


### PR DESCRIPTION
[sonic-mgmt docker]: Added allure-pytest library to sonic-mgmt docker container

* Modified Dockerfile.j2 - added allure-pytest library

Signed-off-by: Petro Pikh <petrop@nvidia.com>

#### Why I did it
This library will allow us to have more human readable test reports

#### How I did it
Added allure-pytest library to Docker file template

#### How to verify it
Executed tests, using new docker-sonic-mgmt container which have installed library allure-pytest

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
Added support for Allure reports 


#### A picture of a cute animal (not mandatory but encouraged)
:)