### PR TITLE
[DellEMC] S6100 Reboot cause determining CPU reset in fast-reboot

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -10,6 +10,7 @@ s6100/scripts/platform_reboot_override usr/share/sonic/device/x86_64-dell_s6100_
 s6100/scripts/fast-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/track_reboot_reason.sh usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/warm-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
+s6100/scripts/reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/ssd-fw-upgrade usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/override.conf /etc/systemd/system/systemd-reboot.service.d
 common/dell_lpc_mon.sh usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_reboot_override
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/platform_reboot_override
@@ -7,8 +7,8 @@ PORT_RES = '/dev/port'
 
 
 def log_software_reboot():
-    # Run plugin script which will track the cli triggered reboot, fastboot, warmboot
-    res = subprocess.check_output(['/usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/fast-reboot_plugin'])
+    # Run plugin script which will track the cli triggered reboot
+    res = subprocess.check_output(['/usr/share/sonic/device/x86_64-dell_s6100_c2538-r0/reboot_plugin'])
     return
 
 def ssd_hdparm_upgrade():

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/reboot_plugin
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/reboot_plugin
@@ -5,7 +5,4 @@ if [[ -d /sys/devices/platform/SMF.512/hwmon/ ]]; then
     echo 0xcc > mb_poweron_reason
 fi
 
-io_rd_wr.py --set --val 40 --offset 0x131
-io_rd_wr.py --set --val 06 --offset 210; io_rd_wr.py --set --val 0B --offset 211; io_rd_wr.py --set --val aa --offset 213
-
 /usr/local/bin/s6100_i2c_enumeration.sh deinit & > /dev/null

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -99,6 +99,7 @@ class Chassis(ChassisBase):
     def _get_reboot_reason_smf_register(self):
         # In S6100, mb_poweron_reason register will
         # Returns 0xaa or 0xcc on software reload
+        # Returns 0x88 on cold-reboot happened during software reload
         # Returns 0xff or 0xbb on power-cycle
         # Returns 0xdd on Watchdog
         # Returns 0xee on Thermal Shutdown
@@ -257,6 +258,8 @@ class Chassis(ChassisBase):
             return (ChassisBase.REBOOT_CAUSE_POWER_LOSS, None)
         elif ((smf_mb_reg_reason == 0xaa) or (smf_mb_reg_reason == 0xcc)):
             return (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, None)
+        elif (smf_mb_reg_reason == 0x88):
+            return (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "CPU_RESET")
         elif (smf_mb_reg_reason == 0xdd):
             return (ChassisBase.REBOOT_CAUSE_WATCHDOG, None)
         elif (smf_mb_reg_reason == 0xee):

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -259,7 +259,7 @@ class Chassis(ChassisBase):
         elif ((smf_mb_reg_reason == 0xaa) or (smf_mb_reg_reason == 0xcc)):
             return (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, None)
         elif (smf_mb_reg_reason == 0x88):
-            return (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "CPU_RESET")
+            return (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "CPU Reset")
         elif (smf_mb_reg_reason == 0xdd):
             return (ChassisBase.REBOOT_CAUSE_WATCHDOG, None)
         elif (smf_mb_reg_reason == 0xee):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Added a check in determining CPU reset in fast-/warm-reboot in their respective platform plugin.
- Introducing reboot plugin for "reboot" command to handle its own platform plugin.

#### How I did it
On branch s6100_fast_warm_check
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        modified:   ../../debian/platform-modules-s6100.install
        modified:   ../scripts/fast-reboot_plugin
        modified:   ../scripts/platform_reboot_override
        new file:   ../scripts/reboot_plugin
        modified:   ../scripts/track_reboot_reason.sh
        modified:   chassis.py


#### How to verify it
- Triggered cold-reset inside fast-reboot to test out the reboot-cause 2.0 API.

[s6100-logs.txt](https://github.com/Azure/sonic-buildimage/files/6737835/s6100-logs.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

