### PR TITLE
Fix bfn version

### DIFF
--- a/files/build/versions/default/versions-web
+++ b/files/build/versions/default/versions-web
@@ -23,8 +23,8 @@ https://deb.nodesource.com/node_14.x/dists/buster/Release==5cf451f38943b867b88ac
 https://deb.nodesource.com/setup_10.x==6742c0148159980e8f6e886df1f8bbe1
 https://deb.nodesource.com/setup_14.x==ac77c69d672c0278c4ef2c3e1ce61b4f
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
-https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnplatform_20210324_deb10.deb==b1f3087f05b82504130c5a7d428b9ef5
-https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnsdk_20210805_sai.1.7.1_deb10.deb.deb==4d1e991a943a2e16be2c1db9bb3c02d6
+https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnplatform_20210805_sai.1.7.1_deb10.deb==8ba915f8843cf57982825f304b629cb3
+https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnsdk_20210805_sai.1.7.1_deb10.deb==4d1e991a943a2e16be2c1db9bb3c02d6
 https://github.com/CentecNetworks/sonic-binaries/raw/master/amd64/libsai_1.6.3-1_amd64.deb==e7a41e5cf06b44ae3ed615d553de40d3
 https://github.com/CentecNetworks/sonic-binaries/raw/master/arm64/sai/libsai_1.6.3-1_arm64.deb==4121f09fbc5319cd488b832d72287f93
 https://github.com/CumulusNetworks/ifupdown2/archive/1.2.8-1.tar.gz==12f45e90d23178e96cf70f68dc9455e6

--- a/files/build/versions/default/versions-web
+++ b/files/build/versions/default/versions-web
@@ -24,7 +24,7 @@ https://deb.nodesource.com/setup_10.x==6742c0148159980e8f6e886df1f8bbe1
 https://deb.nodesource.com/setup_14.x==ac77c69d672c0278c4ef2c3e1ce61b4f
 https://download.docker.com/linux/debian/gpg==1afae06b34a13c1b3d9cb61a26285a15
 https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnplatform_20210324_deb10.deb==b1f3087f05b82504130c5a7d428b9ef5
-https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnsdk_20210324_deb10.deb==40a5468c7b7a003df6f4e6c2f9f98817
+https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/bfnsdk_20210805_sai.1.7.1_deb10.deb.deb==4d1e991a943a2e16be2c1db9bb3c02d6
 https://github.com/CentecNetworks/sonic-binaries/raw/master/amd64/libsai_1.6.3-1_amd64.deb==e7a41e5cf06b44ae3ed615d553de40d3
 https://github.com/CentecNetworks/sonic-binaries/raw/master/arm64/sai/libsai_1.6.3-1_arm64.deb==4121f09fbc5319cd488b832d72287f93
 https://github.com/CumulusNetworks/ifupdown2/archive/1.2.8-1.tar.gz==12f45e90d23178e96cf70f68dc9455e6


### PR DESCRIPTION
#### Why I did it
   Barefoot pipeline is broken, because version has not been update by ci build yet.

#### How I did it
  Manually replaced version for bfn packages to fix pipeline, until ci build not updated the version.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

