### PR TITLE
Fix lacpdu send error when link down

### DIFF
--- a/src/libteam/patch/0013-Fix-lacpdu-send-error-when-link-is-down.patch
+++ b/src/libteam/patch/0013-Fix-lacpdu-send-error-when-link-is-down.patch
@@ -1,0 +1,40 @@
+From 7c7c92dbb47a3ba61d1425c299226113443ce125 Mon Sep 17 00:00:00 2001
+From: pettershao-ragilenetworks <pettershao@ragilenetworks.com>
+Date: Thu, 26 Aug 2021 10:12:31 +0800
+Subject: [PATCH] fix lacpdu_send error when link is down
+
+---
+ teamd/teamd_runner_lacp.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index 5c9159b..5d74fe7 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -1391,10 +1391,22 @@ static int lacpdu_send(struct lacp_port *lacp_port)
+ 	unsigned char hwaddr_len;
+ 	int err;
+ 	bool admin_state;
++	struct team_port *team_port;
+ 
+ 	admin_state = team_get_ifinfo_admin_state(lacp_port->ctx->ifinfo);
+-	if (!admin_state)
++	if (!admin_state) {
++		teamd_log_info("Port %s admin_state is DOWN, cancle lacpdu send. ",
++					lacp_port->tdport->ifname);
++		return 0;
++	}
++
++	team_port = lacp_port->tdport->team_port;
++	bool linkup = team_is_port_link_up(team_port);
++	if (!linkup) {
++		teamd_log_info("Port %s linkup is DOWN, cancle lacpdu send. ",
++					lacp_port->tdport->ifname);
+ 		return 0;
++	}
+ 
+ 	err = teamd_getsockname_hwaddr(lacp_port->sock, &ll_my, 0);
+ 	if (err)
+-- 
+2.25.1
+

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -10,3 +10,4 @@
 0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch
 0011-Remove-extensive-debug-output.patch
 0012-Increase-min_ports-upper-limit-to-1024.patch
+0013-Fix-lacpdu-send-error-when-link-is-down.patch


### PR DESCRIPTION
**- Why I did it**
     when link is down， lacpdu send will fail。
     log like this：
	 ···
	 Aug 24 17:41:05.763283 ** ERR teamd#teamd_PortChannel1[26]: send failed.
         Aug 24 17:41:05.763729 ** DEBUG teamd#teamd_PortChannel1[26]: Failed loop callback: libteam_events, 0x55fd25edbce0
	 ···
     
**- How I did it**
     check link status, when link is down, not send lacpdu

**- How to verify it**
     config portchannle member, then set member link down

**- Description for the changelog**
