### PR TITLE
[MCLAG] Improve performance and fix some bugs

### DIFF
--- a/src/iccpd/include/iccp_ifm.h
+++ b/src/iccpd/include/iccp_ifm.h
@@ -38,5 +38,8 @@ int do_one_neigh_request(struct nlmsghdr *n);
 void iccp_from_netlink_port_state_handler( char * ifname, int state);
 
 void iccp_parse_if_vlan_info_from_netlink(struct nlmsghdr *n);
+
+void iccp_get_if_vlan_info_from_netlink();
+
 #endif // LACP_IFM_H
 

--- a/src/iccpd/include/mlacp_link_handler.h
+++ b/src/iccpd/include/mlacp_link_handler.h
@@ -44,7 +44,7 @@ void peerlink_port_isolate_cleanup(struct CSM* csm);
 void update_peerlink_isolate_from_all_csm_lif(struct CSM* csm);
 
 void del_mac_from_chip(struct MACMsg *mac_msg);
-void add_mac_to_chip(struct MACMsg *mac_msg, uint8_t mac_type);
+void add_mac_to_chip(struct CSM *csm, struct MACMsg *mac_msg, uint8_t mac_type);
 uint8_t set_mac_local_age_flag(struct CSM *csm, struct MACMsg *mac_msg, uint8_t set);
 void iccp_get_fdb_change_from_syncd(void);
 

--- a/src/iccpd/include/mlacp_tlv.h
+++ b/src/iccpd/include/mlacp_tlv.h
@@ -33,6 +33,7 @@
 #define MLACP_SYSCONF_NODEID_NODEID_MASK    0x70
 #define MLACP_SYSCONF_NODEID_FREE_MASK      0x0F
 
