### PR TITLE
enable the emc2305 fan controller and NCP power controller 30ms timeo…

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -147,7 +147,18 @@ start)
         sleep 0.1
         done
 
-        /bin/sh /usr/local/bin/platform_api_mgnt.sh init
+	bus_en=8
+	sleep 1
+	cfg_r=`i2cget -y -f 8 0x60 0xD1`
+	((cfg_w=$cfg_r+$bus_en))	
+	i2cset -y -f 8 0x60 0xD1 $cfg_w
+	sleep 1
+	cfg_r=`i2cget -y -f 9 0x20 0xD1`
+	((cfg_w=$cfg_r+$bus_en))	
+	i2cset -y -f 9 0x20 0xD1 $cfg_w
+	sleep 1
+
+	/bin/sh /usr/local/bin/platform_api_mgnt.sh init
 
         echo "done."
         ;;

--- a/platform/broadcom/sonic-platform-modules-cel/dx010/modules/emc2305.c
+++ b/platform/broadcom/sonic-platform-modules-cel/dx010/modules/emc2305.c
@@ -742,6 +742,7 @@ emc2305_probe(struct i2c_client *client, const struct i2c_device_id *id)
 	int status;
 	int i;
 	int fan_idx;
+	unsigned char dis_to = 0;
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA))
 		return -EIO;
@@ -752,6 +753,11 @@ emc2305_probe(struct i2c_client *client, const struct i2c_device_id *id)
 
 	i2c_set_clientdata(client, data);
 	mutex_init(&data->update_lock);
+	
+	dis_to = i2c_smbus_read_byte_data(client, REG_CONFIGURATION);
+	dis_to &= 0xBF;
+	/* The SMBus timeout function is enabled */
+	(void)i2c_smbus_write_byte_data(client, REG_CONFIGURATION, dis_to);
 
 	status = i2c_smbus_read_byte_data(client, REG_PRODUCT_ID);
 	switch (status) {


### PR DESCRIPTION
…ut mechanism

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fix the dx010 system eeprom unavailable issue
#### How I did it
enable the i2c slave 30ms timeout mechanism 
#### How to verify it
1. i2cstress test in DX010 iSMT controller bus
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.

- [x ] 201811
- [ x] 201911
- [x] 202006
- [x ] 202012
- [x ] 202106

#### Description for the changelog
<!--
enable the i2c slave 30ms timeout mechanism
-->


#### A picture of a cute animal (not mandatory but encouraged)
![image](https://user-images.githubusercontent.com/48576574/125045574-b84f7800-e0cf-11eb-98ca-99d053e5a95c.png)

