### PR TITLE
Upgrade ifupdown2, and clean up some code 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ pr:
     include:
       - master
       - 202012
+      - bullseye
   paths:
     exclude:
       - .github

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -98,7 +98,7 @@ sudo mkdir -p $FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE/
 # Keeping it generic. It should not harm anyways.
 sudo mkdir -p $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 
-# Install a more recent version of ifupdown2  (and its dependencies via 'apt-get -y install -f')
+# Install a patched version of ifupdown2  (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/ifupdown2_*.deb || \
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f
 
@@ -138,6 +138,10 @@ sudo rm -rf $FILESYSTEM_ROOT/$REDIS_DUMP_LOAD_PY2_WHEEL_NAME
 
 # Install Python module for psutil
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install psutil
+
+# Install Python module for ipaddr
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install ipaddr
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install ipaddr
 
 # Install SwSS SDK Python 3 package
 # Note: the scripts will be overwritten by corresponding Python 2 package

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -24,6 +24,7 @@ auto lo
 iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
+   scope host
    post-up ip addr del 127.0.0.1/8 dev lo
 {% endblock loopback %}
 {% block mgmt_interface %}

--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -13,9 +13,9 @@ fi
 # on Single NPU platforms we continue to use loopback adddres
 
 if [[ ($NUM_ASIC -gt 1) ]]; then
-    udp_server_ip=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
+    udp_server_ip=$(ip -j -4 addr list docker0 | jq -r -M '.[0].addr_info[0].local')
 else
-    udp_server_ip=$(ip -o -4 addr list lo scope host | awk '{print $4}' | cut -d/ -f1)
+    udp_server_ip=$(ip -j -4 addr list lo scope host | jq -r -M '.[0].addr_info[0].local')
 fi
 
 sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog.conf.j2 -a "{\"udp_server_ip\": \"$udp_server_ip\"}"  >/etc/rsyslog.conf

--- a/platform/barefoot/docker-syncd-bfn-rpc.mk
+++ b/platform/barefoot/docker-syncd-bfn-rpc.mk
@@ -19,7 +19,7 @@ endif
 $(DOCKER_SYNCD_BFN_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BFN_RPC)_VERSION = 1.0.0-rpc
 $(DOCKER_SYNCD_BFN_RPC)_PACKAGE_NAME = syncd
-$(DOCKER_SYNCD_BFN_RPC)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SYNCD_BFN_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_BFN_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_BFN_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_SYNCD_BFN_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot

--- a/platform/broadcom/docker-pde.mk
+++ b/platform/broadcom/docker-pde.mk
@@ -28,7 +28,7 @@ SONIC_DOCKER_DBG_IMAGES += $(DOCKER_PDE_DBG)
 SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_PDE_DBG)
 
 $(DOCKER_PDE)_CONTAINER_NAME = pde
-$(DOCKER_PDE)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_PDE)_RUN_OPT += --privileged -t
 $(DOCKER_PDE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_PDE)_RUN_OPT += -v /host/machine.conf:/host/machine.conf:ro
 $(DOCKER_PDE)_RUN_OPT += -v /usr/lib/python2.7/dist-packages:/usr/share/sonic/classes:ro

--- a/platform/broadcom/docker-saiserver-brcm.mk
+++ b/platform/broadcom/docker-saiserver-brcm.mk
@@ -8,7 +8,7 @@ $(DOCKER_SAISERVER_BRCM)_LOAD_DOCKERS += $(DOCKER_CONFIG_ENGINE_BUSTER)
 SONIC_DOCKER_IMAGES += $(DOCKER_SAISERVER_BRCM)
 
 $(DOCKER_SAISERVER_BRCM)_CONTAINER_NAME = saiserver
-$(DOCKER_SAISERVER_BRCM)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SAISERVER_BRCM)_RUN_OPT += --privileged -t
 $(DOCKER_SAISERVER_BRCM)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SAISERVER_BRCM)_RUN_OPT += -v /var/run/docker-saiserver:/var/run/sswsyncd
 $(DOCKER_SAISERVER_BRCM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/cavium/docker-syncd-cavm-rpc.mk
+++ b/platform/cavium/docker-syncd-cavm-rpc.mk
@@ -19,6 +19,6 @@ endif
 $(DOCKER_SYNCD_CAVM_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_CAVM_RPC)_VERSION = 1.0.0-rpc
 $(DOCKER_SYNCD_CAVM_RPC)_PACKAGE_NAME = syncd
-$(DOCKER_SYNCD_CAVM_RPC)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SYNCD_CAVM_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_CAVM_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_CAVM_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/cavium/docker-syncd-cavm.mk
+++ b/platform/cavium/docker-syncd-cavm.mk
@@ -20,6 +20,6 @@ $(DOCKER_SYNCD_BASE)_VERSION = 1.0.0
 $(DOCKER_SYNCD_BASE)_PACKAGE_NAME = syncd
 
 $(DOCKER_SYNCD_CAVM)_CONTAINER_NAME = syncd
-$(DOCKER_SYNCD_CAVM)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SYNCD_CAVM)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_CAVM)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_CAVM)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/innovium/docker-syncd-invm-rpc.mk
+++ b/platform/innovium/docker-syncd-invm-rpc.mk
@@ -12,7 +12,7 @@ endif
 $(DOCKER_SYNCD_INVM_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_INVM_RPC)_VERSION = 1.0.0-rpc
 $(DOCKER_SYNCD_INVM_RPC)_PACKAGE_NAME = syncd
