### PR TITLE
Only generate config for existing ports in sonic-vs

### DIFF
--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -47,7 +47,7 @@ else
     # generate and merge buffers configuration into config file
     sonic-cfggen -k $HWSKU -p /usr/share/sonic/device/$PLATFORM/platform.json -t /usr/share/sonic/hwsku/buffers.json.j2 > /tmp/buffers.json
     sonic-cfggen -j /etc/sonic/init_cfg.json -t /usr/share/sonic/hwsku/qos.json.j2 > /tmp/qos.json
-    sonic-cfggen -p /usr/share/sonic/device/$PLATFORM/platform.json -k $HWSKU --print-data > /tmp/ports.json
+    sonic-cfggen -p /usr/share/sonic/device/$PLATFORM/platform.json -k $HWSKU -p /usr/share/sonic/hwsku/port_config.ini --print-data > /tmp/ports.json
     # change admin_status from up to down; Test cases dependent
     sed -i "s/up/down/g" /tmp/ports.json
     sonic-cfggen -j /etc/sonic/init_cfg.json -j /tmp/buffers.json -j /tmp/qos.json -j /tmp/ports.json --print-data > /etc/sonic/config_db.json


### PR DESCRIPTION
#### Why I did it
The current logic in `start.sh` file does not take into account the ports saved in `/usr/share/sonic/hwsku/port_config.ini`.
This change will ensure that the final generated config will only contain ports present in the `port_config.ini` file

Without this change, the vs image will have the full set of (32) ports even when fewer `eth` interface are connected.

#### Which release branch to backport (provide reason below if selected)



- [x ] 201811
- [ x] 201911
- [x ] 202006
- [x ] 202012
- [x ] 202106

#### Description for the changelog
Only generate config for existing ports


