### PR TITLE
Fix for additional interface flap during fast-reboot on platforms due to delayed serdes programming

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -23,6 +23,12 @@ function fast_reboot {
         mv -f /default_routes.json /default_routes.json.1
       fi
 
+      if [[ -f /media_config.json ]];
+      then
+        swssconfig /media_config.json
+        mv -f /media_config.json /media_config.json.1
+      fi
+
       ;;
     *)
       ;;

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -196,6 +196,7 @@ function postStartAction()
         test -e /host/fast-reboot/fdb.json && docker cp /host/fast-reboot/fdb.json swss$DEV:/
         test -e /host/fast-reboot/arp.json && docker cp /host/fast-reboot/arp.json swss$DEV:/
         test -e /host/fast-reboot/default_routes.json && docker cp /host/fast-reboot/default_routes.json swss$DEV:/
+        test -e /host/fast-reboot/media_config.json && docker cp /host/fast-reboot/media_config.json swss$DEV:/
         rm -fr /host/fast-reboot
     fi
     docker exec swss$DEV touch /ready # signal swssconfig.sh to go


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
During fast-reboot, delayed serdes programming done after transceiver detection results in additional interface flap and traffic loss exceeding the required 30s (Issue: Azure/sonic-buildimage#9165)

#### How I did it
Fix includes: 
1. making a backup of media settings from appdb during fast-reboot (Azure/sonic-utilities#1910)
2. loading this to redis after the switch boots up (this PR). 
3. Configuration of serdes triggered by reading media_settings.json file is skipped (https://github.com/Azure/sonic-platform-daemons/pull/221)

#### How to verify it
Run advanced_reboot/test_advanced_reboot.py::test_fast_reboot on 9332 or similar platform that use media_settings.json and ensure that
* no additional interface flap is seen during fast-reboot
* TRANSCEIVER_INFO & SERDES objects are populated in state and asic db as expected
```
2021-11-03 17:20:14 : Summary:
2021-11-03 17:20:14 : --------------------------------------------------
2021-11-03 17:20:14 : Longest downtime period was 0:00:15.611417
2021-11-03 17:20:14 : Reboot time was 0:00:57.564040
2021-11-03 17:20:14 : Expected downtime is less then 0:00:30
2021-11-03 17:20:14 : --------------------------------------------------
2021-11-03 17:20:14 : Additional info:
2021-11-03 17:20:14 : --------------------------------------------------
2021-11-03 17:20:14 : INFO:172.16.142.69:PortChannel interface state changed 1 times
2021-11-03 17:20:14 : INFO:172.16.142.68:PortChannel interface state changed 1 times
2021-11-03 17:20:14 : INFO:172.16.142.70:PortChannel interface state changed 1 times
2021-11-03 17:20:14 : INFO:172.16.142.71:PortChannel interface state changed 1 times
2021-11-03 17:20:14 : INFO:172.16.142.65:PortChannel interface state changed 1 times
2021-11-03 17:20:14 : INFO:172.16.142.64:PortChannel interface state changed 1 times
2021-11-03 17:20:14 : INFO:172.16.142.67:PortChannel interface state changed 1 times
2021-11-03 17:20:14 : INFO:172.16.142.66:PortChannel interface state changed 1 times
2021-11-03 17:20:14 : --------------------------------------------------
2021-11-03 17:20:14 : ==================================================
```
UT logs:

[UT_logs_advanced_reboot.log](https://github.com/Azure/sonic-buildimage/files/7470174/UT_logs_advanced_reboot.log)
[fast-reboot.log](https://github.com/Azure/sonic-buildimage/files/7470176/fast-reboot.log)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

