### PR TITLE
Add ethtool to docker-platform-monitor 

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -22,6 +22,7 @@ RUN apt-get update &&   \
         rrdtool         \
         python-smbus    \
         python3-smbus   \
+        ethtool         \
         dmidecode       \
         i2c-tools       \
         psmisc


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 ethtool can be used to query and change settings such as speed, auto- negotiation and checksum offload on many network devices, especially Ethernet devices. 

#### How I did it
add package extension to docker-platform-monitor/Dockerfile.j2 
#### How to verify it
ethtool -y 
more examples are @ https://linuxhint.com/ethtool_commands_examples/

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006
- [x] 202012

#### Description for the changelog

 ethtool can be used to query and change settings such as speed, auto- negotiation and checksum offload on many network devices, especially Ethernet devices. 

```
root@sonic:/# dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | grep ethtool
593     ethtool
```


#### A picture of a cute animal (not mandatory but encouraged)

