### PR TITLE
[dhcp_relay] DHCP relay support for IPv6 (#7772)

### DIFF
--- a/dockers/docker-dhcp-relay/Dockerfile.j2
+++ b/dockers/docker-dhcp-relay/Dockerfile.j2
@@ -30,6 +30,7 @@ RUN apt-get clean -y         && \
 
 COPY ["docker_init.sh", "start.sh", "/usr/bin/"]
 COPY ["docker-dhcp-relay.supervisord.conf.j2", "port-name-alias-map.txt.j2", "wait_for_intf.sh.j2", "/usr/share/sonic/templates/"]
+COPY ["dhcp-relay.programs.j2", "dhcpv4-relay.agents.j2", "dhcpv6-relay.agents.j2", "dhcpv6-relay.monitors.j2", "/usr/share/sonic/templates/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 

--- a/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
@@ -1,0 +1,17 @@
+[group:isc-dhcp-relay]
+programs=
+{%- set add_preceding_comma = { 'flag': False } %}
+{% for vlan_name in VLAN_INTERFACE %}
+{# Append DHCPv4 agents #}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+{% if add_preceding_comma.flag %},{% endif %}
+{% set _dummy = add_preceding_comma.update({'flag': True}) %}
+isc-dhcpv4-relay-{{ vlan_name }}
+{%- endif %}
+{# Append DHCPv6 agents #}
+{% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
+{% if add_preceding_comma.flag %},{% endif %}
+{% set _dummy = add_preceding_comma.update({'flag': True}) %}
+isc-dhcpv6-relay-{{ vlan_name }}
+{%- endif %}
+{% endfor %}

--- a/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
@@ -1,0 +1,40 @@
+{# Append DHCPv4 agents #}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
+{% if dhcp_server | ipv4 %}
+{% set _dummy = relay_for_ipv4.update({'flag': True}) %}
+{% endif %}
+{% endfor %}
+{% if relay_for_ipv4.flag %}
+{% set _dummy = relay_for_ipv4.update({'flag': False}) %}
+[program:isc-dhcpv4-relay-{{ vlan_name }}]
+{# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}
+{#- Dual ToR Option #}
+{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -U Loopback0 -dt{% endif -%}
+{#- si option to use intf addr in relay #}
+{% if DEVICE_METADATA['localhost']['deployment_id'] == '8' %} -si{% endif -%}
+{#- We treat all other interfaces as upstream interfaces (-iu), as we only want to listen for replies #}
+{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
+{% if prefix | ipv4 and name != vlan_name %} -iu {{ name }}{% endif -%}
+{% endfor %}
+{% for (name, prefix) in INTERFACE|pfx_filter %}
+{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
+{% endfor %}
+{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
+{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
+{% endfor %}
+{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
+{%- if dhcp_server | ipv4 %} {{ dhcp_server }}{% endif -%}
+{% endfor %}
+
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=start:exited
+
+{% endif %}
+{% endif %}

--- a/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
@@ -1,0 +1,37 @@
+{# Append DHCPv6 agents #}
+{% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
+{% for dhcpv6_server in VLAN[vlan_name]['dhcpv6_servers'] %}
+{% if dhcpv6_server | ipv6 %}
+{% set _dummy = relay_for_ipv6.update({'flag': True}) %}
+{% endif %}
+{% endfor %}
+{% if relay_for_ipv6.flag %}
+{% set _dummy = relay_for_ipv6.update({'flag': False}) %}
+[program:isc-dhcpv6-relay-{{ vlan_name }}]
+{# We treat this VLAN as a downstream interface (-l), as we only want to listen for requests #}
+command=/usr/sbin/dhcrelay -d -6 --name-alias-map-file /tmp/port-name-alias-map.txt -l {{ vlan_name }}
+{#- We treat all other interfaces as upstream interfaces (-u), as we only want to listen for replies #}
+{%- for dhcpv6_server in VLAN[vlan_name]['dhcpv6_servers'] %}
+{%- if dhcpv6_server | ipv6 %}
+{%- for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
+{%- if prefix | ipv6 and name != vlan_name %} -u {{ dhcpv6_server }}%%{{ name }} {% endif -%}
+{% endfor %}
+{% for (name, prefix) in INTERFACE|pfx_filter %}
+{% if prefix | ipv6 %} -u {{ dhcpv6_server }}%%{{ name }} {% endif -%}
+{% endfor %}
+{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
+{% if prefix | ipv6 %} -u {{ dhcpv6_server }}%%{{ name }} {% endif -%}
+{% endfor %}
+{% endif -%}
+{% endfor %}
+
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=start:exited
+
+{% endif %}
+{% endif %}

--- a/dockers/docker-dhcp-relay/dhcpv6-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.monitors.j2
@@ -1,0 +1,79 @@
+[group:dhcpmon]
+programs=
+{%- set add_preceding_comma = { 'flag': False } %}
+{% set monitor_instance = { 'flag': False } %}
+{% for vlan_name in VLAN_INTERFACE %}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+{% set _dummy = monitor_instance.update({'flag': True}) %}
+{%- endif %}
+{% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
+{% set _dummy = monitor_instance.update({'flag': True}) %}
+{%- endif %}
+{% if monitor_instance.flag %}
+{% if add_preceding_comma.flag %},{% endif %}
+{% set _dummy = add_preceding_comma.update({'flag': True}) %}
+dhcpmon-{{ vlan_name }}
+{%- set _dummy = monitor_instance.update({'flag': False}) %}
+{%- endif %}
+{% endfor %}
+
+
+{# Create a program entry for each DHCP MONitor instance #}
+{% set relay_for_ipv4 = { 'flag': False } %}
+{% set relay_for_ipv6 = { 'flag': False } %}
+{% for vlan_name in VLAN_INTERFACE %}
+{# Check DHCPv4 agents #}
+{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
+{% if dhcp_server | ipv4 %}
+{% set _dummy = relay_for_ipv4.update({'flag': True}) %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{# Check DHCPv6 agents #}
+{% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
+{% for dhcpv6_server in VLAN[vlan_name]['dhcpv6_servers'] %}
+{% if dhcpv6_server | ipv6 %}
+{% set _dummy = relay_for_ipv6.update({'flag': True}) %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if relay_for_ipv4.flag or relay_for_ipv6.flag %}
+[program:dhcpmon-{{ vlan_name }}]
+{# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
+command=/usr/sbin/dhcpmon -id {{ vlan_name }}
+{#- Dual ToR Option #}
+{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -u Loopback0{% endif -%}
+{#- We treat all other interfaces as upstream interfaces (-iu), as we only want to listen for replies #}
+{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
+{% if prefix | ipv4 and name != vlan_name %} -iu {{ name }}{% endif -%}
+{% endfor %}
+{% for (name, prefix) in INTERFACE|pfx_filter %}
+{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
+{% endfor %}
+{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
+{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
+{% endfor %}
+{% if MGMT_INTERFACE %}
+{% for (name, prefix) in MGMT_INTERFACE|pfx_filter %}
+{% if prefix | ipv4 %} -im {{ name }}{% endif -%}
+{% endfor %}
+{% endif %}
+{% if relay_for_ipv4.flag %} -4{% endif %}
+{% if relay_for_ipv6.flag %} -6{% endif %}
+
+priority=4
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=
+{%- if relay_for_ipv4.flag %}isc-dhcpv4-relay-{{ vlan_name }}:running {% endif %}
+{% if relay_for_ipv6.flag %}isc-dhcpv6-relay-{{ vlan_name }}:running{% endif %}
+
+
+{% set _dummy = relay_for_ipv4.update({'flag': False}) %}
+{% set _dummy = relay_for_ipv6.update({'flag': False}) %}
+{% endif %}
+{% endfor %}

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -42,125 +42,29 @@ dependent_startup_wait_for=rsyslogd:running
 {# If our configuration has VLANs... #}
 {% if VLAN_INTERFACE %}
 {# Count how many VLANs require a DHCP relay agent... #}
-{% set num_relays = { 'count': 0 } %}
+{% set ipv4_num_relays = { 'count': 0 } %}
+{% set ipv6_num_relays = { 'count': 0 } %}
 {% for vlan_name in VLAN_INTERFACE %}
 {% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% set _dummy = num_relays.update({'count': num_relays.count + 1}) %}
+{% set _dummy = ipv4_num_relays.update({'count': ipv4_num_relays.count + 1}) %}
+{% endif %}
+{% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
+{% set _dummy = ipv6_num_relays.update({'count': ipv6_num_relays.count + 1}) %}
 {% endif %}
 {% endfor %}
 {# If one or more of the VLANs require a DHCP relay agent... #}
-{% if num_relays.count > 0 %}
-[group:isc-dhcp-relay]
-programs=
-{%- set add_preceding_comma = { 'flag': False } %}
-{% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% if add_preceding_comma.flag %},{% endif %}
-{% set _dummy = add_preceding_comma.update({'flag': True}) %}
-isc-dhcp-relay-{{ vlan_name }}
-{%- endif %}
-{% endfor %}
+{% if ipv4_num_relays.count > 0 or ipv6_num_relays.count > 0 %}
+{% include 'dhcp-relay.programs.j2' %}
 
 
 {# Create a program entry for each DHCP relay agent instance #}
 {% set relay_for_ipv4 = { 'flag': False } %}
+{% set relay_for_ipv6 = { 'flag': False } %}
 {% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-{% if dhcp_server | ipv4 %}
-{% set _dummy = relay_for_ipv4.update({'flag': True}) %}
-{% endif %}
-{% endfor %}
-{% if relay_for_ipv4.flag %}
-{% set _dummy = relay_for_ipv4.update({'flag': False}) %}
-[program:isc-dhcp-relay-{{ vlan_name }}]
-{# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}
-{#- Dual ToR Option #}
-{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -U Loopback0 -dt{% endif -%}
-{#- si option to use intf addr in relay #}
-{% if DEVICE_METADATA['localhost']['deployment_id'] == '8' %} -si{% endif -%}
-{#- We treat all other interfaces as upstream interfaces (-iu), as we only want to listen for replies #}
-{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
-{% if prefix | ipv4 and name != vlan_name %} -iu {{ name }}{% endif -%}
-{% endfor %}
-{% for (name, prefix) in INTERFACE|pfx_filter %}
-{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
-{% endfor %}
-{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
-{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
-{% endfor %}
-{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-{%- if dhcp_server | ipv4 %} {{ dhcp_server }}{% endif -%}
+{% include 'dhcpv4-relay.agents.j2' %}
+{% include 'dhcpv6-relay.agents.j2' %}
 {% endfor %}
 
-priority=3
-autostart=false
-autorestart=false
-stdout_logfile=syslog
-stderr_logfile=syslog
-dependent_startup=true
-dependent_startup_wait_for=start:exited
-
-{% endif %}
-{% endif %}
-{% endfor %}
-
-[group:dhcpmon]
-programs=
-{%- set add_preceding_comma = { 'flag': False } %}
-{% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% if add_preceding_comma.flag %},{% endif %}
-{% set _dummy = add_preceding_comma.update({'flag': True}) %}
-dhcpmon-{{ vlan_name }}
-{%- endif %}
-{% endfor %}
-
-
-{# Create a program entry for each DHCP MONitor instance #}
-{% set relay_for_ipv4 = { 'flag': False } %}
-{% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-{% if dhcp_server | ipv4 %}
-{% set _dummy = relay_for_ipv4.update({'flag': True}) %}
-{% endif %}
-{% endfor %}
-{% if relay_for_ipv4.flag %}
-{% set _dummy = relay_for_ipv4.update({'flag': False}) %}
-[program:dhcpmon-{{ vlan_name }}]
-{# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
-command=/usr/sbin/dhcpmon -id {{ vlan_name }}
-{#- Dual ToR Option #}
-{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -u Loopback0{% endif -%}
-{#- We treat all other interfaces as upstream interfaces (-iu), as we only want to listen for replies #}
-{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
-{% if prefix | ipv4 and name != vlan_name %} -iu {{ name }}{% endif -%}
-{% endfor %}
-{% for (name, prefix) in INTERFACE|pfx_filter %}
-{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
-{% endfor %}
-{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
-{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
-{% endfor %}
-{% if MGMT_INTERFACE %}
-{% for (name, prefix) in MGMT_INTERFACE|pfx_filter %}
-{% if prefix | ipv4 %} -im {{ name }}{% endif -%}
-{% endfor %}
-{% endif %}
-
-priority=4
-autostart=false
-autorestart=false
-stdout_logfile=syslog
-stderr_logfile=syslog
-dependent_startup=true
-dependent_startup_wait_for=isc-dhcp-relay-{{ vlan_name }}:running
-
-{% endif %}
-{% endif %}
-{% endfor %}
-
+{% include 'dhcpv6-relay.monitors.j2' %}
 {% endif %}
 {% endif %}

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -40,10 +40,20 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
 [group:isc-dhcp-relay]
-programs=isc-dhcp-relay-Vlan1000
+programs=isc-dhcpv4-relay-Vlan1000,isc-dhcpv6-relay-Vlan1000
 
-[program:isc-dhcp-relay-Vlan1000]
+[program:isc-dhcpv4-relay-Vlan1000]
 command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.1 192.0.0.2
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=start:exited
+
+[program:isc-dhcpv6-relay-Vlan1000]
+command=/usr/sbin/dhcrelay -d -6 --name-alias-map-file /tmp/port-name-alias-map.txt -l Vlan1000 -u fc02:2000::1%%PortChannel04  -u fc02:2000::1%%PortChannel03  -u fc02:2000::1%%PortChannel01  -u fc02:2000::1%%PortChannel02  -u fc02:2000::2%%PortChannel04  -u fc02:2000::2%%PortChannel03  -u fc02:2000::2%%PortChannel01  -u fc02:2000::2%%PortChannel02 
 priority=3
 autostart=false
 autorestart=false
@@ -57,14 +67,13 @@ dependent_startup_wait_for=start:exited
 programs=dhcpmon-Vlan1000
 
 [program:dhcpmon-Vlan1000]
-command=/usr/sbin/dhcpmon -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
+command=/usr/sbin/dhcpmon -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0 -4 -6
 priority=4
 autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcp-relay-Vlan1000:running
-
+dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running isc-dhcpv6-relay-Vlan1000:running
 
 

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -40,10 +40,20 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
 [group:isc-dhcp-relay]
-programs=isc-dhcp-relay-Vlan1000
+programs=isc-dhcpv4-relay-Vlan1000,isc-dhcpv6-relay-Vlan1000
 
-[program:isc-dhcp-relay-Vlan1000]
+[program:isc-dhcpv4-relay-Vlan1000]
 command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.1 192.0.0.2
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=start:exited
+
+[program:isc-dhcpv6-relay-Vlan1000]
+command=/usr/sbin/dhcrelay -d -6 --name-alias-map-file /tmp/port-name-alias-map.txt -l Vlan1000 -u fc02:2000::1%%PortChannel01  -u fc02:2000::1%%PortChannel02  -u fc02:2000::1%%PortChannel03  -u fc02:2000::1%%PortChannel04  -u fc02:2000::2%%PortChannel01  -u fc02:2000::2%%PortChannel02  -u fc02:2000::2%%PortChannel03  -u fc02:2000::2%%PortChannel04 
 priority=3
 autostart=false
 autorestart=false
@@ -57,14 +67,13 @@ dependent_startup_wait_for=start:exited
 programs=dhcpmon-Vlan1000
 
 [program:dhcpmon-Vlan1000]
-command=/usr/sbin/dhcpmon -id Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
+command=/usr/sbin/dhcpmon -id Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0 -4 -6
 priority=4
 autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcp-relay-Vlan1000:running
-
+dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running isc-dhcpv6-relay-Vlan1000:running
 
 


### PR DESCRIPTION
NOTE: This is cherry-pick from master to 202012.
https://github.com/Azure/sonic-buildimage/pull/8045

Why I did it
Currently SONiC use the 'isc-dhcp-relay' package to allow DHCP relay functionality on IPv4 networks only.
This will allow the IPv6 functionality along the IPv4 type.

How I did it
Edit supervisord template to start DHCPv6 instances when configured to do so on Config DB.
Align cfg unit test to the new change.
Add DHCPv6 relay minigraph parsing support and a suitable t0 topology xml file for UT.

How to verify it
Configure DHCPv6 agents as described on the feature HLD: Azure/SONiC#765
Test it with real client/server with IPv6 or use the dedicated automatic test: Azure/sonic-mgmt#3565
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

* Split docker-dhcp-relay.supervisord.conf.j2 template into several files for easier code maintenance

(cherry picked from commit 604becdd5ca06b3304c0cc5dca1079b0d7bfa437)

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

