### PR TITLE
[frrcfgd][bgpcfgd] Add portchannel support

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -189,7 +189,7 @@ class IpNextHop:
     def is_zero_ip(self):
         try:
             return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0
-        except:
+        except socket.error:
             return False
     def is_portchannel(self):
         return True if self.ip.startswith('PortChannel') else False

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -185,7 +185,7 @@ class IpNextHop:
     def __hash__(self):
         return hash((self.af, self.blackhole, self.ip, self.interface, self.distance, self.nh_vrf))
     def is_ip_valid(self):
-        socket.inet_aton(self.ip)
+        socket.inet_pton(self.af, self.ip)
     def is_zero_ip(self):
         try:
             return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -169,7 +169,7 @@ class IpNextHop:
         self.ip = zero_ip(af_id) if dst_ip is None or dst_ip == '' else dst_ip
         self.interface = '' if if_name is None else if_name
         self.nh_vrf = '' if vrf is None else vrf
-        if self.blackhole != 'true' and self.is_zero_ip() and len(self.interface.strip()) == 0:
+        if self.blackhole != 'true' and self.is_zero_ip() and not self.is_portchannel() and len(self.interface.strip()) == 0:
             log_err('Mandatory attribute not found for nexthop')
             raise ValueError
     def __eq__(self, other):
@@ -183,10 +183,12 @@ class IpNextHop:
     def __hash__(self):
         return hash((self.af, self.blackhole, self.ip, self.interface, self.distance, self.nh_vrf))
     def is_zero_ip(self):
-        if self.ip.startswith('PortChannel'):
-            return False
-        else:
+        try:
             return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0
+        except:
+            return False
+    def is_portchannel(self):
+        return True if self.ip.startswith('PortChannel') else False
     def __format__(self, format):
         ret_val = ''
         if self.blackhole == 'true':

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -183,7 +183,10 @@ class IpNextHop:
     def __hash__(self):
         return hash((self.af, self.blackhole, self.ip, self.interface, self.distance, self.nh_vrf))
     def is_zero_ip(self):
-        return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0
+        if self.ip.startswith('PortChannel'):
+            return False
+        else:
+            return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0
     def __format__(self, format):
         ret_val = ''
         if self.blackhole == 'true':

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -169,6 +169,8 @@ class IpNextHop:
         self.ip = zero_ip(af_id) if dst_ip is None or dst_ip == '' else dst_ip
         self.interface = '' if if_name is None else if_name
         self.nh_vrf = '' if vrf is None else vrf
+        if not self.is_portchannel():
+            self.is_ip_valid()
         if self.blackhole != 'true' and self.is_zero_ip() and not self.is_portchannel() and len(self.interface.strip()) == 0:
             log_err('Mandatory attribute not found for nexthop')
             raise ValueError
@@ -182,6 +184,8 @@ class IpNextHop:
                 self.distance != other.distance or self.nh_vrf != other.nh_vrf)
     def __hash__(self):
         return hash((self.af, self.blackhole, self.ip, self.interface, self.distance, self.nh_vrf))
+    def is_ip_valid(self):
+        socket.inet_aton(self.ip)
     def is_zero_ip(self):
         try:
             return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -71,17 +71,37 @@ def test_set():
         ]
     )
 
