### PR TITLE
Fix constant casing for prefix-list mode

### DIFF
--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2
@@ -25,7 +25,7 @@ route-map {{rm_key[0]}} {{rm_val['route_operation']}} {{rm_key[1]}}
  match source-vrf {{rm_val['match_src_vrf']}}
 {% endif %}
 {# ---------------match ip/ipv6-Start-------------------------- #}
-{% set ip_str = {'ipv4':'ip', 'ipv6':'ipv6' } %}
+{% set ip_str = {'IPv4':'ip', 'IPv6':'ipv6' } %}
 {% if PREFIX_SET is defined and PREFIX_SET|length > 0 %}
 {% if 'match_prefix_set' in rm_val %}
 {% for pfx_key, pfx_val in PREFIX_SET.items() %}


### PR DESCRIPTION
This change makes the template match PREFIX_SET and the documentation.

Fix #6943.

Signed-off-by: Christian Svensson <blue@cmd.nu>

#### Why I did it

See #6943.

#### How I did it

I updated the cases in the template as suggested in https://github.com/Azure/sonic-buildimage/issues/6943#issuecomment-789884878.

#### How to verify it

Apply the patch and follow the repro in #6943.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

Why: This is a breaking issue for a quite critical feature in BGP outside datacenter use.

#### Description for the changelog

frr: Fix mode case for prefix lists.

#### A picture of a cute animal (not mandatory but encouraged)

![image](https://user-images.githubusercontent.com/149442/129271409-b9dc6344-96d0-4134-bfc3-224c4ef7969b.png)
