### PR TITLE
DellEMC: Z9332f fix reboot cause issue

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/chassis.py
@@ -110,11 +110,11 @@ class Chassis(ChassisBase):
             34: 2,
             }
 
-    reboot_reason_dict = { 0x11: (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "Power on reset"),
+    reboot_reason_dict = { 0x11: (ChassisBase.REBOOT_CAUSE_POWER_LOSS, "Power on reset"),
                            0x22: (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "Soft-set CPU warm reset"),
                            0x33: (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "Soft-set CPU cold reset"),
                            0x66: (ChassisBase.REBOOT_CAUSE_WATCHDOG, "GPIO watchdog reset"),
-                           0x77: (ChassisBase.REBOOT_CAUSE_HARDWARE_OTHER, "Power cycle reset"),
+                           0x77: (ChassisBase.REBOOT_CAUSE_POWER_LOSS, "Power cycle reset"),
                            0x88: (ChassisBase.REBOOT_CAUSE_WATCHDOG, "CPLD watchdog reset")
                         }
 


### PR DESCRIPTION
#### Why I did it
Power cycle test case fails for Z9332f in sonic-mgmt framework(https://github.com/Azure/sonic-buildimage/issues/8605).
#### How I did it
Modified the platform API to return expected strings.
#### How to verify it
1. Power cycle the device and verify the reboot reason.
2. Run sonic-mgmt test_reboot script.
#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
UT logs: 
[UT logs.txt](https://github.com/Azure/sonic-buildimage/files/7083552/UT.logs.txt)



#### A picture of a cute animal (not mandatory but encouraged)

