### PR TITLE
[201811][jessie] address Jessie docker cert expiry issue

### DIFF
--- a/sonic-slave/Dockerfile
+++ b/sonic-slave/Dockerfile
@@ -330,3 +330,6 @@ RUN add-apt-repository \
 RUN apt-get update
 RUN apt-get install -y docker-ce=17.03.2~ce-0~debian-jessie
 RUN echo "DOCKER_OPTS=\"--experimental --storage-driver=vfs\"" >> /etc/default/docker
+
+# Remove the stale cert and refresh the certs
+RUN apt-get install --reinstall ca-certificates && rm -f /etc/ssl/certs/DST_Root_CA_X3.pem && rm -f /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates


### PR DESCRIPTION
#### Why I did it
201811 branch image build has been failing due to the certificate expiring: https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021. This issue so far only affect Jessie docker because it is using openssl 1.0.

#### How I did it
Remove the expired cert and refresh the certs bundle.

#### How to verify it
Build image.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
