### PR TITLE
Set nl_cli.sock buffer size

### DIFF
--- a/src/libteam/patch/0014-Set-nl_cli.sock-buffer-size.patch
+++ b/src/libteam/patch/0014-Set-nl_cli.sock-buffer-size.patch
@@ -1,0 +1,29 @@
+From f95ae4297c14dbb228aaed5a116213ed48482a1d Mon Sep 17 00:00:00 2001
+From: pettershao-ragilenetworks <pettershao@ragilenetworks.com>
+Date: Fri, 24 Sep 2021 17:28:41 +0800
+Subject: [PATCH]   set nl_cli.sock buffer size
+Fix Loop callback failed with: No buffer space available
+---
+ libteam/libteam.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/libteam/libteam.c b/libteam/libteam.c
+index 2cc80ca..93c3d21 100644
+--- a/libteam/libteam.c
++++ b/libteam/libteam.c
+@@ -652,6 +652,12 @@ int team_init(struct team_handle *th, uint32_t ifindex)
+ 		eventbufsize = NETLINK_RCVBUF;
+ 	}
+ 
++	err = nl_socket_set_buffer_size(th->nl_cli.sock, eventbufsize, 0);
++	if (err) {
++	    err(th, "Failed to set cli socket buffer size.");
++	    return err;
++	}
++
+ 	err = nl_socket_set_buffer_size(th->nl_cli.sock_event, eventbufsize, 0);
+ 	if (err) {
+ 		err(th, "Failed to set cli event socket buffer size.");
+-- 
+2.25.1
+

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -10,3 +10,4 @@
 0010-When-read-of-timerfd-returned-0-don-t-consider-this-.patch
 0011-Remove-extensive-debug-output.patch
 0012-Increase-min_ports-upper-limit-to-1024.patch
+0014-Set-nl_cli.sock-buffer-size.patch


### PR DESCRIPTION
Fix Loop callback failed with: No buffer space available

Signed-off-by: pettershao-ragilenetworks <pettershao@ragilenetworks.com>
#### Why I did it
    Fix Loop callback failed with: No buffer space available
#### How I did it
    Set nl_cli.sock buffer size by RCVBUF sizes 
#### How to verify it
    Interfaces frequently shutdown and up, creating a large number of messages to the kernel.  The bug must appear before setting, and will not appear after setting  

#### Description for the changelog
···
Aug 24 17:41:05.763283 RA-B6510-32C ERR teamd#teamd_PortChannel1[26]: send failed.
Aug 24 17:41:05.763301 RA-B6510-32C WARNING teamd#teamd_PortChannel1[26]: Loop callback failed with: No buffer space available
Aug 24 17:41:05.763729 RA-B6510-32C DEBUG teamd#teamd_PortChannel1[26]: Failed loop callback: libteam_events, 0x55fd25edbce0
···

