### PR TITLE
[swss][arp_update] Send ipv6 pings over vlan sub interfaces

### DIFF
--- a/files/build_templates/arp_update_vars.j2
+++ b/files/build_templates/arp_update_vars.j2
@@ -1,5 +1,6 @@
 {
     "interface": "{% for (name, prefix) in INTERFACE|pfx_filter %}{% if prefix|ipv6 %}{{ name }} {% endif %}{% endfor %}",
     "pc_interface" : "{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}{% if prefix|ipv6 %}{{ name }} {% endif %}{% endfor %}",
+    "vlan_sub_interface": "{% for (name, prefix) in VLAN_SUB_INTERFACE|pfx_filter %}{% if prefix|ipv6 %}{{ name }} {% endif %}{% endfor %}",
     "vlan" : "{% if VLAN %}{{ VLAN.keys() | join(' ') }}{% endif %}"
 }

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -14,8 +14,9 @@ while /bin/true; do
   ARP_UPDATE_VARS=$(sonic-cfggen -d -t ${ARP_UPDATE_VARS_FILE})
   INTERFACE=$(echo $ARP_UPDATE_VARS | jq -r '.interface')
   PC_INTERFACE=$(echo $ARP_UPDATE_VARS | jq -r '.pc_interface')
+  VLAN_SUB_INTERFACE=$(echo $ARP_UPDATE_VARS | jq -r '.vlan_sub_interface')
 
-  ALL_INTERFACE="$INTERFACE $PC_INTERFACE"
+  ALL_INTERFACE="$INTERFACE $PC_INTERFACE $VLAN_SUB_INTERFACE"
   for intf in $ALL_INTERFACE; do
       ping6cmd="ping6 -I $intf -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
       intf_up=$(ip link show $intf | grep "state UP")


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
* `arp_update` fails to ping those neighbors over vlan sub interfaces.

#### How I did it
* modify `arp_update_vars.j2` to get vlan sub interfaces with ipv6 addresses assigned.
* modify `arp_update` to send ipv6 pings over those retrieved vlan sub interfaces.

