### PR TITLE
[Arista]: Set LAG Id range for 7800 chassis

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/chassisdb.conf
+++ b/device/arista/x86_64-arista_7800_sup/chassisdb.conf
@@ -1,2 +1,5 @@
 start_chassis_db=1
 chassis_db_address=127.100.1.1
+
+lag_id_start=1
+lag_id_end=128


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Configure LAG Id range in chassisdb.conf for 7800 chassis.

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

