### PR TITLE
Get Docker proxy info from config

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -480,7 +480,7 @@ with open("'${fl}'", "r") as s:
 if [ "${use_k8s_as_http_proxy}" == "y" ]; then
     # create proxy files for docker using private IP which will
     # be later directed to k8s master upon config
-    PROXY_INFO="http://172.16.1.1:3128/"
+    PROXY_INFO="${kube_docker_proxy}"
     cat <<EOT | sudo tee $FILESYSTEM_ROOT/etc/systemd/system/docker.service.d/http_proxy.conf > /dev/null
 [Service]
 Environment="HTTP_PROXY=${PROXY_INFO}"

--- a/rules/config
+++ b/rules/config
@@ -146,12 +146,14 @@ INCLUDE_DHCP_RELAY = y
 # Uncomment to enable:
 # TELEMETRY_WRITABLE = y
 
+# INCLUDE_MACSEC - build docker-macsec for macsec support
+INCLUDE_MACSEC = y
+
 # INCLUDE_KUBERNETES - if set to y kubernetes packages are installed to be able to
 # run as worker node in kubernetes cluster.
 INCLUDE_KUBERNETES = n
 
-# INCLUDE_MACSEC - build docker-macsec for macsec support
-INCLUDE_MACSEC = y
+KUBE_DOCKER_PROXY = http://172.16.1.1:3128/
 
 # KUBERNETES_VERSION - Set to the required version.
 # K8s_GCR_IO_PAUSE_VERSION - Version of k8s universal pause container image

--- a/slave.mk
+++ b/slave.mk
@@ -941,6 +941,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	export shutdown_bgp_on_start="$(SHUTDOWN_BGP_ON_START)"
 	export default_buffer_model="$(SONIC_BUFFER_MODEL)"
 	export include_kubernetes="$(INCLUDE_KUBERNETES)"
+	export kube_docker_proxy="$(KUBE_DOCKER_PROXY)"
 	export enable_pfcwd_on_start="$(ENABLE_PFCWD_ON_START)"
 	export installer_debs="$(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$($*_INSTALLS))"
 	export lazy_installer_debs="$(foreach deb, $($*_LAZY_INSTALLS),$(foreach device, $($(deb)_PLATFORM),$(addprefix $(device)@, $(IMAGE_DISTRO_DEBS_PATH)/$(deb))))"


### PR DESCRIPTION
This helps not to hard code the docker proxy IP, but take it from config file during build time.
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

