### PR TITLE
[Mellanox] Change thermal recover threshold from temp_trip_norm to temp_trip_high

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -46,7 +46,7 @@ THERMAL_ZONE_GEARBOX_PATH = "/var/run/hw-management/thermal/mlxsw-gearbox{}/"
 THERMAL_ZONE_MODE = "thermal_zone_mode"
 THERMAL_ZONE_POLICY = "thermal_zone_policy"
 THERMAL_ZONE_TEMPERATURE = "thermal_zone_temp"
-THERMAL_ZONE_NORMAL_TEMPERATURE = "temp_trip_norm"
+THERMAL_ZONE_NORMAL_TEMPERATURE = "temp_trip_high"
 
 MODULE_TEMPERATURE_FAULT_PATH = "/var/run/hw-management/thermal/module{}_temp_fault"
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Change thermal recover threshold from temp_trip_norm to temp_trip_high, so that thermal algorithm would set fan speed to minimum allowed earlier and save power.

#### How I did it

Change thermal recover threshold from temp_trip_norm to temp_trip_high

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

