### PR TITLE
added aioredis package to snmp container for supporting linkup/down t…

### DIFF
--- a/dockers/docker-snmp/Dockerfile.j2
+++ b/dockers/docker-snmp/Dockerfile.j2
@@ -44,7 +44,8 @@ RUN locale-gen
 RUN pip3 install --no-cache-dir \
         hiredis                             \
         pyyaml                              \
-        smbus
+        smbus                               \
+        aioredis==1.3.0
 
 {% if docker_snmp_whls.strip() -%}
 # Copy locally-built Python wheel dependencies


### PR DESCRIPTION
…raps

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
snmp-subagent needs aioredis package to support linkup/down and config change traps.
#### How I did it
Using aioredis package used for snmp traps support
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
aioredis package is used to generate linkup/down and config change snmp traps

#### A picture of a cute animal (not mandatory but encouraged)

