### PR TITLE
[Mellanox] Fix split configuration for Mellanox SN3800-D112C8 SKU SAI profile for fast-reboot performance

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/sai_3800_112x50g_8x100g.xml
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/sai_3800_112x50g_8x100g.xml
@@ -46,7 +46,7 @@
                 <width>4</width>
                 <module>51</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -78,7 +78,7 @@
                 <width>4</width>
                 <module>55</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -110,7 +110,7 @@
                 <width>4</width>
                 <module>59</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -142,7 +142,7 @@
                 <width>4</width>
                 <module>63</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -174,7 +174,7 @@
                 <width>4</width>
                 <module>15</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -206,7 +206,7 @@
                 <width>4</width>
                 <module>11</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -238,7 +238,7 @@
                 <width>4</width>
                 <module>7</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -270,7 +270,7 @@
                 <width>4</width>
                 <module>3</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -302,7 +302,7 @@
                 <width>4</width>
                 <module>47</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -334,7 +334,7 @@
                 <width>4</width>
                 <module>43</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -364,7 +364,7 @@
                 <width>4</width>
                 <module>39</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -394,7 +394,7 @@
                 <width>4</width>
                 <module>35</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -426,7 +426,7 @@
                 <width>4</width>
                 <module>19</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -458,7 +458,7 @@
                 <width>4</width>
                 <module>23</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -488,7 +488,7 @@
                 <width>4</width>
                 <module>27</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -518,7 +518,7 @@
                 <width>4</width>
                 <module>31</module>
                 <breakout-modes>3</breakout-modes>
-				<split>2</split>
+                <split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
         </ports-list>

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/sai_3800_112x50g_8x100g.xml
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/sai_3800_112x50g_8x100g.xml
@@ -46,6 +46,7 @@
                 <width>4</width>
                 <module>51</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -77,6 +78,7 @@
                 <width>4</width>
                 <module>55</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -108,6 +110,7 @@
                 <width>4</width>
                 <module>59</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -139,6 +142,7 @@
                 <width>4</width>
                 <module>63</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -170,6 +174,7 @@
                 <width>4</width>
                 <module>15</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -201,6 +206,7 @@
                 <width>4</width>
                 <module>11</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -232,6 +238,7 @@
                 <width>4</width>
                 <module>7</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -263,6 +270,7 @@
                 <width>4</width>
                 <module>3</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -294,6 +302,7 @@
                 <width>4</width>
                 <module>47</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -325,6 +334,7 @@
                 <width>4</width>
                 <module>43</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -354,6 +364,7 @@
                 <width>4</width>
                 <module>39</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -383,6 +394,7 @@
                 <width>4</width>
                 <module>35</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -414,6 +426,7 @@
                 <width>4</width>
                 <module>19</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -445,6 +458,7 @@
                 <width>4</width>
                 <module>23</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -474,6 +488,7 @@
                 <width>4</width>
                 <module>27</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
             <port-info>
@@ -503,6 +518,7 @@
                 <width>4</width>
                 <module>31</module>
                 <breakout-modes>3</breakout-modes>
+				<split>2</split>
                 <port-speed>384</port-speed>
             </port-info>
         </ports-list>


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Wrong SKU configuration will lead to longer init flow.
This will affect fast-reboot feature by increasing the traffic downtime.
Since MLNX met the required downtime period with this SKU this bug found with a delay.

#### How I did it
Add the required split labels for ports.

#### How to verify it
Run fast-reboot with this platform using SN3800-D112C8 SKU.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

