### PR TITLE
Revert "[docker-mgmt-framework]: update mgmt framework docker to support sonic-cli cmd"

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -7,7 +7,21 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y g++ python3-dev libxml2 libcurl3-gnutls libcjson-dev
+    apt-get install -y g++ python3-dev libxml2
+
+# TODO: Remove these lines once we no longer need Python 2
+RUN apt-get install -f -y python-dev python-pip
+RUN pip2 install --upgrade 'pip<21'
+RUN apt-get purge -y python-pip
+RUN pip2 install setuptools==40.8.0
+RUN pip2 install wheel==0.35.1
+RUN pip2 install connexion==1.1.15 \
+                setuptools==21.0.0 \
+                grpcio-tools==1.20.0 \
+                certifi==2017.4.17 \
+                python-dateutil==2.6.0 \
+                six==1.11.0 \
+                urllib3==1.21.1
 
 RUN pip3 install connexion==2.7.0 \
                  setuptools==21.0.0 \
@@ -32,12 +46,11 @@ COPY ["start.sh", "rest-server.sh", "/usr/bin/"]
 COPY ["mgmt_vars.j2", "/usr/share/sonic/templates/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 
+# TODO: Remove this line once we no longer need Python 2
+RUN apt-get purge -y python-dev
+
 RUN apt-get remove -y g++ python3-dev
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
-
-## TODO: symbolic links will be removed when AAA improvements get merged
-RUN ln -sf /host_etc/passwd /etc/passwd	
-RUN ln -sf /host_etc/group /etc/group
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-mgmt-framework/base_image_files/sonic-cli
+++ b/dockers/docker-sonic-mgmt-framework/base_image_files/sonic-cli
@@ -1,21 +1,4 @@
 #!/bin/bash
 
-# Disallow CLI for the root user, since we don't have auth certs for root
-if [[ "$(id -u)" == 0 ]]
-then
-    echo "FATAL: root cannot launch CLI" >&2
-    exit 1
-fi
-TIMEOUT=605
-if [[ "$1" =~ "prompt=" ]]
-then
-   SYSTEM_NAME=`echo $1 | cut -d"=" -f2`
-   shift
-   docker exec -e SYSTEM_NAME=$SYSTEM_NAME -e CLI_USER="$USER" -u $(id -u):$(id -g) -it mgmt-framework /usr/sbin/cli/clish_start -t "$TIMEOUT" "$@"
-else
-   docker exec -e CLI_USER="$USER" -e SYSTEM_NAME=$HOSTNAME -u $(id -u):$(id -g) -it mgmt-framework /usr/sbin/cli/clish_start -t "$TIMEOUT" "$@"
-fi
-ret=$?
-if [ $ret -ne 0 ]; then
-   [[ -e /tmp/fast-reboot-progress || -e /tmp/reboot-progress ]] && sleep infinity
-fi
+docker exec -it mgmt-framework /usr/sbin/cli/clish_start "$@"
+

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -302,8 +302,6 @@ RUN apt-get update && apt-get install -y \
         xsltproc \
         python-lxml \
         libexpat1-dev \
-        libcurl3-gnutls \
-        libcjson-dev \
 # For WPA supplication
         qtbase5-dev          \
         aspell-en            \


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#6148.

Causes debug build failure.

When building docker-sonic-mgmt-framework-dbg, openssl-client will be installed, it will add a group as below. During the docker build, the /host_etc does not exist.

```
johnar@0c7bd7e98baf:/sonic/dockers/docker-sonic-mgmt-framework$ grep openssh Dockerfile-dbg 
RUN apt-get update && apt-get install -f -y gdb gdbserver vim openssh-client sshpass strace

I have no name!@fd2a27db6a3c:/# /usr/sbin/groupadd -g 100 ssh
groupadd: cannot open /etc/group
I have no name!@fd2a27db6a3c:/#

I have no name!@fd2a27db6a3c:/# ls /etc/group -l
lrwxrwxrwx 1 0 0 15 Jun 14 10:08 /etc/group -> /host_etc/group


```