### PR TITLE
Reapply the fix to address set MTU > 1500 causing portmgrd crash on BRCM platforms

### DIFF
--- a/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+++ b/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
@@ -6341,6 +6341,11 @@ bkn_init_ndev(u8 *mac, char *name)
         dev->mtu = rx_buffer_size;
     }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0))
+    dev->min_mtu = 68;
+    dev->max_mtu = rx_buffer_size;
+#endif
+
     /* Device vectors */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,29))
     dev->netdev_ops = &bkn_netdev_ops;


### PR DESCRIPTION
#### Why I did it
This is to address the issue (https://github.com/Azure/sonic-buildimage/issues/8404)
The original fix which was introduced by (https://github.com/Azure/sonic-buildimage/pull/3895) was removed when onboarding BRCM SAI 4.3  (https://github.com/Azure/sonic-buildimage/pull/6526).  
At that time this change was removed because there was another way to set the port default MTU to 9100 which caused this change being removed.  It was most likely not anticipated that user may need to change the port MTU via CLI at which time this fix when not present will cause portmrgd to crash.
I have create a Case with BRCM (CS00012203989) to ask them to look into this issue to either take this change in and include it to all their future SAI releases and patch their current SAI releases or provide a better alternative to address this issue at which time BRCM team should revert this PR when raising their official fix to address the set interface MTU > 1500 causing portmgrd crash issue.

#### How I did it
Add back the same change done by (https://github.com/Azure/sonic-buildimage/pull/3895)

#### How to verify it
Loaded the image and tested with the "sudo config interface mtu Ethernet0 1501" and observe MTU setting go through fine without causing any crash.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012
- [X] 202106

#### Description for the changelog
Fix set MTU > 1500 on interface causing portmgrd crash on BRCM platforms


#### A picture of a cute animal (not mandatory but encouraged)

