### PR TITLE
[202012][hostcfgd] differentiate between UnitFileState and UnitFilePreset (#8…

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -454,14 +454,25 @@ class HostConfigDaemon:
 
         return feature_names, feature_suffixes
 
+    def get_systemd_unit_state(self, unit):
+        """ Returns service configuration """
+
+        cmd = "sudo systemctl show {} --property UnitFileState".format(unit)
+        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+        if proc.returncode != 0:
+            syslog.syslog(syslog.LOG_ERR, "Failed to get status of {}: rc={} stderr={}".format(unit, proc.returncode, stderr))
+            return 'invalid'  # same as systemd's "invalid indicates that it could not be determined whether the unit file is enabled".
+
+        props = dict([line.split("=") for line in stdout.decode().strip().splitlines()])
+        return props["UnitFileState"]
+
     def enable_feature(self, feature_names, feature_suffixes):
         start_cmds = []
         for feature_name in feature_names:
             # Check if it is already enabled, if yes skip the system call
-            cmd = "sudo systemctl status {}.{} | grep Loaded".format(feature_name, feature_suffixes[-1])
-            proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout, stderr) = proc.communicate()
-            if "enabled" in str(stdout):
+            unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
+            if unit_file_state == "enabled":
                 continue
 
             for suffix in feature_suffixes:
@@ -485,10 +496,8 @@ class HostConfigDaemon:
         stop_cmds = []
         for feature_name in feature_names:
             # Check if it is already disabled, if yes skip the system call
-            cmd = "sudo systemctl status {}.{} | grep Loaded".format(feature_name, feature_suffixes[-1])
-            proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout, stderr) = proc.communicate()
-            if "disabled" in str(stdout) or "masked" in str(stdout):
+            unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
+            if unit_file_state in ("disabled", "masked"):
                 continue
 
             for suffix in reversed(feature_suffixes):


### PR DESCRIPTION
…169)

It can be that service is not enabled but UnitFilePreset=enabled (case
for Application Extension):

```
    Loaded: loaded (/lib/systemd/system/cpu-report.service; disabled; vendor preset: enabled)
```

This makes existing logic skip enabling the service.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

Original PR: https://github.com/Azure/sonic-buildimage/pull/8169

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

