### PR TITLE
Fix z9332flpmode issue

### DIFF
--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/plugins/sfputil.py
@@ -26,7 +26,7 @@ class SfpUtil(SfpUtilBase):
 
     PORT_START = 1
     PORT_END = 34
-    PORTS_IN_BLOCK = 34
+    PORTS_IN_BLOCK = 32
 
     BASE_RES_PATH = "/sys/bus/pci/devices/0000:09:00.0/resource0"
 

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/plugins/sfputil.py
@@ -89,16 +89,12 @@ class SfpUtil(SfpUtilBase):
 
     def pci_mem_read(self, mm, offset):
         mm.seek(offset)
-        read_data_stream = mm.read(4)
-        reg_val = struct.unpack('I', read_data_stream)
-        mem_val = str(reg_val)[1:-2]
-        # print "reg_val read:%x"%reg_val
-        return mem_val
+        return mm.read_byte()
 
     def pci_mem_write(self, mm, offset, data):
         mm.seek(offset)
         # print "data to write:%x"%data
-        mm.write(struct.pack('I', data))
+        mm.write_byte(data)
 
     def pci_set_value(self, resource, val, offset):
         fd = open(resource, O_RDWR)
@@ -181,7 +177,8 @@ class SfpUtil(SfpUtilBase):
         # Check for invalid port_num
         if port_num < self.port_start or port_num > self.port_end:
             return False
-
+        if port_num > self.PORTS_IN_BLOCK:
+            return False
         # Port offset starts with 0x4000
         port_offset = 16384 + ((port_num-1) * 16)
 
@@ -205,6 +202,8 @@ class SfpUtil(SfpUtilBase):
 
         # Check for invalid port_num
         if port_num < self.port_start or port_num > self.port_end:
+            return False
+        if port_num > self.PORTS_IN_BLOCK:
             return False
 
         # Port offset starts with 0x4000

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
@@ -311,16 +311,12 @@ class Sfp(SfpBase):
 
     def pci_mem_read(self, mm, offset):
         mm.seek(offset)
-        read_data_stream = mm.read(4)
-        reg_val = struct.unpack('I', read_data_stream)
-        mem_val = str(reg_val)[1:-2]
-        # print "reg_val read:%x"%reg_val
-        return mem_val
+        return mm.read_byte()
 
     def pci_mem_write(self, mm, offset, data):
         mm.seek(offset)
         # print "data to write:%x"%data
-        mm.write(struct.pack('I', data))
+        mm.write_byte(data)
 
     def pci_set_value(self, resource, val, offset):
         fd = os.open(resource, os.O_RDWR)
@@ -993,7 +989,7 @@ class Sfp(SfpBase):
         """
         lpmode_state = False
         try:
-            if self.sfp_type.startswith('QSFP'):
+            if self.port_type == 'QSFP_DD'::
                 # Port offset starts with 0x4000
                 port_offset = 16384 + ((self.index-1) * 16)
 
@@ -1004,7 +1000,8 @@ class Sfp(SfpBase):
                 mask = (1 << 6)
 
                 lpmode_state = (reg_value & mask)
-        except  ValueError: pass
+        except ValueError:
+            pass
         return lpmode_state
 
     def get_power_override(self):


### PR DESCRIPTION
#### Why I did it
Low power is not set in DellEMC Z9332f
#### How I did it
Modified platform API to set the lpmode.
#### How to verify it
1.Execute "config interface transceiver EthernetX enable/disable" and check "show interfaces transceiver lpmode".
2.Execute the platform API's from python3 interpreter.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
[lpmode_UT.txt](https://github.com/Azure/sonic-buildimage/files/7120342/lpmode_UT.txt)

#### A picture of a cute animal (not mandatory but encouraged)

