### PR TITLE
[Dell] S6000 I2C not responding to certain optics

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
@@ -6,6 +6,7 @@
 try:
     import time
     import datetime
+    import fcntl
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
@@ -19,6 +20,7 @@ class SfpUtil(SfpUtilBase):
     PORTS_IN_BLOCK = 32
 
     EEPROM_OFFSET = 20
+    SFP_LOCK_FILE="/var/run/platform_cache/sfp_lock"
 
     _port_to_eeprom_mapping = {}
     port_dict = {}
@@ -73,6 +75,12 @@ class SfpUtil(SfpUtilBase):
             return False
 
         try:
+            fd = open(self.SFP_LOCK_FILE, "r")
+        except IOError as e:
+            print("Error: unable to open file: "+ str(e))
+        self.set_modsel(port_num)
+
+        try:
             reg_file = open("/sys/devices/platform/dell-s6000-cpld.0/qsfp_modprs")
         except IOError as e:
             print("Error: unable to open file: %s" % str(e))
@@ -85,12 +93,100 @@ class SfpUtil(SfpUtilBase):
 
         # Mask off the bit corresponding to our port
         mask = (1 << port_num)
-
+        fcntl.flock(fd, fcntl.LOCK_UN)
         # ModPrsL is active low
         if reg_value & mask == 0:
             return True
 
         return False
+
+    def get_modsel(self, port_num):
+        # Check for invalid port_num
+        if port_num < self.port_start or port_num > self.port_end:
+            return False
+
+        try:
+            reg_file = open("/sys/devices/platform/dell-s6000-cpld.0/qsfp_modsel")
+        except IOError as e:
+            print("Error: unable to open file: %s" % str(e))
+            return False
+
+        content = reg_file.readline().rstrip()
+
+        # content is a string containing the hex representation of the register
+        reg_value = int(content, 16)
+
+        # Mask off the bit corresponding to our port
+        mask = (1 << port_num)
+
+        if reg_value & mask == 1:
+            return False
+
+        return True
+
+    def set_modsel(self, port_num):
+        # Check for invalid port_num
+        if port_num < self.port_start or port_num > self.port_end:
+            return False
+
+        try:
+            reg_file = open("/sys/devices/platform/dell-s6000-cpld.0/qsfp_modsel", "r+")
+        except IOError as e:
+            print("Error: unable to open file: %s" % str(e))
+            return False
+
+        content = reg_file.readline().rstrip()
+
+        # content is a string containing the hex representation of the register
+        reg_value = int(content, 16)
+
+        # Mask off the bit corresponding to our port
+        mask = (1 << port_num)
+        clear_bit = "0xffffffff"
+        clear_bit = int(clear_bit, 16)
+        reg_value = reg_value | clear_bit
+        reg_value = reg_value & ~mask
+
+        # Convert our register value back to a hex string and write back
+        content = hex(reg_value)
+
+        reg_file.seek(0)
+        reg_file.write(content)
+        reg_file.close()
+
+        return True
+
+    def get_eeprom_raw(self, port_num, num_bytes=256):
+        # Read interface id EEPROM at addr 0x50
+        try:
+            fd = open(self.SFP_LOCK_FILE, "r")
+        except IOError as e:
+            print("Error: unable to open file: %s" % str(e))
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        self.set_modsel(port_num)
+        eeprom_bytes = self._read_eeprom_devid(port_num, self.IDENTITY_EEPROM_ADDR, 0, num_bytes)
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return eeprom_bytes
+
+    def get_eeprom_dom_raw(self, port_num):
+        if port_num in self.osfp_ports:
+            return None
+        if port_num in self.qsfp_ports:
+            # QSFP DOM EEPROM is also at addr 0x50 and thus also stored in eeprom_ifraw
+            return None
+        else:
+            # Read dom eeprom at addr 0x51
+            if not self.get_modsel(port_num):
+                try:
+                    fd = open(self.SFP_LOCK_FILE, "r")
+                except IOError as e:
+                    print("Error: unable to open file: %s" % str(e))
+                self.set_modsel(port_num)
+                eeprom_bytes = self._read_eeprom_devid(port_num, self.DOM_EEPROM_ADDR, 0)
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                return eeprom_bytes
+            else:
+                return self._read_eeprom_devid(port_num, self.DOM_EEPROM_ADDR, 0)
 
     def get_low_power_mode(self, port_num):
         # Check for invalid port_num

--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
@@ -20,7 +20,7 @@ class SfpUtil(SfpUtilBase):
     PORTS_IN_BLOCK = 32
 
     EEPROM_OFFSET = 20
-    SFP_LOCK_FILE="/var/run/platform_cache/sfp_lock"
+    SFP_LOCK_FILE="/etc/sonic/sfp_lock"
 
     _port_to_eeprom_mapping = {}
     port_dict = {}

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/modules/dell_s6000_platform.c
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/modules/dell_s6000_platform.c
@@ -312,6 +312,25 @@ static ssize_t get_modsel(struct device *dev, struct device_attribute *devattr, 
     return sprintf(buf, "0x%08x\n", data);
 }
 
