### PR TITLE
sonic-yang-models updates for MPLS

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/crm.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/crm.json
@@ -77,5 +77,43 @@
 	"desc": "IPMC_WITH_WRONG_THRESHOLD_TYPE pattern failure.",
         "eStrKey": "Pattern",
 	"eStr": ["wrong" ]
+    },
+    "MPLS_INSEG_WITH_WRONG_THRESHOLD_TYPE": {
+	"desc": "MPLS_INSEG_WITH_WRONG_THRESHOLD_TYPE pattern failure.",
+        "eStrKey": "Pattern",
+	"eStr": ["wrong" ]
+    },
+    "MPLS_INSEG_WITH_WRONG_PERCENTAGE": {
+	"desc": "MPLS_INSEG_WITH_WRONG_PERCENTAGE must condition failure.",
+        "eStrKey": "Must"
+    },
+    "MPLS_INSEG_WITH_HIGH_THRESHOLD_ERR": {
+	"desc": "MPLS_INSEG_WITH_HIGH_THRESHOLD_ERR must condition failure  about high threshold being lower than low threshold.",
+	"eStr": ["high_threshold should be more than low_threshold"]
+    },
+    "MPLS_INSEG_WITH_CORRECT_USED_VALUE": {
+	"desc": "MPLS_INSEG_WITH_CORRECT_USED_VALUE no failure."
+    },
+    "MPLS_INSEG_WITH_CORRECT_FREE_VALUE": {
+	"desc": "MPLS_INSEG_WITH_CORRECT_FREE_VALUE no failure."
+    },
+    "MPLS_NH_WITH_WRONG_THRESHOLD_TYPE": {
+	"desc": "MPLS_NH_WITH_WRONG_THRESHOLD_TYPE pattern failure.",
+        "eStrKey": "Pattern",
+	"eStr": ["wrong" ]
+    },
+    "MPLS_NH_WITH_WRONG_PERCENTAGE": {
+	"desc": "MPLS_NH_WITH_WRONG_PERCENTAGE must condition failure.",
+        "eStrKey": "Must"
+    },
+    "MPLS_NH_WITH_HIGH_THRESHOLD_ERR": {
+	"desc": "MPLS_NH_WITH_HIGH_THRESHOLD_ERR must condition failure  about high threshold being lower than low threshold.",
+	"eStr": ["high_threshold should be more than low_threshold"]
+    },
+    "MPLS_NH_WITH_CORRECT_USED_VALUE": {
+	"desc": "MPLS_NH_WITH_CORRECT_USED_VALUE no failure."
+    },
+    "MPLS_NH_WITH_CORRECT_USED_VALUE": {
+	"desc": "MPLS_NH_WITH_CORRECT_USED_VALUE no failure."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/crm.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/crm.json
@@ -218,5 +218,115 @@
                 }
             }
         }
