### PR TITLE
[202012] Fix arp_update script

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -25,6 +25,8 @@ while /bin/true; do
       fi
   done
 
+  sleep 1
+
   VLAN=$(echo $ARP_UPDATE_VARS | jq -r '.vlan')
   for vlan in $VLAN; do
       # generate a list of arping commands:

--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -25,8 +25,6 @@ while /bin/true; do
       fi
   done
 
-  sleep 1
-
   VLAN=$(echo $ARP_UPDATE_VARS | jq -r '.vlan')
   for vlan in $VLAN; do
       # generate a list of arping commands:
@@ -39,7 +37,7 @@ while /bin/true; do
       eval `eval $ipcmd`
 
       # send ipv6 multicast pings to Vlan interfaces to get/refresh link-local addrs
-      ping6cmd="ping6 -I $vlan -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
+      ping6cmd="timeout 1 ping6 -I $vlan -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
       eval $ping6cmd
 
       # generate a list of ndisc6 commands (exclude link-local addrs since it is done above):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix #7968 

Issue is detected on `SONiC.20201231.11`
In `test_static_route.py::test_static_route_ecmp` static routes are configured, but neighbors are not resolved after config reload even after 10 minutes.
It looks like the `arp_update` script is starting to ping when Vlan1000 is not fully configured.
When issue is reproduced, stuck ping6 process is observed in swss container :
```
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         180  0.1  0.0   6296  1272 pts/0    S    17:03   0:03 ping6 -I Vlan1000 -n -q -i 0 -c 1 -W 0 ff02::1
```
And when arp_update script successfully resolves neighbors, we observe `sleep 300` instead of ping process 
#### How I did it
Add sleep to be sure that all interfaces in up state and can be reachable by ping command
#### How to verify it
Run it manually with -x option
and run `test_static_route.py`  
```
route/test_static_route.py::test_static_route PASSED
route/test_static_route.py::test_static_route_ecmp PASSED
route/test_static_route.py::test_static_route_ipv6 PASSED
route/test_static_route.py::test_static_route_ecmp_ipv6 SKIPPED
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)
![image](https://user-images.githubusercontent.com/84025678/128868146-547e6212-8b02-4def-935f-0eeb1537b242.png)

