### PR TITLE
[Nokia][supervisor]Fixed the asic_type for Nokia IXR7250E supervisor card

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_asic
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_asic
@@ -1,1 +1,1 @@
-broadcom
+broadcom-dnx


### PR DESCRIPTION
#### Why I did it
The  Nokia  IXR7250E supervisor card asic_type should be broadcom-dnx instead of broadcom. Fixes #9140
#### How I did it
Changed the "broadcom" to "broadcom-dnx" in the device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_asic file

#### How to verify it
Edit the file device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_asic on platform to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

