### PR TITLE
[as7726-32x] Fix module_reset sysfs

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/modules/accton_as7726_32x_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/modules/accton_as7726_32x_cpld.c
@@ -498,6 +498,10 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
     if (attr->index >= MODULE_PRESENT_1 && attr->index <= MODULE_PRESENT_34) {
         revert = 1;
     }
+    if (attr->index >= MODULE_RESET_1 && attr->index <= MODULE_RESET_32) {
+        revert = 1;
+    }
+    
 
     mutex_lock(&data->update_lock);
 	status = as7726_32x_cpld_read_internal(client, reg);


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix modules_reset sysfs due to need to do revert.
#### How I did it
Add to do revert when read modules_reset sysfs
#### How to verify it
#cat module_reset_1
1
#echo 1 > module_reset_1
 #cat module_reset_1
1
#echo 0 > module_reset_1
#cat module_reset_1
0

# cat module_reset_31
0

# echo 1 > module_reset_31
# cat module_reset_31
1
# echo 0 > module_reset_31
# cat module_reset_31
0
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

