### PR TITLE
[fstrim] delay fstrim timer after sonic.target

### DIFF
--- a/files/image_config/fstrim/fstrim.timer
+++ b/files/image_config/fstrim/fstrim.timer
@@ -1,6 +1,7 @@
 [Unit]
 Description=Discard unused blocks once a week
 Documentation=man:fstrim
+After=sonic.target
 
 [Timer]
 OnCalendar=weekly


### PR DESCRIPTION
#### Why I did it
fstrim has dependency on pmon docker.

#### How I did it
start fstrim timer after sonic.target.

#### How to verify it
local test and PR test.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>


#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

