### PR TITLE
[202012] [BRCM} start_led.sh re-enable LED INIT for Warm Reboot

### DIFF
--- a/platform/broadcom/docker-syncd-brcm/start_led.sh
+++ b/platform/broadcom/docker-syncd-brcm/start_led.sh
@@ -31,8 +31,9 @@ wait_syncd() {
 }
 
 # If this platform has an initialization file for the Broadcom LED microprocessor, load it
-if [[ -r "$LED_PROC_INIT_SOC" && ! -f /var/warmboot/warm-starting ]]; then
-    wait_syncd
+if [ -r "$LED_PROC_INIT_SOC" ]; then
+    if [ ! -f /var/warmboot/warm-starting ]; then
+        wait_syncd
+    fi
     /usr/bin/bcmcmd -t 60 "rcload $LED_PROC_INIT_SOC"
 fi
-


### PR DESCRIPTION
#### Why I did it
For BRCM platform where LED INIT is required there was an issue with BRCM SAI 4.3.3 which can cause all the interfaces flap if this is executed.  A fix was provided in BRCM SAI 4.3.3.7 where we now can safely re-enable LED INIT at warm reboot time as well.  This is needed for WARM REBOOT. If not done, a device went through WARM REBOOT will see its LED not functioning any more.
We will map this same change to master branch later when we can validate that the same fix is in BRCM SAI 5.0.
There is a similar SAI change based on SAI 3.7 is not yet validated. Once that is ready a separate PR will be raised to include this change for 201911 branch.

#### How to verify it
The verification was done using S6100 SKU where we first observed the issue.
Attempt Warm reboot and without the fix you can see the LED are OFF.
With this change in place, attempt WARM reboot.  Once completed,  you can see the LED are ON and no port flapping occurred during WARM Reboot (check syslog and SAI REDIS Record)
While DUT is already up, re-execute LED INIT operation manually and observed LED remains ON and no interfaces flapped with BRCM SAI 4.3.3.7.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

Note :
201911 branch requires new BRCM SAI change to go in first and will need to raise a different PR for it.  Please do not cherry pick this PR for 201911.
Master branch requires BRCM SAI 5.0 based fix validation. I will be raising a different PR for it when validation is done on master branch.

#### Description for the changelog
[202012] [BRCM} start_led.sh re-enable LED INIT for Warm Reboot


#### A picture of a cute animal (not mandatory but encouraged)

