### PR TITLE
[multi-asic] Make asic-id in DEVICE_METADATA optional 

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -398,7 +398,7 @@ def main():
             device_id = get_asic_device_id(asic_id)
             # if the device_id obtained is None, exit with error
             if device_id is None:
-                print('Failed to get device ID from asic.conf file for', asic_name, file=sys.stderr)
+                print('Warning: Failed to get device ID from asic.conf file for', asic_name, file=sys.stderr)
             else:
                 hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
 

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -392,14 +392,16 @@ def main():
             'platform': platform,
             'mac': mac,
             }}}
+
         # The ID needs to be passed to the SAI to identify the asic.
         if asic_name is not None:
             device_id = get_asic_device_id(asic_id)
             # if the device_id obtained is None, exit with error
             if device_id is None:
-                print('Failed to get device ID for', asic_name, file=sys.stderr)
-                sys.exit(1)
-            hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
+                print('Failed to get device ID from asic.conf file for', asic_name, file=sys.stderr)
+            else:
+                hardware_data['DEVICE_METADATA']['localhost'].update(asic_id=device_id)
+
         deep_update(data, hardware_data)
 
     paths = ['/', '/usr/share/sonic/templates']


### PR DESCRIPTION
### Why I did it
There was a discussion and requirement in Chassis discussion forum to not make the asic-id field in the DEVICE_METADATA mandatory. If this field "asic-id" is not present the orchagent will be started without the -i <asic_id> parameter 

Ref: https://github.com/Azure/sonic-buildimage/blob/master/dockers/docker-orchagent/orchagent.sh#L39

#### How I did it
Made the check to see if the asic-id is valid and update the asic-id field in the DEVICE_METADATA

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

