### PR TITLE
[Accton][PDDF] Fix high CPU utilization caused by chassis.get_change_event()

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/chassis.py
@@ -8,8 +8,8 @@
 
 try:
     import sys
-    import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -21,45 +21,11 @@ class Chassis(PddfChassis):
 
     def __init__(self, pddf_data=None, pddf_plugin_data=None):
         PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self._sfpevent = SfpEvent(self.get_all_sfps())
 
     # Provide the functions/variables below for which implementation is to be overwritten
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_change_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
-
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
-
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-
-        bitmap = 0
-        for i in range(58):
-            modpres = self.get_sfp(i+1).get_presence()
-            if modpres:
-                bitmap = bitmap | (1 << i)
-
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
-            for i in range(58):
-                if (changed_ports & (1 << i)):
-                    if (bitmap & (1 << i)) == 0:
-                        port_dict[i+1] = '0'
-                    else:
-                        port_dict[i+1] = '1'
-
-
-            # Update teh cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
-            return True, change_dict
-        else:
-            return True, change_dict
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/event.py
@@ -1,0 +1,60 @@
+try:
+    import time
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.get_position_in_parent() - 1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.get_position_in_parent() - 1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/sfp.py
@@ -15,3 +15,6 @@ class Sfp(PddfSfp):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_position_in_parent(self):
+        """Retrieves 1-based relative physical position in parent device."""
+        return self.port_index

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/chassis.py
@@ -8,8 +8,8 @@
 
 try:
     import sys
-    import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -21,46 +21,11 @@ class Chassis(PddfChassis):
 
     def __init__(self, pddf_data=None, pddf_plugin_data=None):
         PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self._sfpevent = SfpEvent(self.get_all_sfps())
 
     # Provide the functions/variables below for which implementation is to be overwritten
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_change_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
-
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
-
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-        
-        bitmap = 0
-        for i in range(34):
-            modpres = self.get_sfp(i+1).get_presence()
-            if modpres:
-                bitmap = bitmap | (1 << i)
-
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
-            for i in range(34):
-                if (changed_ports & (1 << i)):
-                    if (bitmap & (1 << i)) == 0:
-                        port_dict[i+1] = '0'
-                    else:
-                        port_dict[i+1] = '1'
-
-
-            # Update teh cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
-            return True, change_dict
-        else:
-            return True, change_dict
-
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/event.py
@@ -1,0 +1,60 @@
+try:
+    import time
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.get_position_in_parent() - 1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.get_position_in_parent() - 1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/sfp.py
@@ -15,3 +15,6 @@ class Sfp(PddfSfp):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_position_in_parent(self):
+        """Retrieves 1-based relative physical position in parent device."""
+        return self.port_index

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/chassis.py
@@ -8,8 +8,8 @@
 
 try:
     import sys
-    import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -21,46 +21,11 @@ class Chassis(PddfChassis):
 
     def __init__(self, pddf_data=None, pddf_plugin_data=None):
         PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self._sfpevent = SfpEvent(self.get_all_sfps())
 
     # Provide the functions/variables below for which implementation is to be overwritten
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_change_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
-
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
-
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-        
-        bitmap = 0
-        for i in range(64):
-            modpres = self.get_sfp(i+1).get_presence()
-            if modpres:
-                bitmap = bitmap | (1 << i)
-
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
-            for i in range(64):
-                if (changed_ports & (1 << i)):
-                    if (bitmap & (1 << i)) == 0:
-                        port_dict[i+1] = '0'
-                    else:
-                        port_dict[i+1] = '1'
-
-
-            # Update teh cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
-            return True, change_dict
-        else:
-            return True, change_dict
-
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/event.py
@@ -1,0 +1,60 @@
+try:
+    import time
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.get_position_in_parent() - 1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.get_position_in_parent() - 1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/sfp.py
@@ -15,3 +15,6 @@ class Sfp(PddfSfp):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_position_in_parent(self):
+        """Retrieves 1-based relative physical position in parent device."""
+        return self.port_index

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/chassis.py
@@ -8,8 +8,8 @@
 
 try:
     import sys
-    import time
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
+    from .event import SfpEvent
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -21,46 +21,11 @@ class Chassis(PddfChassis):
 
     def __init__(self, pddf_data=None, pddf_plugin_data=None):
         PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
+        self._sfpevent = SfpEvent(self.get_all_sfps())
 
     # Provide the functions/variables below for which implementation is to be overwritten
