### PR TITLE
Platform/cisco-8000 module for sonic-buildimage (8172)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ platform/broadcom/sonic-platform-modules-dell/s6100/modules/dell_s6100_lpc.c
 platform/broadcom/sonic-platform-modules-dell/z9100/modules/dell_ich.c
 platform/broadcom/sonic-platform-modules-dell/z9100/modules/dell_mailbox.c
 platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/ipmihelper.py
+platform/cisco-8000/
 
 # buildinfo
 files/build/buildinfo

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,19 @@
 NOJESSIE ?= 1
 NOSTRETCH ?= 0
 
+ifeq ($(NOJESSIE),0)
+BUILD_JESSIE=1
+endif
+
+ifeq ($(NOSTRETCH),0)
+BUILD_STRETCH=1
+endif
+
+PLATFORM_PATH := platform/$(if $(PLATFORM),$(PLATFORM),$(CONFIGURED_PLATFORM))
+PLATFORM_CHECKOUT := platform/checkout
+PLATFORM_CHECKOUT_FILE := $(PLATFORM_CHECKOUT)/$(PLATFORM).ini
+PLATFORM_CHECKOUT_CMD := $(shell if [ -f $(PLATFORM_CHECKOUT_FILE) ]; then PLATFORM_PATH=$(PLATFORM_PATH) j2 $(PLATFORM_CHECKOUT)/template.j2 $(PLATFORM_CHECKOUT_FILE); fi)
+
 %::
 	@echo "+++ --- Making $@ --- +++"
 ifeq ($(NOJESSIE), 0)
@@ -29,15 +42,27 @@ init:
 	@echo "+++ Making $@ +++"
 	make -f Makefile.work $@
 
-clean configure reset showtag sonic-slave-build sonic-slave-bash :
+#
+# Function to invoke target $@ in Makefile.work with proper BLDENV
+#
+define make_work
 	@echo "+++ Making $@ +++"
-ifeq ($(NOJESSIE), 0)
-	make -f Makefile.work $@
-endif
-ifeq ($(NOSTRETCH), 0)
-	BLDENV=stretch make -f Makefile.work $@
-endif
+	$(if $(BUILD_JESSIE),make -f Makefile.work $@,)
+	$(if $(BUILD_STRETCH),BLDENV=stretch make -f Makefile.work $@,)
 	BLDENV=buster make -f Makefile.work $@
+endef
+
+.PHONY: $(PLATFORM_PATH)
+
+$(PLATFORM_PATH):
+	@echo "+++ Cheking $@ +++"
+	$(PLATFORM_CHECKOUT_CMD)
+
+configure : $(PLATFORM_PATH)
+	$(call make_work, $@)
+
+clean reset showtag sonic-slave-build sonic-slave-bash :
+	$(call make_work, $@)
 
 # Freeze the versions, see more detail options: scripts/versions_manager.py freeze -h
 freeze:

--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,0 +1,3 @@
+[module]
+repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
+ref=202012-v0.2

--- a/platform/checkout/template.j2
+++ b/platform/checkout/template.j2
@@ -1,0 +1,11 @@
+{% set path = env('PLATFORM_PATH') %}
+if [ ! -d {{ path }} ]; then git clone {{ module.repo }} {{ path }}; fi;
+if [ -d {{ path }}/.git ]; then cd {{ path }} &&
+
+{% if module.ref is defined %}
+git checkout {{ module.ref }} && git submodule update --init --recursive;
+{% else %}
+git submodule update --init --recursive;
+{% endif %}
+
+else echo "{{ path }}/.git not found"; exit 1; fi


### PR DESCRIPTION
    Update Makefile, so it does the following:
    For a given platform, verify if platform/checkout/.ini exists and
    hence run the platform/checkout/template.j2. This allows platform
    code to be checked out during the 'make configure' stage.

Signed-off-by: Anand Mehra <anamehra@cisco.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

