### PR TITLE
Fix TH3 Warm-reboot failure due to Tunnel termination SAI failure

### DIFF
--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_tunnel_global_sip_mask_enable=1
 core_clock_frequency=1325
 dpr_clock_frequency=1000
 device_clock_frequency=1325

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
@@ -1,3 +1,4 @@
+sai_tunnel_global_sip_mask_enable=1
 core_clock_frequency=1325
 dpr_clock_frequency=1000
 device_clock_frequency=1325

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
@@ -1,3 +1,4 @@
+sai_tunnel_global_sip_mask_enable=1
 core_clock_frequency=1325
 dpr_clock_frequency=1000
 device_clock_frequency=1325

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -235,6 +235,7 @@ sai_preinit_cmd_file
 sai_preinit_warmboot_cmd_file
 sai_postinit_cmd_file
 sai_postinit_warmboot_cmd_file
+sai_tunnel_global_sip_mask_enable
 help_cli_enable
 memlist_enable
 serdes_lane_config_dfe


### PR DESCRIPTION
#### Why I did it
To fix tunnel termination issue on TH3 which resulted in warm-reboot failure tracked by issue - https://github.com/Azure/sonic-buildimage/issues/8397

#### How I did it
Add SOC property to enable tunnel termination entry creation for TH3

#### How to verify it
Verified logs and ASIC-DB for tunnel termination entry creation, tested warm-reboot on 9332f platforms. Failure seen before adding SOC property was resolved after this change.

#### Which release branch to backport (provide reason below if selected)


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
Add SOC property to enable Tunnel termination entry creation on TH3

#### A picture of a cute animal (not mandatory but encouraged)

