### PR TITLE
[build]: Fix missing the depended files of dpkg cache in config engine

### DIFF
--- a/rules/sonic-config.dep
+++ b/rules/sonic-config.dep
@@ -4,7 +4,7 @@ SPATH       := $($(SONIC_CONFIG_ENGINE_PY2)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-config.mk rules/sonic-config.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(SPATH))
-DEP_FILES	+= files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-fpm-quagga/bgpd.conf.j2 dockers/docker-fpm-quagga/zebra.conf.j2 dockers/docker-orchagent/ipinip.json.j2 device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/qos.json.j2 files/build_templates/qos_config.j2 device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/qos.json.j2 dockers/docker-orchagent/switch.json.j2 files/image_config/constants/constants.yml
+DEP_FILES   += files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-fpm-quagga/bgpd.conf.j2 dockers/docker-fpm-quagga/zebra.conf.j2 dockers/docker-orchagent/ipinip.json.j2 device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/qos.json.j2 files/build_templates/qos_config.j2 device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/qos.json.j2 dockers/docker-orchagent/switch.json.j2 files/image_config/constants/constants.yml
 
 $(SONIC_CONFIG_ENGINE_PY2)_CACHE_MODE  := GIT_CONTENT_SHA 
 $(SONIC_CONFIG_ENGINE_PY2)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)

--- a/rules/sonic-config.dep
+++ b/rules/sonic-config.dep
@@ -4,6 +4,7 @@ SPATH       := $($(SONIC_CONFIG_ENGINE_PY2)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-config.mk rules/sonic-config.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(SPATH))
+DEP_FILES	+= files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-fpm-quagga/bgpd.conf.j2 dockers/docker-fpm-quagga/zebra.conf.j2 dockers/docker-orchagent/ipinip.json.j2 device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/qos.json.j2 files/build_templates/qos_config.j2 device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/qos.json.j2 dockers/docker-orchagent/switch.json.j2 files/image_config/constants/constants.yml
 
 $(SONIC_CONFIG_ENGINE_PY2)_CACHE_MODE  := GIT_CONTENT_SHA 
 $(SONIC_CONFIG_ENGINE_PY2)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The PR checkers do not re-run the sonic-config-engine test cases, caused by some of the config files changes not detected.

https://sonic-jenkins.westus2.cloudapp.azure.com/job/mellanox/job/buildimage-mlnx-all/660/console
…
07:13:24  ======================================================================
07:13:24  ERROR: test_bgpd_quagga (tests.test_j2files.TestJ2Files)
07:13:24  ----------------------------------------------------------------------
…
07:13:24  ======================================================================
07:13:24  ERROR: test_zebra_quagga (tests.test_j2files.TestJ2Files)
07:13:24  ----------------------------------------------------------------------
…
07:13:24  error: Test failed: <unittest.runner.TextTestResult run=161 errors=2 failures=0>
07:13:24  [  FAIL LOG END  ] [ target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl ]
07:13:24  make: *** [slave.mk:603: target/python-wheels/sonic_config_engine-1.0-py2-none-any.whl] Error 1
07:13:24  Makefile.work:292: recipe for target 'target/sonic-mellanox.bin' failed
07:13:24  make[1]: *** [target/sonic-mellanox.bin] Error 2
07:13:24  make[1]: Leaving directory '/data2/johnar/workspace/mellanox/buildimage-mlnx-all'
07:13:24  Makefile:7: recipe for target 'target/sonic-mellanox.bin' failed
07:13:24  make: *** [target/sonic-mellanox.bin] Error 2

See PR: https://github.com/Azure/sonic-buildimage/pull/7476


#### How I did it
Add the depended files.
See src/sonic-config-engine/tests/test_j2files.py

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

