### PR TITLE
Add service to restore TACACS from old config (#7560)

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -334,6 +334,13 @@ sudo cp $IMAGE_CONFIGS/config-setup/config-setup $FILESYSTEM_ROOT/usr/bin/config
 echo "config-setup.service" | sudo tee -a $GENERATED_SERVICE_FILE
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable config-setup.service
 
+# Add delayed tacacs application service
+sudo cp files/build_templates/tacacs-config.timer $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
+echo "tacacs-config.timer" | sudo tee -a $GENERATED_SERVICE_FILE
+
+sudo cp files/build_templates/tacacs-config.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
+echo "tacacs-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
+
 # Copy SNMP configuration files
 sudo cp $IMAGE_CONFIGS/snmp/snmp.yml $FILESYSTEM_ROOT/etc/sonic/
 

--- a/files/build_templates/tacacs-config.service
+++ b/files/build_templates/tacacs-config.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=TACACS application
+Requires=updategraph.service
+After=updategraph.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/config-setup apply_tacacs
+RemainAfterExit=yes
+

--- a/files/build_templates/tacacs-config.timer
+++ b/files/build_templates/tacacs-config.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Delays tacacs apply until SONiC has started
+PartOf=tacacs-config.service
+After=updategraph.service
+
+[Timer]
+OnUnitActiveSec=0 sec
+OnBootSec=5min 30 sec
+Unit=tacacs-config.service
+
+[Install]
+WantedBy=timers.target updategraph.service

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -110,12 +110,19 @@ reload_minigraph()
 {
     echo "Reloading minigraph..."
     config load_minigraph -y -n 
+    config save -y
+}
+
+# Apply tacacs config
+apply_tacacs()
+{
     if [ -r /etc/sonic/old_config/${TACACS_JSON_BACKUP} ]; then
         sonic-cfggen -j /etc/sonic/old_config/${TACACS_JSON_BACKUP} --write-to-db
+        echo "Applied tacacs json to restore tacacs credentials"
+        config save -y
     else
         echo "Missing tacacs json to restore tacacs credentials"
     fi
-    config save -y
 }
 
 # Reload exisitng config db file on disk
@@ -443,6 +450,11 @@ fi
 # Take a backup of current configuration
 if [ "$CMD" = "backup" ]; then
     do_config_backup
+fi
+
+# Apply tacacs from old configuration
+if [ "$CMD" = "apply_tacacs" ]; then
+    apply_tacacs
 fi
 
 exit 0


### PR DESCRIPTION
Why I did it
In upgrade scenarios, where config_db.json is not carry forwarded to new image, it could be left w/o TACACS credentials.
Added a service to trigger 5 minutes after boot and restore TACACS, if /etc/sonic/old_config/tacacs.json is present.

How I did it
By adding a service, that would fire 5 mins after boot.
This service apply tacacs if available.

How to verify it
Upgrade and watch status of tacacs.timer & tacacs.service
You may create /etc/sonic/old_config/tacacs.json, with updated credentials
(before 5mins after boot) and see that appears in config & persisted too.

Which release branch to backport (provide reason below if selected)
 201911
 202006
 202012

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

