### PR TITLE
[sonic-frr/Makefile]: Checkout gracefully if branch exists already.

### DIFF
--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -10,7 +10,7 @@ STG_BRANCH = stg_temp.$(SUFFIX)
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Build the package
 	pushd ./frr
-	git checkout -b $(FRR_BRANCH) origin/$(FRR_BRANCH)
+	git checkout $(FRR_BRANCH) || git checkout -b $(FRR_BRANCH) origin/$(FRR_BRANCH)
 	stg branch --create $(STG_BRANCH) $(FRR_TAG)
 	stg import -s ../patch/series
 	tools/tarsource.sh -V -e '-sonic'

--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -10,7 +10,7 @@ STG_BRANCH = stg_temp.$(SUFFIX)
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Build the package
 	pushd ./frr
-	git checkout $(FRR_BRANCH) || git checkout -b $(FRR_BRANCH) origin/$(FRR_BRANCH)
+	git checkout -b $(FRR_BRANCH) origin/$(FRR_BRANCH) || git checkout $(FRR_BRANCH)
 	stg branch --create $(STG_BRANCH) $(FRR_TAG)
 	stg import -s ../patch/series
 	tools/tarsource.sh -V -e '-sonic'


### PR DESCRIPTION
This is useful to avoid "branch exists" error while rebuild FRR.

Signed-off-by: Praveen Chaudhary<pchaudhary@linkedin.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

If branch exist already, today FRR build fails. Branch may exist on rebuild.
With this PR,  we will Checkout branch gracefully if branch exists already.

#### How I did it

Use git checkout $(FRR_BRANCH) || git checkout -b $(FRR_BRANCH) origin/$(FRR_BRANCH) in src/sonic-frr/Makefile.

#### How to verify it

Rebuild works fine. Fresh build works fine as well.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

