### PR TITLE
[build] Refactor device-data Makefile and fix bug

### DIFF
--- a/src/sonic-device-data/Makefile
+++ b/src/sonic-device-data/Makefile
@@ -17,11 +17,13 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Create hwsku for virtual switch
 	for d in `find -L ../../../device -maxdepth 3 -mindepth 3 -type d | grep -vE "(plugins|led-code)"`; do \
 		cp -Lr $$d device/x86_64-kvm_x86_64-r0/ ; \
-		cp ./sai.vs_profile device/x86_64-kvm_x86_64-r0/$$(basename $$d)/sai.profile; \
-		grep -v ^# device/x86_64-kvm_x86_64-r0/$$(basename $$d)/port_config.ini | awk '{i=i+1;print "eth"i":"$$2}' > device/x86_64-kvm_x86_64-r0/$$(basename $$d)/lanemap.ini
-		cp ./pai.vs_profile device/x86_64-kvm_x86_64-r0/$$(basename $$d)/pai.profile; \
 		grep -v ^# device/x86_64-kvm_x86_64-r0/$$(basename $$d)/port_config.ini | awk '{i=i+1;print "eth"i":"$$2}' > device/x86_64-kvm_x86_64-r0/$$(basename $$d)/lanemap.ini
 
+	done;
+
+	for d in `find -L ../../../device -maxdepth 3 -mindepth 3 -type d | grep -vE "(plugins|led-code)"`; do \
+		cp ./sai.vs_profile device/x86_64-kvm_x86_64-r0/$$(basename $$d)/sai.profile; \
+		cp ./pai.vs_profile device/x86_64-kvm_x86_64-r0/$$(basename $$d)/pai.profile
 	done;
 
 	# Build the package


### PR DESCRIPTION
#### Why I did it

There was a missing ; which meant the pai.profile processing wasn't happening

#### How I did it

Refactored the processing slightly to make extensions easier and fixed the missing ; in the process

Signed-off-by: Joe Tricklebank-Owens <joet@microsoft.com>
