### PR TITLE
[build]: Allow build-time specification of alternative docker registries

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -185,7 +185,6 @@ SONIC_VERSION_CONTROL_COMPONENTS ?= none
 
 # SONiC docker registry
 #
-# Uncomment below line to enable pulling sonic-slave docker from registry
-# ENABLE_DOCKER_BASE_PULL = y
-REGISTRY_PORT=443
-REGISTRY_SERVER=sonicdev-microsoft.azurecr.io
+# Set the env variable ENABLE_DOCKER_BASE_PULL = y to enable pulling sonic-slave docker from registry
+REGISTRY_PORT ?= 443
+REGISTRY_SERVER ?= sonicdev-microsoft.azurecr.io


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Allows users to host their own local docker registries and utilize them via the `REGISTRY_SERVER` and `REGISTRY_PORT` environmental variables

#### How I did it

Only set `REGISTRY_SERVER` and `REGISTRY_PORT` in `rules/config` if they are unset.

#### How to verify it

1. Export environmental variables `REGISTRY_SERVER` and `REGISTRY_PORT` to an alternative docker registry. Export the environmental variable `ENABLE_DOCKER_BASE_PULL` to `y`.
2. Ensure the required `sonic-slave` docker images are not present locally, but are available in the docker registry
3. Execute `make init` and `make configure`
4. Confirm that the appropriate docker images were pulled from the appropriate docker registry, and not built locally

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
Allow build-time specification of alternative docker registries

#### A picture of a cute animal (not mandatory but encouraged)
![image](https://user-images.githubusercontent.com/77471509/125007239-a957bf80-e014-11eb-8996-81b0ba1a877f.png)

