### PR TITLE
Brcm SAI bcm update to 5.0.0.6-1

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,12 +1,12 @@
-BRCM_SAI = libsaibcm_5.0.0.4_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_5.0.0.4_amd64.deb?sv=2015-04-05&sr=b&sig=ZuEkoLskVsCtNoej4I%2BBuhX01hFJXZC4yuhoFg0jzuw%3D&se=2035-03-21T23%3A30%3A55Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_5.0.0.4_amd64.deb
+BRCM_SAI = libsaibcm_5.0.0.6-1_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_5.0.0.6-1_amd64.deb?sv=2015-04-05&sr=b&sig=HA%2FwgMr%2BHnb6zzFCQDfO1WF%2Bf6PBSmIzH13728LTNz4%3D&se=2035-03-31T20%3A45%3A36Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_5.0.0.6-1_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm-dev_5.0.0.4_amd64.deb?sv=2015-04-05&sr=b&sig=JYxPob3rO%2BnPv%2FTFn9Q3xbVx5l6ZxwrRq7fpg%2BcUqwQ%3D&se=2035-03-21T23%3A31%3A26Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm-dev_5.0.0.6-1_amd64.deb?sv=2015-04-05&sr=b&sig=z634%2BUk14EY5VjEE4tjhvDSP2hiK8s1EJAxjvidl44I%3D&se=2035-03-31T20%3A46%3A17Z&sp=r"
 
 # SAI module for DNX Asic family
-BRCM_DNX_SAI = libsaibcm_dnx_5.0.0.4_amd64.deb
-$(BRCM_DNX_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_dnx_5.0.0.4_amd64.deb?sv=2015-04-05&sr=b&sig=CNtYmID5aZtc0ZFHldWYCQSbzyb9xT18vGxT%2BZj7kHc%3D&se=2035-03-21T23%3A31%3A50Z&sp=r"
+BRCM_DNX_SAI = libsaibcm_dnx_5.0.0.6-1_amd64.deb
+$(BRCM_DNX_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_dnx_5.0.0.6-1_amd64.deb?sv=2015-04-05&sr=b&sig=mDcpzWUcTSzNBM6vPPYNuMQ6D%2BTKQAC9k%2Fv0%2Bnz3L%2BM%3D&se=2035-03-31T20%3A46%3A44Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 SONIC_ONLINE_DEBS += $(BRCM_DNX_SAI)


### PR DESCRIPTION

#### Why I did it
Move SAI libraries for Broadcom for XGS and DNX families to 5.0.0.6

Included fixes 

```
CS00012195263 | [4.3][5.0][TD3]   Packets with broken IP headers received on VLAN interface are not dropped
CS00012192505 | [4.3] Re-encap   IPinIP decap packets
CS00012192502 | [3.7.5.2] Start   LED shell script execution on all DELL based platforms causing all ports   flapping on SAI 3.7.5.2
CS00012191363 | [4.3] Support   of memscan thread to detect TCAM parity error
CS00012190932 | [4.3]   SAI_PORT_PFC_X_RX_PKTS incremented incorrectly even when no PFC frames are   received on that priority
CS00012183901 | [4.3][WARMBOOT]   WARMReboot with active traffic causes port flap reported during warm reboot
CS00011382163 | [4.4] Support   warm-boot from 3.5 to 4.3
CS00011318937 | [4.3] MACSec   SAI Support for Jericho2c+
CS00011318926 | [4.3] Provide   SAI support for Jericho2c+
CS00012195263 | [4.3][5.0][TD3]   Packets with broken IP headers received on VLAN interface are not dropped
CS00012195261 | [4.3][5.0][TD3]VLAN   tagged IP packet received on untagged interface being routed instead of   dropped
CS00012183901 | [4.3][WARMBOOT]   WARMReboot with active traffic causes port flap reported during warm reboot
CS00012196056 | [4.3.3.8][WARMBOOT]   syncd[2584]: segfault at 5616ad6c3d80 ip 00007f61e0c6bc65 sp 00007fff0c5a7a90   error 4 in libsai.so.1.0[7f61e0a95000+3cd8000]
CS00012195262 | [4.3][5.0][TD3]   Malformed IP packet(missing IP header) received on a VLAN Interface is   flooded to other LVAN members instead of being dropped
CS00012195956 | [4.3.3.8]   [TD3]Syncd Crash at brcm_sai_tnl_mp_create_tunnel()

PR 4346163: Add support for AN/LT
```

#### How I did it

#### How to verify it
Verified loading the saibcm debian package in syncd docker in XGS and DNX devices to make sure basic sanity is ok - interfaces up.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

