### PR TITLE
[platform][barefoot] Add Psu.get_name

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/psu.py
@@ -41,6 +41,9 @@ class Psu(PsuBase):
         """
         return 2
 
+    def get_name(self):
+        return f"psu-{self.__index}"
+
     def get_powergood_status(self):
         """
         Retrieves the oprational status of power supply unit (PSU) defined


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix the following:
```
# psuutil status
Traceback (most recent call last):
  File "/usr/local/bin/psuutil", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/psuutil/main.py", line 93, in status
    psu_name = psu.get_name()
  File "/usr/local/lib/python3.7/dist-packages/sonic_platform_base/device_base.py", line 28, in get_name
    raise NotImplementedError
NotImplementedError
```
#### How I did it
Implemented get_name

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Implemented Psu.get_name in barefoot sonic_platform
-->


#### A picture of a cute animal (not mandatory but encouraged)

