### PR TITLE
redis-dump-load: Pin the redis package to use 3.5.3

### DIFF
--- a/src/redis-dump-load.patch/0003-use-redis-3.5.3.patch
+++ b/src/redis-dump-load.patch/0003-use-redis-3.5.3.patch
@@ -1,0 +1,25 @@
+Pin the redis package to version 3.5.3 (the last version that supports both
+Python 2 and 3).
+
+Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>
+
+diff --git a/requirements.txt b/requirements.txt
+index 7800f0f..3fc0632 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1 +1 @@
+-redis
++redis==3.5.3
+diff --git a/setup.py b/setup.py
+index 8ccf31f..6db9ec4 100644
+--- a/setup.py
++++ b/setup.py
+@@ -17,7 +17,7 @@ setup(name=package_name,
+     author_email='oleg@bsdpower.com',
+     url='http://github.com/p/redis-dump-load',
+     py_modules=['redisdl'],
+-    install_requires=['redis'],
++    install_requires=['redis==3.5.3'],
+     data_files=[
+         (doc_dir, data_files),
+     ],

--- a/src/redis-dump-load.patch/series
+++ b/src/redis-dump-load.patch/series
@@ -1,2 +1,3 @@
 0001-Use-pipelines-when-dumping-52.patch
 0002-Fix-setup.py-for-test-and-bdist_wheel.patch
+0003-use-redis-3.5.3.patch


### PR DESCRIPTION
Redis 4.0.0b1 has been uploaded to pip as a prerelease version. This
version drops support for Python 2 and only supports Python 3. Because
setup.py is being run, it will use the latest version of a package and
not the latest stable version (which is still 3.5.3).

Therefore, pin the redis package to version 3.5.3, so that it will work
for both Python 2 and 3.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

#### Why I did it

#### How I did it

#### How to verify it

Make sure that redis-dump-load for Python 2 builds today.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

