### PR TITLE
Enable Autorestart of the daemons in PMON for unexpected exit

### DIFF
--- a/dockers/docker-platform-monitor/critical_processes
+++ b/dockers/docker-platform-monitor/critical_processes
@@ -1,3 +1,0 @@
-program:ledd
-program:xcvrd
-program:psud

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -33,10 +33,10 @@ dependent_startup=true
 command=/usr/local/bin/chassisd
 priority=3
 autostart=false
-autorestart=false
+autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=0
+startsecs=10
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}
@@ -45,10 +45,10 @@ dependent_startup_wait_for=rsyslogd:running
 command=/usr/local/bin/chassis_db_init
 priority=3
 autostart=false
-autorestart=false
+autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=0
+startsecs=10
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
@@ -83,10 +83,10 @@ dependent_startup_wait_for=rsyslogd:running
 command={% if API_VERSION == 3 and 'ledd' not in python2_daemons %}python3 {% else %} python2 {% endif %}/usr/local/bin/ledd
 priority=5
 autostart=false
-autorestart=false
+autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=0
+startsecs=10
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}
@@ -100,10 +100,10 @@ command={% if API_VERSION == 3 and 'xcvrd' not in python2_daemons %}python3 {% e
 {% endif %}
 priority=6
 autostart=false
-autorestart=false
+autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=0
+startsecs=10
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}
@@ -113,10 +113,10 @@ dependent_startup_wait_for=rsyslogd:running
 command={% if API_VERSION == 3 and 'psud' not in python2_daemons %}python3 {% else %} python2 {% endif %}/usr/local/bin/psud
 priority=7
 autostart=false
-autorestart=false
+autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=0
+startsecs=10
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix the issue #8239 
#### How I did it
Enable Autorestart of the daemons in PMON for unexpected exit 
Remove the daemon list from the critical_process which prevent the PMON
from restarting when the individual daemon crashes.
#### How to verify it
Run sonic-mgmt/tests/platform-test/daemon/test_ledd.py and 
verify the test_pmon_ledd_kill_and_start_status
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

