### PR TITLE
[CI] Fix azp built docker-sonic-mgmt image

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -32,7 +32,7 @@ stages:
 - stage: Build
   jobs:
   - job: Build
-    pool: sonicbld
+    pool: sonictest
     timeoutInMinutes: 360
     steps:
     - template: cleanup.yml


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
UserID is different with the image built by Jenkins if we build docker-sonic-mgmt in sonicbld pool.
So we build this image in sonictest pool. There is a sonictmp user with UserID 1001.
This will make docker image same as the image built in Jenkins
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

