### PR TITLE
[PINS] Add submit to ingress port to copp_cfg file

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -13,7 +13,7 @@
 		    "trap_priority":"4",
 		    "queue": "4"
 	    },
-	    "queue4_group2": {            
+	    "queue4_group2": {
 		    "trap_action":"copy",
 		    "trap_priority":"4",
 		    "queue": "4",
@@ -60,7 +60,10 @@
 		    "trap_action": "trap",
 		    "trap_priority": "1"
 
-	    }
+	    }{%- if include_p4rt == "y" %},
+	    "trap.group.send_to_ingress" : {
+		    "submit_to_ingress_name" : "send_to_ingress"
+	    }{% endif %}
     },
     "COPP_TRAP": {
 	    "bgp": {


### PR DESCRIPTION
Submission containing materials of a third party:
    Copyright Google LLC; Licensed under Apache 2.0

Co-authored-by: Glenn Connery <gconnery@google.com>

Depends on:
- [ ] https://github.com/Azure/sonic-buildimage/pull/9083
- [ ] https://github.com/Azure/sonic-swss/pull/1952

#### Why I did it

Adds support for submit_to_ingress port required for PINS packet out path

More details in this HLD:
https://github.com/pins/SONiC/blob/master/doc/pins/Packet_io.md

#### How to verify it

Build the SONiC image and verify that the submit_to_ingress netdev is created

#### Which release branch to backport (provide reason below if selected)

None

#### Description for the changelog

Add submit to ingress port to copp_cfg file