### PR TITLE
[AS7326-56X] Support mulit PSU SN in PDDF

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
@@ -915,7 +915,7 @@
                 { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xF", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
                 { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x3", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
                 { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x7", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
-                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_offset":"0xB", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2","attr_offset":"0xB", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
             ]
         }
     },
@@ -955,7 +955,7 @@
                 { "attr_name":"xcvr_present", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x10", "attr_mask":"0x0", "attr_cmpval":"0x0", "attr_len":"1"},
                 { "attr_name":"xcvr_txfault", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0x4", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
                 { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x62", "attr_devtype":"cpld","attr_devname":"CPLD2",  "attr_offset":"0x8", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"},
-                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_offset":"0xC", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x62", "attr_devtype":"cpld", "attr_devname":"CPLD2", "attr_offset":"0xC", "attr_mask":"0x0", "attr_cmpval":"0x1", "attr_len":"1"}
             ]
         }
     },
@@ -2409,10 +2409,10 @@
             "topo_info": { "parent_bus":"0x54", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
             "attr_list":
             [
-                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_devname":"CPLD1", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1B","attr_devname":"CPLD1",  "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
-                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x15", "attr_devname":"CPLD1", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
-                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x18", "attr_devname":"CPLD1","attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x4", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1B", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x15", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x18", "attr_mask":"0x4", "attr_cmpval":"0x10", "attr_len":"1"}
             ]
         }
     },
@@ -2449,10 +2449,10 @@
             "topo_info": { "parent_bus":"0x55", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
             "attr_list":
             [
-                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x1B", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
-                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x15", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
-                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x18", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x11", "attr_mask":"0x5", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1B", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1","attr_offset":"0x15", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1",   "attr_offset":"0x18", "attr_mask":"0x5", "attr_cmpval":"0x20", "attr_len":"1"}
             ]
         }
     },    
@@ -2489,10 +2489,10 @@
             "topo_info": { "parent_bus":"0x56", "dev_addr":"0x53", "dev_type":"pddf_xcvr"},
             "attr_list":
             [
-                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_devname":"CPLD1","attr_offset":"0x1C", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
-                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x16", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
-                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_devname":"CPLD1", "attr_offset":"0x19", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
+                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0x12", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
+                { "attr_name":"xcvr_txfault", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x1C", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_txdisable", "attr_devaddr":"0x60", "attr_devtype":"cpld","attr_devname":"CPLD1", "attr_offset":"0x16", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"},
+                { "attr_name":"xcvr_rxlos", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_devname":"CPLD1", "attr_offset":"0x19", "attr_mask":"0x1", "attr_cmpval":"0x2", "attr_len":"1"}
             ]
         }
     },

--- a/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
@@ -49,6 +49,10 @@
             "pddf_fan_module",
             "pddf_led_module",
             "pddf_sysstatus_module"
+        ],
+        "custom_kos":
+        [
+            "pddf_custom_psu"
         ]
     },
 
@@ -181,7 +185,8 @@
         {
             "interface":
             [
-                { "itf":"pmbus", "dev":"PSU2-PMBUS"}
+                { "itf":"pmbus", "dev":"PSU2-PMBUS"},
+                { "itf":"eeprom", "dev":"PSU2-EEPROM" }
             ]
         }
     },
