### PR TITLE
Added delay of 2 seconds for MgmtInit during OIR

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/sfp.py
@@ -97,7 +97,7 @@ sff8436_parser = {
       'Temperature': [QSFP_DOM_OFFSET,  22,  2, 'parse_temperature'],
           'Voltage': [QSFP_DOM_OFFSET,  26,  2, 'parse_voltage'],
    'ChannelMonitor': [QSFP_DOM_OFFSET,  34, 16, 'parse_channel_monitor_params'],
-   'ChannelMonitor_TxPower': 
+   'ChannelMonitor_TxPower':
                      [QSFP_DOM_OFFSET,  34, 24, 'parse_channel_monitor_params_with_tx_power'],
 
        'cable_type': [QSFP_INFO_OFFSET, -1, -1, 'parse_sfp_info_bulk'],
@@ -936,7 +936,7 @@ class Sfp(SfpBase):
         else:
             channel_monitor_data = self._get_eeprom_data('ChannelMonitor')
             if (channel_monitor_data is not None):
-                tx1_pw = channel_monitor_data['data']['TXPower']['value'] 
+                tx1_pw = channel_monitor_data['data']['TXPower']['value']
                 tx2_pw = 'N/A'
                 tx3_pw = 'N/A'
                 tx4_pw = 'N/A'
@@ -981,7 +981,8 @@ class Sfp(SfpBase):
 
             # Convert our register value back to a hex string and write back
             self.pci_set_value(self.BASE_RES_PATH, reg_value, port_offset)
-
+            # 2 seconds duration for MgmtInit
+            time.sleep(2)
             return True
 
         else:

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
@@ -175,18 +175,20 @@ class Chassis(ChassisBase):
                 if(presence and self._global_port_pres_dict[port_num] == '0'):
                     self._global_port_pres_dict[port_num] = '1'
                     port_dict[port_num] = '1'
+                    # Reset the sfp to re-initailze the management interface
+                    self.get_sfp(port_num).reset()
                 elif(not presence and
                         self._global_port_pres_dict[port_num] == '1'):
                     self._global_port_pres_dict[port_num] = '0'
                     port_dict[port_num] = '0'
 
             if(len(port_dict) > 0):
-                return True, change_dict 
+                return True, change_dict
 
             if timeout:
                 now_ms = time.time() * 1000
                 if (now_ms - start_ms >= timeout):
-                    return True, change_dict 
+                    return True, change_dict
 
 
     def get_sfp(self, index):
@@ -294,7 +296,7 @@ class Chassis(ChassisBase):
         Returns :
             An integer represents the number of Fans on the chassis.
         """
-        return self._num_fans 
+        return self._num_fans
 
     def get_num_sfps(self):
         """
@@ -345,7 +347,7 @@ class Chassis(ChassisBase):
         return self.sys_ledcolor
 
     def set_status_led(self, color):
-        """ 
+        """
         Set system LED status based on the color type passed in the argument.
         Argument: Color to be set
         Returns:


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes #8124 Issue in transceiver eeprom during OIR 

#### How I did it
For QSFP modules, added a delay of 2 seconds after ResetL pin is de-asserted. This delay is the recommended delay as per QSFP hw spec for management interface initialization. When module presence is detected, the management interface is re-initialized.


#### How to verify it
Following testing is pending:-
Verify the eeprom dump under following scenarios:

1. Multiple reboots with optics from different vendors across various ports
2. OIR same optics multiple times on same port
3. Swap optics from different vendors on same port
4. Repeat 2 and 3 across multiple ports

#### Which release branch to backport (provide reason below if selected)
TBD

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

