### PR TITLE
[DEBUG] Add option to build deb targets whithout the optimization

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -63,6 +63,9 @@ DEFAULT_PASSWORD = YourPaSsWoRd
 # Uncomment next line to enable:
 # INSTALL_DEBUG_TOOLS = y
 
+# Disables compiler optimizations (-O0) for deb targets
+# SONIC_DEB_BUILD_NOOPT = y
+
 # SONIC_USE_PDDF_FRAMEWORK - Use PDDF generic drivers and plugins
 # Uncomment next line to enable:
 SONIC_USE_PDDF_FRAMEWORK = y
@@ -78,14 +81,6 @@ SONIC_ROUTING_STACK = frr
 
 # Enable Origanization Extensions - Specific to the deployment scenarios of the Organization
 ENABLE_ORGANIZATION_EXTENSIONS = y
-
-# Debugging option allows sonic debian packages to get built including symbols
-# information. Profiling option, disables compiler optimizations (-O0) as well
-# as includes symbols information. Given that 'profiling' option is a superset
-# of 'debugging' one, user should only enable either one option or the other --
-# if both options are enabled, the 'profiling' one will prevail.
-#SONIC_DEBUGGING_ON = y
-#SONIC_PROFILING_ON = y
 
 # DEFAULT_KERNEL_PROCURE_METHOD - default method for obtaining kernel
 #   build:    build kernel from source

--- a/slave.mk
+++ b/slave.mk
@@ -174,12 +174,8 @@ else
 $(warning PASSWORD given on command line: could be visible to other users)
 endif
 
-ifeq ($(SONIC_DEBUGGING_ON),y)
-DEB_BUILD_OPTIONS_GENERIC := nostrip
-endif
-
-ifeq ($(SONIC_PROFILING_ON),y)
-DEB_BUILD_OPTIONS_GENERIC := nostrip noopt
+ifeq ($(SONIC_DEB_BUILD_NOOPT),y)
+DEB_BUILD_OPTIONS_GENERIC := noopt
 endif
 
 ifeq ($(SONIC_BUILD_JOBS),)
@@ -241,8 +237,7 @@ $(info "HTTP_PROXY"                      : "$(HTTP_PROXY)")
 $(info "HTTPS_PROXY"                     : "$(HTTPS_PROXY)")
 $(info "NO_PROXY"                        : "$(NO_PROXY)")
 $(info "ENABLE_ZTP"                      : "$(ENABLE_ZTP)")
-$(info "SONIC_DEBUGGING_ON"              : "$(SONIC_DEBUGGING_ON)")
-$(info "SONIC_PROFILING_ON"              : "$(SONIC_PROFILING_ON)")
+$(info "SONIC_DEB_BUILD_NOOPT"           : "$(SONIC_DEB_BUILD_NOOPT)")
 $(info "KERNEL_PROCURE_METHOD"           : "$(KERNEL_PROCURE_METHOD)")
 $(info "BUILD_TIMESTAMP"                 : "$(BUILD_TIMESTAMP)")
 $(info "BUILD_LOG_TIMESTAMP"             : "$(BUILD_LOG_TIMESTAMP)")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To be able to build a target without optimization

#### How I did it
Add `SONIC_DEB_BUILD_NOOPT` option which will set noopt for deb-buildpackage tool
I also remove `SONIC_DEBUGGING_ON` and `SONIC_PROFILING_ON` as they cause build fail for many targets as they expect stripped package. E.g:
https://github.com/Azure/sonic-buildimage/blob/4612f680e6ab69e9bd3530d65efb8126ec8ed9c0/rules/swss.mk#L14
https://github.com/Azure/sonic-buildimage/blob/0e554e09ce13421da961c49810b8198a4edddd07/rules/snmpd.mk#L29

#### How to verify it
Uncomment `SONIC_PROFILING_ON=y` in `config` file. Then:
```
sonic-buildimage$  make target/debs/buster/swss-dbg_1.0.0_amd64.deb
sonic-buildimage$ strings src/sonic-swss/cfgmgr/vrfmgrd-orch.o | grep -- -O
GNU C++14 8.3.0 -mtune=generic -march=x86-64 -g -g -O0 -std=c++14 -fPIC -fstack-protector-strong

```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

