### PR TITLE
[docker-orchagent][201911] Pass ASIC vendor information to swss docker as docker level environment variable

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -245,11 +245,6 @@ start() {
     echo "Creating new {{docker_container_name}}$DEV container with HWSKU $HWSKU"
     {%- endif %}
 
-    {%- if docker_container_name == "swss" %}
-    # Obtain the vendor name
-    ASIC_VENDOR=`$SONIC_CFGGEN -y /etc/sonic/sonic_version.yml -v asic_type`
-    {%- endif %}
-
     # In Multi ASIC platforms the global database config file database_global.json will exist.
     # Parse the file and get the include path for the database_config.json files used in
     # various namesapces. The database_config paths are relative to the DIR of SONIC_DB_GLOBAL_JSON.
@@ -341,7 +336,7 @@ start() {
 {%- endif %}
 {%- endif %}
 {%- if docker_container_name == "swss" %}
-        -e ASIC_VENDOR=$ASIC_VENDOR \
+        -e ASIC_VENDOR={{ sonic_asic_platform }} \
 {%- endif %}
 {%- if docker_container_name == "bgp" %}
         -v /etc/sonic/frr/$DEV:/etc/frr:rw \

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -245,6 +245,11 @@ start() {
     echo "Creating new {{docker_container_name}}$DEV container with HWSKU $HWSKU"
     {%- endif %}
 
+    {%- if docker_container_name == "swss" %}
+    # Obtain the vendor name
+    ASIC_VENDOR=`$SONIC_CFGGEN -y /etc/sonic/sonic_version.yml -v asic_type`
+    {%- endif %}
+
     # In Multi ASIC platforms the global database config file database_global.json will exist.
     # Parse the file and get the include path for the database_config.json files used in
     # various namesapces. The database_config paths are relative to the DIR of SONIC_DB_GLOBAL_JSON.
@@ -334,6 +339,9 @@ start() {
 {%- if docker_container_name == "syncd" %}
         -v /var/run/docker-syncd$DEV:/var/run/sswsyncd \
 {%- endif %}
+{%- endif %}
+{%- if docker_container_name == "swss" %}
+        -e ASIC_VENDOR=$ASIC_VENDOR \
 {%- endif %}
 {%- if docker_container_name == "bgp" %}
         -v /etc/sonic/frr/$DEV:/etc/frr:rw \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Recently, the reserved buffer of admin-down ports is going to be reclaimed.
However, the way to do this differs among vendors.
We need to find a way to pass vendor information to swss docker.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it
Fetch the ASIC vendor information when the docker is created and pass it to the docker as environment variable `ASIC_VENDOR`.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

