### PR TITLE
[bgpcfgd] Remove unnecessary dependency for StaticRouteMgr

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -51,7 +51,6 @@ class StaticRouteMgr(Manager):
         if not self.static_routes.get(vrf, {}):
             if self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/bgp_asn"):
                 cmd_list.extend(self.enable_redistribution_command(vrf))
-                self.vrf_pending_redistribution.discard(vrf)
             else:
                 self.vrf_pending_redistribution.add(vrf)
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -16,12 +16,14 @@ class StaticRouteMgr(Manager):
         """
         super(StaticRouteMgr, self).__init__(
             common_objs,
-            [("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/bgp_asn"),],
+            [],
             db,
             table,
         )
-
+        
+        self.directory.subscribe([("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/bgp_asn"),], self.on_bgp_asn_change)
         self.static_routes = {}
+        self.vrf_pending_redistribution = set()
 
     OP_DELETE = 'DELETE'
     OP_ADD = 'ADD'
@@ -47,15 +49,11 @@ class StaticRouteMgr(Manager):
 
         # Enable redistribution of static routes when it is the first one get set
         if not self.static_routes.get(vrf, {}):
-            log_debug("Enabling static route redistribution")
-            bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
-            if vrf == 'default':
-                cmd_list.append("router bgp %s" % bgp_asn)
+            if self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/bgp_asn"):
+                cmd_list.extend(self.enable_redistribution_command(vrf))
+                self.vrf_pending_redistribution.discard(vrf)
             else:
-                cmd_list.append("router bgp %s vrf %s" % (bgp_asn, vrf))
-            for af in ["ipv4", "ipv6"]:
-                cmd_list.append(" address-family %s" % af)
-                cmd_list.append("  redistribute static")
+                self.vrf_pending_redistribution.add(vrf)
 
         if cmd_list:
             self.cfg_mgr.push_list(cmd_list)
@@ -78,15 +76,9 @@ class StaticRouteMgr(Manager):
 
         # Disable redistribution of static routes when it is the last one to delete
         if self.static_routes.get(vrf, {}).keys() == {ip_prefix}:
-            log_debug("Disabling static route redistribution")
-            bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
-            if vrf == 'default':
-                cmd_list.append("router bgp %s" % bgp_asn)
-            else:
-                cmd_list.append("router bgp %s vrf %s" % (bgp_asn, vrf))
-            for af in ["ipv4", "ipv6"]:
-                cmd_list.append(" address-family %s" % af)
-                cmd_list.append("  no redistribute static")
+            if self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/bgp_asn"):
+                cmd_list.extend(self.disable_redistribution_command(vrf))
+            self.vrf_pending_redistribution.discard(vrf)
 
         if cmd_list:
             self.cfg_mgr.push_list(cmd_list)
@@ -134,6 +126,38 @@ class StaticRouteMgr(Manager):
             ip_nh,
             ' vrf {}'.format(vrf) if vrf != 'default' else ''
         )
+
+    def enable_redistribution_command(self, vrf):
+        log_debug("Enabling static route redistribution")
+        cmd_list = []
+        bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
+        if vrf == 'default':
+            cmd_list.append("router bgp %s" % bgp_asn)
+        else:
+            cmd_list.append("router bgp %s vrf %s" % (bgp_asn, vrf))
+        for af in ["ipv4", "ipv6"]:
+            cmd_list.append(" address-family %s" % af)
+            cmd_list.append("  redistribute static")
+        return cmd_list
+
+    def disable_redistribution_command(self, vrf):
+        log_debug("Disabling static route redistribution")
+        cmd_list = []
+        bgp_asn = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
+        if vrf == 'default':
+            cmd_list.append("router bgp %s" % bgp_asn)
+        else:
+            cmd_list.append("router bgp %s vrf %s" % (bgp_asn, vrf))
+        for af in ["ipv4", "ipv6"]:
+            cmd_list.append(" address-family %s" % af)
+            cmd_list.append("  no redistribute static")
+        return cmd_list
+
+    def on_bgp_asn_change(self):
+        if self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/bgp_asn"):
+            for vrf in self.vrf_pending_redistribution:
+                self.cfg_mgr.push_list(self.enable_redistribution_command(vrf))
+            self.vrf_pending_redistribution.clear()
 
 class IpNextHop:
     def __init__(self, af_id, blackhole, dst_ip, if_name, dist, vrf):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Static route configuration should not depend on BGP_ASN. Remove the dependency on BGP_ASN for StaticRouteMgr.
Fix https://github.com/Azure/sonic-buildimage/issues/8027

#### How I did it
Check if BGP_ASN field before configuring static route redistribution and wait until BGP_ASN is available to enable static route redistribution.

#### How to verify it
Add unit test to cover the scenario and verify the functionality on a virtual switch.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

