### PR TITLE
[teamd]: Warm/Fast reboot: Send USR1/USR2 only to subscribers

### DIFF
--- a/files/scripts/teamd.sh
+++ b/files/scripts/teamd.sh
@@ -5,7 +5,7 @@
 function debug()
 {
     /usr/bin/logger $1
-    /bin/echo `date` "- $1" >> ${DEBUGLOG}
+    /bin/echo `date` "- $1" >> ${DEBUG_LOG}
 }
 
 function check_warm_boot()
@@ -87,13 +87,13 @@ stop() {
         # Send USR1 signal to all teamd instances to stop them
         # It will prepare teamd for warm-reboot
         # Note: We must send USR1 signal before syncd, because it will send the last packet through CPU port
-        docker exec -i ${SERVICE}$DEV pkill -USR1 ${SERVICE} > /dev/null || [ $? == 1 ]
+        docker exec -i ${SERVICE}$DEV pkill -USR1 -f ${TEAMD_CMD} > /dev/null || [ $? == 1 ]
     elif [[ x"$FAST_BOOT" == x"true" ]]; then
         # Kill teamd processes inside of teamd container with SIGUSR2 to allow them to send last LACP frames
         # We call `docker kill teamd` to ensure the container stops as quickly as possible,
         # Note: teamd must be killed before syncd, because it will send the last packet through CPU port
-        docker exec -i ${SERVICE}$DEV pkill -USR2 ${SERVICE} || [ $? == 1 ]
-        while docker exec -i ${SERVICE}$DEV pgrep ${SERVICE} > /dev/null; do
+        docker exec -i ${SERVICE}$DEV pkill -USR2 -f ${TEAMD_CMD} || [ $? == 1 ]
+        while docker exec -i ${SERVICE}$DEV pgrep -f ${TEAMD_CMD} > /dev/null; do
             sleep 0.05
         done
         docker kill ${SERVICE}$DEV  &> /dev/null || debug "Docker ${SERVICE}$DEV is not running ($?) ..."
@@ -106,7 +106,8 @@ stop() {
 DEV=$2
 
 SERVICE="teamd"
-DEBUGLOG="/tmp/teamd-debug$DEV.log"
+TEAMD_CMD="/usr/bin/teamd"
+DEBUG_LOG="/tmp/teamd-debug$DEV.log"
 NAMESPACE_PREFIX="asic"
 if [ "$DEV" ]; then
     NET_NS="$NAMESPACE_PREFIX$DEV" #name of the network namespace


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

**SONiC LAG configuration:**
```bash
root@r-leopard-56:/home/admin# show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev         Protocol     Ports
-----  ---------------  -----------  --------------
 0001  PortChannel0001  LACP(A)(Dw)  Ethernet224(D)
 0002  PortChannel0002  LACP(A)(Dw)  Ethernet232(D)
 0003  PortChannel0003  LACP(A)(Dw)  Ethernet240(D)
 0004  PortChannel0004  LACP(A)(Dw)  Ethernet248(D)
```

**Before:**
```bash
Sep 27 15:36:39.593423 sonic NOTICE admin: Pre-shutdown succeeded, state: pre-shutdown-succeeded ...
Sep 27 15:36:39.818878 sonic NOTICE admin: Backing up database ...
Sep 27 15:36:39.892730 sonic NOTICE teamd#tlm_teamd: :- remove_lag: The LAG 'PortChannel0003' has been removed.
Sep 27 15:36:39.892826 sonic NOTICE teamd#tlm_teamd: :- remove_lag: The LAG 'PortChannel0004' has been removed.
Sep 27 15:36:39.892877 sonic NOTICE teamd#tlm_teamd: :- remove_lag: The LAG 'PortChannel0002' has been removed.
Sep 27 15:36:39.892899 sonic NOTICE teamd#tlm_teamd: :- remove_lag: The LAG 'PortChannel0001' has been removed.
Sep 27 15:36:39.980706 sonic INFO database#/supervisord: redis 35:M 27 Sep 2021 15:36:39.980 * DB saved on disk
Sep 27 15:36:40.104994 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-etc-sonic.mount: Succeeded.
Sep 27 15:36:40.125423 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-usr-share-sonic-platform.mount: Succeeded.
Sep 27 15:36:40.156169 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-run-redis.mount: Succeeded.
Sep 27 15:36:40.182548 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-etc-resolv.conf.mount: Succeeded.
Sep 27 15:36:40.202195 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-etc-hostname.mount: Succeeded.
Sep 27 15:36:40.221990 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-etc-hosts.mount: Succeeded.
Sep 27 15:36:40.397449 sonic NOTICE admin: Stopping teamd ...
Sep 27 15:36:40.406095 sonic INFO systemd[1]: Stopping TEAMD container...
Sep 27 15:36:40.413385 sonic NOTICE admin: Stopping teamd service...
Sep 27 15:36:40.615055 sonic NOTICE admin: Warm boot flag: teamd true.
Sep 27 15:36:40.621085 sonic NOTICE admin: Fast boot flag: teamd false.
Sep 27 15:36:40.755013 sonic INFO teamd#supervisord 2021-09-27 15:36:40,754 INFO exited: tlm_teamd (terminated by SIGUSR1; not expected)
Sep 27 15:36:40.979849 sonic DEBUG /container: container_stop: BEGIN
Sep 27 15:36:40.980191 sonic DEBUG /container: read_data: config:True feature:teamd fields:[('set_owner', 'local'), ('no_fallback_to_local', False)] val:['local', False]
Sep 27 15:36:40.980440 sonic DEBUG /container: read_data: config:False feature:teamd fields:[('current_owner', 'none'), ('remote_state', 'none'), ('container_id', '')] val:['none', 'none', '']
Sep 27 15:36:40.980672 sonic DEBUG /container: container_stop: teamd: set_owner:local current_owner:none remote_state:none docker_id:teamd
Sep 27 15:36:41.758506 sonic INFO teamd#supervisord 2021-09-27 15:36:41,756 INFO reaped unknown pid 25 (exit status 0)
Sep 27 15:36:41.758506 sonic INFO teamd#supervisord 2021-09-27 15:36:41,756 INFO reaped unknown pid 34 (exit status 0)
Sep 27 15:36:41.758506 sonic INFO teamd#supervisord 2021-09-27 15:36:41,757 INFO reaped unknown pid 42 (exit status 0)
Sep 27 15:36:41.758506 sonic INFO teamd#supervisord 2021-09-27 15:36:41,757 INFO reaped unknown pid 50 (exit status 0)
Sep 27 15:36:41.766193 sonic INFO teamd#/supervisor-proc-exit-listener: Process 'tlm_teamd' exited unexpectedly. Terminating supervisor 'teamd'
Sep 27 15:36:41.767071 sonic INFO teamd#supervisord 2021-09-27 15:36:41,766 WARN received SIGTERM indicating exit request
Sep 27 15:36:41.767331 sonic INFO teamd#supervisord 2021-09-27 15:36:41,766 INFO waiting for supervisor-proc-exit-listener, rsyslogd, teammgrd, teamsyncd to die
Sep 27 15:36:43.770027 sonic NOTICE teamd#teamsyncd: :- cleanTeamSync: Cleaning up LAG teamd resources ...
Sep 27 15:36:43.771247 sonic NOTICE teamd#teamsyncd: :- main: Received SIGTERM Exiting
Sep 27 15:36:44.416124 sonic INFO teamd#supervisord 2021-09-27 15:36:44,415 INFO stopped: teamsyncd (exit status 0)
Sep 27 15:36:45.417286 sonic NOTICE teamd#teammgrd: :- cleanTeamProcesses: Cleaning up LAGs during shutdown...
Sep 27 15:36:45.418185 sonic INFO teamd#supervisord 2021-09-27 15:36:45,417 INFO waiting for supervisor-proc-exit-listener, rsyslogd, teammgrd to die
Sep 27 15:36:45.421040 sonic INFO teamd#/supervisord: teammgrd cat: /var/run/teamd/PortChannel0001.pid: No such file or directory
Sep 27 15:36:45.421795 sonic ERR teamd#teammgrd: :- main: Runtime error: cat "/var/run/teamd/PortChannel0001.pid" :
Sep 27 15:36:46.271465 sonic INFO teamd#supervisord 2021-09-27 15:36:46,270 INFO stopped: teammgrd (exit status 1)
Sep 27 15:36:47.425981 sonic INFO containerd[486]: time="2021-09-27T15:36:47.424407649Z" level=info msg="shim reaped" id=90f942c9e7be6991ae0ce30bc71738de51f1f599773106caf1c70860cb87731a
Sep 27 15:36:47.436674 sonic INFO dockerd[726]: time="2021-09-27T15:36:47.434422086Z" level=info msg="ignoring event" module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
Sep 27 15:36:47.446982 sonic INFO systemd[1]: var-lib-docker-containers-90f942c9e7be6991ae0ce30bc71738de51f1f599773106caf1c70860cb87731a-mounts-shm.mount: Succeeded.
Sep 27 15:36:47.469852 sonic INFO systemd[1]: var-lib-docker-overlay2-06a63c38bf0b38196702d168ba789fed9969900a0ac534ea6836a280b3b643d5-merged.mount: Succeeded.
Sep 27 15:36:47.497159 sonic INFO /container: docker cmd: wait for teamd
Sep 27 15:36:47.498422 sonic INFO /container: docker cmd: stop for teamd
Sep 27 15:36:47.498678 sonic DEBUG /container: container_stop: END
Sep 27 15:36:47.527123 sonic NOTICE admin: Stopped teamd service...
Sep 27 15:36:47.529288 sonic INFO systemd[1]: teamd.service: Succeeded.
Sep 27 15:36:47.529910 sonic INFO systemd[1]: Stopped TEAMD container.
Sep 27 15:36:47.535760 sonic NOTICE admin: Stopped  teamd ...
```

**After:**
```bash
Sep 27 15:43:53.121517 sonic NOTICE admin: Pre-shutdown succeeded, state: pre-shutdown-succeeded ...
Sep 27 15:43:53.355894 sonic NOTICE admin: Backing up database ...
Sep 27 15:43:53.429249 sonic NOTICE teamd#tlm_teamd: :- remove_lag: The LAG 'PortChannel0003' has been removed.
Sep 27 15:43:53.429249 sonic NOTICE teamd#tlm_teamd: :- remove_lag: The LAG 'PortChannel0002' has been removed.
Sep 27 15:43:53.429249 sonic NOTICE teamd#tlm_teamd: :- remove_lag: The LAG 'PortChannel0004' has been removed.
Sep 27 15:43:53.429368 sonic NOTICE teamd#tlm_teamd: :- remove_lag: The LAG 'PortChannel0001' has been removed.
Sep 27 15:43:53.523066 sonic INFO database#/supervisord: redis 36:M 27 Sep 2021 15:43:53.522 * DB saved on disk
Sep 27 15:43:53.647846 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-etc-sonic.mount: Succeeded.
Sep 27 15:43:53.673307 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-usr-share-sonic-platform.mount: Succeeded.
Sep 27 15:43:53.706143 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-run-redis.mount: Succeeded.
Sep 27 15:43:53.753142 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-etc-resolv.conf.mount: Succeeded.
Sep 27 15:43:53.776188 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-etc-hostname.mount: Succeeded.
Sep 27 15:43:53.799224 sonic INFO systemd[1]: var-lib-docker-overlay2-669b2b0b164bc3da2be6b7bed86437d1a47a9235297a62c71e1f159a292ba970-merged-etc-hosts.mount: Succeeded.
Sep 27 15:43:53.956416 sonic NOTICE admin: Stopping teamd ...
Sep 27 15:43:53.965053 sonic INFO systemd[1]: Stopping TEAMD container...
Sep 27 15:43:53.973066 sonic NOTICE admin: Stopping teamd service...
Sep 27 15:43:54.179522 sonic NOTICE admin: Warm boot flag: teamd true.
Sep 27 15:43:54.186392 sonic NOTICE admin: Fast boot flag: teamd false.
Sep 27 15:43:54.540820 sonic DEBUG /container: container_stop: BEGIN
Sep 27 15:43:54.541168 sonic DEBUG /container: read_data: config:True feature:teamd fields:[('set_owner', 'local'), ('no_fallback_to_local', False)] val:['local', False]
Sep 27 15:43:54.541496 sonic DEBUG /container: read_data: config:False feature:teamd fields:[('current_owner', 'none'), ('remote_state', 'none'), ('container_id', '')] val:['none', 'none', '']
Sep 27 15:43:54.541765 sonic DEBUG /container: container_stop: teamd: set_owner:local current_owner:none remote_state:none docker_id:teamd
Sep 27 15:43:55.103875 sonic INFO teamd#supervisord 2021-09-27 15:43:55,101 INFO reaped unknown pid 26 (exit status 0)
Sep 27 15:43:55.103875 sonic INFO teamd#supervisord 2021-09-27 15:43:55,102 INFO reaped unknown pid 34 (exit status 0)
Sep 27 15:43:55.103875 sonic INFO teamd#supervisord 2021-09-27 15:43:55,102 INFO reaped unknown pid 42 (exit status 0)
Sep 27 15:43:55.103875 sonic INFO teamd#supervisord 2021-09-27 15:43:55,102 INFO reaped unknown pid 50 (exit status 0)
Sep 27 15:43:56.104759 sonic INFO teamd#supervisord 2021-09-27 15:43:56,104 WARN received SIGTERM indicating exit request
Sep 27 15:43:56.105595 sonic INFO teamd#supervisord 2021-09-27 15:43:56,104 INFO waiting for supervisor-proc-exit-listener, rsyslogd, teammgrd, teamsyncd, tlm_teamd to die
Sep 27 15:43:57.105912 sonic NOTICE teamd#tlm_teamd: :- main: Exiting
Sep 27 15:43:57.817711 sonic INFO teamd#supervisord 2021-09-27 15:43:57,817 INFO stopped: tlm_teamd (exit status 0)
Sep 27 15:43:58.818834 sonic NOTICE teamd#teamsyncd: :- cleanTeamSync: Cleaning up LAG teamd resources ...
Sep 27 15:43:58.820140 sonic NOTICE teamd#teamsyncd: :- main: Received SIGTERM Exiting
Sep 27 15:43:58.948445 sonic INFO teamd#supervisord 2021-09-27 15:43:58,947 INFO stopped: teamsyncd (exit status 0)
Sep 27 15:43:59.949582 sonic NOTICE teamd#teammgrd: :- cleanTeamProcesses: Cleaning up LAGs during shutdown...
Sep 27 15:43:59.950284 sonic INFO teamd#supervisord 2021-09-27 15:43:59,949 INFO waiting for supervisor-proc-exit-listener, rsyslogd, teammgrd to die
Sep 27 15:43:59.953287 sonic INFO teamd#/supervisord: teammgrd cat: /var/run/teamd/PortChannel0001.pid: No such file or directory
Sep 27 15:43:59.954101 sonic ERR teamd#teammgrd: :- main: Runtime error: cat "/var/run/teamd/PortChannel0001.pid" :
Sep 27 15:44:00.790477 sonic INFO teamd#supervisord 2021-09-27 15:44:00,789 INFO stopped: teammgrd (exit status 1)
Sep 27 15:44:01.939112 sonic INFO containerd[486]: time="2021-09-27T15:44:01.936948014Z" level=info msg="shim reaped" id=90f942c9e7be6991ae0ce30bc71738de51f1f599773106caf1c70860cb87731a
Sep 27 15:44:01.949213 sonic INFO dockerd[675]: time="2021-09-27T15:44:01.947031450Z" level=info msg="ignoring event" module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
Sep 27 15:44:01.958717 sonic INFO systemd[1]: var-lib-docker-containers-90f942c9e7be6991ae0ce30bc71738de51f1f599773106caf1c70860cb87731a-mounts-shm.mount: Succeeded.
Sep 27 15:44:01.982581 sonic INFO systemd[1]: var-lib-docker-overlay2-06a63c38bf0b38196702d168ba789fed9969900a0ac534ea6836a280b3b643d5-merged.mount: Succeeded.
Sep 27 15:44:02.026851 sonic INFO /container: docker cmd: wait for teamd
Sep 27 15:44:02.028477 sonic INFO /container: docker cmd: stop for teamd
Sep 27 15:44:02.028767 sonic DEBUG /container: container_stop: END
Sep 27 15:44:02.057161 sonic NOTICE admin: Stopped teamd service...
Sep 27 15:44:02.060093 sonic INFO systemd[1]: teamd.service: Succeeded.
Sep 27 15:44:02.061628 sonic INFO systemd[1]: Stopped TEAMD container.
```

#### Why I did it
* To fix `teamd` signal handling:
```bash
Sep 27 15:36:40.755013 sonic INFO teamd#supervisord 2021-09-27 15:36:40,754 INFO exited: tlm_teamd (terminated by SIGUSR1; not expected)
Sep 27 15:36:41.766193 sonic INFO teamd#/supervisor-proc-exit-listener: Process 'tlm_teamd' exited unexpectedly. Terminating supervisor 'teamd'
```

#### How I did it
* N/A

#### How to verify it
* N/A

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```