### PR TITLE
[as9726-32d] branch:202012 sfp lpmode support control by CPLD(R0C).

### DIFF
--- a/device/accton/x86_64-accton_as9726_32d-r0/plugins/sfputil.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/plugins/sfputil.py
@@ -125,61 +125,45 @@ class SfpUtil(SfpUtilBase):
     def get_low_power_mode(self, port_num):
         if port_num > self.QSFP_PORT_END: #sfp not support lpmode
             return False
+
+        if port_num <= 16:
+            lpmode_path = self.BASE_CPLD2_PATH + "module_lpmode_" + str(port_num)
+        else:
+            lpmode_path = self.BASE_CPLD3_PATH + "module_lpmode_" + str(port_num)
         try:
-            eeprom = None
-
-            if not self.get_presence(port_num):
-                return False
-
-            eeprom = open(self.port_to_eeprom_mapping[port_num], "rb")
-            eeprom.seek(93)
-            lpmode = ord(eeprom.read(1))
-
-            if ((lpmode & 0x3) == 0x3):
-                return True  # Low Power Mode if "Power override" bit is 1 and "Power set" bit is 1
-            else:
-                # High Power Mode if one of the following conditions is matched:
-                # 1. "Power override" bit is 0
-                # 2. "Power override" bit is 1 and "Power set" bit is 0
-                return False
+            val_file = open(lpmode_path)
+            content = val_file.readline().rstrip()
+            val_file.close()
         except IOError as e:
             print("Error: unable to open file: %s" % str(e))
             return False
-        finally:
-            if eeprom is not None:
-                eeprom.close()
-                time.sleep(0.01)
+        if content == "0":
+            return True
+
+        return False
+
 
     def set_low_power_mode(self, port_num, lpmode):
         # Check for invalid port_num
         if port_num > self.QSFP_PORT_END: #sfp not support lpmode:
             return False
+        if not self.get_presence(port_num):
+            return False  # Port is not present, unable to set lpmode
 
-        try:
-            eeprom = None
-            if not self.get_presence(port_num):
-                return False  # Port is not present, unable to set the eeprom
+        if port_num <= 16:
+            lpmode_path = self.BASE_CPLD2_PATH + "module_lpmode_" + str(port_num)
+        else:
+            lpmode_path = self.BASE_CPLD3_PATH + "module_lpmode_" + str(port_num)
 
-            # Fill in write buffer
-            # 0x3:Low Power Mode. "Power override" bit is 1 and "Power set" bit is 1
-            # 0x9:High Power Mode. "Power override" bit is 1 ,"Power set" bit is 0 and "High Power Class Enable" bit is 1
-            regval = 0x3 if lpmode else 0x9
+        self.__port_to_mod_lpmode = lpmode_path
 
-            buffer = create_string_buffer(1)
-            buffer[0] = regval
+        if lpmode is True:
+            ret = self.__write_txt_file(self.__port_to_mod_lpmode, 0) #sysfs 1: enable lpmode
+        else:
+            ret = self.__write_txt_file(self.__port_to_mod_lpmode, 1) #sysfs 1: disable lpmode
 
