### PR TITLE
[Marvell] Update amd64 SAI version

### DIFF
--- a/platform/marvell/sai.mk
+++ b/platform/marvell/sai.mk
@@ -1,6 +1,6 @@
 # Marvell SAI
 
-export MRVL_SAI_VERSION = 1.5.1
+export MRVL_SAI_VERSION = 1.8.1-1
 export MRVL_SAI = mrvllibsai_amd64_$(MRVL_SAI_VERSION).deb
 
 $(MRVL_SAI)_SRC_PATH = $(PLATFORM_PATH)/sai


### PR DESCRIPTION
Signed-off-by: Rajkumar Pennadam Ramamoorthy <rpennadamram@marvell.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Move Marvell SAI deb version to 1.8.1-1 for amd64 platform
#### How I did it
Validate the compilation. 
#### How to verify it
Install the image and check syncd SAI version
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

