### PR TITLE
Parse DHCP_RELAY table

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -516,6 +516,7 @@ def parse_dpg(dpg, hname):
         vlanintfs = child.find(str(QName(ns, "VlanInterfaces")))
         vlans = {}
         vlan_members = {}
+        dhcp_relay_table = {}
         vlantype_name = ""
         intf_vlan_mbr = defaultdict(list)
         for vintf in vlanintfs.findall(str(QName(ns, "VlanInterface"))):
@@ -543,6 +544,7 @@ def parse_dpg(dpg, hname):
                     vlan_members[(sonic_vlan_member_name, vmbr_list[i])] = {'tagging_mode': 'untagged'}
 
             vlan_attributes = {'vlanid': vlanid, 'members': vmbr_list }
+            dhcp_attributes = {}
 
             # If this VLAN requires a DHCP relay agent, it will contain a <DhcpRelays> element
             # containing a list of DHCP server IPs
@@ -557,6 +559,9 @@ def parse_dpg(dpg, hname):
                 vintfdhcpservers = vintf_node.text
                 vdhcpserver_list = vintfdhcpservers.split(';')
                 vlan_attributes['dhcpv6_servers'] = vdhcpserver_list
+                dhcp_attributes['dhcpv6_servers'] = vdhcpserver_list
+            sonic_vlan_member_name = "Vlan%s" % (vlanid)
+            dhcp_relay_table[sonic_vlan_member_name] = dhcp_attributes
 
             vlanmac = vintf.find(str(QName(ns, "MacAddress")))
             if vlanmac is not None and vlanmac.text is not None:
@@ -566,29 +571,6 @@ def parse_dpg(dpg, hname):
             if sonic_vlan_name != vintfname:
                 vlan_attributes['alias'] = vintfname
             vlans[sonic_vlan_name] = vlan_attributes
-
-        dhcp = child.find(str(QName(ns, "Dhcp")))
-        dhcp_table = {}
-
-        if dhcp is not None:
-            for vintf in dhcp.findall(str(QName(ns, "VlanInterface"))):
-                vintfname = vintf.find(str(QName(ns, "Name"))).text
-
-                dhcp_attributes = {}
-
-                dhcp_node = vintf.find(str(QName(ns, "Dhcpv6Relays")))
-                if dhcp_node is not None and dhcp_node.text is not None:
-                    dhcpservers = dhcp_node.text
-                    vdhcpserver_list = dhcpservers.split(';')
-                    dhcp_attributes['dhcpv6_servers'] = vdhcpserver_list
-
-                option_linklayer_addr = vintf.find(str(QName(ns, "Dhcpv6OptionRfc6939")))
-                if option_linklayer_addr is not None and option_linklayer_addr.text == "true":
-                    dhcp_attributes['dhcpv6_option|rfc6939_support'] = "true"
-                elif option_linklayer_addr is not None and option_linklayer_addr.text == "false":
-                    dhcp_attributes['dhcpv6_option|rfc6939_support'] = "false"
-
-                dhcp_table[vintfname] = dhcp_attributes
 
         acls = {}
         for aclintf in aclintfs.findall(str(QName(ns, "AclInterface"))):
@@ -704,7 +686,7 @@ def parse_dpg(dpg, hname):
                     if mg_key in mg_tunnel.attrib:
                         tunnelintfs[tunnel_type][tunnel_name][table_key] = mg_tunnel.attrib[mg_key]
 
-        return intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, dhcp_table, pcs, pc_members, acls, vni, tunnelintfs, dpg_ecmp_content
+        return intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, dhcp_relay_table, pcs, pc_members, acls, vni, tunnelintfs, dpg_ecmp_content
     return None, None, None, None, None, None, None, None, None, None, None, None, None
 
 def parse_host_loopback(dpg, hname):
@@ -1131,7 +1113,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     tunnel_intfs = None
     vlans = None
     vlan_members = None
-    dhcp_table = None
+    dhcp_relay_table = None
     pcs = None
     mgmt_intf = None
     lo_intfs = None
@@ -1191,7 +1173,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     for child in root:
         if asic_name is None:
             if child.tag == str(QName(ns, "DpgDec")):
