### PR TITLE
[copp] bind copp-config.service to sonic.target

### DIFF
--- a/files/image_config/copp/copp-config.service
+++ b/files/image_config/copp/copp-config.service
@@ -2,10 +2,12 @@
 Description=Update CoPP configuration
 Requires=updategraph.service
 After=updategraph.service
+BindsTo=sonic.target
+After=sonic.target
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/copp-config.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sonic.target


### PR DESCRIPTION
#### Why I did it
Noticed that on T0 testbed, the dhcp copp rule might be missing from the copp config.

#### How I did it
copp-config service needs to be started after sonic.target so that it could render the copp-config with the latest information.

It also needs to be restarted when config reload or load_minigraph is invoked.

#### How to verify it
Tested on a testbed hit this issue.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

