### PR TITLE
[Arista] Add VOQ information for Clearwater2

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/port_config.ini
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/port_config.ini
@@ -1,51 +1,51 @@
-# name              lanes     alias               index  role   speed
-Ethernet0           6,7       Ethernet1/1         1      Ext   100000
-Ethernet4           2,3       Ethernet2/1         2      Ext   100000
-Ethernet8           4,5       Ethernet3/1         3      Ext   100000
-Ethernet12          0,1       Ethernet4/1         4      Ext   100000
-Ethernet16          14,15     Ethernet5/1         5      Ext   100000
-Ethernet20          10,11     Ethernet6/1         6      Ext   100000
-Ethernet24          12,13     Ethernet7/1         7      Ext   100000
-Ethernet28          8,9       Ethernet8/1         8      Ext   100000
-Ethernet32          22,23     Ethernet9/1         9      Ext   100000
-Ethernet36          18,19     Ethernet10/1        10     Ext   100000
-Ethernet40          20,21     Ethernet11/1        11     Ext   100000
-Ethernet44          16,17     Ethernet12/1        12     Ext   100000
-Ethernet48          30,31     Ethernet13/1        13     Ext   100000
-Ethernet52          26,27     Ethernet14/1        14     Ext   100000
-Ethernet56          28,29     Ethernet15/1        15     Ext   100000
-Ethernet60          24,25     Ethernet16/1        16     Ext   100000
-Ethernet64          38,39     Ethernet17/1        17     Ext   100000
-Ethernet68          34,35     Ethernet18/1        18     Ext   100000
-Ethernet72          36,37     Ethernet19/1        19     Ext   100000
-Ethernet76          32,33     Ethernet20/1        20     Ext   100000
-Ethernet80          46,47     Ethernet21/1        21     Ext   100000
-Ethernet84          42,43     Ethernet22/1        22     Ext   100000
-Ethernet88          44,45     Ethernet23/1        23     Ext   100000
-Ethernet92          40,41     Ethernet24/1        24     Ext   100000
-Ethernet96          94,95     Ethernet25/1        25     Ext   100000
-Ethernet100         90,91     Ethernet26/1        26     Ext   100000
-Ethernet104         92,93     Ethernet27/1        27     Ext   100000
-Ethernet108         88,89     Ethernet28/1        28     Ext   100000
-Ethernet112         86,87     Ethernet29/1        29     Ext   100000
-Ethernet116         82,83     Ethernet30/1        30     Ext   100000
-Ethernet120         84,85     Ethernet31/1        31     Ext   100000
-Ethernet124         80,81     Ethernet32/1        32     Ext   100000
-Ethernet128         78,79     Ethernet33/1        33     Ext   100000
-Ethernet132         74,75     Ethernet34/1        34     Ext   100000
-Ethernet136         76,77     Ethernet35/1        35     Ext   100000
-Ethernet140         72,73     Ethernet36/1        36     Ext   100000
-Ethernet144         70,71     Ethernet37/1        37     Ext   100000
-Ethernet148         66,67     Ethernet38/1        38     Ext   100000
-Ethernet152         68,69     Ethernet39/1        39     Ext   100000
-Ethernet156         64,65     Ethernet40/1        40     Ext   100000
-Ethernet160         62,63     Ethernet41/1        41     Ext   100000
-Ethernet164         58,59     Ethernet42/1        42     Ext   100000
-Ethernet168         60,61     Ethernet43/1        43     Ext   100000
-Ethernet172         56,57     Ethernet44/1        44     Ext   100000
-Ethernet176         54,55     Ethernet45/1        45     Ext   100000
-Ethernet180         50,51     Ethernet46/1        46     Ext   100000
-Ethernet184         52,53     Ethernet47/1        47     Ext   100000
-Ethernet188         48,49     Ethernet48/1        48     Ext   100000
-Recirc0             221       Recirc0/0           51     Rec   400000
-Recirc1             222       Recirc0/1           52     Rec   400000
+# name              lanes     alias               index  role   speed    coreId     corePortId     numVoq
+Ethernet0           6,7       Ethernet1/1         1      Ext   100000    0          1              8
+Ethernet4           2,3       Ethernet2/1         2      Ext   100000    0          2              8
+Ethernet8           4,5       Ethernet3/1         3      Ext   100000    0          3              8
+Ethernet12          0,1       Ethernet4/1         4      Ext   100000    0          4              8
+Ethernet16          14,15     Ethernet5/1         5      Ext   100000    0          5              8
+Ethernet20          10,11     Ethernet6/1         6      Ext   100000    0          6              8
+Ethernet24          12,13     Ethernet7/1         7      Ext   100000    0          7              8
+Ethernet28          8,9       Ethernet8/1         8      Ext   100000    0          8              8
+Ethernet32          22,23     Ethernet9/1         9      Ext   100000    0          9              8
+Ethernet36          18,19     Ethernet10/1        10     Ext   100000    0          10             8
+Ethernet40          20,21     Ethernet11/1        11     Ext   100000    0          11             8
+Ethernet44          16,17     Ethernet12/1        12     Ext   100000    0          12             8
+Ethernet48          30,31     Ethernet13/1        13     Ext   100000    0          13             8
+Ethernet52          26,27     Ethernet14/1        14     Ext   100000    0          14             8
+Ethernet56          28,29     Ethernet15/1        15     Ext   100000    0          15             8
+Ethernet60          24,25     Ethernet16/1        16     Ext   100000    0          16             8
+Ethernet64          38,39     Ethernet17/1        17     Ext   100000    0          17             8
+Ethernet68          34,35     Ethernet18/1        18     Ext   100000    0          18             8
+Ethernet72          36,37     Ethernet19/1        19     Ext   100000    0          19             8
+Ethernet76          32,33     Ethernet20/1        20     Ext   100000    0          20             8
+Ethernet80          46,47     Ethernet21/1        21     Ext   100000    0          21             8
+Ethernet84          42,43     Ethernet22/1        22     Ext   100000    0          22             8
+Ethernet88          44,45     Ethernet23/1        23     Ext   100000    0          23             8
+Ethernet92          40,41     Ethernet24/1        24     Ext   100000    0          24             8
+Ethernet96          94,95     Ethernet25/1        25     Ext   100000    1          25             8
+Ethernet100         90,91     Ethernet26/1        26     Ext   100000    1          26             8
+Ethernet104         92,93     Ethernet27/1        27     Ext   100000    1          27             8
+Ethernet108         88,89     Ethernet28/1        28     Ext   100000    1          28             8
+Ethernet112         86,87     Ethernet29/1        29     Ext   100000    1          29             8
+Ethernet116         82,83     Ethernet30/1        30     Ext   100000    1          30             8
+Ethernet120         84,85     Ethernet31/1        31     Ext   100000    1          31             8
+Ethernet124         80,81     Ethernet32/1        32     Ext   100000    1          32             8
+Ethernet128         78,79     Ethernet33/1        33     Ext   100000    1          33             8
+Ethernet132         74,75     Ethernet34/1        34     Ext   100000    1          34             8
+Ethernet136         76,77     Ethernet35/1        35     Ext   100000    1          35             8
+Ethernet140         72,73     Ethernet36/1        36     Ext   100000    1          36             8
+Ethernet144         70,71     Ethernet37/1        37     Ext   100000    1          37             8
+Ethernet148         66,67     Ethernet38/1        38     Ext   100000    1          38             8
+Ethernet152         68,69     Ethernet39/1        39     Ext   100000    1          39             8
+Ethernet156         64,65     Ethernet40/1        40     Ext   100000    1          40             8
+Ethernet160         62,63     Ethernet41/1        41     Ext   100000    1          41             8
+Ethernet164         58,59     Ethernet42/1        42     Ext   100000    1          42             8
+Ethernet168         60,61     Ethernet43/1        43     Ext   100000    1          43             8
+Ethernet172         56,57     Ethernet44/1        44     Ext   100000    1          44             8
+Ethernet176         54,55     Ethernet45/1        45     Ext   100000    1          45             8
+Ethernet180         50,51     Ethernet46/1        46     Ext   100000    1          46             8
+Ethernet184         52,53     Ethernet47/1        47     Ext   100000    1          47             8
+Ethernet188         48,49     Ethernet48/1        48     Ext   100000    1          48             8
+Ethernet-Rec0       221       Recirc0/0           51     Rec   400000    0          221            8
+Ethernet-IB0        222       Recirc0/1           52     Inb   400000    1          222            8


### PR DESCRIPTION
#### What I did

This change introduce 3 columns in the port_config.ini file.
These are coreId, corePortId and numVoq.
The ports for inband and recirc were also renamed properly.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [X] 202106

This change is desired on 202106 for chassis support

#### Description for the changelog
Fix port_config.ini for Clearwater2
