### PR TITLE
[Arista] Fix flash size computation for Lodoga

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -478,7 +478,6 @@ write_platform_specific_cmdline() {
     if [ "$platform" = "crow" ]; then
         # Assuming sid=Clearlake
         aboot_machine=arista_7050_qx32s
-        flash_size=3700
         cmdline_add modprobe.blacklist=radeon,sp5100_tco
     fi
     if [ "$sid" = "Upperlake" ] || [ "$sid" = "UpperlakeES" ]; then
@@ -592,7 +591,7 @@ write_platform_specific_cmdline() {
 
     if [ $flash_size -ge 28000 ]; then
         varlog_size=4096
-    elif [ $flash_size -gt 3700 ]; then
+    elif [ $flash_size -gt 4000 ]; then
         varlog_size=400
     else
         varlog_size=256


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The Lodoga platform also matched crow which was hardcoding the flash
size to 3700. 

#### How I did it

By removing the 3700 hardcoding on crow, this change enables autodetect on Clearlake
which in turns allows autodetect for Lodoga.

The threshold was also bumped from 3700 to 4000 because size computation can
differ slightly and report slightly above 3700.

#### How to verify it

Verify that `docker_inram` is no longer set on `/proc/cmdline`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix flash size computation in boot0 for Lodoga