### PR TITLE
[multi-asic][vs]: Add context_config.json files for multi-asic vs hwskus

### DIFF
--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_four_asic_vs/0/context_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_four_asic_vs/0/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd0",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "tcp://127.0.0.1:5555",
+            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : "0"
+                }
+            ]
+        }
+    ]
+}

--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_four_asic_vs/1/context_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_four_asic_vs/1/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd1",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "tcp://127.0.0.1:5555",
+            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : "1"
+                }
+            ]
+        }
+    ]
+}

--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_four_asic_vs/2/context_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_four_asic_vs/2/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd2",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "tcp://127.0.0.1:5555",
+            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : "2"
+                }
+            ]
+        }
+    ]
+}

--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_four_asic_vs/3/context_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_four_asic_vs/3/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd3",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "tcp://127.0.0.1:5555",
+            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : "3"
+                }
+            ]
+        }
+    ]
+}

--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/0/context_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/0/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd0",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "tcp://127.0.0.1:5555",
+            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : "0"
+                }
+            ]
+        }
+    ]
+}

--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/1/context_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/1/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd1",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "tcp://127.0.0.1:5555",
+            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : "1"
+                }
+            ]
+        }
+    ]
+}

--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/2/context_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/2/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd2",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "tcp://127.0.0.1:5555",
+            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : "2"
+                }
+            ]
+        }
+    ]
+}

--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/3/context_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/3/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd3",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "tcp://127.0.0.1:5555",
+            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : "3"
+                }
+            ]
+        }
+    ]
+}

--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/4/context_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/4/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd4",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "tcp://127.0.0.1:5555",
+            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : "4"
+                }
+            ]
+        }
+    ]
+}

--- a/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/5/context_config.json
+++ b/device/virtual/x86_64-kvm_x86_64-r0/msft_multi_asic_vs/5/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd5",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": false,
+            "zmq_endpoint": "tcp://127.0.0.1:5555",
+            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : "5"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For multi-asic platforms, orchagent process in swss docker is started by passing device_ids(or asic_ids). 
Each swss docker starts orchagent with a different device_id. This device_id is passed as Hardware info to syncd. For syncd to start with the right hwinfo, context_config.json is passed as an argument. context_config.json file is looked up to get the hwinfo information. 
sonic-sairedis PRs required for this diff to be used to bring up multi-asic VS:
https://github.com/Azure/sonic-sairedis/pull/830
https://github.com/Azure/sonic-sairedis/pull/832
#### How I did it
Add context_config.json for each asic in the same structure as provided here: https://github.com/Azure/sonic-sairedis/blob/master/lib/src/context_config.json
Each asic context_config.json will have different hwinfo string. 
hwinfo string will be same as device id retrieved from asic.conf file. 

