### PR TITLE
[iccpd][docker] fix initial startup configuration

### DIFF
--- a/dockers/docker-iccpd/iccpd.j2
+++ b/dockers/docker-iccpd/iccpd.j2
@@ -2,7 +2,7 @@
 mclag_id:{{mclag_id}}
     local_ip:{{MC_LAG[mclag_id]['local_ip']}}
     peer_ip:{{MC_LAG[mclag_id]['peer_ip']}}
-{% if MC_LAG[mclag_id].has_key('peer_link') %}
+{% if 'peer_link' in MC_LAG[mclag_id] %}
     peer_link:{{MC_LAG[mclag_id]['peer_link']}}
 {% endif %}
     mclag_interface:{{MC_LAG[mclag_id]['mclag_interface']}}

--- a/dockers/docker-iccpd/start.sh
+++ b/dockers/docker-iccpd/start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -e
 
 ICCPD_CONF_PATH=/etc/iccpd
 


### PR DESCRIPTION
#### Why I did it
The process of config generation (sonic-cfggen) fails, but the services continue to run with invalid config

#### How I did it
* add exit with error on errors in start.sh script (because supervisord relies on start.sh return code).
* fix jinja template. Jinja use common python expressions under the hood and `has_key` method was removed from dict in py3, so use check by `in` operator as it is supported by both py2 and py3.
#### How to verify it
* compile sonic with enabled iccp. 
* add mclag config to CONFIG_DB. 
    ``` 
    'MC_LAG|1' => {
        "local_ip": "10.0.0.2",
        "peer_ip": "10.0.0.3",
        "peer_link": "Ethernet8",
        "mclag_interface": "Ethernet12" 
    }
* unmaks, enable and start swss and iccpd services in sonic.
* log in into the iccpd container and check the config file `/etc/iccpd/iccpd.conf`
* expected config:
    ```
    mclag_id:1
        local_ip:10.0.0.2
        peer_ip:10.0.0.3
        peer_link:Ethernet8
        mclag_interface:Ethernet12
    system_mac:YOUR_SYSTEM_MAC

#### Which release branch to backport (provide reason below if selected)


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012 (contains the same bug)
- [x] 202106 (contains the same bug)


#### Description for the changelog
Fixed initial iccpd startup configuration.


