### PR TITLE
Dell Z9332 systems optimized MMU settings for T0/T1 topology

### DIFF
--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/buffers_defaults_t0.j2
@@ -26,13 +26,13 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "66800476",
+            "size": "66394076",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "8644128"
         },
         "egress_lossless_pool": {
-            "size": "66800476",
+            "size": "55921148",
             "type": "egress",
             "mode": "static"
         }
@@ -41,7 +41,7 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"66800476"
+            "static_th":"66394076"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/buffers_defaults_t1.j2
@@ -26,13 +26,13 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "66800476",
+            "size": "66394076",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "8644128"
         },
         "egress_lossless_pool": {
-            "size": "66800476",
+            "size": "55921148",
             "type": "egress",
             "mode": "static"
         }
@@ -41,7 +41,7 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"66800476"
+            "static_th":"66394076"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
@@ -31,7 +31,6 @@ max_vp_lags.0=0
 tdma_intr_enable=1
 tdma_timeout_usec.0=5000000
 parity_correction.0=1
-mmu_lossless.0=0
 bcm_num_cos=10
 default_cpu_tx_queue=7
 pktdma_poll_mode_channel_bitmap=1

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/buffers_defaults_t0.j2
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/buffers_defaults_t0.j2
@@ -10,13 +10,13 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "66435732",
+            "size": "66394076",
             "type": "ingress",
             "mode": "dynamic",
-            "xoff": "27400374"
+            "xoff": "27200352"
         },
         "egress_lossless_pool": {
-            "size": "66435732",
+            "size": "38462204",
             "type": "egress",
             "mode": "static"
         }
@@ -25,7 +25,7 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"66435732"
+            "static_th":"66394076"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/buffers_defaults_t1.j2
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/buffers_defaults_t1.j2
@@ -10,13 +10,13 @@
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "66435732",
+            "size": "66394076",
             "type": "ingress",
             "mode": "dynamic",
-            "xoff": "27400374"
+            "xoff": "27200352"
         },
         "egress_lossless_pool": {
-            "size": "66435732",
+            "size": "38462204",
             "type": "egress",
             "mode": "static"
         }
@@ -25,7 +25,7 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"66435732"
+            "static_th":"66394076"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
@@ -31,7 +31,6 @@ max_vp_lags.0=0
 tdma_intr_enable=1
 tdma_timeout_usec.0=5000000
 parity_correction.0=1
-mmu_lossless.0=0
 bcm_num_cos=10
 default_cpu_tx_queue=7
 pktdma_poll_mode_channel_bitmap=1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Optimize MMU settings for Dell Z9332 systems in T0/T1 topology

#### How I did it
Updated SONIC buffer profile settings for TH3 in T0/T1 topology

#### How to verify it
I cross-verify the MMU configuration with BRCM spreadsheet as well as did basic test on systems.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Updated SONIC buffer profile settings for TH3 in T0/T1 topology

#### A picture of a cute animal (not mandatory but encouraged)

