### PR TITLE
[DHCPv6 relay] [202106] Fix DHCPv6 design to support multiple VLANS

### DIFF
--- a/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
@@ -1,17 +1,23 @@
 [group:isc-dhcp-relay]
 programs=
 {%- set add_preceding_comma = { 'flag': False } %}
-{% for vlan_name in VLAN_INTERFACE %}
 {# Append DHCPv4 agents #}
+{% if ipv4_num_relays.count > 0 %}
+{% for vlan_name in VLAN_INTERFACE %}
 {% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
 {% if add_preceding_comma.flag %},{% endif %}
 {% set _dummy = add_preceding_comma.update({'flag': True}) %}
 isc-dhcpv4-relay-{{ vlan_name }}
 {%- endif %}
-{# Append DHCPv6 agents #}
+{% endfor %}
+{% endif %}
+{# Append DHCPv6 agent #}
+{% if ipv6_num_relays.count > 0 %}
+{% for vlan_name in VLAN_INTERFACE %}
 {% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% if add_preceding_comma.flag %},{% endif %}
-{% set _dummy = add_preceding_comma.update({'flag': True}) %}
-isc-dhcpv6-relay-{{ vlan_name }}
+{% set _dummy = v6_vlan_list.append( vlan_name ) %}
 {%- endif %}
 {% endfor %}
+{% if add_preceding_comma.flag %},{% endif %}
+isc-dhcpv6-relay-{{ v6_vlan_list|join("-") }}
+{% endif %}

--- a/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
@@ -1,4 +1,6 @@
 {# Append DHCPv4 agents #}
+{% set relay_for_ipv4 = { 'flag': False } %}
+{% for vlan_name in VLAN_INTERFACE %}
 {% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
 {% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
 {% if dhcp_server | ipv4 %}
@@ -38,3 +40,4 @@ dependent_startup_wait_for=start:exited
 
 {% endif %}
 {% endif %}
+{% endfor %}

--- a/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
@@ -1,20 +1,23 @@
-{# Append DHCPv6 agents #}
-{% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% for dhcpv6_server in VLAN[vlan_name]['dhcpv6_servers'] %}
-{% if dhcpv6_server | ipv6 %}
-{% set _dummy = relay_for_ipv6.update({'flag': True}) %}
-{% endif %}
-{% endfor %}
-{% if relay_for_ipv6.flag %}
-{% set _dummy = relay_for_ipv6.update({'flag': False}) %}
-[program:isc-dhcpv6-relay-{{ vlan_name }}]
-{# We treat this VLAN as a downstream interface (-l), as we only want to listen for requests #}
-command=/usr/sbin/dhcrelay -d -6 --name-alias-map-file /tmp/port-name-alias-map.txt -l {{ vlan_name }}
-{#- We treat all other interfaces as upstream interfaces (-u), as we only want to listen for replies #}
+{# Append DHCPv6 agent #}
+{% set relay_for_ipv6 = { 'flag': False } %}
+[program:isc-dhcpv6-relay-{{ v6_vlan_list|join("-") }}]
+command=/usr/sbin/dhcrelay -d -6 --name-alias-map-file /tmp/port-name-alias-map.txt
+{#- We get all DHCPv6 servers only once #}
+{%- set dhcpv6_server_list = [] %}
+{%- for vlan_name in v6_vlan_list %}
 {%- for dhcpv6_server in VLAN[vlan_name]['dhcpv6_servers'] %}
+{%- if dhcpv6_server | ipv6 and dhcpv6_server not in dhcpv6_server_list %}
+{%- set _dummy = dhcpv6_server_list.append( dhcpv6_server ) %}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+{#- We treat each VLAN as a downstream interface (-l), as we only want to listen for requests #}
+{%- for vlan_name in v6_vlan_list %} -l {{ vlan_name }}{% endfor -%}
+{#- We treat all other interfaces as upstream interfaces (-u), as we only want to listen for replies #}
+{%- for dhcpv6_server in dhcpv6_server_list %}
 {%- if dhcpv6_server | ipv6 %}
 {%- for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
-{%- if prefix | ipv6 and name != vlan_name %} -u {{ dhcpv6_server }}%%{{ name }} {% endif -%}
+{%- if prefix | ipv6  %} -u {{ dhcpv6_server }}%%{{ name }} {% endif -%}
 {% endfor %}
 {% for (name, prefix) in INTERFACE|pfx_filter %}
 {% if prefix | ipv6 %} -u {{ dhcpv6_server }}%%{{ name }} {% endif -%}
@@ -22,7 +25,7 @@ command=/usr/sbin/dhcrelay -d -6 --name-alias-map-file /tmp/port-name-alias-map.
 {% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
 {% if prefix | ipv6 %} -u {{ dhcpv6_server }}%%{{ name }} {% endif -%}
 {% endfor %}
-{% endif -%}
+{% endif %}
 {% endfor %}
 
 priority=3
@@ -33,5 +36,3 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=start:exited
 
-{% endif %}
-{% endif %}

--- a/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
@@ -17,7 +17,7 @@ command=/usr/sbin/dhcrelay -d -6 --name-alias-map-file /tmp/port-name-alias-map.
 {%- for dhcpv6_server in dhcpv6_server_list %}
 {%- if dhcpv6_server | ipv6 %}
 {%- for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
-{%- if prefix | ipv6  %} -u {{ dhcpv6_server }}%%{{ name }} {% endif -%}
+{%- if prefix | ipv6 and name not in v6_vlan_list%} -u {{ dhcpv6_server }}%%{{ name }} {% endif -%}
 {% endfor %}
 {% for (name, prefix) in INTERFACE|pfx_filter %}
 {% if prefix | ipv6 %} -u {{ dhcpv6_server }}%%{{ name }} {% endif -%}

--- a/dockers/docker-dhcp-relay/dhcpv6-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.monitors.j2
@@ -70,7 +70,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=
 {%- if relay_for_ipv4.flag %}isc-dhcpv4-relay-{{ vlan_name }}:running {% endif %}
-{% if relay_for_ipv6.flag %}isc-dhcpv6-relay-{{ vlan_name }}:running{% endif %}
+{% if relay_for_ipv6.flag %}isc-dhcpv6-relay-{{ v6_vlan_list|join("-") }}:running{% endif %}
 
 
 {% set _dummy = relay_for_ipv4.update({'flag': False}) %}

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -39,9 +39,11 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
+{% block dhcp_relay_block %}
 {# If our configuration has VLANs... #}
 {% if VLAN_INTERFACE %}
 {# Count how many VLANs require a DHCP relay agent... #}
+{% set v6_vlan_list = [] %}
 {% set ipv4_num_relays = { 'count': 0 } %}
 {% set ipv6_num_relays = { 'count': 0 } %}
 {% for vlan_name in VLAN_INTERFACE %}
@@ -56,15 +58,15 @@ dependent_startup_wait_for=rsyslogd:running
 {% if ipv4_num_relays.count > 0 or ipv6_num_relays.count > 0 %}
 {% include 'dhcp-relay.programs.j2' %}
 
-
 {# Create a program entry for each DHCP relay agent instance #}
-{% set relay_for_ipv4 = { 'flag': False } %}
-{% set relay_for_ipv6 = { 'flag': False } %}
-{% for vlan_name in VLAN_INTERFACE %}
+{% if ipv4_num_relays.count > 0 %}
 {% include 'dhcpv4-relay.agents.j2' %}
+{% endif %}
+{% if ipv6_num_relays.count > 0 %}
 {% include 'dhcpv6-relay.agents.j2' %}
-{% endfor %}
+{% endif %}
 
 {% include 'dhcpv6-relay.monitors.j2' %}
 {% endif %}
 {% endif %}
+{% endblock %}

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -62,7 +62,6 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=start:exited
 
-
 [group:dhcpmon]
 programs=dhcpmon-Vlan1000
 

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -62,7 +62,6 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=start:exited
 
-
 [group:dhcpmon]
 programs=dhcpmon-Vlan1000
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
If multiple Vlans are configured to have DHCPv6 relay, only one relay instance is able to capture DHCP packets received from upstream, this is as a result of kernel design to operate this way (SO_REUSEPORT).
DHCPv6 transmit unicast packets to clients, only multicast packets can be captured on multiple application listening on the same UDP port.
This issue causing only one Vlan interface to get packets from servers.

#### How I did it
Change the design to neglect Vlan isolation and run only one relay instance serving all Vlans with all configured DHCP servers.

#### How to verify it
Run DHCPv6 relay test with 2 Vlans configured do have a DHCP relay.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

