### PR TITLE
[202012] BRCM Disable ACL Drop counted towards interface RX_DRP counters

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-Q16S64/td2-a7050-qx32-16x40G+32x10G+8x40G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-Q16S64/td2-a7050-qx32-16x40G+32x10G+8x40G.config.bcm
@@ -24,6 +24,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 # From old config file
 os=unix
 higig2_hdr_mode=1

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/td2-a7050-qx32-32x40G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/td2-a7050-qx32-32x40G.config.bcm
@@ -24,6 +24,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 # From old config file
 os=unix
 higig2_hdr_mode=1

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/td2-a7050-q31s4-31x40G-4x10G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/td2-a7050-q31s4-31x40G-4x10G.config.bcm
@@ -4,6 +4,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 # From old config file
 os=unix
 higig2_hdr_mode=1

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/td2-a7050-qx32s-32x40G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/td2-a7050-qx32s-32x40G.config.bcm
@@ -18,6 +18,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 # From old config file
 os=unix
 higig2_hdr_mode=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 phy_an_allow_pll_change=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 phy_an_allow_pll_change=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/th-a7060-cx32s-8x100G+24x40G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/th-a7060-cx32s-8x100G+24x40G.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 phy_an_allow_pll_change=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 phy_an_allow_pll_change=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 phy_an_allow_pll_change=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/th-a7060-cx32s-8x100G+96x25G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/th-a7060-cx32s-8x100G+96x25G.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 phy_an_allow_pll_change=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-C64/th3-a7060px4-32-64x100G.config.bcm
+++ b/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-C64/th3-a7060px4-32-64x100G.config.bcm
@@ -1,3 +1,5 @@
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile.0=2
 bcm_num_cos.0=8

