### PR TITLE
Fix lldpmgrd syntax issue

### DIFF
--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -73,9 +73,9 @@ class LldpManager(daemon_base.DaemonBase):
 
         proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = proc.communicate()
-        
+
         if proc.returncode != 0:
-            log_warning("Command failed '{}': {}".format(cmd, stderr))
+            self.log_warning("Command failed '{}': {}".format(cmd, stderr))
         else:
             self.hostname = hostname
 
@@ -91,15 +91,15 @@ class LldpManager(daemon_base.DaemonBase):
 
         proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = proc.communicate()
-        
+
         if proc.returncode != 0:
-            log_warning("Command failed '{}': {}".format(cmd, stderr))
+            self.log_warning("Command failed '{}': {}".format(cmd, stderr))
         else:
             self.mgmt_ip = ip
 
     def is_port_up(self, port_name):
         """
-        Determine if a port is up or down by looking into the oper-status for the port in 
+        Determine if a port is up or down by looking into the oper-status for the port in
         PORT TABLE in the Application DB
         """
         # Retrieve all entires for this port from the Port table
@@ -117,7 +117,7 @@ class LldpManager(daemon_base.DaemonBase):
                 return False
         else:
             # Retrieve PortInitDone entry from the Port table
-            (init_status, init_fvp) = port_table.get("PortInitDone")
+            (init_status, init_fvp) = self.port_table.get("PortInitDone")
             # The initialization procedure is done, but don't have this port entry
             if init_status:
                 self.log_error("Port '{}' not found in {} table in App DB".format(
@@ -192,7 +192,7 @@ class LldpManager(daemon_base.DaemonBase):
             self.pending_cmds.pop(port_name, None)
 
     def lldp_get_mgmt_ip(self):
-        mgmt_intf_keys = self.mgmt_table.getKeys()        
+        mgmt_intf_keys = self.mgmt_table.getKeys()
         ipv4_addr = "None"
         ipv6_addr = "None"
         for key in mgmt_intf_keys:
@@ -205,7 +205,7 @@ class LldpManager(daemon_base.DaemonBase):
                             ipv4_addr = ip[0]
                         else:
                             ipv6_addr = ip[0]
-        
+
         if ipv4_addr != "None":
             return ipv4_addr
         elif ipv6_addr != "None":
@@ -228,7 +228,7 @@ class LldpManager(daemon_base.DaemonBase):
                 else:
                     if not self.mgmt_ip == ip[0]:
                         if '.' in ip[0]:
-                            self.update_mgmt_addr(ip[0]) 
+                            self.update_mgmt_addr(ip[0])
                         elif '.' not in self.mgmt_ip:
                             self.update_mgmt_addr(ip[0])
 
@@ -275,11 +275,11 @@ class LldpManager(daemon_base.DaemonBase):
         # Subscribe to PORT table notifications in the App DB
         sst_appdb = swsscommon.SubscriberStateTable(self.appl_db, swsscommon.APP_PORT_TABLE_NAME)
         sel.addSelectable(sst_appdb)
-        
+
         # Subscribe to MGMT PORT table notifications in the Config DB
         sst_mgmt_ip_confdb = swsscommon.SubscriberStateTable(self.config_db, swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME)
         sel.addSelectable(sst_mgmt_ip_confdb)
-        
+
         # Subscribe to DEVICE_METADATA table notifications in the Config DB
         sst_device_confdb = swsscommon.SubscriberStateTable(self.config_db, swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)
         sel.addSelectable(sst_device_confdb)


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is to fix #7740 
```lldpmgrd``` crashed during test with following errors
```
syslog.54.gz:May 27 11:49:47.677883 str2-msn4600c-acs-01 INFO lldp#lldpmgrd[36]: Starting up...
syslog.54.gz:May 27 11:49:47.741594 str2-msn4600c-acs-01 INFO lldp#/supervisord: lldpmgrd Traceback (most recent call last):
syslog.54.gz:May 27 11:49:47.741594 str2-msn4600c-acs-01 INFO lldp#/supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 364, in <module>
syslog.54.gz:May 27 11:49:47.741594 str2-msn4600c-acs-01 INFO lldp#/supervisord: lldpmgrd     main()
syslog.54.gz:May 27 11:49:47.741594 str2-msn4600c-acs-01 INFO lldp#/supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 347, in main
syslog.54.gz:May 27 11:49:47.741594 str2-msn4600c-acs-01 INFO lldp#/supervisord: lldpmgrd     lldpmgr.run()
syslog.54.gz:May 27 11:49:47.741594 str2-msn4600c-acs-01 INFO lldp#/supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 292, in run
syslog.54.gz:May 27 11:49:47.741594 str2-msn4600c-acs-01 INFO lldp#/supervisord: lldpmgrd     if self.is_port_up(key):
syslog.54.gz:May 27 11:49:47.741594 str2-msn4600c-acs-01 INFO lldp#/supervisord: lldpmgrd   File "/usr/bin/lldpmgrd", line 119, in is_port_up
syslog.54.gz:May 27 11:49:47.741594 str2-msn4600c-acs-01 INFO lldp#/supervisord: lldpmgrd     (init_status, init_fvp) = port_table.get("PortInitDone")
syslog.54.gz:May 27 11:49:47.741594 str2-msn4600c-acs-01 INFO lldp#/supervisord: lldpmgrd NameError: name 'port_table' is not defined
```
While fixing this issue, I notices that there are two similar issues when calling ```log_warning```. Also fixed.

#### How I did it
Fix syntax error.

#### How to verify it
Verified on SN4600. No crash is observerd after the fix.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix lldpmgrd syntax error.

#### A picture of a cute animal (not mandatory but encouraged)

