### PR TITLE
Fix platform_asic_checker script in order to run stretch Python 3.5.3

### DIFF
--- a/src/sonic-device-data/tests/platform_asic_checker
+++ b/src/sonic-device-data/tests/platform_asic_checker
@@ -29,11 +29,16 @@ def main(argv):
 
     # Load all the valid platforms as strings
     platforms = set()
-    with os.scandir(args.platform_folder) as it:
+    it = os.scandir(args.platform_folder)
+    try:
         for entry in it:
             p = entry.path
             if entry.is_dir() and os.path.isfile(os.path.join(p, 'rules.mk')):
                 platforms.add(entry.name)
+    finally:
+        # os.scandir().close() is only available in python 3.6 and later
+        if callable(getattr(it, "close", None)):
+            it.close()
     # dnx platform is special broadcom platform, add it manually
     platforms.add('broadcom-dnx')
 


### PR DESCRIPTION
#### Why I did it
It is required by stretch/sonic-device-data_1.0-1_all.deb, which is required by docker-sonic-mgmt.gz.
Stretch distribution has old Python 3.5.3.

scandir.close() is new in Python version 3.6.
ref: https://docs.python.org/3/library/os.html#os.scandir.close

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

