### PR TITLE
DellEMC: Enable Z9332f LED firmware

### DIFF
--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/sai_preinit_cmd.soc
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/sai_preinit_cmd.soc
@@ -1,3 +1,2 @@
-#Not supported in current SAI version
 m0 load 0 0x0 /usr/share/sonic/hwsku/linkscan_led_fw.bin
 m0 load 0 0x3800 /usr/share/sonic/hwsku/custom_led.bin

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
@@ -514,6 +514,5 @@ serdes_lane_config_media_type_27=copper
 serdes_lane_config_media_type_28=copper
 serdes_lane_config_media_type_24=copper
 
-#sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
+sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
 sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
-

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/sai_preinit_cmd.soc
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/sai_preinit_cmd.soc
@@ -1,3 +1,2 @@
-#Not supported Until SAI 3.6
 m0 load 0 0x0 /usr/share/sonic/hwsku/linkscan_led_fw.bin
 m0 load 0 0x3800 /usr/share/sonic/hwsku/custom_led.bin

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/sai_preinit_cmd.soc
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/sai_preinit_cmd.soc
@@ -1,3 +1,3 @@
 #Not supported Until SAI 3.6
-#m0 load 0 0x0 /usr/share/sonic/hwsku/linkscan_led_fw.bin
-#m0 load 0 0x3800 /usr/share/sonic/hwsku/custom_led.bin
+m0 load 0 0x0 /usr/share/sonic/hwsku/linkscan_led_fw.bin
+m0 load 0 0x3800 /usr/share/sonic/hwsku/custom_led.bin

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
@@ -574,6 +574,5 @@ serdes_lane_config_media_type_27=copper
 serdes_lane_config_media_type_28=copper
 serdes_lane_config_media_type_24=copper
 
-#sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
+sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
 sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
-

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/sai_preinit_cmd.soc
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/sai_preinit_cmd.soc
@@ -1,3 +1,2 @@
-#Not supported Until SAI 3.6
-#m0 load 0 0x0 /usr/share/sonic/hwsku/linkscan_led_fw.bin
-#m0 load 0 0x3800 /usr/share/sonic/hwsku/custom_led.bin
+m0 load 0 0x0 /usr/share/sonic/hwsku/linkscan_led_fw.bin
+m0 load 0 0x3800 /usr/share/sonic/hwsku/custom_led.bin

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
@@ -514,6 +514,5 @@ serdes_lane_config_media_type_27=copper
 serdes_lane_config_media_type_28=copper
 serdes_lane_config_media_type_24=copper
 
-#sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
+sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
 sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
-

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/led_proc_init.soc
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/led_proc_init.soc
@@ -3,5 +3,5 @@
 #
 #Led0
 #Support only after SAI 3.6
-led auto on
+#led auto on
 led start

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/led_proc_init.soc
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/led_proc_init.soc
@@ -3,5 +3,5 @@
 #
 #Led0
 #Support only after SAI 3.6
-#led auto on
-#led start
+led auto on
+led start


### PR DESCRIPTION

#### Why I did it
Front end LED fw is not loaded in DellEMC Z9332f. 
#### How I did it
Enabled LED fw files
#### How to verify it
Check LED status after loading the firmware.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012


#### A picture of a cute animal (not mandatory but encouraged)

