### PR TITLE
[WIP][202012] Fix sonic-host-services setup

### DIFF
--- a/src/sonic-host-services/setup.py
+++ b/src/sonic-host-services/setup.py
@@ -28,7 +28,8 @@ setup(
     ],
     tests_require = [
         'pytest',
-        'sonic-py-common'
+        'sonic-py-common',
+        'parameterized~=0.8.1',
     ],
     classifiers = [
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
#### Why I did it
  Sonic [build failed](https://dev.azure.com/mssonic/build/_build/results?buildId=19875&view=logs&j=993d6e22-aeec-5c03-fa19-35ecba587dd9&t=d0538dec-1681-5ff8-bd45-c0de13be9706&l=658) . Locally I've got the same error.
Python package `parameterized` is [external dependency](https://github.com/Azure/sonic-buildimage/blob/199c75f36b232856a2a4bca08a5e86a75ad9f96c/src/sonic-host-services/tests/hostcfgd/hostcfgd_test.py#L5) for host services tests.

#### How I did it
Just added package `parameterized` to tests requirements.
