### PR TITLE
[console][minigraph] Avoid generate config for self console port

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -198,18 +198,18 @@ def parse_png(png, hname, dpg_ecmp_content = None):
                     startport = link.find(str(QName(ns, "StartPort"))).text
                     baudrate = link.find(str(QName(ns, "Bandwidth"))).text
                     flowcontrol = 1 if link.find(str(QName(ns, "FlowControl"))) is not None and link.find(str(QName(ns, "FlowControl"))).text == 'true' else 0
-                    if enddevice.lower() == hname.lower():
+                    if enddevice.lower() == hname.lower() and endport.isdigit():
                         console_ports[endport] = {
                             'remote_device': startdevice,
                             'baud_rate': baudrate,
                             'flow_control': flowcontrol
-                            }
-                    else:
+                        }
+                    elif startport.isdigit():
                         console_ports[startport] = {
                             'remote_device': enddevice,
                             'baud_rate': baudrate,
                             'flow_control': flowcontrol
-                            }
+                        }
                     continue
 
                 if linktype == "DeviceInterfaceLink":

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -190,6 +190,15 @@
         <ElementType>DeviceSerialLink</ElementType>
         <Bandwidth>9600</Bandwidth>
         <EndDevice>switch-t0</EndDevice>
+        <EndPort>console</EndPort>
+        <FlowControl>true</FlowControl>
+        <StartDevice>switch-t1</StartDevice>
+        <StartPort>1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase i:type="DeviceSerialLink">
+        <ElementType>DeviceSerialLink</ElementType>
+        <Bandwidth>9600</Bandwidth>
+        <EndDevice>switch-t0</EndDevice>
         <EndPort>1</EndPort>
         <FlowControl>true</FlowControl>
         <StartDevice>managed_device</StartDevice>


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For `MgmtTsToR` device, it can manage 48/96 devices via console. Besides, it also have it own console port (console) which will be modeled in minigraph as a device serial link. Current code will generate configuration for it, but there are no change to do the reverse control and the configuration can lead confuse for users.

#### How I did it
Only generate console config for console ports which is in digital format.

#### How to verify it
Add new test data and existing unit test will cover this case.
```
test_minigraph_console_port (tests.test_minigraph_case.TestCfgGenCaseInsensitive) ... ok
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

