### PR TITLE
[gearbox] Use separator ':' for GB_ASIC_DB, GB_COUNTERS_DB and GB_FLE…

### DIFF
--- a/dockers/docker-database/database_config.json.j2
+++ b/dockers/docker-database/database_config.json.j2
@@ -66,17 +66,17 @@
         },
         "GB_ASIC_DB" : {
             "id" : 9,
-            "separator": "|",
+            "separator": ":",
             "instance" : "redis"
         },
         "GB_COUNTERS_DB" : {
             "id" : 10,
-            "separator": "|",
+            "separator": ":",
             "instance" : "redis"
         },
         "GB_FLEX_COUNTER_DB" : {
             "id" : 11,
-            "separator": "|",
+            "separator": ":",
             "instance" : "redis"
         },
         "CHASSIS_APP_DB" : {


### PR DESCRIPTION
…X_COUNTER_DB

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Keep GB_ASIC_DB, etc consistent with the ones in sonic-swss-common/common/database_config.json

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