@@ -195,10 +200,8 @@
             "attr_list": 
             [  
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
                 { "attr_name":"psu_mfr_id", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
-                { "attr_name":"psu_serial_num", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" },
                 { "attr_name":"psu_fan_dir", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
                 { "attr_name":"psu_v_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
                 { "attr_name":"psu_i_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
@@ -208,7 +211,21 @@
             ]
         }
     },
-    
+
+    "PSU2-EEPROM":
+    {
+        "dev_info": { "device_type":"PSU-EEPROM", "device_name":"PSU2-EEPROM", "device_parent":"MUX2", "virt_parent":"PSU2"},
+        "i2c":
+        {
+            "topo_info":{ "parent_bus":"0xd", "dev_addr":"0x53", "dev_type":"psu_eeprom"}, 
+            "attr_list": 
+            [  
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x15", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"11" },
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x2e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"17" }
+                
+            ]
+        }
+    },
     "PSU1":
     {
         "dev_info": { "device_type":"PSU", "device_name":"PSU1", "device_parent":"MUX3" },
@@ -217,7 +234,8 @@
         {
             "interface":
             [
-                { "itf":"pmbus", "dev":"PSU1-PMBUS"}
+                { "itf":"pmbus", "dev":"PSU1-PMBUS"},
+                { "itf":"eeprom", "dev":"PSU1-EEPROM" }
             ]
         }
     },
@@ -230,11 +248,9 @@
             "topo_info": { "parent_bus":"0x11", "dev_addr":"0x59", "dev_type":"psu_pmbus"},
             "attr_list": 
             [  
-                { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+                { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},                
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x8", "attr_cmpval":"0x8", "attr_len":"1"},
                 { "attr_name":"psu_mfr_id", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
-                { "attr_name":"psu_serial_num", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x9e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" },
                 { "attr_name":"psu_fan_dir", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
                 { "attr_name":"psu_v_out", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
                 { "attr_name":"psu_i_out", "attr_devaddr":"0x59", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
@@ -244,7 +260,19 @@
             ]
         }
     },
-    
+    "PSU1-EEPROM":
+    {
+        "dev_info": { "device_type":"PSU-EEPROM", "device_name":"PSU1-EEPROM", "device_parent":"MUX2", "virt_parent":"PSU1"},
+        "i2c":
+        {
+            "topo_info":{ "parent_bus":"0x11", "dev_addr":"0x51", "dev_type":"psu_eeprom"}, 
+            "attr_list": 
+            [  
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x15", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"11" },
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x2e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"17" }
+            ]
+        }
+    },
     "CPLD1":
     {
         "dev_info": { "device_type":"CPLD", "device_name":"CPLD1", "device_parent":"MUX3"},

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/Makefile
@@ -3,7 +3,11 @@ obj-m:= accton_i2c_cpld.o \
     accton_as7326_56x_fan.o accton_as7326_56x_leds.o \
     accton_as7326_56x_psu.o ym2651y.o \
     pddf_custom_psu.o
-    
+
+	    
+CFLAGS_pddf_custom_psu.o := -I$(M)/../../../../pddf/i2c/modules/include
+KBUILD_EXTRA_SYMBOLS := $(M)/../../../../pddf/i2c/Module.symvers.PDDF
+
 else
 ifeq (,$(KERNEL_SRC))
 $(error KERNEL_SRC is not defined)

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/Makefile
@@ -1,8 +1,9 @@
 ifneq ($(KERNELRELEASE),)
 obj-m:= accton_i2c_cpld.o \
     accton_as7326_56x_fan.o accton_as7326_56x_leds.o \
-    accton_as7326_56x_psu.o ym2651y.o
-
+    accton_as7326_56x_psu.o ym2651y.o \
+    pddf_custom_psu.o
+    
 else
 ifeq (,$(KERNEL_SRC))
 $(error KERNEL_SRC is not defined)

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/pddf_custom_psu.c
@@ -1,0 +1,204 @@
+#include <linux/module.h>
+#include <linux/jiffies.h>
+#include <linux/i2c.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/err.h>
+#include <linux/delay.h>
+#include <linux/mutex.h>
+#include <linux/sysfs.h>
+#include <linux/slab.h>
+#include <linux/dmi.h>
+#include "../../../../pddf/i2c/modules/include/pddf_psu_defs.h"
+
+ssize_t pddf_get_custom_psu_model_name(struct device *dev, struct device_attribute *da, char *buf);
+ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribute *da, char *buf);
+extern PSU_SYSFS_ATTR_DATA access_psu_model_name;
+extern PSU_SYSFS_ATTR_DATA access_psu_serial_num;
+
+#define MAX_MODEL_NAME          16
+#define MAX_SERIAL_NUMBER       19
+
+enum psu_type {
+    PSU_TYPE_AC_110V,
+    PSU_TYPE_DC_48V,
+    PSU_TYPE_DC_12V,
+    PSU_TYPE_AC_ACBEL_FSF019
+};
+
+struct model_name_info {
+    enum psu_type type;
+    u8 offset;
+    u8 length;
+    u8 chk_length;
+    char* model_name;
+};
+
+struct serial_number_info {
+    enum psu_type type;
+    u8 offset;
+    u8 length;
+    u8 chk_length;
+    char* serial_number;
+};
+
+struct model_name_info models[] = {
+{PSU_TYPE_AC_110V, 0x20, 8, 8,  "YM-2651Y"},
+{PSU_TYPE_DC_48V,  0x20, 8, 8,  "YM-2651V"},
+{PSU_TYPE_DC_12V,  0x00, 11, 11, "PSU-12V-750"},
+{PSU_TYPE_AC_ACBEL_FSF019, 0x15, 10, 7, "FSF019-"}
+
+};
+
+struct serial_number_info serials[] = {
+{PSU_TYPE_AC_110V, 0x2e, 18, 18,  "YM-2651Y"},
+{PSU_TYPE_DC_48V,  0x2e, 18, 18,  "YM-2651V"},
+{PSU_TYPE_DC_12V,  0x2e, 18, 18,  "PSU-12V-750"},
+{PSU_TYPE_AC_ACBEL_FSF019, 0x2e, 16, 16, "FSF019-"}
+
+};
+
+struct pddf_psu_data {    
+    char model_name[MAX_MODEL_NAME+1];
+    char serial_number[MAX_SERIAL_NUMBER+1];
+};
+
+
+static int pddf_psu_read_block(struct i2c_client *client, u8 command, u8 *data,
+                                     int data_len)
+{
+    int result = 0;
+    int retry_count = 10;
+
+    while (retry_count) {
+        retry_count--;
+
+        result = i2c_smbus_read_i2c_block_data(client, command, data_len, data);
+
+        if (unlikely(result < 0)) {
+            msleep(10);
+            continue;
+        }
+
+        if (unlikely(result != data_len)) {
+            result = -EIO;
+            msleep(10);
+            continue;
+        }
+
+        result = 0;
+        break;
+    }
+
+    return result;
+}
+
+ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribute *da, char *buf)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct pddf_psu_data data;
+    int i, status;
+
+    for (i = 0; i < ARRAY_SIZE(models); i++) {
+        memset(data.serial_number, 0, sizeof(data.serial_number));
+
+        status = pddf_psu_read_block(client, models[i].offset,
+                                           data.model_name, models[i].length);
+        if (status < 0) {
+            data.serial_number[0] = '\0';
+            dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x%x)\n",
+                                  client->addr, serials[i].offset);
+            return status;
+        }
+        else {
+            data.serial_number[serials[i].length] = '\0';
+        }
+
+        /* Determine if the model name is known, if not, read next index
+         */
+        if (strncmp(data.model_name, models[i].model_name, models[i].chk_length) == 0) {
+            status = pddf_psu_read_block(client, serials[i].offset,
+                                           data.serial_number, serials[i].length);
+            
+            if (status < 0) {
+                data.serial_number[0] = '\0';
+                dev_dbg(&client->dev, "unable to read serial num from (0x%x) offset(0x%x)\n",
+                                  client->addr, serials[i].offset);
+                return status;
+            }
+            else {
+                data.serial_number[serials[i].length] = '\0';
+	            return sprintf(buf, "%s\n", data.serial_number);
+            }
+                        
+            return 0;
+        }
+        else {
+            data.serial_number[0] = '\0';
+        }
+    }
+
+    return -ENODATA;
+
+	
+}
+
+ssize_t pddf_get_custom_psu_model_name(struct device *dev, struct device_attribute *da, char *buf)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct pddf_psu_data data;
+    int i, status;
+    
+    for (i = 0; i < ARRAY_SIZE(models); i++) {
+        memset(data.model_name, 0, sizeof(data.model_name));
+
+        status = pddf_psu_read_block(client, models[i].offset,
+                                           data.model_name, models[i].length);
+        if (status < 0) {
+            data.model_name[0] = '\0';
+            dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x%x)\n",
+                                  client->addr, models[i].offset);
+            return status;
+        }
+        else {
+            data.model_name[models[i].length] = '\0';
+        }
+
+        /* Determine if the model name is known, if not, read next index
+         */
+        if (strncmp(data.model_name, models[i].model_name, models[i].chk_length) == 0) {
+            return sprintf(buf, "%s\n", data.model_name);
+        }
+        else {
+            data.model_name[0] = '\0';
+        }
+    }
+
+    return -ENODATA;
+
+}
+
+static int __init pddf_custom_psu_init(void)
+{
+	access_psu_serial_num.show = pddf_get_custom_psu_serial_num;
+	access_psu_serial_num.do_get = NULL;
+	
+	access_psu_model_name.show = pddf_get_custom_psu_model_name;
+	access_psu_model_name.do_get = NULL;
+	
+	return 0;
+}
+
+static void __exit pddf_custom_psu_exit(void)
+{
+	printk(KERN_ERR "pddf_custom_psu_exit\n");
+	return;
+}
+
+MODULE_AUTHOR("Broadcom");
+MODULE_DESCRIPTION("pddf custom psu api");
+MODULE_LICENSE("GPL");
+
+module_init(pddf_custom_psu_init);
+module_exit(pddf_custom_psu_exit);
+

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/pddf_custom_psu.c
@@ -105,9 +105,9 @@ ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribu
         status = pddf_psu_read_block(client, models[i].offset,
                                            data.model_name, models[i].length);
         if (status < 0) {
-            data.serial_number[0] = '\0';
+            data.model_name[0] = '\0';
             dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x%x)\n",
