### PR TITLE
[azure-pipeline][multi-asic]: Add azure pipeline script to generate multi asic vs image

### DIFF
--- a/.azure-pipelines/official-build-multi-asic.yml
+++ b/.azure-pipelines/official-build-multi-asic.yml
@@ -1,0 +1,51 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+schedules:
+- cron: "0 18 * * Sun,Wed,Fri"
+  displayName: "Alternate day build"
+  branches:
+    include:
+    - master
+  always: true
+
+trigger: none
+pr: none
+
+stages:
+- stage: Build
+  pool: sonicbld
+  variables:
+    NUM_ASIC: 4
+    CACHE_MODE: wcache
+    ${{ if eq(variables['Build.SourceBranchName'], '202012') }}:
+      VERSION_CONTROL_OPTIONS: 'SONIC_VERSION_CONTROL_COMPONENTS=deb,py2,py3,web'
+  jobs:
+  - template: .azure-pipelines/azure-pipelines-build.yml
+    parameters:
+      buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=$(nproc) NUM_ASIC=${{ variables.NUM_ASIC }} ${{ variables.VERSION_CONTROL_OPTIONS }}'
+      jobGroups:
+      - name: vs
+
+- stage: Test
+  variables:
+  - name: inventory
+    value: veos_vtb
+  - name: testbed_file
+    value: vtestbed.csv
+
+  jobs:
+  - job:
+    pool: sonictest
+    displayName: "kvmtest-multi-asic-t1-lag"
+    timeoutInMinutes: 240
+
+    steps:
+    - template: .azure-pipelines/run-test-template.yml
+      parameters:
+        dut: vlab-08
+        tbname: vms-kvm-four-asic-t1-lag
+        ptf_name: ptf_vms6-4
+        tbtype: multi-asic-t1-lag

--- a/.azure-pipelines/official-build-multi-asic.yml
+++ b/.azure-pipelines/official-build-multi-asic.yml
@@ -25,7 +25,7 @@ stages:
   jobs:
   - template: azure-pipelines-build.yml
     parameters:
-      buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=$(nproc) NUM_ASIC=${{ variables.NUM_ASIC }} ${{ variables.VERSION_CONTROL_OPTIONS }}'
+      buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=$(nproc) BUILD_MULTIASIC_KVM=y ${{ variables.VERSION_CONTROL_OPTIONS }}'
       jobGroups:
       - name: vs
 
@@ -49,3 +49,4 @@ stages:
         tbname: vms-kvm-four-asic-t1-lag
         ptf_name: ptf_vms6-4
         tbtype: multi-asic-t1-lag
+        image: sonic-4asic-vs.img.gz

--- a/.azure-pipelines/official-build-multi-asic.yml
+++ b/.azure-pipelines/official-build-multi-asic.yml
@@ -23,7 +23,7 @@ stages:
     ${{ if eq(variables['Build.SourceBranchName'], '202012') }}:
       VERSION_CONTROL_OPTIONS: 'SONIC_VERSION_CONTROL_COMPONENTS=deb,py2,py3,web'
   jobs:
-  - template: .azure-pipelines/azure-pipelines-build.yml
+  - template: azure-pipelines-build.yml
     parameters:
       buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=$(nproc) NUM_ASIC=${{ variables.NUM_ASIC }} ${{ variables.VERSION_CONTROL_OPTIONS }}'
       jobGroups:
@@ -43,7 +43,7 @@ stages:
     timeoutInMinutes: 240
 
     steps:
-    - template: .azure-pipelines/run-test-template.yml
+    - template: run-test-template.yml
       parameters:
         dut: vlab-08
         tbname: vms-kvm-four-asic-t1-lag

--- a/.azure-pipelines/official-build-multi-asic.yml
+++ b/.azure-pipelines/official-build-multi-asic.yml
@@ -18,7 +18,6 @@ stages:
 - stage: Build
   pool: sonicbld
   variables:
-    NUM_ASIC: 4
     CACHE_MODE: wcache
     ${{ if eq(variables['Build.SourceBranchName'], '202012') }}:
       VERSION_CONTROL_OPTIONS: 'SONIC_VERSION_CONTROL_COMPONENTS=deb,py2,py3,web'

--- a/.azure-pipelines/run-test-template.yml
+++ b/.azure-pipelines/run-test-template.yml
@@ -7,6 +7,13 @@ parameters:
   type: string
 - name: ptf_name
   type: string
+- name: image
+  type: string
+  default: sonic-vs.img.gz
+  values:
+  - sonic-vs.img.gz
+  - sonic-4asic-vs.img.gz
+  - sonic-6asic-vs.img.gz
 
 steps:
 - checkout: self
@@ -21,7 +28,7 @@ steps:
 - script: |
     set -x
     sudo mkdir -p /data/sonic-vm/images
-    sudo cp -v ../target/sonic-vs.img.gz /data/sonic-vm/images/sonic-vs.img.gz
+    sudo cp -v ../target/${{ parameters.image}} /data/sonic-vm/images/sonic-vs.img.gz
     sudo gzip -fd /data/sonic-vm/images/sonic-vs.img.gz
     username=$(id -un)
     sudo chown -R $username.$username /data/sonic-vm


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To be able to run VS test on official multi asic VS image.
#### How I did it
Add a new script to build multi-asic VS image by passing NUM_ASIC build parameter.
Rung multi-asic t1-lag test cases with the built image.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

