### PR TITLE
[DellEmc] Fix port lanes on alternative S5232 SKUs

### DIFF
--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/port_config.ini
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-100G/port_config.ini
@@ -31,5 +31,5 @@ Ethernet112     113,114,115,116       hundredGigE1/29    29	100000
 Ethernet116     117,118,119,120       hundredGigE1/30    30	100000
 Ethernet120     121,122,123,124       hundredGigE1/31    31	100000
 Ethernet124     125,126,127,128       hundredGigE1/32    32	100000
-Ethernet128     128                   tenGigE1/33        33	10000
-Ethernet129     129                   tenGigE1/34        34	10000
+Ethernet128     129                   tenGigE1/33        33	10000
+Ethernet129     128                   tenGigE1/34        34	10000

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/port_config.ini
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-10G/port_config.ini
@@ -103,5 +103,5 @@ Ethernet112     113,114,115,116       hundredGigE1/29  29	100000
 Ethernet116     117,118,119,120       hundredGigE1/30  30	100000
 Ethernet120     121,122,123,124       hundredGigE1/31  31	100000
 Ethernet124     125,126,127,128       hundredGigE1/32  32	100000
-Ethernet128     128                   tenGigE1/33      33	10000
-Ethernet129     129                   tenGigE1/34      34	10000
+Ethernet128     129                   tenGigE1/33      33	10000
+Ethernet129     128                   tenGigE1/34      34	10000

--- a/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/port_config.ini
+++ b/device/dell/x86_64-dellemc_s5232f_c3538-r0/DellEMC-S5232f-P-25G/port_config.ini
@@ -103,5 +103,5 @@ Ethernet112     113,114,115,116       hundredGigE1/29         29       100000
 Ethernet116     117,118,119,120       hundredGigE1/30         30       100000
 Ethernet120     121,122,123,124       hundredGigE1/31         31       100000
 Ethernet124     125,126,127,128       hundredGigE1/32         32       100000
-Ethernet128     128                   tenGigE1/33             33       10000
-Ethernet129     129                   tenGigE1/34             34       10000
+Ethernet128     129                   tenGigE1/33             33       10000
+Ethernet129     128                   tenGigE1/34             34       10000


### PR DESCRIPTION
Backport the fix (444cede11) that was made for the default SKU
to the alternative SKUs.

#### Why I did it

The `tenGigE1/33` and `tenGigE1/34` works with the default SKU configuration, but not with the one I want to use - `DellEMC-S5232f-P-25G`.

#### How I did it

I looked at the differences between these SKUs as well as the state in `bcmsh` and saw that the `ps` output looked off when `Ethernet129` was enabled.

#### How to verify it

 - Connect a device to one of the two 10G slots (not both)
 - Load e.g. the 25G SKU: `sonic-cfggen -H -k DellEMC-S5232f-P-25G --print-data > /etc/sonic/config_db.json; reboot`
 - Enable the port: `sudo config int startup Ethernet129`
 - Observe the port still being down: `show int status | grep tenGig`
 - Enable the other port: `sudo config int startup Ethernet128`
 - Observe the first port now being up, while the SFP module being on the wrong slot: `show int status | grep tenGig`.

E.g.:
```
admin@localhost:~$ show int status | grep tenGig
Ethernet128              128      10G   9100    N/A           tenGigE1/33  routed      up       up              N/A         N/A
Ethernet129              129      10G   9100    N/A           tenGigE1/34  routed    down       up   SFP/SFP+/SFP28         N/A
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

These are the releases the referenced bug fix was included in, but the alternative SKUs were not fixed.

#### Description for the changelog

- Correct the 10G lane assignments for alternative SKUs for Dell EMC S5232F.

#### A picture of a cute animal (not mandatory but encouraged)
![image](https://user-images.githubusercontent.com/149442/126045959-31535e1b-43a8-4142-9265-8b78eb7c0c26.png)

