### PR TITLE
Support Grouping translation in YANG Models.

### DIFF
--- a/src/sonic-yang-mgmt/setup.py
+++ b/src/sonic-yang-mgmt/setup.py
@@ -26,12 +26,14 @@ setup(
     long_description=readme + '\n\n',
     install_requires = [
         'xmltodict==0.12.0',
-        'ijson==2.6.1'
+        'ijson==2.6.1',
+        'jsondiff>=1.2.0',
     ],
     tests_require = [
         'pytest>3',
         'xmltodict==0.12.0',
-        'ijson==2.6.1'
+        'ijson==2.6.1',
+        'jsondiff>=1.2.0'
     ],
     setup_requires = [
         'pytest-runner',

--- a/src/sonic-yang-mgmt/sonic_yang.py
+++ b/src/sonic-yang-mgmt/sonic_yang.py
@@ -36,6 +36,9 @@ class SonicYang(SonicYangExtMixin):
         self.revXlateJson = dict()
         # below dict store the input config tables which have no YANG models
         self.tablesWithOutYang = dict()
+        # below dict will store preProcessed yang objects, which may be needed by
+        # all yang modules, such as grouping.
+        self.preProcessedYang = dict()
 
         try:
             self.ctx = ly.Context(yang_dir)

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
@@ -341,10 +341,8 @@ class Test_SonicYang(object):
         else:
             print("Xlate and Rev Xlate failed")
             # print for better debugging, in case of failure.
-            print("syc.jIn: {}".format({t:syc.jIn[t].keys() \
-                for t in syc.jIn.keys()}))
-            print("syc.revXlateJson: {}".format({t:syc.revXlateJson[t].keys() \
-                for t in syc.revXlateJson.keys()}))
+            from jsondiff import diff
+            print(diff(syc.jIn, syc.revXlateJson, syntax='symmetric'))
             # make it fail
             assert False == True
 

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -911,7 +911,7 @@
 
         "AAA": {
             "authentication": {
-                "login": "local" 
+                "login": "local"
             }
         },
         "TACPLUS": {
@@ -993,6 +993,10 @@
                 "rrclient":"0"
             },
             "default|192.168.1.1": {
+                "local_asn": "65200",
+                "asn": "65100",
+                "name": "bgp peer 65100",
+                "ebgp_multihop_ttl": "3"
             }
         },
         "BGP_NEIGHBOR_AF": {
@@ -1027,7 +1031,7 @@
         },
         "PREFIX_SET": {
             "prefix1": {
-            } 
+            }
         },
         "PREFIX": {
             "prefix1|1|10.0.0.0/8|8..16": {
@@ -1059,5 +1063,5 @@
             "Error": "This Table is for testing, This Table does not have YANG models."
         }
     }
-    
+
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

[sonic_yang_ext.py]: Support Grouping translation in YANG Models.
Changes:
 -- pre Process Grouping section from all yang models, so it can be used
from any yang model.
-- add jsondiff in setup.py, it is useful for test debugging in case of
failures.
-- use 'stypes' instead of head.
-- pass config DB table name in _createLeafDict().
-- added test config for grouping.
-- white spaces changes.

Note: Changes are done in the way that we can add supoort for other
Generic YANG statement easily for tranlation.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com


#### Why I did it

Need to support Grouping translation in YANG Models.

#### How I did it

Changes:
 -- pre Process Grouping section from all yang models, so it can be used
from any yang model. File: src/sonic-yang-mgmt/sonic_yang_ext.py

-- add jsondiff in setup.py, it is useful for test debugging in case of
failures.
-- use 'stypes' instead of head.
-- pass config DB table name in _createLeafDict(). 
-- added test config for grouping.
-- white spaces changes.

#### How to verify it

Added Build Time Tests: File: src/sonic-yang-models/tests/files/sample_config_db.json

Build the PKG.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

