### PR TITLE
[ci]: Disable nephos docker syncd rpc temporarily

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -93,7 +93,7 @@ jobs:
         - name: nephos
           variables:
             dbg_image: yes
-            docker_syncd_rpc_image: yes
+            docker_syncd_rpc_image: no
             platform_rpc: nephos
 
     buildSteps:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Disable the nephos docker syncd rpc image temporarily

The package libboost-atomic1.71.0 does not exist in the debian:stretch, it has no chance to build a successful rpc image.
Revert the change until the rpc image upgraded to buster.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