-                (intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, dhcp_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, hostname)
+                (intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, dhcp_relay_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, hostname)
             elif child.tag == str(QName(ns, "CpgDec")):
                 (bgp_sessions, bgp_internal_sessions, bgp_asn, bgp_peers_with_range, bgp_monitors) = parse_cpg(child, hostname)
             elif child.tag == str(QName(ns, "PngDec")):
@@ -1206,7 +1188,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
                 (port_speeds_default, port_descriptions) = parse_deviceinfo(child, hwsku)
         else:
             if child.tag == str(QName(ns, "DpgDec")):
-                (intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, dhcp_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, asic_name)
+                (intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, dhcp_relay_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, asic_name)
                 host_lo_intfs = parse_host_loopback(child, hostname)
             elif child.tag == str(QName(ns, "CpgDec")):
                 (bgp_sessions, bgp_internal_sessions, bgp_asn, bgp_peers_with_range, bgp_monitors) = parse_cpg(child, asic_name, local_devices)
@@ -1523,7 +1505,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         results['DEVICE_NEIGHBOR_METADATA'] = { key:devices[key] for key in devices if key in {device['name'] for device in neighbors.values()} }
     results['SYSLOG_SERVER'] = dict((item, {}) for item in syslog_servers)
     results['DHCP_SERVER'] = dict((item, {}) for item in dhcp_servers)
-    results['DHCP'] = dhcp_table
+    results['DHCP_RELAY'] = dhcp_relay_table
     results['NTP_SERVER'] = dict((item, {}) for item in ntp_servers)
     results['TACPLUS_SERVER'] = dict((item, {'priority': '1', 'tcp_port': '49'}) for item in tacacs_servers)
     results['ACL_TABLE'] = filter_acl_table_bindings(acls, neighbors, pcs, sub_role)

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -567,6 +567,29 @@ def parse_dpg(dpg, hname):
                 vlan_attributes['alias'] = vintfname
             vlans[sonic_vlan_name] = vlan_attributes
 
+        dhcp = child.find(str(QName(ns, "Dhcp")))
+        dhcp_table = {}
+
+        if dhcp is not None:
+            for vintf in dhcp.findall(str(QName(ns, "VlanInterface"))):
+                vintfname = vintf.find(str(QName(ns, "Name"))).text
+
+                dhcp_attributes = {}
+
+                dhcp_node = vintf.find(str(QName(ns, "Dhcpv6Relays")))
+                if dhcp_node is not None and dhcp_node.text is not None:
+                    dhcpservers = dhcp_node.text
+                    vdhcpserver_list = dhcpservers.split(';')
+                    dhcp_attributes['dhcpv6_servers'] = vdhcpserver_list
+
+                option_linklayer_addr = vintf.find(str(QName(ns, "Dhcpv6OptionRfc6939")))
+                if option_linklayer_addr is not None and option_linklayer_addr.text == "true":
+                    dhcp_attributes['dhcpv6_option|rfc6939_support'] = "true"
+                elif option_linklayer_addr is not None and option_linklayer_addr.text == "false":
+                    dhcp_attributes['dhcpv6_option|rfc6939_support'] = "false"
+
+                dhcp_table[vintfname] = dhcp_attributes
+
         acls = {}
         for aclintf in aclintfs.findall(str(QName(ns, "AclInterface"))):
             if aclintf.find(str(QName(ns, "InAcl"))) is not None:
@@ -681,8 +704,8 @@ def parse_dpg(dpg, hname):
                     if mg_key in mg_tunnel.attrib:
                         tunnelintfs[tunnel_type][tunnel_name][table_key] = mg_tunnel.attrib[mg_key]
 
-        return intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, pcs, pc_members, acls, vni, tunnelintfs, dpg_ecmp_content
-    return None, None, None, None, None, None, None, None, None, None
+        return intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, dhcp_table, pcs, pc_members, acls, vni, tunnelintfs, dpg_ecmp_content
+    return None, None, None, None, None, None, None, None, None, None, None, None, None
 
 def parse_host_loopback(dpg, hname):
     for child in dpg:
@@ -1108,6 +1131,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     tunnel_intfs = None
     vlans = None
     vlan_members = None
+    dhcp_table = None
     pcs = None
     mgmt_intf = None
     lo_intfs = None
@@ -1167,7 +1191,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     for child in root:
         if asic_name is None:
             if child.tag == str(QName(ns, "DpgDec")):
