### PR TITLE
[barefoot][platform] Refactor chassis.py

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
@@ -3,8 +3,8 @@
 try:
     import sys
     from sonic_platform_base.chassis_base import ChassisBase
-    from sonic_platform.sfp import Sfp
-    from sonic_platform.psu import Psu
+    from sonic_platform.sfp import Sfp, sfp_list_get
+    from sonic_platform.psu import psu_list_get
     from sonic_platform.fan_drawer import fan_drawer_list_get
     from sonic_platform.thermal import thermal_list_get
     from eeprom import Eeprom
@@ -18,18 +18,21 @@ class Chassis(ChassisBase):
     def __init__(self):
         ChassisBase.__init__(self)
 
-        self._eeprom = Eeprom()
-
-        for index in range(Sfp.port_start(), Sfp.port_end() + 1):
-            sfp_node = Sfp(index)
-            self._sfp_list.append(sfp_node)
-
-        for i in range(1, Psu.get_num_psus() + 1):
-            psu = Psu(i)
-            self._psu_list.append(psu)
-
+        self.__eeprom = None
         self.__fan_drawers = None
         self.__thermals = None
+        self.__psu_list = None
+        self.__sfp_list = None
+
+    @property
+    def _eeprom(self):
+        if self.__eeprom is None:
+            self.__eeprom = Eeprom()
+        return self.__eeprom
+
+    @_eeprom.setter
+    def _eeprom(self, value):
+        pass
 
     @property
     def _fan_drawer_list(self):
@@ -49,6 +52,26 @@ class Chassis(ChassisBase):
 
     @_thermal_list.setter
     def _thermal_list(self, value):
+        pass
+
+    @property
+    def _psu_list(self):
+        if self.__psu_list is None:
+            self.__psu_list = psu_list_get()
+        return self.__psu_list
+
+    @_psu_list.setter
+    def _psu_list(self, value):
+        pass
+
+    @property
+    def _sfp_list(self):
+        if self.__sfp_list is None:
+            self.__sfp_list = sfp_list_get()
+        return self.__sfp_list
+
+    @_sfp_list.setter
+    def _sfp_list(self, value):
         pass
 
     def get_name(self):

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
@@ -104,3 +104,10 @@ class Psu(PsuBase):
 
     def is_replaceable(self):
         return True
+
+def psu_list_get():
+    psu_list = []
+    for i in range(1, Psu.get_num_psus() + 1):
+        psu = Psu(i)
+        psu_list.append(psu)
+    return psu_list

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/sfp.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/sfp.py
@@ -269,3 +269,10 @@ class Sfp(SfpBase):
 
     def get_change_event(self, timeout=0):
         return Sfp.get_transceiver_change_event(timeout)
+
+def sfp_list_get():
+    sfp_list = []
+    for index in range(Sfp.port_start(), Sfp.port_end() + 1):
+        sfp_node = Sfp(index)
+        sfp_list.append(sfp_node)
+    return sfp_list


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On our platforms syncd must be up while using the sonic_platform.
The issue is warm-reboot script first disables syncd then instantiate Chassis, which tries to connect syncd in __init__.
#### How I did it
Refactor Chassis to lazy initialize components.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

