### PR TITLE
[barefoot] add platform.json and hwsku.json for Newport

### DIFF
--- a/device/barefoot/x86_64-accton_as9516_32d-r0/newport/hwsku.json
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/newport/hwsku.json
@@ -1,0 +1,100 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet8": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet16": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet24": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet32": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet40": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet48": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet56": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet64": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet72": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet80": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet88": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet96": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet104": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet112": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet120": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet128": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet136": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet144": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet152": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet160": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet168": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet176": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet184": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet192": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet200": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet208": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet216": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet224": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet232": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet240": {
+            "default_brkout_mode": "1x400G[200G]"
+        },
+        "Ethernet248": {
+            "default_brkout_mode": "1x400G[200G]"
+        }
+    }
+}

--- a/device/barefoot/x86_64-accton_as9516_32d-r0/platform.json
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/platform.json
@@ -1,0 +1,388 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "index": "1,1,1,1,1,1,1,1",
+            "lanes": "0,1,2,3,4,5,6,7",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet0"],
+                "2x200G[100G,40G]": ["Ethernet0, Ethernet4"],
+                "4x100G[50G]": ["Ethernet0", "Ethernet2", "Ethernet4", "Ethernet6"],
+                "8x50G[25G,10G]": ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6", "Ethernet7"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet0", "Ethernet4", "Ethernet5", "Ethernet6", "Ethernet7"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3", "Ethernet4"]
+            }
+        },
+        "Ethernet8": {
+            "index": "2,2,2,2,2,2,2,2",
+            "lanes": "8,9,10,11,12,13,14,15",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet8"],
+                "2x200G[100G,40G]": ["Ethernet8", "Ethernet12"],
+                "4x100G[50G]": ["Ethernet8", "Ethernet10", "Ethernet12", "Ethernet14"],
+                "8x50G[25G,10G]": ["Ethernet8", "Ethernet9", "Ethernet10", "Ethernet11", "Ethernet12", "Ethernet13", "Ethernet14", "Ethernet15"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet8", "Ethernet12", "Ethernet13", "Ethernet14", "Ethernet15"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet8", "Ethernet9", "Ethernet10", "Ethernet11", "Ethernet12"]
+            }
+        },
+        "Ethernet16": {
+            "index": "3,3,3,3,3,3,3,3",
+            "lanes": "16,17,18,19,20,21,22,23",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet16"],
+                "2x200G[100G,40G]": ["Ethernet16", "Ethernet20"],
+                "4x100G[50G]": ["Ethernet16", "Ethernet18", "Ethernet20", "Ethernet22"],
+                "8x50G[25G,10G]": ["Ethernet16", "Ethernet17", "Ethernet18", "Ethernet19", "Ethernet20", "Ethernet21", "Ethernet22", "Ethernet23"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet16", "Ethernet20", "Ethernet21", "Ethernet22", "Ethernet23"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet16", "Ethernet17", "Ethernet18", "Ethernet19", "Ethernet20"]
+            }
+        },
+        "Ethernet24": {
+            "index": "4,4,4,4,4,4,4,4",
+            "lanes": "24,25,26,27,28,29,30,31",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet24"],
+                "2x200G[100G,40G]": ["Ethernet24", "Ethernet28"],
+                "4x100G[50G]": ["Ethernet24", "Ethernet26", "Ethernet28", "Ethernet30"],
+                "8x50G[25G,10G]": ["Ethernet24", "Ethernet25", "Ethernet26", "Ethernet27", "Ethernet28", "Ethernet29", "Ethernet30", "Ethernet31"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet24", "Ethernet28", "Ethernet29", "Ethernet30", "Ethernet31"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet24", "Ethernet25", "Ethernet26", "Ethernet27", "Ethernet28"]
+            }
+        },
+        "Ethernet32": {
+            "index": "5,5,5,5,5,5,5,5",
+            "lanes": "32,33,34,35,36,37,38,39",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet32"],
+                "2x200G[100G,40G]": ["Ethernet32", "Ethernet36"],
+                "4x100G[50G]": ["Ethernet32", "Ethernet34", "Ethernet36", "Ethernet38"],
+                "8x50G[25G,10G]": ["Ethernet32", "Ethernet33", "Ethernet34", "Ethernet35", "Ethernet36", "Ethernet37", "Ethernet38", "Ethernet39"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet32", "Ethernet36", "Ethernet37", "Ethernet38", "Ethernet39"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet32", "Ethernet33", "Ethernet34", "Ethernet35", "Ethernet36"]
+            }
+        },
+        "Ethernet40": {
+            "index": "6,6,6,6,6,6,6,6",
+            "lanes": "40,41,42,43,44,45,46,47",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet40"],
+                "2x200G[100G,40G]": ["Ethernet40", "Ethernet44"],
+                "4x100G[50G]": ["Ethernet40", "Ethernet42", "Ethernet44", "Ethernet46"],
+                "8x50G[25G,10G]": ["Ethernet40", "Ethernet41", "Ethernet42", "Ethernet43", "Ethernet44", "Ethernet45", "Ethernet46", "Ethernet47"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet40", "Ethernet44", "Ethernet45", "Ethernet46", "Ethernet47"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet40", "Ethernet41", "Ethernet42", "Ethernet43", "Ethernet44"]
+            }
+        },
+        "Ethernet48": {
+            "index": "7,7,7,7,7,7,7,7",
+            "lanes": "48,49,50,51,52,53,54,55",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet48"],
+                "2x200G[100G,40G]": ["Ethernet48", "Ethernet52"],
+                "4x100G[50G]": ["Ethernet48", "Ethernet50", "Ethernet52", "Ethernet54"],
+                "8x50G[25G,10G]": ["Ethernet48", "Ethernet49", "Ethernet50", "Ethernet51", "Ethernet52", "Ethernet53", "Ethernet54", "Ethernet55"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet48", "Ethernet52", "Ethernet53", "Ethernet54", "Ethernet55"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet48", "Ethernet49", "Ethernet50", "Ethernet51", "Ethernet52"]
+            }
+        },
+        "Ethernet56": {
+            "index": "8,8,8,8,8,8,8,8",
+            "lanes": "56,57,58,59,60,61,62,63",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet56"],
+                "2x200G[100G,40G]": ["Ethernet56", "Ethernet60"],
+                "4x100G[50G]": ["Ethernet56", "Ethernet58", "Ethernet60", "Ethernet62"],
+                "8x50G[25G,10G]": ["Ethernet56", "Ethernet57", "Ethernet58", "Ethernet59", "Ethernet60", "Ethernet61", "Ethernet62", "Ethernet63"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet56", "Ethernet60", "Ethernet61", "Ethernet62", "Ethernet63"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet56", "Ethernet57", "Ethernet58", "Ethernet59", "Ethernet60"]
+            }
+        },
+        "Ethernet64": {
+            "index": "9,9,9,9,9,9,9,9",
+            "lanes": "64,65,66,67,68,69,70,71",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet64"],
+                "2x200G[100G,40G]": ["Ethernet64", "Ethernet68"],
+                "4x100G[50G]": ["Ethernet64", "Ethernet66", "Ethernet68", "Ethernet70"],
+                "8x50G[25G,10G]": ["Ethernet64", "Ethernet65", "Ethernet66", "Ethernet67", "Ethernet68", "Ethernet69", "Ethernet70", "Ethernet71"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet64", "Ethernet68", "Ethernet69", "Ethernet70", "Ethernet71"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet64", "Ethernet65", "Ethernet66", "Ethernet67", "Ethernet68"]
+            }
+        },
+        "Ethernet72": {
+            "index": "10,10,10,10,10,10,10,10",
+            "lanes": "72,73,74,75,76,77,78,79",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet72"],
+                "2x200G[100G,40G]": ["Ethernet72", "Ethernet76"],
+                "4x100G[50G]": ["Ethernet72", "Ethernet74", "Ethernet76", "Ethernet78"],
+                "8x50G[25G,10G]": ["Ethernet72", "Ethernet73", "Ethernet74", "Ethernet75", "Ethernet76", "Ethernet77", "Ethernet78", "Ethernet79"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet72", "Ethernet76", "Ethernet77", "Ethernet78", "Ethernet79"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet72", "Ethernet73", "Ethernet74", "Ethernet75", "Ethernet76"]
+            }
+        },
+        "Ethernet80": {
+            "index": "11,11,11,11,11,11,11,11",
+            "lanes": "80,81,82,83,84,85,86,87",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet80"],
+                "2x200G[100G,40G]": ["Ethernet80", "Ethernet84"],
+                "4x100G[50G]": ["Ethernet80", "Ethernet82", "Ethernet84", "Ethernet86"],
+                "8x50G[25G,10G]": ["Ethernet80", "Ethernet81", "Ethernet82", "Ethernet83", "Ethernet84", "Ethernet85", "Ethernet86", "Ethernet87"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet80", "Ethernet84", "Ethernet85", "Ethernet86", "Ethernet87"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet80", "Ethernet81", "Ethernet82", "Ethernet83", "Ethernet84"]
+            }
+        },
+        "Ethernet88": {
+            "index": "12,12,12,12,12,12,12,12",
+            "lanes": "88,89,90,91,92,93,94,95",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet88"],
+                "2x200G[100G,40G]": ["Ethernet88", "Ethernet92"],
+                "4x100G[50G]": ["Ethernet88", "Ethernet90", "Ethernet92", "Ethernet94"],
+                "8x50G[25G,10G]": ["Ethernet88", "Ethernet89", "Ethernet90", "Ethernet91", "Ethernet92", "Ethernet93", "Ethernet94", "Ethernet95"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet88", "Ethernet92", "Ethernet93", "Ethernet94", "Ethernet95"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet88", "Ethernet89", "Ethernet90", "Ethernet91", "Ethernet92"]
+            }
+        },
+        "Ethernet96": {
+            "index": "13,13,13,13,13,13,13,13",
+            "lanes": "96,97,98,99,100,101,102,103",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet96"],
+                "2x200G[100G,40G]": ["Ethernet96", "Ethernet100"],
+                "4x100G[50G]": ["Ethernet96", "Ethernet98", "Ethernet100", "Ethernet102"],
+                "8x50G[25G,10G]": ["Ethernet96", "Ethernet97", "Ethernet98", "Ethernet99", "Ethernet100", "Ethernet101", "Ethernet102", "Ethernet103"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet96", "Ethernet100", "Ethernet101", "Ethernet102", "Ethernet103"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet96", "Ethernet97", "Ethernet98", "Ethernet99", "Ethernet100"]
+            }
+        },
+        "Ethernet104": {
+            "index": "14,14,14,14,14,14,14,14",
+            "lanes": "104,105,106,107,108,109,110,111",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet104"],
+                "2x200G[100G,40G]": ["Ethernet104", "Ethernet108"],
+                "4x100G[50G]": ["Ethernet104", "Ethernet106", "Ethernet108", "Ethernet110"],
+                "8x50G[25G,10G]": ["Ethernet104", "Ethernet105", "Ethernet106", "Ethernet107", "Ethernet108", "Ethernet109", "Ethernet110", "Ethernet111"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet104", "Ethernet108", "Ethernet109", "Ethernet110", "Ethernet111"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet104", "Ethernet105", "Ethernet106", "Ethernet107", "Ethernet108"]
+            }
+        },
+        "Ethernet112": {
+            "index": "15,15,15,15,15,15,15,15",
+            "lanes": "112,113,114,115,116,117,118,119",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet112"],
+                "2x200G[100G,40G]": ["Ethernet112", "Ethernet116"],
+                "4x100G[50G]": ["Ethernet112", "Ethernet114", "Ethernet116", "Ethernet118"],
+                "8x50G[25G,10G]": ["Ethernet112", "Ethernet113", "Ethernet114", "Ethernet115", "Ethernet116", "Ethernet117", "Ethernet118", "Ethernet119"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet112", "Ethernet116", "Ethernet117", "Ethernet118", "Ethernet119"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet112", "Ethernet113", "Ethernet114", "Ethernet115", "Ethernet116"]
+            }
+        },
+        "Ethernet120": {
+            "index": "16,16,16,16,16,16,16,16",
+            "lanes": "120,121,122,123,124,125,126,127",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet120"],
+                "2x200G[100G,40G]": ["Ethernet120", "Ethernet124"],
+                "4x100G[50G]": ["Ethernet120", "Ethernet122", "Ethernet124", "Ethernet126"],
+                "8x50G[25G,10G]": ["Ethernet120", "Ethernet121", "Ethernet122", "Ethernet123", "Ethernet124", "Ethernet125", "Ethernet126", "Ethernet127"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet120", "Ethernet124", "Ethernet125", "Ethernet126", "Ethernet127"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet120", "Ethernet121", "Ethernet122", "Ethernet123", "Ethernet124"]
+            }
+        },
+        "Ethernet128": {
+            "index": "17,17,17,17,17,17,17,17",
+            "lanes": "128,129,130,131,132,133,134,135",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet128"],
+                "2x200G[100G,40G]": ["Ethernet128", "Ethernet132"],
+                "4x100G[50G]": ["Ethernet128", "Ethernet130", "Ethernet132", "Ethernet134"],
+                "8x50G[25G,10G]": ["Ethernet128", "Ethernet129", "Ethernet130", "Ethernet131", "Ethernet132", "Ethernet133", "Ethernet134", "Ethernet135"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet128", "Ethernet132", "Ethernet133", "Ethernet134", "Ethernet135"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet128", "Ethernet129", "Ethernet130", "Ethernet131", "Ethernet132"]
+            }
+        },
+        "Ethernet136": {
+            "index": "18,18,18,18,18,18,18,18",
+            "lanes": "136,137,138,139,140,141,142,143",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet136"],
+                "2x200G[100G,40G]": ["Ethernet136", "Ethernet140"],
+                "4x100G[50G]": ["Ethernet136", "Ethernet138", "Ethernet140", "Ethernet142"],
+                "8x50G[25G,10G]": ["Ethernet136", "Ethernet137", "Ethernet138", "Ethernet139", "Ethernet140", "Ethernet141", "Ethernet142", "Ethernet143"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet136", "Ethernet140", "Ethernet141", "Ethernet142", "Ethernet143"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet136", "Ethernet137", "Ethernet138", "Ethernet139", "Ethernet140"]
+            }
+        },
+        "Ethernet144": {
+            "index": "19,19,19,19,19,19,19,19",
+            "lanes": "144,145,146,147,148,149,150,151",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet144"],
+                "2x200G[100G,40G]": ["Ethernet144", "Ethernet148"],
+                "4x100G[50G]": ["Ethernet144", "Ethernet146", "Ethernet148", "Ethernet150"],
+                "8x50G[25G,10G]": ["Ethernet144", "Ethernet145", "Ethernet146", "Ethernet147", "Ethernet148", "Ethernet149", "Ethernet150", "Ethernet151"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet144", "Ethernet148", "Ethernet149", "Ethernet150", "Ethernet151"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet144", "Ethernet145", "Ethernet146", "Ethernet147", "Ethernet148"]
+            }
+        },
+        "Ethernet152": {
+            "index": "20,20,20,20,20,20,20,20",
+            "lanes": "152,153,154,155,156,157,158,159",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet152"],
+                "2x200G[100G,40G]": ["Ethernet152", "Ethernet156"],
+                "4x100G[50G]": ["Ethernet152", "Ethernet154", "Ethernet156", "Ethernet158"],
+                "8x50G[25G,10G]": ["Ethernet152", "Ethernet153", "Ethernet154", "Ethernet155", "Ethernet156", "Ethernet157", "Ethernet158", "Ethernet159"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet152", "Ethernet156", "Ethernet157", "Ethernet158", "Ethernet159"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet152", "Ethernet153", "Ethernet154", "Ethernet155", "Ethernet156"]
+            }
+        },
+        "Ethernet160": {
+            "index": "21,21,21,21,21,21,21,21",
+            "lanes": "160,161,162,163,164,165,166,167",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet160"],
+                "2x200G[100G,40G]": ["Ethernet160", "Ethernet164"],
+                "4x100G[50G]": ["Ethernet160", "Ethernet162", "Ethernet164", "Ethernet166"],
+                "8x50G[25G,10G]": ["Ethernet160", "Ethernet161", "Ethernet162", "Ethernet163", "Ethernet164", "Ethernet165", "Ethernet166", "Ethernet167"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet160", "Ethernet164", "Ethernet165", "Ethernet166", "Ethernet167"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet160", "Ethernet161", "Ethernet162", "Ethernet163", "Ethernet164"]
+            }
+        },
+        "Ethernet168": {
+            "index": "22,22,22,22,22,22,22,22",
+            "lanes": "168,169,170,171,172,173,174,175",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet168"],
+                "2x200G[100G,40G]": ["Ethernet168", "Ethernet172"],
+                "4x100G[50G]": ["Ethernet168", "Ethernet170", "Ethernet172", "Ethernet174"],
+                "8x50G[25G,10G]": ["Ethernet168", "Ethernet169", "Ethernet170", "Ethernet171", "Ethernet172", "Ethernet173", "Ethernet174", "Ethernet175"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet168", "Ethernet172", "Ethernet173", "Ethernet174", "Ethernet175"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet168", "Ethernet169", "Ethernet170", "Ethernet171", "Ethernet172"]
+            }
+        },
+        "Ethernet176": {
+            "index": "23,23,23,23,23,23,23,23",
+            "lanes": "176,177,178,179,180,181,182,183",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet176"],
+                "2x200G[100G,40G]": ["Ethernet176", "Ethernet180"],
+                "4x100G[50G]": ["Ethernet176", "Ethernet178", "Ethernet180", "Ethernet182"],
+                "8x50G[25G,10G]": ["Ethernet176", "Ethernet177", "Ethernet178", "Ethernet179", "Ethernet180", "Ethernet181", "Ethernet182", "Ethernet183"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet176", "Ethernet180", "Ethernet181", "Ethernet182", "Ethernet183"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet176", "Ethernet177", "Ethernet178", "Ethernet179", "Ethernet180"]
+            }
+        },
+        "Ethernet184": {
+            "index": "24,24,24,24,24,24,24,24",
+            "lanes": "184,185,186,187,188,189,190,191",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet184"],
+                "2x200G[100G,40G]": ["Ethernet184", "Ethernet188"],
+                "4x100G[50G]": ["Ethernet184", "Ethernet186", "Ethernet188", "Ethernet190"],
+                "8x50G[25G,10G]": ["Ethernet184", "Ethernet185", "Ethernet186", "Ethernet187", "Ethernet188", "Ethernet189", "Ethernet190", "Ethernet191"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet184", "Ethernet188", "Ethernet189", "Ethernet190", "Ethernet191"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet184", "Ethernet185", "Ethernet186", "Ethernet187", "Ethernet188"]
+            }
+        },
+        "Ethernet192": {
+            "index": "25,25,25,25,25,25,25,25",
+            "lanes": "192,193,194,195,196,197,198,199",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet192"],
+                "2x200G[100G,40G]": ["Ethernet192", "Ethernet196"],
+                "4x100G[50G]": ["Ethernet192", "Ethernet194", "Ethernet196", "Ethernet198"],
+                "8x50G[25G,10G]": ["Ethernet192", "Ethernet193", "Ethernet194", "Ethernet195", "Ethernet196", "Ethernet197", "Ethernet198", "Ethernet199"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet192", "Ethernet196", "Ethernet197", "Ethernet198", "Ethernet199"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet192", "Ethernet193", "Ethernet194", "Ethernet195", "Ethernet196"]
+            }
+        },
+        "Ethernet200": {
+            "index": "26,26,26,26,26,26,26,26",
+            "lanes": "200,201,202,203,204,205,206,207",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet200"],
+                "2x200G[100G,40G]": ["Ethernet200", "Ethernet204"],
+                "4x100G[50G]": ["Ethernet200", "Ethernet202", "Ethernet204", "Ethernet206"],
+                "8x50G[25G,10G]": ["Ethernet200", "Ethernet201", "Ethernet202", "Ethernet203", "Ethernet204", "Ethernet205", "Ethernet206", "Ethernet207"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet200", "Ethernet204", "Ethernet205", "Ethernet206", "Ethernet207"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet200", "Ethernet201", "Ethernet202", "Ethernet203", "Ethernet204"]
+            }
+        },
+        "Ethernet208": {
+            "index": "27,27,27,27,27,27,27,27",
+            "lanes": "208,209,210,211,212,213,214,215",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet208"],
+                "2x200G[100G,40G]": ["Ethernet208", "Ethernet212"],
+                "4x100G[50G]": ["Ethernet208", "Ethernet210", "Ethernet212", "Ethernet214"],
+                "8x50G[25G,10G]": ["Ethernet208", "Ethernet209", "Ethernet210", "Ethernet211", "Ethernet212", "Ethernet213", "Ethernet214", "Ethernet215"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet208", "Ethernet212", "Ethernet213", "Ethernet214", "Ethernet215"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet208", "Ethernet209", "Ethernet210", "Ethernet211", "Ethernet212"]
+            }
+        },
+        "Ethernet216": {
+            "index": "28,28,28,28,28,28,28,28",
+            "lanes": "216,217,218,219,220,221,222,223",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet216"],
+                "2x200G[100G,40G]": ["Ethernet216", "Ethernet220"],
+                "4x100G[50G]": ["Ethernet216", "Ethernet218", "Ethernet220", "Ethernet222"],
+                "8x50G[25G,10G]": ["Ethernet216", "Ethernet217", "Ethernet218", "Ethernet219", "Ethernet220", "Ethernet221", "Ethernet222", "Ethernet223"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet216", "Ethernet220", "Ethernet221", "Ethernet222", "Ethernet223"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet216", "Ethernet217", "Ethernet218", "Ethernet219", "Ethernet220"]
+            }
+        },
+        "Ethernet224": {
+            "index": "29,29,29,29,29,29,29,29",
+            "lanes": "224,225,226,227,228,229,230,231",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet224"],
+                "2x200G[100G,40G]": ["Ethernet224", "Ethernet228"],
+                "4x100G[50G]": ["Ethernet224", "Ethernet226", "Ethernet228", "Ethernet230"],
+                "8x50G[25G,10G]": ["Ethernet224", "Ethernet225", "Ethernet226", "Ethernet227", "Ethernet228", "Ethernet229", "Ethernet230", "Ethernet231"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet224", "Ethernet228", "Ethernet229", "Ethernet230", "Ethernet231"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet224", "Ethernet225", "Ethernet226", "Ethernet227", "Ethernet228"]
+            }
+        },
+        "Ethernet232": {
+            "index": "30,30,30,30,30,30,30,30",
+            "lanes": "232,233,234,235,236,237,238,239",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet232"],
+                "2x200G[100G,40G]": ["Ethernet232", "Ethernet236"],
+                "4x100G[50G]": ["Ethernet232", "Ethernet234", "Ethernet236", "Ethernet238"],
+                "8x50G[25G,10G]": ["Ethernet232", "Ethernet233", "Ethernet234", "Ethernet235", "Ethernet236", "Ethernet237", "Ethernet238", "Ethernet239"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet232", "Ethernet236", "Ethernet237", "Ethernet238", "Ethernet239"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet232", "Ethernet233", "Ethernet234", "Ethernet235", "Ethernet236"]
+            }
+        },
+        "Ethernet240": {
+            "index": "31,31,31,31,31,31,31,31",
+            "lanes": "240,241,242,243,244,245,246,247",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet240"],
+                "2x200G[100G,40G]": ["Ethernet240", "Ethernet244"],
+                "4x100G[50G]": ["Ethernet240", "Ethernet242", "Ethernet244", "Ethernet246"],
+                "8x50G[25G,10G]": ["Ethernet240", "Ethernet241", "Ethernet242", "Ethernet243", "Ethernet244", "Ethernet245", "Ethernet246", "Ethernet247"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet240", "Ethernet244", "Ethernet245", "Ethernet246", "Ethernet247"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet240", "Ethernet241", "Ethernet242", "Ethernet243", "Ethernet244"]
+            }
+        },
+        "Ethernet248": {
+            "index": "32,32,32,32,32,32,32,32",
+            "lanes": "248,249,250,251,252,253,254,255",
+            "breakout_modes": {
+                "1x400G[200G]": ["Ethernet248"],
+                "2x200G[100G,40G]": ["Ethernet248", "Ethernet252"],
+                "4x100G[50G]": ["Ethernet248", "Ethernet250", "Ethernet252", "Ethernet254"],
+                "8x50G[25G,10G]": ["Ethernet248", "Ethernet249", "Ethernet250", "Ethernet251", "Ethernet252", "Ethernet253", "Ethernet254", "Ethernet255"],
+                "1x200G[100G,40G](4)+4x50G[25G,10G](4)": ["Ethernet248", "Ethernet252", "Ethernet253", "Ethernet254", "Ethernet255"],
+                "4x50G[25G,10G](4)+1x200G[100G,40G](4)": ["Ethernet248", "Ethernet249", "Ethernet250", "Ethernet251", "Ethernet252"]
+            }
+        }
+    }
+}

