### PR TITLE
Added DHCPv6 messages to DHCP monitor

### DIFF
--- a/src/dhcpmon/src/dhcp_device.h
+++ b/src/dhcpmon/src/dhcp_device.h
@@ -31,6 +31,14 @@ typedef enum
     DHCP_MESSAGE_TYPE_RELEASE  = 7,
     DHCP_MESSAGE_TYPE_INFORM   = 8,
 
+    DHCPv6_MESSAGE_TYPE_SOLICIT = 1,
+    DHCPv6_MESSAGE_TYPE_ADVERTISE = 2,
+    DHCPv6_MESSAGE_TYPE_REQUEST = 3,
+    DHCPv6_MESSAGE_TYPE_CONFIRM = 4,
+    DHCPv6_MESSAGE_TYPE_REPLY = 7,
+    DHCPv6_MESSAGE_TYPE_RELAY_FORW = 12,
+    DHCPv6_MESSAGE_TYPE_RELAY_REPL = 13,
+
     DHCP_MESSAGE_TYPE_COUNT
 } dhcp_message_type_t;
 
@@ -42,6 +50,15 @@ typedef enum
 
     DHCP_DIR_COUNT
 } dhcp_packet_direction_t;
+
+/** DHCP version type */
+typedef enum
+{
+    DHCPv4,    
+    DHCPv6,   
+
+    DHCP_TYPE
+} dhcp_type;
 
 /** counters type */
 typedef enum
@@ -67,6 +84,11 @@ typedef enum
     DHCP_MON_CHECK_POSITIVE,    /** Validate that received DORA packets are relayed */
 } dhcp_mon_check_t;
 
+/** dhcp message */
+struct dhcpv6_msg {
+    uint8_t msg_type;
+};
+
 /** DHCP device (interface) context */
 typedef struct
 {
@@ -78,7 +100,7 @@ typedef struct
     char intf[IF_NAMESIZE];         /** device (interface) name */
     uint8_t *buffer;                /** buffer used to read socket data */
     size_t snaplen;                 /** snap length or buffer size */
-    uint64_t counters[DHCP_COUNTERS_COUNT][DHCP_DIR_COUNT][DHCP_MESSAGE_TYPE_COUNT];
+    uint64_t counters[DHCP_COUNTERS_COUNT][DHCP_DIR_COUNT][DHCP_TYPE][DHCP_MESSAGE_TYPE_COUNT];
                                     /** current/snapshot counters of DHCP packets */
 } dhcp_device_context_t;
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Monitor DHCPv6 messages and ensure DHCPv6 Relay is healthy

#### How I did it
Modified dhcpmon to listen to DHCPv6 messages

#### How to verify it
Send dhcpv6 packets to interface and track the number of packets in syslog

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

