### PR TITLE
[bgpcfgd][voq] Fix for unit test failure in bgpcfgd config for voq switch

### DIFF
--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.conf
@@ -30,6 +30,7 @@ router bgp 55555
   bgp graceful-restart restart-time 240
   bgp graceful-restart
   bgp graceful-restart preserve-fw-state
+  bgp graceful-restart select-defer-time 45
 !
   bgp router-id 55.55.55.56
 !


### PR DESCRIPTION
#### Why I did it

To fix Azure pipeline failure due to unit test failure in sonic-bgpcfgd submodule. 

#### How I did it

The unit test failure was due to missing bgp graceful restart select defer time configuration in voq_chassis.conf. Modified sample output data file voq_chassis.conf to include this configuration.

#### How to verify it

- Trigger Azure pipeline build. 
- Observe pipeline completes successfully.

#### Which release branch to backport (provide reason below if selected)

N/A

#### Description for the changelog

Fix for unit test failure in bgpcfgd for voq switch