--- a/device/barefoot/x86_64-accton_as9516_32d-r0/platform.json
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/platform.json
@@ -1,4 +1,206 @@
 {
+    "chassis": {
+        "name": "Newport",
+        "fans": [
+            {
+                "name": "counter-rotating-fan-1"
+            },
+            {
+                "name": "counter-rotating-fan-2"
+            },
+            {
+                "name": "counter-rotating-fan-3"
+            },
+            {
+                "name": "counter-rotating-fan-4"
+            },
+            {
+                "name": "counter-rotating-fan-5"
+            },
+            {
+                "name": "counter-rotating-fan-6"
+            }
+        ],
+        "fan_drawers":[
+            {
+                "name": "fantray",
+                "num_fans" : 6,
+                "fans": [
+                    {
+                        "name": "counter-rotating-fan-1"
+                    },
+                    {
+                        "name": "counter-rotating-fan-2"
+                    },
+                    {
+                        "name": "counter-rotating-fan-3"
+                    },
+                    {
+                        "name": "counter-rotating-fan-4"
+                    },
+                    {
+                        "name": "counter-rotating-fan-5"
+                    },
+                    {
+                        "name": "counter-rotating-fan-6"
+                    }
+                ]
+            }
+        ],
+        "psus": [
+            {
+                "name": "psu-1"
+            },
+            {
+                "name": "psu-2"
+            }
+        ],
+        "thermals": [
+            {
+                "name": "tmp75-i2c-3-4b:switch-temp"
+            },
+            {
+                "name": "com_e_driver-i2c-4-33:memory-temp"
+            },
+            {
+                "name": "com_e_driver-i2c-4-33:cpu-temp"
+            },
+            {
+                "name": "coretemp-isa-0000:core-0"
+            },
+            {
+                "name": "coretemp-isa-0000:core-1"
+            },
+            {
+                "name": "coretemp-isa-0000:core-2"
+            },
+            {
+                "name": "coretemp-isa-0000:core-3"
+            },
+            {
+                "name": "coretemp-isa-0000:package-id-0"
+            },
+            {
+                "name": "psu_driver-i2c-7-5a:psu1-temp1"
+            },
+            {
+                "name": "psu_driver-i2c-7-5a:psu1-temp2"
+            },
+            {
+                "name": "psu_driver-i2c-7-5a:psu1-temp3"
+            },
+            {
+                "name": "tmp75-i2c-3-4a:inlet-left-temp"
+            },
+            {
+                "name": "tmp75-i2c-3-4c:inlet-right-temp"
+            },
+            {
+                "name": "tmp75-i2c-3-4d:temp1"
+            },
+            {
+                "name": "tmp75-i2c-3-48:outlet-middle-temp"
+            },
+            {
+                "name": "tmp75-i2c-3-49:inlet-middle-temp"
+            }
+        ],
+        "sfps": [
+            {
+                "name": "Ethernet0"
+            },
+            {
+                "name": "Ethernet8"
+            },
+            {
+                "name": "Ethernet16"
+            },
+            {
+                "name": "Ethernet32"
+            },
+            {
+                "name": "Ethernet40"
+            },
+            {
+                "name": "Ethernet48"
+            },
+            {
+                "name": "Ethernet56"
+            },
+            {
+                "name": "Ethernet64"
+            },
+            {
+                "name": "Ethernet72"
+            },
+            {
+                "name": "Ethernet80"
+            },
+            {
+                "name": "Ethernet88"
+            },
+            {
+                "name": "Ethernet96"
+            },
+            {
+                "name": "Ethernet104"
+            },
+            {
+                "name": "Ethernet112"
+            },
+            {
+                "name": "Ethernet120"
+            },
+            {
+                "name": "Ethernet128"
+            },
+            {
+                "name": "Ethernet136"
+            },
+            {
+                "name": "Ethernet144"
+            },
+            {
+                "name": "Ethernet152"
+            },
+            {
+                "name": "Ethernet160"
+            },
+            {
+                "name": "Ethernet168"
+            },
+            {
+                "name": "Ethernet176"
+            },
+            {
+                "name": "Ethernet184"
+            },
+            {
+                "name": "Ethernet192"
+            },
+            {
+                "name": "Ethernet200"
+            },
+            {
+                "name": "Ethernet208"
+            },
+            {
+                "name": "Ethernet216"
+            },
+            {
+                "name": "Ethernet224"
+            },
+            {
+                "name": "Ethernet232"
+            },
+            {
+                "name": "Ethernet240"
+            },
+            {
+                "name": "Ethernet248"
+            }
+        ]
+    },
     "interfaces": {
         "Ethernet0": {
             "index": "1,1,1,1,1,1,1,1",


### PR DESCRIPTION
Signed-off-by: Mykola Gerasymenko <mykolax.gerasymenko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To support dynamic port breakout configurations on Newport platforms.

#### How I did it
Add platform.json and hwsku.json for dynamic port breakout usage.

#### How to verify it
Manually tested DPB CLI on Newport platform with all modes.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

