### PR TITLE
[sonic-host-services] Add 'parameterized' package as a test dependency

### DIFF
--- a/src/sonic-host-services/setup.py
+++ b/src/sonic-host-services/setup.py
@@ -35,6 +35,7 @@ setup(
         'wheel'
     ],
     tests_require = [
+        'parameterized',
         'pytest',
         'sonic-py-common'
     ],


### PR DESCRIPTION
#### Why I did it

Recently, the build started failing with messages like

```
2021-06-16T16:55:02.8675603Z tests/hostcfgd/hostcfgd_test.py:5: in <module>
2021-06-16T16:55:02.8676208Z     from parameterized import parameterized
2021-06-16T16:55:02.8677145Z E   ModuleNotFoundError: No module named 'parameterized'
```

Unit tests for hostcfgd depend on the `parameterized` Python package, but it was never added as a dependency to the setup.py file. This dependency was added ~3 months ago. I'm not sure why we only started seeing this failure recently.

#### How I did it

Add 'parameterized' package as a test dependency in setup.py for sonic-host-services package

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
