### PR TITLE
[determine-reboot-cause] delay execution

### DIFF
--- a/src/sonic-host-services-data/debian/sonic-host-services-data.determine-reboot-cause.service
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.determine-reboot-cause.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Reboot cause determination service
-Requires=rc-local.service
-After=rc-local.service
+Requires=rc-local.service database.service
+After=rc-local.service database.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Since database.service has been moved to execute after rc-local.service,
and determine-reboot-cause.service rely on database.service, we have to
specify that in "After=".

Signed-off-by: Xichen Lin <xichenlin@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes #8934, "show reboot-cause" always show "Unknown".

#### How I did it
Delay execution of determine-reboot-cause, which produces result for "show reboot-cause"
.
#### How to verify it
Test it on dut.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Include database.service in After and Required for determine-reboot-cause.service.

#### A picture of a cute animal (not mandatory but encouraged)

