### PR TITLE
add onie image install's platform verification

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -87,11 +87,24 @@ generate_onie_installer_image()
           $ONIE_INSTALLER_PAYLOAD
 }
 
+generate_onie_device_list()
+{
+    # Generate asic-specific ONIE device list
+    rm -rf ./installer/x86_64/devices/
+    mkdir -p ./installer/x86_64/devices/
+    for d in `find -L ./device  -maxdepth 2 -mindepth 2 -type d`; do
+            if [ -f $d/platform_asic ] && grep -Fxq "$CONFIGURED_PLATFORM" $d/platform_asic; then
+                touch ./installer/x86_64/devices/${d##*/};
+            fi;
+    done
+}
+
 if [ "$IMAGE_TYPE" = "onie" ]; then
     echo "Build ONIE installer"
     mkdir -p `dirname $OUTPUT_ONIE_IMAGE`
     sudo rm -f $OUTPUT_ONIE_IMAGE
 
+    generate_onie_device_list
     generate_onie_installer_image
 
 ## Build a raw partition dump image using the ONIE installer that can be

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -92,6 +92,39 @@ VAR_LOG_SIZE=4096
 
 [ -r platforms/$onie_platform ] && . platforms/$onie_platform
 
+# Verify image platform is inside devices list
+# Temporarily set TIMEOUT as 10 seconds
+if [ "$install_env" = "onie" ] && [ -d devices ]; then
+    if [ ! -f devices/$onie_platform ]; then
+        TIMEOUT=10
+        echo "The image you're trying to install is of a different platform as the running plaform"
+        while true; do
+            read -t $TIMEOUT -r -p "Do you still wish to install this image?[Y/n]" input
+            STATUS=$?
+            if test $STATUS -eq 0; then
+                case $input in
+                    [Yy])
+                        echo "Force installing..."
+                        break
+                        ;;
+                    [Nn])
+                        echo "Exited installation!"
+                        exit 1
+                        ;;
+                    *)
+                        echo "Error: Invalid input"
+                        ;;
+                esac
+            else
+                echo
+                echo "Timeout! Installation cancelled."
+                exit 1
+            fi
+        done
+
+    fi
+fi
+
 # Pick up console port and speed from install enviroment if not defined yet.
 # Console port and speed setting in cmdline is like "console=ttyS0,9600n",
 # so we can use pattern 'console=ttyS[0-9]+,[0-9]+' to match it.


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Provide onie image install verification
#### How I did it
Add devices folder based on platform_asic and check if current platform inside the list
#### How to verify it
In onie env, install a bin file which differs the running platform's ASIC. For example;
install sonic-broadcom.bin to mellanox ASIC platform
install sonic-vs.bin to broadcom ASIC platform
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

