### PR TITLE
[202012][202106] AS4630-54TE Support SystemHealthMonitor

### DIFF
--- a/device/accton/x86_64-accton_as4630_54te-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as4630_54te-r0/pmon_daemon_control.json
@@ -1,5 +1,5 @@
 {
     "skip_ledd": true,
-    "skip_thermalctld": true
+    "skip_pcied": true
 }
 

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/__init__.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/__init__.py
@@ -1,2 +1,2 @@
-__all__ = ['chassis', 'eeprom', 'platform', 'psu', 'sfp', 'thermal', 'fan']
+__all__ = [ "platform", "chassis", "sfp", "eeprom", "component", "psu", "thermal", "fan", "fan_drawer" ]
 from . import platform 

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
@@ -27,6 +27,13 @@ PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
 HOST_CHK_CMD = "docker > /dev/null 2>&1"
+SYSLED_FNODE = "/sys/class/leds/diag/brightness"
+SYSLED_MODES = {
+    "0" : "STATUS_LED_COLOR_OFF",
+    "1" : "STATUS_LED_COLOR_GREEN",
+    "2" : "STATUS_LED_COLOR_AMBER",
+    "5" : "STATUS_LED_COLOR_GREEN_BLINK"
+}
 
 
 class Chassis(ChassisBase):
@@ -55,12 +62,11 @@ class Chassis(ChassisBase):
         self.sfp_module_initialized = True
 
     def __initialize_fan(self):
-        from sonic_platform.fan import Fan
-        for fant_index in range(0, NUM_FAN_TRAY):
-            for fan_index in range(0, NUM_FAN):
-                fan = Fan(fant_index, fan_index)
-                self._fan_list.append(fan)
-
+        from sonic_platform.fan_drawer import FanDrawer
+        for fant_index in range(NUM_FAN_TRAY):
+            fandrawer = FanDrawer(fant_index)
+            self._fan_drawer_list.append(fandrawer)
+            self._fan_list.extend(fandrawer._fan_list)
     def __initialize_psu(self):
         from sonic_platform.psu import Psu
         for index in range(0, NUM_PSU):
@@ -192,3 +198,39 @@ class Chassis(ChassisBase):
             sys.stderr.write("SFP index {} out of range (1-{})\n".format(
                              index, len(self._sfp_list)))
         return sfp
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+
+
+    def initizalize_system_led(self):
+        return True
+
+    def get_status_led(self):
+        val = self._api_helper.read_txt_file(SYSLED_FNODE)
+        return SYSLED_MODES[val] if val in SYSLED_MODES else "UNKNOWN"
+
+    def set_status_led(self, color):
+        mode = None
+        for key, val in SYSLED_MODES.items():
+            if val == color:
+                mode = key
+                break
+        if mode is None:
+            return False
+        else:
+            return self._api_helper.write_txt_file(SYSLED_FNODE, mode)

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/fan_drawer.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/fan_drawer.py
@@ -1,0 +1,90 @@
+########################################################################
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the Fan-Drawers' information available in the platform.
+#
+########################################################################
+
+try:
+    from sonic_platform_base.fan_drawer_base import FanDrawerBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+FANS_PER_FANTRAY = 2
+
+
+class FanDrawer(FanDrawerBase):
+    """Platform-specific Fan class"""
+
+    def __init__(self, fantray_index):
+
+        FanDrawerBase.__init__(self)
+        # FanTray is 0-based in platforms
+        self.fantrayindex = fantray_index
+        self.__initialize_fan_drawer()
+
+
+    def __initialize_fan_drawer(self):
+        from sonic_platform.fan import Fan
+        for i in range(FANS_PER_FANTRAY):
+            self._fan_list.append(Fan(self.fantrayindex, i))
+
+    def get_name(self):
+        """
+        Retrieves the fan drawer name
+        Returns:
+            string: The name of the device
+        """
+        return "FanTray{}".format(self.fantrayindex+1)
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the device
+        Returns:
+            bool: True if device is present, False if not
+        """
+        return self._fan_list[0].get_presence()
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        return self._fan_list[0].get_model()
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return self._fan_list[0].get_serial()
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the device
+        Returns:
+            A boolean value, True if device is operating properly, False if not
+        """
+        return self._fan_list[0].get_status()
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of
+        entPhysicalContainedIn is'0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device
+            or -1 if cannot determine the position
+        """
+        return (self.fantrayindex+1)
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
@@ -51,7 +51,7 @@ class APIHelper():
 
     def read_txt_file(self, file_path):
         try:
-            with open(file_path, 'r') as fd:
+            with open(file_path, 'r', errors='replace') as fd:
                 data = fd.read()
                 return data.strip()
         except IOError:

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/psu.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/psu.py
@@ -139,8 +139,15 @@ class Psu(PsuBase):
         Returns:
             A string, one of the predefined STATUS_LED_COLOR_* strings above
         """
+        status=self.get_status()
+        if status is None:
+            return  self.STATUS_LED_COLOR_OFF
 
