### PR TITLE
SONIC QOS YANG - Remove qos tables field value reference format

### DIFF
--- a/device/accton/x86_64-accton_as7116_54x-r0/Accton-AS7116-54X-R0/buffers_defaults_t0.j2
+++ b/device/accton/x86_64-accton_as7116_54x-r0/Accton-AS7116-54X-R0/buffers_defaults_t0.j2
@@ -39,19 +39,19 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"78400",
             "xoff":"132160",
             "size":"3584",
             "static_th":"82880"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-1"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-4"
         }

--- a/device/accton/x86_64-accton_as7116_54x-r0/Accton-AS7116-54X-R0/buffers_defaults_t1.j2
+++ b/device/accton/x86_64-accton_as7116_54x-r0/Accton-AS7116-54X-R0/buffers_defaults_t1.j2
@@ -39,19 +39,19 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"78400",
             "xoff":"132160",
             "size":"3584",
             "static_th":"82880"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-1"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-4"
         }

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32-Flex/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32-Flex/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32-Flex/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32-Flex/buffers_defaults_t1.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/buffers_defaults_t1.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/buffers_defaults_t0.j2
@@ -31,17 +31,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/buffers_defaults_t1.j2
@@ -31,17 +31,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/buffers_defaults_t1.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t0.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32599040"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1792",
             "dynamic_th":"-1"
         }

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/buffers_defaults_t1.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32599040"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1792",
             "dynamic_th":"-1"
         }

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/buffers_defaults_t0.j2
@@ -29,17 +29,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32340992"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1792",
             "dynamic_th":"-1"
         }

--- a/device/arista/x86_64-arista_7050sx3_48c8/Arista-7050SX3-48C8/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050sx3_48c8/Arista-7050SX3-48C8/buffers_defaults_t0.j2
@@ -31,17 +31,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7050sx3_48yc8/Arista-7050SX3-48YC8/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050sx3_48yc8/Arista-7050SX3-48YC8/buffers_defaults_t0.j2
@@ -31,17 +31,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/buffers_defaults_t0.j2
@@ -29,17 +29,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/buffers_defaults_t1.j2
@@ -29,17 +29,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/buffers_defaults_t0.j2
@@ -43,17 +43,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/buffers_defaults_t0.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/buffers_defaults_t0.j2
@@ -29,17 +29,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/buffers_defaults_t1.j2
@@ -29,17 +29,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S/buffers_defaults_t0.j2
@@ -29,17 +29,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t0.j2
@@ -37,22 +37,22 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         }
@@ -62,10 +62,10 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t1.j2
@@ -37,22 +37,22 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         }
@@ -62,10 +62,10 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers_defaults_t0.j2
@@ -49,22 +49,22 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         }
@@ -74,10 +74,10 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-Q59S20/buffers_defaults_t1.j2
@@ -49,22 +49,22 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         }
@@ -74,10 +74,10 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t0.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"44302336"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"42349632"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1664",
             "dynamic_th":"-1"
         }

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t1.j2
@@ -32,19 +32,19 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             {# SS Tab1 Row 9 #}
             "static_th":"44302336"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             {# SS Tab2 Row 56 #}
             "static_th":"43481152"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1664",
             "dynamic_th":"-1"
         }

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/buffers_defaults_t0.j2
@@ -36,17 +36,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"44302336"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"42349632"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1664",
             "dynamic_th":"-1"
         }

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t0.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"44302336"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"42349632"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1664",
             "dynamic_th":"-1"
         }

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t1.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"44302336"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"42349632"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1664",
             "dynamic_th":"-1"
         }

--- a/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t0.j2
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t0.j2
@@ -37,22 +37,22 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         }
@@ -62,10 +62,10 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 {%- endmacro %}

--- a/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t1.j2
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t1.j2
@@ -37,22 +37,22 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         }
@@ -62,10 +62,10 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 {%- endmacro %}

--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t0.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"4096",
             "dynamic_th":"0"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"4096",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         }
@@ -66,7 +66,7 @@
 {%- macro generate_pg_profils(port_names) %}
     "BUFFER_PG": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         }
     },
 {%- endmacro %}
@@ -74,10 +74,10 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 {%- endmacro %}

--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t1.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"4096",
             "dynamic_th":"0"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"4096",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         }
@@ -66,7 +66,7 @@
 {%- macro generate_pg_profils(port_names) %}
     "BUFFER_PG": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         }
     },
 {%- endmacro %}
@@ -74,10 +74,10 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 {%- endmacro %}

--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t0.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"4096",
             "dynamic_th":"0"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"4096",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         }
@@ -66,7 +66,7 @@
 {%- macro generate_pg_profils(port_names) %}
     "BUFFER_PG": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         }
     },
 {%- endmacro %}
@@ -74,10 +74,10 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 {%- endmacro %}

--- a/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t1.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_65x-r0/mavericks/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"4096",
             "dynamic_th":"0"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"4096",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         }
@@ -66,7 +66,7 @@
 {%- macro generate_pg_profils(port_names) %}
     "BUFFER_PG": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         }
     },
 {%- endmacro %}
@@ -74,10 +74,10 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 {%- endmacro %}

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i/buffers.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i/qos.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]",
+            "tc_to_pg_map": "AZURE",
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE",
             "pfc_enable": "4,5"
         }
     }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_128x100/buffers.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_128x100/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_128x100/qos.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_128x100/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]", 
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]", 
+            "tc_to_pg_map": "AZURE", 
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE", 
             "pfc_enable": "4,5"
         }
     }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_32x400/buffers.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_32x400/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_32x400/qos.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_32x400/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]",
+            "tc_to_pg_map": "AZURE",
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE",
             "pfc_enable": "4,5"
         }
     }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x100/buffers.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x100/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x100/qos.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x100/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]",
+            "tc_to_pg_map": "AZURE",
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE",
             "pfc_enable": "4,5"
         }
     }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x100nrz/buffers.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x100nrz/buffers.json.j2
@@ -74,48 +74,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x100nrz/qos.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x100nrz/qos.json.j2
@@ -93,9 +93,9 @@
     },
     "PORT_QOS_MAP": {
        "Ethernet180,Ethernet8,Ethernet44,Ethernet184,Ethernet188,Ethernet0,Ethernet4,Ethernet108,Ethernet248,Ethernet100,Ethernet244,Ethernet128,Ethernet104,Ethernet240,Ethernet40,Ethernet228,Ethernet96,Ethernet168,Ethernet148,Ethernet204,Ethernet120,Ethernet220,Ethernet144,Ethernet208,Ethernet160,Ethernet224,Ethernet140,Ethernet56,Ethernet164,Ethernet76,Ethernet72,Ethernet32,Ethernet16,Ethernet36,Ethernet12,Ethernet196,Ethernet28,Ethernet192,Ethernet200,Ethernet124,Ethernet24,Ethernet116,Ethernet80,Ethernet112,Ethernet84,Ethernet152,Ethernet136,Ethernet156,Ethernet92,Ethernet132,Ethernet48,Ethernet232,Ethernet172,Ethernet216,Ethernet236,Ethernet176,Ethernet212,Ethernet64,Ethernet88,Ethernet60,Ethernet52,Ethernet20,Ethernet68,Ethernet252": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]", 
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]", 
+            "tc_to_pg_map": "AZURE", 
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE", 
             "pfc_enable": "4,5"
         }
     }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x200/buffers.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x200/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x200/qos.json.j2
+++ b/device/celestica/x86_64-cel_midstone-r0/Midstone-200i_64x200/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]",
+            "tc_to_pg_map": "AZURE",
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE",
             "pfc_enable": "4,5"
         }
     }

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/buffers_defaults_t0.j2
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/buffers_defaults_t0.j2
@@ -36,17 +36,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/buffers_defaults_t1.j2
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/buffers_defaults_t1.j2
@@ -36,17 +36,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/buffers_defaults_t0.j2
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/buffers_defaults_t0.j2
@@ -51,17 +51,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/centec/x86_64-ew_es6220_x48q2h4-r0/ES6428A-X48Q2H4/qos.json
+++ b/device/centec/x86_64-ew_es6220_x48q2h4-r0/ES6428A-X48Q2H4/qos.json
@@ -83,7 +83,7 @@
     },
     "PORT_QOS_MAP": {
         "Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet49,Ethernet50,Ethernet51,Ethernet52,Ethernet53,Ethernet54": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
             "pfc_enable": "3,4"
         }
     },
