### PR TITLE
[voqsystemlagid] Fix for timing issue in setting system lag id boundary

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -108,8 +108,8 @@ function setPlatformLagIdBoundaries()
     CHASSIS_CONF=/usr/share/sonic/device/$PLATFORM/chassisdb.conf
     if [ -f "$CHASSIS_CONF" ]; then
         source $CHASSIS_CONF
-        $SONIC_DB_CLI CHASSIS_APP_DB SET "SYSTEM_LAG_ID_START" "$lag_id_start"
-        $SONIC_DB_CLI CHASSIS_APP_DB SET "SYSTEM_LAG_ID_END" "$lag_id_end"
+        docker exec -i ${DOCKERNAME} $SONIC_DB_CLI CHASSIS_APP_DB SET "SYSTEM_LAG_ID_START" "$lag_id_start"
+        docker exec -i ${DOCKERNAME} $SONIC_DB_CLI CHASSIS_APP_DB SET "SYSTEM_LAG_ID_END" "$lag_id_end"
     fi
 }
 {%- endif %}


### PR DESCRIPTION
#### Why I did it

In VOQ chassis systems, system lag id boundary is set in redis-chassis server immediately after starting the database-chassis container in the supervisor card. This system lad id boundary was not set correctly all the time. Intermittently there was failure in setting these values in CHASSIS_APP_DB in redis-chassis server. This PR has fix for this.

#### How I did it

The voq system lag id boundary is set in redis-chassis. Changes include
setting this from database-chassis container. This fixes a timing issue
in finding datbase_config.json file from redis directory which is
created from database container. Since database container usually
starts after database-chassis container the existence of this file is
unreliable while running the command. Running the command under
database-chassis container makes sure that the database_config.json form
redis-chassis directory is guaranteed to be available and hence fixes the
timing issue.

#### How to verify it

In VOQ chassis system, set the system lag id start and system lag id end in chassisdb.conf. Reboot the chassis and observe that SYSTEM_LAG_ID_START and SYSTEM_LAG_ID_END are set correctly as mentioned in chassisdb.conf and there are no failures reported in syslog.

#### Which release branch to backport (provide reason below if selected)

N/A
#### Description for the changelog

The voq system lag id boundary is set in redis-chassis. Changes include setting this from database-chassis container. This fixes a timing issue in finding datbase_config.json file from redis directory which is created from database container. Since database container usually starts after database-chassis container the existence of this file is unreliable while running the command. Running the command under database-chassis container makes sure that the database_config.json from redis-chassis directory is guaranteed to be available and hence fixes the timing issue.


#### A picture of a cute animal (not mandatory but encouraged)

