### PR TITLE
Add gdb and pyrasite to ptf image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ files/build/tmp
 dockers/**/buildinfo
 platform/**/buildinfo
 sonic-slave*/**/buildinfo
+
+# Dev tools
+.vscode/
+.idea/

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -57,7 +57,8 @@ RUN sed --in-place 's/httpredir.debian.org/debian-archive.trafficmanager.net/' /
         ntpdate             \
         arping              \
         bridge-utils        \
-        libteam-utils
+        libteam-utils       \
+        gdb
 
 # Install all python modules from pypi. python-scapy is exception, ptf debian package requires python-scapy
 # TODO: Clean up this step
@@ -106,6 +107,7 @@ RUN rm -rf /debs \
     && pip install pyaml   \
     && pip install pybrctl pyro4 rpyc yabgp \
     && pip install unittest-xml-reporting \
+    && pip install pyrasite \
     && mkdir -p /opt       \
     && cd /opt             \
     && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
gdb and pyrasite can be used to print the running python process' stack trace.
It's helpful during debugging multi-thread issues
see : https://gist.github.com/reywood/e221c4061bbf2eccea885c9b2e4ef496
#### How I did it
install gdb and pyrasite during image build
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

