### PR TITLE
[redis-cli][multiasic]redis-cli supports namespace

### DIFF
--- a/dockers/docker-database/base_image_files/redis-cli
+++ b/dockers/docker-database/base_image_files/redis-cli
@@ -2,9 +2,14 @@
 
 DOCKER_EXEC_FLAGS="i"
 
+namespace="$(ip netns identify)"
+if [ "$namespace" != "" ]; then
+    namespace="${namespace/asic/}"
+fi
+
 # Determine whether stdout is on a terminal
 if [ -t 1 ] ; then
     DOCKER_EXEC_FLAGS+="t"
 fi
 
-docker exec -$DOCKER_EXEC_FLAGS database redis-cli "$@"
+docker exec -$DOCKER_EXEC_FLAGS database$namespace redis-cli "$@"


### PR DESCRIPTION
The current redis-cli has been hardcoded only to access to the host database. MThis change modifies the redis-cli to identify the namespace and access to its database
