### PR TITLE
[AS7726-32X] Support show system-health

### DIFF
--- a/device/accton/x86_64-accton_as7726_32x-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pmon_daemon_control.json
@@ -1,5 +1,6 @@
 {
     "skip_ledd": true,
-    "skip_thermalctld": true
+    "skip_pcied": true
 }
+
 

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/__init__.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/__init__.py
@@ -1,2 +1,2 @@
-__all__ = ['chassis', 'eeprom', 'platform', 'psu', 'sfp', 'thermal', 'fan']
+__all__ = [ "platform", "chassis", "sfp", "eeprom", "component", "psu", "thermal", "fan", "fan_drawer" ]
 from . import platform

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/chassis.py
@@ -27,6 +27,12 @@ PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
 HOST_CHK_CMD = "docker > /dev/null 2>&1"
+SYSLED_FNODE = "/sys/class/leds/accton_as7726_32x_led::diag/brightness"
+SYSLED_MODES = {
+    "0" :  "STATUS_LED_COLOR_OFF",
+    "1" : "STATUS_LED_COLOR_GREEN",
+    "3" : "STATUS_LED_COLOR_RED"
+}
 
 
 class Chassis(ChassisBase):
@@ -39,40 +45,40 @@ class Chassis(ChassisBase):
         self.is_host = self._api_helper.is_host()
         
         self.config_data = {}
-        
+
         self.__initialize_fan()
         self.__initialize_psu()
         self.__initialize_thermals()
         self.__initialize_components()
         self.__initialize_sfp()
         self.__initialize_eeprom()
-    
+
     def __initialize_sfp(self):
         from sonic_platform.sfp import Sfp
         for index in range(0, NUM_PORT):
             sfp = Sfp(index)
             self._sfp_list.append(sfp)
         self.sfp_module_initialized = True
-        
+
     def __initialize_fan(self):
-        from sonic_platform.fan import Fan
-        for fant_index in range(0, NUM_FAN_TRAY):
-            for fan_index in range(0, NUM_FAN):
-                fan = Fan(fant_index, fan_index)
-                self._fan_list.append(fan)
-                
+        from sonic_platform.fan_drawer import FanDrawer
+        for fant_index in range(NUM_FAN_TRAY):
+            fandrawer = FanDrawer(fant_index)
+            self._fan_drawer_list.append(fandrawer)
+            self._fan_list.extend(fandrawer._fan_list)
+
     def __initialize_psu(self):
         from sonic_platform.psu import Psu
         for index in range(0, NUM_PSU):
             psu = Psu(index)
             self._psu_list.append(psu)
-    
+
     def __initialize_thermals(self):
         from sonic_platform.thermal import Thermal
         for index in range(0, NUM_THERMAL):
             thermal = Thermal(index)
             self._thermal_list.append(thermal)
-    
+
     def __initialize_eeprom(self):
         from sonic_platform.eeprom import Tlv
         self._eeprom = Tlv()
@@ -142,7 +148,7 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.get_pn()
         
-    def get_serial_number(self):
+    def get_serial(self):
         """
         Retrieves the hardware serial number for the chassis
         Returns:
@@ -210,3 +216,40 @@ class Chassis(ChassisBase):
             sys.stderr.write("SFP index {} out of range (1-{})\n".format(
                              index, len(self._sfp_list)))
         return sfp
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+
+        
+    def initizalize_system_led(self):
+        return True
+
+    def get_status_led(self):
+        val = self._api_helper.read_txt_file(SYSLED_FNODE)
+        return SYSLED_MODES[val] if val in SYSLED_MODES else "UNKNOWN"
+
+    def set_status_led(self, color):
+        mode = None
+        for key, val in SYSLED_MODES.items():
+            if val == color:
+                mode = key
+                break
+        if mode is None:
+            return False
+        else:
+            return self._api_helper.write_txt_file(SYSLED_FNODE, mode)
+            

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/component.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/component.py
@@ -65,7 +65,7 @@ class Component(ComponentBase):
                 return bios_version.strip()
         except Exception as e:
             return None
-   
+
     def __get_cpld_version(self):
         # Retrieves the CPLD firmware version
         cpld_version = dict()
@@ -121,3 +121,55 @@ class Component(ComponentBase):
             A boolean, True if install successfully, False if not
         """
         raise NotImplementedError
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the device
+        Returns:
+            bool: True if device is present, False if not
+        """
+        return True
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        return 'N/A'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return 'N/A'
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the device
+        Returns:
+            A boolean value, True if device is operating properly, False if not
+        """
+        return True
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of
+        entPhysicalContainedIn is'0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device
+            or -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/eeprom.py
@@ -41,7 +41,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
                 _eeprom_info_dict[idx] = value
             except Exception:
                 pass
