### PR TITLE
[Nokia] Add hwsku.json for the Nokia-7215

### DIFF
--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/hwsku.json
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/hwsku.json
@@ -1,0 +1,160 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "port_type": "RJ45"
+        },
+        "Ethernet1": {
+            "port_type": "RJ45"
+        },
+        "Ethernet2": {
+            "port_type": "RJ45"
+        },
+        "Ethernet3": {
+            "port_type": "RJ45"
+        },
+        "Ethernet4": {
+            "port_type": "RJ45"
+        },
+        "Ethernet5": {
+            "port_type": "RJ45"
+        },
+        "Ethernet6": {
+            "port_type": "RJ45"
+        },
+        "Ethernet7": {
+            "port_type": "RJ45"
+        },
+        "Ethernet8": {
+            "port_type": "RJ45"
+        },
+        "Ethernet9": {
+            "port_type": "RJ45"
+        },
+        "Ethernet10": {
+            "port_type": "RJ45"
+        },
+        "Ethernet11": {
+            "port_type": "RJ45"
+        },
+        "Ethernet12": {
+            "port_type": "RJ45"
+        },
+        "Ethernet13": {
+            "port_type": "RJ45"
+        },
+        "Ethernet14": {
+            "port_type": "RJ45"
+        },
+        "Ethernet15": {
+            "port_type": "RJ45"
+        },
+        "Ethernet16": {
+            "port_type": "RJ45"
+        },
+        "Ethernet17": {
+            "port_type": "RJ45"
+        },
+        "Ethernet18": {
+            "port_type": "RJ45"
+        },
+        "Ethernet19": {
+            "port_type": "RJ45"
+        },
+        "Ethernet20": {
+            "port_type": "RJ45"
+        },
+        "Ethernet21": {
+            "port_type": "RJ45"
+        },
+        "Ethernet22": {
+            "port_type": "RJ45"
+        },
+        "Ethernet23": {
+            "port_type": "RJ45"
+        },
+        "Ethernet24": {
+            "port_type": "RJ45"
+        },
+        "Ethernet25": {
+            "port_type": "RJ45"
+        },
+        "Ethernet26": {
+            "port_type": "RJ45"
+        },
+        "Ethernet27": {
+            "port_type": "RJ45"
+        },
+        "Ethernet28": {
+            "port_type": "RJ45"
+        },
+        "Ethernet29": {
+            "port_type": "RJ45"
+        },
+        "Ethernet30": {
+            "port_type": "RJ45"
+        },
+        "Ethernet31": {
+            "port_type": "RJ45"
+        },
+        "Ethernet32": {
+            "port_type": "RJ45"
+        },
+	"Ethernet33": {
+            "port_type": "RJ45"
+        },
+	"Ethernet34": {
+            "port_type": "RJ45"
+        },
+	"Ethernet35": {
+            "port_type": "RJ45"
+        },
+	"Ethernet36": {
+            "port_type": "RJ45"
+        },
+	"Ethernet37": {
+            "port_type": "RJ45"
+        },
+	"Ethernet38": {
+            "port_type": "RJ45"
+        },
+	"Ethernet39": {
+            "port_type": "RJ45"
+        },
+	"Ethernet40": {
+            "port_type": "RJ45"
+        },
+	"Ethernet41": {
+            "port_type": "RJ45"
+        },
+	"Ethernet42": {
+            "port_type": "RJ45"
+        },
+	"Ethernet43": {
+            "port_type": "RJ45"
+        },
+	"Ethernet44": {
+            "port_type": "RJ45"
+        },
+	"Ethernet45": {
+            "port_type": "RJ45"
+        },
+	"Ethernet46": {
+            "port_type": "RJ45"
+        },
+	"Ethernet47": {
+            "port_type": "RJ45"
+        },
+	"Ethernet48": {
+            "port_type": "SFP+"
+        },
+	"Ethernet49": {
+            "port_type": "SFP+"
+        },
+	"Ethernet50": {
+            "port_type": "SFP+"
+        },
+	"Ethernet51": {
+            "port_type": "SFP+"
+        }
+    }	
+}

