### PR TITLE
DellEMC: Z9332f - SFP API get_error_description implementation

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
@@ -1430,7 +1430,7 @@ class Sfp(SfpBase):
             return self.SFP_STATUS_UNPLUGGED
         else:
             if not os.path.isfile(self.eeprom_path):
-                return "EEPROM driver is not initialized"
+                return "EEPROM driver is not attached"
 
             if self.sfp_type == 'SFP':
                 offset = SFP_INFO_OFFSET

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
@@ -1416,3 +1416,34 @@ class Sfp(SfpBase):
             bool: True if it is replaceable.
         """
         return True
+
+    def get_error_description(self):
+        """
+        Retrives the error descriptions of the SFP module
+
+        Returns:
+            String that represents the current error descriptions of vendor specific errors
+            In case there are multiple errors, they should be joined by '|',
+            like: "Bad EEPROM|Unsupported cable"
+        """
+        if not self.get_presence():
+            return self.SFP_STATUS_UNPLUGGED
+        else:
+            if not os.path.isfile(self.eeprom_path):
+                return "EEPROM driver is not initialized"
+
+            if self.sfp_type == 'SFP':
+                offset = SFP_INFO_OFFSET
+            elif self.sfp_type == 'QSFP':
+                offset = QSFP_INFO_OFFSET
+            elif self.sfp_type == 'QSFP_DD':
+                offset = QSFP_DD_PAGE0
+
+            try:
+                with open(self.eeprom_path, mode="rb", buffering=0) as eeprom:
+                    eeprom.seek(offset)
+                    eeprom.read(1)
+            except OSError as e:
+                return "EEPROM read failed ({})".format(e.strerror)
+
+        return self.SFP_STATUS_OK


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To implement SFP API get_error_description for DellEMC Z9332f.

#### How I did it

Implement the API in sfp.py

#### How to verify it

Verified that the return type is as expected. 
UT logs: [Z9332f_UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/7417380/Z9332f_UT_logs.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC: Z9332f - SFP API get_error_description implementation

#### A picture of a cute animal (not mandatory but encouraged)

