### PR TITLE
[202012] Add BRCM SOC Property to not count ACL drops towards interface RX_DRP for DualToR platforms

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
@@ -1,4 +1,5 @@
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
+sai_adjust_acl_drop_in_rx_drop=1
 host_as_route_disable=1
 use_all_splithorizon_groups=1
 riot_enable=1

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
@@ -1,4 +1,5 @@
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
+sai_adjust_acl_drop_in_rx_drop=1
 host_as_route_disable=1
 use_all_splithorizon_groups=1
 riot_enable=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
@@ -13,6 +13,7 @@
 {%-         if 'dualtor' in switch_subtype.lower() %}
 {%-             set IPinIP_sock = 'sai_tunnel_support=1
                                    host_as_route_disable=1
+                                   sai_adjust_acl_drop_in_rx_drop=1
                                    l3_ecmp_levels=2' -%}
 {%-         endif %}
 {%-     endif %}

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
@@ -5,6 +5,7 @@
 {%-     if 'dualtor' in switch_subtype.lower() %}
 {%-         set IPinIP_sock = 'sai_tunnel_support=1
                                host_as_route_disable=1
+                               sai_adjust_acl_drop_in_rx_drop=1
                                l3_ecmp_levels=2' -%}
 {%-     endif %}
 {%- endif %}

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
@@ -13,6 +13,7 @@
 {%-         if 'dualtor' in switch_subtype.lower() %}
 {%-             set IPinIP_sock = 'sai_tunnel_support=1
                                    host_as_route_disable=1
+                                   sai_adjust_acl_drop_in_rx_drop=1
                                    l3_ecmp_levels=2' -%}
 {%-         endif %}
 {%-     endif %}

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -235,3 +235,4 @@ sai_optimized_mmu
 buf.map.egress_pool0.ingress_pool
 buf.map.egress_pool1.ingress_pool
 buf.map.egress_pool2.ingress_pool
+sai_adjust_acl_drop_in_rx_drop


### PR DESCRIPTION
#### Why I did it
For DualToR There will be expected packet drops that should not be counted towards interface RX_DRP counters.
SAI support this feature but is only enabled if the proper SOC property is set in the device's conf.bcm file.
this change is to add the necessary SOC property for the HW SKUs that are purposed for DualToR Roles.
This is to port the exact same fix from master PR (https://github.com/Azure/sonic-buildimage/pull/7945) to 202012 branch due to cherry pick encountered conflict.

#### How to verify it
Send packet that is expected to be drop and check that it is not being counted towards interface RX_DRP counter.
Also tested with the case where  SAI change is not yet there but SOC is already enabled and observe it does not cause any undesirable side-effect.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
Add SOC property to not count ACL Drops towards interface RX_DRP for DualToR role HW SKUs.

#### A picture of a cute animal (not mandatory but encouraged)

