### PR TITLE
[ci]: add native arm64/armhf sonic-slave build pipeline

### DIFF
--- a/.azure-pipelines/docker-sonic-slave-arm64.yml
+++ b/.azure-pipelines/docker-sonic-slave-arm64.yml
@@ -25,10 +25,6 @@ pr:
     - sonic-slave-bullseye
 
 parameters:
-- name: 'arches'
-  type: object
-  default:
-  - arm64
 - name: 'dists'
   type: object
   default:
@@ -41,9 +37,8 @@ stages:
   jobs:
   - ${{ each dist in parameters.dists }}:
     - ${{ if contains(variables['Build.DefinitionName'], dist) }}:
-      - ${{ each arch in parameters.arches }}:
-        - template: docker-sonic-slave-template.yml
-          parameters:
-            pool: sonicbld-arm64
-            arch: ${{ arch }}
-            dist: ${{ dist }}
+      - template: docker-sonic-slave-template.yml
+        parameters:
+          pool: sonicbld-arm64
+          arch: arm64
+          dist: ${{ dist }}

--- a/.azure-pipelines/docker-sonic-slave-arm64.yml
+++ b/.azure-pipelines/docker-sonic-slave-arm64.yml
@@ -28,8 +28,6 @@ parameters:
 - name: 'arches'
   type: object
   default:
-  - amd64
-  - armhf
   - arm64
 - name: 'dists'
   type: object
@@ -37,22 +35,15 @@ parameters:
   - bullseye
   - buster
   - stretch
-  - jessie
-- name: registry_url
-  type: string
-  default: sonicdev-microsoft.azurecr.io
-- name: registry_conn
-  type: string
-  default: sonicdev
 
 stages:
 - stage: Build
   jobs:
   - ${{ each dist in parameters.dists }}:
-    - ${{ if endswith(variables['Build.DefinitionName'], dist) }}:
+    - ${{ if contains(variables['Build.DefinitionName'], dist) }}:
       - ${{ each arch in parameters.arches }}:
         - template: docker-sonic-slave-template.yml
           parameters:
-            pool: sonicbld
+            pool: sonicbld-arm64
             arch: ${{ arch }}
             dist: ${{ dist }}

--- a/.azure-pipelines/docker-sonic-slave-armhf.yml
+++ b/.azure-pipelines/docker-sonic-slave-armhf.yml
@@ -28,31 +28,22 @@ parameters:
 - name: 'arches'
   type: object
   default:
-  - amd64
   - armhf
-  - arm64
 - name: 'dists'
   type: object
   default:
   - bullseye
   - buster
   - stretch
-  - jessie
-- name: registry_url
-  type: string
-  default: sonicdev-microsoft.azurecr.io
-- name: registry_conn
-  type: string
-  default: sonicdev
 
 stages:
 - stage: Build
   jobs:
   - ${{ each dist in parameters.dists }}:
-    - ${{ if endswith(variables['Build.DefinitionName'], dist) }}:
+    - ${{ if contains(variables['Build.DefinitionName'], dist) }}:
       - ${{ each arch in parameters.arches }}:
         - template: docker-sonic-slave-template.yml
           parameters:
-            pool: sonicbld
+            pool: sonicbld-armhf
             arch: ${{ arch }}
             dist: ${{ dist }}

--- a/.azure-pipelines/docker-sonic-slave-armhf.yml
+++ b/.azure-pipelines/docker-sonic-slave-armhf.yml
@@ -25,10 +25,6 @@ pr:
     - sonic-slave-bullseye
 
 parameters:
-- name: 'arches'
-  type: object
-  default:
-  - armhf
 - name: 'dists'
   type: object
   default:
@@ -41,9 +37,8 @@ stages:
   jobs:
   - ${{ each dist in parameters.dists }}:
     - ${{ if contains(variables['Build.DefinitionName'], dist) }}:
-      - ${{ each arch in parameters.arches }}:
-        - template: docker-sonic-slave-template.yml
-          parameters:
-            pool: sonicbld-armhf
-            arch: ${{ arch }}
-            dist: ${{ dist }}
+      - template: docker-sonic-slave-template.yml
+        parameters:
+          pool: sonicbld-armhf
+          arch: armhf
+          dist: ${{ dist }}

