### PR TITLE
[aboot] use ram partition for /var/log for devices with 3.7G disks

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -593,12 +593,16 @@ write_platform_specific_cmdline() {
 
     if [ $flash_size -ge 28000 ]; then
         varlog_size=4096
-    elif [ $flash_size -ge 3700 ]; then
+    elif [ $flash_size -gt 3700 ]; then
         varlog_size=400
-    elif [ $flash_size -le 2000 ]; then
-        # enable docker_inram for switches with less than 2G of flash
-        cmdline_add docker_inram=on
+    else
+        varlog_size=256
         cmdline_add logs_inram=on
+        if [ $flash_size -le 2000 ]; then
+            # enable docker_inram for switches with less than 2G of flash
+            varlog_size=128
+            cmdline_add docker_inram=on
+        fi
     fi
 
     cmdline_add "varlog_size=$varlog_size"

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/sh -e
 
 PREREQS="varlog"
 

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -16,6 +16,7 @@ logs_inram=false
 secureboot=false
 bootloader=generic
 in_kdump=false
+varlog_size=0
 
 # Extract kernel parameters
 for x in $(cat /proc/cmdline); do
@@ -28,6 +29,9 @@ for x in $(cat /proc/cmdline); do
             ;;
         logs_inram=on)
             logs_inram=true
+            ;;
+        varlog_size=*)
+            varlog_size="${x#varlog_size=}"
             ;;
         secure_boot_enable=[y1])
             secureboot=true