+static ssize_t set_modsel(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    int err;
+    unsigned long data = 0;
+    struct cpld_platform_data *pdata = dev->platform_data;
+
+    err = kstrtoul(buf, 16, &data);
+    if (err)
+	return err;
+
+    dell_i2c_smbus_write_byte_data(pdata[slave_cpld].client, 0x0, (u8)(data & 0xff));
+    dell_i2c_smbus_write_byte_data(pdata[slave_cpld].client, 0x1, (u8)((data >> 8) & 0xff));
+    dell_i2c_smbus_write_byte_data(pdata[master_cpld].client, 0xa, (u8)((data >> 16) & 0xff));
+    dell_i2c_smbus_write_byte_data(pdata[master_cpld].client, 0xb, (u8)((data >> 24) & 0xff));
+
+    msleep(2);
+    return count;
+}
+
 static ssize_t get_lpmode(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     int ret;
@@ -1128,7 +1147,7 @@ static ssize_t get_reboot_reason(struct device *dev,
     return sprintf(buf, "0x%x\n", data);
 }
 
-static DEVICE_ATTR(qsfp_modsel, S_IRUGO, get_modsel, NULL);
+static DEVICE_ATTR(qsfp_modsel, S_IRUGO | S_IWUSR, get_modsel, set_modsel);
 static DEVICE_ATTR(qsfp_modprs, S_IRUGO, get_modprs, NULL);
 static DEVICE_ATTR(qsfp_lpmode, S_IRUGO | S_IWUSR, get_lpmode, set_lpmode);
 static DEVICE_ATTR(qsfp_reset,  S_IRUGO | S_IWUSR, get_reset, set_reset);

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/modules/dell_s6000_platform.c
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/modules/dell_s6000_platform.c
@@ -327,7 +327,7 @@ static ssize_t set_modsel(struct device *dev, struct device_attribute *devattr, 
     dell_i2c_smbus_write_byte_data(pdata[master_cpld].client, 0xa, (u8)((data >> 16) & 0xff));
     dell_i2c_smbus_write_byte_data(pdata[master_cpld].client, 0xb, (u8)((data >> 24) & 0xff));
 
-    msleep(2);
+    msleep(2); // As per HW spec
     return count;
 }
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
@@ -97,6 +97,10 @@ remove_python_api_package() {
 # read SONiC immutable variables
 [ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
 
+if [ ! -e /var/run/platform_cache/sfp_lock ]; then
+    touch /var/run/platform_cache/sfp_lock
+fi
+
 if [[ "$1" == "init" ]]; then
         depmod -a
         modprobe nvram

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
@@ -97,8 +97,8 @@ remove_python_api_package() {
 # read SONiC immutable variables
 [ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
 
-if [ ! -e /var/run/platform_cache/sfp_lock ]; then
-    touch /var/run/platform_cache/sfp_lock
+if [ ! -e /etc/sonic/sfp_lock ]; then
+    touch /etc/sonic/sfp_lock
 fi
 
 if [[ "$1" == "init" ]]; then

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py
@@ -155,7 +155,7 @@ class Sfp(SfpBase):
         if (self.sfpInfo is None):
             return None
 
-        SFP_LOCK_FILE="/var/run/platform_cache/sfp_lock"
+        SFP_LOCK_FILE="/etc/sonic/sfp_lock"
         try:
             fd = open(SFP_LOCK_FILE, "r")
         except IOError as e:
@@ -434,7 +434,7 @@ class Sfp(SfpBase):
         Retrieves the presence of the sfp
         """
         presence_ctrl = self.sfp_control + 'qsfp_modprs'
-        SFP_LOCK_FILE="/var/run/platform_cache/sfp_lock"
+        SFP_LOCK_FILE="/etc/sonic/sfp_lock"
 
         try:
             fd = open(SFP_LOCK_FILE, "r")

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py
@@ -152,15 +152,17 @@ class Sfp(SfpBase):
         eeprom_data = None
         page_offset = None
 
+        if (self.sfpInfo is None):
+            return None
+
         SFP_LOCK_FILE="/var/run/platform_cache/sfp_lock"
         try:
             fd = open(SFP_LOCK_FILE, "r")
         except IOError as e:
             print("Error: unable to open file: %s" % str(e))
+            return None
         fcntl.flock(fd, fcntl.LOCK_EX)
         self.set_modsel()
-        if (self.sfpInfo is None):
-            return None
 
         page_offset = sff8436_parser[eeprom_key][PAGE_OFFSET]
         eeprom_data_raw = self._read_eeprom_bytes(
@@ -438,6 +440,7 @@ class Sfp(SfpBase):
             fd = open(SFP_LOCK_FILE, "r")
         except IOError as e:
             print("Error: unable to open file: %s" % str(e))
+            return False
         fcntl.flock(fd, fcntl.LOCK_EX)
         self.set_modsel()
 
@@ -503,10 +506,8 @@ class Sfp(SfpBase):
 
         # Mask off the bit corresponding to our port
         index = self.sfp_ctrl_idx
-        clear_bit = "0xffffffff"
-        clear_bit = int(clear_bit, 16)
 
-        reg_value = reg_value | clear_bit
+        reg_value = reg_value | int("0xffffffff", 16)
         mask = (1 << index)
 
         reg_value = (reg_value & ~mask)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- "sfputil show eeprom" and "sfpshow eeprom" commands displays inconsistency results for certain optics.
- For every execution of the commands, various results are displayed.
- Only certain optics EEPROM contents were not retrieved.
#### How I did it
On branch Master
Your branch is up to date with 'origin/Master'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
        modified:   platform/broadcom/sonic-platform-modules-dell/s6000/modules/dell_s6000_platform.c
        modified:   platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
        modified:   platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py


#### How to verify it
- Just execute "sfputil show eeprom" and "sfpshow eeprom" commands.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