--- a/.azure-pipelines/docker-sonic-slave-template.yml
+++ b/.azure-pipelines/docker-sonic-slave-template.yml
@@ -1,0 +1,108 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+# Build and push sonic-slave-[buster|jessie|stretch] images for amd64/armhf/arm64
+
+parameters:
+- name: arch
+  type: string
+  values:
+  - amd64
+  - armhf
+  - arm64
+- name: dist
+  type: string
+  values:
+  - bullseye
+  - buster
+  - stretch
+  - jessie
+- name: registry_url
+  type: string
+  default: sonicdev-microsoft.azurecr.io
+- name: registry_conn
+  type: string
+  default: sonicdev
+- name: pool
+  type: string
+  default: sonicbld
+  values:
+  - sonicbld
+  - sonicbld-arm64
+  - sonicbld-armhf
+
+jobs:
+- job: Build_${{ parameters.dist }}_${{ parameters.arch }}
+  timeoutInMinutes: 360
+  pool: ${{ parameters.pool }}
+  steps:
+  - template: cleanup.yml
+  - checkout: self
+    clean: true
+    submodules: recursive
+  - bash: |
+      set -ex
+
+      SLAVE_DIR=sonic-slave-${{ parameters.dist }}
+      if [ x${{ parameters.pool }} == x"sonicbld" ]; then
+        if [ x${{ parameters.arch }} == x"amd64" ]; then
+          SLAVE_BASE_IMAGE=${SLAVE_DIR}
+          SLAVE_BASE_IMAGE_UPLOAD=${SLAVE_DIR}
+        elif [ x${{ parameters.pool }} == x"sonicbld" ]; then
+          SLAVE_BASE_IMAGE=${SLAVE_DIR}-march-${{ parameters.arch }}
+          SLAVE_BASE_IMAGE_UPLOAD=${SLAVE_DIR}-march-${{ parameters.arch }}
+        fi
+      elif [[ x${{ parameters.pool }} == x"sonicbld-armhf" && x${{ parameters.arch }} == x"armhf" ]]; then
+        SLAVE_BASE_IMAGE=${SLAVE_DIR}
+        SLAVE_BASE_IMAGE_UPLOAD=${SLAVE_DIR}-armhf
+      elif [[ x${{ parameters.pool }} == x"sonicbld-arm64" && x${{ parameters.arch }} == x"arm64" ]]; then
+        SLAVE_BASE_IMAGE=${SLAVE_DIR}
+        SLAVE_BASE_IMAGE_UPLOAD=${SLAVE_DIR}-arm64
+      else
+        echo "do not support build ${{ parameters.arch }} on ${{ parameters.pool }}"
+        exit 1
+      fi
+
+      if [ x"$(Build.SourceBranchName)" == x"202012" ]; then
+        BUILD_OPTIONS = 'SONIC_VERSION_CONTROL_COMPONENTS=deb,py2,py3,web,git,docker'
+      fi
+
+      containers=$(docker container ls | grep "sonic-slave" | awk '{ print $1 }')
+      if [ ! -z "$containers" ]; then
+        docker container kill $containers || true
+        sleep 5
+      fi
+      images=$(docker images 'sonic-slave-*' -a -q)
+      if [ ! -z "$images" ]; then
+        docker rmi -f $images
+      fi
+
+      tmpfile=$(mktemp)
+
+      echo ${{ parameters.arch }} > .arch
+
+      DOCKER_DATA_ROOT_FOR_MULTIARCH=/data/march/docker BLDENV=${{ parameters.dist }} $(BUILD_OPTIONS) make -f Makefile.work sonic-slave-build | tee $tmpfile
+      SLAVE_BASE_TAG=$(grep "^Checking sonic-slave-base image:" $tmpfile | awk -F ':' '{print $3}')
+      SLAVE_TAG=$(grep "^Checking sonic-slave image:" $tmpfile | awk -F ':' '{print $3}')
+
+      mkdir -p target
+
+      docker tag $SLAVE_BASE_IMAGE:$SLAVE_BASE_TAG $REGISTRY_SERVER/$SLAVE_BASE_IMAGE_UPLOAD:latest
+      docker tag $SLAVE_BASE_IMAGE:$SLAVE_BASE_TAG $REGISTRY_SERVER/$SLAVE_BASE_IMAGE_UPLOAD:$SLAVE_BASE_TAG
+      set +x
+      echo "##vso[task.setvariable variable=VARIABLE_SLAVE_BASE_IMAGE]$SLAVE_BASE_IMAGE_UPLOAD"
+      echo "##vso[task.setvariable variable=VARIABLE_SLAVE_BASE_TAG]$SLAVE_BASE_TAG"
+    env:
+      REGISTRY_SERVER: ${{ parameters.registry_url }}
+    displayName: Build sonic-slave-${{ parameters.dist }}-${{ parameters.arch }}
+
+  - task: Docker@2
+    displayName: Upload image
+    inputs:
+      containerRegistry: ${{ parameters.registry_conn }}
+      repository: $(VARIABLE_SLAVE_BASE_IMAGE)
+      command: push
+      tags: |
+        $(VARIABLE_SLAVE_BASE_TAG)
+        latest


### PR DESCRIPTION
setup sonic-slave template and use the template
for amd64, arm64 and armhf sonic-slave

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
build native docker for armhf and arm64

#### How I did it
move sonic-slave to template

#### How to verify it
run several pipeline.

sonic-slave-buster-arm64
sonic-slave-buster-armhf

https://dev.azure.com/mssonic/build/_build?definitionScope=%5Cbldenv

![image](https://user-images.githubusercontent.com/2293967/138785686-b45c893f-a74c-4dd1-b6ca-d6a64502aa26.png)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

