### PR TITLE
BRCM SAI 5.0.0.8 Catch up fixes since 5.0.0.6

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,12 +1,12 @@
-BRCM_SAI = libsaibcm_5.0.0.6-1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_5.0.0.6-1_amd64.deb?sv=2015-04-05&sr=b&sig=HA%2FwgMr%2BHnb6zzFCQDfO1WF%2Bf6PBSmIzH13728LTNz4%3D&se=2035-03-31T20%3A45%3A36Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_5.0.0.6-1_amd64.deb
+BRCM_SAI = libsaibcm_5.0.0.8_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_5.0.0.8_amd64.deb?sv=2015-04-05&sr=b&sig=T%2FPesnOIeN9802mClMpgk8XFQbqjFAgCnJbbNHxijHo%3D&se=2035-05-13T21%3A34%3A26Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_5.0.0.8_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm-dev_5.0.0.6-1_amd64.deb?sv=2015-04-05&sr=b&sig=z634%2BUk14EY5VjEE4tjhvDSP2hiK8s1EJAxjvidl44I%3D&se=2035-03-31T20%3A46%3A17Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm-dev_5.0.0.8_amd64.deb?sv=2015-04-05&sr=b&sig=X33hZLhRI3L6f4a5JFSlhJvoaTj%2B3zrmNBM9IzIA%2Bj4%3D&se=2035-05-13T21%3A35%3A58Z&sp=r"
 
 # SAI module for DNX Asic family
-BRCM_DNX_SAI = libsaibcm_dnx_5.0.0.6-1_amd64.deb
-$(BRCM_DNX_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_dnx_5.0.0.6-1_amd64.deb?sv=2015-04-05&sr=b&sig=mDcpzWUcTSzNBM6vPPYNuMQ6D%2BTKQAC9k%2Fv0%2Bnz3L%2BM%3D&se=2035-03-31T20%3A46%3A44Z&sp=r"
+BRCM_DNX_SAI = libsaibcm_dnx_5.0.0.8_amd64.deb
+$(BRCM_DNX_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_dnx_5.0.0.8_amd64.deb?sv=2015-04-05&sr=b&sig=uy0OW6ZhWjYntalZunEIIzHUztkOyI7TS3F73Sla9vY%3D&se=2035-05-13T21%3A37%3A06Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 SONIC_ONLINE_DEBS += $(BRCM_DNX_SAI)


### PR DESCRIPTION
#### Why I did it
Fix https://github.com/Azure/sonic-buildimage/issues/8300

Catch up on fixes from BRCM SUG repo to pick up fixes after 5.0.0.6 all the way up to 5.0.0.8
Fixes include the following:
```
  CS00012201827: Warmreboot causes syncd crash with  SAI_API_UNSPECIFIED:syncdb_data_file_read:2230 Failed to parse JSON: error -2
  DNX: Fix for ACL table create with v6 next hdr attr
  and many unspecified changes that also went into 5.0.0.8
```
#### How to verify it
Preliminary tests looks fine on both XGS (gechiang) and DNX (judyjoseph)
On XGS testing done as following:
BGP neighbors were all up with proper routes programmed
interfaces are all up
Manually ran the following test cases on 7260CX3 T0 DUT and all passed:
```
     ipfwd/test_dir_bcast.py
     fdb/test_fdb.py
     fib/test_fib.py
     vlan/test_valn.py
```
Also validated for for CS00012201827 (https://github.com/Azure/sonic-buildimage/issues/8300)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog
BRCM SAI 5.0.0.8 Catch up fixes since 5.0.0.6

#### A picture of a cute animal (not mandatory but encouraged)

