### PR TITLE
[Arista] Rely on automatic flash size detection for Lodoga

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -510,7 +510,6 @@ write_platform_specific_cmdline() {
     fi
     if [ "$sid" = "Lodoga" ]; then
         aboot_machine=arista_7050cx3_32s
-        flash_size=3700
     fi
     if [ "$sid" = "Marysville" ]; then
         aboot_machine=arista_7050sx3_48yc8


### PR DESCRIPTION
#### Why I did it

Lodoga actually has a 8GB storage device.
LodogaSsd variant has a 30GB SSD drive.
However, in boot0 both were mishandled and assigned 4GB for legacy reasons.

#### How I did it

Remove the hardcoding of the flash size and let boot0 autodetect the available space.

#### How to verify it

Check that `/proc/cmdline` and make sure that `logs_inram` isn't set.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

202012 is needed and 202106 is desirable.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Rely on automatic flash size detection for Lodoga product

