### PR TITLE
[201911] Logrotate for wtmp and btmp files to fix size.

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -247,7 +247,8 @@ sudo mkdir -p $FILESYSTEM_ROOT/etc/systemd/system/syslog.socket.d
 sudo cp $IMAGE_CONFIGS/syslog/override.conf $FILESYSTEM_ROOT/etc/systemd/system/syslog.socket.d/override.conf
 sudo cp $IMAGE_CONFIGS/syslog/host_umount.sh $FILESYSTEM_ROOT/usr/bin/
 
-# Copy logrotate.d configuration files
+# Copy logrotate.conf and logrotate.d configuration files
+sudo cp -f $IMAGE_CONFIGS/logrotate/logrotate.conf $FILESYSTEM_ROOT/etc/logrotate.conf
 sudo cp -f $IMAGE_CONFIGS/logrotate/logrotate.d/* $FILESYSTEM_ROOT/etc/logrotate.d/
 
 # Copy systemd-journald configuration files


### PR DESCRIPTION
What I did:

Logically same as https://github.com/Azure/sonic-buildimage/pull/8743  but for Stretch we did not copied `logrotate.conf` that has `wtmp` and `btmp` log rotate config.

