### PR TITLE
[ACL] enable ACL FC when genereting config from minigraph but disable by default

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -43,6 +43,7 @@ def enable_counters():
     enable_counter_group(db, 'QUEUE_WATERMARK')
     enable_counter_group(db, 'BUFFER_POOL_WATERMARK')
     enable_counter_group(db, 'PORT_BUFFER_DROP')
+    enable_counter_group(db, 'ACL')
     enable_rates()
 
 

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -21,8 +21,8 @@
     },
     "FLEX_COUNTER_TABLE": {
         "ACL": {
-            "FLEX_COUNTER_STATUS": "disable",
-            "FLEX_COUNTER_DELAY_STATUS": "false",
+            "FLEX_COUNTER_STATUS": "enable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
             "POLL_INTERVAL": "10000"
         }
     },

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -19,6 +19,13 @@
 {% endfor %}
         }
     },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "false",
+            "POLL_INTERVAL": "10000"
+        }
+    },
 {%- set features = [("bgp", "enabled", false, "enabled"),
                    ("database", "always_enabled", false, "always_enabled"),
                    ("lldp", "enabled", false, "enabled"),

--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -10,6 +10,16 @@ if sys.version_info.major == 3:
 else:
     UNICODE_TYPE = unicode
 
+def generate_common_config(data):
+    data['FLEX_COUNTER_TABLE'] = {
+        'ACL': {
+            'FLEX_COUNTER_STATUS': 'disable',
+            'FLEX_COUNTER_DELAY_STATUS': 'true',
+            'POLL_INTERVAL': '10000'
+        }
+    }
+    return data
+
 # The following config generation methods exits:
 #    't1': generate_t1_sample_config,
 #    'l2': generate_l2_config,
@@ -160,5 +170,6 @@ def get_available_config():
     return list(_sample_generators.keys())
 
 def generate_sample_config(data, setting_name):
+    data = generate_common_config(data)
     return _sample_generators[setting_name.lower()](data)
 

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1271,6 +1271,13 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         'synchronous_mode': 'enable'
         }
     }
+    results['FLEX_COUNTER_TABLE'] = {
+        'ACL': {
+            'FLEX_COUNTER_STATUS': 'enable',
+            'FLEX_COUNTER_DELAY_STATUS': 'false',
+            'POLL_INTERVAL': '10000'
+        }
+    }
 
     cluster = [devices[key] for key in devices if key.lower() == hostname.lower()][0].get('cluster', "")
     if cluster:

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1271,13 +1271,6 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         'synchronous_mode': 'enable'
         }
     }
-    results['FLEX_COUNTER_TABLE'] = {
-        'ACL': {
-            'FLEX_COUNTER_STATUS': 'enable',
-            'FLEX_COUNTER_DELAY_STATUS': 'true',
-            'POLL_INTERVAL': '10000'
-        }
-    }
 
     cluster = [devices[key] for key in devices if key.lower() == hostname.lower()][0].get('cluster', "")
     if cluster:

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1274,7 +1274,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     results['FLEX_COUNTER_TABLE'] = {
         'ACL': {
             'FLEX_COUNTER_STATUS': 'enable',
-            'FLEX_COUNTER_DELAY_STATUS': 'false',
+            'FLEX_COUNTER_DELAY_STATUS': 'true',
             'POLL_INTERVAL': '10000'
         }
     }

--- a/src/sonic-config-engine/tests/sample_output/py3/l1_intfs.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l1_intfs.json
@@ -257,5 +257,12 @@
             "mtu": "9100",
             "speed": "100000"
         }
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/l2switch.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l2switch.json
@@ -264,5 +264,12 @@
         "Vlan1000|Ethernet124": {
             "tagging_mode": "untagged"
         }
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/l2switch_dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l2switch_dualtor.json
@@ -643,5 +643,12 @@
             "server_ipv6": "fc02:1000::19/128",
             "state": "auto"
         }
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/l3_intfs.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l3_intfs.json
@@ -297,5 +297,12 @@
         "Ethernet29": {},
         "Ethernet30": {},
         "Ethernet31": {}
