### PR TITLE
[201811][swssconfig] load dhcpv6 copp rules by default

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -53,7 +53,7 @@ if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; t
   fi
 fi
 
-SWSSCONFIG_ARGS="00-copp.config.json ipinip.json ports.json switch.json "
+SWSSCONFIG_ARGS="00-copp.config.json 01-copp-dhcpv6.config.json ipinip.json ports.json switch.json "
 
 for file in $SWSSCONFIG_ARGS; do
     swssconfig /etc/swss/config.d/$file


### PR DESCRIPTION
#### Why I did it
Need to enable DHCPv6 copp rule

#### How I did it
Add a separate DHCPv6 copp rule config file and load it during cold reboot.

#### How to verify it
cold reboot, and verify config being loaded and dhcpv6 rules got installed.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
