### PR TITLE
[Bash] Fix bash build break when re-build bash issue.

### DIFF
--- a/src/bash/Makefile
+++ b/src/bash/Makefile
@@ -5,6 +5,8 @@ SHELL = /bin/bash
 MAIN_TARGET = bash_$(BASH_VERSION_FULL)_$(CONFIGURED_ARCH).deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
+	# Quilt store applied patches info in .pc folder, if this folder not clean, quilt can't apply patches correctly.
+	rm -rf .pc
 	rm -rf bash-$(BASH_VERSION_MAJOR)
 
 	dget -u https://launchpad.net/debian/+archive/primary/+sourcefiles/bash/$(BASH_VERSION_FULL)/bash_$(BASH_VERSION_FULL).dsc


### PR DESCRIPTION
This pull request will fix bash build break issue when re-build bash.

#### Why I did it
    src/bash project using quilt to manage patches, and quilt can't apply patch correctly when cache folder '.pc' is not clean.

#### How I did it
    Add command in make file to remove quilt cache folder before apply patches.

#### How to verify it
    Re-build bash target target/debs/buster/bash_5.1-2_amd64.deb to validate this fix work.
    Pass all UT.


#### Which release branch to backport (provide reason below if selected)
    N/A

#### Description for the changelog
    Fix bash build break issue when re-build bash.

#### A picture of a cute animal (not mandatory but encouraged)