### PR TITLE
WIP [sonic-host-services] make determine-reboot-cause handle NotImplemented get_reboot_cause

### DIFF
--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -102,6 +102,7 @@ def find_proc_cmdline_reboot_cause():
 
 def get_reboot_cause_from_platform():
     # Find hardware reboot cause using sonic_platform library
+    hardware_reboot_cause_major, hardware_reboot_cause_minor = None, None
     try:
         import sonic_platform
         platform  = sonic_platform.platform.Platform()
@@ -110,7 +111,8 @@ def get_reboot_cause_from_platform():
         sonic_logger.log_info("Platform api returns reboot cause {}, {}".format(hardware_reboot_cause_major, hardware_reboot_cause_minor))
     except ImportError:
         sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
-        hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
+    except NotImplementedError:
+        sonic_logger.log_info("Platform does not support providing reboot cause")
 
     return hardware_reboot_cause_major, hardware_reboot_cause_minor
 
@@ -121,6 +123,7 @@ def find_hardware_reboot_cause():
         sonic_logger.log_info("Platform api indicates reboot cause {}".format(hardware_reboot_cause_major))
     else:
         sonic_logger.log_info("No reboot cause found from platform api")
+        return None
 
     hardware_reboot_cause = "{} ({})".format(hardware_reboot_cause_major, hardware_reboot_cause_minor)
     return hardware_reboot_cause
@@ -187,7 +190,7 @@ def main():
     # If /proc/cmdline does not indicate reboot cause, check if the previous reboot was caused by hardware
     if proc_cmdline_reboot_cause is None:
         previous_reboot_cause = find_hardware_reboot_cause()
-        if previous_reboot_cause.startswith(REBOOT_CAUSE_NON_HARDWARE):
+        if previous_reboot_cause is None or previous_reboot_cause.startswith(REBOOT_CAUSE_NON_HARDWARE):
             # If the reboot cause is non-hardware, get the reboot cause from REBOOT_CAUSE_FILE
             previous_reboot_cause = find_software_reboot_cause()
     else:


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Looks confusing that if platform does not support determining any of REBOOT_CAUSE_ it should return Non-Hardware to make determine-reboot-cause work.
The idea REBOOT_CAUSE_NON_HARDWARE should only mean none of other conditions, which could be tracked by platform (power loss, etc), happened; if platform does not support providing reboot cause it should not implement the function.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
make determine-reboot-cause handle NotImplemented get_reboot_cause

#### A picture of a cute animal (not mandatory but encouraged)

