### PR TITLE
Add BCM multi-instance support in saibcm-modules for XGS and DNX platforms

### DIFF
--- a/platform/broadcom/saibcm-modules/make/Make.config
+++ b/platform/broadcom/saibcm-modules/make/Make.config
@@ -174,6 +174,9 @@ CPPFLAGS += ${INCFLAGS}
 
 CFLAGS += -DSAI_FIXUP -UKCOM_FILTER_MAX -DKCOM_FILTER_MAX=1024
 
+# Flag to enable multi instance support
+CFLAGS += -DBCM_INSTANCE_SUPPORT
+
 #
 # Debug #ifdef control
 #


### PR DESCRIPTION
#### Why I did it
We hit an issue recently in the chassis bringup where the linux bde attach failed with the following ioctl error. 

[ 9058.585960] linux-user-bde (897363): Error: Invalid ioctl (00004c1d)
[ 9105.668237] linux-user-bde (901002): Error: Invalid ioctl (00004c1d)

Debugged with Broadcom team, who suggested to use this flag BCM_INSTANCE_SUPPORT to support multi-instance scenarios ( platforms with more than one asic where there are separate sai/syncd docker instances running controller each asic instance).

This flag was introduced since SDK-6.5.21 and need to be present in SAI and SAI GPL kernel module makefile.

#### How I did it
Add the flag in this flag BCM_INSTANCE_SUPPORT in gpl modules 

#### How to verify it
Found the linux bde attach succeeding and orchagent/syncd up in a  chassis with multiple ASIC's.

Also verified that single ASIC XGS and DNX platforms are ok.

