### PR TITLE
Dell S6100: Monitor serial-getty service

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -25,5 +25,6 @@ s6100/systemd/platform-modules-s6100.service etc/systemd/system
 s6100/systemd/s6100-lpc-monitor.service etc/systemd/system
 s6100/systemd/s6100-reboot-cause.service etc/systemd/system
 s6100/systemd/s6100-i2c-enumerate.service etc/systemd/system
+s6100/scripts/s6100_serial_getty_monitor etc/monit/conf.d
 common/fw-updater usr/local/bin
 common/onie_mode_set usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -52,6 +52,7 @@ if [[ "$1" == "init" ]]; then
     fi
 
     install_python_api_package
+    monit reload
 
 elif [[ "$1" == "deinit" ]]; then
     /usr/local/bin/s6100_i2c_enumeration.sh deinit

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_serial_getty_monitor
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_serial_getty_monitor
@@ -1,0 +1,4 @@
+#Dell S6100 serial getty monitor
+check process serial-getty matching "ttyS"
+start program = "/bin/systemctl start serial-getty@ttyS1.service"
+stop program = "/bin/systemctl stop serial-getty@ttyS1.service"


### PR DESCRIPTION
#### Why I did it
serial-getty service exited in Dell S6100 device randomly. 
#### How I did it
Added serial-getty to monit services.
#### How to verify it
Stop serial-getty in ssh session and check whether the service restarts or not.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
UT: 
[s6100_UT.txt](https://github.com/Azure/sonic-buildimage/files/6914543/s6100_UT.txt)


#### A picture of a cute animal (not mandatory but encouraged)

