### PR TITLE
[Accton] Fix high CPU utilization caused by chassis.get_change_event()

### DIFF
--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
@@ -11,6 +11,7 @@ import os
 try:
     from sonic_platform_base.chassis_base import ChassisBase
     from .helper import APIHelper
+    from .event import SfpEvent
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -42,7 +43,6 @@ class Chassis(ChassisBase):
     def __init__(self):
         ChassisBase.__init__(self)
         self._api_helper = APIHelper()
-        self._api_helper = APIHelper()
         self.is_host = self._api_helper.is_host()
 
         self.config_data = {}
@@ -59,6 +59,7 @@ class Chassis(ChassisBase):
         for index in range(0, PORT_END):
             sfp = Sfp(index)
             self._sfp_list.append(sfp)
+        self._sfpevent = SfpEvent(self._sfp_list)
         self.sfp_module_initialized = True
 
     def __initialize_fan(self):
@@ -175,6 +176,12 @@ class Chassis(ChassisBase):
 
 
         return ('REBOOT_CAUSE_NON_HARDWARE', sw_reboot_cause)
+
+    def get_change_event(self, timeout=0):
+        # SFP event
+        if not self.sfp_module_initialized:
+            self.__initialize_sfp()
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
@@ -27,7 +27,7 @@ HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
 SYSLED_FNODE = "/sys/class/leds/diag/brightness"
 SYSLED_MODES = {
     "0" : "STATUS_LED_COLOR_OFF",

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/event.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/event.py
@@ -1,0 +1,62 @@
+try:
+    import time
+    from .helper import APIHelper
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._api_helper = APIHelper()
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.port_num-1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.port_num-1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/helper.py
@@ -4,7 +4,7 @@ import subprocess
 from mmap import *
 from sonic_py_common import device_info
 
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
 EMPTY_STRING = ""
 
 

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/sfp.py
@@ -126,7 +126,7 @@ class Sfp(SfpBase):
     # Path to sysfs
     PLATFORM_ROOT_PATH = "/usr/share/sonic/device"
     PMON_HWSKU_PATH = "/usr/share/sonic/hwsku"
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
 
     PLATFORM = "x86_64-accton_as4630_54te-r0"
     HWSKU = "Accton-AS4630-54TE"

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/chassis.py
@@ -11,6 +11,7 @@ import os
 try:
     from sonic_platform_base.chassis_base import ChassisBase
     from .helper import APIHelper
+    from .event import SfpEvent
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -59,6 +60,7 @@ class Chassis(ChassisBase):
             else:
                 sfp_module = Sfp(index, 'SFP')
             self._sfp_list.append(sfp_module)
+        self._sfpevent = SfpEvent(self._sfp_list)
         self.sfp_module_initialized = True
 
     def __initialize_fan(self):
@@ -176,6 +178,12 @@ class Chassis(ChassisBase):
 
 
         return ('REBOOT_CAUSE_NON_HARDWARE', sw_reboot_cause)
+
+    def get_change_event(self, timeout=0):
+        # SFP event
+        if not self.sfp_module_initialized:
+            self.__initialize_sfp()
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/chassis.py
@@ -29,7 +29,7 @@ HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
 PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
 
 
 class Chassis(ChassisBase):

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/event.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/event.py
@@ -1,0 +1,62 @@
+try:
+    import time
+    from .helper import APIHelper
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._api_helper = APIHelper()
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp._port_num-1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp._port_num-1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/helper.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/helper.py
@@ -4,7 +4,7 @@ import subprocess
 from mmap import *
 from sonic_py_common import device_info
 
-HOST_CHK_CMD = "docker > /dev/null 2>&1"
+HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
 EMPTY_STRING = ""
 
 

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/sfp.py
@@ -272,7 +272,7 @@ I2C_EEPROM_PATH = '/sys/bus/i2c/devices/{0}-0050/eeprom'
 
 class Sfp(SfpBase):
     """Platform-specific Sfp class"""
-    HOST_CHK_CMD = "docker > /dev/null 2>&1"
+    HOST_CHK_CMD = "which systemctl > /dev/null 2>&1"
     PLATFORM = "x86_64-accton_as9726_32d-r0"
     HWSKU = "Accton-AS9726-32D"
 


### PR DESCRIPTION
Same as https://github.com/Azure/sonic-buildimage/pull/8900
models: AS4630-54TE, AS9726-32D

#### Why I did it
Correct get_change_event() wait and timeout mechanism to avoid high CPU utilization.

#### How I did it
Make sure get_change_event() behaves as documentation said, it can block the caller and handle timeout appropriately.

#### How to verify it
In pmon,

Use top to measure CPU usage of xcvrd. Make a comparison to confirm the improvement on CPU usage.
Code a script to keep polling get_change_event() and see if the returned data is exactly what we expect.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012: some of our customers demands it.
- [x] 202106: some of our customers demands it.

#### Description for the changelog
[Accton] Fix xcvr busy issue

#### A picture of a cute animal (not mandatory but encouraged)
![Alt Text](https://media.giphy.com/media/X3Yj4XXXieKYM/giphy.gif)
