### PR TITLE
[fpmsyncd] updates for MPLS

### DIFF
--- a/src/libnl3/patch/0001-mpls-encap-accessors.patch
+++ b/src/libnl3/patch/0001-mpls-encap-accessors.patch
@@ -11,13 +11,14 @@ Signed-off-by: Ann Pokora <apokora@juniper.net>
  3 files changed, 32 insertions(+)
 
 diff --git a/include/netlink/route/nexthop.h b/include/netlink/route/nexthop.h
-index 5b422dd..a502005 100644
+index 5b422dd..eee84e8 100644
 --- a/include/netlink/route/nexthop.h
 +++ b/include/netlink/route/nexthop.h
-@@ -70,6 +70,8 @@ extern int		rtnl_route_nh_str2flags(const char *);
+@@ -70,6 +70,9 @@ extern int		rtnl_route_nh_str2flags(const char *);
  extern int		rtnl_route_nh_encap_mpls(struct rtnl_nexthop *nh,
  						 struct nl_addr *addr,
  						 uint8_t ttl);
++#define LIBNL3_ENCAP_MPLS
 +extern struct nl_addr *	rtnl_route_nh_get_encap_mpls_dst(struct rtnl_nexthop *);
 +extern uint8_t		rtnl_route_nh_get_encap_mpls_ttl(struct rtnl_nexthop *);
  #ifdef __cplusplus


### PR DESCRIPTION
#### Why I did it
This change is required by https://github.com/Azure/sonic-swss/pull/1794
This change allows sonic-swss build to determine when libnl3 is customized version from sonic-buildimage versus released version from debian.
LGTM and Azure pipelines other than sonic-buildimage use released libnl3 from debian rather than build artifact from sonic-buildimage, necessitating stubs for accessors not available in the released version.

#### How I did it
Added #define LIBNL3_ENCAP_MPLS to customized libnl3 for use by sonic-swss.

#### How to verify it
LGTM and Azure pipeline run.

#### Which release branch to backport (provide reason below if selected)
n/a