-                (intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, hostname)
+                (intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, dhcp_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, hostname)
             elif child.tag == str(QName(ns, "CpgDec")):
                 (bgp_sessions, bgp_internal_sessions, bgp_asn, bgp_peers_with_range, bgp_monitors) = parse_cpg(child, hostname)
             elif child.tag == str(QName(ns, "PngDec")):
@@ -1182,7 +1206,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
                 (port_speeds_default, port_descriptions) = parse_deviceinfo(child, hwsku)
         else:
             if child.tag == str(QName(ns, "DpgDec")):
-                (intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, asic_name)
+                (intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, dhcp_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content) = parse_dpg(child, asic_name)
                 host_lo_intfs = parse_host_loopback(child, hostname)
             elif child.tag == str(QName(ns, "CpgDec")):
                 (bgp_sessions, bgp_internal_sessions, bgp_asn, bgp_peers_with_range, bgp_monitors) = parse_cpg(child, asic_name, local_devices)
@@ -1499,7 +1523,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         results['DEVICE_NEIGHBOR_METADATA'] = { key:devices[key] for key in devices if key in {device['name'] for device in neighbors.values()} }
     results['SYSLOG_SERVER'] = dict((item, {}) for item in syslog_servers)
     results['DHCP_SERVER'] = dict((item, {}) for item in dhcp_servers)
-    results['DHCPv6_SERVER'] = dict((item, {}) for item in dhcpv6_servers)
+    results['DHCP'] = dhcp_table
     results['NTP_SERVER'] = dict((item, {}) for item in ntp_servers)
     results['TACPLUS_SERVER'] = dict((item, {'priority': '1', 'tcp_port': '49'}) for item in tacacs_servers)
     results['ACL_TABLE'] = filter_acl_table_bindings(acls, neighbors, pcs, sub_role)

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -148,6 +148,18 @@
           <MacAddress i:nil="true"/>
         </VlanInterface>
       </VlanInterfaces>
+      <Dhcp>
+        <VlanInterface>
+          <Name>Vlan1000</Name>
+          <Dhcpv6Relays>fc02:2000::1;fc02:2000::2</Dhcpv6Relays>
+          <Dhcpv6OptionRfc6939>true</Dhcpv6OptionRfc6939>
+        </VlanInterface>
+        <VlanInterface>
+          <Name>Vlan2000</Name>
+          <Dhcpv6Relays>fc02:2000::3;fc02:2000::4</Dhcpv6Relays>
+          <Dhcpv6OptionRfc6939>false</Dhcpv6OptionRfc6939>
+        </VlanInterface>
+      </Dhcp>
       <IPInterfaces>
         <IPInterface>
           <Name i:nil="true"/>

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -134,6 +134,7 @@
           <Name>ab1</Name>
           <AttachTo>fortyGigE0/8</AttachTo>
           <DhcpRelays>192.0.0.1;192.0.0.2</DhcpRelays>
+          <Dhcpv6Relays>fc02:2000::1;fc02:2000::2</Dhcpv6Relays>
           <VlanID>1000</VlanID>
           <Tag>1000</Tag>
           <Subnets>192.168.0.0/27</Subnets>
@@ -143,23 +144,12 @@
           <Name>ab2</Name>
           <AttachTo>fortyGigE0/4</AttachTo>
           <DhcpRelays>192.0.0.1</DhcpRelays>
+          <Dhcpv6Relays>fc02:2000::3;fc02:2000::4</Dhcpv6Relays>
           <VlanID>2000</VlanID>
           <Tag>2000</Tag>
           <MacAddress i:nil="true"/>
         </VlanInterface>
       </VlanInterfaces>
-      <Dhcp>
-        <VlanInterface>
-          <Name>Vlan1000</Name>
-          <Dhcpv6Relays>fc02:2000::1;fc02:2000::2</Dhcpv6Relays>
-          <Dhcpv6OptionRfc6939>true</Dhcpv6OptionRfc6939>
-        </VlanInterface>
-        <VlanInterface>
-          <Name>Vlan2000</Name>
-          <Dhcpv6Relays>fc02:2000::3;fc02:2000::4</Dhcpv6Relays>
-          <Dhcpv6OptionRfc6939>false</Dhcpv6OptionRfc6939>
-        </VlanInterface>
-      </Dhcp>
       <IPInterfaces>
         <IPInterface>
           <Name i:nil="true"/>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -684,3 +684,14 @@ class TestCfgGen(TestCase):
         argument = '-a \'{"key1":"value"}\' --var-json INTERFACE'
         output = self.run_script(argument)
         self.assertEqual(output, '')
