### PR TITLE
Update the pcie-check service to support multi configuration files

### DIFF
--- a/files/image_config/pcie-check/pcie-check.service
+++ b/files/image_config/pcie-check/pcie-check.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Check the PCIe device presence and status
-After=rc.local.service database.service
+After=rc.local.service database.service config-setup.service
 
 [Service]
 Type=simple

--- a/files/image_config/pcie-check/pcie-check.sh
+++ b/files/image_config/pcie-check/pcie-check.sh
@@ -5,6 +5,7 @@ VERBOSE="no"
 RESULTS="PCIe Device Checking All Test"
 EXPECTED="PCIe Device Checking All Test ----------->>> PASSED"
 MAX_WAIT_SECONDS=15
+PCIE_STATUS_TABLE="PCIE_DEVICES|status"
 
 function debug()
 {
@@ -19,7 +20,7 @@ function check_and_rescan_pcie_devices()
     PCIE_CHK_CMD='sudo pcieutil check | grep "$RESULTS"'
     PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 
-    if [ ! -f /usr/share/sonic/device/$PLATFORM/pcie.yaml ]; then
+    if [ ! -f /usr/share/sonic/device/$PLATFORM/pcie*.yaml ]; then
         debug "pcie.yaml does not exist! Can't check PCIe status!"
         exit
     fi
@@ -37,7 +38,7 @@ function check_and_rescan_pcie_devices()
         fi
 
         if [ "$(eval $PCIE_CHK_CMD)" = "$EXPECTED" ]; then
-            redis-cli -n 6 HSET "PCIE_DEVICES" "status" "PASSED"
+            redis-cli -n 6 HSET $PCIE_STATUS_TABLE "status" "PASSED"
             debug "PCIe check passed"
             exit
         else
@@ -53,7 +54,7 @@ function check_and_rescan_pcie_devices()
 
      done
      debug "PCIe check failed"
-     redis-cli -n 6 HSET "PCIE_DEVICES" "status" "FAILED"
+     redis-cli -n 6 HSET $PCIE_STATUS_TABLE "status" "FAILED"
 }
 
 check_and_rescan_pcie_devices


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To support multiple pcie configuration for a platform type 
We also extended the platform api with https://github.com/Azure/sonic-platform-common/pull/195

#### How I did it
Accommodate the change, checking if the pcie configuration file exists with wildcard.

#### How to verify it
Restart  DUT with the change and verify if the pcie check is working as expected.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