+    },
+    "FLEX_COUNTER_TABLE": {
+        "ACL": {
+            "FLEX_COUNTER_STATUS": "disable",
+            "FLEX_COUNTER_DELAY_STATUS": "true",
+            "POLL_INTERVAL": "10000"
+        }
     }
 }

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -62,6 +62,7 @@ setup(
                          './yang-models/sonic-nat.yang',
                          './yang-models/sonic-port.yang',
                          './yang-models/sonic-portchannel.yang',
+                         './yang-models/sonic-pfcwd.yang',
                          './yang-models/sonic-route-common.yang',
                          './yang-models/sonic-route-map.yang',
                          './yang-models/sonic-routing-policy-sets.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -879,7 +879,18 @@
                 "polling_interval": "0"
             }
         },
-
+        "PFC_WD": {
+            "Ethernet9": {
+               "action": "drop",
+               "detection_time": "100",
+               "restoration_time": "400"
+            }
+        },
+        "PFC_WD": {
+            "GLOBAL": {
+                "POLL_INTERVAL": "100"
+            }
+        },
         "SFLOW_COLLECTOR": {
             "collector1": {
                 "collector_ip": "10.100.12.13",
@@ -908,7 +919,6 @@
                 "agent_id": "Ethernet0"
             }
         },
-
         "AAA": {
             "authentication": {
                 "login": "local" 
@@ -925,7 +935,6 @@
                 "timeout": "10"
             }
         },
