### PR TITLE
[PDDF] Add get_sfp() to chassis to handle port idx

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
@@ -7,6 +7,7 @@
 #############################################################################
 
 try:
+    import sys
     import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
 except ImportError as e:
@@ -59,3 +60,26 @@ class Chassis(PddfChassis):
             return True, change_dict
         else:
             return True, change_dict
+
+    def get_sfp(self, index):
+        """
+        Retrieves sfp represented by (1-based) index <index>
+
+        Args:
+            index: An integer, the index (1-based) of the sfp to retrieve.
+            The index should be the sequence of a physical port in a chassis,
+            starting from 1.
+            For example, 1 for Ethernet0, 2 for Ethernet4 and so on.
+
+        Returns:
+            An object derived from SfpBase representing the specified sfp
+        """
+        sfp = None
+
+        try:
+            # The index will start from 1
+            sfp = self._sfp_list[index-1]
+        except IndexError:
+            sys.stderr.write("SFP index {} out of range (1-{})\n".format(
+                             index, len(self._sfp_list)))
+        return sfp

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
@@ -39,7 +39,7 @@ class Chassis(PddfChassis):
 
         bitmap = 0
         for i in range(58):
-            modpres = self.get_sfp(i).get_presence()
+            modpres = self.get_sfp(i+1).get_presence()
             if modpres:
                 bitmap = bitmap | (1 << i)
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
@@ -7,6 +7,7 @@
 #############################################################################
 
 try:
+    import sys
     import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
 except ImportError as e:
@@ -59,3 +60,27 @@ class Chassis(PddfChassis):
             return True, change_dict
         else:
             return True, change_dict
+
+
+    def get_sfp(self, index):
+        """
+        Retrieves sfp represented by (1-based) index <index>
+
+        Args:
+            index: An integer, the index (1-based) of the sfp to retrieve.
+            The index should be the sequence of a physical port in a chassis,
+            starting from 1.
+            For example, 1 for Ethernet0, 2 for Ethernet4 and so on.
+
+        Returns:
+            An object derived from SfpBase representing the specified sfp
+        """
+        sfp = None
+
+        try:
+            # The index will start from 1
+            sfp = self._sfp_list[index-1]
+        except IndexError:
+            sys.stderr.write("SFP index {} out of range (1-{})\n".format(
+                             index, len(self._sfp_list)))
+        return sfp

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
@@ -39,7 +39,7 @@ class Chassis(PddfChassis):
         
         bitmap = 0
         for i in range(34):
-            modpres = self.get_sfp(i).get_presence()
+            modpres = self.get_sfp(i+1).get_presence()
             if modpres:
                 bitmap = bitmap | (1 << i)
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/chassis.py
@@ -7,6 +7,7 @@
 #############################################################################
 
 try:
+    import sys
     import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
 except ImportError as e:
@@ -59,3 +60,27 @@ class Chassis(PddfChassis):
             return True, change_dict
         else:
             return True, change_dict
+
+
+    def get_sfp(self, index):
+        """
+        Retrieves sfp represented by (1-based) index <index>
+
+        Args:
+            index: An integer, the index (1-based) of the sfp to retrieve.
+            The index should be the sequence of a physical port in a chassis,
+            starting from 1.
+            For example, 1 for Ethernet0, 2 for Ethernet4 and so on.
+
+        Returns:
+            An object derived from SfpBase representing the specified sfp
+        """
+        sfp = None
+
+        try:
+            # The index will start from 1
+            sfp = self._sfp_list[index-1]
+        except IndexError:
+            sys.stderr.write("SFP index {} out of range (1-{})\n".format(
+                             index, len(self._sfp_list)))
+        return sfp

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/chassis.py
@@ -39,7 +39,7 @@ class Chassis(PddfChassis):
         
         bitmap = 0
         for i in range(64):
-            modpres = self.get_sfp(i).get_presence()
+            modpres = self.get_sfp(i+1).get_presence()
             if modpres:
                 bitmap = bitmap | (1 << i)
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/chassis.py
@@ -7,6 +7,7 @@
 #############################################################################
 
 try:
+    import sys
     import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
 except ImportError as e:
@@ -59,3 +60,27 @@ class Chassis(PddfChassis):
             return True, change_dict
         else:
             return True, change_dict
+
+
+    def get_sfp(self, index):
+        """
+        Retrieves sfp represented by (1-based) index <index>
+
+        Args:
+            index: An integer, the index (1-based) of the sfp to retrieve.
+            The index should be the sequence of a physical port in a chassis,
+            starting from 1.
+            For example, 1 for Ethernet0, 2 for Ethernet4 and so on.
+
+        Returns:
+            An object derived from SfpBase representing the specified sfp
+        """
+        sfp = None
+
+        try:
+            # The index will start from 1
+            sfp = self._sfp_list[index-1]
+        except IndexError:
+            sys.stderr.write("SFP index {} out of range (1-{})\n".format(
+                             index, len(self._sfp_list)))
+        return sfp

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/chassis.py
@@ -39,7 +39,7 @@ class Chassis(PddfChassis):
         
         bitmap = 0
         for i in range(34):
-            modpres = self.get_sfp(i).get_presence()
+            modpres = self.get_sfp(i+1).get_presence()
             if modpres:
                 bitmap = bitmap | (1 << i)
 


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add get_sfp() to chassis to handle port_config.ini port index start from 1.
Configure use port start from 1, but code sfp_list[]  is start from 0.  It will cause port range error.
#### How I did it
Implement get_sfp() to chassis.py
#### How to verify it
Test script to check port range is ok from 1 to 58 on as7326 and other DUT.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

