### PR TITLE
[Nokia ixs7215] Miscellaneous platform API fixes

### DIFF
--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/fan.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/fan.py
@@ -336,10 +336,10 @@ class Fan(FanBase):
         """
 
         if self.is_psu_fan:
-            return False
+            return None
 
         if smbus_present == 0:
-            return False
+            return None
         else:
             bus = smbus.SMBus(0)
             DEVICE_ADDRESS = 0x41
@@ -368,7 +368,7 @@ class Fan(FanBase):
             (off) to 100 (full speed)
         """
         speed = 0
-     
+
         fan_duty = self._get_i2c_register(self.set_fan_speed_reg)
         if (fan_duty != 'ERR'):
             dutyspeed = int(fan_duty)
@@ -380,9 +380,5 @@ class Fan(FanBase):
                 speed = 50
             elif dutyspeed == 255:
                 speed = 100
- 
+
         return speed
-         
-
-
-    

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/fan_drawer.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/fan_drawer.py
@@ -54,7 +54,7 @@ class NokiaFanDrawer(FanDrawerBase):
         return 'intake'
 
     def set_status_led(self, color):
-        return True
+        return self._fan_list[0].set_status_led(color)
 
     def get_status_led(self, color):
         return self._fan_list[0].get_status_led()

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/psu.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/psu.py
@@ -234,3 +234,23 @@ class Psu(PsuBase):
         # The firmware running in the PSU controls the LED
         # and the PSU LED state cannot be changed from CPU.
         return False
+
+    def get_status_master_led(self):
+        """
+        Gets the state of the front panel PSU status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings.
+        """
+        return self._psu_master_led_color
+
+    def set_status_master_led(self, color):
+        """
+        Sets the state of the front panel PSU status LED
+
+        Returns:
+            bool: True if status LED state is set successfully, False if
+                  not
+        """
+        self._psu_master_led_color = color
+        return True

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/thermal.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/thermal.py
@@ -33,9 +33,12 @@ class Thermal(ThermalBase):
                     "CPU Core")
 
     def __init__(self, thermal_index):
+        ThermalBase.__init__(self)
         self.index = thermal_index + 1
         self.is_psu_thermal = False
         self.dependency = None
+        self._minimum = None
+        self._maximum = None
         self.thermal_high_threshold_file = None
         # PCB temperature sensors
         if self.index < 3:
@@ -163,6 +166,10 @@ class Thermal(ThermalBase):
             self.thermal_temperature_file)
         if (thermal_temperature != 'ERR'):
             thermal_temperature = float(thermal_temperature) / 1000
+            if self._minimum is None or self._minimum > thermal_temperature:
+                self._minimum = thermal_temperature
+            if self._maximum is None or self._maximum < thermal_temperature:
+                self._maximum = thermal_temperature
         else:
             thermal_temperature = 0
 
@@ -225,6 +232,16 @@ class Thermal(ThermalBase):
             thermal_high_crit_threshold = 0.0
 
         return float("{:.3f}".format(thermal_high_crit_threshold))
+
+    def get_minimum_recorded(self):
+        if self._minimum is None:
+           self.get_temperature()
+        return self._minimum
+
+    def get_maximum_recorded(self):
+        if self._maximum is None:
+           self.get_temperature()
+        return self._maximum
 
     def get_position_in_parent(self):
         """

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/thermal.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/thermal.py
@@ -234,13 +234,11 @@ class Thermal(ThermalBase):
         return float("{:.3f}".format(thermal_high_crit_threshold))
 
     def get_minimum_recorded(self):
-        if self._minimum is None:
-           self.get_temperature()
+        self.get_temperature()
         return self._minimum
 
     def get_maximum_recorded(self):
-        if self._maximum is None:
-           self.get_temperature()
+        self.get_temperature()
         return self._maximum
 
     def get_position_in_parent(self):


### PR DESCRIPTION
This commit delivers the following fixes for the Nokia ixs7215 platform

- Fix bug in a fan API error path
- Add support for setting the fan drawer led
- Add support for getting/setting the front panel PSU status led
- Add support for getting the min/max observed temperature value

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix bugs in various platform APIs
These fixes improve the sonic-mgmt platform API test pass rate

#### How I did it

#### How to verify it
Run the following sonic-mgmt test cases
- test-fan.py
- test-fan-drawer.py
- test-thermal.py
- test-psu.py

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

