### PR TITLE
[Nokia ixs7215] Add support for SFP eeprom type_abbrv_name attribute

### DIFF
--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/fan_drawer.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/fan_drawer.py
@@ -54,9 +54,25 @@ class NokiaFanDrawer(FanDrawerBase):
         return 'intake'
 
     def set_status_led(self, color):
+        """
+        Sets the state of the fan drawer status LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   fan drawer status LED
+
+        Returns:
+            bool: True if status LED state is set successfully, False if not
+        """
         return self._fan_list[0].set_status_led(color)
 
-    def get_status_led(self, color):
+    def get_status_led(self):
+        """
+        Gets the state of the fan drawer LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings
+        """
         return self._fan_list[0].get_status_led()
 
     def is_replaceable(self):

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/sfp.py
@@ -143,7 +143,7 @@ class Sfp(SfpBase):
                                'model', 'connector', 'encoding', 'ext_identifier',
                                'ext_rateselect_compliance', 'cable_type', 'cable_length',
                                'nominal_bit_rate', 'specification_compliance',
-                               'vendor_date', 'vendor_oui']
+                               'type_abbrv_name', 'vendor_date', 'vendor_oui']
 
         self.dom_dict_keys = ['rx_los', 'tx_fault', 'reset_status', 'power_lpmode',
                               'tx_disable', 'tx_disable_channel', 'temperature',
@@ -274,6 +274,7 @@ class Sfp(SfpBase):
         cable_length               |INT            |cable length in m
         nominal_bit_rate           |INT            |nominal bit rate by 100Mbs
         specification_compliance   |1*255VCHAR     |specification compliance
+        type_abbrv_name            |1*255VCHAR     |type of SFP (abbreviated)
         vendor_date                |1*255VCHAR     |vendor date
         vendor_oui                 |1*255VCHAR     |vendor OUI
         application_advertisement  |1*255VCHAR     |supported applications advertisement
@@ -338,33 +339,47 @@ class Sfp(SfpBase):
             end = start + XCVR_VENDOR_DATE_WIDTH
             sfp_vendor_date_data = sfpi_obj.parse_vendor_date(
                 sfp_interface_bulk_raw[start: end], 0)
-            transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
-            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data['data']['Vendor Name']['value']
-            transceiver_info_dict['model'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
-            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
-            transceiver_info_dict['serial'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
-            transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value']
-            transceiver_info_dict['vendor_date'] = sfp_vendor_date_data[
-                'data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
-            transceiver_info_dict['connector'] = sfp_interface_bulk_data['data']['Connector']['value']
-            transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
-            transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
-            transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
+
+            transceiver_info_dict['type'] = sfp_interface_bulk_data \
+                ['data']['type']['value']
+            transceiver_info_dict['manufacturer'] = sfp_vendor_name_data \
+                ['data']['Vendor Name']['value']
+            transceiver_info_dict['model'] = sfp_vendor_pn_data \
+                ['data']['Vendor PN']['value']
+            transceiver_info_dict['hardware_rev'] = sfp_vendor_rev_data \
+                ['data']['Vendor Rev']['value']
+            transceiver_info_dict['serial'] = sfp_vendor_sn_data \
+                ['data']['Vendor SN']['value']
+            transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data \
+                ['data']['Vendor OUI']['value']
+            transceiver_info_dict['vendor_date'] = sfp_vendor_date_data \
+                ['data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
+            transceiver_info_dict['connector'] = sfp_interface_bulk_data \
+                ['data']['Connector']['value']
+            transceiver_info_dict['encoding'] = sfp_interface_bulk_data \
+                ['data']['EncodingCodes']['value']
+            transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data \
+                ['data']['Extended Identifier']['value']
+            transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data \
+                ['data']['RateIdentifier']['value']
+            transceiver_info_dict['type_abbrv_name'] = sfp_interface_bulk_data \
+                ['data']['type_abbrv_name']['value']
 
             for key in sfp_cable_length_tup:
                 if key in sfp_interface_bulk_data['data']:
                     transceiver_info_dict['cable_type'] = key
-                    transceiver_info_dict['cable_length'] = str(
-                        sfp_interface_bulk_data['data'][key]['value'])
+                    transceiver_info_dict['cable_length'] = \
+                        str(sfp_interface_bulk_data['data'][key]['value'])
 
             for key in sfp_compliance_code_tup:
                 if key in sfp_interface_bulk_data['data']['Specification compliance']['value']:
-                    compliance_code_dict[key] = sfp_interface_bulk_data['data']['Specification compliance']['value'][key]['value']
-            transceiver_info_dict['specification_compliance'] = str(
-                compliance_code_dict)
+                    compliance_code_dict[key] = sfp_interface_bulk_data \
+                        ['data']['Specification compliance']['value'][key]['value']
 
-            transceiver_info_dict['nominal_bit_rate'] = str(
-                sfp_interface_bulk_data['data']['NominalSignallingRate(UnitsOf100Mbd)']['value'])
+            transceiver_info_dict['specification_compliance'] = \
+                str(compliance_code_dict)
+            transceiver_info_dict['nominal_bit_rate'] = \
+                str(sfp_interface_bulk_data['data']['NominalSignallingRate(UnitsOf100Mbd)']['value'])
             transceiver_info_dict['application_advertisement'] = 'N/A'
 
         return transceiver_info_dict


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix error seen when running the sonic_mgmt test-sfp.py platform test cases.
This was reported via Issue# 8745

#### How I did it
Add dictionary key to support the type_abbrv_name eeprom attribute

#### How to verify it
Run the sonic-mgmt SFP platform test cases

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

