### PR TITLE
[rsyslog][multiasic]Fix the syslog server $UDPServerAddress null setting issue

### DIFF
--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -13,7 +13,7 @@ fi
 # on Single NPU platforms we continue to use loopback adddres
 
 if [[ ($NUM_ASIC -gt 1) ]]; then
-    udp_server_ip=$(ip -j -4 addr list docker0 | jq -r -M '.[0].addr_info[0].local')
+    udp_server_ip=$(ip -j -4 addr list docker0 scope global | jq -r -M '.[0].addr_info[0].local')
 else
     udp_server_ip=$(ip -j -4 addr list lo scope host | jq -r -M '.[0].addr_info[0].local')
 fi


### PR DESCRIPTION
#### Why I did it
In multi NPU platform,  rsyslog server doesn't work due to the UDPServerAddress is set to null in the /etc/rsyslog.conf file. i It should be the docker0 interface address. Fixes #9057

#### How I did it
-- In multiasic platform, using shell command "ip -j -4 .." option, the docker0 is not the first entry in the dictionary.  We need to use  the option "scope global" to make sure docker0 interface is the first entry to allow "jq" to parser and derives the correct ip address.

#### How to verify it
1. login on the multiasic platform
2. open the /etc/rsyslog.conf file to verify the UDPServerAddress is set to 240.127.1.1
```
# provides UDP syslog reception
$ModLoad imudp
$UDPServerAddress 240.127.1.1  #bind to localhost before udp server run
$UDPServerRun 514

# provides TCP syslog reception
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

