### PR TITLE
[yang-models] Removing sonic-acl import from sonic-nat.yang

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-nat.yang
+++ b/src/sonic-yang-models/yang-models/sonic-nat.yang
@@ -7,9 +7,10 @@ module sonic-nat {
         prefix inet;
     }
 
-    import sonic-acl {
-        prefix sacl;
-    }
+    // Comment sonic-acl import here until libyang back-links issue is resolved for ACL_TABLE leaf reference.
+    // import sonic-acl {
+    //     prefix sacl;
+    // }
 
     import sonic-types {
         prefix stypes;


### PR DESCRIPTION
#### Why I did it
Fixing issue [[sonic-utilities] Unit test failed when building sonic-utilities #1761](https://github.com/Azure/sonic-utilities/issues/1761)

Importing `sonic-acl` caused getting references by `backlinks()` to break, 

#### How I did it
solution is to comment out the importing statement as it is not used anyway.

#### How to verify it
Ran sonic-utilities unit-tests locally after the fix, and all passed.

