### PR TITLE
Support preemphasis in media_settings.json on AS5835-54T

### DIFF
--- a/device/accton/x86_64-accton_as5835_54t-r0/media_settings.json
+++ b/device/accton/x86_64-accton_as5835_54t-r0/media_settings.json
@@ -1,0 +1,177 @@
+{
+    "GLOBAL_MEDIA_SETTINGS": {
+        "49": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x001b4900",
+                    "lane1": "0x001c4800",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4800"
+                }
+            }
+        },
+        "50": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x001c4800",
+                    "lane1": "0x001c4800",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4503"
+                }
+            }
+        },
+        "51": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x001c4800",
+                    "lane1": "0x001c4305",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4404"
+                }
+            }
+        },
+        "52": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x001c4800",
+                    "lane1": "0x001c4800",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4800"
+                }
+            }
+        },
+        "53": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x001b4900",
+                    "lane1": "0x001c4800",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4800"
+                }
+            }
+        },
+        "54": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x001c4800",
+                    "lane1": "0x001c4800",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4800"
+                }
+            }
+        }
+    }, 
+    "PORT_MEDIA_SETTINGS": {
+        
+    },
+    "SPEED_MEDIA_SETTINGS": {
+        "49": {
+            "10000": {
+                "preemphasis": {
+                    "lane0": "0x000d3800",
+                    "lane1": "0x000d3800",
+                    "lane2": "0x000d3800",
+                    "lane3": "0x000d3800"
+                }
+            },
+            "25000": {
+                "preemphasis": {
+                    "lane0": "0x001b4900",
+                    "lane1": "0x001c4800",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4800"
+                }
+            }
+        },
+        "50": {
+            "10000": {
+                "preemphasis": {
+                    "lane0": "0x000d3800",
+                    "lane1": "0x000f3800",
+                    "lane2": "0x000d3800",
+                    "lane3": "0x000d3800"
+                }
+            },
+            "25000": {
+                "preemphasis": {
+                    "lane0": "0x001c4800",
+                    "lane1": "0x001c4800",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4503"
+                }
+            }
+        },
+        "51": {
+            "10000": {
+                "preemphasis": {
+                    "lane0": "0x000f3800",
+                    "lane1": "0x00103800",
+                    "lane2": "0x000e3800",
+                    "lane3": "0x000f3800"
+                }
+            },
+            "25000": {
+                "preemphasis": {
+                    "lane0": "0x001c4800",
+                    "lane1": "0x001c4305",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4404"
+                }
+            }
+        },
+        "52": {
+            "10000": {
+                "preemphasis": {
+                    "lane0": "0x000b3000",
+                    "lane1": "0x000b3000",
+                    "lane2": "0x000b3000",
+                    "lane3": "0x000b3000"
+                }
+            },
+            "25000": {
+                "preemphasis": {
+                    "lane0": "0x001c4800",
+                    "lane1": "0x001c4800",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4800"
+                }
+            }
+        },
+        "53": {
+            "10000": {
+                "preemphasis": {
+                    "lane0": "0x000b3000",
+                    "lane1": "0x000b3000",
+                    "lane2": "0x000b3000",
+                    "lane3": "0x000b3000"
+                }
+            },
+            "25000": {
+                "preemphasis": {
+                    "lane0": "0x001b4900",
+                    "lane1": "0x001c4800",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4800"
+                }
+            }
+        },
+        "54": {
+            "10000": {
+                "preemphasis": {
+                    "lane0": "0x000b3000",
+                    "lane1": "0x000b3000",
+                    "lane2": "0x000b3000",
+                    "lane3": "0x000d3000"
+                }
+            },
+            "25000": {
+                "preemphasis": {
+                    "lane0": "0x001c4800",
+                    "lane1": "0x001c4800",
+                    "lane2": "0x001c4800",
+                    "lane3": "0x001c4800"
+                }
+            }
+        }
+    }
+}

