### PR TITLE
Remove dirty lags in kernel after teamd warm restart

### DIFF
--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -26,5 +26,6 @@ COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
+COPY ["removeDirtyLagInKernel.sh", "/usr/bin/removeDirtyLagInKernel.sh"]
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-teamd/removeDirtyLagInKernel.sh
+++ b/dockers/docker-teamd/removeDirtyLagInKernel.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -x
+
+old_lags=`ip link show type team | awk -F ':' '{print $2}' | grep PortChannel`
+new_lag=`redis-cli -n 4 keys "PORTCHANNEL|*"`
+for lag in ${old_lags[*]}; do
+    if [[ !($new_lag =~ $lag) ]]
+    then
+        `ip link del $lag`
+    fi
+done


### PR DESCRIPTION
Signed-off-by: pettershao-ragilenetworks <pettershao@ragilenetworks.com>

#### Why I did it
    If teamd warm restart, and lag deletion occurs during teamd restart(assume that the deleted one is lag1), 
	at this time, lag1 does not exist in the CONFIG_DB, and lag1 will not be created after teamd is up, lag1 still exists in the kernel. 
	After teamd warm reboot done, teamdsync will receive the lag1 message notified by the kernel and set table entries to the ASIC_DB. 
	For lag1 has been deleted, so this notification is wrong.
    
#### How I did it
    After warm restart of teamd, compare the existing lags in the kernel with the existing lags in CONFIG_DB. Delete the redundant lags in the kernel through ip link del command.

#### How to verify it
    config lags， eg. lag1, lag2, lag3   
    enable teamd warm restart
    docker stop teamd
    remove lags, like lag2
    docker restart teamd
    verify CONFIG_DB 、ASIC_DB and kernel only have lag1, lag3

#### Description for the changelog
···
root@sonic:/home/admin# redis-cli -n 4 keys "*" | grep Port
PORTCHANNEL|PortChannel1
PORTCHANNEL|PortChannel11
PORTCHANNEL|PortChannel3
PORTCHANNEL|PortChannel2
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# redis-cli -n 4 del PortChannel11
(integer) 0
root@sonic:/home/admin# redis-cli -n 4 del "PORTCHANNEL|PortChannel11"
(integer) 1
root@sonic:/home/admin# redis-cli -n 4 del "PORTCHANNEL|PortChannel3"
(integer) 1
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# docker ps
CONTAINER ID        IMAGE                            COMMAND                  CREATED             STATUS              PORTS               NAMES
443c5afd7ee3        docker-sonic-telemetry:latest    "/usr/bin/supervisord"   12 hours ago        Up 5 minutes                            telemetry
1815a7988254        docker-reup:latest               "/usr/bin/docker-reu…"   12 hours ago        Up 8 minutes                            reup
4a5638c52079        docker-lldp-sv2:latest           "/usr/bin/docker-lld…"   12 hours ago        Up 8 minutes                            lldp
88a940a4820e        docker-platform-monitor:latest   "/usr/bin/docker_ini…"   12 hours ago        Up 9 minutes                            pmon
17526edd3366        docker-fpm-frr:latest            "/usr/bin/supervisord"   12 hours ago        Up 9 minutes                            bgp
1a121ece9755        docker-database:latest           "/usr/local/bin/dock…"   13 hours ago        Up 9 minutes                            database
root@sonic:/home/admin# teamd.sh start
Starting existing teamd container with HWSKU RA-B6510-48V8C
teamd
root@sonic:/home/admin# show warm_restart state
name          restore_count  state
----------  ---------------  -----------
neighsyncd                0
nbrmgrd                   0
orchagent                 0
vxlanmgrd                 0
portsyncd                 0
xcvrd                     0
vlanmgrd                  0
teamsyncd                 6  initialized
intfmgrd                  0
syncd                     0
bgp                       0
coppmgrd                  0
vrfmgrd                   0
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# show warm_restart state
name          restore_count  state
----------  ---------------  -----------
neighsyncd                0
nbrmgrd                   0
orchagent                 0
vxlanmgrd                 0
portsyncd                 0
xcvrd                     0
vlanmgrd                  0
teamsyncd                 6  initialized
intfmgrd                  0
syncd                     0
bgp                       0
coppmgrd                  0
vrfmgrd                   0
root@sonic:/home/admin#
root@sonic:/home/admin# ip link show type team
62: PortChannel1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 58:69:6c:fb:21:38 brd ff:ff:ff:ff:ff:ff
63: PortChannel11: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 58:69:6c:fb:21:38 brd ff:ff:ff:ff:ff:ff
64: PortChannel2: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 58:69:6c:fb:21:38 brd ff:ff:ff:ff:ff:ff
65: PortChannel3: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 58:69:6c:fb:21:38 brd ff:ff:ff:ff:ff:ff
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#

