### PR TITLE
[Mellanox][Pcie] Fix issue on pcied with an id that contains only decimal digits was treated as a decimal number

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/pcie.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/pcie.py
@@ -26,7 +26,7 @@ class Pcie(PcieUtil):
             id_conf = item_conf["id"]
             dev_conf = item_conf["dev"]
             fn_conf = item_conf["fn"]
-            bus_conf = self._device_id_to_bus_map.get(id_conf)
+            bus_conf = self._device_id_to_bus_map.get(str(id_conf))
             if bus_conf and self.check_pcie_sysfs(bus=int(bus_conf, base=16), device=int(dev_conf, base=16),
                                                   func=int(fn_conf, base=16)):
                 item_conf["result"] = "Passed"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
A device that contains only decimal digits was mistreated as a decimal integer resulting in failure to find it in the id to bus map.

#### How I did it
Made sure id from the yaml file was treated as a string

#### How to verify it
Open log on 4600, make sure no error appear.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012
- [X] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