-def test_set_portchannel_nexthop():
+def test_set_nhportchannel():
     mgr = constructor()
     set_del_test(
         mgr,
         "SET",
         ("10.1.0.0/24", {
-            "nexthop": "PortChannel0002",
+            "nexthop": "PortChannel0001",
         }),
         True,
         [
-            "ip route 10.1.0.0/24 PortChannel0002",
+            "ip route 10.1.0.0/24 PortChannel0001",
+            "router bgp 65100",
+            " address-family ipv4",
+            "  redistribute static",
+            " address-family ipv6",
+            "  redistribute static"
+        ]
+    )
+
+def test_set_several_nhportchannels():
+    mgr = constructor()
+    set_del_test(
+        mgr,
+        "SET",
+        ("10.1.0.0/24", {
+            "nexthop": "PortChannel0003,PortChannel0004",
+        }),
+        True,
+        [
+            "ip route 10.1.0.0/24 PortChannel0003",
+            "ip route 10.1.0.0/24 PortChannel0004",
             "router bgp 65100",
             " address-family ipv4",
             "  redistribute static",

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -93,9 +93,7 @@ def test_set_nhportchannel():
     set_del_test(
         mgr,
         "DEL",
-        ("10.1.0.0/24", {
-            "nexthop": "PortChannel0001",
-        }),
+        ("10.1.0.0/24",),
         True,
         [
             "no ip route 10.1.0.0/24 PortChannel0001",

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -90,6 +90,23 @@ def test_set_nhportchannel():
         ]
     )
 
+    set_del_test(
+        mgr,
+        "DEL",
+        ("10.1.0.0/24", {
+            "nexthop": "PortChannel0001",
+        }),
+        True,
+        [
+            "no ip route 10.1.0.0/24 PortChannel0001",
+            "router bgp 65100",
+            " address-family ipv4",
+            "  no redistribute static",
+            " address-family ipv6",
+            "  no redistribute static"
+        ]
+    )
+
 def test_set_several_nhportchannels():
     mgr = constructor()
     set_del_test(

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -71,6 +71,25 @@ def test_set():
         ]
     )
 
+def test_set_portchannel_nexthop():
+    mgr = constructor()
+    set_del_test(
+        mgr,
+        "SET",
+        ("10.1.0.0/24", {
+            "nexthop": "PortChannel0002",
+        }),
+        True,
+        [
+            "ip route 10.1.0.0/24 PortChannel0002",
+            "router bgp 65100",
+            " address-family ipv4",
+            "  redistribute static",
+            " address-family ipv6",
+            "  redistribute static"
+        ]
+    )
+
 def test_set_nhvrf():
     mgr = constructor()
     set_del_test(

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1659,7 +1659,7 @@ class IpNextHop:
     def is_zero_ip(self):
         try:
             return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0
-        except:
+        except socket.error:
             return False
     def is_portchannel(self):
         return True if self.ip.startswith('PortChannel') else False

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1655,7 +1655,7 @@ class IpNextHop:
         return 'AF %d BKH %s IP %s TRACK %d INTF %s TAG %d DIST %d VRF %s' % (
                 self.af, self.blackhole, self.ip, self.track, self.interface, self.tag, self.distance, self.nh_vrf)
     def is_ip_valid(self):
-        return True
+        socket.inet_pton(self.af, self.ip)
     def is_zero_ip(self):
         try:
             return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1636,7 +1636,7 @@ class IpNextHop:
         self.interface = '' if if_name is None else if_name
         self.tag = 0 if tag is None else int(tag)
         self.nh_vrf = '' if vrf is None else vrf
-        if self.blackhole != 'true' and self.is_zero_ip() and len(self.interface.strip()) == 0:
+        if self.blackhole != 'true' and self.is_zero_ip() and not self.is_portchannel() and len(self.interface.strip()) == 0:
             syslog.syslog(syslog.LOG_ERR, 'Mandatory attribute not found for nexthop')
             raise ValueError
     def __eq__(self, other):
@@ -1653,10 +1653,12 @@ class IpNextHop:
         return 'AF %d BKH %s IP %s TRACK %d INTF %s TAG %d DIST %d VRF %s' % (
                 self.af, self.blackhole, self.ip, self.track, self.interface, self.tag, self.distance, self.nh_vrf)
     def is_zero_ip(self):
-        if self.ip.startswith('PortChannel'):
-            return False
-        else:
+        try:
             return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0
+        except:
+            return False
+    def is_portchannel(self):
+        return True if self.ip.startswith('PortChannel') else False
     def get_arg_list(self):
         arg = lambda x: '' if x is None else x
         num_arg = lambda x: '' if x is None or x == 0 else str(x)

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1653,7 +1653,10 @@ class IpNextHop:
         return 'AF %d BKH %s IP %s TRACK %d INTF %s TAG %d DIST %d VRF %s' % (
                 self.af, self.blackhole, self.ip, self.track, self.interface, self.tag, self.distance, self.nh_vrf)
     def is_zero_ip(self):
-        return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0
+        if self.ip.startswith('PortChannel'):
+            return False
+        else:
+            return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0
     def get_arg_list(self):
         arg = lambda x: '' if x is None else x
         num_arg = lambda x: '' if x is None or x == 0 else str(x)

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1636,6 +1636,8 @@ class IpNextHop:
         self.interface = '' if if_name is None else if_name
         self.tag = 0 if tag is None else int(tag)
         self.nh_vrf = '' if vrf is None else vrf
+        if not self.is_portchannel():
+            self.is_ip_valid()
         if self.blackhole != 'true' and self.is_zero_ip() and not self.is_portchannel() and len(self.interface.strip()) == 0:
             syslog.syslog(syslog.LOG_ERR, 'Mandatory attribute not found for nexthop')
             raise ValueError
@@ -1652,6 +1654,8 @@ class IpNextHop:
     def __str__(self):
         return 'AF %d BKH %s IP %s TRACK %d INTF %s TAG %d DIST %d VRF %s' % (
                 self.af, self.blackhole, self.ip, self.track, self.interface, self.tag, self.distance, self.nh_vrf)
+    def is_ip_valid(self):
+        return True
     def is_zero_ip(self):
         try:
             return sum([x for x in socket.inet_pton(self.af, self.ip)]) == 0


### PR DESCRIPTION
#### Why I did it
To add portchannel support in frrcfgd and bgpcfgd.
fix Azure/sonic-buildimage#8907

#### How I did it
Added handling of the portchannel name as an IP address by adding check in is_zero_ip() to prevent parsing portchannel name with socket.inet_pton().

#### How to verify it
```
config portchannel add PortChannel0001
config portchannel add PortChannel0002
sudo config route add prefix 20.0.0.1/32 nexthop PortChannel0001
sudo config route add prefix 20.0.0.1/32 nexthop PortChannel0002
```

```
admin@sonic:~$ show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup

S>* 0.0.0.0/0 [200/0] via 192.168.111.3, eth0, weight 1, 00:00:45
C>* 10.1.0.1/32 is directly connected, Loopback0, 00:00:46
S   20.0.0.1/32 [1/0] is directly connected, PortChannel0001 inactive, weight 1, 00:00:09
                      is directly connected, PortChannel0002 inactive, weight 1, 00:00:09
C>* 30.0.0.0/24 is directly connected, Ethernet0, 00:00:46
C>* 192.168.111.0/24 is directly connected, eth0, 00:00:46
```



