### PR TITLE
[PMON] Skip chassis_db_init task on Mellanox simx platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700_simx-r0/pmon_daemon_control.json
@@ -3,5 +3,6 @@
         "skip_xcvrd": true,
         "skip_psud": true,
         "skip_pcied": true,
-        "skip_thermalctld": true
+        "skip_thermalctld": true,
+        "skip_chassis_db_init": true
 }

--- a/device/mellanox/x86_64-mlnx_msn3700_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn3700_simx-r0/pmon_daemon_control.json
@@ -1,7 +1,1 @@
-{
-        "skip_ledd": true,
-        "skip_xcvrd": true,
-        "skip_psud": true,
-        "skip_pcied": true,
-        "skip_thermalctld": true
-}
+../x86_64-mlnx_msn2700_simx-r0/pmon_daemon_control.json

--- a/device/mellanox/x86_64-mlnx_msn4700_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4700_simx-r0/pmon_daemon_control.json
@@ -1,7 +1,1 @@
-{
-        "skip_ledd": true,
-        "skip_xcvrd": true,
-        "skip_psud": true,
-        "skip_pcied": true,
-        "skip_thermalctld": true
-}
+../x86_64-mlnx_msn2700_simx-r0/pmon_daemon_control.json

--- a/device/mellanox/x86_64-mlnx_msn4800_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4800_simx-r0/pmon_daemon_control.json
@@ -1,7 +1,1 @@
-{
-        "skip_ledd": true,
-        "skip_xcvrd": true,
-        "skip_psud": true,
-        "skip_pcied": true,
-        "skip_thermalctld": true
-}
+../x86_64-mlnx_msn2700_simx-r0/pmon_daemon_control.json

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -41,6 +41,7 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}
 
+{% if not skip_chassis_db_init %}
 [program:chassis_db_init]
 command=/usr/local/bin/chassis_db_init
 priority=3
@@ -51,6 +52,7 @@ stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
+{% endif %}
 
 {% if not skip_sensors and HAVE_SENSORS_CONF == 1 %}
 [program:lm-sensors]


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

"chassis_db_init" task of PMON should be skipped on Mellanox simx platform, since the hardware info which this task is trying to access is not available on simx platforms, It will introduce some error log.

#### How I did it

1. Add the capability for "chassis_db_init"  in the template for it can be skipped by adding configuration in "pmon_daemon_control.json".
2. add "skip_chassis_db_init" configuration for simx platforms.
3. use symbol link for "pmon_daemon_control.json" since all the simx platforms share the same configuration

#### How to verify it

Build an image and install it on simx platform to check whether "chassis_db_init" task is skipped.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

