### PR TITLE
[201811] Dell S6100:Add serial-getty service to monit

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -11,6 +11,7 @@ s6100/scripts/fast-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-
 s6100/scripts/warm-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/soft-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 common/dell_lpc_mon.sh usr/local/bin
+s6100/scripts/s6100_serial_getty_monitor etc/monit/conf.d
 s6100/scripts/s6100_ssd_mon.sh usr/local/bin
 s6100/scripts/s6100_ssd_upgrade_status.sh usr/local/bin
 s6100/scripts/platform_sensors.py usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -58,6 +58,7 @@ if [[ "$1" == "init" ]]; then
     fi
 
     install_python_api_package
+    monit reload
 
 elif [[ "$1" == "deinit" ]]; then
     /usr/local/bin/s6100_i2c_enumeration.sh deinit

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_serial_getty_monitor
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_serial_getty_monitor
@@ -1,0 +1,4 @@
+#Dell S6100 serial getty monitor
+check process serial-getty matching "ttyS"
+start program = "/bin/systemctl start serial-getty@ttyS1.service"
+stop program = "/bin/systemctl stop serial-getty@ttyS1.service"


### PR DESCRIPTION
#### Why I did it
serial-getty service exited in Dell S6100 device randomly.
#### How I did it
Added serial-getty to monit services.
#### How to verify it
Stop serial-getty in ssh session and check whether the service restarts or not.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
UT: 
[console_UT.txt](https://github.com/Azure/sonic-buildimage/files/6960074/console_UT.txt)


#### A picture of a cute animal (not mandatory but encouraged)

