### PR TITLE
Update default cable len to 0m for TD2

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/buffers_defaults_t0.j2
@@ -1,4 +1,4 @@
-{%- set default_cable = '300m' %}
+{%- set default_cable = '0m' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/buffers_defaults_t1.j2
@@ -1,4 +1,4 @@
-{%- set default_cable = '300m' %}
+{%- set default_cable = '0m' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/buffers_defaults_t0.j2
@@ -1,4 +1,4 @@
-{%- set default_cable = '300m' %}
+{%- set default_cable = '0m' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/buffers_defaults_t1.j2
@@ -1,4 +1,4 @@
-{%- set default_cable = '300m' %}
+{%- set default_cable = '0m' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/buffers_defaults_t0.j2
@@ -1,4 +1,4 @@
-{%- set default_cable = '300m' %}
+{%- set default_cable = '0m' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/buffers_defaults_t1.j2
@@ -1,4 +1,4 @@
-{%- set default_cable = '300m' %}
+{%- set default_cable = '0m' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_def.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_def.j2
@@ -1,4 +1,4 @@
-{%- set default_cable = '300m' %}
+{%- set default_cable = '0m' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_t0.j2
@@ -1,4 +1,4 @@
-{%- set default_cable = '300m' %}
+{%- set default_cable = '0m' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers_defaults_t1.j2
@@ -1,4 +1,4 @@
-{%- set default_cable = '300m' %}
+{%- set default_cable = '0m' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}
     {# Generate list of ports #}


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
As part of the buffer reclamation efforts for TD2, setting the default cable len to 0m which means unused ports will have a cable len of 0m. 

#### Why I did it
To align with the changes in Azure/sonic-swss#1830

#### How to verify it
With the default cable len set to 0m and the associated changes in swss, CABLE_LENGTH table had '0m' set for unused ports and accordingly more space was reserved for the shared pool

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

