### PR TITLE
[MCLAG] ICCP send gratuitious ARP and unsolicited NA when standby mod…

### DIFF
--- a/src/iccpd/include/iccp_netlink.h
+++ b/src/iccpd/include/iccp_netlink.h
@@ -38,6 +38,28 @@
 #define ND_OPT_TARGET_LL_ADDR 2
 #define NEXTHDR_ICMP 58
 
+/*
+ * Generic IP address - union of IPv4 and IPv6 address.
+ */
+enum ipaddr_type_t {
+	IPADDR_NONE = 0,
+	IPADDR_V4 = 1, /* IPv4 */
+	IPADDR_V6 = 2, /* IPv6 */
+};
+
+struct ipaddr
+{
+    enum ipaddr_type_t ipa_type;
+    union {
+        uint8_t addr;
+        struct in_addr _v4_addr;
+        struct in6_addr _v6_addr;
+    } ip;
+    LIST_ENTRY(ipaddr) ipaddr_next;
+#define ipaddr_v4 ip._v4_addr
+#define ipaddr_v6 ip._v6_addr
+};
+
 struct nd_msg
 {
     struct icmp6_hdr icmph;
@@ -61,7 +83,7 @@ int iccp_handle_events(struct System * sys);
 void update_if_ipmac_on_standby(struct LocalInterface* lif_po);
 int iccp_sys_local_if_list_get_addr();
 int iccp_netlink_neighbor_request(int family, uint8_t *addr, int add, uint8_t *mac, char *portname);
-int iccp_check_if_addr_from_netlink(int family, uint8_t *addr, struct LocalInterface *lif);
+int iccp_check_if_addr(int family, uint8_t *addr, struct LocalInterface *lif);
 
 #endif
 

--- a/src/iccpd/include/mlacp_link_handler.h
+++ b/src/iccpd/include/mlacp_link_handler.h
@@ -54,6 +54,8 @@ extern int mclagd_ctl_interactive_process(int client_fd);
 extern int parseMacString(const char *str_mac, uint8_t *bin_mac);
 char *show_ip_str(uint32_t ipv4_addr);
 char *show_ipv6_str(char *ipv6_addr);
+char *show_ip_in_str(struct in_addr ipv4_addr);
+char *show_ipv6_in_str(struct in6_addr ipv6_addr);
 
 void syncd_info_close();
 int iccp_connect_syncd();

--- a/src/iccpd/include/port.h
+++ b/src/iccpd/include/port.h
@@ -100,9 +100,9 @@ struct LocalInterface
     uint8_t mac_addr[ETHER_ADDR_LEN];
     uint8_t mac_addr_ori[ETHER_ADDR_LEN];
     uint8_t state;
-    uint32_t ipv4_addr;
+    /*uint32_t ipv4_addr;*/
     uint8_t prefixlen;
-    uint32_t ipv6_addr[4];
+    /*uint32_t ipv6_addr[4];*/
     uint8_t prefixlen_v6;
 
     uint8_t l3_mode;
@@ -121,6 +121,7 @@ struct LocalInterface
     uint8_t port_config_sync;
 
     LIST_HEAD(local_vlan_list, VLAN_ID) vlan_list;
+    LIST_HEAD(ipaddr_list, ipaddr) ipaddr_list;
 
     LIST_ENTRY(LocalInterface) system_next;
     LIST_ENTRY(LocalInterface) system_purge_next;
@@ -152,6 +153,7 @@ int peer_if_clean_unused_vlan(struct PeerInterface* peer_if);
 int local_if_add_vlan(struct LocalInterface* local_if, uint16_t vid);
 void local_if_del_vlan(struct LocalInterface* local_if, uint16_t vid);
 void local_if_del_all_vlan(struct LocalInterface* lif);
+void local_if_del_all_ip_address(struct LocalInterface* lif);
 
 /* ARP manipulation */
 int set_sys_arp_accept_flag(char* ifname, int flag);

--- a/src/iccpd/src/iccp_cmd_show.c
+++ b/src/iccpd/src/iccp_cmd_show.c
@@ -398,7 +398,7 @@ int iccp_local_if_dump(char * *buf,  int *num, int mclag_id)
             else if (lif_po->state == PORT_STATE_TEST)
                 memcpy(mclagd_lif.state, "Test", 4);
 
-            memcpy(mclagd_lif.ipv4_addr, show_ip_str(htonl(lif_po->ipv4_addr)), 16);
+            /*memcpy(mclagd_lif.ipv4_addr, show_ip_str(htonl(lif_po->ipv4_addr)), 16);*/
             mclagd_lif.prefixlen = lif_po->prefixlen;
 
             mclagd_lif.l3_mode = local_if_is_l3_mode(lif_po);

--- a/src/iccpd/src/iccp_consistency_check.c
+++ b/src/iccpd/src/iccp_consistency_check.c
@@ -86,8 +86,8 @@ static int iccp_check_interface_layer3_addr(char* ifname)
     if (peer_if == NULL)
         return -4;
 
-    if (peer_if->ipv4_addr != local_if->ipv4_addr)
-        return -5;
+    /*if (peer_if->ipv4_addr != local_if->ipv4_addr)
+        return -5;*/
 
     return 1;
 }

