### PR TITLE
[DO NOT REVIEW] Checking build failure for patch-sorting in sonic-utils

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,7 +30,8 @@
 	url = https://github.com/p4lang/ptf.git
 [submodule "src/sonic-utilities"]
 	path = src/sonic-utilities
-	url = https://github.com/Azure/sonic-utilities
+	url = https://github.com/ghooo/sonic-utilities.git
+	branch = dev/mghoneim/check_build_failure
 [submodule "platform/broadcom/sonic-platform-modules-arista"]
 	path = platform/broadcom/sonic-platform-modules-arista
 	url = https://github.com/aristanetworks/sonic


### PR DESCRIPTION
DO NOT REVIEW.

Added additional logging to patch-sorting, and re-running the tests.