### PR TITLE
[k8s]: disable http_proxy for docker by default

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/remote_ctr.config.json
+++ b/src/sonic-ctrmgrd/ctrmgr/remote_ctr.config.json
@@ -3,6 +3,6 @@
     "retry_join_interval_seconds": 30,
     "retry_labels_update_seconds": 5,
     "revert_to_local_on_wait_seconds": 60,
-    "use_k8s_as_http_proxy": "y"
+    "use_k8s_as_http_proxy": "n"
 }
 


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
disable http_proxy for docker by default. by default, we should not use proxy.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

