### PR TITLE
[sonic-slave]: Add gmock for sonic-swss-common tests 

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -235,6 +235,8 @@ RUN apt-get update && apt-get install -y \
 # For gtest
         libgtest-dev \
         cmake \
+# For gmock
+        libgmock-dev \
 # For pam_tacplus build
         autoconf-archive \
 # For iproute2

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -243,6 +243,8 @@ RUN apt-get update && apt-get install -y \
 # For gtest
         libgtest-dev \
         cmake \
+# For gmock
+        libgmock-dev \
 # For pam_tacplus build
         autoconf-archive \
 # For iproute2


### PR DESCRIPTION
Signed-off-by: Don Newton <don@opennetworking.org>


#### Why I did it
Sonic-swss-common requires gmock for staged unit tests
#### How I did it
Installed dependency in sonic-buster-build docker file
#### How to verify it
rebuild the build container


