### PR TITLE
Changed DHCP table name to DHCP_RELAY

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -577,11 +577,11 @@ def parse_dpg(dpg, hname):
                 vlan_attributes['alias'] = vintfname
             vlans[sonic_vlan_name] = vlan_attributes
 
-        dhcp = child.find(str(QName(ns, "Dhcp")))
-        dhcp_table = {}
+        dhcp_relay = child.find(str(QName(ns, "DhcpRelay")))
+        dhcp_relay_table = {}
 
-        if dhcp is not None:
-            for vintf in dhcp.findall(str(QName(ns, "VlanInterface"))):
+        if dhcp_relay is not None:
+            for vintf in dhcp_relay.findall(str(QName(ns, "VlanInterface"))):
                 vintfname = vintf.find(str(QName(ns, "Name"))).text
 
                 dhcp_attributes = {}
@@ -598,7 +598,7 @@ def parse_dpg(dpg, hname):
                 elif option_linklayer_addr is not None and option_linklayer_addr.text == "false":
                     dhcp_attributes['dhcpv6_option|rfc6939_support'] = "false"
 
-                dhcp_table[vintfname] = dhcp_attributes
+                dhcp_relay_table[vintfname] = dhcp_attributes
 
         acls = {}
         for aclintf in aclintfs.findall(str(QName(ns, "AclInterface"))):
@@ -714,7 +714,7 @@ def parse_dpg(dpg, hname):
                     if mg_key in mg_tunnel.attrib:
                         tunnelintfs[tunnel_type][tunnel_name][table_key] = mg_tunnel.attrib[mg_key]
 
-        return intfs, lo_intfs, mvrf, mgmt_intf, voq_inband_intfs, vlans, vlan_members, dhcp_table, pcs, pc_members, acls, vni, tunnelintfs, dpg_ecmp_content
+        return intfs, lo_intfs, mvrf, mgmt_intf, voq_inband_intfs, vlans, vlan_members, dhcp_relay_table, pcs, pc_members, acls, vni, tunnelintfs, dpg_ecmp_content
     return None, None, None, None, None, None, None, None, None, None, None, None, None
 
 def parse_host_loopback(dpg, hname):
@@ -1182,7 +1182,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     tunnel_intfs = None
     vlans = None
     vlan_members = None
-    dhcp_table = None
+    dhcp_relay_table = None
     pcs = None
     mgmt_intf = None
     voq_inband_intfs = None
@@ -1241,7 +1241,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     for child in root:
         if asic_name is None:
             if child.tag == str(QName(ns, "DpgDec")):
-                (intfs, lo_intfs, mvrf, mgmt_intf, voq_inband_intfs, vlans, vlan_members, dhcp_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, hostname)
+                (intfs, lo_intfs, mvrf, mgmt_intf, voq_inband_intfs, vlans, vlan_members, dhcp_relay_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, hostname)
             elif child.tag == str(QName(ns, "CpgDec")):
                 (bgp_sessions, bgp_internal_sessions, bgp_voq_chassis_sessions, bgp_asn, bgp_peers_with_range, bgp_monitors) = parse_cpg(child, hostname)
             elif child.tag == str(QName(ns, "PngDec")):
@@ -1256,7 +1256,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
                 (port_speeds_default, port_descriptions, sys_ports) = parse_deviceinfo(child, hwsku)
         else:
             if child.tag == str(QName(ns, "DpgDec")):
-                (intfs, lo_intfs, mvrf, mgmt_intf, voq_inband_intfs, vlans, vlan_members, dhcp_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, asic_name)
+                (intfs, lo_intfs, mvrf, mgmt_intf, voq_inband_intfs, vlans, vlan_members, dhcp_relay_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, asic_name)
                 host_lo_intfs = parse_host_loopback(child, hostname)
             elif child.tag == str(QName(ns, "CpgDec")):
                 (bgp_sessions, bgp_internal_sessions, bgp_voq_chassis_sessions, bgp_asn, bgp_peers_with_range, bgp_monitors) = parse_cpg(child, asic_name, local_devices)
@@ -1604,7 +1604,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         results['DEVICE_NEIGHBOR_METADATA'] = { key:devices[key] for key in devices if key in {device['name'] for device in neighbors.values()} }
     results['SYSLOG_SERVER'] = dict((item, {}) for item in syslog_servers)
     results['DHCP_SERVER'] = dict((item, {}) for item in dhcp_servers)
-    results['DHCP'] = dhcp_table
+    results['DHCP_RELAY'] = dhcp_relay_table
     results['NTP_SERVER'] = dict((item, {}) for item in ntp_servers)
     results['TACPLUS_SERVER'] = dict((item, {'priority': '1', 'tcp_port': '49'}) for item in tacacs_servers)
     results['ACL_TABLE'] = filter_acl_table_bindings(acls, neighbors, pcs, sub_role)

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -134,6 +134,7 @@
           <Name>ab1</Name>
           <AttachTo>fortyGigE0/8</AttachTo>
           <DhcpRelays>192.0.0.1;192.0.0.2</DhcpRelays>
+          <Dhcpv6Relays>fc02:2000::1;fc02:2000::2</Dhcpv6Relays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
           <Subnets>192.168.0.0/27</Subnets>
