### PR TITLE
[docker-sonic-vs] always use separator ':' for GB_ASIC_DB, like ASIC_DB

### DIFF
--- a/platform/vs/docker-sonic-vs/database_config.json
+++ b/platform/vs/docker-sonic-vs/database_config.json
@@ -60,17 +60,17 @@
         },
         "GB_ASIC_DB" : {
             "id" : 8,
-            "separator": "|",
+            "separator": ":",
             "instance" : "redis"
         },
         "GB_COUNTERS_DB" : {
             "id" : 9,
-            "separator": "|",
+            "separator": ":",
             "instance" : "redis"
         },
         "GB_FLEX_COUNTER_DB" : {
             "id" : 10,
-            "separator": "|",
+            "separator": ":",
             "instance" : "redis"
         },
         "CHASSIS_APP_DB" : {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Since ASIC_DB always use ':', GB_ASIC_DB has to use same,  regarding to same sairedis and syncd logic

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

