### PR TITLE
[hostcfgd] [202012] Fix the delay type to 'boot' delay instead of a unit activation delay

### DIFF
--- a/src/sonic-host-services-data/debian/sonic-host-services-data.hostcfgd.timer
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.hostcfgd.timer
@@ -3,7 +3,8 @@ Description=Delays hostcfgd daemon until SONiC has started
 PartOf=hostcfgd.service
 
 [Timer]
-OnActiveSec=1min 30 sec
+OnUnitActiveSec=0 sec
+OnBootSec=1min 30 sec
 Unit=hostcfgd.service
 
 [Install]


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
With current code the delay will take place even if simple 'config reload' command executed and this is not desired.
This delay should be used only when fast-rebooting.

#### How I did it
Change the type of delay to OnBootSec instead of OnActiveSec.

#### How to verify it
Fast-reboot with this PR and observe the delay.
Run 'config-reload' command and observe no delay is running.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

