### PR TITLE
DellEMC: Add pcie.yaml for Z9332f

### DIFF
--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/pcie.yaml
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/pcie.yaml
@@ -1,0 +1,22 @@
+- bus: '00'
+  dev: '03'
+  fn: '0'
+  id: 6f08
+  name: 'PCI bridge: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D PCI
+    Express Root Port 3 (rev 03)'
+- bus: '00'
+  dev: 1c
+  fn: '0'
+  id: 8c10
+  name: 'PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express
+    Root Port #1 (rev d5)'
+- bus: '05'
+  dev: '00'
+  fn: '0'
+  id: b980
+  name: 'Ethernet controller: Broadcom Limited Device b980 (rev 11)'
+- bus: 09
+  dev: '00'
+  fn: '0'
+  id: '7021'
+  name: 'Memory controller: Xilinx Corporation Device 7021'

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/pcie.yaml
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/pcie.yaml
@@ -10,6 +10,12 @@
   id: 8c10
   name: 'PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express
     Root Port #1 (rev d5)'
+- bus: '00'
+  dev: 1f
+  fn: '2'
+  id: 8c02
+  name: 'SATA controller: Intel Corporation 8 Series/C220 Series Chipset Family 6-port
+    SATA Controller 1 [AHCI mode] (rev 05)'
 - bus: '05'
   dev: '00'
   fn: '0'


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To support "pcied" and "pcieutil" commands in DellEMC Z9332f.

#### How I did it

Add 'pcie.yaml' in device/dell/[PLATFORM]/ directory.

#### How to verify it

Execute "pcieutil check" command.
Logs: [UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/6935430/UT_logs.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC: Add pcie.yaml for Z9332f

#### A picture of a cute animal (not mandatory but encouraged)

