### PR TITLE
[202012][saiserver docker]adds saiserver dependences

### DIFF
--- a/platform/broadcom/docker-saiserver-brcm/Dockerfile.j2
+++ b/platform/broadcom/docker-saiserver-brcm/Dockerfile.j2
@@ -1,3 +1,4 @@
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages %}
 FROM docker-config-engine-buster
 
 ARG docker_container_name
@@ -6,7 +7,11 @@ RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%s
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
+## Pre-install the fundamental packages
+RUN apt-get update \
+ && apt-get -y install  \
+    gdb                 \
+    libboost-atomic1.71.0
 
 COPY \
 {% for deb in docker_saiserver_brcm_debs.split(' ') -%}
@@ -14,10 +19,8 @@ debs/{{ deb }}{{' '}}
 {%- endfor -%}
 debs/
 
-RUN dpkg_apt() { [ -f $1 ] && { dpkg -i $1 || apt-get -y install -f; } || return 1; } ; \
-{% for deb in docker_saiserver_brcm_debs.split(' ') -%}
-dpkg_apt debs/{{ deb }}{{'; '}}
-{%- endfor %}
+# Install locally-built Debian packages and implicitly install their dependencies
+{{ install_debian_packages(docker_saiserver_brcm_debs.split(' ')) }}
 
 ## TODO: add kmod into Depends
 RUN apt-get install -yf kmod

--- a/platform/broadcom/docker-saiserver-brcm/supervisord.conf
+++ b/platform/broadcom/docker-saiserver-brcm/supervisord.conf
@@ -20,7 +20,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:saiserver]
-command=/usr/bin/saiserver -p /etc/sai/profile.ini -f /etc/sai/portmap.ini
+command=/usr/sbin/saiserver -p /etc/sai/profile.ini -f /etc/sai/portmap.ini
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add dependences in saiserver docker


#### How I did it
- install libboost-atomic1.71.0 which is dependent by thrift 0.11
- add gdb                 
- replace the dep install script with a function
#### How to verify it
deploy it on broadcom device with sonic in version 202012
run saiserver docker and run test from ptf

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

Thrift only upgraded in 202012 and 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