--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/hwsku.json
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/hwsku.json
@@ -1,160 +1,212 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet1": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet2": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet3": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet4": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet5": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet6": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet7": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet8": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet9": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet10": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet11": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet12": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet13": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet14": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet15": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet16": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet17": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet18": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet19": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet20": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet21": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet22": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet23": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet24": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet25": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet26": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet27": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet28": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet29": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet30": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet31": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
         "Ethernet32": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet33": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet34": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet35": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet36": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet37": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet38": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet39": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet40": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet41": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet42": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet43": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet44": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet45": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet46": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet47": {
-            "port_type": "RJ45"
+            "default_brkout_mode": "1x1G",
+	    "port_type": "RJ45"
         },
 	"Ethernet48": {
-            "port_type": "SFP+"
+            "default_brkout_mode": "1x10G",
+	    "port_type": "SFP+"
         },
 	"Ethernet49": {
-            "port_type": "SFP+"
+            "default_brkout_mode": "1x10G",
+	    "port_type": "SFP+"
         },
 	"Ethernet50": {
-            "port_type": "SFP+"
+            "default_brkout_mode": "1x10G",
+	    "port_type": "SFP+"
         },
 	"Ethernet51": {
-            "port_type": "SFP+"
+            "default_brkout_mode": "1x10G",
+	    "port_type": "SFP+"
         }
     }	
 }

--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/hwsku.json
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/hwsku.json
@@ -2,211 +2,211 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet1": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet2": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet3": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet4": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet5": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet6": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet7": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet8": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet9": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet10": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet11": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet12": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet13": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet14": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet15": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet16": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet17": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet18": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet19": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet20": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet21": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet22": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet23": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet24": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet25": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet26": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet27": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet28": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet29": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet30": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet31": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
         "Ethernet32": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet33": {
+        "Ethernet33": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet34": {
+        "Ethernet34": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet35": {
+        "Ethernet35": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet36": {
+        "Ethernet36": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet37": {
+        "Ethernet37": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet38": {
+        "Ethernet38": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet39": {
+        "Ethernet39": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet40": {
+        "Ethernet40": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet41": {
+        "Ethernet41": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet42": {
+        "Ethernet42": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet43": {
+        "Ethernet43": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet44": {
+        "Ethernet44": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet45": {
+        "Ethernet45": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet46": {
+        "Ethernet46": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet47": {
+        "Ethernet47": {
             "default_brkout_mode": "1x1G",
-	    "port_type": "RJ45"
+            "port_type": "RJ45"
         },
-	"Ethernet48": {
+        "Ethernet48": {
             "default_brkout_mode": "1x10G",
-	    "port_type": "SFP+"
+            "port_type": "SFP+"
         },
-	"Ethernet49": {
+        "Ethernet49": {
             "default_brkout_mode": "1x10G",
-	    "port_type": "SFP+"
+            "port_type": "SFP+"
         },
-	"Ethernet50": {
+        "Ethernet50": {
             "default_brkout_mode": "1x10G",
-	    "port_type": "SFP+"
+            "port_type": "SFP+"
         },
-	"Ethernet51": {
+        "Ethernet51": {
             "default_brkout_mode": "1x10G",
-	    "port_type": "SFP+"
+            "port_type": "SFP+"
         }
-    }	
+    }   
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
hwsku.json port_type attribute is the preferred method for test to differentiate copper vs sfp+ for Nokia-7215.
#### How I did it
added PR 8370 on which this PR depends first -  then added hwsku.json file according to platform specification. 
#### How to verify it

#### Which release branch to backport (provide reason below if selected)
Depends on PR 8370 
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [ ] 202006
-->
Needed for Nokia 7215 test pass
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

