### PR TITLE
Fix the apt-get download package disorder issue

### DIFF
--- a/scripts/build_debian_base_system.sh
+++ b/scripts/build_debian_base_system.sh
@@ -63,14 +63,18 @@ mkdir -p $ARCHIEVES
 mkdir -p $APTLIST
 mkdir -p $TARGET_DEBOOTSTRAP
 PACKAGES=$(sed -E 's/=(=[^=]*)$/\1/' $BASE_VERSIONS)
-URL_ARR=($(apt-get download --print-uris $PACKAGES | cut -d" " -f1 | tr -d "'"))
+URL_ARR=$(apt-get download --print-uris $PACKAGES | cut -d" " -f1 | tr -d "'")
 PACKAGE_ARR=($PACKAGES)
 LENGTH=${#PACKAGE_ARR[@]}
 for ((i=0;i<LENGTH;i++))
 do
     package=${PACKAGE_ARR[$i]}
     packagename=$(echo $package | sed -E 's/=[^=]*$//')
-    url=${URL_ARR[$i]}
+    url=$(echo "$URL_ARR" | grep "/${packagename}_")
+    if [ -z "$url" ] || [[ $(echo "$url" | wc -l) -gt 1 ]]; then
+        echo "No found package or found multiple package for package $packagename, url: $url" 2>&1
+        exit 1
+    fi
     filename=$(basename "$url")
     SKIP_BUILD_HOOK=y wget $url -P $ARCHIEVES
     echo $packagename >> $DEBOOTSTRAP_REQUIRED


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Multiple build failed in 202012 branch
It is caused by the disorder of the package urls retrieved from the command "apt-get download --print-urls <packages>"

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

