### PR TITLE
DellEMC Z9332f: Platform API - Remove EEPROM Vendor Extension decoder

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/eeprom.py
@@ -51,13 +51,7 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
                 tlv = eeprom[tlv_index:tlv_index + 2
                              + eeprom[tlv_index + 1]]
                 code = "0x%02X" % tlv[0]
-
-                if tlv[0] == self._TLV_CODE_VENDOR_EXT:
-                    value = str((tlv[2] << 24) | (tlv[3] << 16) |
-                                (tlv[4] << 8) | tlv[5])
-                    value += tlv[6:6 + tlv[1]].decode('ascii')
-                else:
-                    name, value = self.decoder(None, tlv)
+                name, value = self.decoder(None, tlv)
 
                 self.eeprom_tlv_dict[code] = value
                 if eeprom[tlv_index] == self._TLV_CODE_CRC_32:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To make values returned by 'get_system_eeprom_info' compliant with eeprom_tlvinfo.TlvInfoDecoder. 
Fixes #8573 

#### How I did it

Use eeprom_tlvinfo.TlvInfoDecoder's decoder method for all TLVs.

#### How to verify it

Verify that `platform_tests/cli/test_show_platform.py::test_show_platform_syseeprom` reports Success.
Logs: [UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/7135694/UT_logs.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC Z9332f: Platform API - Remove EEPROM Vendor Extension decoder

#### A picture of a cute animal (not mandatory but encouraged)

