### PR TITLE
[Mellanox] Return N/A for PSU's model, serial and revision on platforms with fixed PSU

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -88,6 +88,10 @@ class Psu(PsuBase):
         self.psu_data = DEVICE_DATA[platform]['psus']
         psu_vpd = filemap[PSU_VPD]
 
+        self.model = "N/A"
+        self.serial = "N/A"
+        self.rev = "N/A"
+
         if psu_vpd is not None:
             self.psu_vpd = os.path.join(self.psu_path, psu_vpd.format(self.index))
             self.vpd_data = self._read_vpd_file(self.psu_vpd)
@@ -95,26 +99,20 @@ class Psu(PsuBase):
             if PN_VPD_FIELD in self.vpd_data:
                 self.model = self.vpd_data[PN_VPD_FIELD]
             else:
-                self.model = ""
                 logger.log_error("Fail to read PSU{} model number: No key {} in VPD {}".format(self.index, PN_VPD_FIELD, self.psu_vpd))
 
             if SN_VPD_FIELD in self.vpd_data:
                 self.serial = self.vpd_data[SN_VPD_FIELD]
             else:
-                self.serial = ""
                 logger.log_error("Fail to read PSU{} serial number: No key {} in VPD {}".format(self.index, SN_VPD_FIELD, self.psu_vpd))
 
             if REV_VPD_FIELD in self.vpd_data:
                 self.rev = self.vpd_data[REV_VPD_FIELD]
             else:
-                self.rev = ""
                 logger.log_error("Fail to read PSU{} serial number: No key {} in VPD {}".format(self.index, REV_VPD_FIELD, self.psu_vpd))
 
         else: 
             logger.log_info("Not reading PSU{} VPD data: Platform is fixed".format(self.index))
-            self.model = "N/A"
-            self.rev = "N/A"
-            self.serial = "N/A"
 
         if not self.psu_data['hot_swappable']:
             self.always_present = True

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -112,7 +112,9 @@ class Psu(PsuBase):
 
         else: 
             logger.log_info("Not reading PSU{} VPD data: Platform is fixed".format(self.index))
-
+            self.model = "N/A"
+            self.rev = "N/A"
+            self.serial = "N/A"
 
         if not self.psu_data['hot_swappable']:
             self.always_present = True


### PR DESCRIPTION
Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The methods `get_model`, `get_serial`, and `get_revision` have been implemented by reading relevant information from VPD and then recording the information into relevant fields.
However, there is no VPD data on platforms with fixed PSUs and relevant fields haven't been initialized, which causes the methods to throw exceptions. which in turn prevents `psud` from inserting fields into PSU table.
Eventually, this causes `show platform psustatus` doesn't output correct info.
```
admin@sonic:~$ show platform psustatus 
PSU    Model    Serial    HW Rev    Voltage (V)    Current (A)    Power (W)    Status    LED
-----  -------  --------  --------  -------------  -------------  -----------  --------  -----
PSU 1                                                                          OK        green
PSU 2                                                                          OK        green
```

#### How I did it
Initliaze those fields as `N/A` on systems with fixed PSUs.

#### How to verify it
Manually test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

