### PR TITLE
[rsyslogd][multiasic] fixed rsyslogd FATAL issue in the database container in multi-asic box

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -36,8 +36,11 @@ function updateSyslogConf()
         TARGET_IP=$(docker network inspect bridge --format={{ "'{{(index .IPAM.Config 0).Gateway}}'" }})
         CONTAINER_NAME="$DOCKERNAME"
         TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
-
+        {%- if docker_container_name == "database" %} 
+        python -c "import jinja2, os; paths=['/usr/share/sonic/templates']; loader = jinja2.FileSystemLoader(paths); env = jinja2.Environment(loader=loader, trim_blocks=True); template_file='/usr/share/sonic/templates/rsyslog-container.conf.j2'; template = env.get_template(os.path.basename(template_file)); data=template.render({\"target_ip\":\"$TARGET_IP\",\"container_name\":\"$CONTAINER_NAME\"}); print(data)" > $TMP_FILE
+        {%- else %}
         sonic-cfggen -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
+        {%- endif %}
         docker cp $TMP_FILE ${DOCKERNAME}:/etc/rsyslog.conf
         rm -rf $TMP_FILE
     fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix for issue https://github.com/Azure/sonic-buildimage/issues/8389

#### How I did it
The /etc/rsyslog.conf is empty file which cause the FATAL of the process rsyslogd in the global instance database container.  The function updateSyslogConf() should only generate the rsyslog.conf for containers in the namespace. it should not do it for the containers in the global instance. Instead, default rsyslog.conf should be used.  Especially for database container, updateSyslogConf() is called before the database container is created.  The result cause the sonic-cfggen failed to generate the rsyslog.conf.  

#### How to verify it
-- Go to the database container and execute the supervisorctl status command:
```
admin@sonic:~$ docker exec -it database bash
root@sonic:/# supervisorctl status
flushdb                          EXITED    Aug 08 03:20 AM
redis                            RUNNING   pid 38, uptime 1 day, 11:49:24
rsyslogd                         RUNNING   pid 37, uptime 1 day, 11:49:24
supervisor-proc-exit-listener    RUNNING   pid 36, uptime 1 day, 11:49:24
root@sonic:/# ls /etc/rsyslog.conf 
/etc/rsyslog.conf
root@sonic:/# ls -al /etc/rsyslog.conf 
-rw-r--r-- 1 root root 1924 Aug  7 21:39 /etc/rsyslog.conf
root@sonic2:/# 
```
-- /etc/rsyslog.conf should not be a empty file

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

