### PR TITLE
ifupdown2: Don't check for new IP addresses if dhcp-wait is set to no

### DIFF
--- a/src/ifupdown2/patch/0002-disable-checks-when-using-no-wait.patch
+++ b/src/ifupdown2/patch/0002-disable-checks-when-using-no-wait.patch
@@ -1,0 +1,36 @@
+Don't check for a new IP address if dhcp-wait=no is set
+
+From: Saikrishna Arcot <sarcot@microsoft.com>
+
+If dhcp-wait=no is specified in the ifupdown2 policy configuration, then
+skip the check for a new IP address. When checking, dhclient probably
+isn't done getting a new IP address from the DHCP server.
+
+This change is needed for ZTP (zero-touch provisioning) in SONiC. The
+expectation is that dhclient will get started on all interfaces
+(both management and in-band), and on some interfaces, there might not
+be a DHCP server on the other end of the link. That'll mean that it may
+get blocked here.
+
+SONiC ZTP needs dhclient to be started, but ifupdown2 shouldn't block on
+dhclient being successful.
+---
+ ifupdown2/addons/dhcp.py |    5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/ifupdown2/addons/dhcp.py b/ifupdown2/addons/dhcp.py
+index 9d5ce27..87f61e7 100644
+--- a/ifupdown2/addons/dhcp.py
++++ b/ifupdown2/addons/dhcp.py
+@@ -103,7 +103,10 @@ class dhcp(Addon, moduleBase):
+ 
+         while retry >= 0:
+             handler(ifname, **handler_kwargs)
+-            retry = self.dhclient_check(ifname, family, ip_config_before, retry, handler_kwargs.get("cmd_prefix"))
++            if handler_kwargs.get("wait", True):
++                retry = self.dhclient_check(ifname, family, ip_config_before, retry, handler_kwargs.get("cmd_prefix"))
++            else:
++                retry = -1
+ 
+     def dhclient_check(self, ifname, family, ip_config_before, retry, dhclient_cmd_prefix):
+         retry -= 1

--- a/src/ifupdown2/patch/series
+++ b/src/ifupdown2/patch/series
@@ -1,1 +1,2 @@
 0001-fix-broadcast-addr-encoding.patch
+0002-disable-checks-when-using-no-wait.patch


### PR DESCRIPTION
Add a patch in ifupdown2 such that if DHCP is used for an interface, and
the policy setting sets dhcp-wait to no (meaning don't wait for dhclient
to acquire an IP address), then don't check to see if the interface has
a new IP address, since dhclient will still be working.

Fixes #8512.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

#### Why I did it

SONiC ZTP (zero-touch provisioning) needs `dhcp-wait` to be set to `no` for ifupdown2, so that it won't wait for dhclient to get an address before moving on to the next interface. Since setting that policy then causes a failure (because of checks that ifupdown2 does to see if dhclient succeeded), add a patch to have it not check and see if dhclient succeeded or not.

#### How I did it

#### How to verify it

Within a KVM image:
1. Log into console.
2. Bring down eth0 using `sudo ifdown eth0`.
3. Edit `/etc/network/interfaces` so that `eth0` gets an address via dhcp, instead of being statically configured. Remove all of the lines in that section for static configuration.
4. On the host machine, start a DHCP server (dhcpd, dnsmasq, or similar), and have it listen on the br1 interface.
5. In the console connection, run `sudo ifup eth0`.
6. Verify that `eth0` has an IP address.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