-$(DOCKER_SYNCD_INVM_RPC)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SYNCD_INVM_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_INVM_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_INVM_RPC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_INVM_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/marvell-arm64/docker-saiserver-mrvl.mk
+++ b/platform/marvell-arm64/docker-saiserver-mrvl.mk
@@ -8,7 +8,7 @@ SONIC_DOCKER_IMAGES += $(DOCKER_SAISERVER_MRVL)
 SONIC_STRETCH_DOCKERS += $(DOCKER_SAISERVER_MRVL)
 
 $(DOCKER_SAISERVER_MRVL)_CONTAINER_NAME = saiserver
-$(DOCKER_SAISERVER_MRVL)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SAISERVER_MRVL)_RUN_OPT += --privileged -t
 $(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /var/run/docker-saiserver:/var/run/sswsyncd
 $(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/marvell-arm64/docker-syncd-mrvl-rpc.mk
+++ b/platform/marvell-arm64/docker-syncd-mrvl-rpc.mk
@@ -20,7 +20,7 @@ endif
 $(DOCKER_SYNCD_MRVL_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_MRVL_RPC)_VERSION = 1.0.0-rpc
 $(DOCKER_SYNCD_MRVL_RPC)_PACKAGE_NAME = syncd
-$(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot

--- a/platform/marvell-armhf/docker-saiserver-mrvl.mk
+++ b/platform/marvell-armhf/docker-saiserver-mrvl.mk
@@ -8,7 +8,7 @@ $(DOCKER_SAISERVER_MRVL)_LOAD_DOCKERS += $(DOCKER_CONFIG_ENGINE_BUSTER)
 SONIC_DOCKER_IMAGES += $(DOCKER_SAISERVER_MRVL)
 
 $(DOCKER_SAISERVER_MRVL)_CONTAINER_NAME = saiserver
-$(DOCKER_SAISERVER_MRVL)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SAISERVER_MRVL)_RUN_OPT += --privileged -t
 $(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /var/run/docker-saiserver:/var/run/sswsyncd
 $(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/marvell-armhf/docker-syncd-mrvl-rpc.mk
+++ b/platform/marvell-armhf/docker-syncd-mrvl-rpc.mk
@@ -19,7 +19,7 @@ endif
 $(DOCKER_SYNCD_MRVL_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_MRVL_RPC)_VERSION = 1.0.0-rpc
 $(DOCKER_SYNCD_MRVL_RPC)_PACKAGE_NAME = syncd
-$(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot

--- a/platform/marvell/docker-syncd-mrvl-rpc.mk
+++ b/platform/marvell/docker-syncd-mrvl-rpc.mk
@@ -20,7 +20,7 @@ endif
 $(DOCKER_SYNCD_MRVL_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_MRVL_RPC)_VERSION = 1.0.0-rpc
 $(DOCKER_SYNCD_MRVL_RPC)_PACKAGE_NAME = syncd
-$(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot

--- a/platform/mellanox/docker-saiserver-mlnx.mk
+++ b/platform/mellanox/docker-saiserver-mlnx.mk
@@ -9,7 +9,7 @@ SONIC_DOCKER_IMAGES += $(DOCKER_SAISERVER_MLNX)
 SONIC_STRETCH_DOCKERS += $(DOCKER_SAISERVER_MLNX)
 
 $(DOCKER_SAISERVER_MLNX)_CONTAINER_NAME = saiserver
-$(DOCKER_SAISERVER_MLNX)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SAISERVER_MLNX)_RUN_OPT += --privileged -t
 $(DOCKER_SAISERVER_MLNX)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SAISERVER_MLNX)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_SYNCD_BASE)_RUN_OPT += --tmpfs /run/criu

--- a/platform/nephos/docker-syncd-nephos-rpc.mk
+++ b/platform/nephos/docker-syncd-nephos-rpc.mk
@@ -20,7 +20,7 @@ endif
 $(DOCKER_SYNCD_NEPHOS_RPC)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_NEPHOS_RPC)_VERSION = 1.0.0-rpc
 $(DOCKER_SYNCD_NEPHOS_RPC)_PACKAGE_NAME = syncd
-$(DOCKER_SYNCD_NEPHOS_RPC)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_SYNCD_NEPHOS_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_NEPHOS_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_NEPHOS_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot
 $(DOCKER_SYNCD_NEPHOS_RPC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd

--- a/platform/template/docker-gbsyncd-base.mk
+++ b/platform/template/docker-gbsyncd-base.mk
@@ -24,6 +24,6 @@ SONIC_BUSTER_DBG_DOCKERS += $(DOCKER_GBSYNCD_BASE_DBG)
 SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_GBSYNCD_BASE_DBG)
 
 $(DOCKER_GBSYNCD_BASE)_CONTAINER_NAME = gbsyncd
-$(DOCKER_GBSYNCD_BASE)_RUN_OPT += --net=host --privileged -t
+$(DOCKER_GBSYNCD_BASE)_RUN_OPT += --privileged -t
 $(DOCKER_GBSYNCD_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_GBSYNCD_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/rules/ifupdown2.mk
+++ b/rules/ifupdown2.mk
@@ -1,6 +1,6 @@
 # ifupdown2 package
 
-IFUPDOWN2_VERSION = 1.2.8-1
+IFUPDOWN2_VERSION = 3.0.0-1
 export IFUPDOWN2_VERSION
 
 IFUPDOWN2 = ifupdown2_$(IFUPDOWN2_VERSION)_all.deb

--- a/slave.mk
+++ b/slave.mk
@@ -482,8 +482,8 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_DPKG_DEBS)) : $(DEBS_PATH)/% : .platform $$(a
 		if [ -f ./autogen.sh ]; then ./autogen.sh $(LOG); fi
 		$(SETUP_OVERLAYFS_FOR_DPKG_ADMINDIR)
 		$(if $($*_DPKG_TARGET),
-			${$*_BUILD_ENV} DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC} ${$*_DEB_BUILD_OPTIONS}" dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --as-root -T$($*_DPKG_TARGET) --admindir $$mergedir $(LOG),
-			${$*_BUILD_ENV} DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC} ${$*_DEB_BUILD_OPTIONS}" dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $$mergedir $(LOG)
+			${$*_BUILD_ENV} DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC} ${$*_DEB_BUILD_OPTIONS}" dpkg-buildpackage -rfakeroot -b -us -uc -tc -j$(SONIC_CONFIG_MAKE_JOBS) --as-root -T$($*_DPKG_TARGET) --admindir $$mergedir $(LOG),
+			${$*_BUILD_ENV} DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC} ${$*_DEB_BUILD_OPTIONS}" dpkg-buildpackage -rfakeroot -b -us -uc -tc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $$mergedir $(LOG)
 		)
 		popd $(LOG_SIMPLE)
 		# Clean up

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -72,6 +72,7 @@ RUN apt-get update && apt-get install -y \
         libzmq5 \
         libzmq3-dev \
         jq \
