### PR TITLE
DellEMC Z9332f: Add platform scripts

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f.install
@@ -7,7 +7,7 @@ z9332f/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64
 z9332f/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
 common/platform_reboot usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
 common/pcisysfs.py usr/bin
-common/io_rd_wr.py usr/bin
+common/io_rd_wr.py usr/local/bin
 common/fw-updater usr/local/bin
 common/onie_mode_set usr/local/bin
 common/onie_stage_fwpkg usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f.install
@@ -7,7 +7,7 @@ z9332f/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64
 z9332f/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
 common/platform_reboot usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
 common/pcisysfs.py usr/bin
-common/io_rd_wr.py usr/local/bin
+common/io_rd_wr.py usr/bin
 common/fw-updater usr/local/bin
 common/onie_mode_set usr/local/bin
 common/onie_stage_fwpkg usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f.install
@@ -6,7 +6,8 @@ z9332f/systemd/platform-modules-z9332f.service etc/systemd/system
 z9332f/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
 z9332f/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
 common/platform_reboot usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
-common/pcisysfs.py usr/bin
+common/pcisysfs.py usr/local/bin
+common/io_rd_wr.py usr/local/bin
 common/fw-updater usr/local/bin
 common/onie_mode_set usr/local/bin
 common/onie_stage_fwpkg usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9332f.install
@@ -6,7 +6,7 @@ z9332f/systemd/platform-modules-z9332f.service etc/systemd/system
 z9332f/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
 z9332f/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
 common/platform_reboot usr/share/sonic/device/x86_64-dellemc_z9332f_d1508-r0
-common/pcisysfs.py usr/local/bin
+common/pcisysfs.py usr/bin
 common/io_rd_wr.py usr/local/bin
 common/fw-updater usr/local/bin
 common/onie_mode_set usr/local/bin


### PR DESCRIPTION
#### Why I did it
some platform script has to be added in DellEMC Z9332f platform.
#### How I did it
The script has to be present independently even though API is available and it will be useful for debugging purpose. 
#### How to verify it
Verified in DellEMC Z9332f platform.
#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog

#### A picture of a cute animal (not mandatory but encouraged)

