### PR TITLE
[docker-sonic-vs]Added support for Mellanox-SN2700 based SKU for docker-sonic-vs

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -176,6 +176,7 @@ COPY ["buffermgrd.sh", "/usr/bin/"]
 COPY ["platform.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/"]
 COPY ["hwsku.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/"]
 COPY ["hwsku.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/brcm_gearbox_vs/"]
+COPY ["hwsku.json", "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/Mellanox-SN2700/"]
 
 # Workaround the tcpdump issue
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump

--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-if [[ -z "$fake_platform"  ]]; then
-    export platform=vs
-else
+#This is required since we have platform based checks in orchagent
+#fakeplatform to be removed once swss migrates to hw-sku
+
+if [ "$HWSKU" == "Mellanox-SN2700" ]; then
+    export platform="mellanox"
+elif  [ -n "$fake_platform"  ]; then
     export platform=$fake_platform
+else
+    export platform=vs
 fi
 
 SWSS_VARS_FILE=/usr/share/sonic/templates/swss_vars.j2

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -53,7 +53,12 @@ else
 fi
 sonic-cfggen -t /usr/share/sonic/templates/copp_cfg.j2 > /etc/sonic/copp_cfg.json
 
+#To be removed once swss migrates to HWSKU
 if [ "$fake_platform" == "mellanox" ]; then
+    cp /usr/share/sonic/hwsku/sai_mlnx.profile /usr/share/sonic/hwsku/sai.profile
+fi
+
+if [ "$HWSKU" == "Mellanox-SN2700" ]; then
     cp /usr/share/sonic/hwsku/sai_mlnx.profile /usr/share/sonic/hwsku/sai.profile
 fi
 


### PR DESCRIPTION
Signed-off-by: Sudharsan Dhamal Gopalarathnam <sudharsand@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added support for Mellanox-SN2700 based SKU for docker-sonic-vs and to differentiate platform based on hw-sku rather than on fake_platform in VS.
Currently SAI VS library uses hwsku based SAI profile to differentiate and mock different platform implementations. The same functionality in swss is achieved using a fake_platform env variable.
Using a fake_platform has some drawbacks that the vs container appears to still use a different vendor hw-sku
```
env
PLATFORM=x86_64-kvm_x86_64-r0
HOSTNAME=dd21a1637723
PWD=/
HOME=/root
TERM=xterm
HWSKU=Force10-S6000
SHLVL=1
fake_platform=mellanox
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
DEBIAN_FRONTEND=noninteractive
_=/usr/bin/env
```

In order to unify the approach at both swss and vs SAI and to be uniform throughout this PR introduces the approach of using hw-sku to differentiate different platforms. This requires support for Mellanox-SN2700 HWSKU for Mellanox platform which is also addressed by this PR.

```
root@23c9ba83b0aa:/# show platform summary
/bin/sh: 1: sudo: not found
Platform: x86_64-kvm_x86_64-r0
HwSKU: Mellanox-SN2700
ASIC: vs
ASIC Count: 1
Serial Number: N/A
Model Number: N/A
Hardware Revision: N/A
root@23c9ba83b0aa:/# env
PLATFORM=x86_64-kvm_x86_64-r0
HOSTNAME=23c9ba83b0aa
PWD=/
HOME=/root
TERM=xterm
HWSKU=Mellanox-SN2700
SHLVL=1
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
DEBIAN_FRONTEND=noninteractive
_=/usr/bin/env
root@23c9ba83b0aa:/#

```
#### How I did it
Copied relevant platform files. Modified orchagent scripts to infer platform from hwsku.

#### How to verify it
Run the tests that depend on platform type in vs and ensure they pass using the new approach.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

