### PR TITLE
[build] Fix pip redis version

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -432,7 +432,7 @@ RUN pip3 install "PyYAML==5.4.1"
 RUN pip3 install "lxml==4.6.2"
 
 # For sonic-platform-common testing
-RUN pip3 install redis
+RUN pip3 install redis==3.5.3
 
 # For vs image build
 RUN pip3 install pexpect==4.8.0

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -455,7 +455,8 @@ RUN pip2 install "lxml==4.6.2"
 RUN pip3 install "lxml==4.6.2"
 
 # For sonic-platform-common testing
-RUN pip3 install redis
+RUN pip2 install redis==3.5.3
+RUN pip3 install redis==3.5.3
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -365,7 +365,8 @@ RUN pip3 install "lxml==4.6.2"
 
 
 # For sonic-platform-common testing
-RUN pip3 install redis
+RUN pip2 install redis==3.5.3
+RUN pip3 install redis==3.5.3
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0


### PR DESCRIPTION
Intention is same as https://github.com/Azure/sonic-buildimage/pull/8997, but using a straightforward method.

#### Why I did it
Fix a recent build error introduced by a pre-release redis-py. This is a general issue because `python setup.py install` (ie `easy_instal`) does not ignore pre-release versions.
```
[ building ] [ target/python-wheels/redis_dump_load-1.1-py2-none-any.whl ] 
Applying patch ../redis-dump-load.patch/0001-Use-pipelines-when-dumping-52.patch
patching file redisdl.py

Applying patch ../redis-dump-load.patch/0002-Fix-setup.py-for-test-and-bdist_wheel.patch
patching file setup.py

Now at patch ../redis-dump-load.patch/0002-Fix-setup.py-for-test-and-bdist_wheel.patch
[ finished ] [ target/python-wheels/redis_dump_load-1.1-py2-none-any.whl ] 
[ FAIL LOG START ] [ target/python-wheels/redis_dump_load-1.1-py2-none-any.whl ]
[ REASON ] :      target/python-wheels/redis_dump_load-1.1-py2-none-any.whl does not exist  
[ FLAGS  FILE    ] : [] 
[ FLAGS  DEPENDS ] : [broadcom] 
[ FLAGS  DIFF    ] : [broadcom ] 
/sonic/src/redis-dump-load /sonic
running test
Searching for redis
Reading https://pypi.org/simple/redis/
Downloading https://files.pythonhosted.org/packages/62/ab/6491b41bbfb938afbc4424164983d1def3c59434c77e8cf710213be03fed/redis-4.0.0b1.tar.gz#sha256=f778e27d542ba1f43a6b02a80fa904d8a49e5d3b824ec5fb3f0d5cbdba11e4cd
Best match: redis 4.0.0b1
Processing redis-4.0.0b1.tar.gz
Writing /tmp/easy_install-ZCmBMQ/redis-4.0.0b1/setup.cfg
Running redis-4.0.0b1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-ZCmBMQ/redis-4.0.0b1/egg-dist-tmp-QcQyOe
Traceback (most recent call last):
  File "setup.py", line 41, in <module>
    'Topic :: System :: Archiving',
  File "/usr/lib/python2.7/dist-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
```

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog

#### A picture of a cute animal (not mandatory but encouraged)

