### PR TITLE
SONiC MAC ACL Yang model update to add support for Source MAC, Destination MAC, Ethertype pattern update, VLAN_ID, PCP, DEI fields.

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -81,5 +81,21 @@
             "key": "sonic-acl:actions",
             "value": [""]
         }
+    },
+    "ACL_TABLE_L2_ACL_FIELDS": {
+        "desc": "Configure L2 ACL with proper rule fields"
+    },
+    "ACL_TABLE_L3_RULE_WITH_L2_FIELDS": {
+        "desc": "Configure L2 Address in L3 ACL.",
+        "eStrKey" : "When",
+        "eStr": ["type"]
+    },
+    "ACL_RULE_L2_INVALID_MAC": {
+        "desc": "Configure invalid MAC address format.",
+        "eStrKey" : "Pattern"
+    },
+    "ACL_RULE_L2_INVALID_ETHER": {
+        "desc": "Configure invalid MAC address format.",
+        "eStrKey" : "Pattern"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -657,5 +657,123 @@
                 ]
             }
         }
+    },
+    "ACL_TABLE_L2_ACL_FIELDS": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "L2ACL",
+                        "SRC_MAC": "00:00:AB:CD:EF:00/FF:FF:FF:00:00:00",
+                        "DST_MAC": "00:00:AB:CD:EF:FF/FF:FF:FF:FF:FF:FF",
+                        "ETHER_TYPE": "0x0800",
+                        "PCP": "5/5",
+                        "DEI": "0",
+                        "PACKET_ACTION": "FORWARD",
+                        "PRIORITY": 999980,
+                        "RULE_NAME": "Rule_20"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "L2ACL",
+                        "policy_desc": "L2ACL Test",
+                        "ports": [ "" ],
+                        "stage": "INGRESS",
+                        "type": "L2"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_TABLE_L3_RULE_WITH_L2_FIELDS": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "L3ACL-MAC-FIELDS",
+                        "SRC_MAC": "00:00:AB:CD:EF:00/FF:FF:FF:00:00:00",
+                        "DST_MAC": "00:00:AB:CD:EF:FF/FF:FF:FF:FF:FF:FF",
+                        "ETHER_TYPE": "0x0800",
+                        "PCP": "5/5",
+                        "DEI": "0",
+                        "PACKET_ACTION": "FORWARD",
+                        "PRIORITY": 999980,
+                        "RULE_NAME": "Rule_20"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "L3ACL-MAC-FIELDS",
+                        "policy_desc": "L2ACL Test",
+                        "ports": [ "" ],
+                        "stage": "INGRESS",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_RULE_L2_INVALID_MAC": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "L2ACL_INVALID_MAC",
+                        "SRC_MAC": "00.00.AB.CD.EF.00/FF.FF.FF.00.00.00",
+                        "DST_MAC": "00.00.AB.CD.EF.FF/FF.FF.FF.FF.FF.FF",
+                        "ETHER_TYPE": "0x0800",
+                        "PCP": "5/5",
+                        "DEI": "0",
+                        "PACKET_ACTION": "FORWARD",
+                        "PRIORITY": 999980,
+                        "RULE_NAME": "Rule_20"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "L2ACL_INVALID_MAC",
+                        "policy_desc": "L2ACL Test",
+                        "ports": [ "" ],
+                        "stage": "INGRESS",
+                        "type": "L2"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_RULE_L2_INVALID_ETHER": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "L2ACL_INVALID_ETHER",
+                        "SRC_MAC": "00.00.AB.CD.EF.00/FF.FF.FF.00.00.00",
+                        "DST_MAC": "00.00.AB.CD.EF.FF/FF.FF.FF.FF.FF.FF",
+                        "ETHER_TYPE": "64",
+                        "PACKET_ACTION": "FORWARD",
+                        "PRIORITY": 999980,
+                        "RULE_NAME": "Rule_20"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "L2ACL_INVALID_ETHER",
+                        "policy_desc": "L2ACL Test",
+                        "ports": [ "" ],
+                        "stage": "INGRESS",
+                        "type": "L2"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -75,8 +75,16 @@ module sonic-acl {
 					}
 				}
 
-				choice ip_prefix {
-
+				choice src_dst_address {
+					case l2_src_dst_address {
+						when "(/acl:sonic-acl/acl:ACL_TABLE/acl:ACL_TABLE_LIST[ACL_TABLE_NAME=current()/acl:ACL_TABLE_NAME]/acl:type = 'L2')";
+						leaf SRC_MAC {
+                            type stypes:mac-addr-and-mask;
+						}
+						leaf DST_MAC {
+                            type stypes:mac-addr-and-mask;
+						}
+					}
 					case ip4_prefix {
 						when "boolean(IP_TYPE[.='ANY' or .='IP' or .='IPV4' or .='IPv4ANY' or .='ARP'])";
 						leaf SRC_IP {
@@ -144,7 +152,7 @@ module sonic-acl {
 
 				leaf ETHER_TYPE {
 					type string {
-						pattern "(0x88CC|0x8100|0x8915|0x0806|0x0800|0x86DD|0x8847)";
+					    pattern "0x0[6-9a-fA-F][0-9a-fA-F]{2}|0x[1-9a-fA-F][0-9a-fA-F]{3}";
 					}
 				}
 
@@ -219,6 +227,26 @@ module sonic-acl {
 
 				leaf INNER_L4_DST_PORT {
 					type uint16;
+				}
+
+				leaf VLAN_ID {
+					type uint16 {
+						range 1..4094;
+					}
+				}
+
+				leaf PCP {
+					when "(/acl:sonic-acl/acl:ACL_TABLE/acl:ACL_TABLE_LIST[ACL_TABLE_NAME=current()/../acl:ACL_TABLE_NAME]/acl:type = 'L2')";
+					type string {
+						pattern "[0-7]|[0-7]/[0-7]";
+					}
+				}
+
+				leaf DEI {
+					when "(/acl:sonic-acl/acl:ACL_TABLE/acl:ACL_TABLE_LIST[ACL_TABLE_NAME=current()/../acl:ACL_TABLE_NAME]/acl:type = 'L2')";
+					type uint8 {
+						range "0..1";
+					}
 				}
 			}
 			/* end of ACL_RULE_LIST */

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -222,6 +222,11 @@ module sonic-types {
         }
     }
 
+    typedef mac-addr-and-mask {
+        type string {
+            pattern "[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}|[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}/[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}";
+        }
+    }
 
 
     /* Required for CVL */


### PR DESCRIPTION
Signed-off-by: Abhishek Dharwadkar <48468617+abhishekd0@users.noreply.github.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently only IP ACL and related model is defined. Support for MAC ACL is missing. Added support for it.

#### How I did it
ACL_RULE table is added with new MAC ACL related fields namely Source MAC, Destination MAC, Ethertype (Pattern updated to match any valid Ethertypes), VLAN, PCP, DEI

#### How to verify it
Yang model tests are attached.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add support for MAC ACL yang model.

#### A picture of a cute animal (not mandatory but encouraged)

