### PR TITLE
[Mellanox] [202106] Fix issue: PSU model/serial/revision info should be updated after replacing PSU

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/vpd_parser.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/vpd_parser.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from sonic_py_common.logger import Logger
+
+from . import utils
+
+logger = Logger()
+SN_VPD_FIELD = "SN_VPD_FIELD"
+PN_VPD_FIELD = "PN_VPD_FIELD"
+REV_VPD_FIELD = "REV_VPD_FIELD"
+
+
+class VpdParser:
+    def __init__(self, file_path):
+        self.vpd_data = {}
+        self.vpd_file = file_path
+        self.vpd_file_last_mtime = None
+
+    def _get_data(self):
+        if not os.path.exists(self.vpd_file):
+            self.vpd_data = {}
+            return False
+
+        try:
+            mtime = os.stat(self.vpd_file).st_mtime
+            if mtime != self.vpd_file_last_mtime:
+                self.vpd_file_last_mtime = mtime
+                self.vpd_data = utils.read_key_value_file(self.vpd_file)
+            return True
+        except Exception as e:
+            self.vpd_data = {}
+            return False
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+
+        Returns:
+            string: Model/part number of device
+        """
+        if self._get_data() and PN_VPD_FIELD not in self.vpd_data:
+            logger.log_error("Fail to read model number: No key {} in VPD {}".format(PN_VPD_FIELD, self.vpd_file))
+            return 'N/A'
+        return self.vpd_data.get(PN_VPD_FIELD, 'N/A')
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+
+        Returns:
+            string: Serial number of device
+        """
+        if self._get_data() and SN_VPD_FIELD not in self.vpd_data:
+            logger.log_error("Fail to read serial number: No key {} in VPD {}".format(SN_VPD_FIELD, self.vpd_file))
+            return 'N/A'
+        return self.vpd_data.get(SN_VPD_FIELD, 'N/A')
+
+    def get_revision(self):
+        """
+        Retrieves the hardware revision of the device
+
+        Returns:
+            string: Revision value of device
+        """
+        if self._get_data() and REV_VPD_FIELD not in self.vpd_data:
+            logger.log_error("Fail to read revision: No key {} in VPD {}".format(REV_VPD_FIELD, self.vpd_file))
+            return 'N/A'
+        return self.vpd_data.get(REV_VPD_FIELD, 'N/A')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This is for 202106 only as there is a big PR https://github.com/Azure/sonic-buildimage/pull/8422 in master which might not be cherry-picked to 202106.

Fix issue:
1. If PSU is missing, error log is printed like "Fail to read PSU1 serial number: No key SN_VPD_FIELD in VPD /var/run/hw-management/eeprom/psu1_vpd"
2. If PSU is replacing by a new one, the model/serial/revision info cannot be updated without a reboot/config reload.

#### How I did it

1. If VPD file does not exist, don't print error log
2. Update model/serial/revision info if VPD file is modified

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

