### PR TITLE
Change sonic-slave building schedule time 6 hours before image building

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -5,7 +5,7 @@
 # Build and push sonic-mgmt image
 
 schedules:
-- cron: "0 8 * * *"
+- cron: "0 2 * * *"
   branches:
     include:
     - master

--- a/.azure-pipelines/docker-sonic-slave.yml
+++ b/.azure-pipelines/docker-sonic-slave.yml
@@ -5,7 +5,7 @@
 # Build and push sonic-slave-[buster|jessie|stretch] images for amd64/armhf/arm64
 
 schedules:
-- cron: "0 8 * * *"
+- cron: "0 2 * * *"
   branches:
     include:
     - master


### PR DESCRIPTION
Signed-off-by: shilongliu <shilongliu@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Build sonic-slave first will accelerate official build.
Reduce queue time around 8:00am UTC
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

