### PR TITLE
[sonic-cfggen] Allow cfggen to work on system without ports

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/Azure/sonic-sairedis
 [submodule "sonic-swss"]
 	path = src/sonic-swss
-	url = https://github.com/liorghub/sonic-swss
+	url = https://github.com/Azure/sonic-swss
 [submodule "src/p4c-bm/p4c-bm"]
 	path = platform/p4/p4c-bm/p4c-bm
 	url = https://github.com/krambn/p4c-bm
@@ -25,16 +25,16 @@
 	url = https://github.com/Azure/sonic-dbsyncd
 [submodule "src/sonic-py-swsssdk"]
 	path = src/sonic-py-swsssdk
-	url = https://github.com/liorghub/sonic-py-swsssdk.git
+	url = https://github.com/Azure/sonic-py-swsssdk.git
 [submodule "src/sonic-snmpagent"]
 	path = src/sonic-snmpagent
-	url = https://github.com/liorghub/sonic-snmpagent
+	url = https://github.com/Azure/sonic-snmpagent
 [submodule "src/ptf"]
 	path = src/ptf
 	url = https://github.com/p4lang/ptf.git
 [submodule "src/sonic-utilities"]
 	path = src/sonic-utilities
-	url = https://github.com/liorghub/sonic-utilities
+	url = https://github.com/Azure/sonic-utilities
 [submodule "platform/broadcom/sonic-platform-modules-arista"]
 	path = platform/broadcom/sonic-platform-modules-arista
 	url = https://github.com/aristanetworks/sonic

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/Azure/sonic-sairedis
 [submodule "sonic-swss"]
 	path = src/sonic-swss
-	url = https://github.com/Azure/sonic-swss
+	url = https://github.com/liorghub/sonic-swss
 [submodule "src/p4c-bm/p4c-bm"]
 	path = platform/p4/p4c-bm/p4c-bm
 	url = https://github.com/krambn/p4c-bm
@@ -25,16 +25,16 @@
 	url = https://github.com/Azure/sonic-dbsyncd
 [submodule "src/sonic-py-swsssdk"]
 	path = src/sonic-py-swsssdk
-	url = https://github.com/Azure/sonic-py-swsssdk.git
+	url = https://github.com/liorghub/sonic-py-swsssdk.git
 [submodule "src/sonic-snmpagent"]
 	path = src/sonic-snmpagent
-	url = https://github.com/Azure/sonic-snmpagent
+	url = https://github.com/liorghub/sonic-snmpagent
 [submodule "src/ptf"]
 	path = src/ptf
 	url = https://github.com/p4lang/ptf.git
 [submodule "src/sonic-utilities"]
 	path = src/sonic-utilities
-	url = https://github.com/Azure/sonic-utilities
+	url = https://github.com/liorghub/sonic-utilities
 [submodule "platform/broadcom/sonic-platform-modules-arista"]
 	path = platform/broadcom/sonic-platform-modules-arista
 	url = https://github.com/aristanetworks/sonic

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -261,9 +261,9 @@ def parse_platform_json_file(hwsku_json_file, platform_json_file):
     port_dict = readJson(platform_json_file)
     hwsku_dict = readJson(hwsku_json_file)
 
-    if not port_dict:
+    if port_dict is None:
         raise Exception("port_dict is none")
-    if not hwsku_dict:
+    if hwsku_dict is None:
         raise Exception("hwsku_dict is none")
 
     if INTF_KEY not in port_dict or INTF_KEY not in  hwsku_dict:
@@ -285,8 +285,8 @@ def parse_platform_json_file(hwsku_json_file, platform_json_file):
 
         ports.update(child_ports)
 
-    if not ports:
-        raise Exception("Ports dictionary is empty")
+    if ports is None:
+        raise Exception("Ports dictionary is None")
 
     for i in ports.keys():
         port_alias_map[ports[i]["alias"]]= i

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -317,9 +317,6 @@ def main():
         if args.port_config is None:
             args.port_config = device_info.get_path_to_port_config_file(hwsku)
         (ports, _, _) = get_port_config(hwsku, platform, args.port_config, asic_id)
-        if not ports:
-            print('Failed to get port config', file=sys.stderr)
-            sys.exit(1)
         deep_update(data, {'PORT': ports})
 
         brkout_table = get_breakout_mode(hwsku, platform, args.port_config)

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -317,6 +317,9 @@ def main():
         if args.port_config is None:
             args.port_config = device_info.get_path_to_port_config_file(hwsku)
         (ports, _, _) = get_port_config(hwsku, platform, args.port_config, asic_id)
+        if ports is None:
+            print('Failed to get port config', file=sys.stderr)
+            sys.exit(1)
         deep_update(data, {'PORT': ports})
 
         brkout_table = get_breakout_mode(hwsku, platform, args.port_config)

--- a/src/sonic-config-engine/tests/test_cfggen_platformJson.py
+++ b/src/sonic-config-engine/tests/test_cfggen_platformJson.py
@@ -2,13 +2,17 @@ import ast
 import json
 import os
 import subprocess
+import sys
 
 import tests.common_utils as utils
 
 from unittest import TestCase
-from unittest import mock
 from portconfig import get_port_config, INTF_KEY
 
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
 
 # Global Variable
 PLATFORM_OUTPUT_FILE = "platform_output.json"

--- a/src/sonic-config-engine/tests/test_cfggen_platformJson.py
+++ b/src/sonic-config-engine/tests/test_cfggen_platformJson.py
@@ -6,6 +6,8 @@ import subprocess
 import tests.common_utils as utils
 
 from unittest import TestCase
+from unittest import mock
+from portconfig import get_port_config, INTF_KEY
 
 
 # Global Variable
@@ -85,3 +87,10 @@ class TestCfgGenPlatformJson(TestCase):
         output_dict = ast.literal_eval(output.strip())
         expected = ast.literal_eval(json.dumps(fh_data))
         self.assertDictEqual(output_dict, expected)
+
+    @mock.patch('portconfig.readJson', mock.MagicMock(return_value={INTF_KEY:{}}))
+    @mock.patch('os.path.isfile', mock.MagicMock(return_value=True))
+    def test_platform_json_no_interfaces(self):
+        (ports, _, _) = get_port_config(port_config_file=self.platform_json)
+        self.assertNotEqual(ports, None)
+        self.assertEqual(ports, {})


### PR DESCRIPTION
Signed-off-by: liora <liora@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Allow cfggen to work on system without ports in platform.json or in port_config.ini

#### How I did it
Add json write of PORT section only if the dictionary that contains the ports is not empty.  

#### How to verify it
sonic-cfggen -k ACS-MSN3700 -H -j /etc/sonic/init_cfg.json --print-data

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

