### PR TITLE
[201911][Monit] Fix the template file of dhcp_relay

### DIFF
--- a/dockers/docker-dhcp-relay/base_image_files/monit_dhcp_relay.j2
+++ b/dockers/docker-dhcp-relay/base_image_files/monit_dhcp_relay.j2
@@ -6,32 +6,32 @@
 ##  dhcrelay
 ################################################################################
 {# If our configuration has VLANs... #}
-{%- if VLAN_INTERFACE -%}
- {# Count how may VLANs require a DHCP relay agent... #}
- {%- set num_relays = namespace(count=0) -%}
-  {%- for vlan_name in VLAN_INTERFACE -%}
-    {%- if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 -%}
-      {%- set num_relays.count = num_relays.count + 1 -%}
-    {%- endif -%}
-  {%- endfor -%}
-  {# if one or more VLANs require DHCP relay agent #}
-  {%- if num_relays.count > 0 -%}
-    {%- set relay_for_ipv4 = namespace(flag=False) -%}
-    {%- for vlan_name in VLAN_INTERFACE -%}
-      {%- if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length >0 -%}
-        {%- for dhcp_server in VLAN[vlan_name]['dhcp_servers'] -%}
-          {%- if dhcp_server | ipv4 -%}
-            {%- set relay_for_ipv4.flag = True -%}
-          {%- endif -%}
-        {%- endfor -%}
-        {%- if relay_for_ipv4.flag -%}
-          {%- set relay_for_ipv4 = False -%}
-          {# Check the running status of each DHCP relay agent instance #}
+{% if VLAN_INTERFACE %}
+{# Count how may VLANs require a DHCP relay agent... #}
+{% set num_relays = namespace(count=0) %}
+{% for vlan_name in VLAN_INTERFACE %}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+{% set num_relays.count = num_relays.count + 1 %}
+{% endif %}
+{% endfor %}
+{# if one or more VLANs require DHCP relay agent #}
+{% if num_relays.count > 0 %}
+{% set relay_for_ipv4 = namespace(flag=False) %}
+{% for vlan_name in VLAN_INTERFACE %}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length >0 %}
+{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
+{% if dhcp_server | ipv4 %}
+{% set relay_for_ipv4.flag = True %}
+{% endif %}
+{% endfor %}
+{% if relay_for_ipv4.flag %}
+{% set relay_for_ipv4 = False %}
+{# Check the running status of each DHCP relay agent instance #}
 check program dhcp_relay|dhcrelay_{{ vlan_name }} with path "/usr/bin/process_checker dhcp_relay /usr/sbin/dhcrelay -d -m discard -a %h:%p %P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
 
-{% endif -%}
-      {%- endif -%}
-    {%- endfor -%}
-  {%- endif -%}
-{%- endif -%}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endif %}

--- a/dockers/docker-dhcp-relay/base_image_files/monit_dhcp_relay.j2
+++ b/dockers/docker-dhcp-relay/base_image_files/monit_dhcp_relay.j2
@@ -29,7 +29,8 @@
           {# Check the running status of each DHCP relay agent instance #}
 check program dhcp_relay|dhcrelay_{{ vlan_name }} with path "/usr/bin/process_checker dhcp_relay /usr/sbin/dhcrelay -d -m discard -a %h:%p %P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
-        {%- endif -%}
+
+{% endif -%}
       {%- endif -%}
     {%- endfor -%}
   {%- endif -%}


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR aims to fix the bug in Monit template file of `dhcp_relay` container. 

If Multi-VLAN were configured on device, multiple `dhcrelay` processes will be spawned in `dhcp_relay` container. Then there will be an entry for each `dhcrelay` process in Monit configuration file of `dhcp_relay` container.

Currently Monit template file of `dhcp_relay` container can not be rendered correctly to generate configuration file and will cause Monit can not start up.

#### How I did it
I removed the indentation in the template file and remove the `minus` sign.

#### How to verify it
I verify this on DuT `str-msn2700-20` which was installed 20191130.78 image.
          
          ################################################################################
          ## Monit configuration file for dhcp_relay container
          ## process list:
          ## dhcrelay
          ################################################################################
          check program dhcp_relay|dhcrelay_Vlan102 with path "/usr/bin/process_checker dhcp_relay /usr/sbin/dhcrelay -d -m discard -a %h:%p %P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan102"
          if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
          
          check program dhcp_relay|dhcrelay_Vlan101 with path "/usr/bin/process_checker dhcp_relay /usr/sbin/dhcrelay -d -m discard -a %h:%p %P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan101"
          if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles

#### Which release branch to backport (provide reason below if selected)
Monit is still used to monitor the running status of critical processes in 201911 branch.

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

