### PR TITLE
[CI] Fix azp build rpc image targets.

### DIFF
--- a/.azure-pipelines/official-build.yml
+++ b/.azure-pipelines/official-build.yml
@@ -44,6 +44,7 @@ stages:
         - name: innovium
         - name: mellanox
           variables:
-            sync_rpc_image: yes
+            docker_syncd_rpc_image: yes
+            syncd_rpc_image: yes
             platform_rpc: mlnx
         - name: nephos


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add rpc image target for 201911 branch.
#### How I did it
201911 branch overwrited official-build.yml. Only changing template file does not work.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

