### PR TITLE
[201911] Dell S6000 I2C not responding to certain optics - porting

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
@@ -5,6 +5,7 @@
 
 try:
     import time
+    import fcntl
     import datetime
     from sonic_sfp.sfputilbase import SfpUtilBase
 except ImportError as e:
@@ -19,6 +20,7 @@ class SfpUtil(SfpUtilBase):
     PORTS_IN_BLOCK = 32
 
     EEPROM_OFFSET = 20
+    SFP_LOCK_FILE="/etc/sonic/sfp_lock"
 
     _port_to_eeprom_mapping = {}
     port_dict = {}
@@ -74,9 +76,43 @@ class SfpUtil(SfpUtilBase):
             return False
 
         try:
+            fd = open(self.SFP_LOCK_FILE, "r")
+        except IOError as e:
+            print("Error: unable to open file: "+ str(e))
+            return False
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        self.set_modsel(port_num)
+
+        try:
             reg_file = open("/sys/devices/platform/dell-s6000-cpld.0/qsfp_modprs")
         except IOError as e:
             print "Error: unable to open file: %s" % str(e)
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            return False
+
+        content = reg_file.readline().rstrip()
+
+        # content is a string containing the hex representation of the register
+        reg_value = int(content, 16)
+
+        # Mask off the bit corresponding to our port
+        mask = (1 << port_num)
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        # ModPrsL is active low
+        if reg_value & mask == 0:
+            return True
+
+        return False
+
+    def get_modsel(self, port_num):
+        # Check for invalid port_num
+        if port_num < self.port_start or port_num > self.port_end:
+            return False
+
+        try:
+            reg_file = open("/sys/devices/platform/dell-s6000-cpld.0/qsfp_modsel")
+        except IOError as e:
+            print("Error: unable to open file: %s" % str(e))
             return False
 
         content = reg_file.readline().rstrip()
@@ -87,11 +123,76 @@ class SfpUtil(SfpUtilBase):
         # Mask off the bit corresponding to our port
         mask = (1 << port_num)
 
-        # ModPrsL is active low
-        if reg_value & mask == 0:
-            return True
+        if reg_value & mask == 1:
+            return False
 
