### PR TITLE
[201811][warmboot finalizer] load dhcpv6 copp rules when missing

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -76,6 +76,18 @@ function stop_control_plane_assistant()
     fi
 }
 
+function load_dhcpv6_copp_rules()
+{
+    KEY="COPP_TABLE:trap.group.dhcpv6"
+    RULE=$(redis-cli -n 0 keys "${KEY}")
+    if [[ -n "${RULE}" ]]; then
+        debug "${KEY} already exist, skip reloading..."
+    else
+        debug "${KEY} not found, reloading..."
+        docker exec -t swss swssconfig /etc/swss/config.d/01-copp-dhcpv6.config.json
+    fi
+}
+
 
 wait_for_database_service
 
@@ -107,4 +119,5 @@ if [[ -n "${list}" ]]; then
     debug "Some components didn't finish reconcile: ${list} ..."
 fi
 
+load_dhcpv6_copp_rules
 finalize_warm_boot


### PR DESCRIPTION
#### Why I did it
Need to enable DHCPv6 COPP rules.

#### How I did it
Load the separate DHCPv6 COPP rules after warm reboot if the rules are missing.

#### How to verify it
Warm reboot from an image doesn't have DHCPv6 COPP rules installed.
Warm reboot from an image have DHCPv6 COPP rules already installed.
In either case, the script did the right thing and only install the COPP rules if it is missing.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