-            # Write to eeprom
-            eeprom = open(self.port_to_eeprom_mapping[port_num], "r+b")
-            eeprom.seek(93)
-            eeprom.write(buffer[0])
-            return True
-        except IOError as e:
-            print("Error: unable to open file: %s" % str(e))
-            return False
-        finally:
-            if eeprom is not None:
-                eeprom.close()
-                time.sleep(0.01)
+        return ret
+
 
     def reset(self, port_num):
         if port_num > self.QSFP_PORT_END: #sfp not support lpmode:

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/psu.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/psu.py
@@ -137,8 +137,18 @@ class Psu(PsuBase):
         Returns:
             A string, one of the predefined STATUS_LED_COLOR_* strings above
         """
+        status_ps=self.get_presence() #present
+        status=self.get_status()   #power good
 
-        return False  #Controlled by HW
+        if status is None or status_ps is False:
+            return  self.STATUS_LED_COLOR_OFF
+
+        return {
+            1: self.STATUS_LED_COLOR_GREEN,
+            0: self.STATUS_LED_COLOR_AMBER
+        }.get(status, self.STATUS_LED_COLOR_OFF)
+
+        return False
 
     def get_temperature(self):
         """

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/sfp.py
@@ -1502,37 +1502,20 @@ class Sfp(SfpBase):
         Returns:
             A Boolean, True if lpmode is enabled, False if disabled
         """
-        if self._port_num > 32: 
+        if self._port_num > 32:
             # SFP doesn't support this feature
             return False
+
+        if self._port_num <= 16:
+            lpmode_path = "{}{}{}".format(CPLD2_I2C_PATH, '/module_lpmode_', self._port_num)
         else:
-            try:
-                eeprom = None
-    
-                if not self.get_presence():
-                    return False
-                # Write to eeprom
-                port_to_i2c_mapping = SFP_I2C_START + self._index
-                port_eeprom_path = I2C_EEPROM_PATH.format(port_to_i2c_mapping)
-    
-                eeprom = open(port_eeprom_path, "rb")
-                eeprom.seek(QSFP_POWEROVERRIDE_OFFSET)
-                lpmode = ord(eeprom.read(1))
-    
-                if ((lpmode & 0x3) == 0x3):
-                    return True  # Low Power Mode if "Power override" bit is 1 and "Power set" bit is 1
-                else:
-                    # High Power Mode if one of the following conditions is matched:
-                    # 1. "Power override" bit is 0
-                    # 2. "Power override" bit is 1 and "Power set" bit is 0
-                    return False
-            except IOError as e:
-                print("Error: unable to open file: %s" % str(e))
-                return False
-            finally:
-                if eeprom is not None:
-                    eeprom.close()
-                    time.sleep(0.01)
+            lpmode_path = "{}{}{}".format(CPLD3_I2C_PATH, '/module_lpmode_', self._port_num)
+
+        val=self._api_helper.read_txt_file(lpmode_path)
+        if val is not None:
+            return int(val, 10)==0
+        else:
+            return False
 
     def get_power_set(self):        
 
@@ -2095,12 +2078,17 @@ class Sfp(SfpBase):
             if not self.get_presence():
                 return False
 
-            if lpmode is True:
-                self.set_power_override(True, True)
+            if self._port_num <= self.CPLD2_PORT_END:
+                lpmode_path = "{}{}{}".format(CPLD2_I2C_PATH, 'module_lpmode_', self._port_num)
             else:
-                self.set_power_override(True, False)
+                lpmode_path = "{}{}{}".format(CPLD3_I2C_PATH, 'module_lpmode_', self._port_num)
 
-            return True
+        if lpmode is True:
+            ret = self.__write_txt_file(lpmode_path, 0) #enable lpmode
+        else:
+            ret = self.__write_txt_file(lpmode_path, 1) #disable lpmode
+
+        return ret
 
     def set_power_override(self, power_override, power_set):
         """

--- a/platform/broadcom/sonic-platform-modules-accton/as9726-32d/modules/x86-64-accton-as9726-32d-cpld.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9726-32d/modules/x86-64-accton-as9726-32d-cpld.c
@@ -72,6 +72,7 @@ MODULE_DEVICE_TABLE(i2c, as9726_32d_cpld_id);
 #define TRANSCEIVER_RXLOS_ATTR_ID(index)   		MODULE_RXLOS_##index
 #define TRANSCEIVER_TXFAULT_ATTR_ID(index)   	MODULE_TXFAULT_##index
 #define TRANSCEIVER_RESET_ATTR_ID(index)   	    MODULE_RESET_##index
