### PR TITLE
[Celestica Seastone2] Add 10G SFP1 front port

### DIFF
--- a/device/celestica/x86_64-cel_seastone_2-r0/Seastone_2/port_config.ini
+++ b/device/celestica/x86_64-cel_seastone_2-r0/Seastone_2/port_config.ini
@@ -31,3 +31,4 @@ Ethernet112  113,114,115,116     QSFP29   rs     29      100000
 Ethernet116  117,118,119,120     QSFP30   rs     30      100000
 Ethernet120  121,122,123,124     QSFP31   rs     31      100000
 Ethernet124  125,126,127,128     QSFP32   rs     32      100000
+Ethernet128  129                 SFP1     none   33      10000

--- a/device/celestica/x86_64-cel_seastone_2-r0/Seastone_2/td3-seastone_2-32x100G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone_2-r0/Seastone_2/td3-seastone_2-32x100G.config.bcm
@@ -18,7 +18,7 @@ serdes_lane_config_dfe=on
 #serdes_fec_enable=1
 serdes_if_type_ce=14
 pbmp_gport_stack.0=0x0000000000000000000000000000000000000000000000000000000000000000
-pbmp_xport_xe=0x88888888888888882222222222222222
+pbmp_xport_xe=0x888888888888888c2222222222222222
 
 ptp_ts_pll_fref=50000000
 ptp_bs_fref_0=50000000
@@ -40,6 +40,7 @@ portmap_49.0=49:100
 portmap_53.0=53:100
 portmap_57.0=57:100
 portmap_61.0=61:100
+
 portmap_67.0=65:100
 portmap_71.0=69:100
 portmap_75.0=73:100
@@ -56,7 +57,7 @@ portmap_115.0=113:100
 portmap_119.0=117:100
 portmap_123.0=121:100
 portmap_127.0=125:100
-#portmap_66.0=129:10:m
+portmap_66.0=129:10:m
 #portmap_130.0=128:10:m
 
 #wc0 lane swap
@@ -189,7 +190,7 @@ phy_chain_rx_lane_map_physical{125.0}=0x3210
 
 #MC lane swap
 phy_chain_tx_lane_map_physical{129.0}=0x3210
-phy_chain_rx_lane_map_physical{129.0}=0x3210
+phy_chain_rx_lane_map_physical{129.0}=0x0231
 
 
 #wc0 P/N flip
@@ -513,7 +514,7 @@ phy_chain_tx_polarity_flip_physical{128.0}=0x0
 phy_chain_rx_polarity_flip_physical{128.0}=0x0
 
 #MC P/N flip
-phy_chain_tx_polarity_flip_physical{129.0}=0x0
+phy_chain_tx_polarity_flip_physical{129.0}=0x1
 phy_chain_rx_polarity_flip_physical{129.0}=0x0
 phy_chain_tx_polarity_flip_physical{130.0}=0x0
 phy_chain_rx_polarity_flip_physical{130.0}=0x0
@@ -554,7 +555,7 @@ dport_map_port_115=29
 dport_map_port_119=30
 dport_map_port_123=31
 dport_map_port_127=32
-#dport_map_port_66=33
+dport_map_port_66=33
 #dport_map_port_130=34
 
 # configuration for 100G optical module


### PR DESCRIPTION
#### Why I did it

The SFP1 port was disabled in the default configuration.

#### How I did it

This commit enables the 10G front port for usage.
This was done using a DX030 together with an Arista switch using `bcmsh` and `phy diag xe0 dsc` to figure out what lane mappings make sense.

Validated on Celestica Seastone2 DX030.

#### How to verify it

1. Own a Celestica DX030
2. Connect the front SFP1 port to something.
3. It works :-)

You can do `tcpdump -i Ethernet128 -n` and you will see both incoming and outgoing LLDP.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

Reason: If 202106 is still open for these additions it would be nice for it to be in.
If not, master is fine as well.

#### Description for the changelog

[Celestica Seastone2] Add SFP1 front port

#### A picture of a cute animal (not mandatory but encouraged)

![image](https://user-images.githubusercontent.com/149442/127207788-b28365e7-de24-4a28-a34d-79a510936af2.png)
