### PR TITLE
[docker-sonic-vs] Removing fake_platform environment variable

### DIFF
--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 
 #This is required since we have platform based checks in orchagent
-#fakeplatform to be removed once swss migrates to hw-sku
 
 if [ "$HWSKU" == "Mellanox-SN2700" ]; then
     export platform="mellanox"
-elif  [ -n "$fake_platform"  ]; then
-    export platform=$fake_platform
 else
     export platform=vs
 fi

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -54,11 +54,6 @@ else
 fi
 sonic-cfggen -t /usr/share/sonic/templates/copp_cfg.j2 > /etc/sonic/copp_cfg.json
 
-#To be removed once swss migrates to HWSKU
-if [ "$fake_platform" == "mellanox" ]; then
-    cp /usr/share/sonic/hwsku/sai_mlnx.profile /usr/share/sonic/hwsku/sai.profile
-fi
-
 if [ "$HWSKU" == "Mellanox-SN2700" ]; then
     cp /usr/share/sonic/hwsku/sai_mlnx.profile /usr/share/sonic/hwsku/sai.profile
 fi


### PR DESCRIPTION
… used

Signed-off-by: Sudharsan Dhamal Gopalarathnam <sudharsand@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Removing fake_platform environment variable. Following the merge of https://github.com/Azure/sonic-buildimage/pull/9044 and https://github.com/Azure/sonic-swss/pull/1978 the fake_platform environment variable is not used in any place and removing the stale references.

#### How I did it
Cleaned up the places where it is used

#### How to verify it
Successful execution of vs tests would ensure it is verified.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