#### How to verify it
* run `arp_update` on `t0-backend` topology with `set -x`
```
root@str2-7050qx-32s-acs-02:/# ./arp_update
+ ARP_UPDATE_VARS_FILE=/usr/share/sonic/templates/arp_update_vars.j2
+ /bin/true
++ sonic-cfggen -d -t /usr/share/sonic/templates/arp_update_vars.j2
+ ARP_UPDATE_VARS='{
    "interface": "",
    "pc_interface" : "",
    "vlan_sub_interface": "Ethernet100.10 Ethernet104.10 Ethernet108.10 Ethernet112.10 Ethernet116.10 Ethernet120.10 Ethernet124.10 Ethernet80.10 Ethernet84.10 Ethernet88.10 Ethernet92.10 Ethernet96.10 ",

    "vlan" : "Vlan1000"
}'
++ echo '{' '"interface":' '"",' '"pc_interface"' : '"",' '"vlan_sub_interface":' '"Ethernet100.10' Ethernet104.10 Ethernet108.10 Ethernet112.10 Ethernet116.10 Ethernet120.10 Ethernet124.10 Ethernet80.10 Ethernet84.10 Ethernet88.10 Ethernet92.10 Ethernet96.10 '",' '"vlan"' : '"Vlan1000"' '}'
++ jq -r .interface
+ INTERFACE=
++ echo '{' '"interface":' '"",' '"pc_interface"' : '"",' '"vlan_sub_interface":' '"Ethernet100.10' Ethernet104.10 Ethernet108.10 Ethernet112.10 Ethernet116.10 Ethernet120.10 Ethernet124.10 Ethernet80.10 Ethernet84.10 Ethernet88.10 Ethernet92.10 Ethernet96.10 '",' '"vlan"' : '"Vlan1000"' '}'
++ jq -r .pc_interface
+ PC_INTERFACE=
++ echo '{' '"interface":' '"",' '"pc_interface"' : '"",' '"vlan_sub_interface":' '"Ethernet100.10' Ethernet104.10 Ethernet108.10 Ethernet112.10 Ethernet116.10 Ethernet120.10 Ethernet124.10 Ethernet80.10 Ethernet84.10 Ethernet88.10 Ethernet92.10 Ethernet96.10 '",' '"vlan"' : '"Vlan1000"' '}'
++ jq -r .vlan_sub_interface
+ VLAN_SUB_INTERFACE='Ethernet100.10 Ethernet104.10 Ethernet108.10 Ethernet112.10 Ethernet116.10 Ethernet120.10 Ethernet124.10 Ethernet80.10 Ethernet84.10 Ethernet88.10 Ethernet92.10 Ethernet96.10 '
+ ALL_INTERFACE='  Ethernet100.10 Ethernet104.10 Ethernet108.10 Ethernet112.10 Ethernet116.10 Ethernet120.10 Ethernet124.10 Ethernet80.10 Ethernet84.10 Ethernet88.10 Ethernet92.10 Ethernet96.10 '
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet100.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet100.10
++ grep 'state UP'
+ intf_up='881: Ethernet100.10@Ethernet100: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 881: Ethernet100.10@Ethernet100: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet100.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet100.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet100.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet104.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet104.10
++ grep 'state UP'
+ intf_up='883: Ethernet104.10@Ethernet104: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 883: Ethernet104.10@Ethernet104: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet104.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet104.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet104.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet108.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet108.10
++ grep 'state UP'
+ intf_up='884: Ethernet108.10@Ethernet108: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 884: Ethernet108.10@Ethernet108: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet108.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet108.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet108.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet112.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet112.10
++ grep 'state UP'
+ intf_up='894: Ethernet112.10@Ethernet112: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 894: Ethernet112.10@Ethernet112: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet112.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet112.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet112.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet116.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet116.10
++ grep 'state UP'
+ intf_up='895: Ethernet116.10@Ethernet116: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 895: Ethernet116.10@Ethernet116: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet116.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet116.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet116.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet120.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet120.10
++ grep 'state UP'
+ intf_up='851: Ethernet120.10@Ethernet120: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 851: Ethernet120.10@Ethernet120: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet120.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet120.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet120.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet124.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet124.10
++ grep 'state UP'
+ intf_up='853: Ethernet124.10@Ethernet124: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 853: Ethernet124.10@Ethernet124: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet124.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet124.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet124.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet80.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet80.10
++ grep 'state UP'
+ intf_up='887: Ethernet80.10@Ethernet80: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 887: Ethernet80.10@Ethernet80: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet80.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet80.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet80.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet84.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet84.10
++ grep 'state UP'
+ intf_up='889: Ethernet84.10@Ethernet84: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 889: Ethernet84.10@Ethernet84: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet84.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet84.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet84.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet88.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet88.10
++ grep 'state UP'
+ intf_up='890: Ethernet88.10@Ethernet88: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 890: Ethernet88.10@Ethernet88: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet88.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet88.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet88.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet92.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet92.10
++ grep 'state UP'
+ intf_up='892: Ethernet92.10@Ethernet92: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 892: Ethernet92.10@Ethernet92: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet92.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet92.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet92.10.
+ for intf in $ALL_INTERFACE
+ ping6cmd='ping6 -I Ethernet96.10 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
++ ip link show Ethernet96.10
++ grep 'state UP'
+ intf_up='893: Ethernet96.10@Ethernet96: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000'
+ [[ -n 893: Ethernet96.10@Ethernet96: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP mode DEFAULT group default qlen 1000 ]]
+ eval ping6 -I Ethernet96.10 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Ethernet96.10 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Ethernet96.10.
++ echo '{' '"interface":' '"",' '"pc_interface"' : '"",' '"vlan_sub_interface":' '"Ethernet100.10' Ethernet104.10 Ethernet108.10 Ethernet112.10 Ethernet116.10 Ethernet120.10 Ethernet124.10 Ethernet80.10 Ethernet84.10 Ethernet88.10 Ethernet92.10 Ethernet96.10 '",' '"vlan"' : '"Vlan1000"' '}'
++ jq -r .vlan
+ VLAN=Vlan1000
+ for vlan in $VLAN
+ arpingcmd='sed -e '\''s/ / -i /'\'' -e '\''s/^/arping -q -w 0 -c 1 /'\'' -e '\''s/$/;/'\'''
+ ipcmd='ip -4 neigh show | grep Vlan1000 | cut -d '\'' '\'' -f 1,3 | sed -e '\''s/ / -i /'\'' -e '\''s/^/arping -q -w 0 -c 1 /'\'' -e '\''s/$/;/'\'''
++ eval ip -4 neigh show '|' grep Vlan1000 '|' cut -d \' \' -f 1,3 '|' sed -e ''\''s/' / -i '/'\''' -e ''\''s/^/arping' -q -w 0 -c 1 '/'\''' -e ''\''s/$/;/'\'''
+++ ip -4 neigh show
+++ grep Vlan1000
+++ cut -d ' ' -f 1,3
+++ sed -e 's/ / -i /' -e 's/^/arping -q -w 0 -c 1 /' -e 's/$/;/'
+ eval
+ ping6cmd='ping6 -I Vlan1000 -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null'
+ eval ping6 -I Vlan1000 -n -q -i 0 -c 1 -W 0 ff02::1 '>/dev/null'
++ ping6 -I Vlan1000 -n -q -i 0 -c 1 -W 0 ff02::1
ping6: Warning: source address might be selected on device other than Vlan1000.
+ ndisc6cmd='sed -e '\''s/^/ndisc6 -q -w 0 -1 /'\'' -e '\''s/$/;/'\'''
+ ip6cmd='ip -6 neigh show | grep -v fe80 | grep Vlan1000 | cut -d '\'' '\'' -f 1,3 | sed -e '\''s/^/ndisc6 -q -w 0 -1 /'\'' -e '\''s/$/;/'\'''
++ eval ip -6 neigh show '|' grep -v fe80 '|' grep Vlan1000 '|' cut -d \' \' -f 1,3 '|' sed -e ''\''s/^/ndisc6' -q -w 0 -1 '/'\''' -e ''\''s/$/;/'\'''
+++ ip -6 neigh show
+++ grep -v fe80
+++ grep Vlan1000
+++ cut -d ' ' -f 1,3
+++ sed -e 's/^/ndisc6 -q -w 0 -1 /' -e 's/$/;/'
+ eval
+ sleep 300
^C
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

