### PR TITLE
[202012] [fstrim] use absolute seconds in time granularity

### DIFF
--- a/files/image_config/fstrim/fstrim.timer
+++ b/files/image_config/fstrim/fstrim.timer
@@ -4,8 +4,8 @@ Documentation=man:fstrim
 
 [Timer]
 OnCalendar=weekly
-OnBootSec=10min
-AccuracySec=1h
+OnBootSec=600
+AccuracySec=3600
 Persistent=true
 
 [Install]


### PR DESCRIPTION
#### Why I did it
At the initial boot, vs images seems to have trouble with the time delay granularity of 10m, 1h, etc. But seems to be good with absolute second values. With this change, vs image will behave more like physical DUTs.

#### How to verify it
This PR test. Also downloaded the vs image built here and tried manually.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
