### PR TITLE
[MCLAG] Fix iccpd crash bug

### DIFF
--- a/src/iccpd/src/iccp_csm.c
+++ b/src/iccpd/src/iccp_csm.c
@@ -140,10 +140,14 @@ void iccp_csm_status_reset(struct CSM* csm, int all)
     csm->heartbeat_send_time = 0;
     csm->heartbeat_update_time = 0;
     csm->peer_warm_reboot_time = 0;
-    csm->warm_reboot_disconn_time = 0;
+    /*csm->warm_reboot_disconn_time = 0;*/
     csm->role_type = STP_ROLE_NONE;
     csm->sock_read_event_ptr = NULL;
-    csm->peer_link_if = NULL;
+    if (csm->peer_link_if)
+    {
+        csm->peer_link_if->is_peer_link = 0;
+        csm->peer_link_if = NULL;
+    }
     csm->u_msg_in_count = 0x0;
     csm->i_msg_in_count = 0x0;
     csm->icc_msg_in_count = 0x0;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. If the peer warm reboot, 'time(&csm->warm_reboot_disconn_time)' is used in function 'mlacp_peer_disconn_handler()' to record the time when the peer enters the warm reboot state; If the neighbor relationship has not been reestablished after 90s, the local switch will migrate from warm reboot disconnected to normal disconnected. However, the 'iccp_csm_status_reset()' function is called immediately after the 'mlacp_peer_disconn_handler()' function, in which 'csm->warm_reboot_disconn_time' will be set to 0. As a result, the local switch cannot migrate to normal disconnected after the 90s timeout.
2. If 'csm->peer_link_if' is set to NULL, 'csm->peer_link_if->is_peer_link' also needs to be set to 0 at the same time; Otherwise, it will lead to the judgment 'if (local_if->is_peer_link)' error, and then use 'csm->peer_link_if' incorrectly, which will lead to iccpd crash.

#### How I did it
1. In the function 'iccp_csm_status_reset()', 'csm->warm_reboot_disconn_time' is not set to 0.
2. If 'csm->peer_link_if' is set to NULL, 'csm->peer_link_if->is_peer_link' also be set to 0 at the same time.

#### How to verify it
Test on the switch.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

