### PR TITLE
[.gitignore] Do not blanket-ignore all  `debian` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ src/**/*.o
 platform/**/*.egg-info
 platform/**/*-none-any.whl
 platform/**/.pybuild
-platform/**/debian/*
 platform/**/build
 platform/**/*.ko
 platform/**/*.mod.c


### PR DESCRIPTION
#### Why I did it

Having a blanket statement to ignore all files under `platform/**/debian/` can pose issues when a vendor adds a new platform, as any new files under a `debian/` directory will not show up in a Git changelist, therefore they can be missed in the commit.

Resolves https://github.com/Azure/sonic-buildimage/issues/7683

#### How I did it

Remove the blanket ignore statement from .gitignore. Platform vendors should be responsible for providing one or more .gitignore files to properly ignore generated files in their platform directories.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
