### PR TITLE
[AS5835-54X] Fix chassis health led bug

### DIFF
--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/chassis.py
@@ -34,8 +34,7 @@ SYSLED_FNODE= "/sys/class/leds/as5835_54x_led::diag/brightness"
 SYSLED_MODES = {
     "0" : "STATUS_LED_COLOR_OFF",
     "1" : "STATUS_LED_COLOR_GREEN",
-    "2" : "STATUS_LED_COLOR_AMBER",
-    "5" : "STATUS_LED_COLOR_GREEN_BLINK"
+    "3" : "STATUS_LED_COLOR_AMBER"
 }
 
 


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Chassis health led has bug and it will let show led fail when health found PSU is not power. 
#### How I did it
Fix chassis.py code.
#### How to verify it
Plug-out one PSU and check "show system-health summary". Led should how amber
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

