### PR TITLE
[Barefoot] Enable 'TELEMETRY_WRITABLE' for telemetry container

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -48,7 +48,7 @@ jobs:
             docker_syncd_rpc_image: yes
             platform_rpc: bfn
             swi_image: yes
-            BUILD_OPTIONS: $(BUILD_OPTIONS) TELEMETRY_WRITABLE=y
+            BUILD_OPTIONS: ${{ parameters.buildOptions }} TELEMETRY_WRITABLE=y
 
         - name: broadcom
           variables:

--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -110,7 +110,11 @@ jobs:
                 mv target/sonic-$(GROUP_NAME).bin target/sonic-$(GROUP_NAME)-dbg.bin
             fi
             if [ $(swi_image) == yes ]; then
-              make $BUILD_OPTIONS ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-$(GROUP_NAME).swi
+              if [ $(GROUP_NAME) == barefoot ]; then
+                make $BUILD_OPTIONS TELEMETRY_WRITABLE=y ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-$(GROUP_NAME).swi
+              else
+                make $BUILD_OPTIONS ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-$(GROUP_NAME).swi
+              fi
             fi
             if [ $(raw_image) == yes ]; then
               make $BUILD_OPTIONS target/sonic-$(GROUP_NAME).raw
@@ -122,6 +126,11 @@ jobs:
               make $BUILD_OPTIONS ENABLE_SYNCD_RPC=y target/sonic-$(GROUP_NAME).bin
               mv target/sonic-mellanox.bin target/sonic-$(GROUP_NAME)-rpc.bin
             fi
-            make $BUILD_OPTIONS target/sonic-$(GROUP_NAME).bin
+
+            if [ $(GROUP_NAME) == barefoot ]; then
+              make $BUILD_OPTIONS TELEMETRY_WRITABLE=y target/sonic-$(GROUP_NAME).bin
+            else
+              make $BUILD_OPTIONS target/sonic-$(GROUP_NAME).bin
+            fi
           fi
         displayName: "Build sonic image"

--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -48,6 +48,7 @@ jobs:
             docker_syncd_rpc_image: yes
             platform_rpc: bfn
             swi_image: yes
+            BUILD_OPTIONS: $(BUILD_OPTIONS) TELEMETRY_WRITABLE=y
 
         - name: broadcom
           variables:
@@ -110,11 +111,7 @@ jobs:
                 mv target/sonic-$(GROUP_NAME).bin target/sonic-$(GROUP_NAME)-dbg.bin
             fi
             if [ $(swi_image) == yes ]; then
-              if [ $(GROUP_NAME) == barefoot ]; then
-                make $BUILD_OPTIONS TELEMETRY_WRITABLE=y ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-$(GROUP_NAME).swi
-              else
-                make $BUILD_OPTIONS ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-$(GROUP_NAME).swi
-              fi
+              make $BUILD_OPTIONS ENABLE_IMAGE_SIGNATURE=y target/sonic-aboot-$(GROUP_NAME).swi
             fi
             if [ $(raw_image) == yes ]; then
               make $BUILD_OPTIONS target/sonic-$(GROUP_NAME).raw
@@ -126,11 +123,6 @@ jobs:
               make $BUILD_OPTIONS ENABLE_SYNCD_RPC=y target/sonic-$(GROUP_NAME).bin
               mv target/sonic-mellanox.bin target/sonic-$(GROUP_NAME)-rpc.bin
             fi
-
-            if [ $(GROUP_NAME) == barefoot ]; then
-              make $BUILD_OPTIONS TELEMETRY_WRITABLE=y target/sonic-$(GROUP_NAME).bin
-            else
-              make $BUILD_OPTIONS target/sonic-$(GROUP_NAME).bin
-            fi
+            make $BUILD_OPTIONS target/sonic-$(GROUP_NAME).bin
           fi
         displayName: "Build sonic image"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For testing `gNMI/gNOI` we need to enable r/w mode for telemetry container

#### How I did it
Added `TELEMETRY_WRITABLE=y` option to `make` command
#### How to verify it
Build SONiC with command `make TELEMETRY_WRITABLE=y target/sonic-aboot-barefoot.swi`
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

