### PR TITLE
[docker-teamd]: Increase teammgrd timeout to allow graceful shutdown

### DIFF
--- a/dockers/docker-teamd/supervisord.conf
+++ b/dockers/docker-teamd/supervisord.conf
@@ -44,6 +44,7 @@ command=/usr/bin/teammgrd
 priority=3
 autostart=false
 autorestart=false
+stopwaitsecs=60
 stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true


### PR DESCRIPTION




<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The PR is a cherry-pick of #7662. 
Same issue is detected in ```202012```.

#### How I did it
Add a timeout for ```teammgrd```.

#### How to verify it
Verified by running ```test_po_cleanup``` on ```SN4600```, with 24 portchannels. 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Increase teammgrd timeout to allow graceful shutdown

#### A picture of a cute animal (not mandatory but encouraged)

