### PR TITLE
[build] For SONIC_MAKE_DEBS targets, call autogen.sh if it exists in the project's root directory

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -429,6 +429,7 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_MAKE_DEBS)) : $(DEBS_PATH)/% : .platform $$(a
 		if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; popd; fi
 		# Build project and take package
 		$(SETUP_OVERLAYFS_FOR_DPKG_ADMINDIR)
+		if [ -f $($*_SRC_PATH)/autogen.sh ]; then $($*_SRC_PATH)/autogen.sh $(LOG); fi		
 		DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC}" make -j$(SONIC_CONFIG_MAKE_JOBS) DEST=$(shell pwd)/$(DEBS_PATH) -C $($*_SRC_PATH) $(shell pwd)/$(DEBS_PATH)/$* $(LOG)
 		# Clean up
 		if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && quilt pop -a -f; [ -d .pc ] && rm -rf .pc; popd; fi


### PR DESCRIPTION
#### Why I did it

Some projects require auto-generation of files to be run before they can be compiled.  This enhancement adds the ability to do that, if required.

#### How I did it

If it exists for the project, added a call to _autogen.sh_ before invoking the make command for the project.

Signed-off-by: Joe Tricklebank-Owens <joet@microsoft.com>

