### PR TITLE
[voq][bgpcfg] BGP_VOQ_CHASSIS_NEIGHBORS timers config

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
@@ -7,11 +7,8 @@
   neighbor {{ neighbor_addr }} peer-group VOQ_CHASSIS_PEER
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
-{# set the bgp neighbor timers if they have not default values #}
-{% if     (bgp_session['keepalive'] is defined and bgp_session['keepalive'] | int != 60)
-      or  (bgp_session['holdtime'] is defined  and bgp_session['holdtime']  | int != 180) %}
-  neighbor {{ neighbor_addr }} timers {{ bgp_session['keepalive'] | default("60") }} {{ bgp_session['holdtime'] | default("180") }}
-{% endif %}
+  neighbor {{ neighbor_addr }} timers 3 10
+  neighbor {{ neighbor_addr }} timers connect 10
 !
 {% if 'admin_status' in bgp_session and bgp_session['admin_status'] == 'down' or 'admin_status' not in bgp_session and 'default_bgp_status' in CONFIG_DB__DEVICE_METADATA['localhost'] and CONFIG_DB__DEVICE_METADATA['localhost']['default_bgp_status'] == 'down' %}
   neighbor {{ neighbor_addr }} shutdown

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_all.conf
@@ -7,7 +7,8 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
-  neighbor 10.10.10.10 timers 5 30
+  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers connect 10
   neighbor 10.10.10.10 shutdown
   address-family ipv4
     maximum-paths ibgp 32

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_base.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_base.conf
@@ -7,6 +7,8 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
+  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64
 !

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_1.conf
@@ -7,6 +7,8 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
+  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers connect 10
   neighbor 10.10.10.10 shutdown
   address-family ipv4
     maximum-paths ibgp 64

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_2.conf
@@ -7,6 +7,8 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
+  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64
 !

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_1.conf
@@ -7,7 +7,8 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
-  neighbor 10.10.10.10 timers 5 180
+  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64
 !

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_2.conf
@@ -7,7 +7,8 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
-  neighbor 10.10.10.10 timers 60 240
+  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64
 !


### PR DESCRIPTION
#### Why I did it

Currently, voq chassis bgp neighbor timer configuration is done similar to general neighbors. i.e., keepalive and holdtime timers are set to configured values, if configured,, otherwise set to default of 60 and 180. This is causing a problem of configuring timer values to 0 & 0 since minigraph configures 0 & 0 for voq chassis neighbors. Voq chassis neighbors are equivalent to multi-asic internal neighbors but we need to configure timers to values other than 0 & 0 since the voq chassis bgp neighbors may go down due to line card failures, for example. This PR fixes this problem of having 0 and 0 timer confiuration for voq chassis neighbors.

#### How I did it

Since the voq chassis bgp neighbors are similar to multi-asic internal neighbors, the voq chassis bgp timers are configured similar to multi-asic internal bgp neighbors. i.e, 3 & 10 are configured (hardcoded) for keepalive and holdtime respectively and the configurations given via config db are ignored. Also, similar to bgp internal neighbors, connection retry timer is also configured for voq chassis bgp neighbors.

#### How to verify it

- Configure BGP_VOQ_CHASSIS_NEIGHBOR using minigraph. The minigraph will generate these neighbors with keepalive and holdtime timer values of 0 & 0 respectively.
- Reboot the chassis with this configuration
- After chassis is up and operational, check the bgp summary and observe voq chassis bgp sessions are up.
- Check the bgp confiuration for the internal neighbors in FRR (using show running-configuration, for example) and observe 3 & 10 are configured for keepalive and holdtime timers for voq chassis bgp neighbors. Also observe that connection retry timer is configured to 10.

#### Which release branch to backport (provide reason below if selected)

N/A

#### Description for the changelog

Keepalive, Holddown and Connection retry timers configuration for BGP_VOQ_CHASSIS_NEIGHBORs 

#### A picture of a cute animal (not mandatory but encouraged)

