### PR TITLE
Fix sonic-cfggen contextlib err

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y build-essential \
                                          vim
 
 RUN pip install cffi==1.10.0 \
+                contextlib2==0.6.0.post1 \
                 cryptography==3.3.2 \
                 "future>=0.16.0" \
                 gitpython \

--- a/src/sonic-config-engine/setup.py
+++ b/src/sonic-config-engine/setup.py
@@ -33,7 +33,8 @@ else:
         'Jinja2<3.0.0',
         'pyangbind==0.6.0',
         'zipp==1.2.0',  # importlib-resources needs zipp and seems to have a bug where it will try to install too new of a version for Python 2
-        'importlib-resources==3.3.1'  # importlib-resources v4.0.0 was released 2020-12-23 and drops support for Python 2
+        'importlib-resources==3.3.1',  # importlib-resources v4.0.0 was released 2020-12-23 and drops support for Python 2
+        'contextlib2==0.6.0.post1'
     ]
 
 # Common modules for python2 and python3


### PR DESCRIPTION
#### Why I did it
A recent version of contextlib2 (https://pypi.org/project/contextlib2/21.6.0/#history) has broken Python2 compatibility, so the version picked up by netaddr when using Python2 must be specified, or else builds fail

#### How I did it
Changed where netaddr is downloaded to also download the previous version of contextlib2

#### How to verify it
Build targets e.g. docker-sonic-mgmt-framework.gz

#### Which release branch to backport (provide reason below if selected)
- [ X] 202012
- May also need variations applied to earlier branches
Reason is that an external dependency has changed, which needs to be fixed on any branch that uses that dependency

#### Description for the changelog
Specify contextlib2 version for use with Python2


#### A picture of a cute animal (not mandatory but encouraged)