+
+    def test_minigraph_dhcp(self):
+        argument = '-m "' + self.sample_graph_simple_case + '" -p "' + self.port_config + '" -v DHCP'
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            utils.to_dict(
+                "{'Vlan1000': {'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2'], 'dhcpv6_option|rfc6939_support': 'true'}, "
+                "'Vlan2000': {'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4'], 'dhcpv6_option|rfc6939_support': 'false'}}"
+            )
+        )

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -686,12 +686,12 @@ class TestCfgGen(TestCase):
         self.assertEqual(output, '')
 
     def test_minigraph_dhcp(self):
-        argument = '-m "' + self.sample_graph_simple_case + '" -p "' + self.port_config + '" -v DHCP'
+        argument = '-m "' + self.sample_graph_simple_case + '" -p "' + self.port_config + '" -v DHCP_RELAY'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),
             utils.to_dict(
-                "{'Vlan1000': {'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2'], 'dhcpv6_option|rfc6939_support': 'true'}, "
-                "'Vlan2000': {'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4'], 'dhcpv6_option|rfc6939_support': 'false'}}"
+                "{'Vlan1000': {'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2']}, "
+                "'Vlan2000': {'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4']}}"
             )
         )

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -357,3 +357,29 @@ class TestCfgGenCaseInsensitive(TestCase):
             utils.to_dict(output.strip()),
             expected_table
         )
+    
+    def test_dhcp_table(self):
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "DHCP"'
+        expected = {
+                   'Vlan1000': {
+                       'dhcpv6_servers': [
+                           "fc02:2000::1",
+                           "fc02:2000::2"
+                       ],
+                       'dhcpv6_option|rfc6939_support': 'true'
+                    },
+                   'Vlan2000': {
+                       'dhcpv6_servers': [
+                           "fc02:2000::3",
+                           "fc02:2000::4"
+                       ],
+                       'dhcpv6_option|rfc6939_support': 'false'
+                    }
+        }
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            expected
+        )
+        
+    

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -102,6 +102,7 @@ class TestCfgGenCaseInsensitive(TestCase):
                    'Vlan1000': {
                        'alias': 'ab1',
                        'dhcp_servers': ['192.0.0.1', '192.0.0.2'],
+                       'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2'],
                        'vlanid': '1000',
                        'mac': '00:aa:bb:cc:dd:ee',
                        'members': ['Ethernet8']
@@ -109,6 +110,7 @@ class TestCfgGenCaseInsensitive(TestCase):
                    'Vlan2000': {
                        'alias': 'ab2',
                        'dhcp_servers': ['192.0.0.1'],
+                       'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4'],
                        'members': ['Ethernet4'],
                        'vlanid': '2000'
                        }
@@ -359,21 +361,19 @@ class TestCfgGenCaseInsensitive(TestCase):
         )
     
     def test_dhcp_table(self):
-        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "DHCP"'
+        argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "DHCP_RELAY"'
         expected = {
                    'Vlan1000': {
                        'dhcpv6_servers': [
                            "fc02:2000::1",
                            "fc02:2000::2"
-                       ],
-                       'dhcpv6_option|rfc6939_support': 'true'
+                       ]
                     },
-                   'Vlan2000': {
+                    'Vlan2000': {
                        'dhcpv6_servers': [
                            "fc02:2000::3",
                            "fc02:2000::4"
-                       ],
-                       'dhcpv6_option|rfc6939_support': 'false'
+                       ]
                     }
         }
         output = self.run_script(argument)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

NOTE: This is cherry-pick from master to 202012.
https://github.com/Azure/sonic-buildimage/pull/8268
https://github.com/Azure/sonic-buildimage/pull/8476

#### Why I did it
Add the following dhcp_relay table to minigraph
<pre>
'DHCP_RELAY': {
        'Vlan1000': {
                'dhcpv6_servers': [
                        'fc02:2000::1',
                        'fc02:2000::2'
                ]
        },
        'Vlan2000': {
                'dhcpv6_servers': [
                        'fc02:2000::3',
                        'fc02:2000::4'
                ]
        }
}
</pre>

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