+#define NEIGH_SYNC_TIME 240
 /*
  * RFC 7275
  * 7.2.3.  mLACP System Config TLV
@@ -369,17 +370,19 @@ struct mLACPMACInfoTLV
 struct ARPMsg
 {
     uint8_t     op_type;
-    char     ifname[MAX_L_PORT_NAME];
+    char        ifname[MAX_L_PORT_NAME];
     uint32_t    ipv4_addr;
     uint8_t     mac_addr[ETHER_ADDR_LEN];
+    time_t      sync_time;
 };
 
 struct NDISCMsg
 {
-    uint8_t op_type;
-    char ifname[MAX_L_PORT_NAME];
+    uint8_t  op_type;
+    char     ifname[MAX_L_PORT_NAME];
     uint32_t ipv6_addr[4];
-    uint8_t mac_addr[ETHER_ADDR_LEN];
+    uint8_t  mac_addr[ETHER_ADDR_LEN];
+    time_t   sync_time;
 };
 
 /*

--- a/src/iccpd/include/openbsd_tree.h
+++ b/src/iccpd/include/openbsd_tree.h
@@ -1,0 +1,571 @@
+/*	$OpenBSD: tree.h,v 1.14 2015/05/25 03:07:49 deraadt Exp $	*/
+/*
+ * Copyright 2002 Niels Provos <provos@citi.umich.edu>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _SYS_TREE_H_
+#define	_SYS_TREE_H_
+
+/*
+ * This file defines data structures for different types of trees:
+ * splay trees and red-black trees.
+ *
+ * A splay tree is a self-organizing data structure.  Every operation
+ * on the tree causes a splay to happen.  The splay moves the requested
+ * node to the root of the tree and partly rebalances it.
+ *
+ * This has the benefit that request locality causes faster lookups as
+ * the requested nodes move to the top of the tree.  On the other hand,
+ * every lookup causes memory writes.
+ *
+ * The Balance Theorem bounds the total access time for m operations
+ * and n inserts on an initially empty tree as O((m + n)lg n).  The
+ * amortized cost for a sequence of m accesses to a splay tree is O(lg n);
+ *
+ * A red-black tree is a binary search tree with the node color as an
+ * extra attribute.  It fulfills a set of conditions:
+ *	- every search path from the root to a leaf consists of the
+ *	  same number of black nodes,
+ *	- each red node (except for the root) has a black parent,
+ *	- each leaf node is black.
+ *
+ * Every operation on a red-black tree is bounded as O(lg n).
+ * The maximum height of a red-black tree is 2lg (n+1).
+ */
+
+#ifndef offsetof
+#ifdef __compiler_offsetof
+#define offsetof(TYPE,MEMBER) __compiler_offsetof(TYPE,MEMBER)
+#else
+#define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#endif
+#endif
+
+#define SPLAY_HEAD(name, type)                                                 \
+	struct name {                                                          \
+		struct type *sph_root; /* root of the tree */                  \
+	}
+
+#define SPLAY_INITIALIZER(root)                                                \
+	{                                                                      \
+		NULL                                                           \
+	}
+
+#define SPLAY_INIT(root)                                                       \
+	do {                                                                   \
+		(root)->sph_root = NULL;                                       \
+	} while (0)
+
+#define SPLAY_ENTRY(type)                                                      \
+	struct {                                                               \
+		struct type *spe_left;  /* left element */                     \
+		struct type *spe_right; /* right element */                    \
+	}
+
+#define SPLAY_LEFT(elm, field)		(elm)->field.spe_left
+#define SPLAY_RIGHT(elm, field)		(elm)->field.spe_right
+#define SPLAY_ROOT(head)		(head)->sph_root
+#define SPLAY_EMPTY(head)		(SPLAY_ROOT(head) == NULL)
+
+/* SPLAY_ROTATE_{LEFT,RIGHT} expect that tmp hold SPLAY_{RIGHT,LEFT} */
+#define SPLAY_ROTATE_RIGHT(head, tmp, field)                                   \
+	do {                                                                   \
+		SPLAY_LEFT((head)->sph_root, field) = SPLAY_RIGHT(tmp, field); \
+		SPLAY_RIGHT(tmp, field) = (head)->sph_root;                    \
+		(head)->sph_root = tmp;                                        \
+	} while (0)
+
+#define SPLAY_ROTATE_LEFT(head, tmp, field)                                    \
+	do {                                                                   \
+		SPLAY_RIGHT((head)->sph_root, field) = SPLAY_LEFT(tmp, field); \
+		SPLAY_LEFT(tmp, field) = (head)->sph_root;                     \
+		(head)->sph_root = tmp;                                        \
+	} while (0)
+
+#define SPLAY_LINKLEFT(head, tmp, field)                                       \
+	do {                                                                   \
+		SPLAY_LEFT(tmp, field) = (head)->sph_root;                     \
+		tmp = (head)->sph_root;                                        \
+		(head)->sph_root = SPLAY_LEFT((head)->sph_root, field);        \
+	} while (0)
+
+#define SPLAY_LINKRIGHT(head, tmp, field)                                      \
+	do {                                                                   \
+		SPLAY_RIGHT(tmp, field) = (head)->sph_root;                    \
+		tmp = (head)->sph_root;                                        \
+		(head)->sph_root = SPLAY_RIGHT((head)->sph_root, field);       \
+	} while (0)
+
+#define SPLAY_ASSEMBLE(head, node, left, right, field)                         \
+	do {                                                                   \
+		SPLAY_RIGHT(left, field) =                                     \
+			SPLAY_LEFT((head)->sph_root, field);                   \
+		SPLAY_LEFT(right, field) =                                     \
+			SPLAY_RIGHT((head)->sph_root, field);                  \
+		SPLAY_LEFT((head)->sph_root, field) =                          \
+			SPLAY_RIGHT(node, field);                              \
+		SPLAY_RIGHT((head)->sph_root, field) =                         \
+			SPLAY_LEFT(node, field);                               \
+	} while (0)
+
+/* Generates prototypes and inline functions */
+
+#define SPLAY_PROTOTYPE(name, type, field, cmp)                                \
+	void name##_SPLAY(struct name *, struct type *);                       \
+	void name##_SPLAY_MINMAX(struct name *, int);                          \
+	struct type *name##_SPLAY_INSERT(struct name *, struct type *);        \
+	struct type *name##_SPLAY_REMOVE(struct name *, struct type *);        \
+                                                                               \
+	/* Finds the node with the same key as elm */                          \
+	static __inline struct type *name##_SPLAY_FIND(struct name *head,      \
+						       struct type *elm)       \
+	{                                                                      \
+		if (SPLAY_EMPTY(head))                                         \
+			return (NULL);                                         \
+		name##_SPLAY(head, elm);                                       \
+		if ((cmp)(elm, (head)->sph_root) == 0)                         \
+			return (head->sph_root);                               \
+		return (NULL);                                                 \
+	}                                                                      \
+                                                                               \
+	static __inline struct type *name##_SPLAY_NEXT(struct name *head,      \
+						       struct type *elm)       \
+	{                                                                      \
+		name##_SPLAY(head, elm);                                       \
+		if (SPLAY_RIGHT(elm, field) != NULL) {                         \
+			elm = SPLAY_RIGHT(elm, field);                         \
+			while (SPLAY_LEFT(elm, field) != NULL) {               \
+				elm = SPLAY_LEFT(elm, field);                  \
+			}                                                      \
+		} else                                                         \
+			elm = NULL;                                            \
+		return (elm);                                                  \
+	}                                                                      \
+                                                                               \
+	static __inline struct type *name##_SPLAY_MIN_MAX(struct name *head,   \
+							  int val)             \
+	{                                                                      \
+		name##_SPLAY_MINMAX(head, val);                                \
+		return (SPLAY_ROOT(head));                                     \
+	}
+
+/* Main splay operation.
+ * Moves node close to the key of elm to top
+ */
+#define SPLAY_GENERATE(name, type, field, cmp)                                 \
+	struct type *name##_SPLAY_INSERT(struct name *head, struct type *elm)  \
+	{                                                                      \
+		if (SPLAY_EMPTY(head)) {                                       \
+			SPLAY_LEFT(elm, field) = SPLAY_RIGHT(elm, field) =     \
+				NULL;                                          \
+		} else {                                                       \
+			int __comp;                                            \
+			name##_SPLAY(head, elm);                               \
+			__comp = (cmp)(elm, (head)->sph_root);                 \
+			if (__comp < 0) {                                      \
+				SPLAY_LEFT(elm, field) =                       \
+					SPLAY_LEFT((head)->sph_root, field);   \
+				SPLAY_RIGHT(elm, field) = (head)->sph_root;    \
+				SPLAY_LEFT((head)->sph_root, field) = NULL;    \
+			} else if (__comp > 0) {                               \
+				SPLAY_RIGHT(elm, field) =                      \
+					SPLAY_RIGHT((head)->sph_root, field);  \
+				SPLAY_LEFT(elm, field) = (head)->sph_root;     \
+				SPLAY_RIGHT((head)->sph_root, field) = NULL;   \
+			} else                                                 \
+				return ((head)->sph_root);                     \
+		}                                                              \
+		(head)->sph_root = (elm);                                      \
+		return (NULL);                                                 \
+	}                                                                      \
+                                                                               \
+	struct type *name##_SPLAY_REMOVE(struct name *head, struct type *elm)  \
+	{                                                                      \
+		struct type *__tmp;                                            \
+		if (SPLAY_EMPTY(head))                                         \
+			return (NULL);                                         \
+		name##_SPLAY(head, elm);                                       \
+		if ((cmp)(elm, (head)->sph_root) == 0) {                       \
+			if (SPLAY_LEFT((head)->sph_root, field) == NULL) {     \
+				(head)->sph_root =                             \
+					SPLAY_RIGHT((head)->sph_root, field);  \
+			} else {                                               \
+				__tmp = SPLAY_RIGHT((head)->sph_root, field);  \
+				(head)->sph_root =                             \
+					SPLAY_LEFT((head)->sph_root, field);   \
+				name##_SPLAY(head, elm);                       \
+				SPLAY_RIGHT((head)->sph_root, field) = __tmp;  \
+			}                                                      \
+			return (elm);                                          \
+		}                                                              \
+		return (NULL);                                                 \
+	}                                                                      \
+                                                                               \
+	void name##_SPLAY(struct name *head, struct type *elm)                 \
+	{                                                                      \
+		struct type __node, *__left, *__right, *__tmp;                 \
+		int __comp;                                                    \
+                                                                               \
+		SPLAY_LEFT(&__node, field) = SPLAY_RIGHT(&__node, field) =     \
+			NULL;                                                  \
+		__left = __right = &__node;                                    \
+                                                                               \
+		while ((__comp = (cmp)(elm, (head)->sph_root))) {              \
+			if (__comp < 0) {                                      \
+				__tmp = SPLAY_LEFT((head)->sph_root, field);   \
+				if (__tmp == NULL)                             \
+					break;                                 \
+				if ((cmp)(elm, __tmp) < 0) {                   \
+					SPLAY_ROTATE_RIGHT(head, __tmp,        \
+							   field);             \
+					if (SPLAY_LEFT((head)->sph_root,       \
+						       field)                  \
+					    == NULL)                           \
+						break;                         \
+				}                                              \
+				SPLAY_LINKLEFT(head, __right, field);          \
+			} else if (__comp > 0) {                               \
+				__tmp = SPLAY_RIGHT((head)->sph_root, field);  \
+				if (__tmp == NULL)                             \
+					break;                                 \
+				if ((cmp)(elm, __tmp) > 0) {                   \
+					SPLAY_ROTATE_LEFT(head, __tmp, field); \
+					if (SPLAY_RIGHT((head)->sph_root,      \
+							field)                 \
+					    == NULL)                           \
+						break;                         \
+				}                                              \
+				SPLAY_LINKRIGHT(head, __left, field);          \
+			}                                                      \
+		}                                                              \
+		SPLAY_ASSEMBLE(head, &__node, __left, __right, field);         \
+	}                                                                      \
+                                                                               \
+	/* Splay with either the minimum or the maximum element                \
+	 * Used to find minimum or maximum element in tree.                    \
+	 */                                                                    \
+	void name##_SPLAY_MINMAX(struct name *head, int __comp)                \
+	{                                                                      \
+		struct type __node, *__left, *__right, *__tmp;                 \
+                                                                               \
+		SPLAY_LEFT(&__node, field) = SPLAY_RIGHT(&__node, field) =     \
+			NULL;                                                  \
+		__left = __right = &__node;                                    \
+                                                                               \
+		while (1) {                                                    \
+			if (__comp < 0) {                                      \
+				__tmp = SPLAY_LEFT((head)->sph_root, field);   \
+				if (__tmp == NULL)                             \
+					break;                                 \
+				if (__comp < 0) {                              \
+					SPLAY_ROTATE_RIGHT(head, __tmp,        \
+							   field);             \
+					if (SPLAY_LEFT((head)->sph_root,       \
+						       field)                  \
+					    == NULL)                           \
+						break;                         \
+				}                                              \
+				SPLAY_LINKLEFT(head, __right, field);          \
+			} else if (__comp > 0) {                               \
+				__tmp = SPLAY_RIGHT((head)->sph_root, field);  \
+				if (__tmp == NULL)                             \
+					break;                                 \
+				if (__comp > 0) {                              \
+					SPLAY_ROTATE_LEFT(head, __tmp, field); \
+					if (SPLAY_RIGHT((head)->sph_root,      \
+							field)                 \
+					    == NULL)                           \
+						break;                         \
+				}                                              \
+				SPLAY_LINKRIGHT(head, __left, field);          \
+			}                                                      \
+		}                                                              \
+		SPLAY_ASSEMBLE(head, &__node, __left, __right, field);         \
+	}
+
+#define SPLAY_NEGINF	-1
+#define SPLAY_INF	1
+
+#define SPLAY_INSERT(name, x, y)	name##_SPLAY_INSERT(x, y)
+#define SPLAY_REMOVE(name, x, y)	name##_SPLAY_REMOVE(x, y)
+#define SPLAY_FIND(name, x, y)		name##_SPLAY_FIND(x, y)
+#define SPLAY_NEXT(name, x, y)		name##_SPLAY_NEXT(x, y)
+#define SPLAY_MIN(name, x)                                                     \
+	(SPLAY_EMPTY(x) ? NULL : name##_SPLAY_MIN_MAX(x, SPLAY_NEGINF))
+#define SPLAY_MAX(name, x)                                                     \
+	(SPLAY_EMPTY(x) ? NULL : name##_SPLAY_MIN_MAX(x, SPLAY_INF))
+
+#define SPLAY_FOREACH(x, name, head)                                           \
+	for ((x) = SPLAY_MIN(name, head); (x) != NULL;                         \
+	     (x) = SPLAY_NEXT(name, head, x))
+
+/*
+ * Copyright (c) 2016 David Gwynne <dlg@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#define RB_BLACK	0
+#define RB_RED		1
+
+struct rb_type {
+	int (*t_compare)(const void *, const void *);
+	void (*t_augment)(void *);
+	unsigned int t_offset; /* offset of rb_entry in type */
+};
+
+struct rbt_tree {
+	struct rb_entry *rbt_root;
+};
+
+struct rb_entry {
+	struct rb_entry *rbt_parent;
+	struct rb_entry *rbt_left;
+	struct rb_entry *rbt_right;
+	unsigned int rbt_color;
+};
+
+#define RB_HEAD(_name, _type)                                                  \
+	struct _name {                                                         \
+		struct rbt_tree rbh_root;                                      \
+	}
+
+#define RB_ENTRY(_type)	struct rb_entry
+
+static inline void _rb_init(struct rbt_tree *rbt)
+{
+	rbt->rbt_root = NULL;
+}
+
+static inline int _rb_empty(struct rbt_tree *rbt)
+{
+	return (rbt->rbt_root == NULL);
+}
+
+void *_rb_insert(const struct rb_type *, struct rbt_tree *, void *);
+void *_rb_remove(const struct rb_type *, struct rbt_tree *, void *);
+void *_rb_find(const struct rb_type *, struct rbt_tree *, const void *);
+void *_rb_nfind(const struct rb_type *, struct rbt_tree *, const void *);
+void *_rb_root(const struct rb_type *, struct rbt_tree *);
+void *_rb_min(const struct rb_type *, struct rbt_tree *);
+void *_rb_max(const struct rb_type *, struct rbt_tree *);
+void *_rb_next(const struct rb_type *, void *);
+void *_rb_prev(const struct rb_type *, void *);
+void *_rb_left(const struct rb_type *, void *);
+void *_rb_right(const struct rb_type *, void *);
+void *_rb_parent(const struct rb_type *, void *);
+void _rb_set_left(const struct rb_type *, void *, void *);
+void _rb_set_right(const struct rb_type *, void *, void *);
+void _rb_set_parent(const struct rb_type *, void *, void *);
+void _rb_poison(const struct rb_type *, void *, unsigned long);
+int _rb_check(const struct rb_type *, void *, unsigned long);
+
+#define RB_INITIALIZER(_head)	{ { NULL } }
+
+#define RB_PROTOTYPE(_name, _type, _field, _cmp)                               \
+	extern const struct rb_type *const _name##_RB_TYPE;                    \
+                                                                               \
+	__attribute__((__unused__)) static inline void _name##_RB_INIT(        \
+		struct _name *head)                                            \
+	{                                                                      \
+		_rb_init(&head->rbh_root);                                     \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_INSERT(struct _name *head, struct _type *elm)      \
+	{                                                                      \
+		return _rb_insert(_name##_RB_TYPE, &head->rbh_root, elm);      \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_REMOVE(struct _name *head, struct _type *elm)      \
+	{                                                                      \
+		return _rb_remove(_name##_RB_TYPE, &head->rbh_root, elm);      \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_FIND(struct _name *head, const struct _type *key)  \
+	{                                                                      \
+		return _rb_find(_name##_RB_TYPE, &head->rbh_root, key);        \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_NFIND(struct _name *head, const struct _type *key) \
+	{                                                                      \
+		return _rb_nfind(_name##_RB_TYPE, &head->rbh_root, key);       \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_ROOT(struct _name *head)                           \
+	{                                                                      \
+		return _rb_root(_name##_RB_TYPE, &head->rbh_root);             \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline int _name##_RB_EMPTY(        \
+		struct _name *head)                                            \
+	{                                                                      \
+		return _rb_empty(&head->rbh_root);                             \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_MIN(struct _name *head)                            \
+	{                                                                      \
+		return _rb_min(_name##_RB_TYPE, &head->rbh_root);              \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_MAX(struct _name *head)                            \
+	{                                                                      \
+		return _rb_max(_name##_RB_TYPE, &head->rbh_root);              \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_NEXT(struct _type *elm)                            \
+	{                                                                      \
+		return _rb_next(_name##_RB_TYPE, elm);                         \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_PREV(struct _type *elm)                            \
+	{                                                                      \
+		return _rb_prev(_name##_RB_TYPE, elm);                         \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_LEFT(struct _type *elm)                            \
+	{                                                                      \
+		return _rb_left(_name##_RB_TYPE, elm);                         \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_RIGHT(struct _type *elm)                           \
+	{                                                                      \
+		return _rb_right(_name##_RB_TYPE, elm);                        \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline struct _type                 \
+		*_name##_RB_PARENT(struct _type *elm)                          \
+	{                                                                      \
+		return _rb_parent(_name##_RB_TYPE, elm);                       \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline void _name##_RB_SET_LEFT(    \
+		struct _type *elm, struct _type *left)                         \
+	{                                                                      \
+		_rb_set_left(_name##_RB_TYPE, elm, left);                      \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline void _name##_RB_SET_RIGHT(   \
+		struct _type *elm, struct _type *right)                        \
+	{                                                                      \
+		_rb_set_right(_name##_RB_TYPE, elm, right);                    \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline void _name##_RB_SET_PARENT(  \
+		struct _type *elm, struct _type *parent)                       \
+	{                                                                      \
+		_rb_set_parent(_name##_RB_TYPE, elm, parent);                  \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline void _name##_RB_POISON(      \
+		struct _type *elm, unsigned long poison)                       \
+	{                                                                      \
+		_rb_poison(_name##_RB_TYPE, elm, poison);                      \
+	}                                                                      \
+                                                                               \
+	__attribute__((__unused__)) static inline int _name##_RB_CHECK(        \
+		struct _type *elm, unsigned long poison)                       \
+	{                                                                      \
+		return _rb_check(_name##_RB_TYPE, elm, poison);                \
+	}
+
+#define RB_GENERATE_INTERNAL(_name, _type, _field, _cmp, _aug)                 \
+	static int _name##_RB_COMPARE(const void *lptr, const void *rptr)      \
+	{                                                                      \
+		const struct _type *l = lptr, *r = rptr;                       \
+		return _cmp(l, r);                                             \
+	}                                                                      \
+	static const struct rb_type _name##_RB_INFO = {                        \
+		_name##_RB_COMPARE, _aug, offsetof(struct _type, _field),      \
+	};                                                                     \
+	const struct rb_type *const _name##_RB_TYPE = &_name##_RB_INFO;
+
+#define RB_GENERATE_AUGMENT(_name, _type, _field, _cmp, _aug)                  \
+	static void _name##_RB_AUGMENT(void *ptr)                              \
+	{                                                                      \
+		struct _type *p = ptr;                                         \
+		return _aug(p);                                                \
+	}                                                                      \
+	RB_GENERATE_INTERNAL(_name, _type, _field, _cmp, _name##_RB_AUGMENT)
+
+#define RB_GENERATE(_name, _type, _field, _cmp)                                \
+	RB_GENERATE_INTERNAL(_name, _type, _field, _cmp, NULL)
+
+#define RB_INIT(_name, _head)		_name##_RB_INIT(_head)
+#define RB_INSERT(_name, _head, _elm)	_name##_RB_INSERT(_head, _elm)
+#define RB_REMOVE(_name, _head, _elm)	_name##_RB_REMOVE(_head, _elm)
+#define RB_FIND(_name, _head, _key)	_name##_RB_FIND(_head, _key)
+#define RB_NFIND(_name, _head, _key)	_name##_RB_NFIND(_head, _key)
+#define RB_ROOT(_name, _head)		_name##_RB_ROOT(_head)
+#define RB_EMPTY(_name, _head)		_name##_RB_EMPTY(_head)
+#define RB_MIN(_name, _head)		_name##_RB_MIN(_head)
+#define RB_MAX(_name, _head)		_name##_RB_MAX(_head)
+#define RB_NEXT(_name, _elm)		_name##_RB_NEXT(_elm)
+#define RB_PREV(_name, _elm)		_name##_RB_PREV(_elm)
+#define RB_LEFT(_name, _elm)		_name##_RB_LEFT(_elm)
+#define RB_RIGHT(_name, _elm)		_name##_RB_RIGHT(_elm)
+#define RB_PARENT(_name, _elm)		_name##_RB_PARENT(_elm)
+#define RB_SET_LEFT(_name, _elm, _l)	_name##_RB_SET_LEFT(_elm, _l)
+#define RB_SET_RIGHT(_name, _elm, _r)	_name##_RB_SET_RIGHT(_elm, _r)
+#define RB_SET_PARENT(_name, _elm, _p)	_name##_RB_SET_PARENT(_elm, _p)
+#define RB_POISON(_name, _elm, _p)	_name##_RB_POISON(_elm, _p)
+#define RB_CHECK(_name, _elm, _p)	_name##_RB_CHECK(_elm, _p)
+
+#define RB_FOREACH(_e, _name, _head)                                           \
+	for ((_e) = RB_MIN(_name, (_head)); (_e) != NULL;                      \
+	     (_e) = RB_NEXT(_name, (_e)))
+
+#define RB_FOREACH_SAFE(_e, _name, _head, _n)                                  \
+	for ((_e) = RB_MIN(_name, (_head));                                    \
+	     (_e) != NULL && ((_n) = RB_NEXT(_name, (_e)), 1); (_e) = (_n))
+
+#define RB_FOREACH_REVERSE(_e, _name, _head)                                   \
+	for ((_e) = RB_MAX(_name, (_head)); (_e) != NULL;                      \
+	     (_e) = RB_PREV(_name, (_e)))
+
+#define RB_FOREACH_REVERSE_SAFE(_e, _name, _head, _n)                          \
+	for ((_e) = RB_MAX(_name, (_head));                                    \
+	     (_e) != NULL && ((_n) = RB_PREV(_name, (_e)), 1); (_e) = (_n))
+
+#endif /* _SYS_TREE_H_ */

--- a/src/iccpd/include/system.h
+++ b/src/iccpd/include/system.h
@@ -52,6 +52,16 @@ struct CSM;
     #define MAX_BUFSIZE 4096
 #endif
 
+RB_HEAD(lif_rb_tree, LocalInterface);
+RB_PROTOTYPE(lif_rb_tree, LocalInterface, lif_entry, lif_node_compare);
+
+#define LIF_RB_REMOVE(name, head, elm) do {  \
+    RB_REMOVE(name, head, elm);              \
+    (elm)->lif_entry.rbt_parent = NULL;   \
+    (elm)->lif_entry.rbt_left = NULL;     \
+    (elm)->lif_entry.rbt_right = NULL;    \
+} while (0)
+
 struct System
 {
     int server_fd;/* Peer-Link Socket*/
@@ -76,7 +86,7 @@ struct System
 
     /* Info List*/
     LIST_HEAD(csm_list, CSM) csm_list;
-    LIST_HEAD(lif_all_list, LocalInterface) lif_list;
+    struct lif_rb_tree lif_tree;
     LIST_HEAD(lif_purge_all_list, LocalInterface) lif_purge_list;
 
     /* Settings */

--- a/src/iccpd/src/Makefile.am
+++ b/src/iccpd/src/Makefile.am
@@ -17,6 +17,7 @@ iccpd_SOURCES = \
 	    mlacp_link_handler.c \
 	    mlacp_sync_prepare.c mlacp_sync_update.c\
 	    mlacp_fsm.c \
-	    iccp_netlink.c
+	    iccp_netlink.c \
+	    openbsd_tree.c
 iccpd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
 iccpd_LDADD = -lnl-genl-3 -lnl-route-3 -lnl-3 -lpthread

--- a/src/iccpd/src/app_csm.c
+++ b/src/iccpd/src/app_csm.c
@@ -238,13 +238,13 @@ int mlacp_bind_local_if(struct CSM* csm, struct LocalInterface* lif)
     {
         if (lif_po->type == IF_T_PORT_CHANNEL && lif_po->po_id == lif->po_id)
         {
-            /*if join a po member, may swss restart, reset portchannel ip mac  to mclagsyncd*/
+            /*if join a po member, may swss restart, reset portchannel ip mac to mclagsyncd*/
             update_if_ipmac_on_standby(lif_po);
             return 0;
         }
     }
 
-    if (lif_po == NULL)
+    /*if (lif_po == NULL)
     {
         lif_po = local_if_find_by_po_id(lif->po_id);
         if (lif_po == NULL)
@@ -257,7 +257,7 @@ int mlacp_bind_local_if(struct CSM* csm, struct LocalInterface* lif)
         LIST_INSERT_HEAD(&(MLACP(csm).lif_list), lif_po, mlacp_next);
         lif_po->port_config_sync = 1;
         ICCPD_LOG_INFO(__FUNCTION__, "Add port_channel %d into local_if_list in CSM %p.", lif->po_id, csm);
-    }
+    }*/
 
     return 0;
 }

--- a/src/iccpd/src/iccp_cmd.c
+++ b/src/iccpd/src/iccp_cmd.c
@@ -32,6 +32,7 @@
 #include "../include/iccp_cmd_show.h"
 #include "../include/iccp_cli.h"
 #include "../include/logger.h"
+#include "mclagdctl/mclagdctl.h"
 
 int set_mc_lag_by_id(uint16_t mid)
 {
@@ -54,8 +55,6 @@ int set_mc_lag_by_id(uint16_t mid)
 
     return ret;
 }
-
-#define CONFIG_LINE_LEN  512
 
 int iccp_config_from_command(char * line)
 {
@@ -150,13 +149,13 @@ int
 iccp_config_from_file(char *config_default_dir)
 {
     FILE *confp = NULL;
-    char command_buf[CONFIG_LINE_LEN];
+    char command_buf[CONFIG_MCLAG_ENABLE_INTF_LEN];
 
     confp = fopen(config_default_dir, "r");
     if (confp == NULL)
         return (1);
 
-    while (fgets(command_buf, CONFIG_LINE_LEN, confp))
+    while (fgets(command_buf, CONFIG_MCLAG_ENABLE_INTF_LEN, confp))
     {
         iccp_config_from_command(command_buf);
     }

--- a/src/iccpd/src/iccp_consistency_check.c
+++ b/src/iccpd/src/iccp_consistency_check.c
@@ -112,13 +112,9 @@ static int iccp_check_interface_vlan(char* ifname)
     if (peer_if == NULL)
         return -4;
 
-    LIST_FOREACH(local_vlan, &(local_if->vlan_list), port_next)
+    RB_FOREACH (local_vlan, vlan_rb_tree, &(local_if->vlan_tree))
     {
-        LIST_FOREACH(peer_vlan, &(peer_if->vlan_list), port_next)
-        {
-            if (peer_vlan->vid == local_vlan->vid)
-                break;
-        }
+        peer_vlan = RB_FIND(vlan_rb_tree, &(peer_if->vlan_tree), local_vlan);
 
         if (peer_vlan == NULL)
         {
@@ -126,14 +122,9 @@ static int iccp_check_interface_vlan(char* ifname)
         }
     }
 
-    LIST_FOREACH(peer_vlan, &(peer_if->vlan_list), port_next)
+    RB_FOREACH (peer_vlan, vlan_rb_tree, &(peer_if->vlan_tree))
     {
-
-        LIST_FOREACH(local_vlan, &(local_if->vlan_list), port_next)
-        {
-            if (peer_vlan->vid == local_vlan->vid)
-                break;
-        }
+        local_vlan = RB_FIND(vlan_rb_tree, &(local_if->vlan_tree), peer_vlan);
 
         if (local_vlan == NULL)
         {

--- a/src/iccpd/src/iccp_csm.c
+++ b/src/iccpd/src/iccp_csm.c
@@ -219,6 +219,8 @@ int iccp_csm_send(struct CSM* csm, char* buf, int msg_len)
 {
     LDPHdr* ldp_hdr = (LDPHdr*)buf;
     ICCParameter* param = NULL;
+    ssize_t rc;
+    uint16_t tlv_type;
 
     if (csm == NULL || buf == NULL || csm->sock_fd <= 0 || msg_len <= 0)
         return MCLAG_ERROR;
@@ -236,7 +238,13 @@ int iccp_csm_send(struct CSM* csm, char* buf, int msg_len)
     if (csm->msg_log.end_index >= 128)
         csm->msg_log.end_index = 0;
 
-    return write(csm->sock_fd, buf, msg_len);
+    tlv_type = ntohs(param->type);
+    rc = write(csm->sock_fd, buf, msg_len);
+    if ((rc <= 0) || (rc != msg_len))
+    {
+        ICCPD_LOG_ERR("ICCP_FSM", "Failed to write msg %s/0x%x, msg_len:%d, rc %d Error:%s ", get_tlv_type_string(tlv_type), tlv_type, msg_len, rc, strerror(errno));
+    }
+    return (rc);
 }
 
 /* Connection State Machine Transition */

--- a/src/iccpd/src/mlacp_fsm.c
+++ b/src/iccpd/src/mlacp_fsm.c
@@ -76,7 +76,7 @@
             lif = LIST_FIRST(&(list)); \
             if (lif->type == IF_T_PORT_CHANNEL && lif->is_arp_accept) { \
                 if ((set_sys_arp_accept_flag(lif->name, 0)) == 0) \
-                lif->is_arp_accept = 0; \
+                    lif->is_arp_accept = 0; \
             } \
             LIST_REMOVE (lif, mlacp_next); \
         } \
@@ -301,6 +301,7 @@ static void mlacp_sync_send_syncNdiscInfo(struct CSM *csm)
 
     return;
 }
+
 static void mlacp_sync_send_syncPortChannelInfo(struct CSM* csm)
 {
     struct System* sys = NULL;
@@ -518,6 +519,7 @@ static void mlacp_sync_recv_ndiscInfo(struct CSM *csm, struct Msg *msg)
 
     return;
 }
+
 static void mlacp_sync_recv_stpInfo(struct CSM* csm, struct Msg* msg)
 {
     /*Don't support currently*/
@@ -1264,8 +1266,12 @@ static void mlacp_exchange_handler(struct CSM* csm, struct Msg* msg)
             /* Send port channel state information*/
             memset(g_csm_buf, 0, CSM_BUFFER_SIZE);
             len = mlacp_prepare_for_Aggport_state(csm, g_csm_buf, CSM_BUFFER_SIZE, lif);
-            iccp_csm_send(csm, g_csm_buf, len);
-            lif->changed = 0;
+            /*If po state send to peer is not successful, next time will try to
+             send again, until then dont unmark lif->changed flag*/
+            if (iccp_csm_send(csm, g_csm_buf, len) > 0)
+            {
+                lif->changed = 0;
+            }
         }
     }
 

--- a/src/iccpd/src/mlacp_sync_prepare.c
+++ b/src/iccpd/src/mlacp_sync_prepare.c
@@ -465,9 +465,9 @@ int mlacp_prepare_for_port_channel_info(struct CSM* csm, char* buf,
         return MCLAG_ERROR;
 
     /* Calculate VLAN ID Length */
-    LIST_FOREACH(vlan_id, &(port_channel->vlan_list), port_next)
-    if (vlan_id != NULL)
-        num_of_vlan_id++;
+    RB_FOREACH(vlan_id, vlan_rb_tree, &(port_channel->vlan_tree))
+        if (vlan_id != NULL)
+            num_of_vlan_id++;
 
     tlv_len = sizeof(struct mLACPPortChannelInfoTLV) + sizeof(struct mLACPVLANData) * num_of_vlan_id;
 
@@ -500,7 +500,7 @@ int mlacp_prepare_for_port_channel_info(struct CSM* csm, char* buf,
     tlv->num_of_vlan_id = htons(num_of_vlan_id);
 
     num_of_vlan_id = 0;
-    LIST_FOREACH(vlan_id, &(port_channel->vlan_list), port_next)
+    RB_FOREACH(vlan_id, vlan_rb_tree, &(port_channel->vlan_tree))
     {
         if (vlan_id != NULL )
         {

--- a/src/iccpd/src/openbsd_tree.c
+++ b/src/iccpd/src/openbsd_tree.c
@@ -1,0 +1,618 @@
+/*	$OpenBSD: subr_tree.c,v 1.9 2017/06/08 03:30:52 dlg Exp $ */
+
+/*
+ * Copyright 2002 Niels Provos <provos@citi.umich.edu>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Copyright (c) 2016 David Gwynne <dlg@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+
+#include <../include/openbsd_tree.h>
+
+static inline struct rb_entry *rb_n2e(const struct rb_type *t, void *node)
+{
+	unsigned long addr = (unsigned long)node;
+
+	return ((struct rb_entry *)(addr + t->t_offset));
+}
+
+static inline void *rb_e2n(const struct rb_type *t, struct rb_entry *rbe)
+{
+	unsigned long addr = (unsigned long)rbe;
+
+	return ((void *)(addr - t->t_offset));
+}
+
+#define RBE_LEFT(_rbe)		(_rbe)->rbt_left
+#define RBE_RIGHT(_rbe)		(_rbe)->rbt_right
+#define RBE_PARENT(_rbe)	(_rbe)->rbt_parent
+#define RBE_COLOR(_rbe)		(_rbe)->rbt_color
+
+#define RBH_ROOT(_rbt)		(_rbt)->rbt_root
+
+static inline void rbe_set(struct rb_entry *rbe, struct rb_entry *parent)
+{
+	RBE_PARENT(rbe) = parent;
+	RBE_LEFT(rbe) = RBE_RIGHT(rbe) = NULL;
+	RBE_COLOR(rbe) = RB_RED;
+}
+
+static inline void rbe_set_blackred(struct rb_entry *black,
+				    struct rb_entry *red)
+{
+	RBE_COLOR(black) = RB_BLACK;
+	RBE_COLOR(red) = RB_RED;
+}
+
+static inline void rbe_augment(const struct rb_type *t, struct rb_entry *rbe)
+{
+	(*t->t_augment)(rb_e2n(t, rbe));
+}
+
+static inline void rbe_if_augment(const struct rb_type *t, struct rb_entry *rbe)
+{
+	if (t->t_augment != NULL)
+		rbe_augment(t, rbe);
+}
+
+static inline void rbe_rotate_left(const struct rb_type *t,
+				   struct rbt_tree *rbt, struct rb_entry *rbe)
+{
+	struct rb_entry *parent;
+	struct rb_entry *tmp;
+
+	tmp = RBE_RIGHT(rbe);
+	RBE_RIGHT(rbe) = RBE_LEFT(tmp);
+	if (RBE_RIGHT(rbe) != NULL)
+		RBE_PARENT(RBE_LEFT(tmp)) = rbe;
+
+	parent = RBE_PARENT(rbe);
+	RBE_PARENT(tmp) = parent;
+	if (parent != NULL) {
+		if (rbe == RBE_LEFT(parent))
+			RBE_LEFT(parent) = tmp;
+		else
+			RBE_RIGHT(parent) = tmp;
+	} else
+		RBH_ROOT(rbt) = tmp;
+
+	RBE_LEFT(tmp) = rbe;
+	RBE_PARENT(rbe) = tmp;
+
+	if (t->t_augment != NULL) {
+		rbe_augment(t, rbe);
+		rbe_augment(t, tmp);
+		parent = RBE_PARENT(tmp);
+		if (parent != NULL)
+			rbe_augment(t, parent);
+	}
+}
+
+static inline void rbe_rotate_right(const struct rb_type *t,
+				    struct rbt_tree *rbt, struct rb_entry *rbe)
+{
+	struct rb_entry *parent;
+	struct rb_entry *tmp;
+
+	tmp = RBE_LEFT(rbe);
+	RBE_LEFT(rbe) = RBE_RIGHT(tmp);
+	if (RBE_LEFT(rbe) != NULL)
+		RBE_PARENT(RBE_RIGHT(tmp)) = rbe;
+
+	parent = RBE_PARENT(rbe);
+	RBE_PARENT(tmp) = parent;
+	if (parent != NULL) {
+		if (rbe == RBE_LEFT(parent))
+			RBE_LEFT(parent) = tmp;
+		else
+			RBE_RIGHT(parent) = tmp;
+	} else
+		RBH_ROOT(rbt) = tmp;
+
+	RBE_RIGHT(tmp) = rbe;
+	RBE_PARENT(rbe) = tmp;
+
+	if (t->t_augment != NULL) {
+		rbe_augment(t, rbe);
+		rbe_augment(t, tmp);
+		parent = RBE_PARENT(tmp);
+		if (parent != NULL)
+			rbe_augment(t, parent);
+	}
+}
+
+static inline void rbe_insert_color(const struct rb_type *t,
+				    struct rbt_tree *rbt, struct rb_entry *rbe)
+{
+	struct rb_entry *parent, *gparent, *tmp;
+
+	while ((parent = RBE_PARENT(rbe)) != NULL
+	       && RBE_COLOR(parent) == RB_RED) {
+		gparent = RBE_PARENT(parent);
+
+		if (parent == RBE_LEFT(gparent)) {
+			tmp = RBE_RIGHT(gparent);
+			if (tmp != NULL && RBE_COLOR(tmp) == RB_RED) {
+				RBE_COLOR(tmp) = RB_BLACK;
+				rbe_set_blackred(parent, gparent);
+				rbe = gparent;
+				continue;
+			}
+
+			if (RBE_RIGHT(parent) == rbe) {
+				rbe_rotate_left(t, rbt, parent);
+				tmp = parent;
+				parent = rbe;
+				rbe = tmp;
+			}
+
+			rbe_set_blackred(parent, gparent);
+			rbe_rotate_right(t, rbt, gparent);
+		} else {
+			tmp = RBE_LEFT(gparent);
+			if (tmp != NULL && RBE_COLOR(tmp) == RB_RED) {
+				RBE_COLOR(tmp) = RB_BLACK;
+				rbe_set_blackred(parent, gparent);
+				rbe = gparent;
+				continue;
+			}
+
+			if (RBE_LEFT(parent) == rbe) {
+				rbe_rotate_right(t, rbt, parent);
+				tmp = parent;
+				parent = rbe;
+				rbe = tmp;
+			}
+
+			rbe_set_blackred(parent, gparent);
+			rbe_rotate_left(t, rbt, gparent);
+		}
+	}
+
+	RBE_COLOR(RBH_ROOT(rbt)) = RB_BLACK;
+}
+
+static inline void rbe_remove_color(const struct rb_type *t,
+				    struct rbt_tree *rbt,
+				    struct rb_entry *parent,
+				    struct rb_entry *rbe)
+{
+	struct rb_entry *tmp;
+
+	while ((rbe == NULL || RBE_COLOR(rbe) == RB_BLACK)
+	       && rbe != RBH_ROOT(rbt) && parent) {
+		if (RBE_LEFT(parent) == rbe) {
+			tmp = RBE_RIGHT(parent);
+			if (RBE_COLOR(tmp) == RB_RED) {
+				rbe_set_blackred(tmp, parent);
+				rbe_rotate_left(t, rbt, parent);
+				tmp = RBE_RIGHT(parent);
+			}
+			if ((RBE_LEFT(tmp) == NULL
+			     || RBE_COLOR(RBE_LEFT(tmp)) == RB_BLACK)
+			    && (RBE_RIGHT(tmp) == NULL
+				|| RBE_COLOR(RBE_RIGHT(tmp)) == RB_BLACK)) {
+				RBE_COLOR(tmp) = RB_RED;
+				rbe = parent;
+				parent = RBE_PARENT(rbe);
+			} else {
+				if (RBE_RIGHT(tmp) == NULL
+				    || RBE_COLOR(RBE_RIGHT(tmp)) == RB_BLACK) {
+					struct rb_entry *oleft;
+
+					oleft = RBE_LEFT(tmp);
+					if (oleft != NULL)
+						RBE_COLOR(oleft) = RB_BLACK;
+
+					RBE_COLOR(tmp) = RB_RED;
+					rbe_rotate_right(t, rbt, tmp);
+					tmp = RBE_RIGHT(parent);
+				}
+
+				RBE_COLOR(tmp) = RBE_COLOR(parent);
+				RBE_COLOR(parent) = RB_BLACK;
+				if (RBE_RIGHT(tmp))
+					RBE_COLOR(RBE_RIGHT(tmp)) = RB_BLACK;
+
+				rbe_rotate_left(t, rbt, parent);
+				rbe = RBH_ROOT(rbt);
+				break;
+			}
+		} else {
+			tmp = RBE_LEFT(parent);
+			if (RBE_COLOR(tmp) == RB_RED) {
+				rbe_set_blackred(tmp, parent);
+				rbe_rotate_right(t, rbt, parent);
+				tmp = RBE_LEFT(parent);
+			}
+
+			if ((RBE_LEFT(tmp) == NULL
+			     || RBE_COLOR(RBE_LEFT(tmp)) == RB_BLACK)
+			    && (RBE_RIGHT(tmp) == NULL
+				|| RBE_COLOR(RBE_RIGHT(tmp)) == RB_BLACK)) {
+				RBE_COLOR(tmp) = RB_RED;
+				rbe = parent;
+				parent = RBE_PARENT(rbe);
+			} else {
+				if (RBE_LEFT(tmp) == NULL
+				    || RBE_COLOR(RBE_LEFT(tmp)) == RB_BLACK) {
+					struct rb_entry *oright;
+
+					oright = RBE_RIGHT(tmp);
+					if (oright != NULL)
+						RBE_COLOR(oright) = RB_BLACK;
+
+					RBE_COLOR(tmp) = RB_RED;
+					rbe_rotate_left(t, rbt, tmp);
+					tmp = RBE_LEFT(parent);
+				}
+
+				RBE_COLOR(tmp) = RBE_COLOR(parent);
+				RBE_COLOR(parent) = RB_BLACK;
+				if (RBE_LEFT(tmp) != NULL)
+					RBE_COLOR(RBE_LEFT(tmp)) = RB_BLACK;
+
+				rbe_rotate_right(t, rbt, parent);
+				rbe = RBH_ROOT(rbt);
+				break;
+			}
+		}
+	}
+
+	if (rbe != NULL)
+		RBE_COLOR(rbe) = RB_BLACK;
+}
+
+static inline struct rb_entry *
+rbe_remove(const struct rb_type *t, struct rbt_tree *rbt, struct rb_entry *rbe)
+{
+	struct rb_entry *child, *parent, *old = rbe;
+	unsigned int color;
+
+	if (RBE_LEFT(rbe) == NULL)
+		child = RBE_RIGHT(rbe);
+	else if (RBE_RIGHT(rbe) == NULL)
+		child = RBE_LEFT(rbe);
+	else {
+		struct rb_entry *tmp;
+
+		rbe = RBE_RIGHT(rbe);
+		while ((tmp = RBE_LEFT(rbe)) != NULL)
+			rbe = tmp;
+
+		child = RBE_RIGHT(rbe);
+		parent = RBE_PARENT(rbe);
+		color = RBE_COLOR(rbe);
+		if (child != NULL)
+			RBE_PARENT(child) = parent;
+		if (parent != NULL) {
+			if (RBE_LEFT(parent) == rbe)
+				RBE_LEFT(parent) = child;
+			else
+				RBE_RIGHT(parent) = child;
+
+			rbe_if_augment(t, parent);
+		} else
+			RBH_ROOT(rbt) = child;
+		if (RBE_PARENT(rbe) == old)
+			parent = rbe;
+		*rbe = *old;
+
+		tmp = RBE_PARENT(old);
+		if (tmp != NULL) {
+			if (RBE_LEFT(tmp) == old)
+				RBE_LEFT(tmp) = rbe;
+			else
+				RBE_RIGHT(tmp) = rbe;
+
+			rbe_if_augment(t, tmp);
+		} else
+			RBH_ROOT(rbt) = rbe;
+
+		RBE_PARENT(RBE_LEFT(old)) = rbe;
+		if (RBE_RIGHT(old))
+			RBE_PARENT(RBE_RIGHT(old)) = rbe;
+
+		if (t->t_augment != NULL && parent != NULL) {
+			tmp = parent;
+			do {
+				rbe_augment(t, tmp);
+				tmp = RBE_PARENT(tmp);
+			} while (tmp != NULL);
+		}
+
+		goto color;
+	}
+
+	parent = RBE_PARENT(rbe);
+	color = RBE_COLOR(rbe);
+
+	if (child != NULL)
+		RBE_PARENT(child) = parent;
+	if (parent != NULL) {
+		if (RBE_LEFT(parent) == rbe)
+			RBE_LEFT(parent) = child;
+		else
+			RBE_RIGHT(parent) = child;
+
+		rbe_if_augment(t, parent);
+	} else
+		RBH_ROOT(rbt) = child;
+color:
+	if (color == RB_BLACK)
+		rbe_remove_color(t, rbt, parent, child);
+
+	return (old);
+}
+
+void *_rb_remove(const struct rb_type *t, struct rbt_tree *rbt, void *elm)
+{
+	struct rb_entry *rbe = rb_n2e(t, elm);
+	struct rb_entry *old;
+
+	old = rbe_remove(t, rbt, rbe);
+
+	return (old == NULL ? NULL : rb_e2n(t, old));
+}
+
+void *_rb_insert(const struct rb_type *t, struct rbt_tree *rbt, void *elm)
+{
+	struct rb_entry *rbe = rb_n2e(t, elm);
+	struct rb_entry *tmp;
+	struct rb_entry *parent = NULL;
+	void *node;
+	int comp = 0;
+
+	tmp = RBH_ROOT(rbt);
+	while (tmp != NULL) {
+		parent = tmp;
+
+		node = rb_e2n(t, tmp);
+		comp = (*t->t_compare)(elm, node);
+		if (comp < 0)
+			tmp = RBE_LEFT(tmp);
+		else if (comp > 0)
+			tmp = RBE_RIGHT(tmp);
+		else
+			return (node);
+	}
+
+	rbe_set(rbe, parent);
+
+	if (parent != NULL) {
+		if (comp < 0)
+			RBE_LEFT(parent) = rbe;
+		else
+			RBE_RIGHT(parent) = rbe;
+
+		rbe_if_augment(t, parent);
+	} else
+		RBH_ROOT(rbt) = rbe;
+
+	rbe_insert_color(t, rbt, rbe);
+
+	return (NULL);
+}
+
+/* Finds the node with the same key as elm */
+void *_rb_find(const struct rb_type *t, struct rbt_tree *rbt, const void *key)
+{
+	struct rb_entry *tmp = RBH_ROOT(rbt);
+	void *node;
+	int comp;
+
+	while (tmp != NULL) {
+		node = rb_e2n(t, tmp);
+		comp = (*t->t_compare)(key, node);
+		if (comp < 0)
+			tmp = RBE_LEFT(tmp);
+		else if (comp > 0)
+			tmp = RBE_RIGHT(tmp);
+		else
+			return (node);
+	}
+
+	return (NULL);
+}
+
+/* Finds the first node greater than or equal to the search key */
+void *_rb_nfind(const struct rb_type *t, struct rbt_tree *rbt, const void *key)
+{
+	struct rb_entry *tmp = RBH_ROOT(rbt);
+	void *node;
+	void *res = NULL;
+	int comp;
+
+	while (tmp != NULL) {
+		node = rb_e2n(t, tmp);
+		comp = (*t->t_compare)(key, node);
+		if (comp < 0) {
+			res = node;
+			tmp = RBE_LEFT(tmp);
+		} else if (comp > 0)
+			tmp = RBE_RIGHT(tmp);
+		else
+			return (node);
+	}
+
+	return (res);
+}
+
+void *_rb_next(const struct rb_type *t, void *elm)
+{
+	struct rb_entry *rbe = rb_n2e(t, elm);
+
+	if (RBE_RIGHT(rbe) != NULL) {
+		rbe = RBE_RIGHT(rbe);
+		while (RBE_LEFT(rbe) != NULL)
+			rbe = RBE_LEFT(rbe);
+	} else {
+		if (RBE_PARENT(rbe) && (rbe == RBE_LEFT(RBE_PARENT(rbe))))
+			rbe = RBE_PARENT(rbe);
+		else {
+			while (RBE_PARENT(rbe)
+			       && (rbe == RBE_RIGHT(RBE_PARENT(rbe))))
+				rbe = RBE_PARENT(rbe);
+			rbe = RBE_PARENT(rbe);
+		}
+	}
+
+	return (rbe == NULL ? NULL : rb_e2n(t, rbe));
+}
+
+void *_rb_prev(const struct rb_type *t, void *elm)
+{
+	struct rb_entry *rbe = rb_n2e(t, elm);
+
+	if (RBE_LEFT(rbe)) {
+		rbe = RBE_LEFT(rbe);
+		while (RBE_RIGHT(rbe))
+			rbe = RBE_RIGHT(rbe);
+	} else {
+		if (RBE_PARENT(rbe) && (rbe == RBE_RIGHT(RBE_PARENT(rbe))))
+			rbe = RBE_PARENT(rbe);
+		else {
+			while (RBE_PARENT(rbe)
+			       && (rbe == RBE_LEFT(RBE_PARENT(rbe))))
+				rbe = RBE_PARENT(rbe);
+			rbe = RBE_PARENT(rbe);
+		}
+	}
+
+	return (rbe == NULL ? NULL : rb_e2n(t, rbe));
+}
+
+void *_rb_root(const struct rb_type *t, struct rbt_tree *rbt)
+{
+	struct rb_entry *rbe = RBH_ROOT(rbt);
+
+	return (rbe == NULL ? rbe : rb_e2n(t, rbe));
+}
+
+void *_rb_min(const struct rb_type *t, struct rbt_tree *rbt)
+{
+	struct rb_entry *rbe = RBH_ROOT(rbt);
+	struct rb_entry *parent = NULL;
+
+	while (rbe != NULL) {
+		parent = rbe;
+		rbe = RBE_LEFT(rbe);
+	}
+
+	return (parent == NULL ? NULL : rb_e2n(t, parent));
+}
+
+void *_rb_max(const struct rb_type *t, struct rbt_tree *rbt)
+{
+	struct rb_entry *rbe = RBH_ROOT(rbt);
+	struct rb_entry *parent = NULL;
+
+	while (rbe != NULL) {
+		parent = rbe;
+		rbe = RBE_RIGHT(rbe);
+	}
+
+	return (parent == NULL ? NULL : rb_e2n(t, parent));
+}
+
+void *_rb_left(const struct rb_type *t, void *node)
+{
+	struct rb_entry *rbe = rb_n2e(t, node);
+	rbe = RBE_LEFT(rbe);
+	return (rbe == NULL ? NULL : rb_e2n(t, rbe));
+}
+
+void *_rb_right(const struct rb_type *t, void *node)
+{
+	struct rb_entry *rbe = rb_n2e(t, node);
+	rbe = RBE_RIGHT(rbe);
+	return (rbe == NULL ? NULL : rb_e2n(t, rbe));
+}
+
+void *_rb_parent(const struct rb_type *t, void *node)
+{
+	struct rb_entry *rbe = rb_n2e(t, node);
+	rbe = RBE_PARENT(rbe);
+	return (rbe == NULL ? NULL : rb_e2n(t, rbe));
+}
+
+void _rb_set_left(const struct rb_type *t, void *node, void *left)
+{
+	struct rb_entry *rbe = rb_n2e(t, node);
+	struct rb_entry *rbl = (left == NULL) ? NULL : rb_n2e(t, left);
+
+	RBE_LEFT(rbe) = rbl;
+}
+
+void _rb_set_right(const struct rb_type *t, void *node, void *right)
+{
+	struct rb_entry *rbe = rb_n2e(t, node);
+	struct rb_entry *rbr = (right == NULL) ? NULL : rb_n2e(t, right);
+
+	RBE_RIGHT(rbe) = rbr;
+}
+
+void _rb_set_parent(const struct rb_type *t, void *node, void *parent)
+{
+	struct rb_entry *rbe = rb_n2e(t, node);
+	struct rb_entry *rbp = (parent == NULL) ? NULL : rb_n2e(t, parent);
+
+	RBE_PARENT(rbe) = rbp;
+}
+
+void _rb_poison(const struct rb_type *t, void *node, unsigned long poison)
+{
+	struct rb_entry *rbe = rb_n2e(t, node);
+
+	RBE_PARENT(rbe) = RBE_LEFT(rbe) = RBE_RIGHT(rbe) =
+		(struct rb_entry *)poison;
+}
+
+int _rb_check(const struct rb_type *t, void *node, unsigned long poison)
+{
+	struct rb_entry *rbe = rb_n2e(t, node);
+
+	return ((unsigned long)RBE_PARENT(rbe) == poison
+		&& (unsigned long)RBE_LEFT(rbe) == poison
+		&& (unsigned long)RBE_RIGHT(rbe) == poison);
+}

--- a/src/iccpd/src/scheduler.c
+++ b/src/iccpd/src/scheduler.c
@@ -308,6 +308,7 @@ void scheduler_init()
     /*Get kernel interface and port */
     iccp_sys_local_if_list_get_init();
     iccp_sys_local_if_list_get_addr();
+    iccp_get_if_vlan_info_from_netlink();
     /*Interfaces must be created before this func called*/
     iccp_config_from_file(sys->config_file_path);
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. VLAN performance improvements and bugs fix
(1) In the original implementation, the VLAN to which the port belongs is stored by list. In the case of a large number of VLANs, such as 4K, there are performance problems.
(2) There are some defects in the way MCLAG obtains the VLAN of the port. The Linux kernel may report VLAN range, but MCLAG does not handle this situation, which may lead to incorrect VLAN of the port.
(3) When the iccpd docker is restarted, the VLAN information of the port may be incomplete. The reason is that Linux kernel sometimes does not carry VLAN information when reporting RTM_NEWLINK messages.
(4) When the command 'mclagdctl dump portlist local' displays the VLAN information of the port, the string length is only 64. If there are many VLANs, the display is incomplete.

2. ARP/ND performance improvements
(1) In the original implementation, ARP and ND are synchronized frequently between the two peers, which affects the performance.
(2) When too much ARP and ND information is read from the Linux kernel, an error may be reported with the wrong sequence number, resulting in an entry error.

3. FDB optimization
(1) When the FDB table item needs to be redirected to peerlink, the ASIC will be directly installed without considering whether the FDB table item is in the same VLAN as peerlink. This results in useless entries in the ASIC.

4. Interface optimization
(1) In the original implementation, the interface is stored by list. In the case of a large number of VLANs, such as 4K, there are performance problems.
(2) In the struct LocalInterface, the string portchannel_member_buf[] is used to store the portchannel members, and the length of the string is 512. When there are many portchannel members, the length may not be enough.
(3) If lots of mclag enabled interfaces are configured, only about 30 can be displayed by the command 'mclagdctl dump state'. The reason is that the length of the string definition used to read the configuration from the configuration file is only 512, which is too short.

#### How I did it
1. VLAN performance improvements and bugs fix
(1) Modify VLAN list as RB tree to improve performance. This modification is based on PR https://github.com/Azure/SONiC/pull/596.
(2) Modify the way to read the VLAN information of the port reported by Linux kernel, so that it can process VLAN range (Function iccp_parse_if_vlan_info_from_netlink()).
(3) When the mclag is initialized, it actively sends a message to read the VLAN information of the port from the Linux kernel (Add function iccp_ge_if_vlan_info_from_netlink()).
(4) Use VLAN bitmap to transfer the VLAN information of the port, and add the display of VLAN range, such as' 3-10 '.

2. ARP/ND performance improvements
(1) The synchronization frequency of ARP and ND between two peers is optimized. The same table item is synchronized only once in 240s to avoid too much information.
(2) When initializing ARP and ND related sockets, add an option to prohibit them from checking the sequence number.

3. FDB optimization
(1) When an FDB entry needs to be redirected to peerlink, if the FDB entry and peerlink are not in the same VLAN, iccpd will save the entry, but the entry will not be installed in ASIC. The result is that 'mclagdctl dump mac' can see the entry, but the command 'show mac' can't. When configuring peerlink to join the associated VLAN, the related FDB table items are reinstalled into ASIC.

4. Interface optimization
(1) Modify interface list as RB tree to improve performance.
(2) Use list to store the portchannel members. At the same time, the method of displaying portchannel members with command ''mclagdctl dump portlist local'' is optimized.
(3) The length definition of string used to read configuration from configuration file is increased from 512 to 8320, which can support about 520 portchannels.

#### How to verify it
Test on the switch.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

