### PR TITLE
[PDDF] Fix missing import on pddf_thermal.py

### DIFF
--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_thermal.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_thermal.py
@@ -12,6 +12,7 @@
 #############################################################################
 
 try:
+    import os
     from sonic_platform_base.thermal_base import ThermalBase
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")


### PR DESCRIPTION
Signed-off-by: Sean Wu <sean_wu@edge-core.com>

#### Why I did it
To fix NameError exception while set_high_threshold() get invoked.
`File "/usr/local/lib/python3.7/dist-packages/sonic_platform_pddf_base/pddf_thermal.py", line 97, in set_high_threshold
    os.system(cmd)
NameError: name 'os' is not defined`

#### How I did it
import os

#### How to verify it
1. The exception is gone.
2. Use `sensors` command to confirm the threshold was changed after set_high_threshold().

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
Fix missing import on pddf_thermal.py

#### A picture of a cute animal (not mandatory but encouraged)

