### PR TITLE
[test] Include chassis fields validation in platform.json unit test

### DIFF
--- a/src/sonic-device-data/tests/platform_json_checker
+++ b/src/sonic-device-data/tests/platform_json_checker
@@ -11,11 +11,79 @@ ATTR_LEN = len(PORT_ATTRIBUTES)
 PORT_REG = "Ethernet(\d+)"
 PLATFORM_JSON = '*platform.json'
 INTF_KEY = "interfaces"
+CHASSIS_KEY = "chassis"
 
 
 def usage():
     print("Usage: " + sys.argv[0] + " <platform_json_file>")
     sys.exit(1)
+
+
+def check_chassis_dict(chassis_dict):
+
+    def check_schema(schema, data):
+        is_valid = True
+        if isinstance(schema, dict):
+            if not isinstance(data, dict):
+                print("Invalid data type {} for {}. Expected dict".format(type(data), data))
+                return False
+
+            for key, data_type in schema.items():
+                if key not in data:
+                    continue
+
+                is_valid = check_schema(data_type, data[key])
+                if not is_valid:
+                    break
+        elif isinstance(schema, list):
+            if not isinstance(data, list):
+                print("Invalid data type {} for {}. Expected list".format(type(data), data))
+                return False
+
+            for ele in data:
+                is_valid = check_schema(schema[0], ele)
+                if not is_valid:
+                    break
+        else:
+            if not isinstance(data, schema):
+                print("Invalid data type {} for {}. Expected {}".format(type(data), data, type(schema())))
+                return False
+
+        return is_valid
+
+    common_schema = {"name": str}
+    controllable_schema = {"controllable": bool}
+    fan_speed_schema = {"maximum": int, "minimum": int}
+    fan_speed_schema.update(controllable_schema)
+
+    status_led_schema = {"colors": [str]}
+    status_led_schema.update(controllable_schema)
+
+    component_schema = common_schema.copy()
+
+    fan_schema = {"speed": fan_speed_schema, "status_led": status_led_schema}
+    fan_schema.update(common_schema)
+
+    fandrawer_schema = {"fans": [fan_schema], "status_led": status_led_schema}
+    fandrawer_schema.update(common_schema)
+
+    psu_schema = {"fans": [fan_schema], "status_led": status_led_schema}
+    psu_schema.update(common_schema)
+
+    sfp_schema = common_schema.copy()
+
+    thermal_schema = common_schema.copy()
+    thermal_schema.update(controllable_schema)
+
+    module_schema = {"components": [component_schema], "fans": [fan_schema],
+                     "fandrawers": [fandrawer_schema], "psus": [psu_schema],
+                     "sfps": [sfp_schema], "thermals": [thermal_schema]}
+    module_schema.update(common_schema)
+
+    chassis_schema = {"modules": [module_schema], "status_led": status_led_schema}
+    chassis_schema.update(module_schema)
+
+    return check_schema(chassis_schema, chassis_dict)
 
 
 def check_port_attr(port_attr):
@@ -44,17 +112,23 @@ def check_file(platform_json_file):
     try:
         platform_cap_file = open(platform_json_file,"r")
         platform_file_data = platform_cap_file.read()
-        port_dict = json.loads(platform_file_data)
+        platform_dict = json.loads(platform_file_data)
+        chassis_dict = platform_dict.get(CHASSIS_KEY)
+        port_dict = platform_dict[INTF_KEY]
 
-        for each_port in port_dict[INTF_KEY]:
+        if chassis_dict:
+            if not check_chassis_dict(chassis_dict):
+                return False
+
+        for each_port in port_dict:
             # Validate port at top level
             port_id = re.search(PORT_REG, each_port)
             if port_id is  None:
                 print("Error: Unknown Interface " + str(each_port) + " at top level")
                 return False
 
-            total_attr = len(list(port_dict[INTF_KEY][each_port].keys()))
-            port_attr = port_dict[INTF_KEY][each_port]
+            total_attr = len(list(port_dict[each_port].keys()))
+            port_attr = port_dict[each_port]
 
             if total_attr != ATTR_LEN:
                 missing_attr = ', '.join(set(PORT_ATTRIBUTES).difference(list(port_attr)))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Include validation of chassis dict in platform.json unit test
Based on: https://github.com/Azure/SONiC/pull/768

#### How I did it

Update `platform_json_checker` to validate fields in chassis dict.

#### How to verify it

Verified that the unit test reports success for correct values of existing and capabilities fields  in platform.json

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[test] Include chassis fields validation in platform.json unit test

#### A picture of a cute animal (not mandatory but encouraged)

