### PR TITLE
Adding pre_pddf_init script in the service file

### DIFF
--- a/platform/pddf/i2c/service/pddf-platform-init.service
+++ b/platform/pddf/i2c/service/pddf-platform-init.service
@@ -5,6 +5,7 @@ DefaultDependencies=no
 
 [Service]
 Type=oneshot
+ExecStartPre=-/usr/local/bin/pre_pddf_init.sh
 ExecStart=/usr/local/bin/pddf_util.py install
 ExecStop=/usr/local/bin/pddf_util.py clean
 RemainAfterExit=yes

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_fan.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_fan.py
@@ -224,7 +224,7 @@ class PddfFan(FanBase):
         target_speed = 0
         if self.is_psu_fan:
             # Target speed not usually supported for PSU fans
-            target_speed = 0
+            raise NotImplementedError
         else:
             idx = (self.fantray_index-1)*self.platform['num_fans_pertray'] + self.fan_index
             attr = "fan" + str(idx) + "_pwm"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Some platforms need to run few steps before the PDDF service is actually started.

#### How I did it
Added a pre_pddf_init script execution as ExecStartPre in the service file

#### How to verify it
Verified on AS7816 and AS9716 platforms. Please check
https://github.com/Azure/sonic-buildimage/pull/7826 
https://github.com/Azure/sonic-buildimage/pull/7827

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