-    sfp_change_event_data = {'valid': 0, 'last': 0, 'present': 0}
-    def get_change_event(self, timeout=2000):
-        now = time.time()
-        port_dict = {}
-        change_dict = {}
-        change_dict['sfp'] = port_dict
-
-        if timeout < 1000:
-            timeout = 1000
-        timeout = timeout / float(1000)  # Convert to secs
-
-        if now < (self.sfp_change_event_data['last'] + timeout) and self.sfp_change_event_data['valid']:
-            return True, change_dict
-        
-        bitmap = 0
-        for i in range(34):
-            modpres = self.get_sfp(i+1).get_presence()
-            if modpres:
-                bitmap = bitmap | (1 << i)
-
-        changed_ports = self.sfp_change_event_data['present'] ^ bitmap
-        if changed_ports:
-            for i in range(34):
-                if (changed_ports & (1 << i)):
-                    if (bitmap & (1 << i)) == 0:
-                        port_dict[i+1] = '0'
-                    else:
-                        port_dict[i+1] = '1'
-
-
-            # Update teh cache dict
-            self.sfp_change_event_data['present'] = bitmap
-            self.sfp_change_event_data['last'] = now
-            self.sfp_change_event_data['valid'] = 1
-            return True, change_dict
-        else:
-            return True, change_dict
-
+    def get_change_event(self, timeout=0):
+        return self._sfpevent.get_sfp_event(timeout)
 
     def get_sfp(self, index):
         """

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/event.py
@@ -1,0 +1,60 @@
+try:
+    import time
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError(repr(e) + " - required module not found")
+
+POLL_INTERVAL_IN_SEC = 1
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    def __init__(self, sfp_list):
+        self._sfp_list = sfp_list
+        self._logger = Logger()
+        self._sfp_change_event_data = {'present': 0}
+
+    def get_presence_bitmap(self):
+        bitmap = 0
+        for sfp in self._sfp_list:
+            modpres = sfp.get_presence()
+            i=sfp.get_position_in_parent() - 1
+            if modpres:
+                bitmap = bitmap | (1 << i)
+        return bitmap
+
+    def get_sfp_event(self, timeout=2000):
+        port_dict = {}
+        change_dict = {}
+        change_dict['sfp'] = port_dict
+
+        if timeout < 1000:
+            cd_ms = 1000
+        else:
+            cd_ms = timeout
+
+        while cd_ms > 0:
+            bitmap = self.get_presence_bitmap()
+            changed_ports = self._sfp_change_event_data['present'] ^ bitmap
+            if changed_ports != 0:
+                break
+            time.sleep(POLL_INTERVAL_IN_SEC)
+            # timeout=0 means wait for event forever
+            if timeout != 0:
+                cd_ms = cd_ms - POLL_INTERVAL_IN_SEC * 1000
+
+        if changed_ports != 0:
+            for sfp in self._sfp_list:
+                i=sfp.get_position_in_parent() - 1
+                if (changed_ports & (1 << i)):
+                    if (bitmap & (1 << i)) == 0:
+                        port_dict[i+1] = '0'
+                    else:
+                        port_dict[i+1] = '1'
+
+
+            # Update the cache dict
+            self._sfp_change_event_data['present'] = bitmap
+            return True, change_dict
+        else:
+            return True, change_dict

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/sfp.py
@@ -15,3 +15,6 @@ class Sfp(PddfSfp):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_position_in_parent(self):
+        """Retrieves 1-based relative physical position in parent device."""
+        return self.port_index


### PR DESCRIPTION
Same as https://github.com/Azure/sonic-buildimage/pull/8900
but only for PDDF models: AS7326-56x, as7726-32x, as7816-64x, as9716-32x

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Correct get_change_event() wait and timeout mechanism to avoid high CPU utilization.

#### How I did it
Make sure get_change_event() behaves as documentation said: can block the caller and handle timeout appropriately.

#### How to verify it
In pmon,

1. Use top to measure CPU usage of xcvrd. Make a comparison to confirm the improvement in CPU usage.
2. Code a script to keep polling get_change_event() and see if the returned data is exactly what we expect.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106: some of our customers demands it.

#### Description for the changelog
[Accton][PDDF] Fix xcvrd busy issue
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### A picture of a cute animal (not mandatory but encouraged)
![Alt Text](https://media.giphy.com/media/X3Yj4XXXieKYM/giphy.gif)
