### PR TITLE
[Flex Counters] Reset flex counters delay flag on config DB when enable_counters script is called

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -47,6 +47,12 @@ def get_uptime():
     with open('/proc/uptime') as fp:
         return float(fp.read().split(' ')[0])
 
+def reset_flex_counters_delay_indicator():
+    db = swsssdk.ConfigDBConnector()
+    db.connect()
+    info = {}
+    info['FLEX_COUNTER_DELAY_STATUS'] = 'false'
+    db.mod_entry("FLEX_COUNTER_TABLE", "FLEX_COUNTER_DELAY", info)
 
 def main():
     # If the switch was just started (uptime less than 5 minutes),
@@ -57,6 +63,7 @@ def main():
         time.sleep(180)
     else:
         time.sleep(60)
+    reset_flex_counters_delay_indicator()
     enable_counters()
 
 


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Reset flex counters delay flag on config DB when enable_counters script is called to allow enablement of flex counters in orchagent.

#### How I did it
Push to config DB 'false' value for delay indication when enable_counters script is called before enabling the counters.

#### How to verify it
Observe counters are created when enable_counters script is called.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

