### PR TITLE
[mellanox] Remove validation for fw filenames with no extension

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -405,10 +405,6 @@ class Component(ComponentBase):
             if name_list[1] != self.image_ext_name:
                 print("ERROR: Extend name of file {} is wrong. Image for {} should have extend name {}".format(image_path, self.name, self.image_ext_name))
                 return False
-        else:
-            if name_list[1]:
-                print("ERROR: Extend name of file {} is wrong. Image for {} shouldn't have extension".format(image_path, self.name))
-                return False
 
         return True
 


### PR DESCRIPTION
#### Why I did it

Currently the mellanox platform API is validating the file extensions of firmware packages to be installed for basic sanity checking. However, ONIE packages do not have an extension and as such if there is a "." in the name it is taken to be an extension and then fails the sanity check. 

#### How I did it

I removed the check which ensures that ONIE images don't have a file extension. 

#### How to verify it

Name the ONIE updater file `2021.onie` and attempt to install it via `fwutil install fw 2021.onie --yes`

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog

[mellanox] Remove validation for fw filenames with no extension


#### A picture of a cute animal (not mandatory but encouraged)
![merlin_190551999_3680585e-dbdd-4bff-96ad-0d74d1239df8-superJumbo](https://user-images.githubusercontent.com/5898707/136599046-08dc97f5-397f-4ff3-bee6-03fd321b5e65.jpg)

