### PR TITLE
Limit the python library Jinja2 version range

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -460,6 +460,7 @@ RUN pip2 install \
 # Install pyangbind here, outside sonic-config-engine dependencies, as pyangbind causes enum34 to be installed.
 # enum34 causes Python 're' package to not work properly as it redefines an incompatible enum.py module
 # https://github.com/robshakir/pyangbind/issues/232
+RUN apt-get install -y python3-jinja2
 RUN pip3 install pyangbind==0.8.1
 RUN pip3 uninstall -y enum34
 

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -353,6 +353,7 @@ RUN pip2 install --force-reinstall --upgrade "Jinja2<3.0.0"
 # Install pyangbind here, outside sonic-config-engine dependencies, as pyangbind causes enum34 to be installed.
 # enum34 causes Python 're' package to not work properly as it redefines an incompatible enum.py module
 # https://github.com/robshakir/pyangbind/issues/232
+RUN apt-get install -y python3-jinja2
 RUN pip3 install pyangbind==0.8.1
 RUN pip3 uninstall -y enum34
 

--- a/src/sonic-config-engine/setup.py
+++ b/src/sonic-config-engine/setup.py
@@ -20,7 +20,7 @@ if sys.version_info.major == 3:
         # Python3 has enum module and so pyangbind should be installed outside
         # dependencies section of setuptools followed by uninstall of enum43
         # 'pyangbind==0.8.1',
-        'Jinja2>=2.10',
+        'Jinja2>=2.10, <=2.11.3',
         'sonic-yang-mgmt>=1.0',
         'sonic-yang-models>=1.0'
     ]
@@ -30,7 +30,7 @@ else:
         # Jinja2 v3.0.0+ dropped support for Python 2.7 and causes setuptools to
         # malfunction on stretch slave docker.
         'future',
-        'Jinja2<3.0.0',
+        'Jinja2>=2.10, <=2.11.3',
         'pyangbind==0.6.0',
         'zipp==1.2.0',  # importlib-resources needs zipp and seems to have a bug where it will try to install too new of a version for Python 2
         'importlib-resources==3.3.1',  # importlib-resources v4.0.0 was released 2020-12-23 and drops support for Python 2


### PR DESCRIPTION
#### Why I did it
Version 3.0.0 introduce breaking change:
```
/sonic/src/sonic-config-engine$ python3 /sonic/src/sonic-config-engine/tests/../sonic-cfggen -m /sonic/src/sonic-config-engine/tests/t0-sample-graph.xml -p /sonic/src/sonic-config-eng
ine/tests/t0-sample-port-config.ini -t /sonic/src/sonic-config-engine/tests/../../../dockers/docker-orchagent/ipinip.json.j2
Warning: Ignoring Control Plane ACL NTP_ACL without type
Traceback (most recent call last):
  File "/sonic/src/sonic-config-engine/tests/../sonic-cfggen", line 443, in <module>
    main()
  File "/sonic/src/sonic-config-engine/tests/../sonic-cfggen", line 408, in main
    template_data = template.render(data)
  File "/usr/local/lib/python3.7/dist-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.7/dist-packages/jinja2/environment.py", line 925, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/sonic/dockers/docker-orchagent/ipinip.json.j2", line 51, in top-level template code
    {% if "mlnx" in DEVICE_METADATA.localhost.platform %}
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'platform'
```

#### How I did it
Limit the python library Jinja2 version range

#### How to verify it
Unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

