### PR TITLE
[Barefoot][azure-pipelines] fix sonic build 202012 bfnplatform

### DIFF
--- a/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
+++ b/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
@@ -22,6 +22,7 @@ parameters:
     default:
     - vs
     - broadcom
+    - barefoot
     - centec
     - generic
     - innovium


### PR DESCRIPTION
Work in progress!
Test PR to trigger azure-pipelines-UpgradeVersion.

__Why I did it__

[Build failed with error "Failed to verify the package"](https://dev.azure.com/mssonic/build/_build/results?buildId=13879&view=logs&j=993d6e22-aeec-5c03-fa19-35ecba587dd9&t=d0538dec-1681-5ff8-bd45-c0de13be9706&l=694)

[The reason of the fail is version verification](https://github.com/Azure/sonic-buildimage/blob/3db6572e6785ffcd4ef0a4575b16f95c7606c327/src/sonic-build-hooks/scripts/buildinfo_base.sh#L79)

[Version manager didn't find dependencies for the barefoot platform](https://github.com/Azure/sonic-buildimage/commit/b0460c7ce182de8abac85294b207eae85fd942b3)

The possible reason is absence of artifacts for the barefoot platform, because the job for barefoot is filtered out.