@@ -111,21 +111,21 @@
     },
     "QUEUE": {
         "Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet49,Ethernet50,Ethernet51,Ethernet52,Ethernet53,Ethernet54|0-2": {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+            "scheduler"     :   "scheduler.1"
         },
         "Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet49,Ethernet50,Ethernet51,Ethernet52,Ethernet53,Ethernet54|5-7": {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
+            "scheduler"     :   "scheduler.2"
         },
         "Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet49,Ethernet50,Ethernet51,Ethernet52,Ethernet53,Ethernet54|0-2": {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
+            "wred_profile"  :   "AZURE_LOSSY"
         },
 		
 		"Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet49,Ethernet50,Ethernet51,Ethernet52,Ethernet53,Ethernet54|5-7": {
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSY]"
+            "wred_profile"  :   "AZURE_LOSSY"
         },
         "Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet49,Ethernet50,Ethernet51,Ethernet52,Ethernet53,Ethernet54|3-4": {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]",
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"     :   "scheduler.0",
+            "wred_profile"  :   "AZURE_LOSSLESS"
         }
     }
 }

--- a/device/cig/x86_64-cig_cs5435_54p-r0/Cig-CS5435-54P/buffers.json.j2
+++ b/device/cig/x86_64-cig_cs5435_54p-r0/Cig-CS5435-54P/buffers.json.j2
@@ -86,19 +86,19 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"78400",
             "xoff":"132160",
             "size":"3584",
             "static_th":"82880"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-1"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-4"
         }

--- a/device/cig/x86_64-cig_cs6436_54p-r0/Cig-CS6436-54P/buffers.json.j2
+++ b/device/cig/x86_64-cig_cs6436_54p-r0/Cig-CS6436-54P/buffers.json.j2
@@ -86,19 +86,19 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"78400",
             "xoff":"132160",
             "size":"3584",
             "static_th":"82880"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-1"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-4"
         }

--- a/device/cig/x86_64-cig_cs6436_56p-r0/Cig-CS6436-56P/buffers.json.j2
+++ b/device/cig/x86_64-cig_cs6436_56p-r0/Cig-CS6436-56P/buffers.json.j2
@@ -86,19 +86,19 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"78400",
             "xoff":"132160",
             "size":"3584",
             "static_th":"82880"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-1"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-4"
         }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q20S48/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q20S48/buffers_defaults_t0.j2
