### PR TITLE
[reboot-cause] Fixed determine-reboot-cause.service failure.

### DIFF
--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -62,7 +62,7 @@ def parse_warmfast_reboot_from_proc_cmdline():
 
 
 def find_software_reboot_cause_from_reboot_cause_file():
-    software_reboot_cause = None
+    software_reboot_cause = REBOOT_CAUSE_UNKNOWN
     if os.path.isfile(REBOOT_CAUSE_FILE):
         with open(REBOOT_CAUSE_FILE) as cause_file:
             software_reboot_cause = cause_file.readline().rstrip('\n')


### PR DESCRIPTION
Signed-off-by: Rajkumar Pennadam Ramamoorthy <rpennadamram@marvell.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Install sonic image from ONIE. Once system is up, execute "config reload" command.

Root cause is that "determine-reboot-cause.service" was in failed state.
root@sonic:/host/reboot-cause# systemctl list-units --failed
UNIT LOAD ACTIVE SUB DESCRIPTION
● determine-reboot-cause.service loaded failed failed Reboot cause determination service

"determine-reboot-cause" script fails with below error.

Jun 17 10:52:13 sonic chassis: Platform api returns reboot cause Non-Hardware, None
Jun 17 10:52:13 sonic chassis: Platform api returns reboot cause Non-Hardware, None
Jun 17 10:52:13 sonic chassis: Platform api indicates reboot cause Non-Hardware
Jun 17 10:52:13 sonic chassis: Reboot cause file /host/reboot-cause/reboot-cause.txt not found
Jun 17 10:52:13 sonic chassis: Platform api indicates reboot cause Non-Hardware
Jun 17 10:52:13 sonic chassis: Reboot cause file /host/reboot-cause/reboot-cause.txt not found
Jun 17 10:52:13 sonic determine-reboot-cause[564]: Traceback (most recent call last):
Jun 17 10:52:13 sonic determine-reboot-cause[564]: File "/usr/local/bin/determine-reboot-cause", line 228, in
Jun 17 10:52:13 sonic determine-reboot-cause[564]: main()
Jun 17 10:52:13 sonic determine-reboot-cause[564]: File "/usr/local/bin/determine-reboot-cause", line 201, in main
Jun 17 10:52:13 sonic determine-reboot-cause[564]: reboot_cause_dict = get_reboot_cause_dict(previous_reboot_cause, additional_reboot_info, reboot_cause_gen_time)
Jun 17 10:52:13 sonic determine-reboot-cause[564]: File "/usr/local/bin/determine-reboot-cause", line 146, in get_reboot_cause_dict
Jun 17 10:52:13 sonic determine-reboot-cause[564]: if re.search(r'User issued', previous_reboot_cause):
Jun 17 10:52:13 sonic determine-reboot-cause[564]: File "/usr/lib/python3.7/re.py", line 183, in search
Jun 17 10:52:13 sonic determine-reboot-cause[564]: return _compile(pattern, flags).search(string)
Jun 17 10:52:13 sonic determine-reboot-cause[564]: TypeError: expected string or bytes-like object
Jun 17 10:52:13 sonic determine-reboot-cause[564]: Traceback (most recent call last):
Jun 17 10:52:13 sonic determine-reboot-cause[564]: File "/usr/local/bin/determine-reboot-cause", line 228, in
Jun 17 10:52:13 sonic determine-reboot-cause[564]: main()
Jun 17 10:52:13 sonic determine-reboot-cause[564]: File "/usr/local/bin/determine-reboot-cause", line 201, in main
Jun 17 10:52:13 sonic determine-reboot-cause[564]: reboot_cause_dict = get_reboot_cause_dict(previous_reboot_cause, additional_reboot_info, reboot_cause_gen_time)
Jun 17 10:52:13 sonic determine-reboot-cause[564]: File "/usr/local/bin/determine-reboot-cause", line 146, in get_reboot_cause_dict
Jun 17 10:52:13 sonic determine-reboot-cause[564]: if re.search(r'User issued', previous_reboot_cause):
Jun 17 10:52:13 sonic determine-reboot-cause[564]: File "/usr/lib/python3.7/re.py", line 183, in search
Jun 17 10:52:13 sonic determine-reboot-cause[564]: return _compile(pattern, flags).search(string)
**Jun 17 10:52:13 sonic determine-reboot-cause[564]: TypeError: expected string or bytes-like object**
Jun 17 10:52:13 sonic systemd[1]: determine-reboot-cause.service: Main process exited, code=exited, status=1/FAILURE
Jun 17 10:52:13 sonic systemd[1]: determine-reboot-cause.service: Failed with result 'exit-code'.
Jun 17 10:52:13 sonic systemd[1]: determine-reboot-cause.service: Main process exited, code=exited, status=1/FAILURE
Jun 17 10:52:13 sonic systemd[1]: determine-reboot-cause.service: Failed with result 'exit-code'.

#### How I did it
Fixed the issue by setting default reason to "REBOOT_CAUSE_UNKNOWN" instead of "None".
#### How to verify it
Check " determine-reboot-cause.service' loaded successfully post image installation from ONIE.
Verify "reboot-cause.txt" file is created and config reload succeeds.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

