### PR TITLE
TACACS: Don't send sshd's bad password to AAA

### DIFF
--- a/src/tacacs/pam/0010-handle-bad-password-set-by-sshd.patch
+++ b/src/tacacs/pam/0010-handle-bad-password-set-by-sshd.patch
@@ -1,0 +1,99 @@
+From eb7f56e4a75050091916841d2d9daec646a4210a Mon Sep 17 00:00:00 2001
+From: Renuka Manavalan <remanava@microsoft.com>
+Date: Fri, 29 Oct 2021 21:40:55 +0000
+Subject: [PATCH] handle bad password set by sshd
+
+---
+ pam_tacplus.c |  7 +++++++
+ support.c     | 39 ++++++++++++++++++++++++++++++++++++++-
+ support.h     |  1 +
+ 3 files changed, 46 insertions(+), 1 deletion(-)
+
+diff --git a/pam_tacplus.c b/pam_tacplus.c
+index d57657a..2f1ed46 100644
+--- a/pam_tacplus.c
++++ b/pam_tacplus.c
+@@ -248,6 +248,13 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
+         return PAM_CRED_INSUFFICIENT;
+     }
+ 
++    if (validate_not_sshd_bad_pass(pass) != PAM_SUCCESS) {
++        syslog(LOG_ERR, "auth fail: Password incorrect");
++        bzero(pass, strlen (pass));
++        free(pass);
++        return PAM_AUTH_ERR;
++    }
++
+     retval = pam_set_item (pamh, PAM_AUTHTOK, pass);
+     if (retval != PAM_SUCCESS) {
+         _pam_log(LOG_ERR, "unable to set password");
+diff --git a/support.c b/support.c
+index 1ea2e30..8a7dfbb 100644
+--- a/support.c
++++ b/support.c
+@@ -114,6 +114,43 @@ int converse(pam_handle_t * pamh, int nargs, const struct pam_message *message,
+     return retval;
+ }
+ 
++/*
++ * Ref: From <https://groups.google.com/g/mailing.unix.openssh-dev/c/ViHvtciKYh0>
++ * For future archive searchers:
++ * > Why does OpenSSH replaces the password entered by the user with the
++ * > bad password - "\b\n\r\177INCORRECT
++ *
++ * There are some situations where sshd determines a user can't log in.
++ * Typical samples of that are DenyUsers or PermitRootLogin.
++ * In those cases sshd *still* calls PAM, so that delays set by it are
++ * still performed to the user (without leaking info about accounts
++ * existing, disabled, etc.). But in order to ensure it can't succeed,
++ * replaces the password with that impossible one.
++ *
++ */
++int validate_not_sshd_bad_pass(const char *pass)
++{
++    const char *SSHD_BAD_PASS = "\010\012\015\177INCORRECT";
++    const int SSHD_BAD_PASS_LEN = strlen(SSHD_BAD_PASS);
++
++    int len = strlen(pass);
++    const char *p = pass;
++
++    if (len == 0)
++        return PAM_SUCCESS;
++
++    while (len > 0) {
++        int l = len < SSHD_BAD_PASS_LEN ? len : SSHD_BAD_PASS_LEN;
++
++        if (strncmp(p, SSHD_BAD_PASS, l) != 0)
++            return PAM_SUCCESS;
++
++        len -= l;
++        p += l;
++    }
++    return PAM_AUTH_ERR;
++}
++
+ /* stolen from pam_stress */
+ int tacacs_get_password (pam_handle_t * pamh, int flags
+     ,int ctrl, char **password) {
+@@ -436,4 +473,4 @@ int _pam_parse (int argc, const char **argv) {
+     }
+ 
+     return ctrl;
+-}    /* _pam_parse */
+\ No newline at end of file
++}    /* _pam_parse */
+diff --git a/support.h b/support.h
+index 20553da..1989530 100644
+--- a/support.h
++++ b/support.h
+@@ -59,6 +59,7 @@ extern struct addrinfo *tac_source_addr;
+ int _pam_parse (int, const char **);
+ unsigned long _resolve_name (char *);
+ unsigned long _getserveraddr (char *serv);
++int validate_not_sshd_bad_pass(const char *pass);
+ int tacacs_get_password (pam_handle_t *, int, int, char **);
+ int converse (pam_handle_t *, int, const struct pam_message *, struct pam_response **);
+ void _pam_log (int, const char *, ...);
+-- 
+2.17.1
+

--- a/src/tacacs/pam/0010-handle-bad-password-set-by-sshd.patch
+++ b/src/tacacs/pam/0010-handle-bad-password-set-by-sshd.patch
@@ -1,16 +1,17 @@
-From eb7f56e4a75050091916841d2d9daec646a4210a Mon Sep 17 00:00:00 2001
+From 36f67d58c39a5aceeec3182e381735c8a4a0a657 Mon Sep 17 00:00:00 2001
 From: Renuka Manavalan <remanava@microsoft.com>
-Date: Fri, 29 Oct 2021 21:40:55 +0000
+Date: Fri, 5 Nov 2021 17:43:10 +0000
 Subject: [PATCH] handle bad password set by sshd
 
 ---
