### PR TITLE
[201911] Change RIF counters to be enabled by default

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -12,6 +12,7 @@ def enable_counters():
     db = swsssdk.ConfigDBConnector()
     db.connect()
     enable_counter_group(db, 'PORT')
+    enable_counter_group(db, 'RIF')
     enable_counter_group(db, 'QUEUE')
     enable_counter_group(db, 'PFCWD')
     enable_counter_group(db, 'PG_WATERMARK')

--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -12,13 +12,14 @@ def enable_counters():
     db = swsssdk.ConfigDBConnector()
     db.connect()
     enable_counter_group(db, 'PORT')
-    enable_counter_group(db, 'RIF')
     enable_counter_group(db, 'QUEUE')
     enable_counter_group(db, 'PFCWD')
     enable_counter_group(db, 'PG_WATERMARK')
     enable_counter_group(db, 'QUEUE_WATERMARK')
     enable_counter_group(db, 'BUFFER_POOL_WATERMARK')
     enable_counter_group(db, 'PORT_BUFFER_DROP')
+    if 'mlnx' in db.get_table('DEVICE_METADATA')['localhost'].get('platform'):
+        enable_counter_group(db, 'RIF')
 
 def get_uptime():
     with open('/proc/uptime') as fp:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

**- How I did it**
Called RIF enable counters in enable_counters.py script.

**- How to verify it**
* Install 201911 image on SONiC switch.
* make sure RIF counters are enabled.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