--- a/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-O32/th3-a7060px4-o32-32x400G.config.bcm
+++ b/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-O32/th3-a7060px4-o32-32x400G.config.bcm
@@ -1,3 +1,5 @@
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile.0=2
 bcm_num_cos.0=8

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
@@ -13,13 +13,13 @@
 {%-         if 'dualtor' in switch_subtype.lower() %}
 {%-             set IPinIP_sock = 'sai_tunnel_support=1
                                    host_as_route_disable=1
-                                   sai_adjust_acl_drop_in_rx_drop=1
                                    l3_ecmp_levels=2' -%}
 {%-         endif %}
 {%-     endif %}
 {%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-64x100G-t1.config.bcm" #}
 
+sai_adjust_acl_drop_in_rx_drop=1
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
@@ -5,11 +5,11 @@
 {%-     if 'dualtor' in switch_subtype.lower() %}
 {%-         set IPinIP_sock = 'sai_tunnel_support=1
                                host_as_route_disable=1
-                               sai_adjust_acl_drop_in_rx_drop=1
                                l3_ecmp_levels=2' -%}
 {%-     endif %}
 {%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-112x50G+8x100G.config.bcm" #}
+sai_adjust_acl_drop_in_rx_drop=1
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
@@ -13,12 +13,12 @@
 {%-         if 'dualtor' in switch_subtype.lower() %}
 {%-             set IPinIP_sock = 'sai_tunnel_support=1
                                    host_as_route_disable=1
-                                   sai_adjust_acl_drop_in_rx_drop=1
                                    l3_ecmp_levels=2' -%}
 {%-         endif %}
 {%-     endif %}
 {%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-64x40G.config.bcm" #}
+sai_adjust_acl_drop_in_rx_drop=1
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/broadcom/x86_64-bcm_xlr-r0/BCM956960K/th_32x100.config.bcm
+++ b/device/broadcom/x86_64-bcm_xlr-r0/BCM956960K/th_32x100.config.bcm
@@ -1,3 +1,6 @@
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 portmap_1=1:100                                       
 portmap_2=5:100                                       
 portmap_3=9:100                                       

--- a/device/celestica/x86_64-cel_e1031-r0/Celestica-E1031-T48S4/helix4-e1031-48x1G+4x10G.config.bcm
+++ b/device/celestica/x86_64-cel_e1031-r0/Celestica-E1031-T48S4/helix4-e1031-48x1G+4x10G.config.bcm
@@ -1,3 +1,6 @@
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 bcm56340_4x10=1
 bcm56340_config=1
 dport_map_direct=0

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
@@ -17,6 +17,9 @@ l3_alpm_enable=2
 ipv6_lpm_128b_enable=1
 mmu_lossless=0
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 ###################################################################################
 # Celestica Customize for SeaStone
 ###################################################################################

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
@@ -1,3 +1,6 @@
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 os=unix 
 l2xmsg_mode=1 
 parity_enable=0 

--- a/device/celestica/x86_64-cel_seastone-r0/th-seastone-dx010-config-flex-all.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/th-seastone-dx010-config-flex-all.bcm
@@ -19,6 +19,9 @@ ipv6_lpm_128b_enable=1
 #Use MMU lossy configuration
 mmu_lossless=0
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 ###################################################################################
 # SeaStone customized configuration
 ###################################################################################

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q20S48/td2-s6000-20x40G-48x10G.config.bcm
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q20S48/td2-s6000-20x40G-48x10G.config.bcm
@@ -10,6 +10,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 # From old config file
 os=unix
 higig2_hdr_mode=1

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q24S32/td2-s6000-24x40G-32x10G.config.bcm
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q24S32/td2-s6000-24x40G-32x10G.config.bcm
@@ -10,6 +10,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 # From old config file
 os=unix
 higig2_hdr_mode=1

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q28S16/td2-s6000-28x40G-16x10G.config.bcm
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q28S16/td2-s6000-28x40G-16x10G.config.bcm
@@ -10,6 +10,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 # From old config file
 os=unix
 higig2_hdr_mode=1

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/td2-s6000-32x40G.config.bcm
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/td2-s6000-32x40G.config.bcm
@@ -10,6 +10,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 # From old config file
 os=unix
 higig2_hdr_mode=1

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t0.config.bcm
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t0.config.bcm
@@ -1,4 +1,7 @@
 #TH S6100 64x40
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 l3_alpm_enable=2
 pfc_deadlock_seq_control=1
 bcm_stat_interval=2000000

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t1.config.bcm
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t1.config.bcm
@@ -1,4 +1,7 @@
 #TH S6100 64x40
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 l3_alpm_enable=2
 pfc_deadlock_seq_control=1
 bcm_stat_interval=2000000

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
@@ -3,6 +3,9 @@ dpr_clock_frequency=1000
 device_clock_frequency=1325
 port_flex_enable=1
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 #firmware load method, use fast load
 load_firmware=0x2
 

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
@@ -3,6 +3,9 @@ dpr_clock_frequency=1000
 device_clock_frequency=1325
 port_flex_enable=1
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 #firmware load method, use fast load
 load_firmware=0x2
 

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
@@ -3,6 +3,9 @@ dpr_clock_frequency=1000
 device_clock_frequency=1325
 port_flex_enable=1
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 #firmware load method, use fast load
 load_firmware=0x2
 


### PR DESCRIPTION
#### Why I did it
For all BRCM ACL Drops there is a way not to count these packet drops towards the interface RX_DRP counters by enabling a new SOC property. This SOC property is being enabled on the chosen BRCM HW SKUs config.bcm files.

#### How to verify it
Send packet that is expected to be drop due to ACL and check that it is not being counted towards interface RX_DRP counter.
Also tested on S6100, 7260, and TD3 WARM Reboot scenario where this SOC property was not present before the WARM Reboot but become enabled after WARM Reboot.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
Add SOC property to not count ACL Drops towards interface RX_DRP for All BRCM HW SKUs.

#### A picture of a cute animal (not mandatory but encouraged)