-                                  client->addr, serials[i].offset);
+                                  client->addr, models[i].offset);
             return status;
         }
         else {

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/pddf_custom_psu.c
@@ -111,7 +111,7 @@ ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribu
             return status;
         }
         else {
-            data.serial_number[serials[i].length] = '\0';
+            data.model_name[models[i].length] = '\0';
         }
 
         /* Determine if the model name is known, if not, read next index
@@ -180,11 +180,11 @@ ssize_t pddf_get_custom_psu_model_name(struct device *dev, struct device_attribu
 
 static int __init pddf_custom_psu_init(void)
 {
-	access_psu_serial_num.show = pddf_get_custom_psu_serial_num;
-	access_psu_serial_num.do_get = NULL;
+    access_psu_serial_num.show = pddf_get_custom_psu_serial_num;
+    access_psu_serial_num.do_get = NULL;
 	
-	access_psu_model_name.show = pddf_get_custom_psu_model_name;
-	access_psu_model_name.do_get = NULL;
+    access_psu_model_name.show = pddf_get_custom_psu_model_name;
+    access_psu_model_name.do_get = NULL;
 	
 	return 0;
 }

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/pddf_custom_psu.c
@@ -51,7 +51,7 @@ struct model_name_info models[] = {
 };
 
 struct serial_number_info serials[] = {
-{PSU_TYPE_AC_110V, 0x2e, 18, 18,  "YM-2651Y"},
+{PSU_TYPE_AC_110V, 0x35, 18, 18,  "YM-2651Y"},
 {PSU_TYPE_DC_48V,  0x2e, 18, 18,  "YM-2651V"},
 {PSU_TYPE_DC_12V,  0x2e, 18, 18,  "PSU-12V-750"},
 {PSU_TYPE_AC_ACBEL_FSF019, 0x2e, 16, 16, "FSF019-"}
@@ -97,6 +97,7 @@ ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribu
 {
     struct i2c_client *client = to_i2c_client(dev);
     struct pddf_psu_data data;
+    char sub_type[4];
     int i, status;
 
     for (i = 0; i < ARRAY_SIZE(models); i++) {
@@ -117,6 +118,30 @@ ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribu
         /* Determine if the model name is known, if not, read next index
          */
         if (strncmp(data.model_name, models[i].model_name, models[i].chk_length) == 0) {
+            /*For YM-2651Y BR. BR use offset-0x2e to store SN.
+             *B01R use offset-0x35 to store store SN. Default use 0x35 for YM-2651Y
+             */
+            if(!strncmp(models[i].model_name, "YM-2651Y", sizeof(models[i].model_name)))
+            {
+            	memset(sub_type, 0, sizeof(sub_type));
+                status = pddf_psu_read_block(client, 0x29,
+                                           sub_type, sizeof(sub_type));
+                
+                if (status < 0) {
+                    data.serial_number[0] = '\0';
+                    dev_dbg(&client->dev, "unable to read sub_type from (0x%x) offset(0x%x)\n",
+                                  client->addr, 0x29);
+                    return status;
+                }
+                else
+                {
+                    if(!strncmp(sub_type,"BR" , 2))
+                    {                       
+                        serials[i].offset=0x2e;
+                    }
+                }
+            }
+            
             status = pddf_psu_read_block(client, serials[i].offset,
                                            data.serial_number, serials[i].length);
             


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
AS7326  support 3Y and ACBEL PSU. So it need customer drv to handle access psu serial_number and model_name on different PSU.
#### How I did it
Implement pddf_custom_psu.c drv code.
#### How to verify it
#pddf_psuutil mfrinfo

PSU    Status    Manufacturer ID    Model       Serial            Fan Airflow Direction
-----  --------  -----------------  ----------  ----------------  -----------------------
PSU1   OK        ACBEL              FSF019-610  FSF0191813105520  EXHAUST
PSU2   OK        ACBEL              FSF019-610  FSF0191813105521  EXHAUST

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

