### PR TITLE
[SNMP]: Add dependency in SNMP service to start after syncd

### DIFF
--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -2,7 +2,7 @@
 Description=SNMP container
 Requires=updategraph.service
 Requisite=swss.service
-After=updategraph.service swss.service
+After=updategraph.service swss.service syncd.service
 Before=ntp-config.service
 
 [Service]


### PR DESCRIPTION
service. SNMP tries to access COUNTERS_DB, to avoid errors
while accessing DB, SNMP should start after syncd.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When SNMP Interface QoS counters is queried around the same time as syncd/swss restarts, the below error is seen:
```
ERR snmp#snmp-subagent [ax_interface] ERROR: MIBUpdater.start() caught an unexpected exception during update_data()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.6/dist-packages/ax_interface/mib.py", line 40, in start#012    self.reinit_data()#012  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py", line 40, in reinit_data#012    self.update_data()#012  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py", line 49, in update_data#012    for sai_id in self.if_id_map}#012  File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py", line 49, in <dictcomp>#012    for sai_id in self.if_id_map}#012  File "/usr/local/lib/python3.6/dist-packages/swsssdk/interface.py", line 38, in wrapped#012    ret_data = f(inst, db_name, *args, **kwargs)#012  File "/usr/local/lib/python3.6/dist-packages/swsssdk/interface.py", line 324, in get_all#012    raise UnavailableDataError(message, _hash)#012swsssdk.exceptions.UnavailableDataError: Key 'b'COUNTERS:oid:0x1000000000029'' unavailable in database 'COUNTERS_DB'
ERR syncd#syncd: _brcm_sai_cosq_stat_get:1340 cosq stat get failed with error Invalid parameter (0xfffffffc).
DEBUG syncd#syncd: brcm_sai_get_queue_stats:884 cosq stat get failed with error -5 for port 57 qid 10
NOTICE syncd#syncd: :- setQueueCounterList: Queue oid:0x3902150000000b does not has supported counters
INFO snmp#supervisord: snmp-subagent ERROR:ax_interface:MIBUpdater.start() caught an unexpected exception during update_data()
INFO snmp#supervisord: snmp-subagent Traceback (most recent call last):
INFO snmp#supervisord: snmp-subagent   File "/usr/local/lib/python3.6/dist-packages/ax_interface/mib.py", line 40, in start
INFO snmp#supervisord: snmp-subagent     self.reinit_data()
INFO snmp#supervisord: snmp-subagent   File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py", line 40, in reinit_data
INFO snmp#supervisord: snmp-subagent     self.update_data()
INFO snmp#supervisord: snmp-subagent   File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py", line 49, in update_data
INFO snmp#supervisord: snmp-subagent     for sai_id in self.if_id_map}
INFO snmp#supervisord: snmp-subagent   File "/usr/local/lib/python3.6/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py", line 49, in <dictcomp>
INFO snmp#supervisord: snmp-subagent     for sai_id in self.if_id_map}
INFO snmp#supervisord: snmp-subagent   File "/usr/local/lib/python3.6/dist-packages/swsssdk/interface.py", line 38, in wrapped
INFO snmp#supervisord: snmp-subagent     ret_data = f(inst, db_name, *args, **kwargs)
INFO snmp#supervisord: snmp-subagent   File "/usr/local/lib/python3.6/dist-packages/swsssdk/interface.py", line 324, in get_all
INFO snmp#supervisord: snmp-subagent     raise UnavailableDataError(message, _hash)
INFO snmp#supervisord: snmp-subagent swsssdk.exceptions.UnavailableDataError: Key 'b'COUNTERS:oid:0x1000000000029'' unavailable in database 'COUNTERS_DB'
```
This error comes only once after service restarts.
This happens because upon config reload, the order of services that comes up is:
swss
snmp 
syncd
When SNMP comes up before syncd and SNMP query for QoS counters is done in parallel, then the above error is seen.

#### How I did it
Add dependency so that SNMP comes up after syncd comes up, which will ensure that COUNTERS_DB is populated when SNMP tries to access it.

#### How to verify it
Run the image after this fix, do a config reload, perform continuous query of qos counters using: 
snmpwalk -v2c -c <community string> <mgmt IP> 1.3.6.1.4.1.9.9.580.1.5.5
continuous query should not generate any error in syslog.
snmp service should come up after swss and syncd services.
Checked "sudo systemctl status <service name> to check start time of each service.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

