### PR TITLE
[7060] put docker partition in the ramdisk for 7060

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -468,6 +468,8 @@ write_platform_specific_cmdline() {
     # detect the size of the flash partition from name in Aboot/EOS/SONiC
     local flash_size=$(($(df "$target_path" | tail -1 | tr -s ' ' | cut -f2 -d' ') / 1000))
 
+    local force_log_on_disk="no"
+
     if [ "$platform" = "raven" ]; then
         # Assuming sid=Cloverdale
         aboot_machine=arista_7050_qx32
@@ -483,11 +485,13 @@ write_platform_specific_cmdline() {
     if [ "$sid" = "Upperlake" ] || [ "$sid" = "UpperlakeES" ]; then
         aboot_machine=arista_7060_cx32s
         flash_size=3700
+        force_log_on_disk="yes"
         cmdline_add docker_inram=on
     fi
     if [ "$sid" = "UpperlakePlus" ]; then
         aboot_machine=arista_7060cx2_32s
         flash_size=3700
+        force_log_on_disk="yes"
         cmdline_add docker_inram=on
     fi
     if [ "$sid" = "Gardena" ] || [ "$sid" = "GardenaE" ]; then
@@ -597,7 +601,9 @@ write_platform_specific_cmdline() {
         varlog_size=400
     else
         varlog_size=256
-        cmdline_add logs_inram=on
+        if [ $force_log_on_disk = "no" ]; then
+            cmdline_add logs_inram=on
+        fi
         if [ $flash_size -le 2000 ]; then
             # enable docker_inram for switches with less than 2G of flash
             varlog_size=128

--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -483,10 +483,12 @@ write_platform_specific_cmdline() {
     if [ "$sid" = "Upperlake" ] || [ "$sid" = "UpperlakeES" ]; then
         aboot_machine=arista_7060_cx32s
         flash_size=3700
+        cmdline_add docker_inram=on
     fi
     if [ "$sid" = "UpperlakePlus" ]; then
         aboot_machine=arista_7060cx2_32s
         flash_size=3700
+        cmdline_add docker_inram=on
     fi
     if [ "$sid" = "Gardena" ] || [ "$sid" = "GardenaE" ]; then
         aboot_machine=arista_7260cx3_64

--- a/onie-image-arm64.conf
+++ b/onie-image-arm64.conf
@@ -28,7 +28,7 @@ FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 DOCKERFS_DIR=docker
 
 ## docker ramfs disk space
-DOCKER_RAMFS_SIZE=1500M
+DOCKER_RAMFS_SIZE=1800M
 
 ## Output file name for onie installer
 OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin

--- a/onie-image-armhf.conf
+++ b/onie-image-armhf.conf
@@ -28,7 +28,7 @@ FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 DOCKERFS_DIR=docker
 
 ## docker ramfs disk space
-DOCKER_RAMFS_SIZE=1500M
+DOCKER_RAMFS_SIZE=1800M
 
 ## Output file name for onie installer
 OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin

--- a/onie-image.conf
+++ b/onie-image.conf
@@ -28,7 +28,7 @@ FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 DOCKERFS_DIR=docker
 
 ## docker ramfs disk space
-DOCKER_RAMFS_SIZE=1500M
+DOCKER_RAMFS_SIZE=1800M
 
 ## Output file name for onie installer
 OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE.bin


### PR DESCRIPTION
#### Why I did it
7060 has 4GB hard drive and they cannot fit full image from 202012 branch.

#### How I did it
Put docker partition in ram so that we could install full image on 7060
Put /var/log partition back on harddrive with space saved from docker partition.

#### How to verify it
1. One image can be installed.
2. Can upgrade from first image to second image.
3. warm reboot test passes (lag recovered increased from 60 to 76 seconds, still within budget)
4. fast reboot test passes
5. this change only affects 7060, 7060_qx still use harddrive for docker partition due to memory limitation.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