@@ -45,17 +45,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q20S48/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q20S48/buffers_defaults_t1.j2
@@ -45,17 +45,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q24S32/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q24S32/buffers_defaults_t0.j2
@@ -37,17 +37,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q24S32/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q24S32/buffers_defaults_t1.j2
@@ -37,17 +37,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q28S16/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q28S16/buffers_defaults_t0.j2
@@ -60,17 +60,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q28S16/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q28S16/buffers_defaults_t1.j2
@@ -60,17 +60,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_def.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_def.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_t1.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/buffers_defaults_t0.j2
@@ -29,17 +29,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/buffers_defaults_t1.j2
@@ -29,17 +29,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C32/buffers_defaults_t1.j2
@@ -29,17 +29,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C8D48/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dell_z9100_c2538-r0/Force10-Z9100-C8D48/buffers_defaults_t0.j2
@@ -43,17 +43,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t0.j2
@@ -16,17 +16,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t1.j2
@@ -16,17 +16,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t0.j2
@@ -16,17 +16,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t1.j2
@@ -16,17 +16,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t0.j2
@@ -16,17 +16,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t1.j2
@@ -16,17 +16,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/qos.json.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/qos.json.j2
@@ -176,50 +176,50 @@
     },
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|DEFAULT]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|DEFAULT]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|DEFAULT]"
+            "dscp_to_tc_map"  : "DEFAULT",
+            "tc_to_queue_map" : "DEFAULT",
+            "tc_to_pg_map"    : "DEFAULT"
         }
     },
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler"   : "[SCHEDULER|scheduler.0]"
+            "scheduler"   : "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]"
+            "scheduler"   : "scheduler.1"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.2]"
+            "scheduler": "scheduler.2"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler": "[SCHEDULER|scheduler.3]"
+            "scheduler": "scheduler.3"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler": "[SCHEDULER|scheduler.4]"
+            "scheduler": "scheduler.4"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.5]"
+            "scheduler": "scheduler.5"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.6]"
+            "scheduler": "scheduler.6"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|7": {
-            "scheduler": "[SCHEDULER|scheduler.7]"
+            "scheduler": "scheduler.7"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t0.j2
@@ -16,17 +16,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t1.j2
@@ -16,17 +16,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/qos.json.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/qos.json.j2
@@ -176,50 +176,50 @@
     },
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|DEFAULT]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|DEFAULT]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|DEFAULT]"
+            "dscp_to_tc_map"  : "DEFAULT",
+            "tc_to_queue_map" : "DEFAULT",
+            "tc_to_pg_map"    : "DEFAULT"
         }
     },
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler"   : "[SCHEDULER|scheduler.0]"
+            "scheduler"   : "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]"
+            "scheduler"   : "scheduler.1"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.2]"
+            "scheduler": "scheduler.2"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler": "[SCHEDULER|scheduler.3]"
+            "scheduler": "scheduler.3"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler": "[SCHEDULER|scheduler.4]"
+            "scheduler": "scheduler.4"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.5]"
+            "scheduler": "scheduler.5"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.6]"
+            "scheduler": "scheduler.6"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|7": {
-            "scheduler": "[SCHEDULER|scheduler.7]"
+            "scheduler": "scheduler.7"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t0.j2
@@ -16,17 +16,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t1.j2
@@ -16,17 +16,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/qos.json.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/qos.json.j2
@@ -176,50 +176,50 @@
     },
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|DEFAULT]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|DEFAULT]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|DEFAULT]"
+            "dscp_to_tc_map"  : "DEFAULT",
+            "tc_to_queue_map" : "DEFAULT",
+            "tc_to_pg_map"    : "DEFAULT"
         }
     },
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler"   : "[SCHEDULER|scheduler.0]"
+            "scheduler"   : "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]"
+            "scheduler"   : "scheduler.1"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.2]"
+            "scheduler": "scheduler.2"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler": "[SCHEDULER|scheduler.3]"
+            "scheduler": "scheduler.3"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler": "[SCHEDULER|scheduler.4]"
+            "scheduler": "scheduler.4"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.5]"
+            "scheduler": "scheduler.5"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.6]"
+            "scheduler": "scheduler.6"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|7": {
-            "scheduler": "[SCHEDULER|scheduler.7]"
+            "scheduler": "scheduler.7"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-10G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-10G/buffers_defaults_t0.j2
@@ -16,12 +16,12 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"32744448"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -31,7 +31,7 @@
 {%- macro generate_pg_profils(port_names_active) %}
     "BUFFER_PG": {
         "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
 {%- endmacro %}
@@ -39,7 +39,7 @@
 {% macro generate_queue_buffers(port_names_active) %}
     "BUFFER_QUEUE": {
         "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 {% endmacro %}

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-10G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-10G/buffers_defaults_t1.j2
@@ -16,12 +16,12 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"32744448"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -31,7 +31,7 @@
 {%- macro generate_pg_profils(port_names_active) %}
     "BUFFER_PG": {
         "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
 {%- endmacro %}
@@ -39,7 +39,7 @@
 {% macro generate_queue_buffers(port_names_active) %}
     "BUFFER_QUEUE": {
         "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 {% endmacro %}

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-10G/qos.json.j2
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-10G/qos.json.j2
@@ -176,50 +176,50 @@
     },
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|DEFAULT]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|DEFAULT]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|DEFAULT]"
+            "dscp_to_tc_map"  : "DEFAULT",
+            "tc_to_queue_map" : "DEFAULT",
+            "tc_to_pg_map"    : "DEFAULT"
         }
     },
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler"   : "[SCHEDULER|scheduler.0]"
+            "scheduler"   : "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]"
+            "scheduler"   : "scheduler.1"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.2]"
+            "scheduler": "scheduler.2"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler": "[SCHEDULER|scheduler.3]"
+            "scheduler": "scheduler.3"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler": "[SCHEDULER|scheduler.4]"
+            "scheduler": "scheduler.4"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.5]"
+            "scheduler": "scheduler.5"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.6]"
+            "scheduler": "scheduler.6"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|7": {
-            "scheduler": "[SCHEDULER|scheduler.7]"
+            "scheduler": "scheduler.7"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/buffers_defaults_t0.j2
@@ -16,12 +16,12 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"32744448"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -31,7 +31,7 @@
 {%- macro generate_pg_profils(port_names_active) %}
     "BUFFER_PG": {
         "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
 {%- endmacro %}
@@ -39,7 +39,7 @@
 {% macro generate_queue_buffers(port_names_active) %}
     "BUFFER_QUEUE": {
         "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 {% endmacro %}

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/buffers_defaults_t1.j2
@@ -16,12 +16,12 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"32744448"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -31,7 +31,7 @@
 {%- macro generate_pg_profils(port_names_active) %}
     "BUFFER_PG": {
         "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
 {%- endmacro %}
@@ -39,7 +39,7 @@
 {% macro generate_queue_buffers(port_names_active) %}
     "BUFFER_QUEUE": {
         "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 {% endmacro %}

--- a/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/qos.json.j2
+++ b/device/dell/x86_64-dellemc_s5248f_c3538-r0/DellEMC-S5248f-P-25G/qos.json.j2
@@ -176,50 +176,50 @@
     },
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|DEFAULT]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|DEFAULT]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|DEFAULT]"
+            "dscp_to_tc_map"  : "DEFAULT",
+            "tc_to_queue_map" : "DEFAULT",
+            "tc_to_pg_map"    : "DEFAULT"
         }
     },
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler"   : "[SCHEDULER|scheduler.0]"
+            "scheduler"   : "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]"
+            "scheduler"   : "scheduler.1"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.2]"
+            "scheduler": "scheduler.2"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler": "[SCHEDULER|scheduler.3]"
+            "scheduler": "scheduler.3"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler": "[SCHEDULER|scheduler.4]"
+            "scheduler": "scheduler.4"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.5]"
+            "scheduler": "scheduler.5"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.6]"
+            "scheduler": "scheduler.6"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|7": {
-            "scheduler": "[SCHEDULER|scheduler.7]"
+            "scheduler": "scheduler.7"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-10G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-10G/buffers_defaults_t0.j2
@@ -16,12 +16,12 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"32744448"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -31,7 +31,7 @@
 {%- macro generate_pg_profils(port_names_active) %}
     "BUFFER_PG": {
         "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
 {%- endmacro %}
@@ -39,7 +39,7 @@
 {% macro generate_queue_buffers(port_names_active) %}
     "BUFFER_QUEUE": {
         "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 {% endmacro %}

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-10G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-10G/buffers_defaults_t1.j2
@@ -16,12 +16,12 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"32744448"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -31,7 +31,7 @@
 {%- macro generate_pg_profils(port_names_active) %}
     "BUFFER_PG": {
         "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
 {%- endmacro %}
@@ -39,7 +39,7 @@
 {% macro generate_queue_buffers(port_names_active) %}
     "BUFFER_QUEUE": {
         "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 {% endmacro %}

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-10G/qos.json.j2
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-10G/qos.json.j2
@@ -176,50 +176,50 @@
     },
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|DEFAULT]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|DEFAULT]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|DEFAULT]"
+            "dscp_to_tc_map"  : "DEFAULT",
+            "tc_to_queue_map" : "DEFAULT",
+            "tc_to_pg_map"    : "DEFAULT"
         }
     },
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler"   : "[SCHEDULER|scheduler.0]"
+            "scheduler"   : "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]"
+            "scheduler"   : "scheduler.1"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.2]"
+            "scheduler": "scheduler.2"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler": "[SCHEDULER|scheduler.3]"
+            "scheduler": "scheduler.3"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler": "[SCHEDULER|scheduler.4]"
+            "scheduler": "scheduler.4"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.5]"
+            "scheduler": "scheduler.5"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.6]"
+            "scheduler": "scheduler.6"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|7": {
-            "scheduler": "[SCHEDULER|scheduler.7]"
+            "scheduler": "scheduler.7"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-25G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-25G/buffers_defaults_t0.j2
@@ -16,12 +16,12 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"32744448"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -31,7 +31,7 @@
 {%- macro generate_pg_profils(port_names_active) %}
     "BUFFER_PG": {
         "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
 {%- endmacro %}
@@ -39,7 +39,7 @@
 {% macro generate_queue_buffers(port_names_active) %}
     "BUFFER_QUEUE": {
         "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 {% endmacro %}

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-25G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-25G/buffers_defaults_t1.j2
@@ -16,12 +16,12 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"32744448"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -31,7 +31,7 @@
 {%- macro generate_pg_profils(port_names_active) %}
     "BUFFER_PG": {
         "{{ port_names_active }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
 {%- endmacro %}
@@ -39,7 +39,7 @@
 {% macro generate_queue_buffers(port_names_active) %}
     "BUFFER_QUEUE": {
         "{{ port_names_active }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 {% endmacro %}

--- a/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-25G/qos.json.j2
+++ b/device/dell/x86_64-dellemc_s5296f_c3538-r0/DellEMC-S5296f-P-25G/qos.json.j2
@@ -176,50 +176,50 @@
     },
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|DEFAULT]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|DEFAULT]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|DEFAULT]"
+            "dscp_to_tc_map"  : "DEFAULT",
+            "tc_to_queue_map" : "DEFAULT",
+            "tc_to_pg_map"    : "DEFAULT"
         }
     },
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler"   : "[SCHEDULER|scheduler.0]"
+            "scheduler"   : "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]"
+            "scheduler"   : "scheduler.1"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.2]"
+            "scheduler": "scheduler.2"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler": "[SCHEDULER|scheduler.3]"
+            "scheduler": "scheduler.3"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler": "[SCHEDULER|scheduler.4]"
+            "scheduler": "scheduler.4"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.5]"
+            "scheduler": "scheduler.5"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.6]"
+            "scheduler": "scheduler.6"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|7": {
-            "scheduler": "[SCHEDULER|scheduler.7]"
+            "scheduler": "scheduler.7"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C64/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C64/buffers_defaults_t1.j2
@@ -24,17 +24,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"43468672"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",             
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C8D112/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C8D112/buffers_defaults_t0.j2
@@ -31,17 +31,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"43468672"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/buffers_defaults_t0.j2
@@ -24,17 +24,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"43468672"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/buffers_defaults_t1.j2
@@ -24,17 +24,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"43468672"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/qos.json.j2
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/qos.json.j2
@@ -175,50 +175,50 @@
     },
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|DEFAULT]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|DEFAULT]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|DEFAULT]"
+            "dscp_to_tc_map"  : "DEFAULT",
+            "tc_to_queue_map" : "DEFAULT",
+            "tc_to_pg_map"    : "DEFAULT"
         }
     },
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler"   : "[SCHEDULER|scheduler.0]"
+            "scheduler"   : "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]"
+            "scheduler"   : "scheduler.1"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.2]"
+            "scheduler": "scheduler.2"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler": "[SCHEDULER|scheduler.3]"
+            "scheduler": "scheduler.3"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler": "[SCHEDULER|scheduler.4]"
+            "scheduler": "scheduler.4"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.5]"
+            "scheduler": "scheduler.5"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.6]"
+            "scheduler": "scheduler.6"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|7": {
-            "scheduler": "[SCHEDULER|scheduler.7]"
+            "scheduler": "scheduler.7"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/qos.json.j2.pfc.reference
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/qos.json.j2.pfc.reference
@@ -175,52 +175,52 @@
     },
     "PORT_QOS_MAP": {
         "{{ port_names_active }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|DEFAULT]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|DEFAULT]",
+            "dscp_to_tc_map"  : "DEFAULT",
+            "tc_to_queue_map" : "DEFAULT",
             "pfc_enable"      : "3,4",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|DEFAULT]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|DEFAULT]"
+            "pfc_to_queue_map": "DEFAULT",
+            "tc_to_pg_map"    : "DEFAULT"
         }
     },
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler"   : "[SCHEDULER|scheduler.0]"
+            "scheduler"   : "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]"
+            "scheduler"   : "scheduler.1"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.2]"
+            "scheduler": "scheduler.2"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler": "[SCHEDULER|scheduler.3]"
+            "scheduler": "scheduler.3"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler": "[SCHEDULER|scheduler.4]"
+            "scheduler": "scheduler.4"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.5]"
+            "scheduler": "scheduler.5"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.6]"
+            "scheduler": "scheduler.6"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|7": {
-            "scheduler": "[SCHEDULER|scheduler.7]"
+            "scheduler": "scheduler.7"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/buffers_defaults_t0.j2
@@ -39,17 +39,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"66394076"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"67117468"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1778",
             "dynamic_th":"1"
         }

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/buffers_defaults_t1.j2
@@ -39,17 +39,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"66394076"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"67117468"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1778",
             "dynamic_th":"1"
         }

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/buffers_defaults_t0.j2
@@ -23,17 +23,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"66394076"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"67117468"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1778",
             "dynamic_th":"1"
         }

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/buffers_defaults_t1.j2
@@ -23,17 +23,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"66394076"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"67117468"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1778",
             "dynamic_th":"1"
         }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if/buffers.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if/qos.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]",
+            "tc_to_pg_map": "AZURE",
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE",
             "pfc_enable": "4,5"
         }
     }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_128x100/buffers.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_128x100/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_128x100/qos.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_128x100/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]", 
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]", 
+            "tc_to_pg_map": "AZURE", 
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE", 
             "pfc_enable": "4,5"
         }
     }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x100/buffers.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x100/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x100/qos.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x100/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]",
