### PR TITLE
Check platform reboot cause to see if any reset happened during fast/warm-reboot

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -60,6 +60,17 @@ function getMountPoint()
     echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.abspath(mnts[0]['Source'])" 2>/dev/null
 }
 
+function isPlatformReset()
+{
+    output=$(python3 -c "import sonic_platform.platform; p = sonic_platform.platform.Platform(); c = p.get_chassis(); hw_rc_major, hw_rc_minor = c.get_reboot_cause(); print(hw_rc_major)" 2>/dev/null)
+    echo "${output}"
+    if [[ "${output}" != "Non-Hardware" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 function getBootType()
 {
     # same code snippet in files/scripts/syncd.sh
@@ -76,6 +87,9 @@ function getBootType()
     *)
         TYPE='cold'
     esac
+    if isPlatformReset; then
+        TYPE='cold'
+    fi
     echo "${TYPE}"
 }
 

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -64,9 +64,12 @@ function getPlatformRebootCause()
 {
     IMPORT_ERR="*ImportError*"
     err=$(python -c "import sonic_platform.platform" 2>&1 > /dev/null)
+    err2=$(python3 -c "import sonic_platform.platform" 2>&1 > /dev/null)
+    output="Non-Hardware"
     if [[ "$err" =~ "$IMPORT_ERR"]]; then
          output=$(python3 -c "import sonic_platform.platform; p = sonic_platform.platform.Platform(); c = p.get_chassis(); hw_rc_major, hw_rc_minor = c.get_reboot_cause(); print(hw_rc_major)" 2>/dev/null)
-    else
+    fi
+    if [[ "$err2" =~ "$IMPORT_ERR"]]; then
          output=$(python -c "import sonic_platform.platform; p = sonic_platform.platform.Platform(); c = p.get_chassis(); hw_rc_major, hw_rc_minor = c.get_reboot_cause(); print(hw_rc_major)" 2>/dev/null)
     fi
     if [[ "${output}" == "Non-Hardware" ]]; then

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -112,6 +112,14 @@ function preStartAction()
     fi
 {%- elif docker_container_name == "snmp" %}
     $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
+{%- elif docker_container_name == "swss" %}
+    if [[ "$BOOT_TYPE" == "fast" ]] && [[ -d /host/fast-reboot ]]; then
+        # Clear the FAST_REBOOT|system db setting if PLATFORM_REBOOT_CAUSE is not "software" before starting swss
+        if  [[ "$PLATFORM_REBOOT_CAUSE" != "software" ]]; then
+            # Delete the FAST_REBOOT|system db setting 
+            $SONIC_DB_CLI STATE_DB DEL "FAST_REBOOT|system" &>/dev/null
+        fi
+    fi
 {%- else %}
     : # nothing
 {%- endif %}
@@ -200,16 +208,10 @@ function postStartAction()
 {%- elif docker_container_name == "swss" %}
     docker exec swss$DEV rm -f /ready   # remove cruft
     if [[ "$BOOT_TYPE" == "fast" ]] && [[ -d /host/fast-reboot ]]; then
-        # Clear the FAST_REBOOT|system db setting if PLATFORM_REBOOT_CAUSE is not "software" before starting swss
-        if  [[ "$PLATFORM_REBOOT_CAUSE" != "software" ]]; then
-            # Delete the FAST_REBOOT|system db setting 
-            $SONIC_DB_CLI STATE_DB DEL "FAST_REBOOT|system" &>/dev/null
-        else
-            test -e /host/fast-reboot/fdb.json && docker cp /host/fast-reboot/fdb.json swss$DEV:/
-            test -e /host/fast-reboot/arp.json && docker cp /host/fast-reboot/arp.json swss$DEV:/
-            test -e /host/fast-reboot/default_routes.json && docker cp /host/fast-reboot/default_routes.json swss$DEV:/
-            rm -fr /host/fast-reboot
-        fi
+        test -e /host/fast-reboot/fdb.json && docker cp /host/fast-reboot/fdb.json swss$DEV:/
+        test -e /host/fast-reboot/arp.json && docker cp /host/fast-reboot/arp.json swss$DEV:/
+        test -e /host/fast-reboot/default_routes.json && docker cp /host/fast-reboot/default_routes.json swss$DEV:/
+        rm -fr /host/fast-reboot
     fi
     docker exec swss$DEV touch /ready # signal swssconfig.sh to go
 {%- elif docker_container_name == "pmon" %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -60,14 +60,21 @@ function getMountPoint()
     echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.abspath(mnts[0]['Source'])" 2>/dev/null
 }
 
-function isPlatformReset()
+function getPlatformRebootCause()
 {
-    output=$(python3 -c "import sonic_platform.platform; p = sonic_platform.platform.Platform(); c = p.get_chassis(); hw_rc_major, hw_rc_minor = c.get_reboot_cause(); print(hw_rc_major)" 2>/dev/null)
-    if [[ "${output}" != "Non-Hardware" ]]; then
-        return 0
+    IMPORT_ERR="*ImportError*"
+    err=$(python -c "import sonic_platform.platform" 2>&1 > /dev/null)
+    if [[ "$err" =~ "$IMPORT_ERR"]]; then
+         output=$(python3 -c "import sonic_platform.platform; p = sonic_platform.platform.Platform(); c = p.get_chassis(); hw_rc_major, hw_rc_minor = c.get_reboot_cause(); print(hw_rc_major)" 2>/dev/null)
     else
-        return 1
+         output=$(python -c "import sonic_platform.platform; p = sonic_platform.platform.Platform(); c = p.get_chassis(); hw_rc_major, hw_rc_minor = c.get_reboot_cause(); print(hw_rc_major)" 2>/dev/null)
     fi
+    if [[ "${output}" == "Non-Hardware" ]]; then
+        PlatformRebootCause='software'
+    else
+        PlatformRebootCause='hardware'
+    fi
+    echo "${PlatformRebootCause}"
 }
 
 function getBootType()
@@ -86,9 +93,6 @@ function getBootType()
     *)
         TYPE='cold'
     esac
-    if isPlatformReset; then
-        TYPE='cold'
-    fi
     echo "${TYPE}"
 }
 
@@ -167,7 +171,8 @@ function postStartAction()
                 fi
             fi
 
-            if [[ "$BOOT_TYPE" == "fast" ]]; then
+	    # Indicates the device performed fast_reboot when the BOOT_TYPE is "fast_reboot" and PLATFORM_REBOOT_CAUSE is "software"
+            if [[ "$BOOT_TYPE" == "fast" ]] && [[ "$PLATFORM_REBOOT_CAUSE" == "software" ]]; then
                 # set the key to expire in 3 minutes
                 $SONIC_DB_CLI STATE_DB SET "FAST_REBOOT|system" "1" "EX" "180"
             fi
@@ -220,6 +225,9 @@ function postStartAction()
 start() {
     # Obtain boot type from kernel arguments
     BOOT_TYPE=`getBootType`
+
+    # Obttain boot type from Platform API
+    PLATFORM_REBOOT_CAUSE=`getPlatformRebootCause`
 
     # Obtain our platform as we will mount directories with these names in each docker
     PLATFORM=${PLATFORM:-`$SONIC_CFGGEN -H -v DEVICE_METADATA.localhost.platform`}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -171,7 +171,7 @@ function postStartAction()
                 fi
             fi
 
-	    # Indicates the device performed fast_reboot when the BOOT_TYPE is "fast_reboot"
+            # Set the db setting to indicate that the device performed fast_reboot when the BOOT_TYPE is "fast_reboot"
             if [[ "$BOOT_TYPE" == "fast" ]]; then
                 # set the key to expire in 3 minutes
                 $SONIC_DB_CLI STATE_DB SET "FAST_REBOOT|system" "1" "EX" "180"
@@ -203,7 +203,7 @@ function postStartAction()
         # Clear the FAST_REBOOT|system db setting if PLATFORM_REBOOT_CAUSE is not "software" before starting swss
         if  [[ "$PLATFORM_REBOOT_CAUSE" != "software" ]]; then
             # Delete the FAST_REBOOT|system db setting 
-            $SONIC_DB_CLI STATE_DB DEL "FAST_REBOOT|system"
+            $SONIC_DB_CLI STATE_DB DEL "FAST_REBOOT|system" &>/dev/null
         else
             test -e /host/fast-reboot/fdb.json && docker cp /host/fast-reboot/fdb.json swss$DEV:/
             test -e /host/fast-reboot/arp.json && docker cp /host/fast-reboot/arp.json swss$DEV:/

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -60,26 +60,6 @@ function getMountPoint()
     echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.abspath(mnts[0]['Source'])" 2>/dev/null
 }
 
-function getPlatformRebootCause()
-{
-    IMPORT_ERR="*ImportError*"
-    err=$(python -c "import sonic_platform.platform" 2>&1 > /dev/null)
-    err2=$(python3 -c "import sonic_platform.platform" 2>&1 > /dev/null)
-    output="Non-Hardware"
-    if [[ "$err" =~ "$IMPORT_ERR"]]; then
-         output=$(python3 -c "import sonic_platform.platform; p = sonic_platform.platform.Platform(); c = p.get_chassis(); hw_rc_major, hw_rc_minor = c.get_reboot_cause(); print(hw_rc_major)" 2>/dev/null)
-    fi
-    if [[ "$err2" =~ "$IMPORT_ERR"]]; then
-         output=$(python -c "import sonic_platform.platform; p = sonic_platform.platform.Platform(); c = p.get_chassis(); hw_rc_major, hw_rc_minor = c.get_reboot_cause(); print(hw_rc_major)" 2>/dev/null)
-    fi
-    if [[ "${output}" == "Non-Hardware" ]]; then
-        PlatformRebootCause='software'
-    else
-        PlatformRebootCause='hardware'
-    fi
-    echo "${PlatformRebootCause}"
-}
-
 function getBootType()
 {
     # same code snippet in files/scripts/syncd.sh
@@ -117,11 +97,20 @@ function preStartAction()
     $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
 {%- elif docker_container_name == "swss" %}
     if [[ "$BOOT_TYPE" == "fast" ]] && [[ -d /host/fast-reboot ]]; then
-        # Clear the FAST_REBOOT|system db setting if PLATFORM_REBOOT_CAUSE is not "software" before starting swss
-        if  [[ "$PLATFORM_REBOOT_CAUSE" != "software" ]]; then
-            # Delete the FAST_REBOOT|system db setting 
-            $SONIC_DB_CLI STATE_DB DEL "FAST_REBOOT|system" &>/dev/null
-        fi
+        if [[ -f /host/reboot-cause/previous-reboot-cause.json ]]; then
+            REG_BOOT_TYPE="fast*"
+	    CAUSE_NO_AVAIL="\"N/A\""
+            REBOOT_CAUSE="$(cat /host/reboot-cause/previous-reboot-cause.json | jq '.cause')"
+            EXTRA_CAUSE="$(cat /host/reboot-cause/previous-reboot-cause.json | jq '.comment')"
+
+            # Clear the FAST_REBOOT|system db setting if EXTRA_REBOOT_CAUSE is not "N/A" before starting swss
+            if [[ $REBOOT_CAUSE =~ $REG_BOOT_TYPE ]]; then
+                if [[ "${EXTRA_CAUSE}" != "${CAUSE_NO_AVAIL}" ]]; then
+                    # Delete the FAST_REBOOT|system db setting
+                    $SONIC_DB_CLI STATE_DB DEL "FAST_REBOOT|system" &>/dev/null
+                 fi
+             fi
+         fi
     fi
 {%- else %}
     : # nothing
@@ -237,8 +226,6 @@ start() {
     # Obtain boot type from kernel arguments
     BOOT_TYPE=`getBootType`
 
-    # Obttain boot type from Platform API
-    PLATFORM_REBOOT_CAUSE=`getPlatformRebootCause`
 
     # Obtain our platform as we will mount directories with these names in each docker
     PLATFORM=${PLATFORM:-`$SONIC_CFGGEN -H -v DEVICE_METADATA.localhost.platform`}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -63,7 +63,6 @@ function getMountPoint()
 function isPlatformReset()
 {
     output=$(python3 -c "import sonic_platform.platform; p = sonic_platform.platform.Platform(); c = p.get_chassis(); hw_rc_major, hw_rc_minor = c.get_reboot_cause(); print(hw_rc_major)" 2>/dev/null)
-    echo "${output}"
     if [[ "${output}" != "Non-Hardware" ]]; then
         return 0
     else

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -171,8 +171,8 @@ function postStartAction()
                 fi
             fi
 
-	    # Indicates the device performed fast_reboot when the BOOT_TYPE is "fast_reboot" and PLATFORM_REBOOT_CAUSE is "software"
-            if [[ "$BOOT_TYPE" == "fast" ]] && [[ "$PLATFORM_REBOOT_CAUSE" == "software" ]]; then
+	    # Indicates the device performed fast_reboot when the BOOT_TYPE is "fast_reboot"
+            if [[ "$BOOT_TYPE" == "fast" ]]; then
                 # set the key to expire in 3 minutes
                 $SONIC_DB_CLI STATE_DB SET "FAST_REBOOT|system" "1" "EX" "180"
             fi
@@ -200,10 +200,16 @@ function postStartAction()
 {%- elif docker_container_name == "swss" %}
     docker exec swss$DEV rm -f /ready   # remove cruft
     if [[ "$BOOT_TYPE" == "fast" ]] && [[ -d /host/fast-reboot ]]; then
-        test -e /host/fast-reboot/fdb.json && docker cp /host/fast-reboot/fdb.json swss$DEV:/
-        test -e /host/fast-reboot/arp.json && docker cp /host/fast-reboot/arp.json swss$DEV:/
-        test -e /host/fast-reboot/default_routes.json && docker cp /host/fast-reboot/default_routes.json swss$DEV:/
-        rm -fr /host/fast-reboot
+        # Clear the FAST_REBOOT|system db setting if PLATFORM_REBOOT_CAUSE is not "software" before starting swss
+        if  [[ "$PLATFORM_REBOOT_CAUSE" != "software" ]]; then
+            # Delete the FAST_REBOOT|system db setting 
+            $SONIC_DB_CLI STATE_DB DEL "FAST_REBOOT|system"
+        else
+            test -e /host/fast-reboot/fdb.json && docker cp /host/fast-reboot/fdb.json swss$DEV:/
+            test -e /host/fast-reboot/arp.json && docker cp /host/fast-reboot/arp.json swss$DEV:/
+            test -e /host/fast-reboot/default_routes.json && docker cp /host/fast-reboot/default_routes.json swss$DEV:/
+            rm -fr /host/fast-reboot
+        fi
     fi
     docker exec swss$DEV touch /ready # signal swssconfig.sh to go
 {%- elif docker_container_name == "pmon" %}

--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -184,15 +184,30 @@ def main():
     # Check if the previous reboot was warm/fast reboot by testing whether there is "fast|fastfast|warm" in /proc/cmdline
     proc_cmdline_reboot_cause = find_proc_cmdline_reboot_cause()
 
+    # Check if the previous reboot was caused by hardware
+    hardware_reboot_cause = find_hardware_reboot_cause()
+
+    # Check if the previous reboot was caused by software, get the reboot cause from REBOOT_CAUSE_FILE
+    software_reboot_cause = find_software_reboot_cause()
+
     # If /proc/cmdline does not indicate reboot cause, check if the previous reboot was caused by hardware
     if proc_cmdline_reboot_cause is None:
-        previous_reboot_cause = find_hardware_reboot_cause()
+        previous_reboot_cause = hardware_reboot_cause
         if previous_reboot_cause.startswith(REBOOT_CAUSE_NON_HARDWARE):
-            # If the reboot cause is non-hardware, get the reboot cause from REBOOT_CAUSE_FILE
-            previous_reboot_cause = find_software_reboot_cause()
+            # If the reboot cause is non-hardware, set the previous reboot cause with software_reboot_cause
+            previous_reboot_cause = software_reboot_cause
+        else:
+            # Check if any software reboot was issued before this hardware reboot happened
+            if software_reboot_cause is not REBOOT_CAUSE_UNKNOWN:
+                additional_reboot_info = software_reboot_cause
+
     else:
         # Get the reboot cause from REBOOT_CAUSE_FILE
-        previous_reboot_cause = find_software_reboot_cause()
+        previous_reboot_cause = software_reboot_cause
+        # Check if there is any hardware reboot or reset
+        if not hardware_reboot_cause.startswith(REBOOT_CAUSE_NON_HARDWARE):
+            # Add the hardware_reboot_cause into additional_reboot_info
+            additional_reboot_info = hardware_reboot_cause
 
     # Current time
     reboot_cause_gen_time = str(datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S'))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Check platform reboot cause to see if any reset happened during fast/warm-reboot 
While starting dockers with boot_type, it's only checking the /proc/cmdline.
If any unexpected Platform reset happens during fast/warm-reboot, it should be detected as platform reboot 
and "FAST_REBOOT|system" should be set in that case.
#### How I did it
Add the platform reboot cause parsing when determining the boot_type
#### How to verify it
Check the logic with reboot
Convert the device with fast-reload and see if the boot_type is detected correctly
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