@@ -143,23 +144,12 @@
           <Name>ab2</Name>
           <AttachTo>fortyGigE0/4</AttachTo>
           <DhcpRelays>192.0.0.1</DhcpRelays>
+          <Dhcpv6Relays>fc02:2000::3;fc02:2000::4</Dhcpv6Relays>
           <VlanID>2000</VlanID>
           <Tag>2000</Tag>
           <MacAddress i:nil="true"/>
         </VlanInterface>
       </VlanInterfaces>
-      <DhcpRelay>
-        <VlanInterface>
-          <Name>Vlan1000</Name>
-          <Dhcpv6Relays>fc02:2000::1;fc02:2000::2</Dhcpv6Relays>
-          <Dhcpv6OptionRfc6939>true</Dhcpv6OptionRfc6939>
-        </VlanInterface>
-        <VlanInterface>
-          <Name>Vlan2000</Name>
-          <Dhcpv6Relays>fc02:2000::3;fc02:2000::4</Dhcpv6Relays>
-          <Dhcpv6OptionRfc6939>false</Dhcpv6OptionRfc6939>
-        </VlanInterface>
-      </DhcpRelay>
       <IPInterfaces>
         <IPInterface>
           <Name i:nil="true"/>

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -148,7 +148,7 @@
           <MacAddress i:nil="true"/>
         </VlanInterface>
       </VlanInterfaces>
-      <Dhcp>
+      <DhcpRelay>
         <VlanInterface>
           <Name>Vlan1000</Name>
           <Dhcpv6Relays>fc02:2000::1;fc02:2000::2</Dhcpv6Relays>
@@ -159,7 +159,7 @@
           <Dhcpv6Relays>fc02:2000::3;fc02:2000::4</Dhcpv6Relays>
           <Dhcpv6OptionRfc6939>false</Dhcpv6OptionRfc6939>
         </VlanInterface>
-      </Dhcp>
+      </DhcpRelay>
       <IPInterfaces>
         <IPInterface>
           <Name i:nil="true"/>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -827,8 +827,8 @@ class TestCfgGen(TestCase):
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Vlan1000': {'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2'], 'dhcpv6_option|rfc6939_support': 'true'}, "
-                "'Vlan2000': {'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4'], 'dhcpv6_option|rfc6939_support': 'false'}}"
+                "{'Vlan1000': {'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2']}, "
+                "'Vlan2000': {'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4']}}"
             )
         )
         

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -822,7 +822,7 @@ class TestCfgGen(TestCase):
         )
 
     def test_minigraph_dhcp(self):
-        argument = '-m "' + self.sample_graph_simple_case + '" -p "' + self.port_config + '" -v DHCP'
+        argument = '-m "' + self.sample_graph_simple_case + '" -p "' + self.port_config + '" -v DHCP_RELAY'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -102,6 +102,7 @@ class TestCfgGenCaseInsensitive(TestCase):
                    'Vlan1000': {
                        'alias': 'ab1',
                        'dhcp_servers': ['192.0.0.1', '192.0.0.2'],
+                       'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2'],
                        'vlanid': '1000',
                        'mac': '00:aa:bb:cc:dd:ee',
                        'members': ['Ethernet8']
@@ -109,6 +110,7 @@ class TestCfgGenCaseInsensitive(TestCase):
                    'Vlan2000': {
                        'alias': 'ab2',
                        'dhcp_servers': ['192.0.0.1'],
+                       'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4'],
                        'members': ['Ethernet4'],
                        'vlanid': '2000'
                        }
@@ -365,15 +367,13 @@ class TestCfgGenCaseInsensitive(TestCase):
                        'dhcpv6_servers': [
                            "fc02:2000::1",
                            "fc02:2000::2"
-                       ],
-                       'dhcpv6_option|rfc6939_support': 'true'
+                       ]
                     },
-                   'Vlan2000': {
+                    'Vlan2000': {
                        'dhcpv6_servers': [
                            "fc02:2000::3",
                            "fc02:2000::4"
-                       ],
-                       'dhcpv6_option|rfc6939_support': 'false'
+                       ]
                     }
         }
         output = self.run_script(argument)

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -359,7 +359,7 @@ class TestCfgGenCaseInsensitive(TestCase):
         )
     
     def test_dhcp_table(self):
-        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "DHCP"'
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "DHCP_RELAY"'
         expected = {
                    'Vlan1000': {
                        'dhcpv6_servers': [


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
DHCP is rather generic and can be used for DHCP servers/other options in future.
#### How I did it
Changed corresponding name in minigraph to Dhcprelay and changed "DHCP" table name to "DHCP_RELAY" in config.

'DHCP_RELAY': {
        'Vlan1000': {
                'dhcpv6_servers': [
                        'fc02:2000::1',
                        'fc02:2000::2'
                ],
                'dhcpv6_option|rfc6939_support': 'true'
        },
        'Vlan2000': {
                'dhcpv6_servers': [
                        'fc02:2000::3',
                        'fc02:2000::4'
                ],
                'dhcpv6_option|rfc6939_support': 'false'
        }
}

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

