### PR TITLE
Fixed changelog file - 1 space at start of line, 2 spaces before day

### DIFF
--- a/src/systemd-sonic-generator/debian/changelog
+++ b/src/systemd-sonic-generator/debian/changelog
@@ -1,3 +1,3 @@
 systemd-sonic-generator (1.0.0) UNRELEASED; urgency=medium
     * Initial version
-    -- Lawrence Lee <t-lale@microsoft.com> Tue, 23 Jul 2019 16:00:00 -0800
+ -- Lawrence Lee <t-lale@microsoft.com>  Tue, 23 Jul 2019 16:00:00 -0800


### PR DESCRIPTION
Signed-off-by: Raphael Tryster <raphaelt@nvidia.com>

#### Why I did it

Malformed changelog file causes build to fail when SONIC_PROFILING_ON = y.

#### How I did it

Changed the number and position of spaces in the file.

#### How to verify it

In rules/config, uncomment the line: SONIC_PROFILING_ON = y
make configure PLATFORM=mellanox
make target/sonic-mellanox.bin-clean
make target/sonic-mellanox.bin

Expect NOT to see warnings or errors relating to debian/changelog, such as
dpkg-genchanges: warning: debian/changelog(l3): found end of file where expected more change data or trailer

However, the build may still fail as long as Azure#8316 is not fixed, due to another issue.

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog

Fixed changelog format.

#### A picture of a cute animal (not mandatory but encouraged)