+            "tc_to_pg_map": "AZURE",
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE",
             "pfc_enable": "4,5"
         }
     }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x200/buffers.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x200/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x200/qos.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x200/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]",
+            "tc_to_pg_map": "AZURE",
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE",
             "pfc_enable": "4,5"
         }
     }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x400/buffers.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x400/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x400/qos.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_32x400/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]",
+            "tc_to_pg_map": "AZURE",
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE",
             "pfc_enable": "4,5"
         }
     }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_64x100/buffers.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_64x100/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_64x100/qos.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_64x100/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]",
+            "tc_to_pg_map": "AZURE",
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE",
             "pfc_enable": "4,5"
         }
     }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_64x200/buffers.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_64x200/buffers.json.j2
@@ -73,48 +73,48 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xoff":"1433600",
             "size":"1518",
             "dynamic_th":"-4",
             "xon_offset":"6272"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "static_th":"9721600"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|4-5": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "{{ port_names }}|0-3": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "{{ port_names }}|6-7": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_64x200/qos.json.j2
+++ b/device/delta/x86_64-delta_et-c032if-r0/Delta-et-c032if_64x200/qos.json.j2
@@ -111,9 +111,9 @@
     },
     "PORT_QOS_MAP": {
        "{{ port_names }}": {
-            "tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP:AZURE]",
-            "tc_to_queue_map": "[TC_TO_QUEUE_MAP:AZURE]",
-            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:AZURE]",
+            "tc_to_pg_map": "AZURE",
+            "tc_to_queue_map": "AZURE",
+            "dscp_to_tc_map": "AZURE",
             "pfc_enable": "4,5"
         }
     }

--- a/device/ingrasys/x86_64-ingrasys_s9130_32x-r0/INGRASYS-S9130-32X/buffers_defaults_t0.j2
+++ b/device/ingrasys/x86_64-ingrasys_s9130_32x-r0/INGRASYS-S9130-32X/buffers_defaults_t0.j2
@@ -36,19 +36,19 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"78400",
             "xoff":"132160",
             "size":"3584",
             "static_th":"82880"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-1"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-4"
         }

--- a/device/ingrasys/x86_64-ingrasys_s9130_32x-r0/INGRASYS-S9130-32X/buffers_defaults_t1.j2
+++ b/device/ingrasys/x86_64-ingrasys_s9130_32x-r0/INGRASYS-S9130-32X/buffers_defaults_t1.j2
@@ -36,19 +36,19 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"78400",
             "xoff":"132160",
             "size":"3584",
             "static_th":"82880"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-1"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-4"
         }

--- a/device/ingrasys/x86_64-ingrasys_s9230_64x-r0/INGRASYS-S9230-64X/buffers_defaults_t0.j2
+++ b/device/ingrasys/x86_64-ingrasys_s9230_64x-r0/INGRASYS-S9230-64X/buffers_defaults_t0.j2
@@ -36,19 +36,19 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"78400",
             "xoff":"132160",
             "size":"3584",
             "static_th":"82880"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-1"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-4"
         }

--- a/device/ingrasys/x86_64-ingrasys_s9230_64x-r0/INGRASYS-S9230-64X/buffers_defaults_t1.j2
+++ b/device/ingrasys/x86_64-ingrasys_s9230_64x-r0/INGRASYS-S9230-64X/buffers_defaults_t1.j2
@@ -36,19 +36,19 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"78400",
             "xoff":"132160",
             "size":"3584",
             "static_th":"82880"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-1"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"3584",
             "dynamic_th":"-4"
         }

--- a/device/inventec/x86_64-inventec_d6332-r0/INVENTEC-D6332/buffers_defaults_t1.j2
+++ b/device/inventec/x86_64-inventec_d6332-r0/INVENTEC-D6332/buffers_defaults_t1.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"3995680"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/inventec/x86_64-inventec_d6332-r0/INVENTEC-D6332/qos.json.j2
+++ b/device/inventec/x86_64-inventec_d6332-r0/INVENTEC-D6332/qos.json.j2
@@ -125,10 +125,10 @@
     },
     "PORT_QOS_MAP": {
         "{{ PORT_ALL|join(',') }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable": "3,4"
         }
     },
@@ -148,14 +148,14 @@
     },
     "QUEUE": {
         "{{ PORT_ALL|join(',') }}|3-4" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]",
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"     :   "scheduler.0",
+            "wred_profile"  :   "AZURE_LOSSLESS"
         },
         "{{ PORT_ALL|join(',') }}|0" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+            "scheduler"     :   "scheduler.1"
         },
         "{{ PORT_ALL|join(',') }}|1" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
+            "scheduler"     :   "scheduler.2"
         }
     }
 }

--- a/device/inventec/x86_64-inventec_d6356-r0/INVENTEC-D6356/buffers_defaults_t0.j2
+++ b/device/inventec/x86_64-inventec_d6356-r0/INVENTEC-D6356/buffers_defaults_t0.j2
@@ -31,17 +31,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"3995680"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/inventec/x86_64-inventec_d6356-r0/INVENTEC-D6356/buffers_defaults_t1.j2
+++ b/device/inventec/x86_64-inventec_d6356-r0/INVENTEC-D6356/buffers_defaults_t1.j2
@@ -31,17 +31,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"3995680"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/inventec/x86_64-inventec_d6356-r0/INVENTEC-D6356/qos.json.j2
+++ b/device/inventec/x86_64-inventec_d6356-r0/INVENTEC-D6356/qos.json.j2
@@ -119,10 +119,10 @@
     },
     "PORT_QOS_MAP": {
         "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable": "3,4"
         }
     },
@@ -142,14 +142,14 @@
     },
     "QUEUE": {
         "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76|3-4" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]",
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"     :   "scheduler.0",
+            "wred_profile"  :   "AZURE_LOSSLESS"
         },
         "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76|0" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+            "scheduler"     :   "scheduler.1"
         },
         "Ethernet0,Ethernet1,Ethernet2,Ethernet3,Ethernet4,Ethernet5,Ethernet6,Ethernet7,Ethernet8,Ethernet9,Ethernet10,Ethernet11,Ethernet12,Ethernet13,Ethernet14,Ethernet15,Ethernet16,Ethernet17,Ethernet18,Ethernet19,Ethernet20,Ethernet21,Ethernet22,Ethernet23,Ethernet24,Ethernet25,Ethernet26,Ethernet27,Ethernet28,Ethernet29,Ethernet30,Ethernet31,Ethernet32,Ethernet33,Ethernet34,Ethernet35,Ethernet36,Ethernet37,Ethernet38,Ethernet39,Ethernet40,Ethernet41,Ethernet42,Ethernet43,Ethernet44,Ethernet45,Ethernet46,Ethernet47,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76|1" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
+            "scheduler"     :   "scheduler.2"
         }
     }
 }

--- a/device/inventec/x86_64-inventec_d7032q28b-r0/INVENTEC-D7032Q28B-C32/buffers.json.j2
+++ b/device/inventec/x86_64-inventec_d7032q28b-r0/INVENTEC-D7032Q28B-C32/buffers.json.j2
@@ -86,7 +86,7 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"18432",
             "xoff":"40560",
             "size":"41808",
@@ -94,35 +94,35 @@
             "xon_offset":"2496"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"6000000"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/inventec/x86_64-inventec_d7032q28b-r0/INVENTEC-D7032Q28B-C32/qos.json
+++ b/device/inventec/x86_64-inventec_d7032q28b-r0/INVENTEC-D7032Q28B-C32/qos.json
@@ -107,10 +107,10 @@
     },
     "PORT_QOS_MAP": {
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable": "3,4"
         }
     },
@@ -130,14 +130,14 @@
     },
     "QUEUE": {
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]",
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"     :   "scheduler.0",
+            "wred_profile"  :   "AZURE_LOSSLESS"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+            "scheduler"     :   "scheduler.1"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|1" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
+            "scheduler"     :   "scheduler.2"
         }
     }
 }

--- a/device/inventec/x86_64-inventec_d7054q28b-r0/INVENTEC-D7054Q28B-S48-Q6/buffers.json.j2
+++ b/device/inventec/x86_64-inventec_d7054q28b-r0/INVENTEC-D7054Q28B-S48-Q6/buffers.json.j2
@@ -86,7 +86,7 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "xon":"18432",
             "xoff":"40560",
             "size":"41808",
