### PR TITLE
[Accton][202012br] Fix high CPU utilization caused by chassis.get_change_event()

### DIFF
--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/chassis.py
@@ -45,7 +45,6 @@ class Chassis(ChassisBase):
     def __init__(self):
         ChassisBase.__init__(self)
         self._api_helper = APIHelper()
-        self._api_helper = APIHelper()
         self.is_host = self._api_helper.is_host()
         
         self.config_data = {}
@@ -62,6 +61,7 @@ class Chassis(ChassisBase):
         for index in range(0, PORT_END):
             sfp = Sfp(index)
             self._sfp_list.append(sfp)
+        self._sfpevent = SfpEvent(self._sfp_list)
         self.sfp_module_initialized = True
         
     def __initialize_fan(self):
@@ -193,10 +193,7 @@ class Chassis(ChassisBase):
         # SFP event
         if not self.sfp_module_initialized:
             self.__initialize_sfp()
-
-        status, sfp_event = SfpEvent(self._sfp_list).get_sfp_event(timeout)
-        
-        return status, sfp_event
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/event.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/event.py
@@ -5,6 +5,7 @@ try:
 except ImportError as e:
     raise ImportError(repr(e) + " - required module not found")
 
+POLL_INTERVAL_IN_SEC = 1
 
 class SfpEvent:
     ''' Listen to insert/remove sfp events '''
@@ -13,30 +14,38 @@ class SfpEvent:
         self._api_helper = APIHelper()
         self._sfp_list = sfp_list
         self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
 
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_sfp_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
-
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
-
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-        
+    def get_presence_bitmap(self):
         bitmap = 0
         for sfp in self._sfp_list:
             modpres = sfp.get_presence()
             i=sfp.port_num-1
             if modpres:
                 bitmap = bitmap | (1 << i)
+        return bitmap
 
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
             for sfp in self._sfp_list:
                 i=sfp.port_num-1
                 if (changed_ports & (1 << i)):
@@ -47,9 +56,7 @@ class SfpEvent:
 
 
             # Update the cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
+            self._sfp_change_event_data['present'] = bitmap
             return True, change_dict
         else:
             return True, change_dict

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/chassis.py
@@ -35,7 +35,6 @@ class Chassis(ChassisBase):
     def __init__(self):
         ChassisBase.__init__(self)
         self._api_helper = APIHelper()
-        self._api_helper = APIHelper()
         self.is_host = self._api_helper.is_host()
         
         self.config_data = {}
@@ -52,6 +51,7 @@ class Chassis(ChassisBase):
         for index in range(0, NUM_PORT):
             sfp = Sfp(index)
             self._sfp_list.append(sfp)
+        self._sfpevent = SfpEvent(self._sfp_list)
         self.sfp_module_initialized = True
         
     def __initialize_fan(self):
@@ -183,10 +183,7 @@ class Chassis(ChassisBase):
         # SFP event
         if not self.sfp_module_initialized:
             self.__initialize_sfp()
-
-        status, sfp_event = SfpEvent(self._sfp_list).get_sfp_event(timeout)
-        
-        return status, sfp_event
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """

--- a/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/event.py
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sonic_platform/event.py
@@ -5,6 +5,7 @@ try:
 except ImportError as e:
     raise ImportError(repr(e) + " - required module not found")
 
+POLL_INTERVAL_IN_SEC = 1
 
 class SfpEvent:
     ''' Listen to insert/remove sfp events '''
@@ -13,30 +14,38 @@ class SfpEvent:
         self._api_helper = APIHelper()
         self._sfp_list = sfp_list
         self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
 
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_sfp_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
-
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
-
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-        
+    def get_presence_bitmap(self):
         bitmap = 0
         for sfp in self._sfp_list:
             modpres = sfp.get_presence()
             i=sfp.port_num-1
             if modpres:
                 bitmap = bitmap | (1 << i)
+        return bitmap
 
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
             for sfp in self._sfp_list:
                 i=sfp.port_num-1
                 if (changed_ports & (1 << i)):
@@ -47,9 +56,7 @@ class SfpEvent:
 
 
             # Update the cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
+            self._sfp_change_event_data['present'] = bitmap
             return True, change_dict
         else:
             return True, change_dict


### PR DESCRIPTION
Models: AS4630-54TE, AS9726-32D

#### Why I did it
Correct get_change_event() wait and timeout mechanism to avoid high CPU utilization.

#### How I did it
Make sure get_change_event() behaves as documentation said, it can block the caller and handle timeout appropriately.

#### How to verify it
In pmon, 
1. Use `top` to measure CPU usage of xcvrd. Make a comparison between before and after the modification.
2. Code a script to keep polling get_change_event() and see if the returned data is exactly what we expect.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012 : some of our customers demands it.
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)
![Alt Text](https://media.giphy.com/media/X3Yj4XXXieKYM/giphy.gif)

