### PR TITLE
[kdump] Fix kdump error message when a reboot is issued

### DIFF
--- a/files/image_config/kdump/kdump-tools
+++ b/files/image_config/kdump/kdump-tools
@@ -10,7 +10,7 @@ KDUMP_CMDLINE_APPEND="irqpoll nr_cpus=1 nousb systemd.unit=kdump-tools.service a
 # Disable advanced pcie features
 # Disable high precision event timer as on some platforms it is interfering with the kdump operation
 # Pass platform identifier string as part of crash kernel command line to be used by the reboot script during kdump
-KDUMP_CMDLINE_APPEND+=" panic=10 debug hpet=disable pcie_port=compat pci=nommconf sonic_platform=__PLATFORM__"
+KDUMP_CMDLINE_APPEND="${KDUMP_CMDLINE_APPEND} panic=10 debug hpet=disable pcie_port=compat pci=nommconf sonic_platform=__PLATFORM__"
 
 # Use SONiC reboot wrapper script present in /usr/local/bin post kdump
 PATH=/usr/local/bin:$PATH


### PR DESCRIPTION
[  342.439096] kdump-tools[13655]: /etc/init.d/kdump-tools: 117: /etc/default/kdump-tools: KDUMP_CMDLINE_APPEND+= panic=10 debug hpet=disable pcie_port=compat pci=nommconf sonic_platform=x86_64-accton_as7326_56x-r0: not found

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The below error message is seen when a reboot is issued.

[  342.439096] kdump-tools[13655]: /etc/init.d/kdump-tools: 117: /etc/default/kdump-tools: KDUMP_CMDLINE_APPEND+= panic=10 debug hpet=disable pcie_port=compat pci=nommconf sonic_platform=x86_64-accton_as7326_56x-r0: not found

#### How I did it
dash doesn't support += operation to append to a variable's value.

#### How to verify it

Use KDUMP_CMDLINE_APPEND="${KDUMP_CMDLINE_APPEND} " instead

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix kdump error message when a reboot is issued

#### A picture of a cute animal (not mandatory but encouraged)

