### PR TITLE
[supervisor]monit container-checker failed due to unexpected "database-chassis" docker running

### DIFF
--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -20,7 +20,7 @@ import docker
 import sys
 
 import swsssdk
-from sonic_py_common import multi_asic
+from sonic_py_common import multi_asic, device_info
 from swsscommon import swsscommon
 
 
@@ -63,6 +63,8 @@ def get_expected_running_containers():
                         always_running_containers.add(container_name + str(asic_id))
             else:
                 always_running_containers.add(container_name)
+    if device_info.is_supervisor():
+        always_running_containers.add("database-chassis")
     return expected_running_containers, always_running_containers
 
 def get_current_running_from_DB(always_running_containers):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixed the monit container_checker fails due to unexpected "database-chassis" docker running on Supervisor card in  the VOQ chassis.  fixes #9042
#### How I did it
Added database-chassis to the always running docker list if platform is supervisor card.
 
#### How to verify it
Execute the CLI command  "sudo monit status container_checker"
```
admin@sonic:~$ sudo monit status container_checker
Monit 5.20.0 uptime: 22h 18m

Program 'container_checker'
  status                       Status ok
  monitoring status            Monitored
  monitoring mode              active
  on reboot                    start
  last exit value              0
  last output                  -
  data collected               Fri, 22 Oct 2021 15:12:50 
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