@@ -94,35 +94,35 @@
             "xon_offset":"2496"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"6000000"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
     "BUFFER_QUEUE": {
         "{{ port_names }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "{{ port_names }}|0-1": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/device/inventec/x86_64-inventec_d7054q28b-r0/INVENTEC-D7054Q28B-S48-Q6/qos.json
+++ b/device/inventec/x86_64-inventec_d7054q28b-r0/INVENTEC-D7054Q28B-S48-Q6/qos.json
@@ -107,10 +107,10 @@
     },
     "PORT_QOS_MAP": {
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124,Ethernet128,Ethernet132,Ethernet136,Ethernet140,Ethernet144,Ethernet148,Ethernet152,Ethernet156,Ethernet160,Ethernet164,Ethernet168,Ethernet172,Ethernet176,Ethernet180,Ethernet184,Ethernet188,Ethernet192,Ethernet196,Ethernet200,Ethernet204,Ethernet208,Ethernet212": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable": "3,4"
         }
     },
@@ -130,14 +130,14 @@
     },
     "QUEUE": {
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124,Ethernet128,Ethernet132,Ethernet136,Ethernet140,Ethernet144,Ethernet148,Ethernet152,Ethernet156,Ethernet160,Ethernet164,Ethernet168,Ethernet172,Ethernet176,Ethernet180,Ethernet184,Ethernet188,Ethernet192,Ethernet196,Ethernet200,Ethernet204,Ethernet208,Ethernet212|3-4" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.0]",
-            "wred_profile"  :   "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"     :   "scheduler.0",
+            "wred_profile"  :   "AZURE_LOSSLESS"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124,Ethernet128,Ethernet132,Ethernet136,Ethernet140,Ethernet144,Ethernet148,Ethernet152,Ethernet156,Ethernet160,Ethernet164,Ethernet168,Ethernet172,Ethernet176,Ethernet180,Ethernet184,Ethernet188,Ethernet192,Ethernet196,Ethernet200,Ethernet204,Ethernet208,Ethernet212|0" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.1]"
+            "scheduler"     :   "scheduler.1"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124,Ethernet128,Ethernet132,Ethernet136,Ethernet140,Ethernet144,Ethernet148,Ethernet152,Ethernet156,Ethernet160,Ethernet164,Ethernet168,Ethernet172,Ethernet176,Ethernet180,Ethernet184,Ethernet188,Ethernet192,Ethernet196,Ethernet200,Ethernet204,Ethernet208,Ethernet212|1" : {
-            "scheduler"     :   "[SCHEDULER|scheduler.2]"
+            "scheduler"     :   "scheduler.2"
         }
     }
 }

--- a/device/juniper/x86_64-juniper_qfx5200-r0/Juniper-QFX5200-32C-S/buffers_defaults_t1.j2
+++ b/device/juniper/x86_64-juniper_qfx5200-r0/Juniper-QFX5200-32C-S/buffers_defaults_t1.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"44302336"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"42349632"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1664",
             "dynamic_th":"-1"
         }

--- a/device/juniper/x86_64-juniper_qfx5210-r0/Juniper-QFX5210-64C/buffers_defaults_t1.j2
+++ b/device/juniper/x86_64-juniper_qfx5210-r0/Juniper-QFX5210-64C/buffers_defaults_t1.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"44302336"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"42349632"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1664",
             "dynamic_th":"-1"
         }

--- a/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON16X25G/buffers_defaults_t0.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON16X25G/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON16X25G/buffers_defaults_t1.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON16X25G/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON16x400G/buffers_defaults_t0.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON16x400G/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON16x400G/buffers_defaults_t1.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON16x400G/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON32X25G/buffers_defaults_t0.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON32X25G/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"170000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON32X25G/buffers_defaults_t1.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_16cd-r0/FALCON32X25G/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"170000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_config.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_config.j2
@@ -133,7 +133,7 @@ def
     "BUFFER_PG": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -146,17 +146,17 @@ def
     "BUFFER_QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/marvell/arm64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_defaults_t0.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_defaults_t1.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_32cd-r0/FALCON32X25G/buffers_defaults_t0.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_32cd-r0/FALCON32X25G/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_32cd-r0/FALCON32X25G/buffers_defaults_t1.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_32cd-r0/FALCON32X25G/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_32cd-r0/FALCON32x400G/buffers_defaults_t0.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_32cd-r0/FALCON32x400G/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_32cd-r0/FALCON32x400G/buffers_defaults_t1.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_32cd-r0/FALCON32x400G/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_config.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_config.j2
@@ -133,7 +133,7 @@ def
     "BUFFER_PG": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -146,17 +146,17 @@ def
     "BUFFER_QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/marvell/arm64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_defaults_t0.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/arm64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_defaults_t1.j2
+++ b/device/marvell/arm64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/armhf-marvell_et6448m_52x-r0/et6448m/buffers_defaults_t1.j2
+++ b/device/marvell/armhf-marvell_et6448m_52x-r0/et6448m/buffers_defaults_t1.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON16X25G/buffers_defaults_t0.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON16X25G/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON16X25G/buffers_defaults_t1.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON16X25G/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON16x400G/buffers_defaults_t0.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON16x400G/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON16x400G/buffers_defaults_t1.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON16x400G/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON32X25G/buffers_defaults_t0.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON32X25G/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"170000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON32X25G/buffers_defaults_t1.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/FALCON32X25G/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"170000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_config.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_config.j2
@@ -133,7 +133,7 @@ def
     "BUFFER_PG": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -146,17 +146,17 @@ def
     "BUFFER_QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_defaults_t0.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_defaults_t1.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_16cd-r0/db98cx8580_16cd/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"330000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/FALCON32X25G/buffers_defaults_t0.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/FALCON32X25G/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/FALCON32X25G/buffers_defaults_t1.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/FALCON32X25G/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/FALCON32x400G/buffers_defaults_t0.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/FALCON32x400G/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/FALCON32x400G/buffers_defaults_t1.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/FALCON32x400G/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_config.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_config.j2
@@ -133,7 +133,7 @@ def
     "BUFFER_PG": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -146,17 +146,17 @@ def
     "BUFFER_QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_defaults_t0.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_defaults_t0.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_defaults_t1.j2
+++ b/device/marvell/x86_64-marvell_db98cx8580_32cd-r0/db98cx8580_32cd/buffers_defaults_t1.j2
@@ -16,18 +16,18 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "mode": "static",
             "size":"340000",
             "static_th":"0"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_pool]",
+            "pool":"egress_pool",
             "size":"0",
             "mode": "dynamic",
             "dynamic_th":"3"

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t0.j2
@@ -42,27 +42,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -73,7 +73,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile_list" : "ingress_lossless_profile,ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -81,7 +81,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -92,17 +92,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t1.j2
@@ -42,27 +42,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -73,7 +73,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile_list" : "ingress_lossless_profile,ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -81,7 +81,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -92,17 +92,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t0.j2
@@ -42,27 +42,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -73,7 +73,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile_list" : "ingress_lossless_profile,ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -81,7 +81,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -92,17 +92,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t1.j2
@@ -42,27 +42,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -73,7 +73,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile_list" : "ingress_lossless_profile,ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -81,7 +81,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -92,17 +92,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/buffers_defaults_t0.j2
@@ -42,27 +42,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -73,7 +73,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile_list" : "ingress_lossless_profile,ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -81,7 +81,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -92,17 +92,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/buffers_defaults_t1.j2
@@ -42,27 +42,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -73,7 +73,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile_list" : "ingress_lossless_profile,ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -81,7 +81,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -92,17 +92,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/buffers_defaults_t0.j2
@@ -32,27 +32,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -63,7 +63,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -71,7 +71,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -82,17 +82,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/buffers_defaults_t1.j2
@@ -32,27 +32,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -63,7 +63,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -71,7 +71,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -82,17 +82,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/buffers_defaults_t0.j2
@@ -32,27 +32,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -63,7 +63,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -71,7 +71,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -82,17 +82,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/buffers_defaults_t1.j2
@@ -32,27 +32,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -63,7 +63,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -71,7 +71,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -82,17 +82,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t0.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t1.j2
@@ -36,27 +36,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -67,7 +67,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "ingress_lossless_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -75,7 +75,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -86,17 +86,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/buffers_defaults_t0.j2
@@ -42,27 +42,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -73,7 +73,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile_list" : "ingress_lossless_profile,ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -81,7 +81,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -92,17 +92,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/buffers_defaults_t1.j2
@@ -42,27 +42,27 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"9216",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -73,7 +73,7 @@
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile_list" : "ingress_lossless_profile,ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -81,7 +81,7 @@
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names.split(',') %}
         "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -92,17 +92,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/buffers_defaults_t1.j2
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/buffers_defaults_t1.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix7_bwde-r0/Quanta-IX7-BWDE-32X/buffers_defaults_def.j2
+++ b/device/quanta/x86_64-quanta_ix7_bwde-r0/Quanta-IX7-BWDE-32X/buffers_defaults_def.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix7_bwde-r0/Quanta-IX7-BWDE-32X/buffers_defaults_t0.j2
+++ b/device/quanta/x86_64-quanta_ix7_bwde-r0/Quanta-IX7-BWDE-32X/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix7_bwde-r0/Quanta-IX7-BWDE-32X/buffers_defaults_t1.j2
+++ b/device/quanta/x86_64-quanta_ix7_bwde-r0/Quanta-IX7-BWDE-32X/buffers_defaults_t1.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"33004032"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix7_bwde-r0/Quanta-IX7-BWDE-32X/qos_config_t1.j2
+++ b/device/quanta/x86_64-quanta_ix7_bwde-r0/Quanta-IX7-BWDE-32X/qos_config_t1.j2
@@ -161,12 +161,12 @@
     "PORT_QOS_MAP": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
 {% if asic_type in pfc_to_pg_map_supported_asics %}
