### PR TITLE
[Build]: Fix the unexpected python packages installed issue

### DIFF
--- a/scripts/prepare_slave_container_buildinfo.sh
+++ b/scripts/prepare_slave_container_buildinfo.sh
@@ -4,6 +4,19 @@ SLAVE_DIR=$1
 ARCH=$2
 DISTRO=$3
 
+# Filter the packages installed in the slave container
+function filter_packages()
+{
+    local file=$1
+    local build_path=$SLAVE_DIR/../files/build/versions/build
+    [ ! -d $build_path ] && return 0
+    while read line; do
+        if grep -q "$line" $build_path -r; then
+            echo $line
+        fi
+    done < $file
+}
+
 # Install the latest debian package sonic-build-hooks in the slave container
 sudo dpkg -i --force-overwrite $SLAVE_DIR/buildinfo/sonic-build-hooks_*.deb > /dev/null
 
@@ -21,4 +34,8 @@ touch ${BUILDINFO_PATH}/versions/versions-deb
 
 rm -f /etc/apt/preferences.d/01-versions-deb
 ([ "$ENABLE_VERSION_CONTROL_DEB" == "y" ] && [ -f $VERSION_DEB_PREFERENCE ]) && cp -f $VERSION_DEB_PREFERENCE /etc/apt/preferences.d/
+
+# Install the python packages if existing, skipping none existing packages
+([ "$ENABLE_VERSION_CONTROL_PY2" == "y" ] && [ -f $BUILDINFO_PATH/versions/versions-py2 ]) && filter_packages $BUILDINFO_PATH/versions/versions-py2 | sudo xargs -n 1 pip2 install >$LOG_PATH/error.log 2>&1 
+([ "$ENABLE_VERSION_CONTROL_PY3" == "y" ] && [ -f $BUILDINFO_PATH/versions/versions-py3 ]) && filter_packages $BUILDINFO_PATH/versions/versions-py3 | sudo xargs -n 1 pip3 install >$LOG_PATH/error.log 2>&1
 exit 0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the unexpected python packages installed issue

It is expected the redis=3.5.3 should be installed in branch 202012, see https://github.com/Azure/sonic-buildimage/blob/82d0539c4eb2634f66458ac1bdd83c616fe595dd/files/build/versions/build/build-sonic-slave-buster/versions-py2#L11, but the version 4.0.0b1 installed, see build: https://dev.azure.com/mssonic/build/_build/results?buildId=44510&view=logs&j=88ce9a53-729c-5fa9-7b6e-3d98f2488e3f&t=8d99be27-49d0-54d0-99b1-cfc0d47f0318

Error logs in detail:
```
[ building ] [ target/python-wheels/redis_dump_load-1.1-py2-none-any.whl ] 
Applying patch ../redis-dump-load.patch/0001-Use-pipelines-when-dumping-52.patch
patching file redisdl.py

Applying patch ../redis-dump-load.patch/0002-Fix-setup.py-for-test-and-bdist_wheel.patch
patching file setup.py

Now at patch ../redis-dump-load.patch/0002-Fix-setup.py-for-test-and-bdist_wheel.patch
[ finished ] [ target/python-wheels/redis_dump_load-1.1-py2-none-any.whl ] 
[ FAIL LOG START ] [ target/python-wheels/redis_dump_load-1.1-py2-none-any.whl ]
[ REASON ] :      target/python-wheels/redis_dump_load-1.1-py2-none-any.whl does not exist  
[ FLAGS  FILE    ] : [] 
[ FLAGS  DEPENDS ] : [broadcom] 
[ FLAGS  DIFF    ] : [broadcom ] 
/sonic/src/redis-dump-load /sonic
running test
Searching for redis
Reading https://pypi.org/simple/redis/
Downloading https://files.pythonhosted.org/packages/62/ab/6491b41bbfb938afbc4424164983d1def3c59434c77e8cf710213be03fed/redis-4.0.0b1.tar.gz#sha256=f778e27d542ba1f43a6b02a80fa904d8a49e5d3b824ec5fb3f0d5cbdba11e4cd
Best match: redis 4.0.0b1
Processing redis-4.0.0b1.tar.gz
Writing /tmp/easy_install-SncEVh/redis-4.0.0b1/setup.cfg
Running redis-4.0.0b1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-SncEVh/redis-4.0.0b1/egg-dist-tmp-ERmW81
Traceback (most recent call last):
  File "setup.py", line 41, in <module>
    'Topic :: System :: Archiving',
```

#### How I did it
Install the packages before building the targets

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