-               
+
         return _eeprom_info_dict
 
     def _load_eeprom(self):

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/fan.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/fan.py
@@ -13,10 +13,10 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 PSU_FAN_MAX_RPM = 25500
-
-CPLD_I2C_PATH = "/sys/bus/i2c/devices/54-0066/fan"
-PSU_HWMON_I2C_PATH ="/sys/bus/i2c/devices/{}-00{}/"
-PSU_I2C_MAPPING = {
+SPEED_TOLERANCE = 15
+CPLD_FAN_I2C_PATH = "/sys/bus/i2c/devices/54-0066/fan"
+I2C_PATH ="/sys/bus/i2c/devices/{}-00{}/"
+PSU_HWMON_I2C_MAPPING = {
     0: {
         "num": 50,
         "addr": "5b"
@@ -24,6 +24,17 @@ PSU_I2C_MAPPING = {
     1: {
         "num": 49,
         "addr": "58"
+    },
+}
+
+PSU_CPLD_I2C_MAPPING = {
+    0: {
+        "num": 50,
+        "addr": "53"
+    },
+    1: {
+        "num": 49,
+        "addr": "50"
     },
 }
 
@@ -39,12 +50,18 @@ class Fan(FanBase):
         self.fan_index = fan_index
         self.fan_tray_index = fan_tray_index
         self.is_psu_fan = is_psu_fan
-        
+
+
         if self.is_psu_fan:
             self.psu_index = psu_index
-            self.psu_i2c_num = PSU_I2C_MAPPING[self.psu_index]['num']
-            self.psu_i2c_addr = PSU_I2C_MAPPING[self.psu_index]['addr']
-            self.psu_hwmon_path = PSU_HWMON_I2C_PATH.format(
+            self.psu_i2c_num = PSU_HWMON_I2C_MAPPING[self.psu_index]['num']
+            self.psu_i2c_addr = PSU_HWMON_I2C_MAPPING[self.psu_index]['addr']
+            self.psu_hwmon_path = I2C_PATH.format(
+                self.psu_i2c_num, self.psu_i2c_addr)
+            
+            self.psu_i2c_num = PSU_CPLD_I2C_MAPPING[self.psu_index]['num']
+            self.psu_i2c_addr = PSU_CPLD_I2C_MAPPING[self.psu_index]['addr']
+            self.psu_cpld_path = I2C_PATH.format(
                 self.psu_i2c_num, self.psu_i2c_addr)
 
         FanBase.__init__(self)
@@ -57,11 +74,11 @@ class Fan(FanBase):
             depending on fan direction
         """
         if not self.is_psu_fan:
-            dir_str = "{}{}{}".format(CPLD_I2C_PATH, self.fan_tray_index+1, '_direction')
+            dir_str = "{}{}{}".format(CPLD_FAN_I2C_PATH, self.fan_tray_index+1, '_direction')
             val=self._api_helper.read_txt_file(dir_str)
             if val is not None: #F2B is FAN_DIRECTION_EXHAUST
                 direction = self.FAN_DIRECTION_EXHAUST if (
-                val == "0") else self.FAN_DIRECTION_INTAKE
+                val == "1") else self.FAN_DIRECTION_INTAKE
             else:
                 direction=self.FAN_DIRECTION_EXHAUST
 
@@ -84,7 +101,7 @@ class Fan(FanBase):
         Returns:
             An integer, the percentage of full fan speed, in the range 0 (off)
                  to 100 (full speed)
-                         
+
         """
         speed = 0
         if self.is_psu_fan:
@@ -97,12 +114,12 @@ class Fan(FanBase):
             else:
                 return 0
         elif self.get_presence():            
-            speed_path = "{}{}".format(CPLD_I2C_PATH, '_duty_cycle_percentage')
+            speed_path = "{}{}".format(CPLD_FAN_I2C_PATH, '_duty_cycle_percentage')
             speed=self._api_helper.read_txt_file(speed_path)
             if speed is None:
                 return 0
         return int(speed)
-            
+
     def get_target_speed(self):
         """
         Retrieves the target (expected) speed of the fan
@@ -116,7 +133,7 @@ class Fan(FanBase):
             0   : when PWM mode is use
             pwm : when pwm mode is not use
         """
-        return False #Not supported
+        return self.get_speed()
 
     def get_speed_tolerance(self):
         """
@@ -125,7 +142,7 @@ class Fan(FanBase):
             An integer, the percentage of variance from target speed which is
                  considered tolerable
         """
-        return False #Not supported
+        return SPEED_TOLERANCE
 
     def set_speed(self, speed):
         """
@@ -139,7 +156,7 @@ class Fan(FanBase):
         """
         
         if not self.is_psu_fan and self.get_presence():            
-            speed_path = "{}{}".format(CPLD_I2C_PATH, '_duty_cycle_percentage')
+            speed_path = "{}{}".format(CPLD_FAN_I2C_PATH, '_duty_cycle_percentage')
             return self._api_helper.write_txt_file(speed_path, int(speed))
 
         return False
@@ -181,7 +198,7 @@ class Fan(FanBase):
             else "PSU-{} FAN-{}".format(self.psu_index+1, self.fan_index+1)
 
         return fan_name
-            
+
     def get_presence(self):
         """
         Retrieves the presence of the FAN
@@ -189,7 +206,7 @@ class Fan(FanBase):
             bool: True if FAN is present, False if not
         """
         if not self.is_psu_fan:
-            present_path = "{}{}{}".format(CPLD_I2C_PATH, self.fan_index+1, '_present')
+            present_path = "{}{}{}".format(CPLD_FAN_I2C_PATH, self.fan_tray_index+1, '_present')
             val=self._api_helper.read_txt_file(present_path)
             if val is not None:
                 return int(val, 10)==1
@@ -212,7 +229,7 @@ class Fan(FanBase):
             else:
                 return False
         else:    
-            path = "{}{}{}".format(CPLD_I2C_PATH, self.fan_index+1, '_fault')
+            path = "{}{}{}".format(CPLD_FAN_I2C_PATH, self.fan_tray_index+1, '_fault')
             val=self._api_helper.read_txt_file(path)
             if val is not None:
                 return int(val, 10)==0
@@ -236,3 +253,25 @@ class Fan(FanBase):
             string: Serial number of device
         """
         return "N/A"
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of
+        entPhysicalContainedIn is'0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device
+            or -1 if cannot determine the position
+        """
+        return (self.fan_tray_index+1) \
+            if not self.is_psu_fan else (self.psu_index+1)
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True if not self.is_psu_fan else False
+

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/fan_drawer.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/fan_drawer.py
@@ -1,0 +1,90 @@
+########################################################################
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the Fan-Drawers' information available in the platform.
+#
+########################################################################
+
+try:
+    from sonic_platform_base.fan_drawer_base import FanDrawerBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+FANS_PER_FANTRAY = 2
+
+
+class FanDrawer(FanDrawerBase):
+    """Platform-specific Fan class"""
+
+    def __init__(self, fantray_index):
+
+        FanDrawerBase.__init__(self)
+        # FanTray is 0-based in platforms
+        self.fantrayindex = fantray_index
+        self.__initialize_fan_drawer()
+        
+
+    def __initialize_fan_drawer(self):
+        from sonic_platform.fan import Fan
+        for i in range(FANS_PER_FANTRAY):
+            self._fan_list.append(Fan(self.fantrayindex, i))
+
+    def get_name(self):
+        """
+        Retrieves the fan drawer name
+        Returns:
+            string: The name of the device
+        """
+        return "FanTray{}".format(self.fantrayindex+1)
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the device
+        Returns:
+            bool: True if device is present, False if not
+        """
+        return self._fan_list[0].get_presence()
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        return self._fan_list[0].get_model()
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return self._fan_list[0].get_serial()
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the device
+        Returns:
+            A boolean value, True if device is operating properly, False if not
+        """
+        return self._fan_list[0].get_status()
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of
+        entPhysicalContainedIn is'0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device
+            or -1 if cannot determine the position
+        """
+        return (self.fantrayindex+1)
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/helper.py
@@ -51,7 +51,7 @@ class APIHelper():
 
     def read_txt_file(self, file_path):
         try:
-            with open(file_path, 'r') as fd:
+            with open(file_path, 'r', errors='replace') as fd:
                 data = fd.read()
                 return data.strip()
         except IOError:

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/psu.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/psu.py
@@ -11,6 +11,7 @@ import logging
 
 try:
     from sonic_platform_base.psu_base import PsuBase
+    from sonic_platform.thermal import Thermal
     from .helper import APIHelper
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -67,6 +68,8 @@ class Psu(PsuBase):
         for fan_index in range(0, PSU_NUM_FAN[self.index]):
             fan = Fan(fan_index, 0, is_psu_fan=True, psu_index=self.index)
             self._fan_list.append(fan)
+        
+        self._thermal_list.append(Thermal(is_psu=True, psu_index=self.index))
 
     def get_voltage(self):
         """
@@ -127,7 +130,7 @@ class Psu(PsuBase):
         Returns:
             bool: True if status LED state is set successfully, False if not
         """
-        
+
         return False  #Controlled by HW
 
     def get_status_led(self):
@@ -255,3 +258,20 @@ class Psu(PsuBase):
         if serial is None:
             return "N/A"
         return serial
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
+        """
+        return self.index+1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/sfp.py
@@ -1108,7 +1108,8 @@ class Sfp(SfpBase):
                 fd.seek(QSFP_POWEROVERRIDE_OFFSET)
                 fd.write(buffer[0])
                 time.sleep(0.01)
-        except Exception:
+
+        except IOError as e:
             print ('Error: unable to open file: ', str(e))
             return False
 
@@ -1164,3 +1165,20 @@ class Sfp(SfpBase):
             A boolean value, True if device is operating properly, False if not
         """
         return self.get_presence() and self.get_transceiver_bulk_status()
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
+        """
+        return self.port_num
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return True

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/thermal.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/thermal.py
@@ -15,21 +15,54 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+PSU_I2C_PATH = "/sys/bus/i2c/devices/{}-00{}/"
+
+PSU_HWMON_I2C_MAPPING = {
+    0: {
+        "num": 50,
+        "addr": "5b"
+    },
+    1: {
+        "num": 49,
+        "addr": "58"
+    },
+}
+
+PSU_CPLD_I2C_MAPPING = {
+    0: {
+        "num": 50,
+        "addr": "53"
+    },
+    1: {
+        "num": 49,
+        "addr": "50"
+    },
+}
+
+THERMAL_NAME_LIST = ["Temp sensor 1", "Temp sensor 2", "Temp sensor 3", 
+                     "Temp sensor 4", "Temp sensor 5"]
+                     
+PSU_THERMAL_NAME_LIST = ["PSU-1 temp sensor 1", "PSU-2 temp sensor 2"]
+
+SYSFS_PATH = "/sys/bus/i2c/devices"
 
 class Thermal(ThermalBase):
     """Platform-specific Thermal class"""
 
-    THERMAL_NAME_LIST = []
-    SYSFS_PATH = "/sys/bus/i2c/devices"
-
-    def __init__(self, thermal_index=0):
+    def __init__(self, thermal_index=0, is_psu=False, psu_index=0):
         self.index = thermal_index
-        # Add thermal name
-        self.THERMAL_NAME_LIST.append("Temp sensor 1")
-        self.THERMAL_NAME_LIST.append("Temp sensor 2")
-        self.THERMAL_NAME_LIST.append("Temp sensor 3")
-        self.THERMAL_NAME_LIST.append("Temp sensor 4")
-        self.THERMAL_NAME_LIST.append("Temp sensor 5")
+        self.is_psu = is_psu
+        self.psu_index = psu_index
+
+        if self.is_psu:
+            psu_i2c_bus = PSU_HWMON_I2C_MAPPING[psu_index]["num"]
+            psu_i2c_addr = PSU_HWMON_I2C_MAPPING[psu_index]["addr"]
+            self.psu_hwmon_path = PSU_I2C_PATH.format(psu_i2c_bus,
+                                                      psu_i2c_addr)
+            psu_i2c_bus = PSU_CPLD_I2C_MAPPING[psu_index]["num"]
+            psu_i2c_addr = PSU_CPLD_I2C_MAPPING[psu_index]["addr"]
+            self.cpld_path = PSU_I2C_PATH.format(psu_i2c_bus, psu_i2c_addr)
+       
 
         # Set hwmon path
         i2c_path = {
@@ -39,9 +72,9 @@ class Thermal(ThermalBase):
             3: "55-004b/hwmon/hwmon*/",
             4: "54-004c/hwmon/hwmon*/"
         }.get(self.index, None)
-          
-        self.hwmon_path = "{}/{}".format(self.SYSFS_PATH, i2c_path)
-        self.ss_key = self.THERMAL_NAME_LIST[self.index]
+
+        self.hwmon_path = "{}/{}".format(SYSFS_PATH, i2c_path)
+        self.ss_key = THERMAL_NAME_LIST[self.index]
         self.ss_index = 1
 
     def __read_txt_file(self, file_path):
@@ -56,7 +89,10 @@ class Thermal(ThermalBase):
         return None
         
     def __get_temp(self, temp_file):
-        temp_file_path = os.path.join(self.hwmon_path, temp_file)
+        if not self.is_psu:
+            temp_file_path = os.path.join(self.hwmon_path, temp_file)
+        else:
+            temp_file_path = temp_file
         raw_temp = self.__read_txt_file(temp_file_path)
         if raw_temp is not None:
             return float(raw_temp)/1000
@@ -64,6 +100,8 @@ class Thermal(ThermalBase):
             return 0        
 
     def __set_threshold(self, file_name, temperature):
+        if self.is_psu:
+            return True
         temp_file_path = os.path.join(self.hwmon_path, file_name)
         for filename in glob.glob(temp_file_path):
             try:
@@ -72,6 +110,7 @@ class Thermal(ThermalBase):
                 return True
             except IOError as e:
                 print("IOError")
+                return False
 
 
     def get_temperature(self):
@@ -81,7 +120,10 @@ class Thermal(ThermalBase):
             A float number of current temperature in Celsius up to nearest thousandth
             of one degree Celsius, e.g. 30.125
         """
-        temp_file = "temp{}_input".format(self.ss_index)
+        if not self.is_psu:
+            temp_file = "temp{}_input".format(self.ss_index)
+        else:
+            temp_file = self.psu_hwmon_path + "psu_temp1_input"
         return self.__get_temp(temp_file)
 
     def get_high_threshold(self):
@@ -91,6 +133,9 @@ class Thermal(ThermalBase):
             A float number, the high threshold temperature of thermal in Celsius
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
+        if self.is_psu:
+            return 80
+
         temp_file = "temp{}_max".format(self.ss_index)
         return self.__get_temp(temp_file)
 
@@ -115,7 +160,10 @@ class Thermal(ThermalBase):
             Returns:
             string: The name of the thermal device
         """
-        return self.THERMAL_NAME_LIST[self.index]
+        if self.is_psu:
+            return PSU_THERMAL_NAME_LIST[self.psu_index]
+        else:
+            return THERMAL_NAME_LIST[self.index]
 
     def get_presence(self):
         """
@@ -123,6 +171,9 @@ class Thermal(ThermalBase):
         Returns:
             bool: True if Thermal is present, False if not
         """
+        if self.is_psu:
+            val = self.__read_txt_file(self.cpld_path + "psu_present")
+            return int(val, 10) == 1
         temp_file = "temp{}_input".format(self.ss_index)
         temp_file_path = os.path.join(self.hwmon_path, temp_file)
         raw_txt = self.__read_txt_file(temp_file_path)
@@ -143,5 +194,39 @@ class Thermal(ThermalBase):
         raw_txt = self.__read_txt_file(file_path)
         if raw_txt is None:
             return False
-        else:     
+        else:
             return int(raw_txt) != 0
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+
+        return "N/A"
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return "N/A"
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Retrieves whether thermal module is replaceable
+        Returns:
+            A boolean value, True if replaceable, False if not
+        """
+        return False

--- a/device/accton/x86_64-accton_as7726_32x-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/system_health_monitoring_config.json
@@ -1,0 +1,15 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic",
+	    "psu.temperature"
+	    
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "STATUS_LED_COLOR_RED",
+        "normal": "STATUS_LED_COLOR_GREEN",
+        "booting": "STATUS_LED_COLOR_GREEN"
+    }
+}

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (C) 2016 Accton Networks, Inc.
 #
@@ -17,7 +17,6 @@
 
 """
 Usage: %(scriptName)s [options] command object
-
 options:
     -h | --help     : this help message
     -d | --debug    : run with debug mode
@@ -26,8 +25,7 @@ command:
     install     : install drivers and generate related sysfs nodes
     clean       : uninstall drivers and remove related sysfs nodes
 """
-
-import commands
+import subprocess
 import getopt
 import sys
 import logging
@@ -41,34 +39,9 @@ verbose = False
 DEBUG = False
 args = []
 ALL_DEVICE = {}
-DEVICE_NO = {'led':5, 'fan1':1, 'fan2':1,'fan3':1,'fan4':1,'fan5':1,'thermal':3, 'psu':2, 'sfp':54}
-
-
-led_prefix ='/sys/devices/platform/as7716_32x_led/leds/accton_'+PROJECT_NAME+'_led::'
-fan_prefix ='/sys/devices/platform/as7716_32x_'
-hwmon_types = {'led': ['diag','fan','loc','psu1','psu2'],
-               'fan1': ['fan'],
-               'fan2': ['fan'],
-               'fan3': ['fan'],
-               'fan4': ['fan'],
-               'fan5': ['fan'],
-              }
-hwmon_nodes = {'led': ['brightness'] ,
-               'fan1': ['fan_duty_cycle_percentage', 'fan1_fault', 'fan1_speed_rpm', 'fan1_direction', 'fanr1_fault', 'fanr1_speed_rpm'],
-               'fan2': ['fan_duty_cycle_percentage','fan2_fault', 'fan2_speed_rpm', 'fan2_direction', 'fanr2_fault', 'fanr2_speed_rpm'],
-               'fan3': ['fan_duty_cycle_percentage','fan3_fault', 'fan3_speed_rpm', 'fan3_direction', 'fanr3_fault', 'fanr3_speed_rpm'],
-               'fan4': ['fan4_duty_cycle_percentage','fan4_fault', 'fan4_speed_rpm', 'fan4_direction', 'fanr4_fault', 'fanr4_speed_rpm'],
-               'fan5': ['fan_duty_cycle_percentage','fan5_fault', 'fan5_speed_rpm', 'fan5_direction', 'fanr5_fault', 'fanr5_speed_rpm'],
-	      }
-hwmon_prefix ={'led': led_prefix,
-               'fan1': fan_prefix,
-               'fan2': fan_prefix,
-               'fan3': fan_prefix,
-               'fan4': fan_prefix,
-               'fan5': fan_prefix,
-              }
 
 i2c_prefix = '/sys/bus/i2c/devices/'
+'''
 i2c_bus = {'fan': ['54-0066'],
            'thermal': ['54-004c', '55-0048','55-0049', '55-004a', '55-004b'] ,
            'psu': ['49-0050','50-0053'],
@@ -77,7 +50,7 @@ i2c_nodes = {'fan': ['present', 'front_speed_rpm', 'rear_speed_rpm'],
            'thermal': ['hwmon/hwmon*/temp1_input'] ,
            'psu': ['psu_present ', 'psu_power_good']    ,
            'sfp': ['module_present_ ', 'module_tx_disable_']}
-
+'''
 sfp_map = [21, 22, 23, 24, 26, 25, 28, 27,
              17, 18, 19, 20, 29, 30, 31, 32,
              33, 34, 35, 36, 45, 46, 47, 48,
@@ -127,8 +100,8 @@ logging.basicConfig(level=logging.INFO)
 
 
 if DEBUG == True:
-    print sys.argv[0]
-    print 'ARGV      :', sys.argv[1:]
+    print(sys.argv[0])
+    print('ARGV      :', sys.argv[1:])
 
 
 def main():
@@ -144,9 +117,9 @@ def main():
                                                        'force',
                                                           ])
     if DEBUG == True:
-        print options
-        print args
-        print len(sys.argv)
+        print(options)
+        print(args)
+        print(len(sys.argv))
 
     for opt, arg in options:
         if opt in ('-h', '--help'):
@@ -167,22 +140,6 @@ def main():
            do_sonic_platform_install()
         elif arg == 'api_clean':   
            do_sonic_platform_clean()
-        elif arg == 'show':
-           device_traversal()
-        elif arg == 'sff':
-            if len(args)!=2:
-                show_eeprom_help()
-            elif int(args[1]) ==0 or int(args[1]) > DEVICE_NO['sfp']:
-                show_eeprom_help()
-            else:
-                show_eeprom(args[1])
-            return
-        elif arg == 'set':
-            if len(args)<3:
-                show_set_help()
-            else:
-                set_device(args[1:])
-            return
         else:
             show_help()
 
@@ -190,33 +147,20 @@ def main():
     return 0
 
 def show_help():
-    print __doc__ % {'scriptName' : sys.argv[0].split("/")[-1]}
-    sys.exit(0)
-
-def  show_set_help():
-    cmd =  sys.argv[0].split("/")[-1]+ " "  + args[0]
-    print  cmd +" [led|sfp|fan]"
-    print  "    use \""+ cmd + " led 0-4 \"  to set led color"
-    print  "    use \""+ cmd + " fan 0-100\" to set fan duty percetage"
-    print  "    use \""+ cmd + " sfp 1-32 {0|1}\" to set sfp# tx_disable"
-    sys.exit(0)
-
-def  show_eeprom_help():
-    cmd =  sys.argv[0].split("/")[-1]+ " "  + args[0]
-    print  "    use \""+ cmd + " 1-32 \" to dump sfp# eeprom"
+    print(__doc__ % {'scriptName' : sys.argv[0].split("/")[-1]})
     sys.exit(0)
 
 def dis_i2c_ir3570a(addr):
     cmd = "i2cset -y 0 0x%x 0xE5 0x01" % addr
-    status, output = commands.getstatusoutput(cmd)
+    status, output = subprocess.getstatusoutput(cmd)
     cmd = "i2cset -y 0 0x%x 0x12 0x02" % addr
-    status, output = commands.getstatusoutput(cmd)
+    status, output = subprocess.getstatusoutput(cmd)
     return status
 
 def ir3570_check():
     cmd = "i2cdump -y 0 0x42 s 0x9a"
     try:
-        status, output = commands.getstatusoutput(cmd)
+        status, output = subprocess.getstatusoutput(cmd)
         lines = output.split('\n')
         hn = re.findall(r'\w+', lines[-1])
         version = int(hn[1], 16)
@@ -225,21 +169,21 @@ def ir3570_check():
         else:
             ret = 0
     except Exception as e:
-        print "Error on ir3570_check() e:" + str(e)
+        print("Error on ir3570_check() e:" + str(e))
         return -1
     return ret
 
 
 def my_log(txt):
     if DEBUG == True:
-        print "[ACCTON DBG]: "+txt
+        print("[ACCTON DBG]: "+txt)
     return
 
 def log_os_system(cmd, show):
     logging.info('Run :'+cmd)
     status = 1
     output = ""
-    status, output = commands.getstatusoutput(cmd)
+    status, output = subprocess.getstatusoutput(cmd)
     my_log (cmd +"with result:" + str(status))
     my_log ("cmd:" + cmd)
     my_log ("      output:"+output)
@@ -289,6 +233,9 @@ def driver_install():
                 return status
     
     #status=cpld_reset_mac()
+    
+    print("Done driver_install")
+
     return 0
 
 def driver_uninstall():
@@ -296,7 +243,6 @@ def driver_uninstall():
     for i in range(0,len(kos)):
         rm = kos[-(i+1)].replace("modprobe", "modprobe -rq")        
         lst = rm.split(" ")
-        print "lst=%s"%lst
         if len(lst) > 3:
             del(lst[3])
         rm = " ".join(lst)
@@ -316,21 +262,22 @@ def device_install():
         
         status, output = log_os_system(mknod[i], 1)        
         if status:
-            print output
+            print(output)
             if FORCE == 0:
                 return status
     
     for i in range(0,len(sfp_map)):
         status, output =log_os_system("echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/new_device", 1)
         if status:
-            print output
+            print(output)
             if FORCE == 0:
                 return status
         status, output =log_os_system("echo port"+str(i)+" > /sys/bus/i2c/devices/"+str(sfp_map[i])+"-0050/port_name", 1)
         if status:
-            print output
+            print(output)
             if FORCE == 0:
                 return status
+    print("Done device_install")
     return
 
 def device_uninstall():
@@ -346,7 +293,7 @@ def device_uninstall():
         target = "/sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/delete_device"
         status, output =log_os_system("echo 0x50 > "+ target, 1)
         if status:
-            print output
+            print(output)
             if FORCE == 0:
                 return status
                 
@@ -359,7 +306,7 @@ def device_uninstall():
         temp[-1] = temp[-1].replace('new_device', 'delete_device')
         status, output = log_os_system(" ".join(temp), 1)
         if status:
-            print output
+            print(output)
             if FORCE == 0:
                 return status
 
@@ -369,7 +316,7 @@ def system_ready():
     if driver_inserted() == False:        
         return False
     if not device_exist():
-        print "not device_exist()"
+        print("not device_exist()")
         return False
     return True
 
@@ -385,10 +332,10 @@ def do_sonic_platform_install():
         if os.path.exists(SONIC_PLATFORM_BSP_WHL_PKG_PY3): 
             status, output = log_os_system("pip3 install "+ SONIC_PLATFORM_BSP_WHL_PKG_PY3, 1)
             if status:
-                print "Error: Failed to install {}".format(PLATFORM_API2_WHL_FILE_PY3)
+                print("Error: Failed to install {}".format(PLATFORM_API2_WHL_FILE_PY3))
                 return status
             else:
-                print "Successfully installed {} package".format(PLATFORM_API2_WHL_FILE_PY3)
+                print("Successfully installed {} package".format(PLATFORM_API2_WHL_FILE_PY3))
         else:
             print('{} is not found'.format(PLATFORM_API2_WHL_FILE_PY3))
     else:        
@@ -417,7 +364,7 @@ def do_install():
             if FORCE == 0:
                 return  status
     else:
-        print PROJECT_NAME.upper()+" drivers detected...."
+        print(PROJECT_NAME.upper()+" drivers detected....")
 
     ir3570_check()
 
@@ -427,7 +374,7 @@ def do_install():
             if FORCE == 0:
                 return  status
     else:
-        print PROJECT_NAME.upper()+" devices detected...."
+        print(PROJECT_NAME.upper()+" devices detected....")
 
     do_sonic_platform_install()
 
@@ -435,18 +382,18 @@ def do_install():
 
 def do_uninstall():
     if not device_exist():
-        print PROJECT_NAME.upper() +" has no device installed...."
+        print(PROJECT_NAME.upper() +" has no device installed....")
     else:
-        print "Removing device...."
+        print("Removing device....")
         status = device_uninstall()
         if status:
             if FORCE == 0:
                 return  status
 
     if driver_inserted()== False :
-        print PROJECT_NAME.upper() +" has no driver installed...."
+        print(PROJECT_NAME.upper() +" has no driver installed....")
     else:
-        print "Removing installed driver...."
+        print("Removing installed driver....")
         status = driver_uninstall()
         if status:
             if FORCE == 0:
@@ -454,184 +401,6 @@ def do_uninstall():
 
     do_sonic_platform_clean() 
 
-    return
-
-def devices_info():
-    global DEVICE_NO
-    global ALL_DEVICE
-    global i2c_bus, hwmon_types
-    for key in DEVICE_NO:
-        ALL_DEVICE[key]= {}
-        for i in range(0,DEVICE_NO[key]):
-            ALL_DEVICE[key][key+str(i+1)] = []
-
-    for key in i2c_bus:
-        buses = i2c_bus[key]
-        nodes = i2c_nodes[key]
-        for i in range(0,len(buses)):
-            for j in range(0,len(nodes)):
-                if  'fan' == key:
-                    for k in range(0,DEVICE_NO[key]):
-                        node = key+str(k+1)
-                        path = i2c_prefix+ buses[i]+"/fan"+str(k+1)+"_"+ nodes[j]
-                        my_log(node+": "+ path)
-                        ALL_DEVICE[key][node].append(path)
-                elif  'sfp' == key:
-                    for k in range(0,DEVICE_NO[key]):
-                        node = key+str(k+1)
-                        path = i2c_prefix+ str(sfp_map[k])+ buses[i]+"/"+ nodes[j]
-                        my_log(node+": "+ path)
-                        ALL_DEVICE[key][node].append(path)
-                else:
-                    node = key+str(i+1)
-                    path = i2c_prefix+ buses[i]+"/"+ nodes[j]
-                    my_log(node+": "+ path)
-                    ALL_DEVICE[key][node].append(path)
-
-    for key in hwmon_types:
-        itypes = hwmon_types[key]
-        nodes = hwmon_nodes[key]
-        for i in range(0,len(itypes)):
-            for j in range(0,len(nodes)):
-                node = key+"_"+itypes[i]
-                path = hwmon_prefix[key]+ itypes[i]+"/"+ nodes[j]
-                my_log(node+": "+ path)
-                ALL_DEVICE[key][ key+str(i+1)].append(path)
-
-    #show dict all in the order
-    if DEBUG == True:
-        for i in sorted(ALL_DEVICE.keys()):
-            print(i+": ")
-            for j in sorted(ALL_DEVICE[i].keys()):
-                print("   "+j)
-                for k in (ALL_DEVICE[i][j]):
-                    print("   "+"   "+k)
-    return
-
-def show_eeprom(index):
-    if system_ready()==False:
-        print("System's not ready.")
-        print("Please install first!")
-        return
-
-    if len(ALL_DEVICE)==0:
-        devices_info()
-    node = ALL_DEVICE['sfp'] ['sfp'+str(index)][0]
-    node = node.replace(node.split("/")[-1], 'eeprom')
-    # check if got hexdump command in current environment
-    ret, log = log_os_system("which hexdump", 0)
-    ret, log2 = log_os_system("which busybox hexdump", 0)
-    if len(log):
-        hex_cmd = 'hexdump'
-    elif len(log2):
-        hex_cmd = ' busybox hexdump'
-    else:
-        log = 'Failed : no hexdump cmd!!'
-        logging.info(log)
-        print log
-        return 1
-    print "node=%s"%node
-    print node + ":"
-    ret, log = log_os_system("cat "+node+"| "+hex_cmd+" -C", 1)
-    if ret==0:
-        print  log
-    else:
-        print "**********device no found**********"
-    return
-
-def set_device(args):
-    global DEVICE_NO
-    global ALL_DEVICE
-    if system_ready()==False:
-        print("System's not ready.")
-        print("Please install first!")
-        return
-
-    if len(ALL_DEVICE)==0:
-        devices_info()
-
-    if args[0]=='led':
-        if int(args[1])>4:
-            show_set_help()
-            return
-        #print  ALL_DEVICE['led']
-        for i in range(0,len(ALL_DEVICE['led'])):
-            for k in (ALL_DEVICE['led']['led'+str(i+1)]):
-                ret, log = log_os_system("echo "+args[1]+" >"+k, 1)
-                if ret:
-                    return ret
-    elif args[0]=='fan':
-        if int(args[1])>100:
-            show_set_help()
-            return
-        #print  ALL_DEVICE['fan']
-        #fan1~6 is all fine, all fan share same setting
-        node = ALL_DEVICE['fan1'] ['fan11'][0]
-        node = node.replace(node.split("/")[-1], 'fan1_duty_cycle_percentage')
-        ret, log = log_os_system("cat "+ node, 1)
-        if ret==0:
-            print ("Previous fan duty: " + log.strip() +"%")
-        ret, log = log_os_system("echo "+args[1]+" >"+node, 1)
-        if ret==0:
-            print ("Current fan duty: " + args[1] +"%")
-        return ret
-    elif args[0]=='sfp':
-        if int(args[1])> DEVICE_NO[args[0]] or int(args[1])==0:
-            show_set_help()
-            return
-        if len(args)<2:
-            show_set_help()
-            return
-
-        if int(args[2])>1:
-            show_set_help()
-            return
-
-        #print  ALL_DEVICE[args[0]]
-        for i in range(0,len(ALL_DEVICE[args[0]])):
-            for j in ALL_DEVICE[args[0]][args[0]+str(args[1])]:
-                if j.find('tx_disable')!= -1:
-                    ret, log = log_os_system("echo "+args[2]+" >"+ j, 1)
-                    if ret:
-                        return ret
-
-    return
-
-#get digits inside a string.
-#Ex: 31 for "sfp31"
-def get_value(input):
-    digit = re.findall('\d+', input)
-    return int(digit[0])
-
-def device_traversal():
-    if system_ready()==False:
-        print("System's not ready.")
-        print("Please install first!")
-        return
-
-    if len(ALL_DEVICE)==0:
-        devices_info()
-    for i in sorted(ALL_DEVICE.keys()):
-        print("============================================")
-        print(i.upper()+": ")
-        print("============================================")
-
-        for j in sorted(ALL_DEVICE[i].keys(), key=get_value):
-            print "   "+j+":",
-            for k in (ALL_DEVICE[i][j]):
-                ret, log = log_os_system("cat "+k, 0)
-                func = k.split("/")[-1].strip()
-                func = re.sub(j+'_','',func,1)
-                func = re.sub(i.lower()+'_','',func,1)
-                if ret==0:
-                    print func+"="+log+" ",
-                else:
-                    print func+"="+"X"+" ",
-            print
-            print("----------------------------------------------------------------")
-
-
-        print
     return
 
 def device_exist():


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add to support show system-health
#### How I did it
Add needed code and file.
#### How to verify it
Test show system-health
root@sonic:/home/admin# show system-health detail
System status summary

  System status LED  STATUS_LED_COLOR_RED
  Services:
    Status: OK
  Hardware:
    Status: Not OK
    Reasons: PSU 1 is out of power
             container_checker is not Status ok

System services and devices monitor list

Name                      Status    Type
------------------------  --------  ----------
container_checker         Not OK    Program
sonic                     OK        System
rsyslog                   OK        Process
root-overlay              OK        Filesystem
var-log                   OK        Filesystem
routeCheck                OK        Program
telemetry|telemetry       OK        Program
telemetry|dialout_client  OK        Program
teamd|teamsyncd           OK        Program
teamd|teammgrd            OK        Program
syncd|syncd               OK        Program
syncd|dsserve             OK        Program
swss|orchagent            OK        Program
swss|portsyncd            OK        Program
swss|neighsyncd           OK        Program
swss|fdbsyncd             OK        Program
swss|vrfmgrd              OK        Program
swss|vlanmgrd             OK        Program
swss|intfmgrd             OK        Program
swss|portmgrd             OK        Program
swss|buffermgrd           OK        Program
swss|nbrmgrd              OK        Program
swss|vxlanmgrd            OK        Program
swss|coppmgrd             OK        Program
swss|tunnelmgrd           OK        Program
snmp|snmpd                OK        Program
snmp|snmp_subagent        OK        Program
sflow|sflowmgrd           OK        Program
lldp|lldpd_monitor        OK        Program
lldp|lldp_syncd           OK        Program
lldp|lldpmgrd             OK        Program
database|redis_server     OK        Program
bgp|zebra                 OK        Program
bgp|fpmsyncd              OK        Program
bgp|bgpd                  OK        Program
bgp|staticd               OK        Program
bgp|bgpcfgd               OK        Program
bgp|bgpmon                OK        Program
PSU 1                     Not OK    PSU
FAN-1F                    OK        Fan
FAN-1R                    OK        Fan
FAN-2F                    OK        Fan
FAN-2R                    OK        Fan
FAN-3F                    OK        Fan
FAN-3R                    OK        Fan
FAN-4F                    OK        Fan
FAN-4R                    OK        Fan
FAN-5F                    OK        Fan
FAN-5R                    OK        Fan
FAN-6F                    OK        Fan
FAN-6R                    OK        Fan
PSU-1 FAN-1               OK        Fan
PSU-2 FAN-1               OK        Fan
PSU 2                     OK        PSU

System services and devices ignore list

Name             Status    Type
---------------  --------  ------
asic             Ignored   Device
psu.temperature  Ignored   Device

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

