### PR TITLE
Fix build with INSTALL_DEBUG_TOOLS=y

### DIFF
--- a/rules/functions
+++ b/rules/functions
@@ -192,7 +192,7 @@ define generate_manifest
     $(eval export tmpfs=$($(1).gz_CONTAINER_TMPFS))
     $(eval export config_cli_plugin=$($(1).gz_CLI_CONFIG_PLUGIN))
     $(eval export show_cli_plugin=$($(1).gz_CLI_SHOW_PLUGIN))
-    j2 $($*.gz_PATH)/Dockerfile.j2 > $($(1).gz_PATH)/Dockerfile
+    j2 $($*.gz_PATH)/Dockerfile$(2).j2 > $($(1).gz_PATH)/Dockerfile$(2)
     j2 --customize scripts/j2cli/json_filter.py files/build_templates/manifest.json.j2 > $($(1).gz_PATH)/manifest.common.json
     if [ -f $($*.gz_PATH)/manifest.part.json.j2 ]; then
         j2 --customize scripts/j2cli/json_filter.py $($(1).gz_PATH)/manifest.part.json.j2 > $($(1).gz_PATH)/manifest.part.json


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
During SONiC build with  `INSTALL_DEBUG_TOOLS=y` an exception is raised:
```
[ 01 ] [ target/docker-sonic-mgmt-framework-dbg.gz ]
Traceback (most recent call last):
  File "/usr/local/bin/j2", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/dist-packages/j2cli/cli.py", line 206, in main
    sys.argv[1:]
  File "/usr/local/lib/python2.7/dist-packages/j2cli/cli.py", line 186, in render_command
    result = renderer.render(args.template, context)
  File "/usr/local/lib/python2.7/dist-packages/j2cli/cli.py", line 87, in render
    .render(context) \
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/sonic/dockers/docker-sonic-mgmt-framework/Dockerfile.j2", line 21, in top-level template code
    {% for deb in docker_sonic_mgmt_framework_debs.split(' ') -%}
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 430, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'docker_sonic_mgmt_framework_debs' is undefined
make: *** [slave.mk:796: target/docker-sonic-mgmt-framework-dbg.gz] Error 1

```

#### Why I did it
To Fix SONiC build with `INSTALL_DEBUG_TOOLS=y`

#### How I did it
Fixed `generate_manifest` function to use version prefix in file names

#### How to verify it
Build SONiC with  `INSTALL_DEBUG_TOOLS=y`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed jinja2 error during SONiC build with  `INSTALL_DEBUG_TOOLS=y`


#### A picture of a cute animal (not mandatory but encouraged)

