### PR TITLE
[CI] Change Azp timeout from 12h to 18h

### DIFF
--- a/.azure-pipelines/azure-pipelines-job-groups.yml
+++ b/.azure-pipelines/azure-pipelines-job-groups.yml
@@ -19,7 +19,7 @@ parameters:
   default: ''
 - name: 'timeoutInMinutes'
   type: 'number'
-  default: 720
+  default: 1080
 - name: 'jobFilters'
   type: object
   default: ''


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
A lot of build timeout found on broadcom & mellanox on 202012 branch.
But not found on other branches.
#### How I did it
Temporally extend time limit on 202012 branch.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