-            "pfc_to_pg_map"   : "[PFC_PRIORITY_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_pg_map"   : "AZURE",
 {% endif %}
             "pfc_enable"      : "3,4"
         }{% if not loop.last %},{% endif %}

--- a/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/buffers_defaults_def.j2
+++ b/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/buffers_defaults_def.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/buffers_defaults_t0.j2
+++ b/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/buffers_defaults_t1.j2
+++ b/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/buffers_defaults_t1.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"33004032"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/qos_config_t1.j2
+++ b/device/quanta/x86_64-quanta_ix7_rglbmc-r0/Quanta-IX7-32X/qos_config_t1.j2
@@ -161,12 +161,12 @@
     "PORT_QOS_MAP": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
 {% if asic_type in pfc_to_pg_map_supported_asics %}
-            "pfc_to_pg_map"   : "[PFC_PRIORITY_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_pg_map"   : "AZURE",
 {% endif %}
             "pfc_enable"      : "3,4"
         }{% if not loop.last %},{% endif %}

--- a/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/buffers_defaults_def.j2
+++ b/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/buffers_defaults_def.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/buffers_defaults_t0.j2
+++ b/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/buffers_defaults_t1.j2
+++ b/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/buffers_defaults_t1.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"33004032"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/qos_config_t1.j2
+++ b/device/quanta/x86_64-quanta_ix8_rglbmc-r0/Quanta-IX8-56X/qos_config_t1.j2
@@ -161,12 +161,12 @@
     "PORT_QOS_MAP": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
 {% if asic_type in pfc_to_pg_map_supported_asics %}
-            "pfc_to_pg_map"   : "[PFC_PRIORITY_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_pg_map"   : "AZURE",
 {% endif %}
             "pfc_enable"      : "3,4"
         }{% if not loop.last %},{% endif %}

--- a/device/quanta/x86_64-quanta_ix8a_bwde-r0/Quanta-IX8A-BWDE-56X/buffers_defaults_def.j2
+++ b/device/quanta/x86_64-quanta_ix8a_bwde-r0/Quanta-IX8A-BWDE-56X/buffers_defaults_def.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix8a_bwde-r0/Quanta-IX8A-BWDE-56X/buffers_defaults_t0.j2
+++ b/device/quanta/x86_64-quanta_ix8a_bwde-r0/Quanta-IX8A-BWDE-56X/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix8a_bwde-r0/Quanta-IX8A-BWDE-56X/buffers_defaults_t1.j2
+++ b/device/quanta/x86_64-quanta_ix8a_bwde-r0/Quanta-IX8A-BWDE-56X/buffers_defaults_t1.j2
@@ -28,17 +28,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"33004032"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/quanta/x86_64-quanta_ix8a_bwde-r0/Quanta-IX8A-BWDE-56X/qos_config_t1.j2
+++ b/device/quanta/x86_64-quanta_ix8a_bwde-r0/Quanta-IX8A-BWDE-56X/qos_config_t1.j2
@@ -161,12 +161,12 @@
     "PORT_QOS_MAP": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
 {% if asic_type in pfc_to_pg_map_supported_asics %}
-            "pfc_to_pg_map"   : "[PFC_PRIORITY_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_pg_map"   : "AZURE",
 {% endif %}
             "pfc_enable"      : "3,4"
         }{% if not loop.last %},{% endif %}

--- a/device/quanta/x86_64-quanta_ix9_bwde-r0/Quanta-IX9-32X/buffers_defaults_t0.j2
+++ b/device/quanta/x86_64-quanta_ix9_bwde-r0/Quanta-IX9-32X/buffers_defaults_t0.j2
@@ -22,17 +22,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"67108864"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -42,7 +42,7 @@
     "BUFFER_PG": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     },
@@ -50,7 +50,7 @@
     "BUFFER_QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/quanta/x86_64-quanta_ix9_bwde-r0/Quanta-IX9-32X/buffers_defaults_t1.j2
+++ b/device/quanta/x86_64-quanta_ix9_bwde-r0/Quanta-IX9-32X/buffers_defaults_t1.j2
@@ -22,17 +22,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"67108864"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
@@ -42,7 +42,7 @@
     "BUFFER_PG": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     },
@@ -50,7 +50,7 @@
     "BUFFER_QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/quanta/x86_64-quanta_ix9_bwde-r0/Quanta-IX9-32X/qos.json.j2
+++ b/device/quanta/x86_64-quanta_ix9_bwde-r0/Quanta-IX9-32X/qos.json.j2
@@ -177,53 +177,53 @@
     "PORT_QOS_MAP": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|DEFAULT]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|DEFAULT]",
+            "dscp_to_tc_map"  : "DEFAULT",
+            "tc_to_queue_map" : "DEFAULT",
             "pfc_enable"      : "3,4",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|DEFAULT]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|DEFAULT]"
+            "pfc_to_queue_map": "DEFAULT",
+            "tc_to_pg_map"    : "DEFAULT"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     },
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler"   : "[SCHEDULER|scheduler.0]"
+            "scheduler"   : "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]"
+            "scheduler"   : "scheduler.1"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.2]"
+            "scheduler": "scheduler.2"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler": "[SCHEDULER|scheduler.3]"
+            "scheduler": "scheduler.3"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler": "[SCHEDULER|scheduler.4]"
+            "scheduler": "scheduler.4"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.5]"
+            "scheduler": "scheduler.5"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.6]"
+            "scheduler": "scheduler.6"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|7": {
-            "scheduler": "[SCHEDULER|scheduler.7]"
+            "scheduler": "scheduler.7"
         }{% if not loop.last %},{% endif %}
 {% endfor %}
     }

--- a/device/virtual/x86_64-kvm_x86_64-r0/brcm_gearbox_vs/buffers_defaults_def.j2
+++ b/device/virtual/x86_64-kvm_x86_64-r0/brcm_gearbox_vs/buffers_defaults_def.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/virtual/x86_64-kvm_x86_64-r0/brcm_gearbox_vs/buffers_defaults_t0.j2
+++ b/device/virtual/x86_64-kvm_x86_64-r0/brcm_gearbox_vs/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/virtual/x86_64-kvm_x86_64-r0/brcm_gearbox_vs/buffers_defaults_t1.j2
+++ b/device/virtual/x86_64-kvm_x86_64-r0/brcm_gearbox_vs/buffers_defaults_t1.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/virtual/x86_64-kvm_x86_64_4_asic-r0/msft_four_asic_vs/0/buffers_defaults_def.j2
+++ b/device/virtual/x86_64-kvm_x86_64_4_asic-r0/msft_four_asic_vs/0/buffers_defaults_def.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/virtual/x86_64-kvm_x86_64_4_asic-r0/msft_four_asic_vs/0/buffers_defaults_t0.j2
+++ b/device/virtual/x86_64-kvm_x86_64_4_asic-r0/msft_four_asic_vs/0/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/virtual/x86_64-kvm_x86_64_4_asic-r0/msft_four_asic_vs/0/buffers_defaults_t1.j2
+++ b/device/virtual/x86_64-kvm_x86_64_4_asic-r0/msft_four_asic_vs/0/buffers_defaults_t1.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/virtual/x86_64-kvm_x86_64_6_asic-r0/msft_multi_asic_vs/0/buffers_defaults_def.j2
+++ b/device/virtual/x86_64-kvm_x86_64_6_asic-r0/msft_multi_asic_vs/0/buffers_defaults_def.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/virtual/x86_64-kvm_x86_64_6_asic-r0/msft_multi_asic_vs/0/buffers_defaults_t0.j2
+++ b/device/virtual/x86_64-kvm_x86_64_6_asic-r0/msft_multi_asic_vs/0/buffers_defaults_t0.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/device/virtual/x86_64-kvm_x86_64_6_asic-r0/msft_multi_asic_vs/0/buffers_defaults_t1.j2
+++ b/device/virtual/x86_64-kvm_x86_64_6_asic-r0/msft_multi_asic_vs/0/buffers_defaults_t1.j2
@@ -27,17 +27,17 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "static_th":"12766208"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -148,7 +148,7 @@ def
         },
 {% endif %}
         "{{ port }}|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
