### PR TITLE
[nvgre] Added YANG model and tests

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1275,6 +1275,19 @@
 	          "pfc_to_pg_map"   : "pfc_prio_to_pg_map2",
 	          "pfc_enable"      : "3,4"
             }
+        },
+
+        "NVGRE_TUNNEL": {
+            "tunnel_1": {
+                "src_ip": "10.0.0.1"
+            }
+        },
+
+        "NVGRE_TUNNEL_MAP": {
+            "tunnel_1|Vlan111": {
+                "vlan_id": "111",
+                "vsid": "5000"
+            }
         }
     },
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/nvgre.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/nvgre.json
@@ -1,0 +1,25 @@
+{
+    "NVGRE_TUNNEL_AND_TUNNEL_MAP": {
+	    "desc": "NVGRE_TUNNEL with NVGRE_TUNNEL_MAP"
+    },
+
+    "NVGRE_TUNNEL_INVALID_SRC_IP": {
+        "desc": "INVALID src_ip value for NVGRE_TUNNEL",
+        "eStrKey": "Pattern"
+    },
+
+    "NVGRE_TUNNEL_MAP_UNEXISTING_NVGRE_TUNNEL_NAME": {
+        "desc": "Unexisting NVGRE_TUNNEL",
+        "eStrKey": "LeafRef"
+    },
+
+    "NVGRE_TUNNEL_MAP_UNEXISTING_VLAN_NAME": {
+        "desc": "Unexisting VLAN NAME",
+        "eStrKey": "LeafRef"
+    },
+
+    "NVGRE_TUNNEL_MAP_INVALID_VSID": {
+        "desc": "INVALID VSID value for NVGRE_TUNNEL_MAP",
+        "eStrKey": "Pattern"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/nvgre.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/nvgre.json
@@ -1,0 +1,125 @@
+{
+    "NVGRE_TUNNEL_AND_TUNNEL_MAP": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan200"
+                    }
+                ]
+            }
+        },
+        "sonic-nvgre-tunnel:sonic-nvgre-tunnel": {
+            "sonic-nvgre-tunnel:NVGRE_TUNNEL": {
+                "NVGRE_TUNNEL_LIST": [
+                    {
+                        "tunnel_name": "tunnel_1",
+                        "src_ip": "10.0.0.1"
+                    }
+                ]
+            },
+            "sonic-nvgre-tunnel:NVGRE_TUNNEL_MAP": {
+                "NVGRE_TUNNEL_MAP_LIST": [
+                    {
+                        "tunnel_name": "tunnel_1",
+                        "vlan_name": "Vlan200",
+                        "vlan_id": 200,
+                        "vsid": 5000
+                    }
+                ]
+            }
+        }
+    },
+
+    "NVGRE_TUNNEL_INVALID_SRC_IP": {
+        "sonic-nvgre-tunnel:sonic-nvgre-tunnel": {
+            "sonic-nvgre-tunnel:NVGRE_TUNNEL": {
+                "NVGRE_TUNNEL_LIST": [
+                    {
+                        "tunnel_name": "tunnel_1",
+                        "src_ip": "INVALID"
+                    }
+                ]
+            }
+        }
+    },
+
+    "NVGRE_TUNNEL_MAP_UNEXISTING_NVGRE_TUNNEL_NAME": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan200"
+                    }
+                ]
+            }
+        },
+        "sonic-nvgre-tunnel:sonic-nvgre-tunnel": {
+            "sonic-nvgre-tunnel:NVGRE_TUNNEL_MAP": {
+                "NVGRE_TUNNEL_MAP_LIST": [
+                    {
+                        "tunnel_name": "INVALID",
+                        "vlan_name": "Vlan200",
+                        "vlan_id": 200,
+                        "vsid": 5000
+                    }
+                ]
+            }
+        }
+    },
+
+    "NVGRE_TUNNEL_MAP_UNEXISTING_VLAN_NAME": {
+        "sonic-nvgre-tunnel:sonic-nvgre-tunnel": {
+            "sonic-nvgre-tunnel:NVGRE_TUNNEL": {
+                "NVGRE_TUNNEL_LIST": [
+                    {
+                        "tunnel_name": "tunnel_1",
+                        "src_ip": "10.0.0.1"
+                    }
+                ]
+            },
+            "sonic-nvgre-tunnel:NVGRE_TUNNEL_MAP": {
+                "NVGRE_TUNNEL_MAP_LIST": [
+                    {
+                        "tunnel_name": "tunnel_1",
+                        "vlan_name": "Vlan200",
+                        "vlan_id": 200,
+                        "vsid": 5000
+                    }
+                ]
+            }
+        }
+    },
+
+    "NVGRE_TUNNEL_MAP_INVALID_VSID": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan200"
+                    }
+                ]
+            }
+        },
+        "sonic-nvgre-tunnel:sonic-nvgre-tunnel": {
+            "sonic-nvgre-tunnel:NVGRE_TUNNEL": {
+                "NVGRE_TUNNEL_LIST": [
+                    {
+                        "tunnel_name": "tunnel_1",
+                        "src_ip": "10.0.0.1"
+                    }
+                ]
+            },
+            "sonic-nvgre-tunnel:NVGRE_TUNNEL_MAP": {
+                "NVGRE_TUNNEL_MAP_LIST": [
+                    {
+                        "tunnel_name": "tunnel_1",
+                        "vlan_name": "Vlan200",
+                        "vlan_id": 200,
+                        "vsid": 1
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-nvgre-tunnel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-nvgre-tunnel.yang
@@ -1,0 +1,94 @@
+module sonic-nvgre-tunnel {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/Azure/sonic-nvgre-tunnel";
+    prefix nvgre;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-vlan {
+        prefix vlan;
+    }
+
+    description "NVGRE Tunnel YANG Module for SONiC OS";
+
+    revision 2021-10-31 {
+        description
+            "First Revision";
+    }
+
+    container sonic-nvgre-tunnel {
+
+        container NVGRE_TUNNEL {
+
+            description "NVGRE_TUNNEL part of config_db.json";
+
+            list NVGRE_TUNNEL_LIST {
+
+                key "tunnel_name";
+
+                leaf tunnel_name {
+                    description "NVGRE Tunnel name";
+
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf src_ip {
+                    mandatory true;
+                    type inet:ipv4-address;
+                }
+
+            }
+            /* end of NVGRE_TUNNEL_LIST */
+
+        }
+        /* end of container NVGRE_TUNNEL */
+
+        container NVGRE_TUNNEL_MAP {
+
+            description "NVGRE_TUNNEL part of config_db.json";
+
+            list NVGRE_TUNNEL_MAP_LIST {
+
+                key "tunnel_name vlan_name";
+
+                leaf tunnel_name {
+                    type leafref {
+                        path /nvgre:sonic-nvgre-tunnel/nvgre:NVGRE_TUNNEL/nvgre:NVGRE_TUNNEL_LIST/nvgre:tunnel_name;
+                    }
+                }
+
+                leaf vlan_name {
+                    type leafref {
+                        path /vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name;
+                    }
+                }
+
+                leaf vlan_id {
+                    type uint16 {
+                        range 1..4094;
+                    }
+                }
+
+                leaf vsid {
+                    type uint32 {
+                        range 4096..16777214;
+                    }
+                }
+
+            }
+            /* end of NVGRE_TUNNEL_MAP_LIST */
+
+        }
+        /* end of container NVGRE_TUNNEL_MAP */
+
+    }
+    /* end of container sonic-nvgre-tunnel */
+
+}
+/* end of module sonic-nvgre-tunnel */


### PR DESCRIPTION
Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`NVGRE Tunnel` feature extends the Config DB with new tables. These tables require a new YANG model.

#### How I did it
Added a new YANG model `sonic-nvgre-tunnel.yang`

#### How to verify it
Added YANG test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

