### PR TITLE
[201811][dhcp_relay] Fix sendto: invalid destination address error

### DIFF
--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -20,7 +20,7 @@ struct event *ev_sigint;
 struct event *ev_sigterm;
 static std::string counter_table = "DHCPv6_COUNTER_TABLE|";
 swss::DBConnector state_db(6, "localhost", 6379, 0);
-swss::RedisClient m_applDbRedisClient(&state_db);
+swss::RedisClient m_stateDbRedisClient(&state_db);
 
 /* DHCPv6 filter */
 /* sudo tcpdump -dd "ip6 dst ff02::1:2 && udp dst port 547" */
@@ -73,17 +73,17 @@ std::map<int, std::string> counterMap = {{1, "Solicit"},
  * @return              none
  */
 void initialize_counter(std::string counterVlan) {
-    m_applDbRedisClient.hset(counterVlan, "Solicit", toString(counters[DHCPv6_MESSAGE_TYPE_SOLICIT]));
-    m_applDbRedisClient.hset(counterVlan, "Advertise", toString(counters[DHCPv6_MESSAGE_TYPE_ADVERTISE]));
-    m_applDbRedisClient.hset(counterVlan, "Request", toString(counters[DHCPv6_MESSAGE_TYPE_REQUEST]));
-    m_applDbRedisClient.hset(counterVlan, "Confirm", toString(counters[DHCPv6_MESSAGE_TYPE_CONFIRM]));
-    m_applDbRedisClient.hset(counterVlan, "Renew", toString(counters[DHCPv6_MESSAGE_TYPE_RENEW]));
-    m_applDbRedisClient.hset(counterVlan, "Rebind", toString(counters[DHCPv6_MESSAGE_TYPE_REBIND]));
-    m_applDbRedisClient.hset(counterVlan, "Reply", toString(counters[DHCPv6_MESSAGE_TYPE_REPLY]));
-    m_applDbRedisClient.hset(counterVlan, "Release", toString(counters[DHCPv6_MESSAGE_TYPE_RELEASE]));
-    m_applDbRedisClient.hset(counterVlan, "Decline", toString(counters[DHCPv6_MESSAGE_TYPE_DECLINE]));
-    m_applDbRedisClient.hset(counterVlan, "Relay-Forward", toString(counters[DHCPv6_MESSAGE_TYPE_RELAY_FORW]));
-    m_applDbRedisClient.hset(counterVlan, "Relay-Reply", toString(counters[DHCPv6_MESSAGE_TYPE_RELAY_REPL]));
+    m_stateDbRedisClient.hset(counterVlan, "Solicit", toString(counters[DHCPv6_MESSAGE_TYPE_SOLICIT]));
+    m_stateDbRedisClient.hset(counterVlan, "Advertise", toString(counters[DHCPv6_MESSAGE_TYPE_ADVERTISE]));
+    m_stateDbRedisClient.hset(counterVlan, "Request", toString(counters[DHCPv6_MESSAGE_TYPE_REQUEST]));
+    m_stateDbRedisClient.hset(counterVlan, "Confirm", toString(counters[DHCPv6_MESSAGE_TYPE_CONFIRM]));
+    m_stateDbRedisClient.hset(counterVlan, "Renew", toString(counters[DHCPv6_MESSAGE_TYPE_RENEW]));
+    m_stateDbRedisClient.hset(counterVlan, "Rebind", toString(counters[DHCPv6_MESSAGE_TYPE_REBIND]));
+    m_stateDbRedisClient.hset(counterVlan, "Reply", toString(counters[DHCPv6_MESSAGE_TYPE_REPLY]));
+    m_stateDbRedisClient.hset(counterVlan, "Release", toString(counters[DHCPv6_MESSAGE_TYPE_RELEASE]));
+    m_stateDbRedisClient.hset(counterVlan, "Decline", toString(counters[DHCPv6_MESSAGE_TYPE_DECLINE]));
+    m_stateDbRedisClient.hset(counterVlan, "Relay-Forward", toString(counters[DHCPv6_MESSAGE_TYPE_RELAY_FORW]));
+    m_stateDbRedisClient.hset(counterVlan, "Relay-Reply", toString(counters[DHCPv6_MESSAGE_TYPE_RELAY_REPL]));
 }
 
 /**
@@ -97,7 +97,7 @@ void initialize_counter(std::string counterVlan) {
  * @return              none
  */
 void update_counter(std::string counterVlan, uint8_t msg_type) {
-    m_applDbRedisClient.hset(counterVlan, counterMap.find(msg_type)->second, toString(counters[msg_type]));
+    m_stateDbRedisClient.hset(counterVlan, counterMap.find(msg_type)->second, toString(counters[msg_type]));
 }
 
 /**

--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -680,9 +680,11 @@ void dhcp6relay_stop()
  */
 void loop_relay(std::vector<relay_config> *vlans) {
     std::vector<int> sockets;
-    
+    std::vector<relay_config *> configs;
+
     for(relay_config vlan: *vlans) {
         relay_config *config = new relay_config(vlan);
+        configs.push_back(config);
         int filter = 0;
         int local_sock = 0; 
         const char *ifname = config->interface.c_str();
@@ -724,6 +726,9 @@ void loop_relay(std::vector<relay_config> *vlans) {
         shutdown();
         for(std::size_t i = 0; i<sockets.size(); i++) {
             close(sockets.at(i));
+        }
+        for(relay_config* config : configs) {
+            delete(config);
         }
     }
 }

--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -680,11 +680,9 @@ void dhcp6relay_stop()
  */
 void loop_relay(std::vector<relay_config> *vlans) {
     std::vector<int> sockets;
-    std::vector<relay_config *> configs;
 
-    for(relay_config vlan: *vlans) {
-        relay_config *config = new relay_config(vlan);
-        configs.push_back(config);
+    for(relay_config &vlan : *vlans) {
+        relay_config *config = &vlan;
         int filter = 0;
         int local_sock = 0; 
         const char *ifname = config->interface.c_str();
@@ -726,9 +724,6 @@ void loop_relay(std::vector<relay_config> *vlans) {
         shutdown();
         for(std::size_t i = 0; i<sockets.size(); i++) {
             close(sockets.at(i));
-        }
-        for(relay_config* config : configs) {
-            delete(config);
         }
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Not all relay forward packets are sent to desired dhcpv6_servers.
Sendto error: invalid destination address

#### How I did it
Memory gets deallocated at end of loop_relay, need to allocate object on the heap.

#### How to verify it
Build dhcp6relay debian package and run dhcpv6 relay tests

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

Signed off by: Kelly Yeh kellyyeh@microsoft.com