### PR TITLE
[chassis][mgmtif][defaultroute] Fix for issue of mgmt if default route

### DIFF
--- a/dockers/docker-fpm-frr/frr/staticd/staticd.default_route.conf.j2
+++ b/dockers/docker-fpm-frr/frr/staticd/staticd.default_route.conf.j2
@@ -1,9 +1,17 @@
 !
 {% block default_route %}
+{% if DEVICE_METADATA['localhost']['sub_role'] == 'FrontEnd' or DEVICE_METADATA['localhost']['sub_role'] == 'BackEnd' or DEVICE_METADATA['localhost']['switch_type'] == 'voq' %}
+{% set multi_asic_chassis = True %}
+{% endif %}
 ! set static default route to mgmt gateway as a backup to learned default
 {% for (name, prefix) in MGMT_INTERFACE|pfx_filter %}
 {% if prefix | ipv4 %}
+{% if multi_asic_chassis == True %}
+! make default route on mgmt interface less preferred than iBGP
+ip route 0.0.0.0/0 {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} 210
+{% else %}
 ip route 0.0.0.0/0 {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} 200
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endblock default_route %}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -33,7 +33,8 @@ link-detect
 !!
 !
 ! set static default route to mgmt gateway as a backup to learned default
-ip route 0.0.0.0/0 10.10.10.1 200
+! make default route on mgmt interface less preferred than iBGP
+ip route 0.0.0.0/0 10.10.10.1 210
 !!
 !
 ! add static ipv6 /64 loopback route to allow bgpd to advertise the loopback route prefix

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.default_route_chassis.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.default_route_chassis.conf
@@ -1,0 +1,5 @@
+!
+! set static default route to mgmt gateway as a backup to learned default
+! make default route on mgmt interface less preferred than iBGP
+ip route 0.0.0.0/0 10.10.10.1 210
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.default_route_chassis.conf.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.default_route_chassis.conf.json
@@ -2,7 +2,8 @@
     "DEVICE_METADATA": {
         "localhost": {
             "bgp_asn": "55555",
-            "hostname": "test_hostname"
+            "hostname": "test_hostname",
+            "switch_type": "voq"
         }
     },
     "MGMT_INTERFACE": {

--- a/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
+++ b/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
@@ -140,3 +140,9 @@ def test_bgp_conf_all():
              "bgpd/bgpd.conf.j2",
              "bgpd.conf.j2/all.json",
              "bgpd.conf.j2/all.conf")
+
+def test_staticd_default_route_chassis():
+    run_test("staticd.default_route.conf.j2",
+             "staticd/staticd.default_route.conf.j2",
+             "staticd/staticd.default_route_chassis.conf.json",
+             "staticd/staticd.default_route_chassis.conf")


### PR DESCRIPTION
#### Why I did it

If management interface is configured in config db, a default route is added with the management interface (eth0) as the gateway with same admin distance as iBGP routes. This is done as a backup reachability for management interface. In chassis using multi-asic image, this route was interfering with the default routes received from the iBGP sessions since static route has higher preference (i.e., the route on eth0 is selected as best route). However since routesync does not send any route on eth0 to orchagent, we do not have a default route in the datapath. This PR fixes this issue

#### How I did it

The backup default route management interface as gateway is added as part of staticd configuration in FRR. This is changed to set the administrative distance greater than the administrative distance of iBGP routes.

#### How to verify it

- In multi-asic imaged chassis (especially with line card with single asics), configure eth0 management interface in MGMT_INTERFACE table.
- Configure a default route with gateway on an eBGP interface. This default route from eBGP sessions will be leaned internally via iBGP in all other asics (via backend asics' iBGP sessions)
- Bring up the chassis and make sure the bgp is up and running and all iBGP and eBGP sessions are up.
- Check the route table for 0.0.0.0/0 route. 
- Observe that the there is a route for 0.0.0.0/0 with gateway equal to the management interface address and this route is not the best route.

#### Description for the changelog

Fix for issue of static default route on management interface interfering with default routes learned via iBGP.