+        cron \
 # For quagga build
         libreadline-dev \
         texlive-latex-base \
@@ -396,7 +397,7 @@ RUN pip3 install setuptools==49.6.00
 RUN pip3 install wheel==0.35.1
 
 # For building sonic-utilities
-RUN pip3 install fastentrypoints
+RUN pip3 install fastentrypoints mock
 
 # For running Python unit tests
 RUN pip3 install pytest-runner==5.2

--- a/src/ifupdown2/Makefile
+++ b/src/ifupdown2/Makefile
@@ -13,6 +13,14 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	tar -z -f $(IFUPDOWN2_VERSION).tar.gz -x
 	pushd ./ifupdown2-$(IFUPDOWN2_VERSION)
 
+	git init
+	git add -f *
+	git commit -m "unmodified ifupdown2 source"
+
+	# Apply patch series
+	stg init
+	stg import -s ../patch/series
+
 	# Build source and Debian packages
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 	popd

--- a/src/ifupdown2/patch/0001-fix-broadcast-addr-encoding.patch
+++ b/src/ifupdown2/patch/0001-fix-broadcast-addr-encoding.patch
@@ -1,0 +1,31 @@
+Fix reading and using broadcast address
+
+When reading the broadcast address, convert it to an IPNetwork object,
+so that it can be encoded/packed later.
+
+From: Saikrishna Arcot <sarcot@microsoft.com>
+---
+ ifupdown2/addons/address.py |    6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/ifupdown2/addons/address.py b/ifupdown2/addons/address.py
+index 8b99b25..2ca41fc 100644
+--- a/ifupdown2/addons/address.py
++++ b/ifupdown2/addons/address.py
+@@ -441,11 +441,15 @@ class address(Addon, moduleBase):
+                         else:
+                             addr_obj = ipnetwork.IPNetwork(addr)
+ 
+-                    for attr_name in ("broadcast", "scope", "preferred-lifetime"):
++                    for attr_name in ("scope", "preferred-lifetime"):
+                         attr_value = ifaceobj.get_attr_value_n(attr_name, index)
+                         if attr_value:
+                             addr_attributes[attr_name] = attr_value
+ 
++                    broadcast = ifaceobj.get_attr_value_n("broadcast", index)
++                    if broadcast:
++                        addr_attributes["broadcast"] = ipnetwork.IPNetwork(broadcast)
++
+                     pointopoint = ifaceobj.get_attr_value_n("pointopoint", index)
+                     try:
+                         if pointopoint:

