### PR TITLE
Update the make cache mode for opennsl-module-dnx

### DIFF
--- a/platform/broadcom/sai-modules.dep
+++ b/platform/broadcom/sai-modules.dep
@@ -1,4 +1,4 @@
-
+# Broadcom SAI modules
 MPATH       := $($(BRCM_OPENNSL_KERNEL)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/broadcom/sai-modules.mk platform/broadcom/sai-modules.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
@@ -8,3 +8,12 @@ $(BRCM_OPENNSL_KERNEL)_CACHE_MODE  := GIT_CONTENT_SHA
 $(BRCM_OPENNSL_KERNEL)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
 $(BRCM_OPENNSL_KERNEL)_DEP_FILES   := $(DEP_FILES)
 
+# SAI bcm modules for DNX family ASIC
+MPATH_DNX   := $($(BRCM_DNX_OPENNSL_KERNEL)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/broadcom/sai-modules.mk platform/broadcom/sai-modules.dep   
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+DEP_FILES   += $(shell git ls-files $(MPATH_DNX))
+
+$(BRCM_DNX_OPENNSL_KERNEL)_CACHE_MODE  := GIT_CONTENT_SHA 
+$(BRCM_DNX_OPENNSL_KERNEL)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(BRCM_DNX_OPENNSL_KERNEL)_DEP_FILES   := $(DEP_FILES)


### PR DESCRIPTION

#### Why I did it
Fix the Warning coming during compilation
```
[ DPKG ] Cache is not enabled for opennsl-modules-dnx_5.0.0.4_amd64.deb package 
```

#### How I did it
Updated the dep files with CACHE_mode

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

