### PR TITLE
[multi-asic] fix network command for internal ipv6 loopback

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -80,7 +80,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% if multi_asic is defined %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") != 'None' %}
   address-family ipv6
-    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/64 route-map HIDE_INTERNAL
+    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/128 route-map HIDE_INTERNAL
   exit-address-family
 {% endif %}
 {% endif %}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -61,7 +61,7 @@ router bgp 55555
     network fc00::1/64
   exit-address-family
   address-family ipv6
-    network fc00::2/64 route-map HIDE_INTERNAL
+    network fc00::2/128 route-map HIDE_INTERNAL
   exit-address-family
 !
   network 10.10.10.1/24

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
@@ -40,7 +40,7 @@ router bgp 55555
     network fc00::1/64
   exit-address-family
   address-family ipv6
-    network fc00::2/64 route-map HIDE_INTERNAL
+    network fc00::2/128 route-map HIDE_INTERNAL
   exit-address-family
 !
   network 10.10.10.1/24

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
@@ -40,7 +40,7 @@ router bgp 55555
     network fc00::1/64
   exit-address-family
   address-family ipv6
-    network fc00::2/64 route-map HIDE_INTERNAL
+    network fc00::2/128 route-map HIDE_INTERNAL
   exit-address-family
 !
   network 10.10.10.1/24

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -80,7 +80,7 @@ router bgp 55555
     network fc00::1/64
   exit-address-family
   address-family ipv6
-    network fc00::2/64 route-map HIDE_INTERNAL
+    network fc00::2/128 route-map HIDE_INTERNAL
   exit-address-family
 !
   network 10.10.10.1/24

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -59,7 +59,7 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
   address-family ipv6
-    network fd00:4::32/64 route-map HIDE_INTERNAL
+    network fd00:4::32/128 route-map HIDE_INTERNAL
   exit-address-family
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -59,7 +59,7 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
   address-family ipv6
-    network fd00:1::32/64 route-map HIDE_INTERNAL
+    network fd00:1::32/128 route-map HIDE_INTERNAL
   exit-address-family
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -59,7 +59,7 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
   address-family ipv6
-    network fd00:4::32/64 route-map HIDE_INTERNAL
+    network fd00:4::32/128 route-map HIDE_INTERNAL
   exit-address-family
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -59,7 +59,7 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
   address-family ipv6
-    network fd00:1::32/64 route-map HIDE_INTERNAL
+    network fd00:1::32/128 route-map HIDE_INTERNAL
   exit-address-family
 !
 !


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In the multi asic platforms all the ASIC are advertising the same IPv6 /64 network from Loopback4096.
Therefore, the IPv6 loopback address of backend asic is not learnt on the frontend asic.
Change this to advertise the Loopback4096 address as /128 

#### How I did it
Change the `bgpd.conf.main.conf.j2 `template file.

#### How to verify it
Verify the route to Loopback4096 address of backend asic is programmed on the Frontend linecard

- Loopback4096 ipv6 address on backend asics
```
admin@sonic:~$ show ipv6 int -d all -n asic4 | grep -i loopback4096
Loopback4096               2603:10e2:400::4/128                       up/up         N/A             N/A
                           fe80::fc68:56ff:fe3a:7f37%Loopback4096/64                N/A             N/A
admin@sonic:~$ show ipv6 int -d all -n asic5 | grep -i loopback4096
Loopback4096               2603:10e2:400::5/128                       up/up         N/A             N/A
                           fe80::705c:bbff:fec5:1c36%Loopback4096/64                N/A             N/A
admin@sonic:~$
```

Verify the route is programmed in the hardware for these addresses
```
admin@sonic:~$ bcmcmd -n 0 "l3 ip6route show" | grep 2603:10e2:0400:0000:0000:0000:0000
27    0        2603:10e2:0400:0000:0000:0000:0000:0000/128  00:00:00:00:00:00 100003    0     0     0    1 n
65565 0        2603:10e2:0400:0000:0000:0000:0000:0002/128  00:00:00:00:00:00 200258    0     0     0    0 n      (ECMP)
30    0        2603:10e2:0400:0000:0000:0000:0000:0003/128  00:00:00:00:00:00 200258    0     0     0    0 n      (ECMP)
65566 0        2603:10e2:0400:0000:0000:0000:0000:0005/128  00:00:00:00:00:00 100008    0     0     0    0 n
31    0        2603:10e2:0400:0000:0000:0000:0000:0001/128  00:00:00:00:00:00 200258    0     0     0    0 n      (ECMP)
65567 0        2603:10e2:0400:0000:0000:0000:0000:0004/128  00:00:00:00:00:00 100009    0     0     0    0 n

```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x ] 201911
- [ x] 202006
- [x ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

