### PR TITLE
Update DHCP_PACKET_MARK schema in state_db

### DIFF
--- a/files/scripts/mark_dhcp_packet.py
+++ b/files/scripts/mark_dhcp_packet.py
@@ -85,7 +85,7 @@ class MarkDhcpPacket(object):
         self.run_command("sudo ebtables -A INPUT -i {} -j mark --mark-set {}".format(intf, mark))
 
     def update_mark_in_state_db(self, intf, mark):
-        self.state_db.set(self.state_db.STATE_DB, 'DHCP_PACKET_MARK', intf, mark)
+        self.state_db.set(self.state_db.STATE_DB, 'DHCP_PACKET_MARK|' + intf, 'mark', mark)
 
     def apply_marks(self):
         """


### PR DESCRIPTION
- update DHCP_PACKET_MARK schema in state_db
- this is an update over https://github.com/Azure/sonic-buildimage/pull/9015

Example output of DHCP_PACKET_MARK table in state_db:

![state_db_mark](https://user-images.githubusercontent.com/22752629/139792909-af3f9203-b1d5-4675-b890-a20dcec187cf.PNG)
 