### PR TITLE
[AS7726-32X] Add to support mulit PSU SN in PDDF

### DIFF
--- a/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
@@ -50,6 +50,10 @@
             "pddf_fan_module",
             "pddf_led_module",
             "pddf_sysstatus_module"
+        ],
+        "custom_kos":
+        [
+            "pddf_custom_psu"
         ]
 	},
 
@@ -1631,7 +1635,8 @@
 		{
 			"interface":
 			[
-				{ "itf":"pmbus", "dev":"PSU2-PMBUS"}
+				{ "itf":"pmbus", "dev":"PSU2-PMBUS"},
+				{ "itf":"eeprom","dev":"PSU2-EEPROM" }
 			]
 		}
 	},
@@ -1644,19 +1649,31 @@
 			"topo_info": { "parent_bus":"0x31", "dev_addr":"0x58", "dev_type":"psu_pmbus"},
 			"attr_list": 
 			[  
-				{ "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
-				{ "attr_name":"psu_model_name", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+				{ "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},			
 				{ "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x14", "attr_cmpval":"0x14", "attr_len":"1"},
-				{ "attr_name":"psu_mfr_id", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
-				{ "attr_name":"psu_serial_num", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x9e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" },
+				{ "attr_name":"psu_mfr_id", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },			
 				{ "attr_name":"psu_fan_dir", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
 				{ "attr_name":"psu_v_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
 				{ "attr_name":"psu_i_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
 				{ "attr_name":"psu_p_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
-				{ "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+				{ "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_temp1_input", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
 			]
 		}
 	},
+	"PSU2-EEPROM":
+    {
+        "dev_info": { "device_type":"PSU-EEPROM", "device_name":"PSU1-EEPROM", "device_parent":"MUX7", "virt_parent":"PSU2"},
+        "i2c":
+        {
+            "topo_info":{ "parent_bus":"0x31", "dev_addr":"0x50", "dev_type":"psu_eeprom"}, 
+            "attr_list": 
+            [  
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x15", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"11" },
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x2e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"17" }
+            ]
+        }
+    },
 
 	"PSU1":
 	{
@@ -1666,7 +1683,8 @@
 		{
 			"interface":
 			[
-				{ "itf":"pmbus", "dev":"PSU1-PMBUS" }
+				{ "itf":"pmbus", "dev":"PSU1-PMBUS" },
+				{ "itf":"eeprom","dev":"PSU1-EEPROM" }
 			]
 		}
 	},
@@ -1679,20 +1697,31 @@
 			"topo_info":{ "parent_bus":"0x32", "dev_addr":"0x5b", "dev_type":"psu_pmbus"}, 
 			"attr_list": 
 			[  
-				{ "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
-				{ "attr_name":"psu_model_name", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
+				{ "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},	
 				{ "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x28", "attr_cmpval":"0x28", "attr_len":"1"},
-				{ "attr_name":"psu_mfr_id", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
-				{ "attr_name":"psu_serial_num", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"20" },
+				{ "attr_name":"psu_mfr_id", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },			
 				{ "attr_name":"psu_fan_dir", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
 				{ "attr_name":"psu_v_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8b", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
 				{ "attr_name":"psu_i_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
 				{ "attr_name":"psu_p_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
-				{ "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+				{ "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_temp1_input", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
 			]
 		}
 	},
-
+    "PSU1-EEPROM":
+    {
+        "dev_info": { "device_type":"PSU-EEPROM", "device_name":"PSU1-EEPROM", "device_parent":"MUX7", "virt_parent":"PSU1"},
+        "i2c":
+        {
+            "topo_info":{ "parent_bus":"0x32", "dev_addr":"0x53", "dev_type":"psu_eeprom"}, 
+            "attr_list": 
+            [  
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x15", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"11" },
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x2e", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"17" }
+            ]
+        }
+    },
 	"FAN-CTRL":
 	{
 		"dev_info": { "device_type":"FAN", "device_name":"FAN-CTRL", "device_parent":"MUX7"},
@@ -1762,7 +1791,7 @@
 		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX7"},
 		"i2c":
 		{
-			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x4c", "dev_type":"lm75"},
+			"topo_info": { "parent_bus":"0x36", "dev_addr":"0x4c", "dev_type":"lm75"},
 			"attr_list":
 			[
 				{ "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
@@ -1825,7 +1854,7 @@
 			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x4b", "dev_type":"lm75"},
 			"attr_list":
 			[
-				{ "attr_name": "temp1_max"},
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp1_max"},
 				{ "attr_name": "temp1_max_hyst"},
 				{ "attr_name": "temp1_input"}
 			]
@@ -1860,8 +1889,8 @@
 			"i2c" : {
 				"attr_list":
 				[
-					{"attr_name":"blue", "descr" : "Blue", "bits" : "7",  "value" : "0x0", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
-					{"attr_name":"off",  "descr" : "Off", "bits" : "7",  "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"}
+					{"attr_name":"STATUS_LED_COLOR_BLUE", "descr" : "", "bits" : "7",  "value" : "0x0", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
+					{"attr_name":"STATUS_LED_COLOR_OFF",  "descr" : "", "bits" : "7",  "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"}
 				]
 			}
 	},
@@ -1873,9 +1902,9 @@
 			"i2c" : {
 				"attr_list":
 				[
-					{"attr_name":"green", "descr" : "Green", "bits" : "1:0", "value" : "0x2", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
-					{"attr_name":"red",   "descr" : "Red" ,"bits" : "1:0", "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
-					{"attr_name":"off",   "descr" : "Off" ,"bits" : "1:0", "value" : "0x3", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"}
+					{"attr_name":"STATUS_LED_COLOR_GREEN", "descr" : "", "bits" : "1:0", "value" : "0x2", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
+					{"attr_name":"STATUS_LED_COLOR_RED",   "descr" : "" ,"bits" : "1:0", "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
+					{"attr_name":"STATUS_LED_COLOR_OFF",   "descr" : "" ,"bits" : "1:0", "value" : "0x3", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"}
 				]
 			}
 

--- a/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
@@ -1663,7 +1663,7 @@
 	},
 	"PSU2-EEPROM":
     {
-        "dev_info": { "device_type":"PSU-EEPROM", "device_name":"PSU1-EEPROM", "device_parent":"MUX7", "virt_parent":"PSU2"},
+        "dev_info": { "device_type":"PSU-EEPROM", "device_name":"PSU2-EEPROM", "device_parent":"MUX7", "virt_parent":"PSU2"},
         "i2c":
         {
             "topo_info":{ "parent_bus":"0x31", "dev_addr":"0x50", "dev_type":"psu_eeprom"}, 

--- a/device/accton/x86_64-accton_as7726_32x-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pmon_daemon_control.json
@@ -1,5 +1,6 @@
 {
     "skip_ledd": true,
+    "skip_pcied": true,
     "skip_thermalctld": true
 }
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/modules/Makefile
@@ -1,8 +1,11 @@
 ifneq ($(KERNELRELEASE),)
 obj-m:= accton_as7726_32x_cpld.o accton_as7726_32x_fan.o  \
 	    accton_as7726_32x_leds.o accton_as7726_32x_psu.o ym2651y.o \
-        pddf_custom_psu.o
-	    
+	    pddf_custom_psu.o
+
+CFLAGS_pddf_custom_psu.o := -I$(M)/../../../../pddf/i2c/modules/include
+KBUILD_EXTRA_SYMBOLS := $(M)/../../../../pddf/i2c/Module.symvers.PDDF
+    
 else
 ifeq (,$(KERNEL_SRC))
 #$(error KERNEL_SRC is not defined)

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/modules/Makefile
@@ -1,6 +1,7 @@
 ifneq ($(KERNELRELEASE),)
 obj-m:= accton_as7726_32x_cpld.o accton_as7726_32x_fan.o  \
-	    accton_as7726_32x_leds.o accton_as7726_32x_psu.o ym2651y.o
+	    accton_as7726_32x_leds.o accton_as7726_32x_psu.o ym2651y.o \
+        pddf_custom_psu.o
 	    
 else
 ifeq (,$(KERNEL_SRC))

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/modules/pddf_custom_psu.c
@@ -1,0 +1,204 @@
+#include <linux/module.h>
+#include <linux/jiffies.h>
+#include <linux/i2c.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/err.h>
+#include <linux/delay.h>
+#include <linux/mutex.h>
+#include <linux/sysfs.h>
+#include <linux/slab.h>
+#include <linux/dmi.h>
+#include "../../../../pddf/i2c/modules/include/pddf_psu_defs.h"
+
+ssize_t pddf_get_custom_psu_model_name(struct device *dev, struct device_attribute *da, char *buf);
+ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribute *da, char *buf);
+extern PSU_SYSFS_ATTR_DATA access_psu_model_name;
+extern PSU_SYSFS_ATTR_DATA access_psu_serial_num;
+
+#define MAX_MODEL_NAME          16
+#define MAX_SERIAL_NUMBER       19
+
+enum psu_type {
+    PSU_TYPE_AC_110V,
+    PSU_TYPE_DC_48V,
+    PSU_TYPE_DC_12V,
+    PSU_TYPE_AC_ACBEL_FSF019
+};
+
+struct model_name_info {
+    enum psu_type type;
+    u8 offset;
+    u8 length;
+    u8 chk_length;
+    char* model_name;
+};
+
+struct serial_number_info {
+    enum psu_type type;
+    u8 offset;
+    u8 length;
+    u8 chk_length;
+    char* serial_number;
+};
+
+struct model_name_info models[] = {
+{PSU_TYPE_AC_110V, 0x20, 8, 8,  "YM-2651Y"},
+{PSU_TYPE_DC_48V,  0x20, 8, 8,  "YM-2651V"},
+{PSU_TYPE_DC_12V,  0x00, 11, 11, "PSU-12V-750"},
+{PSU_TYPE_AC_ACBEL_FSF019, 0x15, 10, 7, "FSF019-"}
+
+};
+
+struct serial_number_info serials[] = {
+{PSU_TYPE_AC_110V, 0x2e, 18, 18,  "YM-2651Y"},
+{PSU_TYPE_DC_48V,  0x2e, 18, 18,  "YM-2651V"},
+{PSU_TYPE_DC_12V,  0x2e, 18, 18,  "PSU-12V-750"},
+{PSU_TYPE_AC_ACBEL_FSF019, 0x2e, 16, 16, "FSF019-"}
+
+};
+
+struct pddf_psu_data {    
+    char model_name[MAX_MODEL_NAME+1];
+    char serial_number[MAX_SERIAL_NUMBER+1];
+};
+
+
+static int pddf_psu_read_block(struct i2c_client *client, u8 command, u8 *data,
+                                     int data_len)
+{
+    int result = 0;
+    int retry_count = 10;
+
+    while (retry_count) {
+        retry_count--;
+
+        result = i2c_smbus_read_i2c_block_data(client, command, data_len, data);
+
+        if (unlikely(result < 0)) {
+            msleep(10);
+            continue;
+        }
+
+        if (unlikely(result != data_len)) {
+            result = -EIO;
+            msleep(10);
+            continue;
+        }
+
+        result = 0;
+        break;
+    }
+
+    return result;
+}
+
+ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribute *da, char *buf)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct pddf_psu_data data;
+    int i, status;
+
+    for (i = 0; i < ARRAY_SIZE(models); i++) {
+        memset(data.serial_number, 0, sizeof(data.serial_number));
+
+        status = pddf_psu_read_block(client, models[i].offset,
+                                           data.model_name, models[i].length);
+        if (status < 0) {
+            data.model_name[0] = '\0';
+            dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x%x)\n",
+                                  client->addr, models[i].offset);
+            return status;
+        }
+        else {
+            data.model_name[models[i].length] = '\0';
+        }
+
+        /* Determine if the model name is known, if not, read next index
+         */
+        if (strncmp(data.model_name, models[i].model_name, models[i].chk_length) == 0) {
+            status = pddf_psu_read_block(client, serials[i].offset,
+                                           data.serial_number, serials[i].length);
+            
+            if (status < 0) {
+                data.serial_number[0] = '\0';
+                dev_dbg(&client->dev, "unable to read serial num from (0x%x) offset(0x%x)\n",
+                                  client->addr, serials[i].offset);
+                return status;
+            }
+            else {
+                data.serial_number[serials[i].length] = '\0';
+	            return sprintf(buf, "%s\n", data.serial_number);
+            }
+                        
+            return 0;
+        }
+        else {
+            data.serial_number[0] = '\0';
+        }
+    }
+
+    return -ENODATA;
+
+	
+}
+
+ssize_t pddf_get_custom_psu_model_name(struct device *dev, struct device_attribute *da, char *buf)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct pddf_psu_data data;
+    int i, status;
+    
+    for (i = 0; i < ARRAY_SIZE(models); i++) {
+        memset(data.model_name, 0, sizeof(data.model_name));
+
+        status = pddf_psu_read_block(client, models[i].offset,
+                                           data.model_name, models[i].length);
+        if (status < 0) {
+            data.model_name[0] = '\0';
+            dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x%x)\n",
+                                  client->addr, models[i].offset);
+            return status;
+        }
+        else {
+            data.model_name[models[i].length] = '\0';
+        }
+
+        /* Determine if the model name is known, if not, read next index
+         */
+        if (strncmp(data.model_name, models[i].model_name, models[i].chk_length) == 0) {
+            return sprintf(buf, "%s\n", data.model_name);
+        }
+        else {
+            data.model_name[0] = '\0';
+        }
+    }
+
+    return -ENODATA;
+
+}
+
+static int __init pddf_custom_psu_init(void)
+{
+    access_psu_serial_num.show = pddf_get_custom_psu_serial_num;
+    access_psu_serial_num.do_get = NULL;
+	
+    access_psu_model_name.show = pddf_get_custom_psu_model_name;
+    access_psu_model_name.do_get = NULL;
+	
+	return 0;
+}
+
+static void __exit pddf_custom_psu_exit(void)
+{
+	printk(KERN_ERR "pddf_custom_psu_exit\n");
+	return;
+}
+
+MODULE_AUTHOR("Broadcom");
+MODULE_DESCRIPTION("pddf custom psu api");
+MODULE_LICENSE("GPL");
+
+module_init(pddf_custom_psu_init);
+module_exit(pddf_custom_psu_exit);
+

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/modules/pddf_custom_psu.c
@@ -9,7 +9,7 @@
 #include <linux/sysfs.h>
 #include <linux/slab.h>
 #include <linux/dmi.h>
-#include "../../../../pddf/i2c/modules/include/pddf_psu_defs.h"
+#include "pddf_psu_defs.h"
 
 ssize_t pddf_get_custom_psu_model_name(struct device *dev, struct device_attribute *da, char *buf);
 ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribute *da, char *buf);
@@ -23,7 +23,8 @@ enum psu_type {
     PSU_TYPE_AC_110V,
     PSU_TYPE_DC_48V,
     PSU_TYPE_DC_12V,
-    PSU_TYPE_AC_ACBEL_FSF019
+    PSU_TYPE_AC_ACBEL_FSF019,
+    PSU_TYPE_AC_ACBEL_FSF045
 };
 
 struct model_name_info {
@@ -46,7 +47,8 @@ struct model_name_info models[] = {
 {PSU_TYPE_AC_110V, 0x20, 8, 8,  "YM-2651Y"},
 {PSU_TYPE_DC_48V,  0x20, 8, 8,  "YM-2651V"},
 {PSU_TYPE_DC_12V,  0x00, 11, 11, "PSU-12V-750"},
-{PSU_TYPE_AC_ACBEL_FSF019, 0x15, 10, 7, "FSF019-"}
+{PSU_TYPE_AC_ACBEL_FSF019, 0x15, 10, 7, "FSF019-"},
+{PSU_TYPE_AC_ACBEL_FSF045, 0x15, 10, 7, "FSF045-"}
 
 };
 
@@ -54,7 +56,8 @@ struct serial_number_info serials[] = {
 {PSU_TYPE_AC_110V, 0x2e, 18, 18,  "YM-2651Y"},
 {PSU_TYPE_DC_48V,  0x2e, 18, 18,  "YM-2651V"},
 {PSU_TYPE_DC_12V,  0x2e, 18, 18,  "PSU-12V-750"},
-{PSU_TYPE_AC_ACBEL_FSF019, 0x2e, 16, 16, "FSF019-"}
+{PSU_TYPE_AC_ACBEL_FSF019, 0x2e, 16, 16, "FSF019-"},
+{PSU_TYPE_AC_ACBEL_FSF019, 0x2e, 16, 16, "FSF045-"}
 
 };
 
@@ -117,9 +120,9 @@ ssize_t pddf_get_custom_psu_serial_num(struct device *dev, struct device_attribu
         /* Determine if the model name is known, if not, read next index
          */
         if (strncmp(data.model_name, models[i].model_name, models[i].chk_length) == 0) {
+
             status = pddf_psu_read_block(client, serials[i].offset,
-                                           data.serial_number, serials[i].length);
-            
+                                      data.serial_number, serials[i].length);
             if (status < 0) {
                 data.serial_number[0] = '\0';
                 dev_dbg(&client->dev, "unable to read serial num from (0x%x) offset(0x%x)\n",


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This DUT support different PSU
#### How I did it
Add drv code to read from PSU eeprom to get model name and then get serial number
#### How to verify it
Test via pddf_psu cmd,
root@sonic:/home/admin# pddf_psuutil mfrinfo
PSU    Status    Manufacturer ID    Model       Serial              Fan Airflow Direction
-----  --------  -----------------  ----------  ------------------  -----------------------
PSU1   OK        ACBEL              FSF019-611  FSF0192105002864    EXHAUST
PSU2   OK        3Y POWER           YM-2651Y    SA070V581905000055  EXHAUST
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

