### PR TITLE
Fix REST_SERVER typo in mgmt_vars.j2

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/mgmt_vars.j2
+++ b/dockers/docker-sonic-mgmt-framework/mgmt_vars.j2
@@ -1,4 +1,4 @@
 {
-    "rest_server": {% if REST_SERVER is defined and "default" in RESET_SERVER.keys() %}{{ REST_SERVER['default'] }}{% else %}""{% endif %},
+    "rest_server": {% if REST_SERVER is defined and "default" in REST_SERVER.keys() %}{{ REST_SERVER['default'] }}{% else %}""{% endif %},
     "x509" : {% if "x509" in DEVICE_METADATA.keys() %}{{ DEVICE_METADATA["x509"] }}{% else %}""{% endif %}
 }


### PR DESCRIPTION
#### Why I did it

The issue was discussed [on the mailing list](https://groups.google.com/g/sonicproject/c/l_XADXY2Mqs) and should be pretty obvious.

The issue:
```
Aug 13 23:12:29.901117 adele WARNING mgmt-framework#python3: :- operator(): Key 'JINJA2_CACHE' field 'f773745d995b9beba2b87a460e6956e2f0c03c1b' unavailable in database 'LOGLEVEL_DB'
Aug 13 23:12:29.922928 adele INFO mgmt-framework#/supervisord: rest-server Traceback (most recent call last):
Aug 13 23:12:29.922928 adele INFO mgmt-framework#/supervisord: rest-server   File "/usr/local/bin/sonic-cfggen", line 431, in <module>
Aug 13 23:12:29.922928 adele INFO mgmt-framework#/supervisord: rest-server     main()
Aug 13 23:12:29.922928 adele INFO mgmt-framework#/supervisord: rest-server   File "/usr/local/bin/sonic-cfggen", line 396, in main
Aug 13 23:12:29.923219 adele INFO mgmt-framework#/supervisord: rest-server     template_data = template.render(data)
Aug 13 23:12:29.923219 adele INFO mgmt-framework#/supervisord: rest-server   File "/usr/local/lib/python3.7/dist-packages/jinja2/environment.py", line 1304, in render
Aug 13 23:12:29.923219 adele INFO mgmt-framework#/supervisord: rest-server     self.environment.handle_exception()
Aug 13 23:12:29.923219 adele INFO mgmt-framework#/supervisord: rest-server   File "/usr/local/lib/python3.7/dist-packages/jinja2/environment.py", line 925, in handle_exception
Aug 13 23:12:29.923219 adele INFO mgmt-framework#/supervisord: rest-server     raise rewrite_traceback_stack(source=source)
Aug 13 23:12:29.923219 adele INFO mgmt-framework#/supervisord: rest-server   File "/usr/share/sonic/templates/mgmt_vars.j2", line 2, in top-level template code
Aug 13 23:12:29.923373 adele INFO mgmt-framework#/supervisord: rest-server     "rest_server": {% if REST_SERVER is defined and "default" in RESET_SERVER.keys() %}{{ REST_SERVER['default'] }}{% else %}""{% endif %},
Aug 13 23:12:29.923373 adele INFO mgmt-framework#/supervisord: rest-server   File "/usr/local/lib/python3.7/dist-packages/jinja2/environment.py", line 474, in getattr
Aug 13 23:12:29.923373 adele INFO mgmt-framework#/supervisord: rest-server     return getattr(obj, attribute)
Aug 13 23:12:29.923373 adele INFO mgmt-framework#/supervisord: rest-server jinja2.exceptions.UndefinedError: 'RESET_SERVER' is undefined
Aug 13 23:12:29.974559 adele INFO mgmt-framework#/supervisord: rest-server Generating temporary TLS server certificate ...
```

#### How I did it

Corrected the typo.

#### How to verify it

Build the image and try to boot it, the error should be gone.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

The issue is present in 202012 and newer and is required to set the REST server configuration.

#### Description for the changelog

rest: Fix typo in REST_SERVER configuration.

#### A picture of a cute animal (not mandatory but encouraged)

![image](https://user-images.githubusercontent.com/149442/129426498-5b4a4e3e-a421-4817-9722-7105249e6329.png)
