### PR TITLE
[7050] define hwsku.json for Arista-7050QX-32S-S4Q31 to skip SFP checks for first 4 ports

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/hwsku.json
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/hwsku.json
@@ -1,15 +1,15 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "1x1G",
+            "default_brkout_mode": "1x10G",
             "port_type": "RJ45"
         },
         "Ethernet1": {
-            "default_brkout_mode": "1x1G",
+            "default_brkout_mode": "1x10G",
             "port_type": "RJ45"
         },
         "Ethernet2": {
-            "default_brkout_mode": "1x1G",
+            "default_brkout_mode": "1x10G",
             "port_type": "RJ45"
         },
         "Ethernet3": {

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/hwsku.json
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/hwsku.json
@@ -1,0 +1,144 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x1G",
+            "port_type": "RJ45"
+        },
+        "Ethernet1": {
+            "default_brkout_mode": "1x1G",
+            "port_type": "RJ45"
+        },
+        "Ethernet2": {
+            "default_brkout_mode": "1x1G",
+            "port_type": "RJ45"
+        },
+        "Ethernet3": {
+            "default_brkout_mode": "1x1G",
+            "port_type": "RJ45"
+        },
+        "Ethernet4": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet12": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet20": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet28": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet36": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet44": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet52": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet60": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet68": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet76": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet84": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet92": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet100": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet108": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet116": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        },
+        "Ethernet124": {
+            "default_brkout_mode": "1x40G",
+            "port_type": "QSFP+"
+        }
+    }
+}


### PR DESCRIPTION
#### Why I did it
The first 4 ports on this dut are breakout ports. They might not always be connected in lab. Mark them as 'RJ45' to skip the SFP check since they are by default disabled.

#### How to verify it
run platform test_reboot.py

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

