### PR TITLE
Add libpci3 pkg to docker-platform-monitor

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -24,7 +24,8 @@ RUN apt-get update &&   \
         python3-smbus   \
         dmidecode       \
         i2c-tools       \
-        psmisc
+        psmisc          \
+        libpci3
 
 # TODO: Remove these lines once we no longer need Python 2
 RUN apt-get install -f -y python-dev python-pip


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 The libpci library provides portable access to configuration registers of devices connected to the PCI bus. 
#### How I did it
update dockers/docker-platform-monitor/Dockerfile.j2. Total usage is: 

root@sonic:/var/log#  dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | grep libpci3
102     libpci3

#### How to verify it
Verify PCI based devices are mounted successfully on the PCI bus 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog

 The libpci library provides portable access to configuration registers of devices connected to the PCI bus.

```
root@sonic:/home/admin# dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | grep libpci3
102     libpci3
```


#### A picture of a cute animal (not mandatory but encouraged)