+    },
+    "MPLS_INSEG_WITH_CORRECT_FREE_VALUE": {
+        "sonic-crm:sonic-crm": {
+            "sonic-crm:CRM": {
+                "Config": {
+                    "mpls_inseg_high_threshold": 90,
+                    "mpls_inseg_low_threshold": 70,
+                    "mpls_inseg_threshold_type": "free"
+                }
+            }
+        }
+    },
+    "MPLS_INSEG_WITH_CORRECT_USED_VALUE": {
+        "sonic-crm:sonic-crm": {
+            "sonic-crm:CRM": {
+                "Config": {
+                    "mpls_inseg_high_threshold": 85,
+                    "mpls_inseg_low_threshold": 25,
+                    "mpls_inseg_threshold_type": "used"
+                }
+            }
+        }
+    },
+    "MPLS_INSEG_WITH_HIGH_THRESHOLD_ERR": {
+        "sonic-crm:sonic-crm": {
+            "sonic-crm:CRM": {
+                "Config": {
+                    "mpls_inseg_high_threshold": 80,
+                    "mpls_inseg_low_threshold": 81,
+                    "mpls_inseg_threshold_type": "PERCENTAGE"
+                }
+            }
+        }
+    },
+    "MPLS_INSEG_WITH_WRONG_PERCENTAGE": {
+        "sonic-crm:sonic-crm": {
+            "sonic-crm:CRM": {
+                "Config": {
+                    "mpls_inseg_high_threshold": 110,
+                    "mpls_inseg_low_threshold": 85,
+                    "mpls_inseg_threshold_type": "PERCENTAGE"
+                }
+            }
+        }
+    },
+    "MPLS_INSEG_WITH_WRONG_THRESHOLD_TYPE": {
+        "sonic-crm:sonic-crm": {
+            "sonic-crm:CRM": {
+                "Config": {
+                    "mpls_inseg_high_threshold": 90,
+                    "mpls_inseg_low_threshold": 70,
+                    "mpls_inseg_threshold_type": "wrong"
+                }
+            }
+        }
+    },
+    "MPLS_NH_WITH_CORRECT_FREE_VALUE": {
+        "sonic-crm:sonic-crm": {
+            "sonic-crm:CRM": {
+                "Config": {
+                    "mpls_nexthop_high_threshold": 90,
+                    "mpls_nexthop_low_threshold": 70,
+                    "mpls_nexthop_threshold_type": "free"
+                }
+            }
+        }
+    },
+    "MPLS_NH_WITH_CORRECT_USED_VALUE": {
+        "sonic-crm:sonic-crm": {
+            "sonic-crm:CRM": {
+                "Config": {
+                    "mpls_nexthop_high_threshold": 85,
+                    "mpls_nexthop_low_threshold": 25,
+                    "mpls_nexthop_threshold_type": "used"
+                }
+            }
+        }
+    },
+    "MPLS_NH_WITH_HIGH_THRESHOLD_ERR": {
+        "sonic-crm:sonic-crm": {
+            "sonic-crm:CRM": {
+                "Config": {
+                    "mpls_nexthop_high_threshold": 80,
+                    "mpls_nexthop_low_threshold": 81,
+                    "mpls_nexthop_threshold_type": "PERCENTAGE"
+                }
+            }
+        }
+    },
+    "MPLS_NH_WITH_WRONG_PERCENTAGE": {
+        "sonic-crm:sonic-crm": {
+            "sonic-crm:CRM": {
+                "Config": {
+                    "mpls_nexthop_high_threshold": 110,
+                    "mpls_nexthop_low_threshold": 85,
+                    "mpls_nexthop_threshold_type": "PERCENTAGE"
+                }
+            }
+        }
+    },
+    "MPLS_NH_WITH_WRONG_THRESHOLD_TYPE": {
+        "sonic-crm:sonic-crm": {
+            "sonic-crm:CRM": {
+                "Config": {
+                    "mpls_nexthop_high_threshold": 90,
+                    "mpls_nexthop_low_threshold": 70,
+                    "mpls_nexthop_threshold_type": "wrong"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-crm.yang
+++ b/src/sonic-yang-models/yang-models/sonic-crm.yang
@@ -353,6 +353,58 @@ module sonic-crm {
                     type threshold;
                 }
 
+                leaf mpls_inseg_threshold_type {
+                    description "CRM threshold support for MPLS in-segment entries";
+
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../mpls_inseg_high_threshold<100 and
+                        ../mpls_inseg_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf mpls_inseg_high_threshold {
+                    description "CRM threshold support for MPLS in-segment entries";
+
+                    must "(current() > ../mpls_inseg_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf mpls_inseg_low_threshold {
+                    description "CRM threshold support for MPLS in-segment entries";
+
+                    type threshold;
+                }
+
+                leaf mpls_nexthop_threshold_type {
+                    description "CRM threshold support for MPLS next-hops";
+
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../mpls_nexthop_high_threshold<100 and
+                        ../mpls_nexthop_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+                }
+
+                leaf mpls_nexthop_high_threshold {
+                    description "CRM threshold support for MPLS next-hops";
+
+                    must "(current() > ../mpls_nexthop_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+
+                leaf mpls_nexthop_low_threshold {
+                    description "CRM threshold support for MPLS next-hops";
+
+                    type threshold;
+                }
+
             }
             /* end of Config */
         }

--- a/src/sonic-yang-models/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-interface.yang
@@ -68,6 +68,13 @@ module sonic-interface {
 					}
                                         default "0";
 				}
+				leaf mpls {
+					description "Enable/disable MPLS routing for the interface";
+					type enumeration {
+						enum enable;
+						enum disable;
+					}
+				}
 			}
 			/* end of INTERFACE_LIST */
 

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -179,6 +179,13 @@ module sonic-portchannel {
 		    }
 		    default "0";
 		}
+		leaf mpls {
+			description "Enable/disable MPLS routing for the portchannel interface";
+                        type enumeration {
+				enum enable;
+				enum disable;
+			}
+		}
             } /* end of list PORTCHANNEL_INTERFACE_LIST */
 
             list PORTCHANNEL_INTERFACE_IPPREFIX_LIST {

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -80,6 +80,13 @@ module sonic-vlan {
 					}
                                         default "0";
 				}
+				leaf mpls {
+					description "Enable/disable MPLS routing for the vlan interface";
+					type enumeration {
+						enum enable;
+						enum disable;
+					}
+				}
 			}
 			/* end of VLAN_INTERFACE_LIST */
 


### PR DESCRIPTION
What I did
SONiC YANG model support in buildimage for MPLS:
1) sonic-yang-model support for MPLS enable/disable
2) sonic-yang-model support for MPLS CRM thresholds

Why I did it
SONiC yang-models support for MPLS

How I verified it
Unit-tests in sonic-swss/tests/test_mpls.py and sonic-utilities/tests
System tests in sonic-mgmt

Details if related
Refer to MPLS HLD https://github.com/Azure/SONiC/pull/706
