### PR TITLE
[swss.sh] fix an issue that dependent services are not read from a file

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -12,6 +12,8 @@ ETC_SONIC_PATH="/etc/sonic/"
 DEPENDENT="radv"
 MULTI_INST_DEPENDENT="teamd"
 
+. /usr/local/bin/asic_status.sh
+
 function debug()
 {
     /usr/bin/logger $1
@@ -28,8 +30,6 @@ function read_dependent_services()
     if [[ -f ${ETC_SONIC_PATH}/${SERVICE}_multi_inst_dependent ]]; then
         MULTI_INST_DEPENDENT="${MULTI_INST_DEPENDENT} cat ${ETC_SONIC_PATH}/${SERVICE}_multi_inst_dependent"
     fi
-
-    . /usr/local/bin/asic_status.sh
 }
 
 function lock_service_state_change()


### PR DESCRIPTION
This is due to the SERVICE variable declared after reading a file

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To fix an issue that dhcp_relay does not restart with swss.

#### How I did it

Fixed in the swss.sh script

#### How to verify it

sudo systemctl restart swss
verify dhcp_relay restarts as well.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

