### PR TITLE
[Accton] Don't include other platforms' python package

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS4630-54PE platforms',
    
    packages=['as4630_54pe'],
-   package_dir={'as4630_54pe': 'as4630-54pe/classes'},
+   package_dir={'as4630_54pe': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54te/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54te/setup.py
@@ -10,5 +10,5 @@ setup(
     description='Module to initialize Accton AS4630-54TE platforms',
 
     packages=['as4630_54te'],
-    package_dir={'as4630_54te': 'as4630-54te/classes'},
+    package_dir={'as4630_54te': 'classes'},
 )

--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS5712-54X platforms',
    
    packages=['as5712_54x'],
-   package_dir={'as5712_54x': 'as5712-54x/classes'},
+   package_dir={'as5712_54x': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54t/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54t/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS5812-54X platforms',
    
    packages=['as5812_54t'],
-   package_dir={'as5812_54t': 'as5812-54t/classes'},
+   package_dir={'as5812_54t': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS5812-54X platforms',
    
    packages=['as5812_54x'],
-   package_dir={'as5812_54x': 'as5812-54x/classes'},
+   package_dir={'as5812_54x': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS5835-54T platforms',
    
    packages=['as5835_54t'],
-   package_dir={'as5835_54t': 'as5835-54t/classes'},
+   package_dir={'as5835_54t': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS5835-54X platforms',
    
    packages=['as5835_54x'],
-   package_dir={'as5835_54x': 'as5835-54x/classes'},
+   package_dir={'as5835_54x': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as6712-32x/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as6712-32x/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS6712-32X platforms',
    
    packages=['as6712_32x'],
-   package_dir={'as6712_32x': 'as6712-32x/classes'},
+   package_dir={'as6712_32x': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54x/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54x/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS7312-54X platforms',
    
    packages=['as7312_54x'],
-   package_dir={'as7312_54x': 'as7312-54x/classes'},
+   package_dir={'as7312_54x': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54xs/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54xs/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS7312-54XS platforms',
    
    packages=['as7312_54xs'],
-   package_dir={'as7312_54xs': 'as7312-54xs/classes'},
+   package_dir={'as7312_54xs': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS7315-27XB platforms',
    
    packages=['as7315_27xb'],
-   package_dir={'as7315_27xb': 'as7315-27xb/classes'},
+   package_dir={'as7315_27xb': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS7326-56X platforms',
    
    packages=['as7326_56x'],
-   package_dir={'as7326_56x': 'as7326-56x/classes'},
+   package_dir={'as7326_56x': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS7712-32X platforms',
    
    packages=['as7712_32x'],
-   package_dir={'as7712_32x': 'as7712-32x/classes'},
+   package_dir={'as7712_32x': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32x/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32x/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS7716-32X platforms',
    
    packages=['as7716_32x'],
-   package_dir={'as7716_32x': 'as7716-32x/classes'},
+   package_dir={'as7716_32x': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS7716-32XB platforms',
    
    packages=['as7716_32xb'],
-   package_dir={'as7716_32xb': 'as7716-32xb/classes'},
+   package_dir={'as7716_32xb': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS7726-32X platforms',
    
    packages=['as7726_32x'],
-   package_dir={'as7726_32x': 'as7726-32x/classes'},
+   package_dir={'as7726_32x': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS7816-64X platforms',
    
    packages=['as7816_64x'],
-   package_dir={'as7816_64x': 'as7816-64x/classes'},
+   package_dir={'as7816_64x': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/setup.py
@@ -11,6 +11,6 @@ setup(
    description='Module to initialize Accton AS9716-32D platforms',
    
    packages=['as9716_32d'],
-   package_dir={'as9716_32d': 'as9716-32d/classes'},
+   package_dir={'as9716_32d': 'classes'},
 )
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9726-32d/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9726-32d/setup.py
@@ -10,5 +10,5 @@ setup(
     description='Module to initialize Accton AS9726_32D platforms',
 
     packages=['as9726_32d'],
-    package_dir={'as9726_32d': 'as9726-32d/classes'},
+    package_dir={'as9726_32d': 'classes'},
 )

--- a/platform/broadcom/sonic-platform-modules-accton/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/rules
@@ -40,8 +40,8 @@ build:
 	#make modules -C $(KERNEL_SRC)/build M=$(MODULE_SRC)
 	(for mod in $(MODULE_DIRS); do \
 		make modules -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
-		$(PYTHON) $${mod}/setup.py build; \
 		cd $(MOD_SRC_DIR)/$${mod}; \
+		$(PYTHON) setup.py build; \
 		if [ -f sonic_platform_setup.py ]; then \
 			$(PYTHON3) sonic_platform_setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}; \
 			echo "Finished makig whl package for $$mod"; \
@@ -73,7 +73,9 @@ binary-indep:
 		cp $(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)/*.ko debian/$(PACKAGE_PRE_NAME)-$${mod}/$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
 		cp $(MOD_SRC_DIR)/$${mod}/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/usr/local/bin/; \
 		cp $(MOD_SRC_DIR)/$${mod}/$(SERVICE_DIR)/*.service debian/$(PACKAGE_PRE_NAME)-$${mod}/lib/systemd/system/; \
-		$(PYTHON) $${mod}/setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME)-$${mod} --install-layout=deb; \
+		cd $(MOD_SRC_DIR)/$${mod}; \
+		$(PYTHON) setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME)-$${mod} --install-layout=deb; \
+		cd -; \
 	done)
 	# Resuming debhelper scripts
 	dh_testroot

--- a/platform/broadcom/sonic-platform-modules-accton/minipack/setup.py
+++ b/platform/broadcom/sonic-platform-modules-accton/minipack/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup, Extension
 os.listdir
 
-module1 = Extension("fbfpgaio", sources = ["minipack/lib/fbfpgaiomodule.c"])
+module1 = Extension("fbfpgaio", sources = ["lib/fbfpgaiomodule.c"])
 
 setup(
    name='minipack',
@@ -13,7 +13,7 @@ setup(
    description='Module to initialize Accton MiniPack platforms',
    
    packages=['minipack'],
-   package_dir={'minipack': 'minipack/classes'},
+   package_dir={'minipack': 'classes'},
    ext_modules=[module1],
    
 )


### PR DESCRIPTION
Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
original:
ubuntu@ip-10-5-1-97:~/sonic-buildimage_202012/sonic-buildimage (ec202012)$ dpkg -c target/debs/buster/sonic-platform-accton-as5835-54t_1.1_amd64.deb
drwxr-xr-x root/root         0 2017-12-19 01:35 ./
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/modules/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/
-rw-r--r-- root/root    371824 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/accton_as5835_54t_cpld.ko
-rw-r--r-- root/root    355904 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/accton_as5835_54t_fan.ko
-rw-r--r-- root/root    332472 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/accton_as5835_54t_leds.ko
-rw-r--r-- root/root    344208 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/accton_as5835_54t_psu.ko
-rw-r--r-- root/root    379944 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/ym2651y.ko
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/systemd/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/systemd/system/
-rw-r--r-- root/root       373 2017-12-19 01:35 ./lib/systemd/system/as5835-54t-platform-init.service
-rw-r--r-- root/root       365 2017-12-19 01:35 ./lib/systemd/system/as5835-54t-platform-monitor-fan.service
-rw-r--r-- root/root       365 2017-12-19 01:35 ./lib/systemd/system/as5835-54t-platform-monitor-psu.service
-rw-r--r-- root/root       377 2017-12-19 01:35 ./lib/systemd/system/as5835-54t-platform-monitor.service
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54npe/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54npe/__init__.py
-rw-r--r-- root/root       144 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54npe/__init__.pyc
-rw-r--r-- root/root      7576 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54npe/fanutil.py
-rw-r--r-- root/root      6777 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54npe/fanutil.pyc
-rw-r--r-- root/root      3217 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54npe/thermalutil.py
-rw-r--r-- root/root      2854 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54npe/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54pe/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54pe/__init__.py
-rw-r--r-- root/root       143 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54pe/__init__.pyc
-rw-r--r-- root/root      7561 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54pe/fanutil.py
-rw-r--r-- root/root      6698 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54pe/fanutil.pyc
-rw-r--r-- root/root      3185 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54pe/thermalutil.py
-rw-r--r-- root/root      2811 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54pe/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54te/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54te/__init__.py
-rw-r--r-- root/root       143 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54te/__init__.pyc
-rw-r--r-- root/root      7516 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54te/fanutil.py
-rw-r--r-- root/root      6688 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54te/fanutil.pyc
-rw-r--r-- root/root      3117 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54te/thermalutil.py
-rw-r--r-- root/root      2703 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as4630_54te/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5712_54x/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5712_54x/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5712_54x/__init__.pyc
-rw-r--r-- root/root      9184 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5712_54x/fanutil.py
-rw-r--r-- root/root      7694 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5712_54x/fanutil.pyc
-rw-r--r-- root/root      4086 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5712_54x/thermalutil.py
-rw-r--r-- root/root      3567 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5712_54x/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54t/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54t/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54t/__init__.pyc
-rw-r--r-- root/root      9406 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54t/fanutil.py
-rw-r--r-- root/root      7920 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54t/fanutil.pyc
-rw-r--r-- root/root      4271 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54t/thermalutil.py
-rw-r--r-- root/root      3766 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54t/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54x/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54x/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54x/__init__.pyc
-rw-r--r-- root/root      9406 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54x/fanutil.py
-rw-r--r-- root/root      7920 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54x/fanutil.pyc
-rw-r--r-- root/root      4271 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54x/thermalutil.py
-rw-r--r-- root/root      3766 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5812_54x/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/__init__.pyc
-rw-r--r-- root/root      8215 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/fanutil.py
-rw-r--r-- root/root      6758 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/fanutil.pyc
-rw-r--r-- root/root      4857 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/thermalutil.py
-rw-r--r-- root/root      4421 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t-1.0.egg-info/
-rw-r--r-- root/root       223 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t-1.0.egg-info/PKG-INFO
-rw-r--r-- root/root         1 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t-1.0.egg-info/dependency_links.txt
-rw-r--r-- root/root        11 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t-1.0.egg-info/top_level.txt
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54x/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54x/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54x/__init__.pyc
-rw-r--r-- root/root      8215 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54x/fanutil.py
-rw-r--r-- root/root      6758 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54x/fanutil.pyc
-rw-r--r-- root/root      4857 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54x/thermalutil.py
-rw-r--r-- root/root      4421 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54x/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as6712_32x/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as6712_32x/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as6712_32x/__init__.pyc
-rw-r--r-- root/root      8833 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as6712_32x/fanutil.py
-rw-r--r-- root/root      6777 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as6712_32x/fanutil.pyc
-rw-r--r-- root/root      4403 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as6712_32x/thermalutil.py
-rw-r--r-- root/root      3799 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as6712_32x/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54x/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54x/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54x/__init__.pyc
-rw-r--r-- root/root      8304 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54x/fanutil.py
-rw-r--r-- root/root      6621 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54x/fanutil.pyc
-rw-r--r-- root/root      4360 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54x/thermalutil.py
-rw-r--r-- root/root      3680 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54x/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54xs/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54xs/__init__.py
-rw-r--r-- root/root       143 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54xs/__init__.pyc
-rw-r--r-- root/root      8947 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54xs/fanutil.py
-rw-r--r-- root/root      7094 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54xs/fanutil.pyc
-rw-r--r-- root/root      4584 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54xs/thermalutil.py
-rw-r--r-- root/root      3994 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7312_54xs/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7315_27xb/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7315_27xb/__init__.py
-rw-r--r-- root/root       143 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7315_27xb/__init__.pyc
-rw-r--r-- root/root      7186 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7315_27xb/fanutil.py
-rw-r--r-- root/root      6421 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7315_27xb/fanutil.pyc
-rw-r--r-- root/root      4399 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7315_27xb/thermalutil.py
-rw-r--r-- root/root      3838 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7315_27xb/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7326_56x/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7326_56x/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7326_56x/__init__.pyc
-rw-r--r-- root/root      8821 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7326_56x/fanutil.py
-rw-r--r-- root/root      6805 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7326_56x/fanutil.pyc
-rw-r--r-- root/root      6264 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7326_56x/thermalutil.py
-rw-r--r-- root/root      5607 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7326_56x/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7712_32x/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7712_32x/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7712_32x/__init__.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32x/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32x/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32x/__init__.pyc
-rw-r--r-- root/root      8860 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32x/fanutil.py
-rw-r--r-- root/root      6853 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32x/fanutil.pyc
-rw-r--r-- root/root      4357 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32x/thermalutil.py
-rw-r--r-- root/root      3785 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32x/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32xb/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32xb/__init__.py
-rw-r--r-- root/root       143 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32xb/__init__.pyc
-rw-r--r-- root/root      9419 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32xb/fanutil.py
-rw-r--r-- root/root      6906 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32xb/fanutil.pyc
-rw-r--r-- root/root      4450 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32xb/thermalutil.py
-rw-r--r-- root/root      3797 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7716_32xb/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7726_32x/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7726_32x/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7726_32x/__init__.pyc
-rw-r--r-- root/root      8746 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7726_32x/fanutil.py
-rw-r--r-- root/root      6855 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7726_32x/fanutil.pyc
-rw-r--r-- root/root      4737 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7726_32x/thermalutil.py
-rw-r--r-- root/root      4364 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7726_32x/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7816_64x/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7816_64x/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7816_64x/__init__.pyc
-rw-r--r-- root/root      8460 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7816_64x/fanutil.py
-rw-r--r-- root/root      6665 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7816_64x/fanutil.pyc
-rw-r--r-- root/root      4287 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7816_64x/thermalutil.py
-rw-r--r-- root/root      3675 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as7816_64x/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9716_32d/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9716_32d/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9716_32d/__init__.pyc
-rw-r--r-- root/root      7513 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9716_32d/fanutil.py
-rw-r--r-- root/root      6836 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9716_32d/fanutil.pyc
-rw-r--r-- root/root      3739 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9716_32d/thermalutil.py
-rw-r--r-- root/root      3224 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9716_32d/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9726_32d/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9726_32d/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9726_32d/__init__.pyc
-rw-r--r-- root/root      7506 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9726_32d/fanutil.py
-rw-r--r-- root/root      6799 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9726_32d/fanutil.pyc
-rw-r--r-- root/root      3473 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9726_32d/thermalutil.py
-rw-r--r-- root/root      2796 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as9726_32d/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/local/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/local/bin/
-rw-r--r-- root/root      3100 2017-12-19 01:35 ./usr/local/bin/README
-rwxr-xr-x root/root      7360 2017-12-19 01:35 ./usr/local/bin/accton_as5835_54t_monitor.py
-rwxr-xr-x root/root      6448 2017-12-19 01:35 ./usr/local/bin/accton_as5835_54t_monitor_fan.py
-rwxr-xr-x root/root      6601 2017-12-19 01:35 ./usr/local/bin/accton_as5835_54t_monitor_psu.py
-rwxr-xr-x root/root     21995 2017-12-19 01:35 ./usr/local/bin/accton_as5835_54t_util.py
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/doc/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/doc/sonic-platform-accton-as5835-54t/
-rw-r--r-- root/root       252 2017-12-19 01:35 ./usr/share/doc/sonic-platform-accton-as5835-54t/changelog.gz
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/sonic/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/sonic/device/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/sonic/device/x86_64-accton_as5835_54t-r0/
-rw-r--r-- root/root     25884 2017-12-19 01:35 ./usr/share/sonic/device/x86_64-accton_as5835_54t-r0/sonic_platform-1.0-py3-none-any.whl

#### How I did it

#### How to verify it
make target/debs/buster/sonic-platform-accton-as7712-32x_1.1_amd64.deb

new:
ubuntu@ip-10-5-1-97:~/sonic-buildimage_202012/sonic-buildimage (ec202012)$ dpkg -c target/debs/buster/sonic-platform-accton-as5835-54t_1.1_amd64.deb
drwxr-xr-x root/root         0 2017-12-19 01:35 ./
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/modules/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/
-rw-r--r-- root/root    371824 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/accton_as5835_54t_cpld.ko
-rw-r--r-- root/root    355904 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/accton_as5835_54t_fan.ko
-rw-r--r-- root/root    332472 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/accton_as5835_54t_leds.ko
-rw-r--r-- root/root    344208 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/accton_as5835_54t_psu.ko
-rw-r--r-- root/root    379944 2017-12-19 01:35 ./lib/modules/4.19.0-12-2-amd64/extra/ym2651y.ko
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/systemd/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./lib/systemd/system/
-rw-r--r-- root/root       373 2017-12-19 01:35 ./lib/systemd/system/as5835-54t-platform-init.service
-rw-r--r-- root/root       365 2017-12-19 01:35 ./lib/systemd/system/as5835-54t-platform-monitor-fan.service
-rw-r--r-- root/root       365 2017-12-19 01:35 ./lib/systemd/system/as5835-54t-platform-monitor-psu.service
-rw-r--r-- root/root       377 2017-12-19 01:35 ./lib/systemd/system/as5835-54t-platform-monitor.service
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/
-rw-r--r-- root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/__init__.py
-rw-r--r-- root/root       142 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/__init__.pyc
-rw-r--r-- root/root      8215 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/fanutil.py
-rw-r--r-- root/root      6758 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/fanutil.pyc
-rw-r--r-- root/root      4857 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/thermalutil.py
-rw-r--r-- root/root      4421 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t/thermalutil.pyc
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t-1.0.egg-info/
-rw-r--r-- root/root       223 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t-1.0.egg-info/PKG-INFO
-rw-r--r-- root/root         1 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t-1.0.egg-info/dependency_links.txt
-rw-r--r-- root/root        11 2017-12-19 01:35 ./usr/lib/python2.7/dist-packages/as5835_54t-1.0.egg-info/top_level.txt
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/local/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/local/bin/
-rw-r--r-- root/root      3100 2017-12-19 01:35 ./usr/local/bin/README
-rwxr-xr-x root/root      7360 2017-12-19 01:35 ./usr/local/bin/accton_as5835_54t_monitor.py
-rwxr-xr-x root/root      6448 2017-12-19 01:35 ./usr/local/bin/accton_as5835_54t_monitor_fan.py
-rwxr-xr-x root/root      6601 2017-12-19 01:35 ./usr/local/bin/accton_as5835_54t_monitor_psu.py
-rwxr-xr-x root/root     21995 2017-12-19 01:35 ./usr/local/bin/accton_as5835_54t_util.py
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/doc/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/doc/sonic-platform-accton-as5835-54t/
-rw-r--r-- root/root       252 2017-12-19 01:35 ./usr/share/doc/sonic-platform-accton-as5835-54t/changelog.gz
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/sonic/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/sonic/device/
drwxr-xr-x root/root         0 2017-12-19 01:35 ./usr/share/sonic/device/x86_64-accton_as5835_54t-r0/
-rw-r--r-- root/root     25884 2017-12-19 01:35 ./usr/share/sonic/device/x86_64-accton_as5835_54t-r0/sonic_platform-1.0-py3-none-any.whl


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

