### PR TITLE
[TACACS] Run timer based tacacs service to restore tacacs credentials

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -250,6 +250,12 @@ sudo cp $IMAGE_CONFIGS/caclmgrd/caclmgrd.service  $FILESYSTEM_ROOT/etc/systemd/s
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable caclmgrd.service
 sudo cp $IMAGE_CONFIGS/caclmgrd/caclmgrd $FILESYSTEM_ROOT/usr/bin/
 
+# Copy tacacs service & script
+sudo cp files/build_templates/tacacs-config.timer $FILESYSTEM_ROOT/etc/systemd/system/
+sudo cp files/build_templates/tacacs-config.service $FILESYSTEM_ROOT/etc/systemd/system/
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable tacacs-config.timer
+sudo cp $IMAGE_CONFIGS/updategraph/apply_tacacs.sh $FILESYSTEM_ROOT/usr/bin/
+
 # Copy systemd timer configuration
 # It implements delayed start of services
 sudo cp $BUILD_TEMPLATES/process-reboot-cause.timer $FILESYSTEM_ROOT/etc/systemd/system/

--- a/files/build_templates/tacacs-config.service
+++ b/files/build_templates/tacacs-config.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=TACACS application
+Requires=updategraph.service
+After=updategraph.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/apply_tacacs.sh
+RemainAfterExit=yes
+

--- a/files/build_templates/tacacs-config.timer
+++ b/files/build_templates/tacacs-config.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Delays tacacs apply until SONiC has started
+PartOf=tacacs-config.service
+After=updategraph.service
+
+[Timer]
+OnUnitActiveSec=0 sec
+OnBootSec=5min 30 sec
+Unit=tacacs-config.service
+
+[Install]
+WantedBy=timers.target updategraph.service

--- a/files/image_config/updategraph/apply_tacacs.sh
+++ b/files/image_config/updategraph/apply_tacacs.sh
@@ -1,5 +1,7 @@
 #! /bin/bash -e
 
+TACACS_JSON_BACKUP=tacacs.json
+
 if [ -r /etc/sonic/old_config/${TACACS_JSON_BACKUP} ]; then
     sonic-cfggen -j /etc/sonic/old_config/${TACACS_JSON_BACKUP} --write-to-db
     echo "Applied tacacs config from /etc/sonic/old_config/${TACACS_JSON_BACKUP}"

--- a/files/image_config/updategraph/apply_tacacs.sh
+++ b/files/image_config/updategraph/apply_tacacs.sh
@@ -1,0 +1,9 @@
+#! /bin/bash -e
+
+if [ -r /etc/sonic/old_config/${TACACS_JSON_BACKUP} ]; then
+    sonic-cfggen -j /etc/sonic/old_config/${TACACS_JSON_BACKUP} --write-to-db
+    echo "Applied tacacs config from /etc/sonic/old_config/${TACACS_JSON_BACKUP}"
+    config save -y
+else
+    echo "Missing tacacs json to restore tacacs credentials"
+fi

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 CONFIG_DB_INDEX=4
-TACACS_JSON_BACKUP=tacacs.json
 
 reload_minigraph()
 {
@@ -16,11 +15,6 @@ reload_minigraph()
         acl-loader update full /etc/sonic/acl.json
     fi
     config qos reload
-    if [ -r /etc/sonic/old_config/${TACACS_JSON_BACKUP} ]; then
-        sonic-cfggen -j /etc/sonic/old_config/${TACACS_JSON_BACKUP} --write-to-db
-    else
-        echo "Missing tacacs json to restore tacacs credentials"
-    fi
     DEVICE_TYPE=`sonic-cfggen -m -v DEVICE_METADATA.localhost.type`
     if [[ "${DEVICE_TYPE}" != "MgmtToRRouter" && "${DEVICE_TYPE}" != "EPMS" ]]; then
         pfcwd start_default


### PR DESCRIPTION
from old config, if present.
This is equivalent to PR #7560 in master.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