#### How to verify it
With the sonic-sairedis changes mentioned above, bring up multi-asic vs image:
./testbed-cli.sh -t vtestbed.csv -m veos_vtb -k ceos add-topo vms-kvm-four-asic-t1-lag password.txt
./testbed-cli.sh -t vtestbed.csv -m veos_vtb deploy-mg vms-kvm-four-asic-t1-lag lab password.txt 
Ensure that interfaces and BGP sessions are coming up:
```
admin@vlab-08:~$ show interfaces status -d all
      Interface        Lanes    Speed    MTU    FEC        Alias             Vlan    Oper    Admin    Type    Asym PFC
---------------  -----------  -------  -----  -----  -----------  ---------------  ------  -------  ------  ----------
      Ethernet0      1,2,3,4      40G   9100    N/A  Ethernet1/1  PortChannel0002      up       up     N/A         off
      Ethernet4      5,6,7,8      40G   9100    N/A  Ethernet1/2  PortChannel0002      up       up     N/A         off
      Ethernet8   9,10,11,12      40G   9100    N/A  Ethernet1/3  PortChannel0005      up       up     N/A         off
     Ethernet12  13,14,15,16      40G   9100    N/A  Ethernet1/4  PortChannel0005      up       up     N/A         off
     Ethernet16      1,2,3,4      40G   9100    N/A  Ethernet1/5  PortChannel0001      up       up     N/A         off
     Ethernet20      5,6,7,8      40G   9100    N/A  Ethernet1/6  PortChannel0003      up       up     N/A         off
     Ethernet24   9,10,11,12      40G   9100    N/A  Ethernet1/7  PortChannel0004      up       up     N/A         off
     Ethernet28  13,14,15,16      40G   9100    N/A  Ethernet1/8  PortChannel0006      up       up     N/A         off
   Ethernet-BP0  17,18,19,20      40G   9100    N/A   Eth4-ASIC0  PortChannel4020      up       up     N/A         off
   Ethernet-BP4  21,22,23,24      40G   9100    N/A   Eth5-ASIC0  PortChannel4020      up       up     N/A         off
   Ethernet-BP8  25,26,27,28      40G   9100    N/A   Eth6-ASIC0  PortChannel4030      up       up     N/A         off
  Ethernet-BP12  29,30,31,32      40G   9100    N/A   Eth7-ASIC0  PortChannel4030      up       up     N/A         off
  Ethernet-BP16  17,18,19,20      40G   9100    N/A   Eth4-ASIC1  PortChannel4021      up       up     N/A         off
  Ethernet-BP20  21,22,23,24      40G   9100    N/A   Eth5-ASIC1  PortChannel4021      up       up     N/A         off
  Ethernet-BP24  25,26,27,28      40G   9100    N/A   Eth6-ASIC1  PortChannel4031      up       up     N/A         off
  Ethernet-BP28  29,30,31,32      40G   9100    N/A   Eth7-ASIC1  PortChannel4031      up       up     N/A         off
  Ethernet-BP32      1,2,3,4      40G   9100    N/A   Eth0-ASIC2  PortChannel4002      up       up     N/A         off
  Ethernet-BP36      5,6,7,8      40G   9100    N/A   Eth1-ASIC2  PortChannel4002      up       up     N/A         off
  Ethernet-BP40   9,10,11,12      40G   9100    N/A   Eth2-ASIC2  PortChannel4012      up       up     N/A         off
  Ethernet-BP44  13,14,15,16      40G   9100    N/A   Eth3-ASIC2  PortChannel4012      up       up     N/A         off
  Ethernet-BP48  17,18,19,20      N/A   9100    N/A   Eth4-ASIC2           routed    down     down     N/A         off
  Ethernet-BP52  21,22,23,24      N/A   9100    N/A   Eth5-ASIC2           routed    down     down     N/A         off
  Ethernet-BP56  25,26,27,28      N/A   9100    N/A   Eth6-ASIC2           routed    down     down     N/A         off
  Ethernet-BP60  29,30,31,32      N/A   9100    N/A   Eth7-ASIC2           routed    down     down     N/A         off
  Ethernet-BP64      1,2,3,4      40G   9100    N/A   Eth0-ASIC3  PortChannel4003      up       up     N/A         off
  Ethernet-BP68      5,6,7,8      40G   9100    N/A   Eth1-ASIC3  PortChannel4003      up       up     N/A         off
  Ethernet-BP72   9,10,11,12      40G   9100    N/A   Eth2-ASIC3  PortChannel4013      up       up     N/A         off
  Ethernet-BP76  13,14,15,16      40G   9100    N/A   Eth3-ASIC3  PortChannel4013      up       up     N/A         off
  Ethernet-BP80  17,18,19,20      N/A   9100    N/A   Eth4-ASIC3           routed    down     down     N/A         off
  Ethernet-BP84  21,22,23,24      N/A   9100    N/A   Eth5-ASIC3           routed    down     down     N/A         off
  Ethernet-BP92  25,26,27,28      N/A   9100    N/A   Eth6-ASIC3           routed    down     down     N/A         off
  Ethernet-BP96  29,30,31,32      N/A   9100    N/A   Eth7-ASIC3           routed    down     down     N/A         off
PortChannel0001          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0002          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0003          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0004          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0005          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel0006          N/A      40G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4002          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4003          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4012          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4013          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4020          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4021          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4030          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A
PortChannel4031          N/A      80G   9100    N/A          N/A           routed      up       up     N/A         N/A

admin@vlab-08:~$ show ip bgp summary -d all

IPv4 Unicast Summary:
asic0: BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 6402
asic1: BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 9062
asic2: BGP router identifier 8.0.0.2, local AS number 65100 vrf-id 0
BGP table version 6398
asic3: BGP router identifier 8.0.0.3, local AS number 65100 vrf-id 0
BGP table version 6398
RIB entries 51176, using 9825792 bytes of memory
Peers 14, using 305424 KiB of memory
Peer groups 12, using 768 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200       3306       3314         0      0       0  00:05:50             6370  ARISTA01T2
10.0.0.5       4  65200       3306       3312         0      0       0  00:05:50             6370  ARISTA03T2
10.0.0.33      4  64001        125       3313         0      0       0  00:05:51                3  ARISTA01T0
10.0.0.35      4  64002        125       3312         0      0       0  00:05:51                3  ARISTA02T0
10.0.0.37      4  64003        126       3313         0      0       0  00:05:51                4  ARISTA03T0
10.0.0.39      4  64004        122       3312         0      0       0  00:05:51                3  ARISTA04T0
10.1.0.0       4  65100       3321       3314         0      0       0  00:05:55             6398  ASIC2
10.1.0.1       4  65100       3314       3321         0      0       0  00:05:56             6377  ASIC0
10.1.0.2       4  65100       3323       3314         0      0       0  00:05:55             6398  ASIC3
10.1.0.3       4  65100       3315       3327         0      0       0  00:05:57             6377  ASIC0
10.1.0.4       4  65100       3321        134         0      0       0  00:05:56             6398  ASIC2
10.1.0.5       4  65100        134       3323         0      0       0  00:05:56               21  ASIC1
10.1.0.6       4  65100       3323        134         0      0       0  00:05:56             6398  ASIC3
10.1.0.7       4  65100        135       3326         0      0       0  00:05:57               21  ASIC1
```
Total number of neighbors 14
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

