### PR TITLE
[201911] Fix error during building docker-sonic-mgmt-framework

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -9,6 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN pip install connexion==1.1.15 \
 		setuptools==21.0.0 \
+		grpcio==1.39.0 \
 		grpcio-tools==1.20.0 \
 		pyangbind==0.6.0 \
 		certifi==2017.4.17 \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix error during building docker-sonic-mgmt-framework on 201911

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it
Cause:
While building sonic-mgmt-framework docker, it needs to install `grpcio-tools` version 1.20.0 which has a dependency on `grpcio` version >=1.20.0.
As `>=1.20.0` is specified, it will install the latest version of `grpcio`.
It had worked well until the grpcio package version 1.40.0 was released 3 days ago.
Looks like some new dependencies are introduced by the latest version.
Fix:
Designate `grpcio` version 1.39.0 explicitly, which is the latest version of `grpcio` that worked well.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

