### PR TITLE
[build] Fix armhf and arm64 build break

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -143,11 +143,13 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install psutil
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install ipaddr
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install ipaddr
 
-# Install Python module for grpcio and grpcio-toole
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install "grpcio==1.39.0"
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip install "grpcio-tools==1.39.0"
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio==1.39.0"
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio-tools==1.39.0"
+if [[ $CONFIGURED_ARCH == amd64 ]]; then
+    # Install Python module for grpcio and grpcio-tools
+    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install "grpcio==1.39.0"
+    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip2 install "grpcio-tools==1.39.0"
+    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio==1.39.0"
+    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio-tools==1.39.0"
+fi
 
 # Install SwSS SDK Python 3 package
 # Note: the scripts will be overwritten by corresponding Python 2 package


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
PR# 8366 added grpcio for both python2 and python 3 to the Sonic build. The
python2 installation is failing for both armhf and arm64. This commit removes
grpcio from the build of ARM based platforms as it is not currently needed.

#### How I did it
Remove grpcio and grpcio-tools python package installation from  target filesystem for all but the amd64 platform.

#### How to verify it
Build the armhf and arm64 platforms

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

