### PR TITLE
[Build]: Cleanup the reproducible mirrors when build complete

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -11,6 +11,7 @@ POST_VERSION_PATH=$BUILDINFO_PATH/post-versions
 VERSION_DEB_PREFERENCE=$BUILDINFO_PATH/versions/01-versions-deb
 WEB_VERSION_FILE=$VERSION_PATH/versions-web
 BUILD_WEB_VERSION_FILE=$BUILD_VERSION_PATH/versions-web
+REPR_MIRROR_URL_PATTERN='http:\/\/packages.trafficmanager.net\/debian'
 
 . $BUILDINFO_PATH/config/buildinfo.config
 
@@ -57,6 +58,22 @@ check_if_url_exist()
     else
         echo n
     fi
+}
+
+# Enable or disable the reproducible mirrors
+set_reproducible_mirrors()
+{
+    # Remove the charater # in front of the line if matched
+    local expression="s/^#\(.*$REPR_MIRROR_URL_PATTERN\)/\1/"
+    if [ "$1" = "-d" ]; then
+        # Add the charater # in front of the line if match
+        expression="s/^deb.*$REPR_MIRROR_URL_PATTERN/#\0/"
+    fi
+
+    local mirrors="/etc/apt/sources.list $(ls /etc/apt/sources.list.d/)"
+    for mirror in $mirrors; do
+        sed -i "$expression" "$mirror"
+    done
 }
 
 download_packages()

--- a/src/sonic-build-hooks/scripts/post_run_buildinfo
+++ b/src/sonic-build-hooks/scripts/post_run_buildinfo
@@ -12,3 +12,4 @@ rm -rf $BUILD_VERSION_PATH/*
 
 # Disable the build hooks
 symlink_build_hooks -d
+set_reproducible_mirrors -d

--- a/src/sonic-build-hooks/scripts/pre_run_buildinfo
+++ b/src/sonic-build-hooks/scripts/pre_run_buildinfo
@@ -10,6 +10,7 @@ mkdir -p $LOG_PATH
 [ -d $PRE_VERSION_PATH ] && rm -rf $PRE_VERSION_PATH
 collect_version_files $PRE_VERSION_PATH
 symlink_build_hooks
+set_reproducible_mirrors
 
 chmod -R a+rw $BUILDINFO_PATH
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The reproducible build mirrors are only used during the build, the mirrors can be removed after that.

#### How I did it
Add a comment character # in front of the mirror source list after build.

#### How to verify it
Run "sudo apt-get update" to verify the reproducible mirrors not used.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

