### PR TITLE
[caclmgrd]Fixed the load_sonic_global_db_config() on single asic platform issue

### DIFF
--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -101,7 +101,8 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         self.lock[DEFAULT_NAMESPACE] = threading.Lock()
         self.num_changes[DEFAULT_NAMESPACE] = 0
 
-        swsscommon.SonicDBConfig.load_sonic_global_db_config()
+        if device_info.is_multi_npu():
+            swsscommon.SonicDBConfig.load_sonic_global_db_config()
         self.config_db_map = {}
         self.iptables_cmd_ns_prefix = {}
         self.config_db_map[DEFAULT_NAMESPACE] = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=DEFAULT_NAMESPACE)


### PR DESCRIPTION
#### Why I did it
python script caclmgrd calls function load_sonic_global_db_config() without checking if the platform is multiasic platform. This cause an error message has been logged. Fixed issue:  https://github.com/Azure/sonic-buildimage/issues/8613
#### How I did it
Check if device is multi npu, then call  load_sonic_global_db_config().

#### How to verify it
1) Reboot the system
2) execute the following command to check the log file
```admin@sonic:~$ sudo grep "Sonic database" /var/log/sys*
   admin@sonic:~ $
```
No such error message shown

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