--- a/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D/hwsku.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D/hwsku.json
@@ -1,0 +1,132 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet8": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet16": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet24": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet32": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet40": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet48": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet56": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet64": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet72": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet80": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet88": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet96": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet104": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet112": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet120": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet128": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet136": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet144": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet152": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet160": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet168": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet176": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet184": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet192": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet200": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet208": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet216": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet224": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet232": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet240": {
+            "default_brkout_mode": "1x400G"
+        },
+
+        "Ethernet248": {
+            "default_brkout_mode": "1x400G"
+        }
+    }
+}
+

--- a/device/accton/x86_64-accton_as9716_32d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/platform.json
@@ -1,0 +1,600 @@
+{
+    "chassis": {
+        "name": "9716-32D",
+        "fans": [
+            {
+                "name": "Fantray1_1"
+            },
+            {
+                "name": "Fantray1_2"
+            },
+            {
+                "name": "Fantray2_1"
+            },
+            {
+                "name": "Fantray2_2"
+            },
+            {
+                "name": "Fantray3_1"
+            },
+            {
+                "name": "Fantray3_2"
+            },
+            {
+                "name": "Fantray4_1"
+            },
+            {
+                "name": "Fantray4_2"
+            },
+            {
+                "name": "Fantray5_1"
+            },
+            {
+                "name": "Fantray5_2"
+            },
+            {
+                "name": "Fantray6_1"
+            },
+            {
+                "name": "Fantray6_2"
+            }
+        ],
+        "psus": [
+            {
+                "name": "PSU1",
+                "fans": [
+                    {
+                        "name": "PSU1_FAN1"
+                    }
+                ]
+            },
+            {
+                "name": "PSU2",
+                "fans": [
+                    {
+                        "name": "PSU2_FAN1"
+                    }
+                ]
+            }
+        ],
+		"sfps": [
+            {
+                "name": "Ethernet0"
+            },
+            {
+                "name": "Ethernet8"
+            },
+            {
+                "name": "Ethernet16"
+            },
+            {
+                "name": "Ethernet24"
+            },
+            {
+                "name": "Ethernet32"
+            },
+            {
+                "name": "Ethernet40"
+            },
+            {
+                "name": "Ethernet48"
+            },
+            {
+                "name": "Ethernet56"
+            },
+            {
+                "name": "Ethernet64"
+            },
+            {
+                "name": "Ethernet72"
+            },
+            {
+                "name": "Ethernet80"
+            },
+            {
+                "name": "Ethernet88"
+            },
+            {
+                "name": "Ethernet96"
+            },
+            {
+                "name": "Ethernet104"
+            },
+            {
+                "name": "Ethernet112"
+            },
+            {
+                "name": "Ethernet120"
+            },
+            {
+                "name": "Ethernet128"
+            },
+            {
+                "name": "Ethernet136"
+            },
+            {
+                "name": "Ethernet144"
+            },
+            {
+                "name": "Ethernet152"
+            },
+            {
+                "name": "Ethernet160"
+            },
+            {
+                "name": "Ethernet168"
+            },
+            {
+                "name": "Ethernet176"
+            },
+            {
+                "name": "Ethernet184"
+            },
+            {
+                "name": "Ethernet192"
+            },
+            {
+                "name": "Ethernet200"
+            },
+            {
+                "name": "Ethernet208"
+            },
+            {
+                "name": "Ethernet216"
+            },
+            {
+                "name": "Ethernet224"
+            },
+            {
+                "name": "Ethernet232"
+            },
+            {
+                "name": "Ethernet240"
+            },
+            {
+                "name": "Ethernet248"
+            }
+        ],
+        "thermals": [
+            {
+                "name": "Temp_1"
+            },
+            {
+                "name": "Temp_2"
+            },
+            {
+                "name": "Temp_3"
+            },
+            {
+                "name": "Temp_4"
+            },
+            {
+                "name": "Temp_5"
+            },
+            {
+                "name": "Temp_6"
+            },
+            {
+                "name": "Temp_7"
+            }
+        ]
+    },
+	"interfaces": {
+        "Ethernet0": {
+            "index": "1,1,1,1,1,1,1,1",
+            "lanes": "73,74,75,76,77,78,79,80",
+            "breakout_modes": {
+                "1x400G": ["Eth1/1(Port1)"],
+                "2x200G": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
+                "4x100G": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"],
+                "1x100G[40G](4)": ["Eth1/1(Port1)"],
+                "2x50G(4)": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
+                "4x25G[10G](4)": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"]
+            }
+        },
+
+        "Ethernet8": {
+            "index": "2,2,2,2,2,2,2,2",
+            "lanes": "65,66,67,68,69,70,71,72",
+            "breakout_modes": {
+                "1x400G": ["Eth2/1(Port2)"],
+                "2x200G": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "4x100G": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"],
+                "1x100G[40G](4)": ["Eth2/1(Port2)"],
+                "2x50G(4)": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "4x25G[10G](4)": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"]
+            }
+        },
+
+        "Ethernet16": {
+            "index": "3,3,3,3,3,3,3,3",
+            "lanes": "81,82,83,84,85,86,87,88",
+            "breakout_modes": {
+                "1x400G": ["Eth3/1(Port3)"],
+                "2x200G": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "4x100G": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"],
+                "1x100G[40G](4)": ["Eth3/1(Port3)"],
+                "2x50G(4)": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "4x25G[10G](4)": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"]
+            }
+        },
+
+        "Ethernet24": {
+            "index": "4,4,4,4,4,4,4,4",
+            "lanes": "89,90,91,92,93,94,95,96",
+            "breakout_modes": {
+                "1x400G": ["Eth4/1(Port4)"],
+                "2x200G": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "4x100G": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"],
+                "1x100G[40G](4)": ["Eth4/1(Port4)"],
+                "2x50G(4)": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "4x25G[10G](4)": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"]
+            }
+        },
+
+        "Ethernet32": {
+            "index": "5,5,5,5,5,5,5,5",
+            "lanes": "97,98,99,100,101,102,103,104",
+            "breakout_modes": {
+                "1x400G": ["Eth5/1(Port5)"],
+                "2x200G": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "4x100G": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"],
+                "1x100G[40G](4)": ["Eth5/1(Port5)"],
+                "2x50G(4)": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "4x25G[10G](4)": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"]
+            }
+        },
+
+        "Ethernet40": {
+            "index": "6,6,6,6,6,6,6,6",
+            "lanes": "105,106,107,108,109,110,111,112",
+            "breakout_modes": {
+                "1x400G": ["Eth6/1(Port6)"],
+                "2x200G": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "4x100G": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"],
+                "1x100G[40G](4)": ["Eth6/1(Port6)"],
+                "2x50G(4)": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "4x25G[10G](4)": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"]
+            }
+        },
+
+        "Ethernet48": {
+            "index": "7,7,7,7,7,7,7,7",
+            "lanes": "113,114,115,116,117,118,119,120",
+            "breakout_modes": {
+                "1x400G": ["Eth7/1(Port7)"],
+                "2x200G": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "4x100G": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"],
+                "1x100G[40G](4)": ["Eth7/1(Port7)"],
+                "2x50G(4)": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "4x25G[10G](4)": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"]
+            }
+        },
+
+        "Ethernet56": {
+            "index": "8,8,8,8,8,8,8,8",
+            "lanes": "121,122,123,124,125,126,127,128",
+            "breakout_modes": {
+                "1x400G": ["Eth8/1(Port8)"],
+                "2x200G": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "4x100G": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"],
+                "1x100G[40G](4)": ["Eth8/1(Port8)"],
+                "2x50G(4)": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "4x25G[10G](4)": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"]
+            }
+        },
+
+        "Ethernet64": {
+            "index": "9,9,9,9,9,9,9,9",
+            "lanes": "41,42,43,44,45,46,47,48",
+            "breakout_modes": {
+                "1x400G": ["Eth9/1(Port9)"],
+                "2x200G": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "4x100G": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"],
+                "1x100G[40G](4)": ["Eth9/1(Port9)"],
+                "2x50G(4)": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "4x25G[10G](4)": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"]
+            }
+        },
+
+        "Ethernet72": {
+            "index": "10,10,10,10,10,10,10,10",
+            "lanes": "33,34,35,36,37,38,39,40",
+            "breakout_modes": {
+                "1x400G": ["Eth10/1(Port10)"],
+                "2x200G": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "4x100G": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"],
+                "1x100G[40G](4)": ["Eth10/1(Port10)"],
+                "2x50G(4)": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "4x25G[10G](4)": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"]
+            }
+        },
+
+        "Ethernet80": {
+            "index": "11,11,11,11,11,11,11,11",
+            "lanes": "49,50,51,52,53,54,55,56",
+            "breakout_modes": {
+                "1x400G": ["Eth11/1(Port11)"],
+                "2x200G": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "4x100G": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"],
+                "1x100G[40G](4)": ["Eth11/1(Port11)"],
+                "2x50G(4)": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "4x25G[10G](4)": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"]
+            }
+        },
+
+        "Ethernet88": {
+            "index": "12,12,12,12,12,12,12,12",
+            "lanes": "57,58,59,60,61,62,63,64",
+            "breakout_modes": {
+                "1x400G": ["Eth12/1(Port12)"],
+                "2x200G": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "4x100G": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"],
+                "1x100G[40G](4)": ["Eth12/1(Port12)"],
+                "2x50G(4)": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "4x25G[10G](4)": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"]
+            }
+        },
+
+        "Ethernet96": {
+            "index": "13,13,13,13,13,13,13,13",
+            "lanes": "129,130,131,132,133,134,135,136",
+            "breakout_modes": {
+                "1x400G": ["Eth13/1(Port13)"],
+                "2x200G": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "4x100G": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"],
+                "1x100G[40G](4)": ["Eth13/1(Port13)"],
+                "2x50G(4)": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "4x25G[10G](4)": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"]
+            }
+        },
+
+        "Ethernet104": {
+            "index": "14,14,14,14,14,14,14,14",
+            "lanes": "137,138,139,140,141,142,143,144",
+            "breakout_modes": {
+                "1x400G": ["Eth14/1(Port14)"],
+                "2x200G": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "4x100G": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"],
+                "1x100G[40G](4)": ["Eth14/1(Port14)"],
+                "2x50G(4)": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "4x25G[10G](4)": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"]
+            }
+        },
+
+        "Ethernet112": {
+            "index": "15,15,15,15,15,15,15,15",
+            "lanes": "145,146,147,148,149,150,151,152",
+            "breakout_modes": {
+                "1x400G": ["Eth15/1(Port15)"],
+                "2x200G": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "4x100G": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"],
+                "1x100G[40G](4)": ["Eth15/1(Port15)"],
+                "2x50G(4)": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "4x25G[10G](4)": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"]
+            }
+        },
+
+        "Ethernet120": {
+            "index": "16,16,16,16,16,16,16,16",
+            "lanes": "153,154,155,156,157,158,159,160",
+            "breakout_modes": {
+                "1x400G": ["Eth16/1(Port16)"],
+                "2x200G": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "4x100G": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"],
+                "1x100G[40G](4)": ["Eth16/1(Port16)"],
+                "2x50G(4)": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "4x25G[10G](4)": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"]
+            }
+        },
+
+        "Ethernet128": {
+            "index": "17,17,17,17,17,17,17,17",
+            "lanes": "169,170,171,172,173,174,175,176",
+            "breakout_modes": {
+                "1x400G": ["Eth17/1(Port17)"],
+                "2x200G": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "4x100G": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"],
+                "1x100G[40G](4)": ["Eth17/1(Port17)"],
+                "2x50G(4)": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "4x25G[10G](4)": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"]
+            }
+        },
+
+        "Ethernet136": {
+            "index": "18,18,18,18,18,18,18,18",
+            "lanes": "161,162,163,164,165,166,167,168",
+            "breakout_modes": {
+                "1x400G": ["Eth18/1(Port18)"],
+                "2x200G": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "4x100G": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"],
+                "1x100G[40G](4)": ["Eth18/1(Port18)"],
+                "2x50G(4)": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "4x25G[10G](4)": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"]
+            }
+        },
+
+        "Ethernet144": {
+            "index": "19,19,19,19,19,19,19,19",
+            "lanes": "177,178,179,180,181,182,183,184",
+            "breakout_modes": {
+                "1x400G": ["Eth19/1(Port19)"],
+                "2x200G": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "4x100G": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"],
+                "1x100G[40G](4)": ["Eth19/1(Port19)"],
+                "2x50G(4)": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "4x25G[10G](4)": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"]
+            }
+        },
+
+        "Ethernet152": {
+            "index": "20,20,20,20,20,20,20,20",
+            "lanes": "185,186,187,188,189,190,191,192",
+            "breakout_modes": {
+                "1x400G": ["Eth20/1(Port20)"],
+                "2x200G": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "4x100G": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"],
+                "1x100G[40G](4)": ["Eth20/1(Port20)"],
+                "2x50G(4)": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "4x25G[10G](4)": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"]
+            }
+        },
+
+        "Ethernet160": {
+            "index": "21,21,21,21,21,21,21,21",
+            "lanes": "1,2,3,4,5,6,7,8",
+            "breakout_modes": {
+                "1x400G": ["Eth21/1(Port21)"],
+                "2x200G": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "4x100G": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"],
+                "1x100G[40G](4)": ["Eth21/1(Port21)"],
+                "2x50G(4)": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "4x25G[10G](4)": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"]
+            }
+        },
+
+        "Ethernet168": {
+            "index": "22,22,22,22,22,22,22,22",
+            "lanes": "9,10,11,12,13,14,15,16",
+            "breakout_modes": {
+                "1x400G": ["Eth22/1(Port22)"],
+                "2x200G": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "4x100G": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"],
+                "1x100G[40G](4)": ["Eth22/1(Port22)"],
+                "2x50G(4)": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "4x25G[10G](4)": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"]
+            }
+        },
+
+        "Ethernet176": {
+            "index": "23,23,23,23,23,23,23,23",
+            "lanes": "17,18,19,20,21,22,23,24",
+            "breakout_modes": {
+                "1x400G": ["Eth23/1(Port23)"],
+                "2x200G": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "4x100G": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"],
+                "1x100G[40G](4)": ["Eth23/1(Port23)"],
+                "2x50G(4)": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "4x25G[10G](4)": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"]
+            }
+        },
+
+        "Ethernet184": {
+            "index": "24,24,24,24,24,24,24,24",
+            "lanes": "25,26,27,28,29,30,31,32",
+            "breakout_modes": {
+                "1x400G": ["Eth24/1(Port24)"],
+                "2x200G": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "4x100G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"],
+                "1x100G[40G](4)": ["Eth24/1(Port24)"],
+                "2x50G(4)": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "4x25G[10G](4)": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"]
+            }
+        },
+
+        "Ethernet192": {
+            "index": "25,25,25,25,25,25,25,25",
+            "lanes": "201,202,203,204,205,206,207,208",
+            "breakout_modes": {
+                "1x400G": ["Eth25/1(Port25)"],
+                "2x200G": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "4x100G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"],
+                "1x100G[40G](4)": ["Eth25/1(Port25)"],
+                "2x50G(4)": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "4x25G[10G](4)": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"]
+            }
+        },
+
+        "Ethernet200": {
+            "index": "26,26,26,26,26,26,26,26",
+            "lanes": "193,194,195,196,197,198,199,200",
+            "breakout_modes": {
+                "1x400G": ["Eth26/1(Port26)"],
+                "2x200G": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "4x100G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"],
+                "1x100G[40G](4)": ["Eth26/1(Port26)"],
+                "2x50G(4)": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "4x25G[10G](4)": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"]
+            }
+        },
+
+        "Ethernet208": {
+            "index": "27,27,27,27,27,27,27,27",
+            "lanes": "217,218,219,220,221,222,223,224",
+            "breakout_modes": {
+                "1x400G": ["Eth27/1(Port27)"],
+                "2x200G": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "4x100G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"],
+                "1x100G[40G](4)": ["Eth27/1(Port27)"],
+                "2x50G(4)": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "4x25G[10G](4)": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"]
+            }
+        },
+
+        "Ethernet216": {
+            "index": "28,28,28,28,28,28,28,28",
+            "lanes": "209,210,211,212,213,214,215,216",
+            "breakout_modes": {
+                "1x400G": ["Eth28/1(Port28)"],
+                "2x200G": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "4x100G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"],
+                "1x100G[40G](4)": ["Eth28/1(Port28)"],
+                "2x50G(4)": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "4x25G[10G](4)": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"]
+            }
+        },
+
+        "Ethernet224": {
+            "index": "29,29,29,29,29,29,29,29",
+            "lanes": "233,234,235,236,237,238,239,240",
+            "breakout_modes": {
+                "1x400G": ["Eth29/1(Port29)"],
+                "2x200G": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "4x100G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"],
+                "1x100G[40G](4)": ["Eth29/1(Port29)"],
+                "2x50G(4)": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "4x25G[10G](4)": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"]
+            }
+        },
+
+        "Ethernet232": {
+            "index": "30,30,30,30,30,30,30,30",
+            "lanes": "225,226,227,228,229,230,231,232",
+            "breakout_modes": {
+                "1x400G": ["Eth30/1(Port30)"],
+                "2x200G": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "4x100G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"],
+                "1x100G[40G](4)": ["Eth30/1(Port30)"],
+                "2x50G(4)": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "4x25G[10G](4)": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"]
+            }
+        },
+
+        "Ethernet240": {
+            "index": "31,31,31,31,31,31,31,31",
+            "lanes": "249,250,251,252,253,254,255,256",
+            "breakout_modes": {
+                "1x400G": ["Eth31/1(Port31)"],
+                "2x200G": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "4x100G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"],
+                "1x100G[40G](4)": ["Eth31/1(Port31)"],
+                "2x50G(4)": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "4x25G[10G](4)": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"]
+            }
+        },
+
+        "Ethernet248": {
+            "index": "32,32,32,32,32,32,32,32",
+            "lanes": "241,242,243,244,245,246,247,248",
+            "breakout_modes": {
+                "1x400G": ["Eth32/1(Port32)"],
+                "2x200G": ["Eth32/1(Port32)", "Eth32/2(Port32)"],
+                "4x100G": ["Eth32/1(Port32)", "Eth32/2(Port32)", "Eth32/3(Port32)", "Eth32/4(Port32)"],
+                "1x100G[40G](4)": ["Eth32/1(Port32)"],
+                "2x50G(4)": ["Eth32/1(Port32)", "Eth32/2(Port32)"],
+                "4x25G[10G](4)": ["Eth32/1(Port32)", "Eth32/2(Port32)", "Eth32/3(Port32)", "Eth32/4(Port32)"]
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Support preemphasis in media_settings.json on AS5835-54T

#### Why I did it
     Support preemphasis value settings via xcvrd

#### How I did it
     Define preemphasis values in GLOBAL_MEDIA_SETTINGS and SPEED_MEDIA_SETTINGS

#### How to verify it
     phy diag port dsc

#### Which release branch to backport (provide reason below if selected)

- [ ] 202012
- [ ] 202106

#### Description for the changelog

 Support preemphasis value settings via xcvrd


#### A picture of a cute animal (not mandatory but encouraged)