-        return False
+        return True
+
+    def set_modsel(self, port_num):
+        # Check for invalid port_num
+        if port_num < self.port_start or port_num > self.port_end:
+            return False
+
+        try:
+            reg_file = open("/sys/devices/platform/dell-s6000-cpld.0/qsfp_modsel", "r+")
+        except IOError as e:
+            print("Error: unable to open file: %s" % str(e))
+            return False
+
+        content = reg_file.readline().rstrip()
+
+        # content is a string containing the hex representation of the register
+        reg_value = int(content, 16)
+
+        # Mask off the bit corresponding to our port
+        mask = (1 << port_num)
+        reg_value = reg_value | int("0xffffffff", 16)
+        reg_value = reg_value & ~mask
+
+        # Convert our register value back to a hex string and write back
+        content = hex(reg_value)
+
+        reg_file.seek(0)
+        reg_file.write(content)
+        reg_file.close()
+
+        return True
+
+    def get_eeprom_raw(self, port_num, num_bytes=256):
+        # Read interface id EEPROM at addr 0x50
+        try:
+            fd = open(self.SFP_LOCK_FILE, "r")
+        except IOError as e:
+            print("Error: unable to open file: %s" % str(e))
+            return None
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        self.set_modsel(port_num)
+        eeprom_bytes = self._read_eeprom_devid(port_num, self.IDENTITY_EEPROM_ADDR, 0, num_bytes)
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return eeprom_bytes
+
+    def get_eeprom_dom_raw(self, port_num):
+        if port_num in self.osfp_ports:
+            return None
+        if port_num in self.qsfp_ports:
+            # QSFP DOM EEPROM is also at addr 0x50 and thus also stored in eeprom_ifraw
+            return None
+        else:
+            # Read dom eeprom at addr 0x51
+            if not self.get_modsel(port_num):
+                try:
+                    fd = open(self.SFP_LOCK_FILE, "r")
+                except IOError as e:
+                    print("Error: unable to open file: %s" % str(e))
+                    return None
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                self.set_modsel(port_num)
+                eeprom_bytes = self._read_eeprom_devid(port_num, self.DOM_EEPROM_ADDR, 0)
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                return eeprom_bytes
+            else:
+                return self._read_eeprom_devid(port_num, self.DOM_EEPROM_ADDR, 0)
+
 
     def get_low_power_mode(self, port_num):
         # Check for invalid port_num

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
@@ -93,6 +93,10 @@ remove_python_api_package() {
 # read SONiC immutable variables
 [ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
 
+if [ ! -e /etc/sonic/sfp_lock ]; then
+    touch /etc/sonic/sfp_lock
+fi
+
 if [[ "$1" == "init" ]]; then
         depmod -a
         modprobe nvram

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py
@@ -10,6 +10,7 @@
 
 try:
     import os
+    import fcntl
     import time
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_platform_base.sfp_base import SfpBase
@@ -149,6 +150,15 @@ class Sfp(SfpBase):
         if (self.sfpInfo is None):
             return None
 
+        SFP_LOCK_FILE="/etc/sonic/sfp_lock"
+        try:
+            fd = open(SFP_LOCK_FILE, "r")
+        except IOError as e:
+            print("Error: unable to open file: %s" % str(e))
+            return None
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        self.set_modsel()
+
         page_offset = sff8436_parser[eeprom_key][PAGE_OFFSET]
         eeprom_data_raw = self._read_eeprom_bytes(
             self.eeprom_path,
@@ -167,6 +177,7 @@ class Sfp(SfpBase):
                     self.sfpDomInfo, sff8436_parser[eeprom_key][FUNC_NAME])(
                     eeprom_data_raw, 0)
 
+        fcntl.flock(fd, fcntl.LOCK_UN)
         return eeprom_data
 
 
@@ -410,6 +421,16 @@ class Sfp(SfpBase):
         Retrieves the presence of the sfp
         """
         presence_ctrl = self.sfp_control + 'qsfp_modprs'
+        SFP_LOCK_FILE="/etc/sonic/sfp_lock"
+
+        try:
+            fd = open(SFP_LOCK_FILE, "r")
+        except IOError as e:
+            print("Error: unable to open file: %s" % str(e))
+            return False
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        self.set_modsel()
+
         try:
             reg_file = open(presence_ctrl)
         except IOError as e:
@@ -424,11 +445,68 @@ class Sfp(SfpBase):
         # Mask off the bit corresponding to our port
         mask = (1 << self.sfp_ctrl_idx)
 
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
         # ModPrsL is active low
         if ((reg_value & mask) == 0):
             return True
 
         return False
+
+    def get_modsel(self):
+        modsel_ctrl = self.sfp_control + 'qsfp_modsel'
+        try:
+            reg_file = open(modsel_ctrl, "r+")
+        except IOError as e:
+            return False
+
+        reg_hex = reg_file.readline().rstrip()
+
+        # content is a string containing the hex
+        # representation of the register
+        reg_value = int(reg_hex, 16)
+
+        # Mask off the bit corresponding to our port
+        index = self.sfp_ctrl_idx
+
+        mask = (1 << index)
+
+        if ((reg_value & mask) == 1):
+            modsel_state = False
+        else:
+            modsel_state = True
+
+        return modsel_state
+
+    def set_modsel(self):
+        modsel_ctrl = self.sfp_control + 'qsfp_modsel'
+        try:
+            reg_file = open(modsel_ctrl, "r+")
+        except IOError as e:
+            return False
+
+        reg_hex = reg_file.readline().rstrip()
+
+        # content is a string containing the hex
+        # representation of the register
+        reg_value = int(reg_hex, 16)
+
+        # Mask off the bit corresponding to our port
+        index = self.sfp_ctrl_idx
+
+        reg_value = reg_value | int("0xffffffff", 16)
+        mask = (1 << index)
+
+        reg_value = (reg_value & ~mask)
+
+        # Convert our register value back to a hex string and write back
+        content = hex(reg_value)
+
+        reg_file.seek(0)
+        reg_file.write(content)
+        reg_file.close()
+
+        return True
 
     def get_model(self):
         """


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- "sfputil show eeprom" and "sfpshow eeprom" commands displays inconsistency results for certain optics.
- For every execution of the commands, various results are displayed.
- Only certain optics EEPROM contents were not retrieved.
- Porting from master - https://github.com/Azure/sonic-buildimage/pull/8736

#### How I did it
On branch s6000-i2c-201911
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   device/dell/x86_64-dell_s6000_s1220-r0/plugins/sfputil.py
        modified:   platform/broadcom/sonic-platform-modules-dell/s6000/modules/dell_s6000_platform.c
        modified:   platform/broadcom/sonic-platform-modules-dell/s6000/scripts/s6000_platform.sh
        modified:   platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/sfp.py

#### How to verify it
- ust execute "sfputil show eeprom" and "sfpshow eeprom" commands.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

