### PR TITLE
DellEMC: Z9332f fix LED issue

### DIFF
--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
@@ -516,3 +516,4 @@ serdes_lane_config_media_type_24=copper
 
 sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
 sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
+led_fw_path=/usr/share/sonic/hwsku/

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
@@ -579,3 +579,4 @@ serdes_lane_config_media_type_24=copper
 
 sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
 sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
+led_fw_path=/usr/share/sonic/hwsku/

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
@@ -519,3 +519,4 @@ serdes_lane_config_media_type_24=copper
 
 sai_preinit_cmd_file=/usr/share/sonic/hwsku/sai_preinit_cmd.soc
 sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
+led_fw_path=/usr/share/sonic/hwsku/


### PR DESCRIPTION

#### Why I did it
LED errors were seen in DELLEMC Z9332f during bootup(https://github.com/Azure/sonic-buildimage/issues/8620). 
#### How I did it
Initialized led_fw_path variable
#### How to verify it
Verified the led status and the color displayed on the switch.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

