### PR TITLE
[as7326-56x] Modify to check eeprom by pre_pddf_init.sh

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pre_pddf_init.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pre_pddf_init.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Steps to check syseeprom i2c address
+modprobe i2c-i801
+modprobe i2c-dev
+use_57_eeprom=true
+i2cget -y -f 0 0x56 0x0
+if [ $? -eq 0 ]; then
+    use_57_eeprom=false
+    echo "The board has system EEPROM at I2C address 0x56."
+fi
+
+if $use_57_eeprom ; then
+    echo "The board has system EEPROM at I2C address 0x57."
+    # syseeprom is at the i2c address 0x57. Change the PDDF JSON file
+    if [ -f /usr/share/sonic/device/x86_64-accton_as7326_56x-r0/pddf_support ] && \
+       [ -f /usr/share/sonic/device/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json ]; then
+        sed 's@"topo_info": {"parent_bus": "0x0", "dev_addr": "0x56", "dev_type": "24c04"},@\
+            "topo_info": {"parent_bus": "0x0", "dev_addr": "0x57", "dev_type": "24c02"},@g' \
+            /usr/share/sonic/device/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
+        sync
+    fi
+fi

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pre_pddf_init.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pre_pddf_init.sh
@@ -15,7 +15,7 @@ if $use_57_eeprom ; then
     # syseeprom is at the i2c address 0x57. Change the PDDF JSON file
     if [ -f /usr/share/sonic/device/x86_64-accton_as7326_56x-r0/pddf_support ] && \
        [ -f /usr/share/sonic/device/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json ]; then
-        sed 's@"topo_info": {"parent_bus": "0x0", "dev_addr": "0x56", "dev_type": "24c04"},@\
+        sed -i 's@"topo_info": {"parent_bus": "0x0", "dev_addr": "0x56", "dev_type": "24c04"},@\
             "topo_info": {"parent_bus": "0x0", "dev_addr": "0x57", "dev_type": "24c02"},@g' \
             /usr/share/sonic/device/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
         sync

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.postinst
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.postinst
@@ -2,27 +2,7 @@
 # Disable monitor, monitor-fan, monitor-psu (not enabling them would imply they will be disabled by default)
 # Enable pddf-platform-monitor
 
-# Steps to check syseeprom i2c address
-modprobe i2c-i801
-modprobe i2c-dev
-use_57_eeprom=true
-(i2cget -y -f 0 0x56 0x0) > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-    use_57_eeprom=false
-fi
-
-if $use_57_eeprom ; then
-    echo "The board has system EEPROM at I2C address 0x57"
-    # syseeprom is at the i2c address 0x57. Change the PDDF JSON file
-    sed -i 's@"topo_info": {"parent_bus": "0x0", "dev_addr": "0x56", "dev_type": "24c04"},@\
-        "topo_info": {"parent_bus": "0x0", "dev_addr": "0x57", "dev_type": "24c02"},@g' \
-        /usr/share/sonic/device/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
-    sync
-fi
-
 depmod -a
-systemctl enable as7326-platform-handle_mac.service
-systemctl start as7326-platform-handle_mac.service
 systemctl enable pddf-platform-init.service
 systemctl start pddf-platform-init.service
 systemctl enable as7326-56x-pddf-platform-monitor.service

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.postinst
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.postinst
@@ -3,6 +3,8 @@
 # Enable pddf-platform-monitor
 
 depmod -a
+systemctl enable as7326-platform-handle_mac.service
+systemctl start as7326-platform-handle_mac.service
 systemctl enable pddf-platform-init.service
 systemctl start pddf-platform-init.service
 systemctl enable as7326-56x-pddf-platform-monitor.service


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Modify to check eeprom by pre_pddf_init.sh
#### How I did it
Add pre_pddf_init.sh to code base.
#### How to verify it
Test eeprom and other pddf cmd that are fine
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