--- a/src/iccpd/src/iccp_ifm.c
+++ b/src/iccpd/src/iccp_ifm.c
@@ -691,7 +691,7 @@ void do_arp_update_from_reply_packet(unsigned int ifindex, unsigned int addr, ui
     if (!verify_arp)
         return;
 
-    if (iccp_check_if_addr_from_netlink(AF_INET, (uint8_t *)&addr, arp_lif))
+    if (iccp_check_if_addr(AF_INET, (uint8_t *)&addr, arp_lif))
     {
         ICCPD_LOG_DEBUG(__FUNCTION__, "ARP %s is identical with the ip address of interface %s",
                                       show_ip_str(arp_msg->ipv4_addr), arp_lif->name);
@@ -837,7 +837,7 @@ void do_ndisc_update_from_reply_packet(unsigned int ifindex, char *ipv6_addr, ui
     if (!verify_ndisc)
         return;
 
-    if (iccp_check_if_addr_from_netlink(AF_INET6, (uint8_t *)ndisc_msg->ipv6_addr, ndisc_lif))
+    if (iccp_check_if_addr(AF_INET6, (uint8_t *)ndisc_msg->ipv6_addr, ndisc_lif))
     {
         ICCPD_LOG_DEBUG(__FUNCTION__, "NA %s is identical with the ipv6 address of interface %s",
                                       show_ipv6_str((char *)ndisc_msg->ipv6_addr), ndisc_lif->name);

--- a/src/iccpd/src/mlacp_link_handler.c
+++ b/src/iccpd/src/mlacp_link_handler.c
@@ -73,6 +73,22 @@ char *show_ip_str(uint32_t ipv4_addr)
     return g_ipv4_str;
 }
 
+char *show_ip_in_str(struct in_addr ipv4_addr)
+{
+    memset(g_ipv4_str, 0, sizeof(g_ipv4_str));
+    inet_ntop(AF_INET, &ipv4_addr, g_ipv4_str, INET_ADDRSTRLEN);
+
+    return g_ipv4_str;
+}
+
+char *show_ipv6_in_str(struct in6_addr ipv6_addr)
+{
+    memset(g_ipv6_str, 0, sizeof(g_ipv6_str));
+    inet_ntop(AF_INET6, &ipv6_addr, g_ipv6_str, INET6_ADDRSTRLEN);
+
+    return g_ipv6_str;
+}
+
 char *show_ipv6_str(char *ipv6_addr)
 {
     memset(g_ipv6_str, 0, sizeof(g_ipv6_str));
@@ -238,6 +254,7 @@ done:
  * Port-Channel Status Handler
  *
  ****************************************/
+ #if 0
 static void set_route_by_linux_route(struct CSM* csm,
                                      struct LocalInterface *local_if,
                                      int is_add)
@@ -270,6 +287,7 @@ static void set_route_by_linux_route(struct CSM* csm,
 
     return;
 }
+#endif
 
 static void update_vlan_if_info(struct CSM *csm,
                                 struct LocalInterface *local_if,

--- a/src/iccpd/src/mlacp_sync_prepare.c
+++ b/src/iccpd/src/mlacp_sync_prepare.c
@@ -489,7 +489,7 @@ int mlacp_prepare_for_port_channel_info(struct CSM* csm, char* buf,
     tlv->icc_parameter.type = htons(TLV_T_MLACP_PORT_CHANNEL_INFO);
     tlv->icc_parameter.len = htons(sizeof(struct mLACPPortChannelInfoTLV) - sizeof(ICCParameter) + sizeof(struct mLACPVLANData) * num_of_vlan_id);
     tlv->agg_id = htons(port_channel->po_id);
-    tlv->ipv4_addr = htonl(port_channel->ipv4_addr);
+    /*tlv->ipv4_addr = htonl(port_channel->ipv4_addr);*/
     tlv->l3_mode = port_channel->l3_mode;
     tlv->po_id = htons(port_channel->po_id);
 
@@ -507,11 +507,11 @@ int mlacp_prepare_for_port_channel_info(struct CSM* csm, char* buf,
             tlv->vlanData[num_of_vlan_id].vlan_id = htons(vlan_id->vid);
 
             num_of_vlan_id++;
-            ICCPD_LOG_DEBUG(__FUNCTION__, "PortChannel%d: ipv4 addr = %s vlan id %d num %d ", port_channel->po_id, show_ip_str( tlv->ipv4_addr), vlan_id->vid, num_of_vlan_id );
+            /*ICCPD_LOG_DEBUG(__FUNCTION__, "PortChannel%d: ipv4 addr = %s vlan id %d num %d ", port_channel->po_id, show_ip_str(tlv->ipv4_addr), vlan_id->vid, num_of_vlan_id );*/
         }
     }
 
-    ICCPD_LOG_DEBUG(__FUNCTION__, "PortChannel%d: ipv4 addr = %s  l3 mode %d", port_channel->po_id, show_ip_str( tlv->ipv4_addr),  tlv->l3_mode);
+    /*ICCPD_LOG_DEBUG(__FUNCTION__, "PortChannel%d: ipv4 addr = %s l3 mode %d", port_channel->po_id, show_ip_str( tlv->ipv4_addr),  tlv->l3_mode);*/
 
     return msg_len;
 }

--- a/src/iccpd/src/mlacp_sync_update.c
+++ b/src/iccpd/src/mlacp_sync_update.c
@@ -874,7 +874,7 @@ int mlacp_fsm_update_port_channel_info(struct CSM* csm,
         }
 
         /* Record peer info*/
-        peer_if->ipv4_addr = ntohl(tlv->ipv4_addr);
+        /*peer_if->ipv4_addr = ntohl(tlv->ipv4_addr);*/
         peer_if->l3_mode = tlv->l3_mode;
 
         for (i = 0; i < ntohs(tlv->num_of_vlan_id); i++)
@@ -886,7 +886,7 @@ int mlacp_fsm_update_port_channel_info(struct CSM* csm,
 
         iccp_consistency_check(peer_if->name);
 
-        ICCPD_LOG_DEBUG(__FUNCTION__, "Peer intf %s info: ipv4 addr %s l3 mode %d", peer_if->name, show_ip_str( tlv->ipv4_addr), peer_if->l3_mode);
+        /*ICCPD_LOG_DEBUG(__FUNCTION__, "Peer intf %s info: ipv4 addr %s l3 mode %d", peer_if->name, show_ip_str(tlv->ipv4_addr), peer_if->l3_mode);*/
         break;
     }
 


### PR DESCRIPTION
…ifies systemid

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Signed-off-by: dongjianjun@inspur.com

#### Why I did it
1. In the original implementation, in strcuct LocalInterface{}, unit32_t ipv4_ addr is used to record IP address, unit32_ t ipv6_ addr[4] to record IPv6 address, and only one IPv4 and IPv6 address can be recorded; When the IP address changes, such as add or remove, it may lead to the error of judging whether the interface is L3 interface.
2. In L3 scenario, if the master fails, standby switches the system ID back to the original MAC; At this time, if the switch is a gateway, the hosts connected below cannot update the gateway address in time, which will cause traffic interruption.

#### How I did it
1. The list is used to record IP addresses, including IPv4 address and IPv6 address, but excluding IPv6 linklocal address; When the list is not empty, the interface is L3, otherwise it is L2.
2. In L3 scenario, if the master fails, standby switches the system ID back to the original MAC; At this time, standby will traverse the IP address list and send gratutious ARP or unsolicited NA to the connected hosts to update the gateway address.

#### How to verify it
Test on the switch.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

