### PR TITLE
Fix supervisor-proc-exit-listener startup issue in restapi

### DIFF
--- a/dockers/docker-sonic-restapi/supervisord.conf
+++ b/dockers/docker-sonic-restapi/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
-command=python /usr/bin/supervisor-proc-exit-listener --container-name restapi
+command=python2 /usr/bin/supervisor-proc-exit-listener --container-name restapi
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=false

--- a/dockers/docker-sonic-restapi/supervisord.conf
+++ b/dockers/docker-sonic-restapi/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/bin/supervisor-proc-exit-listener --container-name restapi
+command=python /usr/bin/supervisor-proc-exit-listener --container-name restapi
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=false


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
docker ```restapi``` is ```docker-config-engine-stretch``` and ```python3``` is not available. Hence ```supervisor-proc-exit-listener``` is not able to startup. This PR is to address the issue.
```
root@str-msn4600c-acs-02:/# supervisorctl status
dependent-startup                EXITED    May 24 03:06 AM
restapi                          RUNNING   pid 290, uptime 0:00:15
rsyslogd                         RUNNING   pid 73, uptime 0:09:58
start                            EXITED    May 24 03:06 AM
supervisor-proc-exit-listener    FATAL     Exited too quickly (process log may have details)
```
Signed-off-by: bingwang <bingwang@microsoft.com>

#### How I did it
Specific ```python2``` environment.

#### How to verify it
Verified by checking the status of ```supervisor-proc-exit-listener```
```
root@str-msn4600c-acs-02:/# supervisorctl status
dependent-startup                EXITED    May 24 03:38 AM
restapi                          RUNNING   pid 19, uptime 0:15:01
rsyslogd                         RUNNING   pid 13, uptime 0:15:04
start                            EXITED    May 24 03:38 AM
supervisor-proc-exit-listener    RUNNING   pid 8, uptime 0:15:05
```
And the container will be restarted if ```restapi``` process is stopped.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix supervisor-proc-exit-listener startup issue in restapi

#### A picture of a cute animal (not mandatory but encouraged)