@@ -44,6 +48,12 @@ done
 
 set_tmpfs_log_partition_size()
 {
+    if [ $varlog_size -gt 0 ]; then
+        # Use the varlog_size passed in from command line
+        varlogsize=$varlog_size
+        return
+    fi
+
     varlogsize=128
 
     # set varlogsize to existing var-log.ext4 size

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 
 PREREQS="varlog"
 

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -167,7 +167,13 @@ mount --bind ${rootmnt}/host/$image_dir/boot ${rootmnt}/boot
 if $logs_inram; then
     # NOTE: some platforms, when reaching initramfs stage, have a small
     #       limit of mounting tmpfs partition, potentially due to amount
-    #       of RAM available in this stage. e.g. Arista 7050-qx32[s] and 7060-cx32s
+    #       of RAM available in this stage. Therefore limiting the size
+    #       set for tmpfs partitions.
+    #
+    #       Another reason for using tmpfs /var/log partition is:
+    #       Some platforms have a small flash and therefore the log partition takes valuable space.
+    #       To improve the longevity of these devices storing the logs in memory will permit more
+    #       SONiC image growth before being bottlenecked.
     set_tmpfs_log_partition_size
     mount -t tmpfs -o rw,nosuid,nodev,size=${varlogsize}M tmpfs ${rootmnt}/var/log
     if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
@@ -176,8 +182,6 @@ if $logs_inram; then
 else
     if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
         fsck.ext4 -v -p ${rootmnt}/host/disk-img/var-log.ext4 2>&1 | gzip -c >> /tmp/fsck.log.gz
-    fi
-    if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
         mount -t ext4 -o loop,rw ${rootmnt}/host/disk-img/var-log.ext4 ${rootmnt}/var/log
     fi
 fi

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -51,15 +51,14 @@ set_tmpfs_log_partition_size()
     if [ $varlog_size -gt 0 ]; then
         # Use the varlog_size passed in from command line
         varlogsize=$varlog_size
-        return
-    fi
+    else
+        varlogsize=128
 
-    varlogsize=128
-
-    # set varlogsize to existing var-log.ext4 size
-    if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
-        varlogsize=$(ls -l ${rootmnt}/host/disk-img/var-log.ext4 | awk '{print $5}')
-        varlogsize=$(($varlogsize/1024/1024))
+        # set varlogsize to existing var-log.ext4 size
+        if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
+            varlogsize=$(ls -l ${rootmnt}/host/disk-img/var-log.ext4 | awk '{print $5}')
+            varlogsize=$(($varlogsize/1024/1024))
+        fi
     fi
 
     # make sure varlogsize is between 5% to 10% of total memory size

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -44,22 +44,26 @@ done
 
 set_tmpfs_log_partition_size()
 {
-  varlogsize=128
+    varlogsize=128
 
-  # set varlogsize to existing var-log.ext4 size
-  if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
-    varlogsize=$(ls -l ${rootmnt}/host/disk-img/var-log.ext4 | awk '{print $5}')
-    varlogsize=$(($varlogsize/1024/1024))
-  fi
+    # set varlogsize to existing var-log.ext4 size
+    if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
+        varlogsize=$(ls -l ${rootmnt}/host/disk-img/var-log.ext4 | awk '{print $5}')
+        varlogsize=$(($varlogsize/1024/1024))
+    fi
 
-  # make sure varlogsize is between 5% to 10% of total memory size
-  memkb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
-  memmb=$(($memkb/1024))
-  minsize=$(($memmb*5/100))
-  maxsize=$(($memmb*10/100))
+    # make sure varlogsize is between 5% to 10% of total memory size
+    memkb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+    memmb=$(($memkb/1024))
+    minsize=$(($memmb*5/100))
+    maxsize=$(($memmb*10/100))
 
-  [ $minsize -ge $varlogsize ] && varlogsize=$minsize
-  [ $maxsize -le $varlogsize ] && varlogsize=$maxsize
+    if [ $minsize -ge $varlogsize ]; then
+        varlogsize=$minsize
+    fi
+    if [ $maxsize -le $varlogsize ]; then
+        varlogsize=$maxsize
+    fi
 }
 
 remove_not_in_allowlist_files()
@@ -151,16 +155,21 @@ mount --bind ${rootmnt}/host/$image_dir/boot ${rootmnt}/boot
 
 ## Mount loop device or tmpfs for /var/log
 if $logs_inram; then
-  # NOTE: some platforms, when reaching initramfs stage, have a small
-  #       limit of mounting tmpfs partition, potentially due to amount
-  #       of RAM available in this stage. e.g. Arista 7050-qx32[s] and 7060-cx32s
-  set_tmpfs_log_partition_size
-  mount -t tmpfs -o rw,nosuid,nodev,size=${varlogsize}M tmpfs ${rootmnt}/var/log
-  [ -f ${rootmnt}/host/disk-img/var-log.ext4 ] && rm -rf ${rootmnt}/host/disk-img/var-log.ext4
+    # NOTE: some platforms, when reaching initramfs stage, have a small
+    #       limit of mounting tmpfs partition, potentially due to amount
+    #       of RAM available in this stage. e.g. Arista 7050-qx32[s] and 7060-cx32s
+    set_tmpfs_log_partition_size
+    mount -t tmpfs -o rw,nosuid,nodev,size=${varlogsize}M tmpfs ${rootmnt}/var/log
+    if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
+        rm -rf ${rootmnt}/host/disk-img/var-log.ext4
+    fi
 else
-  [ -f ${rootmnt}/host/disk-img/var-log.ext4 ] && fsck.ext4 -v -p ${rootmnt}/host/disk-img/var-log.ext4 2>&1 \
-                                                  | gzip -c >> /tmp/fsck.log.gz
-  [ -f ${rootmnt}/host/disk-img/var-log.ext4 ] && mount -t ext4 -o loop,rw ${rootmnt}/host/disk-img/var-log.ext4 ${rootmnt}/var/log
+    if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
+        fsck.ext4 -v -p ${rootmnt}/host/disk-img/var-log.ext4 2>&1 | gzip -c >> /tmp/fsck.log.gz
+    fi
+    if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
+        mount -t ext4 -o loop,rw ${rootmnt}/host/disk-img/var-log.ext4 ${rootmnt}/var/log
+    fi
 fi
 
 ## fscklog file: /tmp will be lost when overlayfs is mounted


### PR DESCRIPTION
#### Why I did it
Master/202012 image size grew quite a bit. 3.7G harddrive can no longer hold one image and safely upgrade to another image. Every bit of harddrive space is precious to save now.

Also sh syntax seemingly changed, [ condition ] && action was a legit syntax in 201911 branch but it is an error when condition not met with 202012 or later images. Change the syntax to if statement to avoid the issue.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

