### PR TITLE
[sonic-config] Include buffer templates in config dependency list

### DIFF
--- a/rules/sonic-config.dep
+++ b/rules/sonic-config.dep
@@ -4,7 +4,7 @@ SPATH       := $($(SONIC_CONFIG_ENGINE_PY2)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-config.mk rules/sonic-config.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(SPATH))
-DEP_FILES   += files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-orchagent/ipinip.json.j2 device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/qos.json.j2 files/build_templates/qos_config.j2 device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/qos.json.j2 dockers/docker-orchagent/switch.json.j2 files/image_config/constants/constants.yml
+DEP_FILES   += files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-orchagent/ipinip.json.j2 $(wildcard device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/*.j2 device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/*.j2) files/build_templates/qos_config.j2 dockers/docker-orchagent/switch.json.j2 files/image_config/constants/constants.yml
 
 $(SONIC_CONFIG_ENGINE_PY2)_CACHE_MODE  := GIT_CONTENT_SHA 
 $(SONIC_CONFIG_ENGINE_PY2)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Changes in the buffer template did not trigger a new sonic-config-engine wheel build and the cached build was used for the PR merge. When the new wheel build got trigged, few sonic-cfggen testcases started failing because of the changes made in the buffer templates.

#### How to verify it
Updated the dependency to include buffer templates and built sonic_config_engine-1.0-py3-none-any.whl. Testcase failure was seen as expected

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