-
         "NAT_BINDINGS": {
             "bind1": {
                 "nat_pool": "pool1",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
@@ -1,0 +1,42 @@
+{
+    "PFC_WDOG_WITH_CORRECT_ACTION_DROP_VALUE": {
+        "desc": "PFC_WDOG_WITH_CORRECT_ACTION_DROP_VALUE no failure."
+    },
+    "PFC_WDOG_WITH_CORRECT_ACTION_FORWARD_VALUE": {
+        "desc": "PFC_WDOG_WITH_CORRECT_ACTION_FORWARD_VALUE no failure."
+    },
+    "PFC_WDOG_WITH_CORRECT_ACTION_ALERT_VALUE": {
+        "desc": "PFC_WDOG_WITH_CORRECT_ACTION_ALERT_VALUE no failure."
+    },
+    "PFC_WDOG_WITH_WRONG_ACTION_VALUE": {
+        "desc": "PFC_WDOG_WITH_WRONG_ACTION_VALUE must contain a valid action",
+        "eStr": [ "wrong" ]
+    },
+    "PFC_WDOG_WITH_CORRECT_POLL_INTERVAL_VALUE": {
+        "desc": "PFC_WDOG_WITH_CORRECT_POLL_INTERVAL_VALUE no failure"
+    },
+    "PFC_WDOG_WITH_WRONG_POLL_INTERVAL_LOW_VALUE": {
+        "desc": "PFC_WDOG_WITH_WRONG_POLL_INTERVAL_LOW_VALUE",
+        "eStr": "range"
+    },
+    "PFC_WDOG_WITH_WRONG_POLL_INTERVAL_HIGH_VALUE": {
+        "desc": "PFC_WDOG_WITH_WRONG_POLL_INTERVAL_HIGH_VALUE",
+        "eStr": "range"
+    },
+    "PFC_WDOG_WITH_WRONG_DETECTION_TIME_LOW_VALUE": {
+        "desc": "PFC_WDOG_WITH_WRONG_DETECTION_TIME_LOW_VALUE",
+        "eStr": "range"
+    },
+    "PFC_WDOG_WITH_WRONG_DETECTION_TIME_HIGH_VALUE": {
+        "desc": "PFC_WDOG_WITH_WRONG_DETECTION_TIME_HIGH_VALUE",
+        "eStr": "range"
+    },
+    "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_LOW_VALUE": {
+        "desc": "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_LOW_VALUE",
+        "eStr": "range"
+    },
+    "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_HIGH_VALUE": {
+        "desc": "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_HIGH_VALUE",
+        "eStr": "range"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/pfc.json
@@ -1,0 +1,199 @@
+{
+    "PFC_WDOG_WITH_CORRECT_ACTION_DROP_VALUE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 300,
+                        "restoration_time": 3000
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_CORRECT_ACTION_FORWARD_VALUE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "forward",
+                        "detection_time": 300,
+                        "restoration_time": 3000
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_CORRECT_ACTION_ALERT_VALUE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "alert",
+                        "detection_time": 300,
+                        "restoration_time": 3000
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_WRONG_ACTION_VALUE": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "wrong",
+                        "detection_time": 300,
+                        "restoration_time": 3000
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_CORRECT_POLL_INTERVAL_VALUE": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "GLOBAL",
+                        "POLL_INTERVAL": 101
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_WRONG_POLL_INTERVAL_LOW_VALUE": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "GLOBAL",
+                        "POLL_INTERVAL":99
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_WRONG_POLL_INTERVAL_HIGH_VALUE": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "GLOBAL",
+                        "POLL_INTERVAL": 3001
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_WRONG_DETECTION_TIME_LOW_VALUE": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 99,
+                        "restoration_time": 3000
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_WRONG_DETECTION_TIME_HIGH_VALUE": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "wrong",
+                        "detection_time": 5001,
+                        "restoration_time": 3000
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_LOW_VALUE": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 99,
+                        "restoration_time": 3000
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_HIGH_VALUE": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "wrong",
+                        "detection_time": 60001,
+                        "restoration_time": 3000
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
@@ -1,0 +1,79 @@
+module sonic-pfcwd {
+    namespace "http://github.com/Azure/sonic-pfcwd";
+    prefix sonic-pfcwd;
+
+    yang-version 1.1;
+
+    import sonic-port {
+        prefix port;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONIC PFC Watchdog parameters";
+
+    revision 2021-07-01 {
+        description
+            "Initial revision.";
+    }
+
+    container sonic-pfcwd {
+        container PFC_WD {
+            list PFC_WD_LIST {
+                key "ifname";
+                leaf ifname {
+                    type union {
+                        type leafref {
+                            path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
+                        }
+                        type string {
+                            pattern "GLOBAL" {
+                                error-message "Invalid interface name";
+                                error-app-tag interface-name-invalid;
+                            }
+                        }
+                    }
+                }
+                leaf action {
+                    must "../ifname != 'GLOBAL'";
+                    type enumeration {
+                        enum drop;
+                        enum forward;
+                        enum alert;
+                    }
+                    description
+                        "PFC watchdog action when entering storm state.";
+                }
+                leaf detection_time {
+                    must "../ifname != 'GLOBAL'";
+                    type uint32 {
+                        range 100..5000;
+                    }
+                    description
+                        "Detection interval for pause storm in msec.";
+                }
+                leaf restoration_time {
+                    must "../ifname != 'GLOBAL'";
+                    type uint32 {
+                        range 100..60000;
+                    }
+                    description
+                        "Time delay before resuming normal PFC operation in msec.";
+                }
+                leaf POLL_INTERVAL {
+                    must "../ifname = 'GLOBAL'";
+                    type uint32 {
+                        range 100..3000;
+                    }
+                    description
+                        "PFC watchdog global polling interval in msec.";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To support ACL counters on Flex Counter Infrastructure.

#### How I did it

Enable ACL FC in init_cfg and minigraph. Disable when genereting configuration from preset.

#### How to verify it

Together with depends PRs. Run ACL/Everflow test suite.

DEPENDS ON: Azure/sonic-swss-common#533 Azure/sonic-sairedis#953 Azure/sonic-swss#1943
HLD: Azure/SONiC#857

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