+#define TRANSCEIVER_LPMODE_ATTR_ID(index)   	MODULE_LPMODE_##index
 #define CPLD_INTR_ATTR_ID(index)   	            CPLD_INTR_##index
 
 enum as9726_32d_cpld_sysfs_attributes {
@@ -150,6 +151,38 @@ enum as9726_32d_cpld_sysfs_attributes {
 	TRANSCEIVER_RESET_ATTR_ID(30),
 	TRANSCEIVER_RESET_ATTR_ID(31),
 	TRANSCEIVER_RESET_ATTR_ID(32),
+	TRANSCEIVER_LPMODE_ATTR_ID(1),
+	TRANSCEIVER_LPMODE_ATTR_ID(2),
+	TRANSCEIVER_LPMODE_ATTR_ID(3),
+	TRANSCEIVER_LPMODE_ATTR_ID(4),
+	TRANSCEIVER_LPMODE_ATTR_ID(5),
+	TRANSCEIVER_LPMODE_ATTR_ID(6),
+	TRANSCEIVER_LPMODE_ATTR_ID(7),
+	TRANSCEIVER_LPMODE_ATTR_ID(8),
+	TRANSCEIVER_LPMODE_ATTR_ID(9),
+	TRANSCEIVER_LPMODE_ATTR_ID(10),
+	TRANSCEIVER_LPMODE_ATTR_ID(11),
+	TRANSCEIVER_LPMODE_ATTR_ID(12),
+	TRANSCEIVER_LPMODE_ATTR_ID(13),
+	TRANSCEIVER_LPMODE_ATTR_ID(14),
+	TRANSCEIVER_LPMODE_ATTR_ID(15),
+	TRANSCEIVER_LPMODE_ATTR_ID(16),
+	TRANSCEIVER_LPMODE_ATTR_ID(17),
+	TRANSCEIVER_LPMODE_ATTR_ID(18),
+	TRANSCEIVER_LPMODE_ATTR_ID(19),
+	TRANSCEIVER_LPMODE_ATTR_ID(20),
+	TRANSCEIVER_LPMODE_ATTR_ID(21),
+	TRANSCEIVER_LPMODE_ATTR_ID(22),
+	TRANSCEIVER_LPMODE_ATTR_ID(23),
+	TRANSCEIVER_LPMODE_ATTR_ID(24),
+	TRANSCEIVER_LPMODE_ATTR_ID(25),
+	TRANSCEIVER_LPMODE_ATTR_ID(26),
+	TRANSCEIVER_LPMODE_ATTR_ID(27),
+	TRANSCEIVER_LPMODE_ATTR_ID(28),
+	TRANSCEIVER_LPMODE_ATTR_ID(29),
+	TRANSCEIVER_LPMODE_ATTR_ID(30),
+	TRANSCEIVER_LPMODE_ATTR_ID(31),
+	TRANSCEIVER_LPMODE_ATTR_ID(32),
 	CPLD_INTR_ATTR_ID(1),
 	CPLD_INTR_ATTR_ID(2),
 	CPLD_INTR_ATTR_ID(3),
@@ -172,6 +205,10 @@ static ssize_t show_version(struct device *dev, struct device_attribute *da,
 static ssize_t get_mode_reset(struct device *dev, struct device_attribute *da,
 			char *buf);
 static ssize_t set_mode_reset(struct device *dev, struct device_attribute *da,
+			const char *buf, size_t count);
+static ssize_t get_mode_lpmode(struct device *dev, struct device_attribute *da,
+			char *buf);
+static ssize_t set_mode_lpmode(struct device *dev, struct device_attribute *da,
 			const char *buf, size_t count);
 static int as9726_32d_cpld_read_internal(struct i2c_client *client, u8 reg);
 static int as9726_32d_cpld_write_internal(struct i2c_client *client, u8 reg, u8 value);
@@ -201,6 +238,10 @@ static int as9726_32d_cpld_write_internal(struct i2c_client *client, u8 reg, u8 
 	static SENSOR_DEVICE_ATTR(cpld_intr_##index, S_IRUGO, show_interrupt, NULL, CPLD_INTR_##index)
 #define DECLARE_CPLD_INTR_ATTR(index)  &sensor_dev_attr_cpld_intr_##index.dev_attr.attr
 
+/*lpmode*/
+#define DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(index) \
+	static SENSOR_DEVICE_ATTR(module_lpmode_##index, S_IWUSR | S_IRUGO, get_mode_lpmode, set_mode_lpmode, MODULE_LPMODE_##index)
+#define DECLARE_TRANSCEIVER_LPMODE_ATTR(index) &sensor_dev_attr_module_lpmode_##index.dev_attr.attr
 
 
 static SENSOR_DEVICE_ATTR(version, S_IRUGO, show_version, NULL, CPLD_VERSION);
@@ -278,6 +319,38 @@ DECLARE_CPLD_DEVICE_INTR_ATTR(1);
 DECLARE_CPLD_DEVICE_INTR_ATTR(2);
 DECLARE_CPLD_DEVICE_INTR_ATTR(3);
 DECLARE_CPLD_DEVICE_INTR_ATTR(4);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(1);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(2);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(3);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(4);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(5);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(6);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(7);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(8);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(9);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(10);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(11);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(12);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(13);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(14);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(15);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(16);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(17);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(18);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(19);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(20);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(21);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(22);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(23);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(24);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(25);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(26);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(27);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(28);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(29);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(30);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(31);
+DECLARE_TRANSCEIVER_LPMODE_SENSOR_DEVICE_ATTR(32);
 
 
 
@@ -326,6 +399,22 @@ static struct attribute *as9726_32d_cpld2_attributes[] = {
 	DECLARE_TRANSCEIVER_RESET_ATTR(14),
 	DECLARE_TRANSCEIVER_RESET_ATTR(15),
 	DECLARE_TRANSCEIVER_RESET_ATTR(16),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(1),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(2),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(3),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(4),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(5),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(6),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(7),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(8),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(9),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(10),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(11),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(12),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(13),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(14),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(15),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(16),
 	DECLARE_CPLD_INTR_ATTR(1),
 	DECLARE_CPLD_INTR_ATTR(2),
 	NULL
@@ -374,6 +463,22 @@ static struct attribute *as9726_32d_cpld3_attributes[] = {
 	DECLARE_TRANSCEIVER_RESET_ATTR(30),
 	DECLARE_TRANSCEIVER_RESET_ATTR(31),
 	DECLARE_TRANSCEIVER_RESET_ATTR(32),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(17),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(18),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(19),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(20),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(21),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(22),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(23),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(24),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(25),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(26),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(27),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(28),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(29),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(30),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(31),
+	DECLARE_TRANSCEIVER_LPMODE_ATTR(32),
 	DECLARE_CPLD_INTR_ATTR(3),
 	DECLARE_CPLD_INTR_ATTR(4),
 	NULL
@@ -645,6 +750,116 @@ static ssize_t show_version(struct device *dev, struct device_attribute *attr, c
     }
 	
     return sprintf(buf, "0x%x\n", val);
+}
+
+static ssize_t get_mode_lpmode(struct device *dev, struct device_attribute *da,
+			char *buf)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    struct i2c_client *client = to_i2c_client(dev);
+    struct as9726_32d_cpld_data *data = i2c_get_clientdata(client);
+	int status = 0;
+	u8 reg = 0, mask = 0;
+
+	switch (attr->index) {
+	case MODULE_LPMODE_1 ... MODULE_LPMODE_8:
+		reg  = 0x60;
+		mask = 0x1 << (attr->index - MODULE_LPMODE_1);
+		break;
+	case MODULE_LPMODE_9 ... MODULE_LPMODE_16:
+		reg  = 0x61;
+		mask = 0x1 << (attr->index - MODULE_LPMODE_9);
+		break;
+	case MODULE_LPMODE_17 ... MODULE_LPMODE_24:
+		reg  = 0x60;
+		mask = 0x1 << (attr->index - MODULE_LPMODE_17);
+		break;
+	case MODULE_LPMODE_25 ... MODULE_LPMODE_32:
+		reg  = 0x61;
+		mask = 0x1 << (attr->index - MODULE_LPMODE_25);
+	    break;
+	default:
+		return 0;
+	}
+
+    mutex_lock(&data->update_lock);
+	status = as9726_32d_cpld_read_internal(client, reg);
+
+	if (unlikely(status < 0)) {
+		goto exit;
+	}
+	mutex_unlock(&data->update_lock);
+
+	return sprintf(buf, "%d\r\n", !(status & mask));
+
+exit:
+	mutex_unlock(&data->update_lock);
+	return status;
+
+}
+
+static ssize_t set_mode_lpmode(struct device *dev, struct device_attribute *da,
+			const char *buf, size_t count)
+{
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    struct i2c_client *client = to_i2c_client(dev);
+    struct as9726_32d_cpld_data *data = i2c_get_clientdata(client);
+    long lpmode;
+    int status=0, val, error;
+	u8 reg = 0, mask = 0;
+
+    error = kstrtol(buf, 10, &lpmode);
+    if (error) {
+        return error;
+    }
+
+    switch (attr->index) {
+	case MODULE_LPMODE_1 ... MODULE_LPMODE_8:
+		reg  = 0x60;
+		mask = 0x1 << (attr->index - MODULE_LPMODE_1);
+		break;
+	case MODULE_LPMODE_9 ... MODULE_LPMODE_16:
+		reg  = 0x61;
+		mask = 0x1 << (attr->index - MODULE_LPMODE_9);
+		break;
+	case MODULE_LPMODE_17 ... MODULE_LPMODE_24:
+		reg  = 0x60;
+		mask = 0x1 << (attr->index - MODULE_LPMODE_17);
+		break;
+	case MODULE_LPMODE_25 ... MODULE_LPMODE_32:
+		reg  = 0x61;
+		mask = 0x1 << (attr->index - MODULE_LPMODE_25);
+		break;
+	default:
+		return 0;
+	}
+	mutex_lock(&data->update_lock);
+
+	status = as9726_32d_cpld_read_internal(client, reg);
+	if (unlikely(status < 0)) {
+		goto exit;
+	}
+
+	/* Update lp_mode status */
+    if (lpmode)
+    {
+        val = status&(~mask);
+    }
+    else
+    {
+        val =status | (mask);
+    }
+
+	status = as9726_32d_cpld_write_internal(client, reg, val);
+	if (unlikely(status < 0)) {
+		goto exit;
+	}
+	mutex_unlock(&data->update_lock);
+	return count;
+
+exit:
+	mutex_unlock(&data->update_lock);
+	return status;
 }
 
 static ssize_t get_mode_reset(struct device *dev, struct device_attribute *da,

--- a/platform/broadcom/sonic-platform-modules-accton/as9726-32d/modules/x86-64-accton-as9726-32d-psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9726-32d/modules/x86-64-accton-as9726-32d-psu.c
@@ -94,15 +94,15 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
     //printk("data->status=0x%x, attr->index=%d,data->index=%d \n", data->status, attr->index, data->index);
     if (attr->index == PSU_PRESENT) {
         if(data->index==0)
-            status = !( (data->status) & 0x1);
-        else
             status = !( (data->status >> 1) & 0x1);
+        else
+            status = !( (data->status) & 0x1);
     }
     else { /* PSU_POWER_GOOD */
         if(data->index==0)
-           status = ( (data->status >> 2) & 0x1);
+           status = ( (data->status >> 3) & 0x1);
         else
-           status = ( (data->status >> 3) & 0x1); 
+           status = ( (data->status >> 2) & 0x1);
     }
 
     return sprintf(buf, "%d\n", status);


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Our Hardware layout sfp low power mode(lpmode) support control by CPLD.
#### How I did it
1. CPLD add lpmode sysfs
2. sfputil.py and sfp.py all update support get/set lpmode from CPLD.
#### How to verify it
CPLD address=0x61 offset=0x60
>  i2cget -f -y 10 0x61 0x60
0x00
> sfputil lpmode on Ethernet1
Enabling low-power mode for port Ethernet1... OK
> root@sonic:/# i2cget -f -y 10 0x61 0x60
0x01
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
sfp setting lpmode change control by CPLD.

#### A picture of a cute animal (not mandatory but encouraged)

