### PR TITLE
[sonic-yang] Backlinks are none when there is 0 backlinks

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang.py
+++ b/src/sonic-yang-mgmt/sonic_yang.py
@@ -526,7 +526,7 @@ class SonicYang(SonicYangExtMixin):
 
             schema_node = ly.Schema_Node_Leaf(data_node.schema())
             backlinks = schema_node.backlinks()
-            if backlinks.number() > 0:
+            if backlinks is not None and backlinks.number() > 0:
                 for link in backlinks.schema():
                      node_set = node.find_path(link.path())
                      for data_set in node_set.data():


### PR DESCRIPTION
#### Why I did it
Backlinks are none when there is 0 backlinks. without this change `backlinks.number()` throws an exception when backlinks==None.

#### How I did it
Allow backlinks to be None, so we get an empty list as a return from find_data_dependencies

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

