### PR TITLE
[multi-asic][cli][chassis-db] Avoid connecting to chassis db when cli commands are executed from linecards

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -374,6 +374,22 @@ def is_multi_npu():
     return (num_npus > 1)
 
 
+def is_voq_supervisor():
+    asic_conf_file_path = get_asic_conf_file_path()
+    if asic_conf_file_path is None:
+        return False
+    with open(asic_conf_file_path) as asic_conf_file:
+        for line in asic_conf_file:
+            tokens = line.split('=')
+            if len(tokens) < 2:
+               continue
+            if tokens[0].lower() == 'voq_supervisor':
+                val = tokens[1].strip()
+                if val == '1':
+                    return True
+        return False
+ 
+
 def get_npu_id_from_name(npu_name):
     if npu_name.startswith(NPU_NAME_PREFIX):
         return npu_name[len(NPU_NAME_PREFIX):]

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -29,6 +29,7 @@ HWSKU_JSON_FILE = 'hwsku.json'
 NPU_NAME_PREFIX = "asic"
 NAMESPACE_PATH_GLOB = "/run/netns/*"
 ASIC_CONF_FILENAME = "asic.conf"
+PLATFORM_ENV_CONF_FILENAME = "platform_env.conf"
 FRONTEND_ASIC_SUB_ROLE = "FrontEnd"
 BACKEND_ASIC_SUB_ROLE = "BackEnd"
 
@@ -160,6 +161,29 @@ def get_asic_conf_file_path():
     for asic_conf_file_path in asic_conf_path_candidates:
         if os.path.isfile(asic_conf_file_path):
             return asic_conf_file_path
+
+    return None
+
+
+def get_platform_env_conf_file_path():
+    """
+    Retrieves the path to the PLATFORM ENV conguration file on the device
+
+    Returns:
+        A string containing the path to the PLATFORM ENV conguration file on success,
+        None on failure
+    """
+    platform_env_conf_path_candidates = []
+
+    platform_env_conf_path_candidates.append(os.path.join(CONTAINER_PLATFORM_PATH, PLATFORM_ENV_CONF_FILENAME))
+
+    platform = get_platform()
+    if platform:
+        platform_env_conf_path_candidates.append(os.path.join(HOST_DEVICE_PATH, platform, PLATFORM_ENV_CONF_FILENAME))
+
+    for platform_env_conf_file_path in platform_env_conf_path_candidates:
+        if os.path.isfile(platform_env_conf_file_path):
+            return platform_env_conf_file_path
 
     return None
 
@@ -374,16 +398,16 @@ def is_multi_npu():
     return (num_npus > 1)
 
 
-def is_voq_supervisor():
-    asic_conf_file_path = get_asic_conf_file_path()
-    if asic_conf_file_path is None:
+def is_supervisor():
+    platform_env_conf_file_path = get_platform_env_conf_file_path()
+    if platform_env_conf_file_path is None:
         return False
-    with open(asic_conf_file_path) as asic_conf_file:
-        for line in asic_conf_file:
+    with open(platform_env_conf_file_path) as platform_env_conf_file:
+        for line in platform_env_conf_file:
             tokens = line.split('=')
             if len(tokens) < 2:
                continue
-            if tokens[0].lower() == 'voq_supervisor':
+            if tokens[0].lower() == 'supervisor':
                 val = tokens[1].strip()
                 if val == '1':
                     return True

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -8,6 +8,7 @@ from swsscommon import swsscommon
 from .device_info import CONTAINER_PLATFORM_PATH
 from .device_info import HOST_DEVICE_PATH
 from .device_info import get_platform
+from .device_info import is_voq_supervisor
 
 ASIC_NAME_PREFIX = 'asic'
 NAMESPACE_PATH_GLOB = '/run/netns/*'
@@ -45,7 +46,11 @@ def connect_config_db_for_ns(namespace=DEFAULT_NAMESPACE):
 def connect_to_all_dbs_for_ns(namespace=DEFAULT_NAMESPACE):
     """
     The function connects to the DBs for a given namespace and
-    returns the handle
+    returns the handle 
+    
+    For voq chassis systems, the db list includes databases from 
+    supervisor card. Avoid connecting to these databases from linecards
+
     If no namespace is provided, it will connect to the db in the
     default namespace.
     In case of multi ASIC, the default namespace is the
@@ -56,7 +61,15 @@ def connect_to_all_dbs_for_ns(namespace=DEFAULT_NAMESPACE):
         handle to all the dbs for a namespaces
     """
     db = swsscommon.SonicV2Connector(namespace=namespace)
-    for db_id in db.get_db_list():
+    db_list = list(db.get_db_list())
+    if not is_voq_supervisor():
+        try:
+            db_list.remove('CHASSIS_APP_DB')
+            db_list.remove('CHASSIS_STATE_DB')
+        except Exception:
+            pass
+
+    for db_id in db_list:
         db.connect(db_id)
     return db
 

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -8,7 +8,7 @@ from swsscommon import swsscommon
 from .device_info import CONTAINER_PLATFORM_PATH
 from .device_info import HOST_DEVICE_PATH
 from .device_info import get_platform
-from .device_info import is_voq_supervisor
+from .device_info import is_supervisor
 
 ASIC_NAME_PREFIX = 'asic'
 NAMESPACE_PATH_GLOB = '/run/netns/*'
@@ -62,7 +62,7 @@ def connect_to_all_dbs_for_ns(namespace=DEFAULT_NAMESPACE):
     """
     db = swsscommon.SonicV2Connector(namespace=namespace)
     db_list = list(db.get_db_list())
-    if not is_voq_supervisor():
+    if not is_supervisor():
         try:
             db_list.remove('CHASSIS_APP_DB')
             db_list.remove('CHASSIS_STATE_DB')


### PR DESCRIPTION
#### Why I did it

Currently, for all the cli commands, we connect to all databases mentioned in the database_config.json. The database_config.json also includes the databases from chassis redis server from supervisor card. It is unnecessary to connect to databases from chassis redis server when cli commands are executed form linecard. But we need to allow connection to chassis databases when the cli commands are executed from supervisor card. This PR fixes this problem

#### How I did it

This PR requires that platform_env.conf in supervisor card includes a variable **"supervisor"** with value 1 to identify the supervisor card. The connect_to_all_dbs_for_ns() is changed to skip chassis databases form the list of collected databases if the card is not supervisor card. This PR requires sonic-utilities PR https://github.com/Azure/sonic-utilities/pull/1707 to have complete fix

#### How to verify it

In voq chassis, execute cli commands (show, config etc.) and make sure that commands are successful irrespective whether there is supervisor card or not.

#### Which release branch to backport (provide reason below if selected)
N/A

#### Description for the changelog

multi-asic cli to skip connecting to chassis databases when commands are executed from line card.