Jul 15 14:14:21.724556 sonic INFO teamd#supervisord 2021-07-15 14:14:11,730 INFO spawned: 'teammgrd' with pid 20
Jul 15 14:14:21.724556 sonic INFO teamd#supervisord 2021-07-15 14:14:12,864 INFO success: rsyslogd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Jul 15 14:14:21.724556 sonic INFO teamd#supervisord 2021-07-15 14:14:12,864 INFO success: teammgrd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Jul 15 14:14:21.724556 sonic INFO teamd#supervisord 2021-07-15 14:14:13,902 INFO spawned: 'teamsyncd' with pid 44
Jul 15 14:14:21.724556 sonic INFO teamd#supervisord 2021-07-15 14:14:18,926 INFO success: teamsyncd entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
Jul 15 14:14:21.724556 sonic INFO teamd#supervisord 2021-07-15 14:14:19,964 INFO exited: dependent-startup (exit status 0; expected)
Jul 15 14:15:13.036460 sonic NOTICE teamd#teammgrd: message repeated 61 times: [ :- removeDirtyLagInKernel: 337: teammgr m_warmstart 222222222]
Jul 15 14:15:13.036460 sonic NOTICE teamd#teammgrd: :- removeDirtyLagInKernel: 342: teammgr m_pending_timeout 3333333333
Jul 15 14:15:13.042427 sonic INFO teamd#supervisord: teammgrd ++ ip link show type team
Jul 15 14:15:13.042780 sonic INFO teamd#supervisord: teammgrd ++ awk -F : '{print $2}'
Jul 15 14:15:13.042780 sonic INFO teamd#supervisord: teammgrd ++ grep PortChannel
Jul 15 14:15:13.058155 sonic INFO teamd#supervisord: teammgrd + old_lags=' PortChannel1
Jul 15 14:15:13.058155 sonic INFO teamd#supervisord: teammgrd  PortChannel11
Jul 15 14:15:13.058155 sonic INFO teamd#supervisord: teammgrd  PortChannel2
Jul 15 14:15:13.058155 sonic INFO teamd#supervisord: teammgrd  PortChannel3'
Jul 15 14:15:13.058971 sonic INFO teamd#supervisord: teammgrd ++ redis-cli -n 4 keys 'PORTCHANNEL|*'
Jul 15 14:15:13.066191 sonic INFO teamd#supervisord: teammgrd + new_lag='PORTCHANNEL|PortChannel1
Jul 15 14:15:13.066191 sonic INFO teamd#supervisord: teammgrd PORTCHANNEL|PortChannel2'
Jul 15 14:15:13.066649 sonic INFO teamd#supervisord: teammgrd + for lag in ${old_lags[*]}
Jul 15 14:15:13.066649 sonic INFO teamd#supervisord: teammgrd + [[ PORTCHANNEL|PortChannel1
Jul 15 14:15:13.066677 sonic INFO teamd#supervisord: teammgrd PORTCHANNEL|PortChannel2 =~ PortChannel1 ]]
Jul 15 14:15:13.066694 sonic INFO teamd#supervisord: teammgrd + for lag in ${old_lags[*]}
Jul 15 14:15:13.066727 sonic INFO teamd#supervisord: teammgrd + [[ PORTCHANNEL|PortChannel1
Jul 15 14:15:13.066748 sonic INFO teamd#supervisord: teammgrd PORTCHANNEL|PortChannel2 =~ PortChannel11 ]]
Jul 15 14:15:13.067553 sonic INFO teamd#supervisord: teammgrd ++ ip link del PortChannel11
Jul 15 14:15:13.074411 sonic DEBUG teamd#teamd_PortChannel2[36]: <ifinfo_list>
Jul 15 14:15:13.074411 sonic DEBUG teamd#teamd_PortChannel1[25]: <ifinfo_list>
Jul 15 14:15:13.074411 sonic DEBUG teamd#teamd_PortChannel2[36]:  64: PortChannel2: 58:69:6c:fb:21:38: 0: : admin_up: Keep
Jul 15 14:15:13.074411 sonic DEBUG teamd#teamd_PortChannel2[36]: </ifinfo_list>
Jul 15 14:15:13.074411 sonic DEBUG teamd#teamd_PortChannel1[25]:  62: PortChannel1: 58:69:6c:fb:21:38: 0: : admin_up: Keep
Jul 15 14:15:13.074411 sonic DEBUG teamd#teamd_PortChannel1[25]: </ifinfo_list>
Jul 15 14:15:13.115969 sonic INFO teamd#supervisord: teammgrd + for lag in ${old_lags[*]}
Jul 15 14:15:13.115969 sonic INFO teamd#supervisord: teammgrd + [[ PORTCHANNEL|PortChannel1
Jul 15 14:15:13.115969 sonic INFO teamd#supervisord: teammgrd PORTCHANNEL|PortChannel2 =~ PortChannel2 ]]
Jul 15 14:15:13.116388 sonic INFO teamd#supervisord: teammgrd + for lag in ${old_lags[*]}
Jul 15 14:15:13.116388 sonic INFO teamd#supervisord: teammgrd + [[ PORTCHANNEL|PortChannel1
Jul 15 14:15:13.116388 sonic INFO teamd#supervisord: teammgrd PORTCHANNEL|PortChannel2 =~ PortChannel3 ]]
Jul 15 14:15:13.116701 sonic INFO teamd#supervisord: teammgrd ++ ip link del PortChannel3
Jul 15 14:15:13.123582 sonic DEBUG teamd#teamd_PortChannel1[25]: <ifinfo_list>
Jul 15 14:15:13.123633 sonic DEBUG teamd#teamd_PortChannel2[36]: <ifinfo_list>
Jul 15 14:15:13.123633 sonic DEBUG teamd#teamd_PortChannel1[25]:  62: PortChannel1: 58:69:6c:fb:21:38: 0: : admin_up: Keep
Jul 15 14:15:13.123633 sonic DEBUG teamd#teamd_PortChannel2[36]:  64: PortChannel2: 58:69:6c:fb:21:38: 0: : admin_up: Keep
Jul 15 14:15:13.123633 sonic DEBUG teamd#teamd_PortChannel1[25]: </ifinfo_list>
Jul 15 14:15:13.123633 sonic DEBUG teamd#teamd_PortChannel2[36]: </ifinfo_list>
Jul 15 14:15:15.130890 sonic NOTICE teamd#teamsyncd: :- applyState: 84: Applying state
Jul 15 14:15:15.131677 sonic NOTICE teamd#teamsyncd: :- dump: getting took 0.000274 sec
Jul 15 14:15:15.132431 sonic NOTICE teamd#teamsyncd: :- dump: getting took 0.000107 sec
Jul 15 14:15:15.132747 sonic NOTICE teamd#teamsyncd: :- setWarmStartState: 195: teamsyncd warm start state changed to reconciled


root@sonic:/home/admin# show warm_restart state
name          restore_count  state
----------  ---------------  ----------
neighsyncd                0
nbrmgrd                   0
orchagent                 0
vxlanmgrd                 0
portsyncd                 0
xcvrd                     0
vlanmgrd                  0
teamsyncd                 6  reconciled
intfmgrd                  0
syncd                     0
bgp                       0
coppmgrd                  0
vrfmgrd                   0
root@sonic:/home/admin# ip link show type team
62: PortChannel1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 58:69:6c:fb:21:38 brd ff:ff:ff:ff:ff:ff
64: PortChannel2: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 58:69:6c:fb:21:38 brd ff:ff:ff:ff:ff:ff
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# redis-cli -n 4 keys "PORTCHANNEL|*"
1) "PORTCHANNEL|PortChannel11"
2) "PORTCHANNEL|PortChannel2"

···