### PR TITLE
[multiasic][voq][bgpconf] Fix for the issue of same BGP router id in all asics

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -60,7 +60,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
 !
 {# set router-id #}
-{% if DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
+{% if DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' or  (multi_asic is defined and DEVICE_METADATA['localhost']['switch_type'] == 'voq') %}
   bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}
 {% else %}
   bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}

--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -60,7 +60,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
 !
 {# set router-id #}
-{% if DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' or  (multi_asic is defined and DEVICE_METADATA['localhost']['switch_type'] == 'voq') %}
+{% if DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' or DEVICE_METADATA['localhost']['switch_type'] == 'voq' %}
   bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}
 {% else %}
   bgp router-id {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}
@@ -68,7 +68,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
 {# advertise loopback #}
   network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/32
-{% if multi_asic is defined  %}
+{% if multi_asic is defined or DEVICE_METADATA['localhost']['switch_type'] == 'voq' %}
   network {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/32 route-map HIDE_INTERNAL
 {% endif %}
 !
@@ -77,7 +77,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64
   exit-address-family
 {% endif %}
-{% if multi_asic is defined %}
+{% if multi_asic is defined or DEVICE_METADATA['localhost']['switch_type'] == 'voq'%}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") != 'None' %}
   address-family ipv6
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") | ip }}/128 route-map HIDE_INTERNAL

--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -31,6 +31,9 @@ ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq {{ loop.index * 5 }} permit {{ prefi
 {% endfor %}
 !
 {% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' or DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' %}
+{% set multi_asic = True %}
+{% endif %}
+{% if multi_asic is defined or DEVICE_METADATA['localhost']['switch_type'] == 'voq' %}
 route-map HIDE_INTERNAL permit 10
   set community no-export
 {% if constants.bgp.peers is defined and constants.bgp.peers.internal is defined and constants.bgp.peers.internal.community is defined %}
@@ -38,7 +41,6 @@ route-map HIDE_INTERNAL permit 10
 route-map HIDE_INTERNAL permit 20
   set community {{ constants.bgp.peers.internal.community }} additive
 {% endif %}
-{% set multi_asic = True %}
 !
 {% endif %}
 !
@@ -99,7 +101,7 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endblock vlan_advertisement %}
 !
 !
-{% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' %}
+{% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' or DEVICE_METADATA['localhost']['switch_type'] == 'voq' %}
   address-family ipv4
     redistribute connected route-map HIDE_INTERNAL
   exit-address-family

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.conf
@@ -1,0 +1,66 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
+!
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.0/24
+!
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 10 permit fc01::/64
+!
+route-map HIDE_INTERNAL permit 10
+  set community no-export
+!
+!
+router bgp 55555
+!
+  bgp log-neighbor-changes
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+  bgp bestpath as-path multipath-relax
+!
+  bgp graceful-restart restart-time 240
+  bgp graceful-restart
+  bgp graceful-restart preserve-fw-state
+!
+  bgp router-id 55.55.55.56
+!
+  network 55.55.55.55/32
+  network 55.55.55.56/32 route-map HIDE_INTERNAL
+!
+  address-family ipv6
+    network fc00::1/64
+  exit-address-family
+  address-family ipv6
+    network fc00::2/128 route-map HIDE_INTERNAL
+  exit-address-family
+!
+  network 10.10.10.1/24
+  address-family ipv6
+   network fc01::1/64
+  exit-address-family
+!
+  address-family ipv4
+    redistribute connected route-map HIDE_INTERNAL
+  exit-address-family
+  address-family ipv6
+    redistribute connected route-map HIDE_INTERNAL
+  exit-address-family
+!
+  address-family ipv4
+    maximum-paths 64
+  exit-address-family
+  address-family ipv6
+    maximum-paths 64
+  exit-address-family
+!
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.json
@@ -1,0 +1,35 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "55555",
+            "sub_role": "",
+            "switch_type": "voq"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|55.55.55.55/32": {},
+        "Loopback0|fc00::1/128": {},
+        "Loopback4096|55.55.55.56/32": {},
+        "Loopback4096|fc00::2/128": {}
+    },
+    "VLAN_INTERFACE": {
+        "Vlan10|10.10.10.1/24": {},
+        "Vlan10|fc01::1/64": {},
+        "Vlan20": {"vnet_name": "Vnet1"},
+        "Vlan20|20.20.20.1/24": {},
+        "Vlan20|fd01::1/64": {}
+    },
+    "constants": {
+        "bgp": {
+            "multipath_relax": {
+                "enabled": true
+            },
+            "graceful_restart": {
+                "enabled": true
+            },
+            "maximum_paths": {
+                "enabled": true
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
+++ b/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
@@ -45,6 +45,12 @@ def test_bgpd_main_conf_defaults():
              "bgpd.main.conf.j2/defaults.json",
              "bgpd.main.conf.j2/defaults.conf")
 
+def test_bgpd_main_conf_voq_chassis():
+    run_test("VOQ bgpd.main.conf.j2",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/voq_chassis.json",
+             "bgpd.main.conf.j2/voq_chassis.conf")
+
 def test_tsa_isolate():
     run_test("tsa/bgpd.tsa.isolate.conf.j2",
              "bgpd/tsa/bgpd.tsa.isolate.conf.j2",


### PR DESCRIPTION
#### Why I did it

For multiasic, the back end asics use ip addresss of Loopback4096 for BGP router id. In VOQ multi-asic chassis there are no back end asics. All the asics are front end and the iBGP connections are established via Ethernet-IB of asics. Since these asics are not designated as BackEnd, the ip address of interface Loopback0 is used as BGP router id. Since the ip address of Loopback0 is same for all the asics in the line card, same router id is used for voq iBGP configurations and hence the iBGP connections are not established. Changes are done to fix this

#### How I did it

To fix this (i.e., to have different router ids for differen iBGP peers), we need to use the ip address of Loopback4096 for
the front end asics also in VOQ chassis systems. The bgp main configuration template is adjusted to take ip address of Loopback4096 as router id for asics (both in single asic line card and multi-asic line card) in chassis voq systems irrespective of whether the asic is front end or not.

#### How to verify it

- In  multi-asic voq chassis system have the following in the config_db.json of multiple asics
- Configure different IP addresses for Loopback4096 loop back interface in different asics
- Configure BGP_VOQ_CHASSIS_NEIGHBORS for the Ethernet-IB interfaces.
- Reboot the chassis
- Observe that all iBGP sessions are established state.
