### PR TITLE
[YANG][DPB] Added regex with no 40G mode

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/breakout.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/breakout.json
@@ -30,6 +30,14 @@
                     {
                         "brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
                         "port": "Ethernet24"
+                    },
+                    {
+                        "brkout_mode": "2x50G[25G,10G,1G]",
+                        "port": "Ethernet28"
+                    },
+                    {
+                        "brkout_mode": "2x50G[25G,10G]",
+                        "port": "Ethernet32"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -47,7 +47,7 @@ module sonic-breakout_cfg {
                          * Add any other breakout-mode to allow Dynamic Port
                          * Breakout to that breakout-mode.
                          */
-                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]|1x25G\[10G,1G\]|1x100G\[50G,40G,25G,10G,1G\]|2x50G\[40G,25G,10G,1G\]|4x25G\[10G,1G\]|1x400G\[200G,100G,50G,40G,25G,10G,1G\]|2x200G\[100G,50G,40G,25G,10G,1G\]|4x100G\[50G,40G,25G,10G,1G\]';
+                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]|1x25G\[10G,1G\]|1x100G\[50G,40G,25G,10G,1G\]|2x50G\[25G,10G,1G\]|2x50G\[25G,10G\]|2x50G\[40G,25G,10G,1G\]|4x25G\[10G,1G\]|1x400G\[200G,100G,50G,40G,25G,10G,1G\]|2x200G\[100G,50G,40G,25G,10G,1G\]|4x100G\[50G,40G,25G,10G,1G\]';
                     }
                 }
             }


### PR DESCRIPTION
Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix for the issue caused by - [pull/8712)](https://github.com/Azure/sonic-buildimage/pull/8712).
For some platforms was removed `40G` speed mode, but the regex for Dynamic Port breakout modes validation remains the same.

#### How I did it
Added new regex for - `2x50G[25G,10G]` and `2x50G[25G,10G,1G]` breakout modes

#### How to verify it
Extended existing test case with new values.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

