### PR TITLE
[port_config] Introduce ad-hoc mport_config.json file

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -117,7 +117,8 @@ clean_flash() {
            [ $f != "old_config" ] &&
            [ $f != "minigraph.xml" ] &&
            [ $f != "snmp.yml" ] &&
-           [ $f != "acl.json" ]
+           [ $f != "acl.json" ] &&
+           [ $f != "port_config.json" ]
         then
             rm -rf "$target_path/$f"
         fi

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -305,7 +305,7 @@ check_all_config_db_present()
 do_config_migration()
 {
     # Identify list of files to migrate
-    copy_list="minigraph.xml snmp.yml acl.json frr telemetry"
+    copy_list="minigraph.xml snmp.yml acl.json port_config.json frr telemetry"
 
     # Migrate all configuration files from old to new
     copy_config_files_and_directories $copy_list

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -120,6 +120,8 @@ migrate_nos_configuration()
         MG_FILE=$NOS_DIR/minigraph.xml
         ACL_GZFILE=$NOS_DIR/acl.json.gz.base64.txt
         ACL_FILE=$NOS_DIR/acl.json
+        PORT_CONFIG_GZFILE=$NOS_DIR/port_config.json.gz.base64.txt
+        PORT_CONFIG_FILE=$NOS_DIR/port_config.json
         SNMP_FILE=$NOS_DIR/snmp.yml
         mkdir -p $NOS_DIR
 
@@ -131,11 +133,13 @@ migrate_nos_configuration()
             # decode & unzip minigraph.xml.gz.base64.txt
             [ -f $MG_GZFILE ] && /usr/bin/base64 -d $MG_GZFILE | /bin/gunzip > $MG_FILE
             [ -f $ACL_GZFILE ] && /usr/bin/base64 -d $ACL_GZFILE | /bin/gunzip > $ACL_FILE
+            [ -f $PORT_CONFIG_GZFILE ] && /usr/bin/base64 -d $PORT_CONFIG_GZFILE | /bin/gunzip > $PORT_CONFIG_FILE
 
             # Copy relevant files
             nos_migration_import $NOS_DIR/mgmt_interface.cfg /host/migration
             nos_migration_import $MG_FILE /host/migration
             nos_migration_import $ACL_FILE /host/migration
+            nos_migration_import $PORT_CONFIG_FILE /host/migration
             nos_migration_import $SNMP_FILE /host/migration
 
             if [ "$sonic_fast_reboot" == true ]; then
@@ -243,12 +247,14 @@ if [ -f $FIRST_BOOT_FILE ]; then
         mkdir -p /etc/sonic/old_config
         mv /host/minigraph.xml /etc/sonic/old_config/
         [ -f /host/acl.json ] && mv /host/acl.json /etc/sonic/old_config/
+        [ -f /host/port_config.json ] && mv /host/port_config.json /etc/sonic/old_config/
         [ -f /host/snmp.yml ] && mv /host/snmp.yml /etc/sonic/old_config/
         touch /tmp/pending_config_migration
     elif [ -n "$migration" ] && [ -f /host/migration/minigraph.xml ];  then
         mkdir -p /etc/sonic/old_config
         mv /host/migration/minigraph.xml /etc/sonic/old_config/
         [ -f /host/migration/acl.json ] && mv /host/migration/acl.json /etc/sonic/old_config/
+        [ -f /host/migration/port_config.json ] && mv /host/migration/port_config.json /etc/sonic/old_config/
         [ -f /host/migration/snmp.yml ] && mv /host/migration/snmp.yml /etc/sonic/old_config/
         touch /tmp/pending_config_migration
         [ -f /etc/sonic/updategraph.conf ] && sed -i -e "s/enabled=false/enabled=true/g" /etc/sonic/updategraph.conf

--- a/files/image_config/secureboot/allowlist_paths.conf
+++ b/files/image_config/secureboot/allowlist_paths.conf
@@ -25,6 +25,7 @@ etc/sonic/acl.json
 etc/sonic/config_db.json
 etc/sonic/minigraph.xml
 etc/sonic/old_config/.*
+etc/sonic/port_config.json
 etc/sonic/snmp.yml
 etc/sonic/sonic-environment
 etc/sonic/updategraph.conf


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The port state will be reset to up if user use `config load_minigraph` to recover configurations.
In another PR, we supported consume `port_config.json` file with minigraph: Related PR: https://github.com/Azure/sonic-utilities/pull/1705

This PR is for support `port_config.json` in image level, includes migration/secure boot.

#### How I did it
The usage of `port_config.json` is very similar with `acl.json`, thus I modified existing codebase and add `port_config.json` to all places that involved `acl.json`

#### How to verify it
TODO

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
1. Modified `Aboot/boot0.j2` to support remove `port_config.json` during flash cleaning
2. Modified `config-setup` script to support copy `port_config.json` file to backup directory
3. Modified `platform/rc.local` script to support decode/unzip/copy `port_config.json` during nos migration and support copy `port_config.json` to `/etc/sonic/old_config` for migration preparing during first boot task

#### A picture of a cute animal (not mandatory but encouraged)

