### PR TITLE
[sonic-device-data]: add port_type to OPTIONAL_PORT_ATTRIBUTES

### DIFF
--- a/src/sonic-device-data/tests/hwsku_json_checker
+++ b/src/sonic-device-data/tests/hwsku_json_checker
@@ -7,7 +7,7 @@ import sys
 
 # Global variable
 PORT_ATTRIBUTES = ["default_brkout_mode"]
-OPTIONAL_PORT_ATTRIBUTES = ["fec", "autoneg"]
+OPTIONAL_PORT_ATTRIBUTES = ["fec", "autoneg", "port_type"]
 PORT_REG = "Ethernet(\d+)"
 HWSKU_JSON = '*hwsku.json'
 INTF_KEY = "interfaces"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
enable automated test suites to selectively run relevant tests ( or not run tests ) based upon a new port_type identifier in hwsku.json
#### How I did it
Modified the valid optional fields in validity check for hwsku.json per recommendation from Joe in 
https://github.com/Azure/sonic-mgmt/pull/2654/files
#### How to verify it

#### Which release branch to backport (provide reason below if selected)
backport to 202012 so that the enhanced automation tests can skip copper ports for sfp tests
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [ ] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

