### PR TITLE
/proc/sys/vm/compact_memory doesn't exist in Ubuntu 20.04, delete ref…

### DIFF
--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -59,7 +59,11 @@ free -m
 if [[ "$vs_build_prepare_mem" == "yes" ]]; then
     # Force o.s. to drop cache and compact memory so that KVM can get 2G memory
     bash -c 'echo 1 > /proc/sys/vm/drop_caches'
-    bash -c 'echo 1 > /proc/sys/vm/compact_memory'
+    # Not all kernels support compact_memory
+    if [[ -w '/proc/sys/vm/compact_memory' ]]
+    then	    
+        bash -c 'echo 1 > /proc/sys/vm/compact_memory'
+    fi
     free -m
 fi
 


### PR DESCRIPTION
…erence to it.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Builld was failing for PLATFORM=vs on a Ubuntu 20.04 system

#### How I did it
Edited scripts/build_kvm_image.sh to knock out line which was referring to /proc/sys/vm/compact_memory

#### How to verify it
Eyeball the affected script

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Remove reference to /proc/sys/vm/compact_memory so that PLATFORM=vs will build on Ubuntu 20.04
-->


#### A picture of a cute animal (not mandatory but encouraged)

