### PR TITLE
[PINS] Add APPL_STATE_DB and response path log rotation

### DIFF
--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -88,6 +88,11 @@
             "id" : 13,
             "separator": "|",
             "instance" : "redis_chassis"
+        },
+        "APPL_STATE_DB" : {
+            "id" : 14,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"

--- a/files/image_config/logrotate/logrotate.d/rsyslog
+++ b/files/image_config/logrotate/logrotate.d/rsyslog
@@ -33,6 +33,7 @@
 /var/log/frr/zebra.log
 /var/log/swss/sairedis*.rec
 /var/log/swss/swss*.rec
+/var/log/swss/responsepublisher.rec
 {
     size 1M
     rotate 5000

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -173,6 +173,7 @@ start() {
         $SONIC_DB_CLI GB_COUNTERS_DB FLUSHDB
         $SONIC_DB_CLI RESTAPI_DB FLUSHDB
         clean_up_tables STATE_DB "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'LAG_TABLE*', 'LAG_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*', 'FDB_TABLE*', 'FG_ROUTE_TABLE*', 'BUFFER_POOL*', 'BUFFER_PROFILE*', 'MUX_CABLE_TABLE*'"
+        $SONIC_DB_CLI APPL_STATE_DB FLUSHDB
     fi
 
     # On supervisor card, skip starting asic related services here. In wait(),

--- a/platform/vs/docker-sonic-vs/database_config.json
+++ b/platform/vs/docker-sonic-vs/database_config.json
@@ -77,6 +77,11 @@
             "id" : 12,
             "separator": "|",
             "instance" : "redis_chassis"
+        },
+        "APPL_STATE_DB" : {
+            "id" : 14,
+            "separator": ":",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"


### PR DESCRIPTION
- Add APPL_STATE_DB to database_config.json
- Clear APPL_STATE_DB during SwSS container restarts
- Add response path log file to logrotate config:
    responsepublisher.rec

Submission containing materials of a third party:
    Copyright Google LLC; Licensed under Apache 2.0

Co-authored-by: Mike Attig <mikeattig@google.com>
Co-authored-by: Runming Wu <runmingwu@google.com>
Co-authored-by: Akarsh Gupta <akarshgupta@google.com>

#### Why I did it

Adds support for APPL_STATE_DB and response path required for PINS.

Described in this HLD:
https://github.com/pins/SONiC/blob/master/doc/pins/appl_state_db_response_path_hld.md

#### How to verify it

Any build should do the trick, then verify that the APPL_STATE_DB is empty after restarting swss.

#### Which release branch to backport (provide reason below if selected)

None

#### Description for the changelog

Add APPL_STATE_DB and response path log rotation