### PR TITLE
docker-dhcp-relay: Fix waiting for interfaces to get set up

### DIFF
--- a/dockers/docker-dhcp-relay/start.sh
+++ b/dockers/docker-dhcp-relay/start.sh
@@ -10,8 +10,8 @@ then
     ${CTR_SCRIPT} -f dhcp_relay -o ${RUNTIME_OWNER} -v ${IMAGE_VERSION}
 fi
 
-# If our supervisor config has entries in the "isc-dhcp-relay" group...
-if [ $(supervisorctl status | grep -c "^isc-dhcp-relay:") -gt 0 ]; then
+# If our supervisor config has entries in the "dhcp-relay" group...
+if [ $(supervisorctl status | grep -c "^dhcp-relay:") -gt 0 ]; then
     # Wait for all interfaces to come up and be assigned IPv4 addresses before
     # starting the DHCP relay agent(s). If an interface the relay should listen
     # on is down, the relay agent will not start. If an interface the relay

--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -38,3 +38,8 @@ wait_until_iface_ready {{ name }} {{ prefix }}
 wait_until_iface_ready {{ name }} {{ prefix }}
 {% endif %}
 {% endfor %}
+
+# Wait 10 seconds for the rest of interfaces to get added/populated.
+# dhcrelay listens on each of the interfaces (in addition to the port
+# channels and vlan interfaces)
+sleep 10

--- a/src/sonic-config-engine/tests/sample_output/py2/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/py2/wait_for_intf.sh
@@ -30,3 +30,7 @@ wait_until_iface_ready PortChannel03 10.0.0.60/31
 wait_until_iface_ready PortChannel04 10.0.0.62/31
 wait_until_iface_ready PortChannel01 10.0.0.56/31
 
+# Wait 10 seconds for the rest of interfaces to get added/populated.
+# dhcrelay listens on each of the interfaces (in addition to the port
+# channels and vlan interfaces)
+sleep 10

--- a/src/sonic-config-engine/tests/sample_output/py3/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/py3/wait_for_intf.sh
@@ -30,3 +30,7 @@ wait_until_iface_ready PortChannel02 10.0.0.58/31
 wait_until_iface_ready PortChannel03 10.0.0.60/31
 wait_until_iface_ready PortChannel04 10.0.0.62/31
 
+# Wait 10 seconds for the rest of interfaces to get added/populated.
+# dhcrelay listens on each of the interfaces (in addition to the port
+# channels and vlan interfaces)
+sleep 10


### PR DESCRIPTION
Fix the check used to wait for interfaces to come up. The group name in
the supervisor config files has changed from isc-dhcp-relay to
dhcp-relay.

Also, in the wait script, wait 10 additional seconds after the vlans,
port channels, and any interfaces are up. This is because dhcrelay
listens on all interfaces (in addition to port channels and vlans), and
to ensure that it stays in a clean state during runtime, wait some extra
time to make sure that those interfaces are created as well.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

In the output of `sudo ss -nlp`, for `dhcrelay` and `dhcp6relay`, verify that all of the sockets that are bound to an interface have a valid interface name, and not some interface index number (e.g. `if512`, `if4294967295`, ...).

Example of sockets bound to interfaces that no longer exist:

```
udp                UNCONN              0                    0                                                                                    0.0.0.0%if1689:67                                                0.0.0.0:*                      users:(("dhcrelay",pid=155973,fd=13))
udp                UNCONN              0                    0                                                                                    0.0.0.0%if1690:67                                                0.0.0.0:*                      users:(("dhcrelay",pid=155973,fd=12))
udp                UNCONN              0                    0                                                                                    0.0.0.0%if1691:67                                                0.0.0.0:*                      users:(("dhcrelay",pid=155973,fd=11))
udp                UNCONN              0                    0                                                                                    0.0.0.0%if1692:67                                                0.0.0.0:*                      users:(("dhcrelay",pid=155973,fd=10))
udp                UNCONN              0                    0                                                                                    0.0.0.0%if1693:67                                                0.0.0.0:*                      users:(("dhcrelay",pid=155973,fd=9))
udp                UNCONN              0                    0                                                                                    0.0.0.0%if1694:67                                                0.0.0.0:*                      users:(("dhcrelay",pid=155973,fd=8))
udp                UNCONN              0                    0                                                                                    0.0.0.0%if1695:67                                                0.0.0.0:*                      users:(("dhcrelay",pid=155973,fd=7))
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

![Sloth](https://cdn.pixabay.com/photo/2012/10/25/23/34/pygmy-sloth-62869_960_720.jpg)