### PR TITLE
Disable ALPM distributed hitbit thread that is used for debug purpose only but interfered with Other functional operations

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-Q16S64/td2-a7050-qx32-16x40G+32x10G+8x40G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-Q16S64/td2-a7050-qx32-16x40G+32x10G+8x40G.config.bcm
@@ -24,6 +24,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/td2-a7050-qx32-32x40G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32/Arista-7050-QX32/td2-a7050-qx32-32x40G.config.bcm
@@ -24,6 +24,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/td2-a7050-q31s4-31x40G-4x10G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX-32S-S4Q31/td2-a7050-q31s4-31x40G-4x10G.config.bcm
@@ -4,6 +4,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/td2-a7050-qx32s-32x40G.config.bcm
+++ b/device/arista/x86_64-arista_7050_qx32s/Arista-7050QX32S-Q32/td2-a7050-qx32s-32x40G.config.bcm
@@ -18,6 +18,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/td3-a7050cx3-32s-32x100G.config.bcm
@@ -1,4 +1,5 @@
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
+l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 host_as_route_disable=1
 use_all_splithorizon_groups=1

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
@@ -1,4 +1,5 @@
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
+l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 host_as_route_disable=1
 use_all_splithorizon_groups=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/th-a7060-cx32s-8x100G+24x40G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/th-a7060-cx32s-8x100G+24x40G.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/th-a7060-cx32s-8x100G+96x25G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/th-a7060-cx32s-8x100G+96x25G.config.bcm
@@ -1,5 +1,8 @@
 # Arista 7060CX-32S
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-C64/th3-a7060px4-32-64x100G.config.bcm
+++ b/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-C64/th3-a7060px4-32-64x100G.config.bcm
@@ -1,5 +1,7 @@
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile.0=2
 bcm_num_cos.0=8

--- a/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-O32/th3-a7060px4-o32-32x400G.config.bcm
+++ b/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-O32/th3-a7060px4-o32-32x400G.config.bcm
@@ -1,5 +1,7 @@
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile.0=2
 bcm_num_cos.0=8

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
@@ -19,6 +19,7 @@
 {%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-64x100G-t1.config.bcm" #}
 
+l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
@@ -9,6 +9,7 @@
 {%-     endif %}
 {%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-112x50G+8x100G.config.bcm" #}
+l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
@@ -18,6 +18,7 @@
 {%-     endif %}
 {%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-64x40G.config.bcm" #}
+l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000

--- a/device/broadcom/x86_64-bcm_xlr-r0/BCM956960K/th_32x100.config.bcm
+++ b/device/broadcom/x86_64-bcm_xlr-r0/BCM956960K/th_32x100.config.bcm
@@ -1,6 +1,9 @@
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 portmap_1=1:100                                       
 portmap_2=5:100                                       
 portmap_3=9:100                                       

--- a/device/celestica/x86_64-cel_e1031-r0/Celestica-E1031-T48S4/helix4-e1031-48x1G+4x10G.config.bcm
+++ b/device/celestica/x86_64-cel_e1031-r0/Celestica-E1031-T48S4/helix4-e1031-48x1G+4x10G.config.bcm
@@ -1,3 +1,6 @@
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
@@ -17,6 +17,9 @@ l3_alpm_enable=2
 ipv6_lpm_128b_enable=1
 mmu_lossless=0
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
@@ -17,6 +17,9 @@ l3_alpm_enable=2
 ipv6_lpm_128b_enable=1
 mmu_lossless=0
 
+# Disable bcmALPMDH (ALPM distributed hitbit) thread that is used for debug only
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
@@ -1,3 +1,6 @@
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/celestica/x86_64-cel_seastone-r0/th-seastone-dx010-config-flex-all.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/th-seastone-dx010-config-flex-all.bcm
@@ -19,6 +19,9 @@ ipv6_lpm_128b_enable=1
 #Use MMU lossy configuration
 mmu_lossless=0
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q20S48/td2-s6000-20x40G-48x10G.config.bcm
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q20S48/td2-s6000-20x40G-48x10G.config.bcm
@@ -10,6 +10,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q24S32/td2-s6000-24x40G-32x10G.config.bcm
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q24S32/td2-s6000-24x40G-32x10G.config.bcm
@@ -10,6 +10,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q28S16/td2-s6000-28x40G-16x10G.config.bcm
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000-Q28S16/td2-s6000-28x40G-16x10G.config.bcm
@@ -10,6 +10,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/td2-s6000-32x40G.config.bcm
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/Force10-S6000/td2-s6000-32x40G.config.bcm
@@ -10,6 +10,9 @@ ipv6_lpm_128b_enable=1
 l2_mem_entries=32768
 l3_mem_entries=16384
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t0.config.bcm
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t0.config.bcm
@@ -1,4 +1,8 @@
 #TH S6100 64x40
+
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t1.config.bcm
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t1.config.bcm
@@ -1,4 +1,8 @@
 #TH S6100 64x40
+
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
@@ -4,6 +4,9 @@ dpr_clock_frequency=1000
 device_clock_frequency=1325
 port_flex_enable=1
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
@@ -4,6 +4,9 @@ dpr_clock_frequency=1000
 device_clock_frequency=1325
 port_flex_enable=1
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
@@ -4,6 +4,9 @@ dpr_clock_frequency=1000
 device_clock_frequency=1325
 port_flex_enable=1
 
+# disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose
+l3_alpm_hit_skip=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -301,3 +301,4 @@ ifa_enable
 port_gmii_mode
 phy_force_firmware_load
 phy_pcs_repeater
+l3_alpm_hit_skip


### PR DESCRIPTION
This is to address an issue where it was observed that SAI operations sometime may take a very long to time complete (over 45ms).  It was determined that the ALPM distributed thread was causing this issue.
The fix is to disable this debug thread that has no functional purpose.

Preliminary tests looks fine. BGP neighbors were all up with proper routes programmed
interfaces are all up
Manually ran the fib test cases on 7050CX3 (TD3), TD2, TH, TH2, and TH3 based platforms  and
thy all passed. 
Note: the testing was done over 20201230 image and are porting this change to master branch.
No need to port this to 20201230 branch as a separate PR was already done for that branch. (https://github.com/Azure/sonic-buildimage/pull/9190)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106

#### Description for the changelog
Disable bcmALPMDH thread for it is only for debug and it causing timing issues on other functional code.


#### A picture of a cute animal (not mandatory but encouraged)