--- a/src/ifupdown2/patch/series
+++ b/src/ifupdown2/patch/series
@@ -1,0 +1,1 @@
+0001-fix-broadcast-addr-encoding.patch

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces
@@ -8,6 +8,7 @@ auto lo
 iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
+   scope host
    post-up ip addr del 127.0.0.1/8 dev lo
 
 # The management network interface

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -17,6 +17,7 @@ auto lo
 iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
+   scope host
    post-up ip addr del 127.0.0.1/8 dev lo
 
 # The management network interface

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces
@@ -8,6 +8,7 @@ auto lo
 iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
+   scope host
    post-up ip addr del 127.0.0.1/8 dev lo
 
 # The management network interface

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -17,6 +17,7 @@ auto lo
 iface lo inet loopback
    address 127.0.0.1
    netmask 255.255.0.0
+   scope host
    post-up ip addr del 127.0.0.1/8 dev lo
 
 # The management network interface

--- a/src/tacacs/nss/patch/0009-fix-compile-error-strncpy.patch
+++ b/src/tacacs/nss/patch/0009-fix-compile-error-strncpy.patch
@@ -1,0 +1,29 @@
+Fix calls to strncpy
+
+From: Saikrishna Arcot <sarcot@microsoft.com>
+
+Calls to strncpy don't guarantee that the destination buffer will be
+terminated with a null-byte. GCC, with the -D_FORTIFY_SOURCE=2 flag, will
+error out when strncpy is being called with a max size equal to the size of
+the destination buffer.
+
+Change these calls to pass in one less than the size of the destination
+buffer, and explicitly add a null byte at the end of the buffer.
+---
+ nss_tacplus.c |    3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/nss_tacplus.c b/nss_tacplus.c
+index cc6f0aa..2de00a6 100644
+--- a/nss_tacplus.c
++++ b/nss_tacplus.c
+@@ -127,7 +127,8 @@ static int parse_tac_server(char *srv_buf)
+                 }
+             }
+             else if(!strncmp(token, "vrf=", 4)){
+-                strncpy(vrfname, token + 4, sizeof(vrfname));
++                strncpy(vrfname, token + 4, sizeof(vrfname) - 1);
++                vrfname[sizeof(vrfname) - 1] = '\0';
+             }
+             else if(!strncmp(token, "secret=", 7)) {
+                 if(tac_srv[tac_srv_no].key)

--- a/src/tacacs/nss/patch/series
+++ b/src/tacacs/nss/patch/series
@@ -6,3 +6,4 @@
 0006-fix-compiling-warning-about-token-dereference.patch
 0007-Add-support-for-TACACS-source-address.patch
 0008-do-not-create-or-modify-local-user-if-there-is-no-pr.patch
+0009-fix-compile-error-strncpy.patch


### PR DESCRIPTION
#### Why I did it

These changes are in preparation for upgrading the base OS to Bullseye.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog

1. Upgrade ifupdown2 from 1.2.8 to 3.0.0 (the latest version). Add a patch to fix handling broadcast addresses.
2. Remove `--net=host` from the `RUN_OPT` of other docker containers. This is now handled by `files/build_templates/docker_image_ctl.j2`. Specifying this twice in a `docker run` command will be considered an error starting from Docker 20.10.
3. For tacplus, fix a code issue that gets detected with GCC 10 related to `strncpy` not guaranteeing that the destination buffer will have a null byte.
4. Update the Bullseye slave image with some changes needed there.
5. For deb package builds that are done directly from `slave.mk`, do a clean after building it, to remove generated and compiled files. This will be needed for Bullseye, as some components will be built once for Buster and once for Bullseye, and having existing generated files will mess up the builds (at least for autoconf-based packages).

#### A picture of a cute animal (not mandatory but encouraged)