```
==============
XGS
==============
admin@str-s6000-acs-10:~$ show int status
      Interface            Lanes    Speed    MTU    FEC           Alias             Vlan    Oper    Admin            Type    Asym PFC
---------------  ---------------  -------  -----  -----  --------------  ---------------  ------  -------  --------------  ----------
      Ethernet0      29,30,31,32      40G   9100    N/A    fortyGigE0/0           routed    down     down  QSFP+ or later         off
      Ethernet4      25,26,27,28      40G   9100    N/A    fortyGigE0/4            trunk      up       up  QSFP+ or later         off
      Ethernet8      37,38,39,40      40G   9100    N/A    fortyGigE0/8            trunk      up       up  QSFP+ or later         off
     Ethernet12      33,34,35,36      40G   9100    N/A   fortyGigE0/12            trunk      up       up  QSFP+ or later         off
     Ethernet16      41,42,43,44      40G   9100    N/A   fortyGigE0/16            trunk      up       up  QSFP+ or later         off
     Ethernet20      45,46,47,48      40G   9100    N/A   fortyGigE0/20            trunk      up       up  QSFP+ or later         off
     Ethernet24          5,6,7,8      40G   9100    N/A   fortyGigE0/24            trunk      up       up  QSFP+ or later         off
     Ethernet28          1,2,3,4      40G   9100    N/A   fortyGigE0/28            trunk      up       up  QSFP+ or later         off
     Ethernet32       9,10,11,12      40G   9100    N/A   fortyGigE0/32            trunk      up       up  QSFP+ or later         off
     Ethernet36      13,14,15,16      40G   9100    N/A   fortyGigE0/36            trunk      up       up  QSFP+ or later         off
     Ethernet40      21,22,23,24      40G   9100    N/A   fortyGigE0/40            trunk      up       up  QSFP+ or later         off
     Ethernet44      17,18,19,20      40G   9100    N/A   fortyGigE0/44            trunk      up       up  QSFP+ or later         off
     Ethernet48      49,50,51,52      40G   9100    N/A   fortyGigE0/48            trunk      up       up  QSFP+ or later         off
     Ethernet52      53,54,55,56      40G   9100    N/A   fortyGigE0/52            trunk      up       up  QSFP+ or later         off
     Ethernet56      61,62,63,64      40G   9100    N/A   fortyGigE0/56            trunk      up       up  QSFP+ or later         off
     Ethernet60      57,58,59,60      40G   9100    N/A   fortyGigE0/60            trunk      up       up  QSFP+ or later         off
     Ethernet64      65,66,67,68      40G   9100    N/A   fortyGigE0/64            trunk      up       up  QSFP+ or later         off
     Ethernet68      69,70,71,72      40G   9100    N/A   fortyGigE0/68            trunk      up       up  QSFP+ or later         off
     Ethernet72      77,78,79,80      40G   9100    N/A   fortyGigE0/72            trunk      up       up  QSFP+ or later         off
     Ethernet76      73,74,75,76      40G   9100    N/A   fortyGigE0/76            trunk      up       up  QSFP+ or later         off
     Ethernet80  105,106,107,108      40G   9100    N/A   fortyGigE0/80            trunk      up       up  QSFP+ or later         off
     Ethernet84  109,110,111,112      40G   9100    N/A   fortyGigE0/84            trunk      up       up  QSFP+ or later         off
     Ethernet88  117,118,119,120      40G   9100    N/A   fortyGigE0/88            trunk      up       up  QSFP+ or later         off
     Ethernet92  113,114,115,116      40G   9100    N/A   fortyGigE0/92            trunk      up       up  QSFP+ or later         off
     Ethernet96  121,122,123,124      40G   9100    N/A   fortyGigE0/96            trunk      up       up  QSFP+ or later         off
    Ethernet100  125,126,127,128      40G   9100    N/A  fortyGigE0/100           routed    down     down  QSFP+ or later         off
    Ethernet104      85,86,87,88      40G   9100    N/A  fortyGigE0/104           routed    down     down  QSFP+ or later         off
    Ethernet108      81,82,83,84      40G   9100    N/A  fortyGigE0/108           routed    down     down  QSFP+ or later         off
    Ethernet112      89,90,91,92      40G   9100    N/A  fortyGigE0/112  PortChannel0001      up       up  QSFP+ or later         off
    Ethernet116      93,94,95,96      40G   9100    N/A  fortyGigE0/116  PortChannel0002      up       up  QSFP+ or later         off
    Ethernet120     97,98,99,100      40G   9100    N/A  fortyGigE0/120  PortChannel0003      up       up  QSFP+ or later         off
    Ethernet124  101,102,103,104      40G   9100    N/A  fortyGigE0/124  PortChannel0004      up       up  QSFP+ or later         off
PortChannel0001              N/A      40G   9100    N/A             N/A           routed      up       up             N/A         N/A
PortChannel0002              N/A      40G   9100    N/A             N/A           routed      up       up             N/A         N/A
PortChannel0003              N/A      40G   9100    N/A             N/A           routed      up       up             N/A         N/A
PortChannel0004              N/A      40G   9100    N/A             N/A           routed      up       up             N/A         N/A
admin@str-s6000-acs-10:~$ 
admin@str-s6000-acs-10:~$ show ip bgp summary 

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 9117
RIB entries 12807, using 2458944 bytes of memory
Peers 4, using 87264 KiB of memory
Peer groups 4, using 256 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd  NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.57      4  64600       3214       8435         0      0    1581  00:00:30             6400  ARISTA01T1
10.0.0.59      4  64600       3213       7221         0      0    2792  00:00:30             6400  ARISTA02T1
10.0.0.61      4  64600       3214       8867         0      0    1148  00:00:30             6400  ARISTA03T1
10.0.0.63      4  64600       3214       7087         0      0    2928  00:00:30             6400  ARISTA04T1

Total number of neighbors 4
admin@str-s6000-acs-10:~$ show int portchannel 
show version
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev         Protocol     Ports
-----  ---------------  -----------  --------------
 0001  PortChannel0001  LACP(A)(Up)  Ethernet112(S)
 0002  PortChannel0002  LACP(A)(Up)  Ethernet116(S)
 0003  PortChannel0003  LACP(A)(Up)  Ethernet120(S)
 0004  PortChannel0004  LACP(A)(Up)  Ethernet124(S)

admin@str-s6000-acs-10:~$ sudo show version

SONiC Software Version: SONiC.master-8002.21672-7664d9005
Distribution: Debian 10.10
Kernel: 4.19.0-12-2-amd64
Build commit: 7664d9005
Build date: Tue Jun 29 02:28:14 UTC 2021
Built by: AzDevOps@sonic-build-workers-000FHS

Platform: x86_64-dell_s6000_s1220-r0
HwSKU: Force10-S6000
ASIC: broadcom
ASIC Count: 1
Serial Number: DQBRX42
Model Number: 00NX1V
Hardware Revision: N/A
Uptime: 20:18:35 up 5 min,  1 user,  load average: 2.86, 3.54, 1.74

Docker images:
REPOSITORY                    TAG                           IMAGE ID            SIZE
docker-platform-monitor       latest                        cef476007e00        630MB
docker-platform-monitor       master-8002.21672-7664d9005   cef476007e00        630MB
docker-snmp                   latest                        050cf40110bd        454MB
docker-snmp                   master-8002.21672-7664d9005   050cf40110bd        454MB
docker-sflow                  latest                        fd0f3c2b8772        425MB
docker-sflow                  master-8002.21672-7664d9005   fd0f3c2b8772        425MB
docker-teamd                  latest                        f7c62a59eaee        424MB
docker-teamd                  master-8002.21672-7664d9005   f7c62a59eaee        424MB
docker-nat                    latest                        ce6d265d7289        427MB
docker-nat                    master-8002.21672-7664d9005   ce6d265d7289        427MB
docker-dhcp-relay             latest                        bb169da92e52        420MB
docker-dhcp-relay             master-8002.21672-7664d9005   bb169da92e52        420MB
docker-macsec                 latest                        c9003457baf7        427MB
docker-macsec                 master-8002.21672-7664d9005   c9003457baf7        427MB
docker-orchagent              latest                        907b04096b40        442MB
docker-orchagent              master-8002.21672-7664d9005   907b04096b40        442MB
docker-database               latest                        0e4655f0b79d        413MB
docker-database               master-8002.21672-7664d9005   0e4655f0b79d        413MB
docker-router-advertiser      latest                        137312508977        413MB
docker-router-advertiser      master-8002.21672-7664d9005   137312508977        413MB
docker-sonic-mgmt-framework   latest                        3c074129f44f        570MB
docker-sonic-mgmt-framework   master-8002.21672-7664d9005   3c074129f44f        570MB
docker-lldp                   latest                        8a48ecf289c6        453MB
docker-lldp                   master-8002.21672-7664d9005   8a48ecf289c6        453MB
docker-sonic-telemetry        latest                        3b2dcf58c875        501MB
docker-sonic-telemetry        master-8002.21672-7664d9005   3b2dcf58c875        501MB
docker-fpm-frr                latest                        d4ab729a25c0        442MB
docker-fpm-frr                master-8002.21672-7664d9005   d4ab729a25c0        442MB
docker-syncd-brcm             latest                        6ff6df9a63e5        705MB
docker-syncd-brcm             master-8002.21672-7664d9005   6ff6df9a63e5        705MB

==============
DNX
==============
admin@str-a7280cr3-2:~$ show version

SONiC Software Version: SONiC.master-8002.21672-7664d9005
Distribution: Debian 10.10
Kernel: 4.19.0-12-2-amd64
Build commit: 7664d9005
Build date: Tue Jun 29 01:59:04 UTC 2021
Built by: AzDevOps@sonic-build-workers-000FHS

Platform: x86_64-arista_7280cr3k_32p4
HwSKU: Arista-7280CR3-C40
ASIC: broadcom
ASIC Count: 1
Serial Number: JPE19362918
Model Number: DCS-7280CR3K-32P4
Hardware Revision: N/A
Uptime: 20:19:36 up 19 min,  1 user,  load average: 0.39, 1.02, 0.74

Docker images:
REPOSITORY                    TAG                           IMAGE ID            SIZE
docker-platform-monitor       latest                        cef476007e00        630MB
docker-platform-monitor       master-8002.21672-7664d9005   cef476007e00        630MB
docker-snmp                   latest                        050cf40110bd        454MB
docker-snmp                   master-8002.21672-7664d9005   050cf40110bd        454MB
docker-sflow                  latest                        fd0f3c2b8772        425MB
docker-sflow                  master-8002.21672-7664d9005   fd0f3c2b8772        425MB
docker-teamd                  latest                        f7c62a59eaee        424MB
docker-teamd                  master-8002.21672-7664d9005   f7c62a59eaee        424MB
docker-nat                    latest                        ce6d265d7289        427MB
docker-nat                    master-8002.21672-7664d9005   ce6d265d7289        427MB
docker-dhcp-relay             latest                        bb169da92e52        420MB
docker-dhcp-relay             master-8002.21672-7664d9005   bb169da92e52        420MB
docker-macsec                 latest                        c9003457baf7        427MB
docker-macsec                 master-8002.21672-7664d9005   c9003457baf7        427MB
docker-orchagent              latest                        907b04096b40        442MB
docker-orchagent              master-8002.21672-7664d9005   907b04096b40        442MB
docker-database               latest                        0e4655f0b79d        413MB
docker-database               master-8002.21672-7664d9005   0e4655f0b79d        413MB
docker-router-advertiser      latest                        137312508977        413MB
docker-router-advertiser      master-8002.21672-7664d9005   137312508977        413MB
docker-sonic-mgmt-framework   latest                        3c074129f44f        570MB
docker-sonic-mgmt-framework   master-8002.21672-7664d9005   3c074129f44f        570MB
docker-lldp                   latest                        8a48ecf289c6        453MB
docker-lldp                   master-8002.21672-7664d9005   8a48ecf289c6        453MB
docker-sonic-telemetry        latest                        3b2dcf58c875        501MB
docker-sonic-telemetry        master-8002.21672-7664d9005   3b2dcf58c875        501MB
docker-fpm-frr                latest                        d4ab729a25c0        442MB
docker-fpm-frr                master-8002.21672-7664d9005   d4ab729a25c0        442MB
docker-syncd-brcm-dnx         latest                        48b358959cbc        842MB
docker-syncd-brcm-dnx         master-8002.21672-7664d9005   48b358959cbc        842MB

admin@str-a7280cr3-2:~$ show ip bgp summary 

IPv4 Unicast Summary:
BGP router identifier 10.1.0.32, local AS number 65100 vrf-id 0
BGP table version 26
RIB entries 47, using 9024 bytes of memory
Peers 24, using 523584 KiB of memory
Peer groups 2, using 128 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200          0          0         0      0       0  never      Active          ARISTA01T2
10.0.0.5       4  65200         88        104         0      0       0  00:04:11   1               ARISTA03T2
10.0.0.9       4  65200         89        107         0      0       0  00:04:14   1               ARISTA05T2
10.0.0.13      4  65200         89        110         0      0       0  00:04:14   1               ARISTA07T2
10.0.0.17      4  65200         89        107         0      0       0  00:04:15   1               ARISTA09T2
10.0.0.21      4  65200         89        107         0      0       0  00:04:15   1               ARISTA11T2
10.0.0.25      4  65200         89        106         0      0       0  00:04:12   1               ARISTA13T2
10.0.0.29      4  65200         88        104         0      0       0  00:04:11   1               ARISTA15T2
10.0.0.33      4  64001         87        103         0      0       0  00:04:08   1               ARISTA01T0
10.0.0.35      4  64002         87        103         0      0       0  00:04:08   1               ARISTA02T0
10.0.0.37      4  64003         87        103         0      0       0  00:04:08   1               ARISTA03T0
10.0.0.39      4  64004         87        103         0      0       0  00:04:08   1               ARISTA04T0
10.0.0.41      4  64005         87        103         0      0       0  00:04:08   1               ARISTA05T0
10.0.0.43      4  64006         87        103         0      0       0  00:04:08   1               ARISTA06T0
10.0.0.45      4  64007         87        103         0      0       0  00:04:08   1               ARISTA07T0
10.0.0.47      4  64008         87        103         0      0       0  00:04:08   1               ARISTA08T0
10.0.0.49      4  64009         87        103         0      0       0  00:04:08   1               ARISTA09T0
10.0.0.51      4  64010         87        103         0      0       0  00:04:08   1               ARISTA10T0
10.0.0.53      4  64011         87        103         0      0       0  00:04:08   1               ARISTA11T0
10.0.0.55      4  64012         87        103         0      0       0  00:04:08   1               ARISTA12T0
10.0.0.57      4  64013         88        104         0      0       0  00:04:10   1               ARISTA13T0
10.0.0.59      4  64014         87        103         0      0       0  00:04:08   1               ARISTA14T0
10.0.0.61      4  64015         87        103         0      0       0  00:04:08   1               ARISTA15T0
10.0.0.63      4  64016         87        103         0      0       0  00:04:08   1               ARISTA16T0

Total number of neighbors 24
admin@str-a7280cr3-2:~$ show int portchannel 
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev         Protocol     Ports
-----  ---------------  -----------  ---------------------------
 0002  PortChannel0002  LACP(A)(Dw)  Ethernet4(S*) Ethernet0(D)
 0005  PortChannel0005  LACP(A)(Up)  Ethernet12(S) Ethernet8(S)
 0008  PortChannel0008  LACP(A)(Up)  Ethernet20(S) Ethernet16(S)
 0011  PortChannel0011  LACP(A)(Up)  Ethernet28(S) Ethernet24(S)
 0014  PortChannel0014  LACP(A)(Up)  Ethernet32(S) Ethernet36(S)
 0017  PortChannel0017  LACP(A)(Up)  Ethernet40(S) Ethernet44(S)
 0020  PortChannel0020  LACP(A)(Up)  Ethernet52(S) Ethernet48(S)
 0023  PortChannel0023  LACP(A)(Up)  Ethernet56(S) Ethernet60(S)
admin@str-a7280cr3-2:~$ show int status
      Interface        Lanes    Speed    MTU    FEC         Alias             Vlan    Oper    Admin             Type    Asym PFC
---------------  -----------  -------  -----  -----  ------------  ---------------  ------  -------  ---------------  ----------
      Ethernet0          0,1     100G   9100     rs   Ethernet1/1  PortChannel0002      up       up  QSFP28 or later         off
      Ethernet4          2,3     100G   9100     rs   Ethernet2/1  PortChannel0002      up       up  QSFP28 or later         off
      Ethernet8          4,5     100G   9100     rs   Ethernet3/1  PortChannel0005      up       up  QSFP28 or later         off
     Ethernet12          6,7     100G   9100     rs   Ethernet4/1  PortChannel0005      up       up  QSFP28 or later         off
     Ethernet16          8,9     100G   9100     rs   Ethernet5/1  PortChannel0008      up       up  QSFP28 or later         off
     Ethernet20        10,11     100G   9100     rs   Ethernet6/1  PortChannel0008      up       up  QSFP28 or later         off
     Ethernet24        12,13     100G   9100     rs   Ethernet7/1  PortChannel0011      up       up  QSFP28 or later         off
     Ethernet28        14,15     100G   9100     rs   Ethernet8/1  PortChannel0011      up       up  QSFP28 or later         off
     Ethernet32        16,17     100G   9100     rs   Ethernet9/1  PortChannel0014      up       up  QSFP28 or later         off
     Ethernet36        18,19     100G   9100     rs  Ethernet10/1  PortChannel0014      up       up  QSFP28 or later         off
     Ethernet40        20,21     100G   9100     rs  Ethernet11/1  PortChannel0017      up       up  QSFP28 or later         off
     Ethernet44        22,23     100G   9100     rs  Ethernet12/1  PortChannel0017      up       up  QSFP28 or later         off
     Ethernet48        24,25     100G   9100     rs  Ethernet13/1  PortChannel0020      up       up  QSFP28 or later         off
     Ethernet52        26,27     100G   9100     rs  Ethernet14/1  PortChannel0020      up       up  QSFP28 or later         off
     Ethernet56        28,29     100G   9100     rs  Ethernet15/1  PortChannel0023      up       up  QSFP28 or later         off
     Ethernet60        30,31     100G   9100     rs  Ethernet16/1  PortChannel0023      up       up  QSFP28 or later         off
     Ethernet64        72,73     100G   9100     rs  Ethernet17/1           routed      up       up  QSFP28 or later         off
     Ethernet68        74,75     100G   9100     rs  Ethernet18/1           routed      up       up  QSFP28 or later         off
     Ethernet72        76,77     100G   9100     rs  Ethernet19/1           routed      up       up  QSFP28 or later         off
     Ethernet76        78,79     100G   9100     rs  Ethernet20/1           routed      up       up  QSFP28 or later         off
     Ethernet80        64,65     100G   9100     rs  Ethernet21/1           routed      up       up  QSFP28 or later         off
     Ethernet84        66,67     100G   9100     rs  Ethernet22/1           routed      up       up  QSFP28 or later         off
     Ethernet88        68,69     100G   9100     rs  Ethernet23/1           routed      up       up  QSFP28 or later         off
     Ethernet92        70,71     100G   9100     rs  Ethernet24/1           routed      up       up  QSFP28 or later         off
     Ethernet96        56,57     100G   9100     rs  Ethernet25/1           routed      up       up  QSFP28 or later         off
    Ethernet100        58,59     100G   9100     rs  Ethernet26/1           routed      up       up  QSFP28 or later         off
    Ethernet104        60,61     100G   9100     rs  Ethernet27/1           routed      up       up  QSFP28 or later         off
    Ethernet108        62,63     100G   9100     rs  Ethernet28/1           routed      up       up  QSFP28 or later         off
    Ethernet112        48,49     100G   9100     rs  Ethernet29/1           routed      up       up  QSFP28 or later         off
    Ethernet116        50,51     100G   9100     rs  Ethernet30/1           routed      up       up  QSFP28 or later         off
    Ethernet120        52,53     100G   9100     rs  Ethernet31/1           routed      up       up  QSFP28 or later         off
    Ethernet124        54,55     100G   9100     rs  Ethernet32/1           routed      up       up  QSFP28 or later         off
    Ethernet128  32,33,34,35     100G   9100     rs  Ethernet33/1           routed    down     down              N/A         off
    Ethernet132  36,37,38,39     100G   9100     rs  Ethernet33/5           routed    down     down              N/A         off
    Ethernet136  40,41,42,43     100G   9100     rs  Ethernet34/1           routed    down     down              N/A         off
    Ethernet140  44,45,46,47     100G   9100     rs  Ethernet34/5           routed    down     down              N/A         off
    Ethernet144  88,89,90,91     100G   9100     rs  Ethernet35/1           routed    down     down              N/A         off
    Ethernet148  92,93,94,95     100G   9100     rs  Ethernet35/5           routed    down     down              N/A         off
    Ethernet152  80,81,82,83     100G   9100     rs  Ethernet36/1           routed    down     down              N/A         off
    Ethernet156  84,85,86,87     100G   9100     rs  Ethernet36/5           routed    down     down              N/A         off
PortChannel0002          N/A     200G   9100    N/A           N/A           routed    down       up              N/A         N/A
PortChannel0005          N/A     200G   9100    N/A           N/A           routed      up       up              N/A         N/A
PortChannel0008          N/A     200G   9100    N/A           N/A           routed      up       up              N/A         N/A
PortChannel0011          N/A     200G   9100    N/A           N/A           routed      up       up              N/A         N/A
PortChannel0014          N/A     200G   9100    N/A           N/A           routed      up       up              N/A         N/A
PortChannel0017          N/A     200G   9100    N/A           N/A           routed      up       up              N/A         N/A
PortChannel0020          N/A     200G   9100    N/A           N/A           routed      up       up              N/A         N/A
PortChannel0023          N/A     200G   9100    N/A           N/A           routed      up       up              N/A         N/A
admin@str-a7280cr3-2:~$ cat /proc/linux-kernel-bde 
Broadcom Device Enumerator (linux-kernel-bde)
Module parameters:
        maxpayload=128
        usemsi=1
        dmasize=32M
        himem=(null)
        himemaddr=(null)
DMA Memory (kernel): 33554432 bytes, 0 used, 33554432 free, local mmap
Devices:
        0 (swi) : PCI device 05:00.0 0x14e4:0x8690:18:0xe4800000:0xe4000000:50 (MSI)
                imask:imask2:fmask 0x0:0x33333330:0xffffffff  unique_id=0x500 inst_id INVALID
admin@str-a7280cr3-2:~$ cat /proc/bcm/knet/debug 
Configuration:
  debug:          0x5020
  mac_addr:       02:10:18:ba:7d:d4
  rx_buffer_size: 9238 (0x2416)
  rcpu_mode:      0
  rcpu_dmac:      00:00:00:00:00:00
  rcpu_smac:      00:00:00:00:00:00
  rcpu_ethertype: 0xde08
  rcpu_signature: 0x0
  rcpu_vlan:      1
  use_rx_skb:     1
  num_rx_prio:    1
  check_rcpu_sig: 0
  default_mtu:    9100
  rx_sync_retry:  1000
  use_napi:       0
  napi_weight:    64
  basedev_susp:   0
  force_tagged:   0
  ft_tpid:        33024
  ft_pri:         0
  ft_pri:         0
  ft_tpid:        0
Active IOCTLs:
  Command:        0
  Event:          1
Device 0:
  base_addr:      0x00000000ab44bb0b
  dev_no:         0
  cmic_type:      x
  dcb_type:       39
  dcb_wsize:      4
  pkt_hdr_size:   0
  rx_chans:       7
  cdma_chans:     0x0
  irq_mask:       0x33333330
  dma_events:     0x0
  dcb_dma:        0x0000000080eeaffc
  dcb_mem_size:   0x2080
  rcpu_sig:       0x8690
  napi_poll_mode: 0
  inst_id:        0xffffffff
  evt_queue:      0


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

