### PR TITLE
[minigraph.py]: Remove members list from VLAN, it is not supported in YANG models.

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1566,6 +1566,10 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     if is_storage_device:
         results['DEVICE_METADATA']['localhost']['storage_device'] = "true"
 
+    # clean vlan members field before final assignment
+    for vlan_name in vlans.keys():
+        if 'members' in vlans[vlan_name]:
+            del vlans[vlan_name]['members']
     results['VLAN'] = vlans
     results['VLAN_MEMBER'] = vlan_members
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove members list from VLAN, it is not supported in YANG models.

**- How I did it**
Let vlan['members'] get filled in parse_dpg(), but remove it from json before assignment in result in function parse_xml().

**- How to verify it**
Before Fix:

```
sonic-cfggen -H -m /etc/sonic/minigraph.xml --print-data | grep -A 20 VLAN
–
"VLAN": {
"Vlan1000": {
"vlanid": "1000",
"members": [
"Ethernet4",
"Ethernet8",
"Ethernet12",
"Ethernet16",
"Ethernet20",
"Ethernet24",
"Ethernet28",
"Ethernet32",
"Ethernet36",
"Ethernet40",
"Ethernet44",
"Ethernet48",
"Ethernet52",
"Ethernet56",
"Ethernet60",
"Ethernet64",
"Ethernet68",
–
```

After Fix:
sonic-cfggen -H -m /etc/sonic/minigraph.xml --print-data | grep -A 20 VLAN

```
--
"VLAN": {
"Vlan1000":
{ "vlanid": "1000", "dhcp_servers": [ "192.0.0.1", "192.0.0.2", "192.0.0.3", "192.0.0.4" ] }

},
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
