### PR TITLE
Advance the broadcom SAI to 5.0.0.11

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,12 +1,12 @@
-BRCM_SAI = libsaibcm_5.0.0.8_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_5.0.0.8_amd64.deb?sv=2015-04-05&sr=b&sig=T%2FPesnOIeN9802mClMpgk8XFQbqjFAgCnJbbNHxijHo%3D&se=2035-05-13T21%3A34%3A26Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_5.0.0.8_amd64.deb
+BRCM_SAI = libsaibcm_5.0.0.11_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_5.0.0.11_amd64.deb?sv=2020-04-08&st=2021-10-11T23%3A05%3A48Z&se=2026-01-13T00%3A05%3A00Z&sr=b&sp=r&sig=ibf4R3MH4eb9IVdf%2F8iN6tvYjxroPaxRub7oIGdRxSI%3D"
+BRCM_SAI_DEV = libsaibcm-dev_5.0.0.11_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm-dev_5.0.0.8_amd64.deb?sv=2015-04-05&sr=b&sig=X33hZLhRI3L6f4a5JFSlhJvoaTj%2B3zrmNBM9IzIA%2Bj4%3D&se=2035-05-13T21%3A35%3A58Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm-dev_5.0.0.11_amd64.deb?sv=2020-04-08&st=2021-10-11T23%3A06%3A45Z&se=2026-01-13T00%3A06%3A00Z&sr=b&sp=r&sig=LXhLM8%2Bfu%2B9ywI49nSrs4TBy1w5CY0e6CRyv1dLwJnI%3D"
 
 # SAI module for DNX Asic family
-BRCM_DNX_SAI = libsaibcm_dnx_5.0.0.8_amd64.deb
-$(BRCM_DNX_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_dnx_5.0.0.8_amd64.deb?sv=2015-04-05&sr=b&sig=uy0OW6ZhWjYntalZunEIIzHUztkOyI7TS3F73Sla9vY%3D&se=2035-05-13T21%3A37%3A06Z&sp=r"
+BRCM_DNX_SAI = libsaibcm_dnx_5.0.0.11_amd64.deb
+$(BRCM_DNX_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/5.0/master/libsaibcm_dnx_5.0.0.11_amd64.deb?sv=2020-04-08&st=2021-10-11T23%3A07%3A43Z&se=2026-01-13T00%3A07%3A00Z&sr=b&sp=r&sig=p1kqeugBvmdeggplqYk%2FY2nHTkwrTg6KTeNUYotfDyc%3D"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 SONIC_ONLINE_DEBS += $(BRCM_DNX_SAI)

--- a/platform/broadcom/saibcm-modules/debian/changelog
+++ b/platform/broadcom/saibcm-modules/debian/changelog
@@ -1,3 +1,9 @@
+opennsl (5.0.0.11) unstable; urgency=medium
+
+  * Update to Broadcom SAI 5.0.0.11
+
+ -- Judy Joseph <jujoseph@microsoft.com>  Fri, 8 Oct 2021 18:36:38 +0000
+
 opennsl (5.0.0.4) unstable; urgency=medium
 
   * Update to Broadcom SAI 5.0.0.4

--- a/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+++ b/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
@@ -6346,6 +6346,11 @@ bkn_init_ndev(u8 *mac, char *name)
     dev->max_mtu = rx_buffer_size;
 #endif
 
+    /* SAI_FIXUP SDK--255753 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0))
+    dev->max_mtu = rx_buffer_size;
+#endif
+
     /* Device vectors */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,29))
     dev->netdev_ops = &bkn_netdev_ops;


### PR DESCRIPTION
#### Why I did it
Advance the broadcom SAI to 5.0.0.11

#### How I did it

Includes the following commits/CSPs
```
9a1765cf CS00012203989: Max mtu not set at init knet interfaces
9b59e33f Fixes for CS00012195261, CS00012195512, CS00012194313, CS00012178692, CS00012192505, SDK SIDs
```

#### How to verify it
<To be updated>

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

