### PR TITLE
[MMU] define T1 MMU configuratino for Arista-7260CX3-Q64

### DIFF
--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers.json.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers.json.j2
@@ -1,3 +1,3 @@
-{%- set default_topo = 't0' %}
+{%- set default_topo = 't1' %}
 {%- include 'buffers_config.j2' %}
 

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t1.j2
@@ -1,0 +1,46 @@
+{%- set default_cable = '300m' %}
+
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(0,64) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx * 4)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "33329088",
+            "type": "ingress",
+            "mode": "dynamic",
+            "xoff": "7827456"
+        },
+        "egress_lossy_pool": {
+            "size": "26663272",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "42349632",
+            "type": "egress",
+            "mode": "static"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "static_th":"44302336"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "static_th":"42349632"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"1664",
+            "dynamic_th":"-1"
+        }
+    },
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
@@ -1,11 +1,20 @@
 {# Construct config.bcm to include additional soc properties per specific device metadata requirement #}
+{%- set mmu_sock = 'mmu_init_config="MSFT-TH2-Tier1"' -%}
 {%- set IPinIP_sock = '' -%}
-{%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['subtype'] is defined -%}
-{%-     set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
-{%-     if 'dualtor' in switch_subtype.lower() %}
-{%-         set IPinIP_sock = 'sai_tunnel_support=1
-                               host_as_route_disable=1
-                               l3_ecmp_levels=2' -%}
+{%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined -%}
+{%-     if DEVICE_METADATA['localhost']['type'] is defined -%}
+{%-         set switch_role = DEVICE_METADATA['localhost']['type'] -%}
+{%-         if 'torrouter' in switch_role.lower() or 'torswitch' in switch_role.lower() %}
+{%-             set mmu_sock = 'mmu_init_config="MSFT-TH2-Tier0"' -%}
+{%-         endif %}
+{%-     endif %}
+{%-     if DEVICE_METADATA['localhost']['subtype'] is defined -%}
+{%-         set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
+{%-         if 'dualtor' in switch_subtype.lower() %}
+{%-             set IPinIP_sock = 'sai_tunnel_support=1
+                                   host_as_route_disable=1
+                                   l3_ecmp_levels=2' -%}
+{%-         endif %}
 {%-     endif %}
 {%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-64x40G.config.bcm" #}
@@ -1023,5 +1032,5 @@ serdes_preemphasis_115=0x61c01
 serdes_preemphasis_116=0x105004
 serdes_preemphasis_117=0x105004
 
-mmu_init_config="MSFT-TH2-Tier0"
+{{ mmu_sock }}
 {{ IPinIP_sock }}


### PR DESCRIPTION
#### Why I did it
Arista-7260CX3-Q64 is missing T1 MMU configuration.

#### How I did it
Define T1 MMU configuration for Arista-7260CX3-Q64.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [x]  201911
- [ ] 202006
- [x] 202012

