### PR TITLE
[sonic-yang] Backlinks are none when there is 0 backlinks

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang.py
+++ b/src/sonic-yang-mgmt/sonic_yang.py
@@ -526,7 +526,7 @@ class SonicYang(SonicYangExtMixin):
 
             schema_node = ly.Schema_Node_Leaf(data_node.schema())
             backlinks = schema_node.backlinks()
-            if backlinks.number() > 0:
+            if backlinks is not None and backlinks.number() > 0:
                 for link in backlinks.schema():
                      node_set = node.find_path(link.path())
                      for data_set in node_set.data():

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_SonicYang.json
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_SonicYang.json
@@ -59,10 +59,12 @@
 
   "dependencies":[
 	  {"xpath":"/test-port:port/PORT/PORT_LIST[port_name='Ethernet8']/port_name",
-           "dependencies":
-                 ["/test-acl:acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='PACL-V6']/ports[.='Ethernet8']",
-                  "/test-interface:interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='10.1.1.64/26']/interface",
-                  "/test-interface:interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='2000:f500:40:a749::/126']/interface"]}
+    "dependencies":
+          ["/test-acl:acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='PACL-V6']/ports[.='Ethernet8']",
+           "/test-interface:interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='10.1.1.64/26']/interface",
+           "/test-interface:interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='2000:f500:40:a749::/126']/interface"]},
+    {"xpath":"/test-port:port/PORT/PORT_LIST[port_name='Ethernet8']/alias",
+     "dependencies":[]}
   ],
   "schema_dependencies":[
           {"xpath":"/test-port:port/test-port:PORT/test-port:PORT_LIST/test-port:port_name",


### PR DESCRIPTION
#### Why I did it
Backlinks are none when there is 0 backlinks. without this change `backlinks.number()` throws an exception when backlinks==None.

#### How I did it
Allow backlinks to be None, so we get an empty list as a return from find_data_dependencies

#### How to verify it
```python
    def test_find_leaf_dependencies_no_schema_dependencies(self):
        sy = sonic_yang.SonicYang(YANG_DIR)
        sy.loadYangModel()
        sy.loadData(json.loads("""
{
    "PORT": {
        "Ethernet0": {
            "alias":"eth0",
            "lanes": "65",
            "speed": "100000"
        }
    }
}
            """))

        # the PORT alias has no leafrefs pointing to it
        xpath = "/sonic-port:sonic-port/PORT/PORT_LIST[name='Ethernet0']/alias"
        deps = sy.find_data_dependencies(xpath)

        self.assertEqual(0, len(deps))
```
(added UT for the same idea)

#### Which release branch to backport (provide reason below if selected)

