### PR TITLE
Enable the cache build for the platform ragile and ruijie.

### DIFF
--- a/platform/broadcom/rules.dep
+++ b/platform/broadcom/rules.dep
@@ -13,6 +13,8 @@ include $(PLATFORM_PATH)/platform-modules-delta.dep
 include $(PLATFORM_PATH)/platform-modules-quanta.dep
 #include $(PLATFORM_PATH)/platform-modules-mitac.dep
 include $(PLATFORM_PATH)/platform-modules-juniper.dep
+include $(PLATFORM_PATH)/platform-modules-ragile.dep
+include $(PLATFORM_PATH)/platform-modules-ruijie.dep
 include $(PLATFORM_PATH)/platform-modules-brcm-xlr-gts.dep
 include $(PLATFORM_PATH)/docker-syncd-brcm.dep
 include $(PLATFORM_PATH)/docker-syncd-brcm-rpc.dep


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

[ DPKG ] Cache is not enabled for platform-modules-ruijie-b6510-48vs8cq_1.0_amd64.deb package 
[ DPKG ] Cache is not enabled for platform-modules-ragile-ra-b6510-48v8c_1.0_amd64.deb package 

#### How I did it
Add the platform ruihie and ragile .dep file to platform/broadcom/rules.dep

#### How to verify it
Run a build and check if the warning message is there or not and also check the packages are copied under 'target/cache' directory after the first build.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

