### PR TITLE
[multi-asic] Fix for sonic-cfggen exception during platform string read

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -366,6 +366,7 @@ def main():
     if args.from_db:
         use_unix_sock = True if os.getuid() == 0 else False
         if args.namespace is None:
+            SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
             configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, **db_kwargs)
         else:
             configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, namespace=args.namespace, **db_kwargs)
@@ -433,6 +434,7 @@ def main():
 
     if args.write_to_db:
         if args.namespace is None:
+            SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
             configdb = ConfigDBPipeConnector(use_unix_socket_path=True, **db_kwargs)
         else:
             configdb = ConfigDBPipeConnector(use_unix_socket_path=True, namespace=args.namespace, **db_kwargs)

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -305,10 +305,6 @@ def main():
                                 'localhost': {'namespace_id': namespace_id}
                              }
                           })
-    # Load the database config for the namespace from global database json
-    if args.namespace is not None:
-        SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
-
     if hwsku is not None:
         hardware_data = {'DEVICE_METADATA': {'localhost': {
             'hwsku': hwsku
@@ -366,9 +362,9 @@ def main():
     if args.from_db:
         use_unix_sock = True if os.getuid() == 0 else False
         if args.namespace is None:
-            SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
             configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, **db_kwargs)
         else:
+            SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
             configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, namespace=args.namespace, **db_kwargs)
 
         configdb.connect()
@@ -434,9 +430,9 @@ def main():
 
     if args.write_to_db:
         if args.namespace is None:
-            SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
             configdb = ConfigDBPipeConnector(use_unix_socket_path=True, **db_kwargs)
         else:
+            SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
             configdb = ConfigDBPipeConnector(use_unix_socket_path=True, namespace=args.namespace, **db_kwargs)
 
         configdb.connect(False)


### PR DESCRIPTION
during fresh install and start of sonic in multi asic, /var/run/redisX/ is created after database docker is
started. Currently sonic-cfggen is throwing exception while reading platform string from /usr/bin/database.sh

 sonic python3[2259]: :- parseDatabaseConfig: Sonic database config file doesn't exist at /var/run/redis/sonic-db/../../redis0/sonic-db/database_config.json
 sonic python3[2259]: :- initializeGlobalConfig: Sonic database config file syntax error >> Sonic database config file doesn't exist at /var/run/redis/sonic-db/../../redis0/sonic-db/database_config.json
 sonic database.sh[2259]: Traceback (most recent call last):
 sonic database.sh[2259]:   File "/usr/local/bin/sonic-cfggen", line 452, in <module>
 sonic database.sh[2259]:     main()
 sonic database.sh[2259]:   File "/usr/local/bin/sonic-cfggen", line 310, in main
 sonic database.sh[2259]:     SonicDBConfig.load_sonic_global_db_config(namespace=args.namespace)
 sonic database.sh[2259]:   File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1342, in load_sonic_global_db_config
 sonic database.sh[2259]:     SonicDBConfig.initializeGlobalConfig(global_db_file_path)
 sonic database.sh[2259]: RuntimeError: Sonic database config file syntax error >> Sonic database config file doesn't exist at /var/run/redis/sonic-db/../../redis0/sonic-db/database_config.json
 sonic database.sh[2246]: Creating new database0 container
 sonic database.sh[2516]: 4be09b19659f7db6f8399455f32b9f7c7a47ee66f67c4d0dddf1c54fb0f9d59c
 sonic database.sh[3296]: database0

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

