### PR TITLE
DellEMC: Buffer profile changes

### DIFF
--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t0.j2
@@ -23,13 +23,11 @@
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "static",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C32/buffers_defaults_t1.j2
@@ -23,13 +23,11 @@
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "static",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t0.j2
@@ -23,13 +23,11 @@
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "static",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-C8D48/buffers_defaults_t1.j2
@@ -23,13 +23,11 @@
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "static",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t0.j2
@@ -23,13 +23,11 @@
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "static",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/buffers_defaults_t1.j2
@@ -23,13 +23,11 @@
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "static",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t0.j2
@@ -23,13 +23,11 @@
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "static",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/buffers_defaults_t1.j2
@@ -23,13 +23,11 @@
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "static",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t0.j2
@@ -23,13 +23,11 @@
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "static",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/buffers_defaults_t1.j2
@@ -23,13 +23,11 @@
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "static",
             "static_th":"32575488"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "mode": "dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C64/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C64/buffers_defaults_t1.j2
@@ -36,7 +36,6 @@
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"1518",             
-            "mode":"dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C8D112/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-C8D112/buffers_defaults_t0.j2
@@ -43,7 +43,6 @@
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"1518",
-            "mode":"dynamic",
             "dynamic_th":"3"
         }
     },

--- a/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_z9264f_c3538-r0/DellEMC-Z9264f-Q64/buffers_defaults_t0.j2
@@ -36,7 +36,6 @@
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"1518",
-            "mode":"dynamic",
             "dynamic_th":"3"
         }
     },


### PR DESCRIPTION

#### Why I did it
In QoS buffer profile, mode field is not needed.
#### How I did it
Edited buffer_defaults_t0/t1 for Dell HWSKU's.
#### How to verify it
Check syslog, swss processes and buffer values in NPU shell
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
UT logs: 
[buffer_UT.txt](https://github.com/Azure/sonic-buildimage/files/6810746/buffer_UT.txt)


#### A picture of a cute animal (not mandatory but encouraged)

