### PR TITLE
[ARM] Fix issue whre the ping6 tool is missing from orchagent docker

### DIFF
--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -24,9 +24,11 @@ RUN apt-get update &&       \
         python3-dev
 
 {% if ( CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" ) %}
-# Fix for gcc/python not found in arm docker
+# Fix for gcc/python/iputils-ping not found in arm docker
 RUN apt-get install -f -y python2.7 python2.7-dev
-RUN apt-get install -y gcc-8
+RUN apt-get install -y   \
+        gcc-8            \
+        iputils-ping
 {% endif %}
 {% if CONFIGURED_ARCH == "armhf" %}
 RUN ln -s -f /usr/bin/gcc-8 /usr/bin/arm-linux-gnueabihf-gcc


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This is for fixing issue: https://github.com/Azure/sonic-buildimage/issues/8337

#### How I did it

Explicitly install the `iputils-ping` which include the `ping6` tool to the orchagent docker

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Install `iputils-ping` to orchagent docker for arm platform

#### A picture of a cute animal (not mandatory but encouraged)

