### PR TITLE
[DHCPv6 Relay] [202106] Fix kernel memory allocation issue and log verbosity for unreachable network

### DIFF
--- a/files/dhcp/90-dhcp6-systcl.conf.j2
+++ b/files/dhcp/90-dhcp6-systcl.conf.j2
@@ -5,3 +5,5 @@ net.ipv6.conf.eth0.accept_ra = 0
 net.ipv6.conf.eth0.accept_ra_defrtr = 1
 net.ipv6.conf.eth0.accept_ra = 1
 {% endif %}
+{# socket memory allocation size = (default value)20480 * 2 #}
+net.core.optmem_max=40960

--- a/src/isc-dhcp/patch/0013-Change-verbosity-level-for-unreachable-network-error.patch
+++ b/src/isc-dhcp/patch/0013-Change-verbosity-level-for-unreachable-network-error.patch
@@ -1,0 +1,20 @@
+diff --git a/common/socket.c b/common/socket.c
+index da9f501..fa2a49c 100644
+--- a/common/socket.c
++++ b/common/socket.c
+@@ -975,7 +975,14 @@ ssize_t send_packet6(struct interface_info *interface,
+ 
+ 	result = sendmsg(interface->wfdesc, &m, 0);
+ 	if (result < 0) {
+-		log_error("send_packet6: %m");
++		/* 'Network is unreachable' should log as INFO,
++		since not all up link interfaces have routes to the DHCP servers. */
++		if (errno == 101) {
++			log_info("send_packet6: %m");
++		}
++		else {
++			log_error("send_packet6: %m");
++		}
+ 	}
+ 	return result;
+ }

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -11,3 +11,4 @@
 0010-Bugfix-correctly-set-interface-netmask.patch
 0011-dhcp-relay-Prevent-Buffer-Overrun.patch
 0012-add-option-si-to-support-using-src-intf-ip-in-relay.patch
+0013-Change-verbosity-level-for-unreachable-network-error.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This PR fix 2 issues for DHCPv6 relay.
1. Kernel socket memory allocation size is too small for 'setsockopt', causing an exception and crashing the DHCPv6 daemon:
 **setsockopt: IPV6_JOIN_GROUP: Cannot allocate memory**
Too fix it, the memory size for sockets enlarged to 40960.

2. By design, the DHCPv6 relay will start while considering all L3 interfaces as up link interfaces.
When a DHCPv6 packet get to the CPU the relay will try to transmit it to all up link interfaces.
This can lead to ERROR messages in the log: "ERR dhcp_relay#dhcrelay[40]: send_packet6: Network is unreachable"
Since there is no route to the DHCP server from all up link interfaces, this error message will print out.
Thus, changing the verbosity is required for not alert unnecessary ERROR messages in syslog.

#### How I did it

1. Change net.core.optmem_max=40960.
2. Change verbosity level.

#### How to verify it

Configure DHCPv6 relay.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

