### PR TITLE
[device]: Add SAI checksum verify to TD3 config

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
@@ -1,5 +1,6 @@
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 sai_adjust_acl_drop_in_rx_drop=1
+sai_verify_incoming_chksum=0
 host_as_route_disable=1
 use_all_splithorizon_groups=1
 riot_enable=1

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
@@ -1,5 +1,6 @@
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 sai_adjust_acl_drop_in_rx_drop=1
+sai_verify_incoming_chksum=0
 host_as_route_disable=1
 use_all_splithorizon_groups=1
 riot_enable=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -237,3 +237,4 @@ buf.map.egress_pool0.ingress_pool
 buf.map.egress_pool1.ingress_pool
 buf.map.egress_pool2.ingress_pool
 sai_adjust_acl_drop_in_rx_drop
+sai_verify_incoming_chksum


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
A new config option was added to control the value of IPV4_INCR_CHECKSUM_ORIGINAL_VALUE_VERIFY in the EGR_FLEX_CONFIG control register (this prevents checksums of 0xffff from being propagated to other devices)

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

