### PR TITLE
[202012] Replace swsssdk with swsscommon in sonic-host-services and update submodule sonic-swss-common

### DIFF
--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -20,7 +20,6 @@ try:
 
     from sonic_py_common import daemon_base, device_info
     from swsscommon import swsscommon
-    from swsssdk import SonicDBConfig, ConfigDBConnector
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
 
@@ -103,10 +102,10 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         self.lock[DEFAULT_NAMESPACE] = threading.Lock()
         self.num_changes[DEFAULT_NAMESPACE] = 0
 
-        SonicDBConfig.load_sonic_global_db_config()
+        swsscommon.SonicDBConfig.load_sonic_global_db_config()
         self.config_db_map = {}
         self.iptables_cmd_ns_prefix = {}
-        self.config_db_map[DEFAULT_NAMESPACE] = ConfigDBConnector(use_unix_socket_path=True, namespace=DEFAULT_NAMESPACE)
+        self.config_db_map[DEFAULT_NAMESPACE] = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=DEFAULT_NAMESPACE)
         self.config_db_map[DEFAULT_NAMESPACE].connect()
         self.iptables_cmd_ns_prefix[DEFAULT_NAMESPACE] = ""
         self.namespace_mgmt_ip = self.get_namespace_mgmt_ip(self.iptables_cmd_ns_prefix[DEFAULT_NAMESPACE], DEFAULT_NAMESPACE)
@@ -124,7 +123,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             self.lock[front_asic_namespace] = threading.Lock()
             self.num_changes[front_asic_namespace] = 0
 
-            self.config_db_map[front_asic_namespace] = ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespace)
+            self.config_db_map[front_asic_namespace] = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespace)
             self.config_db_map[front_asic_namespace].connect()
             self.iptables_cmd_ns_prefix[front_asic_namespace] = "ip netns exec " + front_asic_namespace + " "
             self.namespace_docker_mgmt_ip[front_asic_namespace] = self.get_namespace_mgmt_ip(self.iptables_cmd_ns_prefix[front_asic_namespace],

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -9,7 +9,7 @@ import syslog
 
 import jinja2
 from sonic_py_common import device_info
-from swsssdk import ConfigDBConnector
+from swsscommon.swsscommon import ConfigDBConnector
 
 # FILE
 PAM_AUTH_CONF = "/etc/pam.d/common-auth-sonic"

--- a/src/sonic-host-services/scripts/procdockerstatsd
+++ b/src/sonic-host-services/scripts/procdockerstatsd
@@ -12,7 +12,7 @@ import time
 from datetime import datetime
 
 from sonic_py_common import daemon_base
-import swsssdk
+from swsscommon import swsscommon
 
 VERSION = '1.0'
 
@@ -25,7 +25,7 @@ class ProcDockerStats(daemon_base.DaemonBase):
 
     def __init__(self, log_identifier):
         super(ProcDockerStats, self).__init__(log_identifier)
-        self.state_db = swsssdk.SonicV2Connector(host=REDIS_HOSTIP)
+        self.state_db = swsscommon.SonicV2Connector(host=REDIS_HOSTIP)
         self.state_db.connect("STATE_DB")
 
     def run_command(self, cmd):

--- a/src/sonic-host-services/scripts/process-reboot-cause
+++ b/src/sonic-host-services/scripts/process-reboot-cause
@@ -12,7 +12,7 @@ try:
     import pwd
     import sys
 
-    import swsssdk
+    from swsscommon import swsscommon
     from sonic_py_common import logger
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
@@ -39,7 +39,7 @@ sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
 # ============================= Functions =============================
 def read_reboot_cause_files_and_save_state_db():
     # Connect State DB
-    state_db = swsssdk.SonicV2Connector(host=REDIS_HOSTIP)
+    state_db = swsscommon.SonicV2Connector(host=REDIS_HOSTIP)
     state_db.connect(state_db.STATE_DB)
 
     # Sort the previous reboot cause files by creation time

--- a/src/sonic-host-services/setup.py
+++ b/src/sonic-host-services/setup.py
@@ -20,7 +20,6 @@ setup(
     install_requires = [
         'Jinja2>=2.10',
         'sonic-py-common',
-        'swsssdk>=2.0.1',
     ],
     setup_requires = [
         'pytest-runner',

--- a/src/sonic-host-services/tests/determine-reboot-cause_test.py
+++ b/src/sonic-host-services/tests/determine-reboot-cause_test.py
@@ -2,7 +2,7 @@ import sys
 import os
 import pytest
 
-import swsssdk
+from swsscommon import swsscommon
 from sonic_py_common.general import load_module_from_source
 
 # TODO: Remove this if/else block once we no longer support Python 2
@@ -21,7 +21,7 @@ else:
 
 from .mock_connector import MockConnector
 
-swsssdk.SonicV2Connector = MockConnector
+swsscommon.SonicV2Connector = MockConnector
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)

--- a/src/sonic-host-services/tests/hostcfgd/hostcfgd_test.py
+++ b/src/sonic-host-services/tests/hostcfgd/hostcfgd_test.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import swsssdk
+import swsscommon
 
 from parameterized import parameterized
 from sonic_py_common.general import load_module_from_source
@@ -10,7 +10,7 @@ from .test_vectors import HOSTCFGD_TEST_VECTOR
 from .mock_configdb import MockConfigDb
 
 
-swsssdk.ConfigDBConnector = MockConfigDb
+swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
 test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")

--- a/src/sonic-host-services/tests/procdockerstatsd_test.py
+++ b/src/sonic-host-services/tests/procdockerstatsd_test.py
@@ -2,12 +2,12 @@ import sys
 import os
 import pytest
 
-import swsssdk
+from swsscommon import swsscommon
 from sonic_py_common.general import load_module_from_source
 
 from .mock_connector import MockConnector
 
-swsssdk.SonicV2Connector = MockConnector
+swsscommon.SonicV2Connector = MockConnector
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)


### PR DESCRIPTION
#### Why I did it
Backport https://github.com/Azure/sonic-buildimage/pull/8034 to 202012 branch

sonic-swss-common submodule updating includes below commits
```
a6b98da 2021-04-29 | Add support for config_db subscribe and unsubscribe python apis (#481) [arlakshm]
2506ca0 2021-08-22 | [ci] Fix azure pipeline DownloadPipelineArtifact source branch (#514) [Qi Luo]
```

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