-        return False  #Controlled by HW
+        return {
+            1: self.STATUS_LED_COLOR_GREEN,
+            0: self.STATUS_LED_COLOR_RED
+        }.get(status, self.STATUS_LED_COLOR_OFF)
+
 
     def get_temperature(self):
         """
@@ -226,3 +233,45 @@ class Psu(PsuBase):
             return int(val, 10) == 1
         else:
             return 0
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        model_path="{}{}".format(self.cpld_path, 'psu_model_name')
+        model=self._api_helper.read_txt_file(model_path)
+        if model is None:
+            return "N/A"
+
+        return model
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        serial_path="{}{}".format(self.cpld_path, 'psu_serial_number')
+        serial=self._api_helper.read_txt_file(serial_path)
+        if serial is None:
+            return "N/A"
+        return serial
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
+        """
+        return self.index+1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True

--- a/device/accton/x86_64-accton_as4630_54te-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as4630_54te-r0/system_health_monitoring_config.json
@@ -1,0 +1,15 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+        "psu.temperature"
+
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "STATUS_LED_COLOR_AMBER",
+        "normal": "STATUS_LED_COLOR_GREEN",
+        "booting": "STATUS_LED_COLOR_GREEN_BLINK"
+    }
+}


### PR DESCRIPTION
Same content as https://github.com/Azure/sonic-buildimage/pull/8183, but merge to branch 202012 and 202106

1. Implement FanDrawer-Fan hierarchy.
2. Enable thermalctld, disable pcied.
3. Implement SystemLED in Chassis.
4. Correct Fan direction
5. Implement require Fan APIs for SystemHealthMonitoring.
6. Handle non-ascii character while reading PSU model/serial num.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To support system health monitoring feature.

#### How I did it
Mainly provided a config file, system_health_monitoring_config.json. Then implement the SystemLED part that'd be manipulated by HealthChecker. Others are just to correct the provided information which will be utilized by HardwareChecker.

#### How to verify it
Check if System-health can pass the check and display the SystemLED correctly.
```

///////// booting, DIAG_LED = GREEN_BLINKING /////////

root@sonic:/tmp# show system-health detail 
System is currently booting...
root@sonic:/tmp# cat /sys/class/leds/diag/brightness 
5


///////// container_checker fail, DIAG_LED = AMBER /////////

root@sonic:/sys/bus/i2c/devices# show system-health detail
System status summary

  System status LED  STATUS_LED_COLOR_AMBER
  Services:
    Status: OK
  Hardware:
    Status: Not OK
    Reasons: container_checker is not Status ok

System services and devices monitor list

Name                        Status    Type
--------------------------  --------  ----------
container_checker           Not OK    Program
sonic                       OK        System
rsyslog                     OK        Process
root-overlay                OK        Filesystem
var-log                     OK        Filesystem
routeCheck                  OK        Program
diskCheck                   OK        Program
container_memory_telemetry  OK        Program
FAN-1F                      OK        Fan
FAN-1R                      OK        Fan
FAN-2F                      OK        Fan
FAN-2R                      OK        Fan
FAN-3F                      OK        Fan
FAN-3R                      OK        Fan
PSU-1 FAN-1                 OK        Fan
PSU-2 FAN-1                 OK        Fan
PSU 1                       OK        PSU
PSU 2                       OK        PSU

System services and devices ignore list

Name             Status    Type
---------------  --------  ------
asic             Ignored   Device
psu.temperature  Ignored   Device

///////// skip container_checker, DIAG_LED = GREEN /////////

root@sonic:/sys/bus/i2c/devices# vi /usr/share/sonic/device/x86_64-accton_as4630_54te-r0/system_health_monitoring_config.json 
root@sonic:/sys/bus/i2c/devices# 
root@sonic:/sys/bus/i2c/devices# 
root@sonic:/sys/bus/i2c/devices# show system-health detail
System status summary

  System status LED  STATUS_LED_COLOR_GREEN
  Services:
    Status: OK
  Hardware:
    Status: OK

System services and devices monitor list

Name                        Status    Type
--------------------------  --------  ----------
sonic                       OK        System
rsyslog                     OK        Process
root-overlay                OK        Filesystem
var-log                     OK        Filesystem
routeCheck                  OK        Program
diskCheck                   OK        Program
container_memory_telemetry  OK        Program
FAN-1F                      OK        Fan
FAN-1R                      OK        Fan
FAN-2F                      OK        Fan
FAN-2R                      OK        Fan
FAN-3F                      OK        Fan
FAN-3R                      OK        Fan
PSU-1 FAN-1                 OK        Fan
PSU-2 FAN-1                 OK        Fan
PSU 1                       OK        PSU
PSU 2                       OK        PSU

System services and devices ignore list

Name               Status    Type
-----------------  --------  -------
container_checker  Ignored   Service
psu.temperature    Ignored   Device
asic               Ignored   Device

```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
Some of our customers still rely on old branches.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[Accton] AS4630-54TE support SystemHealthMonitor

#### A picture of a cute animal (not mandatory but encouraged)
https://media.giphy.com/media/13CoXDiaCcCoyk/giphy.gif
