### PR TITLE
Remove the rw folder from the image after installing in KVM

### DIFF
--- a/check_install.py
+++ b/check_install.py
@@ -37,22 +37,19 @@ def main():
                 raise
             time.sleep(1)
 
-    # select ONIE embed
+    # select default SONiC Image
     p.expect(grub_selection)
-    p.sendline(KEY_DOWN)
+    p.sendline()
 
-    # install sonic image
+    # bootup sonic image
     while True:
-        i = p.expect([login_prompt, passwd_prompt, grub_selection, cmd_prompt])
+        i = p.expect([login_prompt, passwd_prompt, cmd_prompt])
         if i == 0:
             # send user name
             p.sendline(args.u)
         elif i == 1:
             # send password
             p.sendline(args.P)
-        elif i == 2:
-            # select onie install
-            p.sendline()
         else:
             break
 

--- a/check_install.py
+++ b/check_install.py
@@ -15,11 +15,6 @@ def main():
 
     args = parser.parse_args()
 
-    KEY_UP = '\x1b[A'
-    KEY_DOWN = '\x1b[B'
-    KEY_RIGHT = '\x1b[C'
-    KEY_LEFT = '\x1b[D'
-
     login_prompt = 'sonic login:'
     passwd_prompt = 'Password:'
     cmd_prompt = "{}@sonic:~\$ $".format(args.u)
@@ -60,8 +55,6 @@ def main():
     p.sendline('show version')
     p.expect([cmd_prompt])
     p.sendline('show ip bgp sum')
-    p.expect([cmd_prompt])
-    p.sendline('sudo rm -r /host/image-*/rw/')
     p.expect([cmd_prompt])
     p.sendline('sync')
     p.expect([cmd_prompt])

--- a/check_install.py
+++ b/check_install.py
@@ -64,6 +64,8 @@ def main():
     p.expect([cmd_prompt])
     p.sendline('show ip bgp sum')
     p.expect([cmd_prompt])
+    p.sendline('sudo rm -r /host/image-*/rw/')
+    p.expect([cmd_prompt])
     p.sendline('sync')
     p.expect([cmd_prompt])
 

--- a/install_sonic.py
+++ b/install_sonic.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import argparse
+import pexpect
+import sys
+import time
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description='test_login cmdline parser')
+    parser.add_argument('-p', type=int, default=9000, help='local port')
+
+    args = parser.parse_args()
+
+    KEY_UP = '\x1b[A'
+    KEY_DOWN = '\x1b[B'
+    KEY_RIGHT = '\x1b[C'
+    KEY_LEFT = '\x1b[D'
+
+    grub_selection = "The highlighted entry will be executed"
+
+    i = 0
+    while True:
+        try:
+            p = pexpect.spawn("telnet 127.0.0.1 {}".format(args.p), timeout=600, logfile=sys.stdout, encoding='utf-8')
+            break
+        except Exception as e:
+            print(str(e))
+            i += 1
+            if i == 10:
+                raise
+            time.sleep(1)
+
+    # select ONIE embed
+    p.expect(grub_selection)
+    p.sendline(KEY_DOWN)
+
+    # select ONIE install
+    p.expect(['ONIE: Install OS'])
+    p.expect([grub_selection])
+    p.sendline()
+
+    # wait for grub, and exit
+    p.expect([grub_selection])
+
+
+if __name__ == '__main__':
+    main()

--- a/install_sonic.py
+++ b/install_sonic.py
@@ -13,10 +13,10 @@ def main():
 
     args = parser.parse_args()
 
-    KEY_UP = '\x1b[A'
+    #KEY_UP = '\x1b[A'
     KEY_DOWN = '\x1b[B'
-    KEY_RIGHT = '\x1b[C'
-    KEY_LEFT = '\x1b[D'
+    #KEY_RIGHT = '\x1b[C'
+    #KEY_LEFT = '\x1b[D'
 
     grub_selection = "The highlighted entry will be executed"
 

--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -67,6 +67,8 @@ kvm_log=$(mktemp)
 trap on_exit EXIT
 trap on_error ERR
 
+echo "Installing SONiC"
+
 /usr/bin/kvm -m $MEM \
     -name "onie" \
     -boot "order=cd,once=d" -cdrom "$ONIE_RECOVERY_ISO" \
@@ -76,6 +78,34 @@ trap on_error ERR
     -vga std \
     -drive file=$DISK,media=disk,if=virtio,index=0 \
     -drive file=$INSTALLER_DISK,if=virtio,index=1 \
+    -serial telnet:127.0.0.1:$KVM_PORT,server > $kvm_log 2>&1 &
+
+kvm_pid=$!
+
+sleep 2.0
+
+[ -d "/proc/$kvm_pid" ] || {
+        echo "ERROR: kvm died."
+        cat $kvm_log
+        exit 1
+}
+
+echo "to kill kvm:  sudo kill $kvm_pid"
+
+./install_sonic.py
+
+kill $kvm_pid
+
+echo "Booting up SONiC"
+
+/usr/bin/kvm -m $MEM \
+    -name "onie" \
+    -device e1000,netdev=onienet \
+    -netdev user,id=onienet,hostfwd=:0.0.0.0:3041-:22 \
+    -vnc 0.0.0.0:0 \
+    -vga std \
+    -snapshot \
+    -drive file=$DISK,media=disk,if=virtio,index=0 \
     -serial telnet:127.0.0.1:$KVM_PORT,server > $kvm_log 2>&1 &
 
 kvm_pid=$!


### PR DESCRIPTION



#### Why I did it

When the image is installed from within KVM and then loaded, some files
(such as timer stamp files) are created as part of that bootup that then
get into the final image. This can cause some side effects, such as
systemd thinking that some persistent timers need to run because the
last trigger time got missed.

Therefore, at the end of the check_install.py script, remove the rw
folder so that it doesn't exist in the image, and that when this image
is started up in a KVM setup for the first time, it starts with a truly
clean slate.

Without this change, the issue seen was that for fstrim.timer, a stamp
file would be present in /var/lib/systemd/timers (and for other timers
that are marked as persistent). This would then cause fstrim.service to
get started immediately when starting a QEMU setup if the timer for that
service missed a trigger, and not wait 10 minutes after bootup. In the
case of fstrim.timer, that means if the image was started in QEMU after
next Monday, since that timer is scheduled to be triggered weekly.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

