### PR TITLE
[Arista] Added pcie.yaml for x86_64-arista_7170_32cd

### DIFF
--- a/device/arista/x86_64-arista_7170_32cd/pcie.yaml
+++ b/device/arista/x86_64-arista_7170_32cd/pcie.yaml
@@ -1,0 +1,433 @@
+- bus: '00'
+  dev: '00'
+  fn: '0'
+  id: 6f00
+  name: 'Host bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D DMI2
+    (rev 03)'
+- bus: '00'
+  dev: '01'
+  fn: '0'
+  id: 6f02
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 1 (rev 03)'
+- bus: '00'
+  dev: '01'
+  fn: '1'
+  id: 6f03
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 1 (rev 03)'
+- bus: '00'
+  dev: '02'
+  fn: '0'
+  id: 6f04
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 2 (rev 03)'
+- bus: '00'
+  dev: '02'
+  fn: '2'
+  id: 6f06
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 2 (rev 03)'
+- bus: '00'
+  dev: '03'
+  fn: '0'
+  id: 6f08
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 3 (rev 03)'
+- bus: '00'
+  dev: '05'
+  fn: '0'
+  id: 6f28
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Map/VTd_Misc/System Management (rev 03)'
+- bus: '00'
+  dev: '05'
+  fn: '1'
+  id: 6f29
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D IIO Hot Plug (rev 03)'
+- bus: '00'
+  dev: '05'
+  fn: '2'
+  id: 6f2a
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D IIO RAS/Control Status/Global Errors (rev 03)'
+- bus: '00'
+  dev: '05'
+  fn: '4'
+  id: 6f2c
+  name: 'PIC: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D I/O APIC (rev
+    03)'
+- bus: '00'
+  dev: '14'
+  fn: '0'
+  id: 8c31
+  name: 'USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB
+    xHCI (rev 05)'
+- bus: '00'
+  dev: 1a
+  fn: '0'
+  id: 8c2d
+  name: 'USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB
+    EHCI #2 (rev 05)'
+- bus: '00'
+  dev: 1c
+  fn: '0'
+  id: 8c10
+  name: 'PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express
+    Root Port #1 (rev d5)'
+- bus: '00'
+  dev: 1c
+  fn: '4'
+  id: 8c18
+  name: 'PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express
+    Root Port #5 (rev d5)'
+- bus: '00'
+  dev: 1d
+  fn: '0'
+  id: 8c26
+  name: 'USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB
+    EHCI #1 (rev 05)'
+- bus: '00'
+  dev: 1f
+  fn: '0'
+  id: 8c54
+  name: 'ISA bridge: Intel Corporation C224 Series Chipset Family Server Standard
+    SKU LPC Controller (rev 05)'
+- bus: '00'
+  dev: 1f
+  fn: '2'
+  id: 8c02
+  name: 'SATA controller: Intel Corporation 8 Series/C220 Series Chipset Family 6-port
+    SATA Controller 1 [AHCI mode] (rev 05)'
+- bus: '00'
+  dev: 1f
+  fn: '3'
+  id: 8c22
+  name: 'SMBus: Intel Corporation 8 Series/C220 Series Chipset Family SMBus Controller
+    (rev 05)'
+- bus: '00'
+  dev: 1f
+  fn: '6'
+  id: 8c24
+  name: 'Signal processing controller: Intel Corporation 8 Series Chipset Family Thermal
+    Management Controller (rev 05)'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: '1682'
+  name: 'Ethernet controller: Broadcom Limited NetXtreme BCM57762 Gigabit Ethernet
+    PCIe (rev 20)'
+- bus: '02'
+  dev: '00'
+  fn: '0'
+  id: '1682'
+  name: 'Ethernet controller: Broadcom Limited NetXtreme BCM57762 Gigabit Ethernet
+    PCIe (rev 20)'
+- bus: '03'
+  dev: '00'
+  fn: '0'
+  id: 6f50
+  name: 'System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology
+    Register DMA Channel 0'
+- bus: '03'
+  dev: '00'
+  fn: '1'
+  id: 6f51
+  name: 'System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology
+    Register DMA Channel 1'
+- bus: '03'
+  dev: '00'
+  fn: '2'
+  id: 6f52
+  name: 'System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology
+    Register DMA Channel 2'
+- bus: '03'
+  dev: '00'
+  fn: '3'
+  id: 6f53
+  name: 'System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology
+    Register DMA Channel 3'
+- bus: '04'
+  dev: '00'
+  fn: '0'
+  id: 15ab
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection X552 10 GbE Backplane'
+- bus: '04'
+  dev: '00'
+  fn: '1'
+  id: 15ab
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection X552 10 GbE Backplane'
+- bus: '06'
+  dev: '00'
+  fn: '0'
+  id: '0001'
+  name: 'System peripheral: Arastra Inc. Device 0001'
+- bus: '07'
+  dev: '00'
+  fn: '0'
+  id: '0010'
+  name: 'Unassigned class [ff00]: Device 1d1c:0010 (rev 10)'
+- bus: ff
+  dev: 0b
+  fn: '0'
+  id: 6f81
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R3 QPI Link 0/1 (rev 03)'
+- bus: ff
+  dev: 0b
+  fn: '1'
+  id: 6f36
+  name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R3 QPI Link 0/1 (rev 03)'
+- bus: ff
+  dev: 0b
+  fn: '2'
+  id: 6f37
+  name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R3 QPI Link 0/1 (rev 03)'
+- bus: ff
+  dev: 0b
+  fn: '3'
+  id: '0001'
+  name: 'System peripheral: Arastra Inc. Device 0001 (rev 03)'
+- bus: ff
+  dev: 0c
+  fn: '0'
+  id: 6fe0
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0c
+  fn: '1'
+  id: 6fe1
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0f
+  fn: '0'
+  id: 6ff8
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0f
+  fn: '4'
+  id: 6ffc
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0f
+  fn: '5'
+  id: 6ffd
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: 0f
+  fn: '6'
+  id: 6ffe
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Caching Agent (rev 03)'
+- bus: ff
+  dev: '10'
+  fn: '0'
+  id: 6f1d
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R2PCIe Agent (rev 03)'
+- bus: ff
+  dev: '10'
+  fn: '1'
+  id: 6f34
+  name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D R2PCIe Agent (rev 03)'
+- bus: ff
+  dev: '10'
+  fn: '5'
+  id: 6f1e
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Ubox (rev 03)'
+- bus: ff
+  dev: '10'
+  fn: '6'
+  id: 6f7d
+  name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Ubox (rev 03)'
+- bus: ff
+  dev: '10'
+  fn: '7'
+  id: 6f1f
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Ubox (rev 03)'
+- bus: ff
+  dev: '12'
+  fn: '0'
+  id: 6fa0
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Home Agent 0 (rev 03)'
+- bus: ff
+  dev: '12'
+  fn: '1'
+  id: 6f30
+  name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Home Agent 0 (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '0'
+  id: 6fa8
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '1'
+  id: 6f71
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '2'
+  id: 6faa
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '3'
+  id: 6fab
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '4'
+  id: 6fac
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '5'
+  id: 6fad
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '6'
+  id: 6fae
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Channel 0/1 Broadcast (rev 03)'
+- bus: ff
+  dev: '13'
+  fn: '7'
+  id: 6faf
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Global Broadcast (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '0'
+  id: 6fb0
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 0 Thermal Control (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '1'
+  id: 6fb1
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 1 Thermal Control (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '2'
+  id: 6fb2
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 0 Error (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '3'
+  id: 6fb3
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 1 Error (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '4'
+  id: 6fbc
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Channel 0/1 Interface (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '5'
+  id: 6fbd
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Channel 0/1 Interface (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '6'
+  id: 6fbe
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Channel 0/1 Interface (rev 03)'
+- bus: ff
+  dev: '14'
+  fn: '7'
+  id: 6fbf
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D DDRIO Channel 0/1 Interface (rev 03)'
+- bus: ff
+  dev: '15'
+  fn: '0'
+  id: 6fb4
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 2 Thermal Control (rev 03)'
+- bus: ff
+  dev: '15'
+  fn: '1'
+  id: 6fb5
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 3 Thermal Control (rev 03)'
+- bus: ff
+  dev: '15'
+  fn: '2'
+  id: 6fb6
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 2 Error (rev 03)'
+- bus: ff
+  dev: '15'
+  fn: '3'
+  id: 6fb7
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Memory Controller 0 - Channel 3 Error (rev 03)'
+- bus: ff
+  dev: 1e
+  fn: '0'
+  id: 6f98
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1e
+  fn: '1'
+  id: 6f99
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1e
+  fn: '2'
+  id: 6f9a
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1e
+  fn: '3'
+  id: 6fc0
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1e
+  fn: '4'
+  id: 6f9c
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1f
+  fn: '0'
+  id: 6f88
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'
+- bus: ff
+  dev: 1f
+  fn: '2'
+  id: 6f8a
+  name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
+    D Power Control Unit (rev 03)'


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <andriyx.kokhan@intel.com>

#### Why I did it
Process pcied failed on Arista-7170-32CD-C32
```
root@sonic:/# supervisorctl 
chassis_db_init                  EXITED    Jun 03 08:48 AM
dependent-startup                EXITED    Jun 03 08:48 AM
ledd                             RUNNING   pid 28, uptime 3:07:49
lm-sensors                       EXITED    Jun 03 08:48 AM
pcied                            FATAL     Exited too quickly (process log may have details)
```

#### How I did it
Generated pcie.yaml with `pcieutil generate`

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

