### PR TITLE
[201811] Invoke disk check periodically

### DIFF
--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -25,6 +25,5 @@ check process rsyslog with pidfile /var/run/rsyslogd.pid
 # Raise syslog error message, in case of underlying issues
 #
 check program diskCheck with path "/usr/local/bin/disk_check.py"
-    every 5 cycles
-    if status != 0 for 3 cycle then alert repeat every 1 cycles
+    if status != 0 then alert
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When disk become read-only (kernel bug), it blocks new remote users access.
This fix would enable remote user access even in read-only state

#### How I did it
Keep monitoring disk state.
If it becomes read-only, mount /etc & home dir in tmpfs to become RW and periodically write error logs
With /etc & /home set in RW state, this allows remote user access

#### How to verify it
1) Make sure TACACS is configured
2) Make disk read-only (`sudo bash -c "echo u > /proc/sysrq-trigger"`)
3) Try logging in as remote user, who has not logged in before.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

