### PR TITLE
[ci]: Increase pipeline build timeout from 12 hours to 15 hours

### DIFF
--- a/.azure-pipelines/azure-pipelines-job-groups.yml
+++ b/.azure-pipelines/azure-pipelines-job-groups.yml
@@ -19,7 +19,7 @@ parameters:
   default: ''
 - name: 'timeoutInMinutes'
   type: 'number'
-  default: 720
+  default: 900
 - name: 'jobFilters'
   type: object
   default: ''


### PR DESCRIPTION
Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

With a Bullseye upgrade, a change that requires everything to get
rebuilt (including the slave containers) takes about 12 hours (the vs
job that builds the virtual switch image as well as the PTF container
sometimes times out towards the end). Part of this is because the kernel
is now built after all of the sonic containers (kernel is built in a
Bullseye slave, the docker containers are built in a Buster slave).
Another part is because during the ptf container build, for some reason,
all of the docker containers are rebuilt.

Therefore, to make sure PRs don't time out after Bullseye gets merged
in, bump up the timeout from 12 hours to 15 hours. This should be enough
for the builds to complete.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