- pam_tacplus.c |  7 +++++++
+ pam_tacplus.c | 11 +++++++++--
  support.c     | 39 ++++++++++++++++++++++++++++++++++++++-
  support.h     |  1 +
- 3 files changed, 46 insertions(+), 1 deletion(-)
+ tacc.c        |  4 ++--
+ 4 files changed, 50 insertions(+), 5 deletions(-)
 
 diff --git a/pam_tacplus.c b/pam_tacplus.c
-index d57657a..2f1ed46 100644
+index d57657a..eb53c94 100644
 --- a/pam_tacplus.c
 +++ b/pam_tacplus.c
 @@ -248,6 +248,13 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
@@ -19,7 +20,7 @@ index d57657a..2f1ed46 100644
  
 +    if (validate_not_sshd_bad_pass(pass) != PAM_SUCCESS) {
 +        syslog(LOG_ERR, "auth fail: Password incorrect");
-+        bzero(pass, strlen (pass));
++        memset(pass, 0, strlen (pass));
 +        free(pass);
 +        return PAM_AUTH_ERR;
 +    }
@@ -27,6 +28,24 @@ index d57657a..2f1ed46 100644
      retval = pam_set_item (pamh, PAM_AUTHTOK, pass);
      if (retval != PAM_SUCCESS) {
          _pam_log(LOG_ERR, "unable to set password");
+@@ -481,7 +488,7 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
+         syslog(LOG_DEBUG, "%s: exit with pam status: %d", __FUNCTION__, status);
+ 
+     if (NULL != pass) {
+-        bzero(pass, strlen (pass));
++        memset(pass, 0, strlen (pass));
+         free(pass);
+         pass = NULL;
+     }
+@@ -978,7 +985,7 @@ finish:
+         syslog(LOG_DEBUG, "%s: exit with pam status: %d", __FUNCTION__, status);
+ 
+     if (NULL != pass) {
+-        bzero(pass, strlen(pass));
++        memset(pass, 0, strlen(pass));
+         free(pass);
+         pass = NULL;
+     }
 diff --git a/support.c b/support.c
 index 1ea2e30..8a7dfbb 100644
 --- a/support.c
@@ -94,6 +113,28 @@ index 20553da..1989530 100644
  int tacacs_get_password (pam_handle_t *, int, int, char **);
  int converse (pam_handle_t *, int, const struct pam_message *, struct pam_response **);
  void _pam_log (int, const char *, ...);
+diff --git a/tacc.c b/tacc.c
+index fcc7d8c..bf0f2a3 100644
+--- a/tacc.c
++++ b/tacc.c
+@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
+ 				break;
+ 			case 'L':
+ 				// tac_login is a global variable initialized in libtac
+-				bzero(tac_login, sizeof(tac_login));
++				memset(tac_login, 0, sizeof(tac_login));
+ 				strncpy(tac_login, optarg, sizeof(tac_login) - 1);
+ 				break;
+ 			case 'p':
+@@ -312,7 +312,7 @@ int main(int argc, char **argv) {
+ 	}
+ 
+ 	/* we no longer need the password in our address space */
+-	bzero(pass, strlen(pass));
++	memset(pass, 0, strlen(pass));
+ 	pass = NULL;
+ 
+ 	if (do_account) {
 -- 
 2.17.1
 

--- a/src/tacacs/pam/Makefile
+++ b/src/tacacs/pam/Makefile
@@ -23,6 +23,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git apply ../0007-Fix-memory-leak-when-parse-configuration.patch
 	git apply ../0008-Extract-tacacs-support-functions-into-library.patch
 	git apply ../0009-Add-setting-flag-for-authorization-and-accounting.patch
+	git apply ../0010-handle-bad-password-set-by-sshd.patch
 
 	dpkg-buildpackage -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 	popd


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When sshd realizes that this login can't succeed due to internal device state
or configuration, instead of failing right there, it proceeds to prompt for
password, so as the user does not get any clue on where is the failure point.

Yet to ensure that this login does not proceed, sshd replaces user provided password
with a specific pattern of characters matching length of user provided password.
This pattern is "<BS><LF><CR><DEL>INCORRECT", which is bound to fail.

If user provided length is smaller/equal, the substring of pattern is overwritten.
If user provided length is greater, the pattern is repeated until length is exhausted.

But if the PAM-tacacs plugin would send this password to AAA, the user could get
locked out by AAA, for providing incorrect value.

#### How I did it
Hence this fix, matches obtained password against the pattern. If match, fail just before
reaching AAA server.

#### How to verify it

1. Make sure tacacs is properly configured.
2. Try logging in as, say "user-A"; ensure it succeeds
3. Pick another user, say user-B and ensure this user has not logged into this device before (_look into /etc/passed & folders under /home_)
4. Disable monit service (_as that could fix the issue using disk_check.py_)
5. Start TCP dump for all TACACS servers.
6. Simulate Read-only disk
7. Try logging in using  user-B.
8. Verify it fails, after 3 attempts
9. Stop tcp dump.
10. TCP dump should show "authentication" for user-A only

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

