### PR TITLE
[barefoot][platform] Chassis.get_reboot_cause

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
@@ -138,3 +138,16 @@ class Chassis(ChassisBase):
     def get_change_event(self, timeout=0):
         ready, event_sfp = Sfp.get_transceiver_change_event(timeout)
         return ready, { 'sfp': event_sfp } if ready else {}
+
+    def get_reboot_cause(self):
+        """
+        Retrieves the cause of the previous reboot
+
+        Returns:
+            A tuple (string, string) where the first element is a string
+            containing the cause of the previous reboot. This string must be
+            one of the predefined strings in this class. If the first string
+            is "REBOOT_CAUSE_HARDWARE_OTHER", the second string can be used
+            to pass a description of the reboot cause.
+        """
+        return self.REBOOT_CAUSE_NON_HARDWARE, ''


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix determine-reboot-cause service which was failing due to non-implemented thrown from get_reboot_case, if the reboot was done with `sudo reboot` (cold reboot)

#### How I did it
Added get_reboot_case implementation that will always return Non-Hardware reason.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
barefoot implementation of sonic_platform.chassis.Chassis.get_reboot_cause

#### A picture of a cute animal (not mandatory but encouraged)