### PR TITLE
BRCM Disable ACL Drop counted towards interface RX_DRP counters part II

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
@@ -17,6 +17,9 @@ l3_alpm_enable=2
 ipv6_lpm_128b_enable=1
 mmu_lossless=0
 
+# Disable Counting ACL Drop towards interface RX_DRP counter
+sai_adjust_acl_drop_in_rx_drop=1
+
 ###################################################################################
 # Celestica Customize for SeaStone
 ###################################################################################


### PR DESCRIPTION
This is to make up the HW SKU that was missed by (https://github.com/Azure/sonic-buildimage/pull/8382)
For details on what this new SOC property does please refer to the original PR.
#### Why I did it
On previous PR a HW SKU was missed and this PR is created to include the missing HW SKU so that the ACL caused Drops does not get counted towards the Interface drop counter.

#### How to verify it
Once included ACL Dropped packet count does not get included as part of the interface RX_DRP counter.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
Add SOC property to not count ACL Drops towards interface RX_DRP for BRCM HW SKU DX010 T1s

#### A picture of a cute animal (not mandatory but encouraged)