@@ -161,17 +161,17 @@ def
     "BUFFER_QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -178,15 +178,15 @@
 {% for port in PORT_ACTIVE %}
         "{{ port }}": {
 {% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] in backend_device_types and 'storage_device' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['storage_device'] == 'true' %}
-            "dot1p_to_tc_map" : "[DOT1P_TO_TC_MAP|AZURE]",
+            "dot1p_to_tc_map" : "AZURE",
 {% else %}
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
 {% endif %}
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
 {% if asic_type in pfc_to_pg_map_supported_asics %}
-            "pfc_to_pg_map"   : "[PFC_PRIORITY_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_pg_map"   : "AZURE",
 {% endif %}
             "pfc_enable"      : "3,4"
         }{% if not loop.last %},{% endif %}
@@ -217,39 +217,39 @@
     "QUEUE": {
 {% for port in PORT_ACTIVE %}
         "{{ port }}|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
 {% endfor %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}

--- a/src/sonic-config-engine/tests/sample_output/msn27.32ports.json
+++ b/src/sonic-config-engine/tests/sample_output/msn27.32ports.json
@@ -59,62 +59,62 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"0"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"4096",
             "dynamic_th":"3"
         },
         "pg_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "pool":"ingress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "q_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"0",
             "dynamic_th":"7"
         },
         "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"0",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile_list" : "ingress_lossless_profile,ingress_lossy_profile"
         }
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile_list" : "egress_lossless_profile,egress_lossy_profile"
         }
     },
     "BUFFER_PG": {
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0-1": {
-            "profile" : "[BUFFER_PROFILE|pg_lossy_profile]"
+            "profile" : "pg_lossy_profile"
         }
     },
     "BUFFER_QUEUE": {
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|3-4": {
-            "profile" : "[BUFFER_PROFILE|q_lossless_profile]"
+            "profile" : "q_lossless_profile"
         },
         "Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124|0-1": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+            "profile" : "q_lossy_profile"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
@@ -89,552 +89,552 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "Ethernet8|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet9|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet0|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet1|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet6|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet7|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet4|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet5|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet58|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet52|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet53|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet54|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet55|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet56|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet57|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet38|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet39|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet32|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet15|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet16|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet17|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet36|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet37|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet12|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet13|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet14|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet30|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet31|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet48|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet10|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet42|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet41|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet40|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet29|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet28|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet11|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet21|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet20|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet23|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet22|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet25|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet24|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet27|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet26|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
 
     "BUFFER_QUEUE": {
         "Ethernet8|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet9|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet0|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet1|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet6|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet7|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet4|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet5|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet58|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet52|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet53|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet54|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet55|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet56|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet57|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet38|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet39|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet32|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet15|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet16|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet17|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet36|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet37|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet12|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet13|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet14|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet30|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet31|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet48|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet10|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet42|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet41|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet40|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet29|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet28|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet11|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet21|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet20|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet23|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet22|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet25|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet24|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet27|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet26|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet8|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet9|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet0|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet1|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet6|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet7|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet4|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet5|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet58|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet52|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet53|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet54|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet55|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet56|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet57|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet38|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet39|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet32|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet15|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet16|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet17|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet36|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet37|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet12|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet13|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet14|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet30|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet31|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet48|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet10|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet42|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet41|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet40|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet29|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet28|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet11|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet21|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet20|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet23|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet22|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet25|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet24|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet27|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet26|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet8|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet9|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet0|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet1|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet6|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet7|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet4|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet5|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet58|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet52|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet53|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet54|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet55|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet56|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet57|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet38|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet39|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet32|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet15|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet16|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet17|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet36|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet37|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet12|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet13|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet14|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet30|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet31|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet48|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet10|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet42|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet41|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet40|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet29|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet28|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet11|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet21|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet20|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet23|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet22|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet25|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet24|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet27|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet26|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py2/qos-arista7050.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/qos-arista7050.json
@@ -115,199 +115,199 @@
     },
     "PORT_QOS_MAP": {
         "Ethernet4": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet8": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet12": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet16": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet20": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet24": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet28": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet32": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet36": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet40": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet44": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet48": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet52": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet56": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet60": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet64": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet68": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet72": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet76": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet80": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet84": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet88": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet92": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet96": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet112": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet116": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet120": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet124": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         }
     },
@@ -330,648 +330,648 @@
     },
     "QUEUE": {
         "Ethernet4|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet8|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet12|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet16|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet20|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet24|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet28|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet32|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet36|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet40|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet44|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet48|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet52|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet56|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet60|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet64|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet68|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet72|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet76|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet80|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet84|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet88|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet92|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet96|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet112|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet116|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet120|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet124|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet4|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet8|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet12|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet16|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet20|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet24|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet28|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet32|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet36|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet40|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet44|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet48|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet52|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet56|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet60|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet64|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet68|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet72|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet76|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet80|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet84|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet88|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet92|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet96|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet112|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet116|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet120|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet124|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet4|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet44|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet60|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet68|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet76|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet84|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet92|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet116|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet124|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet44|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet60|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet68|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet76|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet84|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet92|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet116|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet124|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet44|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet60|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet68|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet76|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet84|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet92|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet116|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet124|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet44|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet60|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet68|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet76|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet84|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet92|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet116|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet124|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet44|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet60|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet68|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet76|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet84|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet92|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet116|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet124|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py2/qos-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/qos-dell6100.json
@@ -115,311 +115,311 @@
     },
     "PORT_QOS_MAP": {
         "Ethernet0": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet1": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet4": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet5": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet6": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet7": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet8": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet9": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet10": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet11": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet12": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet13": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet14": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet15": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet16": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet17": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet20": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet21": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet22": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet23": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet24": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet25": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet26": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet27": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet28": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet29": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet30": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet31": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet32": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet36": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet37": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet38": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet39": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet40": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet41": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet42": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet48": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet52": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet53": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet54": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet55": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet56": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet57": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet58": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         }
     },
@@ -442,1016 +442,1016 @@
     },
     "QUEUE": {
         "Ethernet0|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet1|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet4|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet5|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet6|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet7|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet8|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet9|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet10|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet11|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet12|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet13|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet14|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet15|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet16|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet17|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet20|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet21|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet22|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet23|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet24|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet25|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet26|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet27|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet28|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet29|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet30|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet31|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet32|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet36|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet37|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet38|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet39|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet40|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet41|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet42|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet48|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet52|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet53|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet54|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet55|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet56|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet57|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet58|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet0|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet1|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet4|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet5|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet6|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet7|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet8|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet9|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet10|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet11|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet12|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet13|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet14|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet15|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet16|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet17|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet20|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet21|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet22|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet23|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet24|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet25|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet26|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet27|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet28|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet29|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet30|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet31|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet32|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet36|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet37|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet38|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet39|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet40|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet41|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet42|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet48|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet52|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet53|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet54|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet55|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet56|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet57|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet58|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet0|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet1|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet5|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet6|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet7|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet9|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet10|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet11|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet13|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet14|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet15|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet17|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet21|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet22|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet23|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet25|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet26|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet27|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet29|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet30|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet31|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet37|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet38|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet39|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet41|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet42|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet53|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet54|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet55|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet57|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet58|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet1|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet5|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet6|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet7|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet9|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet10|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet11|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet13|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet14|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet15|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet17|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet21|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet22|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet23|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet25|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet26|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet27|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet29|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet30|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet31|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet37|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet38|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet39|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet41|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet42|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet53|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet54|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet55|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet57|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet58|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet1|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet5|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet6|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet7|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet9|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet10|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet11|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet13|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet14|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet15|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet17|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet21|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet22|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet23|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet25|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet26|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet27|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet29|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet30|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet31|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet37|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet38|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet39|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet41|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet42|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet53|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet54|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet55|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet57|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet58|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet1|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet5|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet6|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet7|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet9|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet10|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet11|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet13|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet14|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet15|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet17|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet21|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet22|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet23|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet25|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet26|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet27|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet29|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet30|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet31|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet37|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet38|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet39|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet41|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet42|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet53|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet54|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet55|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet57|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet58|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet1|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet5|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet6|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet7|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet9|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet10|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet11|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet13|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet14|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet15|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet17|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet21|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet22|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet23|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet25|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet26|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet27|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet29|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet30|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet31|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet37|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet38|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet39|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet41|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet42|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet53|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet54|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet55|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet57|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet58|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
@@ -89,552 +89,552 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"3"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "pool":"egress_lossless_pool",
             "size":"1518",
             "static_th":"15982720"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "pool":"egress_lossy_pool",
             "size":"1518",
             "dynamic_th":"3"
         }
     },
     "BUFFER_PG": {
         "Ethernet0|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet1|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet4|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet5|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet16|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet17|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet20|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet21|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet6|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet7|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet8|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet9|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet10|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet11|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet12|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet13|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet14|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet15|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet32|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet36|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet37|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet38|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet39|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet40|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet41|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet42|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet22|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet23|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet24|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet25|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet26|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet27|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet28|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet29|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet30|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet31|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet48|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet52|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet53|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet54|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet55|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet56|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet57|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         },
         "Ethernet58|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+            "profile" : "ingress_lossy_profile"
         }
     },
 
     "BUFFER_QUEUE": {
         "Ethernet0|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet1|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet4|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet5|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet16|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet17|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet20|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet21|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet6|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet7|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet8|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet9|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet10|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet11|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet12|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet13|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet14|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet15|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet32|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet36|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet37|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet38|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet39|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet40|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet41|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet42|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet22|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet23|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet24|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet25|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet26|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet27|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet28|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet29|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet30|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet31|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet48|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet52|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet53|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet54|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet55|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet56|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet57|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet58|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+            "profile" : "egress_lossless_profile"
         },
         "Ethernet0|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet1|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet4|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet5|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet16|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet17|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet20|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet21|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet6|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet7|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet8|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet9|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet10|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet11|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet12|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet13|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet14|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet15|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet32|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet36|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet37|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet38|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet39|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet40|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet41|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet42|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet22|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet23|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet24|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet25|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet26|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet27|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet28|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet29|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet30|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet31|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet48|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet52|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet53|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet54|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet55|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet56|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet57|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet58|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet0|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet1|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet4|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet5|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet16|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet17|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet20|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet21|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet6|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet7|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet8|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet9|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet10|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet11|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet12|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet13|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet14|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet15|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet32|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet36|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet37|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet38|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet39|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet40|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet41|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet42|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet22|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet23|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet24|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet25|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet26|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet27|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet28|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet29|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet30|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet31|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet48|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet52|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet53|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet54|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet55|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet56|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet57|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet58|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-arista7050.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-arista7050.json
