### PR TITLE
[201911][multi-asic] fix network command for internal ipv6 loopback

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -79,7 +79,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% if multi_asic is defined %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") != 'None' %}
   address-family ipv6
-    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/64 route-map HIDE_INTERNAL
+    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/128 route-map HIDE_INTERNAL
   exit-address-family
 {% endif %}
 {% endif %}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -66,7 +66,7 @@ router bgp 55555
     network fc00::1/64
   exit-address-family
   address-family ipv6
-    network fc00::2/64 route-map HIDE_INTERNAL
+    network fc00::2/128 route-map HIDE_INTERNAL
   exit-address-family
 !
   address-family ipv6

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
@@ -41,7 +41,7 @@ router bgp 55555
     network fc00::1/64
   exit-address-family
   address-family ipv6
-    network fc00::2/64 route-map HIDE_INTERNAL
+    network fc00::2/128 route-map HIDE_INTERNAL
   exit-address-family
 !
   network 10.10.10.1/24

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
@@ -41,7 +41,7 @@ router bgp 55555
     network fc00::1/64
   exit-address-family
   address-family ipv6
-    network fc00::2/64 route-map HIDE_INTERNAL
+    network fc00::2/128 route-map HIDE_INTERNAL
   exit-address-family
 !
   network 10.10.10.1/24

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -75,7 +75,7 @@ router bgp 55555
     network fc00::1/64
   exit-address-family
   address-family ipv6
-    network fc00::2/64 route-map HIDE_INTERNAL
+    network fc00::2/128 route-map HIDE_INTERNAL
   exit-address-family
 !
   address-family ipv6

--- a/src/sonic-config-engine/tests/sample_output/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/bgpd_frr_backend_asic.conf
@@ -58,7 +58,7 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
   address-family ipv6
-    network fd00:4::32/64 route-map HIDE_INTERNAL
+    network fd00:4::32/128 route-map HIDE_INTERNAL
   exit-address-family
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/bgpd_frr_frontend_asic.conf
@@ -58,7 +58,7 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
   address-family ipv6
-    network fd00:1::32/64 route-map HIDE_INTERNAL
+    network fd00:1::32/128 route-map HIDE_INTERNAL
   exit-address-family
 !
 !


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Port this PR to 201911 https://github.com/Azure/sonic-buildimage/pull/7878
#### How I did it

#### How to verify it
Verify the internal loopback address are present in the all the frontend asics
```
admin@sonic:~$ bcmcmd -n 0 "l3 ip6route show" | grep 2603:10e2:0400:0000:0000:0000:0000
1888  0        2603:10e2:0400:0000:0000:0000:0000:0000/128  00:00:00:00:00:00 100003    0     0     0    1 n
67424 0        2603:10e2:0400:0000:0000:0000:0000:0004/128  00:00:00:00:00:00 100004    0     0     0    0 n
1889  0        2603:10e2:0400:0000:0000:0000:0000:0005/128  00:00:00:00:00:00 100005    0     0     0    0 n
67428 0        2603:10e2:0400:0000:0000:0000:0000:0001/128  00:00:00:00:00:00 200258    0     0     0    0 n      (ECMP)
1895  0        2603:10e2:0400:0000:0000:0000:0000:0002/128  00:00:00:00:00:00 200258    0     0     0    0 n      (ECMP)
67431 0        2603:10e2:0400:0000:0000:0000:0000:0003/128  00:00:00:00:00:00 200258    0     0     0    0 n      (ECMP)
admin@sonic:~$ 


admin@sonic:~$ show ipv6 bgp network 2603:10e2:0400::4/128 -n asic1
BGP routing table entry for 2603:10e2:400::4/128
Paths: (1 available, best #1, table default, not advertised to EBGP peer)
  Not advertised to any peer
  Local
    2603:10e2:400:1::9 from 2603:10e2:400:1::9 (8.0.0.4)
    (fe80::42:f0ff:fe7f:106) (prefer-global)
      Origin IGP, metric 0, localpref 100, valid, internal, best (First path received)
      Community: 8075:9306 no-export
      Last update: Tue Jun 15 21:42:47 2021
admin@sonic:~$ 
admin@sonic:~$ 
admin@sonic:~$ 
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

