### PR TITLE
[dhcp_relay] fix data type in dhcp6relay, add protection in packet data parsing

### DIFF
--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -538,7 +538,7 @@ void callback(evutil_socket_t fd, short event, void *arg) {
         do {
             ext_header = (const struct ip6_ext *)current_position;
             current_position += ext_header->ip6e_len;
-            if((current_position == prev) || (current_position <= (uint8_t *)ptr + sizeof(message_buffer))) {
+            if((current_position == prev) || (current_position >= (uint8_t *)ptr + sizeof(message_buffer))) {
                 return;
             }
             prev = current_position;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Error in socket receiver, causing dhcp6relay to be stuck in infinite while loop when parsing through packet data.

#### How I did it
Fix recv datatype, add a protection check to check if the next pointer of packet is the same as current pointer.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

Signed off by Kelly Yeh kellyyeh@microsoft.com