@@ -115,199 +115,199 @@
     },
     "PORT_QOS_MAP": {
         "Ethernet4": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet8": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet12": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet16": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet20": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet24": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet28": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet32": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet36": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet40": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet44": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet48": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet52": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet56": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet60": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet64": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet68": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet72": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet76": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet80": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet84": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet88": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet92": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet96": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet112": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet116": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet120": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet124": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         }
     },
@@ -330,648 +330,648 @@
     },
     "QUEUE": {
         "Ethernet4|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet8|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet12|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet16|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet20|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet24|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet28|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet32|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet36|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet40|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet44|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet48|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet52|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet56|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet60|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet64|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet68|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet72|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet76|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet80|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet84|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet88|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet92|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet96|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet112|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet116|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet120|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet124|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet4|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet8|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet12|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet16|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet20|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet24|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet28|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet32|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet36|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet40|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet44|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet48|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet52|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet56|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet60|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet64|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet68|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet72|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet76|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet80|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet84|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet88|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet92|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet96|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet112|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet116|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet120|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet124|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet4|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet44|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet60|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet68|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet76|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet84|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet92|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet116|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet124|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet44|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet60|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet68|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet76|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet84|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet92|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet116|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet124|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet44|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet60|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet68|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet76|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet84|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet92|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet116|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet124|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet44|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet60|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet68|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet76|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet84|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet92|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet116|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet124|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet44|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet60|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet64|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet68|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet72|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet76|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet80|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet84|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet88|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet92|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet96|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet112|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet116|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet120|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet124|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-dell6100.json
@@ -115,311 +115,311 @@
     },
     "PORT_QOS_MAP": {
         "Ethernet0": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet1": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet4": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet5": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet6": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet7": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet8": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet9": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet10": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet11": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet12": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet13": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet14": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet15": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet16": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet17": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet20": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet21": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet22": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet23": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet24": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet25": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet26": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet27": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet28": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet29": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet30": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet31": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet32": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet36": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet37": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet38": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet39": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet40": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet41": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet42": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet48": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet52": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet53": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet54": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet55": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet56": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet57": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         },
         "Ethernet58": {
-            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
-            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
-            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
-            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "tc_to_pg_map"    : "AZURE",
+            "pfc_to_queue_map": "AZURE",
             "pfc_enable"      : "3,4"
         }
     },
@@ -442,1016 +442,1016 @@
     },
     "QUEUE": {
         "Ethernet0|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet1|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet4|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet5|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet6|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet7|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet8|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet9|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet10|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet11|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet12|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet13|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet14|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet15|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet16|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet17|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet20|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet21|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet22|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet23|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet24|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet25|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet26|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet27|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet28|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet29|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet30|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet31|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet32|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet36|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet37|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet38|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet39|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet40|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet41|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet42|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet48|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet52|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet53|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet54|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet55|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet56|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet57|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet58|3": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet0|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet1|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet4|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet5|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet6|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet7|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet8|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet9|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet10|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet11|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet12|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet13|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet14|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet15|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet16|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet17|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet20|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet21|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet22|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet23|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet24|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet25|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet26|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet27|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet28|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet29|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet30|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet31|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet32|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet36|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet37|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet38|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet39|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet40|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet41|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet42|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet48|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet52|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet53|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet54|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet55|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet56|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet57|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet58|4": {
-            "scheduler"   : "[SCHEDULER|scheduler.1]",
-            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+            "scheduler"   : "scheduler.1",
+            "wred_profile": "AZURE_LOSSLESS"
         },
         "Ethernet0|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet1|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet5|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet6|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet7|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet9|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet10|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet11|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet13|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet14|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet15|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet17|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet21|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet22|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet23|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet25|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet26|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet27|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet29|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet30|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet31|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet37|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet38|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet39|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet41|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet42|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet53|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet54|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet55|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet57|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet58|0": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet1|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet5|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet6|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet7|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet9|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet10|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet11|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet13|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet14|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet15|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet17|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet21|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet22|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet23|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet25|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet26|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet27|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet29|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet30|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet31|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet37|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet38|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet39|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet41|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet42|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet53|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet54|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet55|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet57|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet58|1": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet1|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet5|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet6|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet7|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet9|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet10|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet11|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet13|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet14|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet15|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet17|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet21|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet22|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet23|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet25|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet26|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet27|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet29|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet30|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet31|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet37|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet38|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet39|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet41|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet42|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet53|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet54|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet55|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet57|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet58|2": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet1|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet5|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet6|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet7|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet9|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet10|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet11|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet13|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet14|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet15|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet17|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet21|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet22|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet23|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet25|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet26|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet27|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet29|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet30|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet31|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet37|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet38|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet39|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet41|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet42|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet53|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet54|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet55|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet57|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet58|5": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet0|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet1|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet4|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet5|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet6|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet7|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet8|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet9|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet10|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet11|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet12|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet13|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet14|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet15|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet16|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet17|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet20|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet21|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet22|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet23|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet24|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet25|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet26|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet27|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet28|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet29|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet30|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet31|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet32|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet36|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet37|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet38|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet39|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet40|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet41|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet42|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet48|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet52|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet53|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet54|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet55|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet56|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet57|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         },
         "Ethernet58|6": {
-            "scheduler": "[SCHEDULER|scheduler.0]"
+            "scheduler": "scheduler.0"
         }
     }
 }


### PR DESCRIPTION
Depends on https://github.com/Azure/sonic-utilities/pull/1626
Depends on https://github.com/Azure/sonic-swss/pull/1754

QOS tables in config db used ABNF format i.e "[TABLE_NAME|name] to refer fieldvalue to other qos tables.

Example:
Config DB:
"Ethernet92|3": {
"scheduler": "[SCHEDULER|scheduler.1]",
"wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
},
"Ethernet0|0": {
"profile": "[BUFFER_PROFILE|ingress_lossy_profile]"
},
"Ethernet0": {
"dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]",
"pfc_enable": "3,4",
"pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
"tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
"tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE]"
},

This format is not consistent with other DB schema followed in sonic.
And also this reference in DB is not required, This is taken care by YANG "leafref".

Removed this format from all platform files to consistent with other sonic db schema.
Example:
"Ethernet92|3": {
"scheduler": "scheduler.1",
"wred_profile": "AZURE_LOSSLESS"
},

Dependent pull requests: 
https://github.com/Azure/sonic-buildimage/pull/7752  - To modify platfrom files 
https://github.com/Azure/sonic-buildimage/pull/7281 - Yang model 
https://github.com/Azure/sonic-utilities/pull/1626   - DB migration 
https://github.com/Azure/sonic-swss/pull/1754    - swss change to remove ABNF format