### PR TITLE
[enable_counters] Set default values only on the first start

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -11,10 +11,12 @@ DEFAULT_ALPHA = '0.18'
 
 
 def enable_counter_group(db, name):
-    info = {}
-    info['FLEX_COUNTER_STATUS'] = 'enable'
-    db.mod_entry("FLEX_COUNTER_TABLE", name, info)
+    entry_info = db.get_entry("FLEX_COUNTER_TABLE", name)
 
+    if not entry_info:
+        info = {}
+        info['FLEX_COUNTER_STATUS'] = 'enable'
+        db.mod_entry("FLEX_COUNTER_TABLE", name, info)
 
 def enable_rates():
     # set the default interval for rates


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
after "config reload" or "docker swss restart" all counterpoll counters were enabled even if they were disabled before

#### How I did it
check if entry already exist before set default values

#### How to verify it
disable few counters

```
counterpoll pg-drop disable
counterpoll port disable
```
Save and reload
```
config save
config reload
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

