### PR TITLE
Added retry to sonic-mgmt docker container

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -69,6 +69,7 @@ RUN pip install cffi==1.10.0 \
                 tabulate \
                 textfsm \
                 virtualenv \
+		retry \
     && git clone https://github.com/p4lang/scapy-vxlan.git \
     && cd scapy-vxlan \
     && python setup.py install \

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -69,7 +69,7 @@ RUN pip install cffi==1.10.0 \
                 tabulate \
                 textfsm \
                 virtualenv \
-		retry \
+                retry \
     && git clone https://github.com/p4lang/scapy-vxlan.git \
     && cd scapy-vxlan \
     && python setup.py install \


### PR DESCRIPTION
Signed-off-by: Sharon Lutati <slutati@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

the motivation for this PR is to add retry_call to several test cases in the community, for example, the following cases:

- test_show_platform_fanstatus_mocked
- test_show_platform_temperature_mocked

are executing a command once and comparing the output to the expected mock data,
sometimes differences between the mock and the actual are causing the tests to fail. 

retry will make these tests more stable.
retry will also be more efficient than sleep which will cause the tests to run longer because sometimes it is not necessary to sleep all that time, retry will only run a function only until it passed.

#### How I did it

added retry to the docker file

#### How to verify it
I run the tests with retry on the docker after installing the retry package 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
adding retry to dockerfile so that retry module will be supported on sonic-mgmt
