### PR TITLE
[TS/TSA/B/C]: Update traffic-shift scripts with bgp neighbor check enhancement

### DIFF
--- a/dockers/docker-fpm-frr/TS
+++ b/dockers/docker-fpm-frr/TS
@@ -50,3 +50,18 @@ function find_num_routemap()
   done
   return $c
 }
+
+function find_num_ebgp_neighbors()
+{
+  count=0
+  summary=$(vtysh -c "show bgp summary json")
+  local_as=$(echo "$summary" | sed -n 's/ *"as":\(\S*\),/\1/p' | uniq)
+  for remote_as in $(echo "$summary" | sed -n 's/ *"remoteAs":\(\S*\),/\1/p');
+  do
+    if [[ $remote_as -ne $local_as ]];
+    then
+      count=$((count+1))
+    fi
+  done
+  return $count
+}

--- a/dockers/docker-fpm-frr/TSA
+++ b/dockers/docker-fpm-frr/TSA
@@ -3,12 +3,12 @@
 # Load the common functions
 source /usr/bin/TS
 
-find_num_routemap
-routemap_count=$?
+find_num_ebgp_neighbors
+neighbor_count=$?
 check_not_installed
 not_installed=$?
 
-if [[ $routemap_count -eq 0 ]];
+if [[ $neighbor_count -eq 0 ]];
 then
   echo "System Mode: No external neighbors"
 elif [[ $not_installed -ne 0 ]];

--- a/dockers/docker-fpm-frr/TSB
+++ b/dockers/docker-fpm-frr/TSB
@@ -3,12 +3,12 @@
 # Load the common functions
 source /usr/bin/TS
 
-find_num_routemap
-routemap_count=$?
+find_num_ebgp_neighbors
+neighbor_count=$?
 check_installed
 installed=$?
 
-if [[ $routemap_count -eq 0 ]];
+if [[ $neighbor_count -eq 0 ]];
 then
   echo "System Mode: No external neighbors"
 elif [[ $installed -ne 0 ]]; 

--- a/dockers/docker-fpm-frr/TSC
+++ b/dockers/docker-fpm-frr/TSC
@@ -3,15 +3,15 @@
 # Load the common functions
 source /usr/bin/TS
 
-find_num_routemap
-routemap_count=$?
+find_num_ebgp_neighbors
+neighbor_count=$?
 check_not_installed
 not_installed=$?
 
 check_installed
 installed=$?
 
-if [[ $routemap_count -eq 0 ]];
+if [[ $neighbor_count -eq 0 ]];
 then 
   echo "System Mode: No external neighbors"
 elif [[ $installed -eq 0 ]];


### PR DESCRIPTION
#### Why I did it
The test case `test_TSA_B_C_with_no_neighbors` from _bgp/test_traffic_shift.py_ may fail because of the way ebgp neighbors are counted in _sonic-buildimage/dockers/docker-fpm-frr/TSA_ in source code or _/usr/bin/TSA_ in bgp container (the same applies to TSB and TSC as well). Our (LinkedIn) configuration profile is a bit different, but the issue should be common.

If there is no eBGP neighbor, TSA/TSB/TSC are supposed to return "System Mode: No external neighbors". However, this "no eBGP" check is done by looking at the number of route-maps from running-config.

In _buildimage/dockers/docker-fpm-frr/TSA_:
```
find_num_routemap
routemap_count=$?
check_not_installed
not_installed=$?

if [[ $routemap_count -eq 0 ]];
then
  echo "System Mode: No external neighbors"
```

In _buildimage/dockers/docker-fpm-frr/TS_:
```
function find_num_routemap()
{
  c=0
  config=$(vtysh -c "show run")
  for route_map_name in $(echo "$config" | sed -ne 's/  neighbor \S* route-map \(\S*\) out/\1/p' | egrep 'V4|V6' | uniq);
  do
    is_internal_route_map $route_map_name && continue
    c=$((c+1))
  done
  return $c
}
```

The idea is to find out the number of ebgp neighbors by checking if any ebgp-specific outbound route-maps are being used by any neighbors. However, this can be problematic and lead to incorrect result, in twofold:

- The numebr of "neighbor ... route-map ... out" doesn't always equal the number of neighbors. For example, if peer-groups are configured and a set of bgp neighbors are inheriting outbound route-maps via peer-groups, the find_num_routemap won't return the correct number of ebgp neighbors. Similar problem would happen with dynamic neighbors.
- As demonstrated by the test case test_TSA_B_C_with_no_neighbors, when all the neighbors are gone (e.g., deleted via sonic-cfggen), the peer-groups can still be there in running-config. As a result, TSA/TSB/TSC won't show the expected result, i.e., "System Mode: No external neighbors".

#### How I did it
We can get the eBGP neighbor count by checking "show bgp summary". This proposal introduces a function `find_num_ebgp_neighbors` to parse "show bgp summary json" output and return the number of eBGP neighbors (remote-ASN different from local-ASN).

#### How to verify it
1. Run Pytest `case test_TSA_B_C_with_no_neighbors` from _bgp/test_traffic_shift.py_.
2. Unit test of TSA/TSB/TSC with:
  - no BGP neighbor
  - no eBGP neighbor but iBGP neighbors
  - both eBGP and iBGP neighbors

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
Update traffic-shift scripts with bgp neighbor check enhancement.

#### A picture of a cute animal (not mandatory but encouraged)
