### PR TITLE
Add PG_DROP yang model

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/yangTest.json
@@ -886,6 +886,9 @@
                 "PFCWD": {
                     "FLEX_COUNTER_STATUS": "enable"
                 },
+                "PG_DROP": {
+                    "FLEX_COUNTER_STATUS": "enable"
+                },
                 "PG_WATERMARK": {
                     "FLEX_COUNTER_STATUS": "enable"
                 },
@@ -967,6 +970,9 @@
 		"sonic-flex_counter:sonic-flex_counter": {
 			"sonic-flex_counter:FLEX_COUNTER_TABLE": {
 				"QUEUE": {
+					"FLEX_COUNTER_STATUS": "enable"
+				},
+				"PG_DROP": {
 					"FLEX_COUNTER_STATUS": "enable"
 				},
 				"PG_WATERMARK": {
@@ -1678,6 +1684,9 @@
         },
         "FLEX_COUNTER_TABLE": {
             "PFCWD": {
+                "FLEX_COUNTER_STATUS": "enable"
+            },
+            "PG_DROP": {
                 "FLEX_COUNTER_STATUS": "enable"
             },
             "PG_WATERMARK": {

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -48,6 +48,13 @@ module sonic-flex_counter {
                 }
             }
 
+            container PG_DROP {
+                /* PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+            }
+
             container PG_WATERMARK {
                 /* PG_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {


### PR DESCRIPTION
Signed-off-by: Mykola Gerasymenko <mykolax.gerasymenko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
The same PR was created to merge to 202012 branch.

Why I did it
Dynamic Port Breakout falls cause of PG_DROP yang model missing

How I did it
Add PG_DROP yang model and add check this field in unit test for yang model

How to verify it
Firstly try to do DPB (2x50G) for Ethernet0 port:
sudo config interface breakout Ethernet0 2x50G -f
After that try to do DPB (1x100G[40G]) for Ethernet0 port:
sudo config interface breakout Ethernet0 1x100G[40G] -f
Both commands should work correctly.

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

