### PR TITLE
[Nokia ixs7215] Add support for changing the console baud rate

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -186,7 +186,17 @@ program_console_speed()
         CONSOLE_SPEED=$speed
     fi
 
-    sed -i "s|\-\-keep\-baud .* %I| $CONSOLE_SPEED %I|g" /lib/systemd/system/serial-getty@.service
+    # Set correct baud rate in getty service
+    # First boot will find keep-baud argument with multiple baud rates as per Debian convention
+    # Subsequent boots may have new baud rate without finding keep-baud argument
+    grep agetty /lib/systemd/system/serial-getty@.service |grep keep-baud
+    if [ $? = 0 ]; then
+        sed -i "s|\-\-keep\-baud .* %I| $CONSOLE_SPEED %I|g" /lib/systemd/system/serial-getty@.service
+    else
+        sed -i "s|u' .* %I|u' $CONSOLE_SPEED %I|g" /lib/systemd/system/serial-getty@.service
+    fi
+
+    # Reload systemd config
     systemctl daemon-reload
 }
 

--- a/platform/marvell-armhf/platform.conf
+++ b/platform/marvell-armhf/platform.conf
@@ -45,9 +45,9 @@ elif [ "$PLATFORM" = "armhf-nokia_ixs7215_52x-r0" ]; then
 
     fdt_fname="/boot/armada-385-ipd6448m.dtb"
 
-    BOOTARGS='setenv bootargs root=/dev/'$demo_dev' rw rootwait rootfstype=ext4 panic=1 console=ttyS0,115200 ${othbootargs} ${mtdparts} ${linuxargs}'
+    BOOTARGS='setenv bootargs root=/dev/'$demo_dev' rw rootwait rootfstype=ext4 panic=1 console=ttyS0,${baudrate} ${othbootargs} ${mtdparts} ${linuxargs}'
     UBI_LOAD='scsi init; ext4load scsi 0:2 $kernel_addr $image_name; ext4load scsi 0:2 $fdt_addr $fdt_name; ext4load scsi 0:2 $initrd_addr $initrd_name'
-    BOOTARGS_OLD='setenv bootargs root=/dev/'$demo_dev' rw rootwait rootfstype=ext4 panic=1 console=ttyS0,115200 ${othbootargs} ${mtdparts} ${linuxargs_old}'
+    BOOTARGS_OLD='setenv bootargs root=/dev/'$demo_dev' rw rootwait rootfstype=ext4 panic=1 console=ttyS0,${baudrate} ${othbootargs} ${mtdparts} ${linuxargs_old}'
     UBI_LOAD_OLD='scsi init; ext4load scsi 0:2 $kernel_addr $image_name_old; ext4load scsi 0:2 $fdt_addr $fdt_name_old; ext4load scsi 0:2 $initrd_addr $initrd_name_old'
     UBIBOOTCMD='run ubi_sonic_boot_bootargs; run ubi_sonic_boot_load; test -n "$boot_once" && setenv boot_once "" && saveenv; bootz $kernel_addr $initrd_addr $fdt_addr'
     UBIBOOTCMD_OLD='run ubi_sonic_boot_bootargs_old; run ubi_sonic_boot_load_old; test -n "$boot_once" && setenv boot_once "" && saveenv; bootz $kernel_addr $initrd_addr $fdt_addr'


### PR DESCRIPTION
This commit adds support for changing the default console baud rate configured
within the U-Boot bootloader. That default baud rate is exposed via the value
of the U-Boot 'baudrate' environment variable. This commit removes logic that
hardcoded the console baud rate to 115200 and instead ensures that the U-Boot
'baudrate' variable is always used when constructing the Linux kernel boot
arguments used when booting Sonic.

A change is also made to rc.local to ensure that the specified baud rate is set
correctly in the serial getty service.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Allow the default Sonic console baud rate to be changed

#### How I did it
Ensure that the U-Boot console baudrate value is passed as a Linux kernel boot argument.
Ensure that the serial getty service uses this passed baud rate value

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

