### PR TITLE
Dell: S6100 fix xcvrd crash

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/sfp.py
@@ -15,8 +15,8 @@ try:
     from sonic_platform_base.sfp_base import SfpBase
     from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
     from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
-except ImportError as e:
-    raise ImportError(str(e) + "- required module not found")
+except ImportError as err:
+    raise ImportError(str(err) + "- required module not found")
 
 
 PAGE_OFFSET = 0
@@ -422,28 +422,24 @@ class Sfp(SfpBase):
         presence_ctrl = self.sfp_control + 'qsfp_modprs'
         try:
             reg_file = open(presence_ctrl)
-        except IOError as e:
-            return False
 
-        reg_hex = reg_file.readline().rstrip()
+            reg_hex = reg_file.readline().rstrip()
+            # content is a string containing the hex
+            # representation of the register
+            reg_value = int(reg_hex, 16)
+            # Mask off the bit corresponding to our port
+            if (self.sfp_ctrl_idx > 15):
+                index = self.sfp_ctrl_idx % 16
+            else:
+                index = self.sfp_ctrl_idx
 
-        # content is a string containing the hex
-        # representation of the register
-        reg_value = int(reg_hex, 16)
-
-        # Mask off the bit corresponding to our port
-        if (self.sfp_ctrl_idx > 15):
-            index = self.sfp_ctrl_idx % 16
-        else:
-            index = self.sfp_ctrl_idx
-
-        # Mask off the bit corresponding to our port
-        mask = (1 << index)
-
-        # ModPrsL is active low
-        if ((reg_value & mask) == 0):
-            return True
-
+            # Mask off the bit corresponding to our port
+            mask = (1 << index)
+            # ModPrsL is active low
+            if ((reg_value & mask) == 0):
+                return True
+        except (IOError, ValueError) as err:
+            print("Error:%s" %str(err))
         return False
 
     def get_model(self):
@@ -478,28 +474,27 @@ class Sfp(SfpBase):
         reset_ctrl = self.sfp_control + 'qsfp_reset'
         try:
             reg_file = open(reset_ctrl, "r+")
-        except IOError as e:
+
+            reg_hex = reg_file.readline().rstrip()
+            # content is a string containing the hex
+            # representation of the register
+            reg_value = int(reg_hex, 16)
+            # Mask off the bit corresponding to our port
+            if (self.sfp_ctrl_idx > 15):
+                index = self.sfp_ctrl_idx % 16
+            else:
+                index = self.sfp_ctrl_idx
+
+            mask = (1 << index)
+
+            if ((reg_value & mask) == 0):
+                reset_status = True
+            else:
+                reset_status = False
+
+        except (IOError, ValueError) as err:
+            print("Error:%s" %str(err))
             return False
-
-        reg_hex = reg_file.readline().rstrip()
-
-        # content is a string containing the hex
-        # representation of the register
-        reg_value = int(reg_hex, 16)
-
-        # Mask off the bit corresponding to our port
-        if (self.sfp_ctrl_idx > 15):
-            index = self.sfp_ctrl_idx % 16
-        else:
-            index = self.sfp_ctrl_idx
-
-        mask = (1 << index)
-
-        if ((reg_value & mask) == 0):
-            reset_status = True
-        else:
-            reset_status = False
-
         return reset_status
 
     def get_rx_los(self):
@@ -615,27 +610,29 @@ class Sfp(SfpBase):
         lpmode_ctrl = self.sfp_control + 'qsfp_lpmode'
         try:
             reg_file = open(lpmode_ctrl, "r+")
-        except IOError as e:
+
+            reg_hex = reg_file.readline().rstrip()
+
+            # content is a string containing the hex
+            # representation of the register
+            reg_value = int(reg_hex, 16)
+
+            # Mask off the bit corresponding to our port
+            if (self.sfp_ctrl_idx > 15):
+                index = self.sfp_ctrl_idx % 16
+            else:
+                index = self.sfp_ctrl_idx
+
+            mask = (1 << index)
+
+            if ((reg_value & mask) == 0):
+                lpmode_state = False
+            else:
+                lpmode_state = True
+
+        except (IOError, ValueError) as err:
+            print("Error:%s" %str(err))
             return False
-
-        reg_hex = reg_file.readline().rstrip()
-
-        # content is a string containing the hex
-        # representation of the register
-        reg_value = int(reg_hex, 16)
-
-        # Mask off the bit corresponding to our port
-        if (self.sfp_ctrl_idx > 15):
-            index = self.sfp_ctrl_idx % 16
-        else:
-            index = self.sfp_ctrl_idx
-
-        mask = (1 << index)
-
-        if ((reg_value & mask) == 0):
-            lpmode_state = False
-        else:
-            lpmode_state = True
 
         return lpmode_state
 
@@ -731,45 +728,41 @@ class Sfp(SfpBase):
         try:
             # Open reset_ctrl in both read & write mode
             reg_file = open(reset_ctrl, "r+")
-        except IOError as e:
-            return False
 
-        reg_hex = reg_file.readline().rstrip()
-        reg_value = int(reg_hex, 16)
+            reg_hex = reg_file.readline().rstrip()
+            reg_value = int(reg_hex, 16)
+            # Mask off the bit corresponding to our port
+            if (self.sfp_ctrl_idx > 15):
+                index = self.sfp_ctrl_idx % 16
+            else:
+                index = self.sfp_ctrl_idx
 
-        # Mask off the bit corresponding to our port
-        if (self.sfp_ctrl_idx > 15):
-            index = self.sfp_ctrl_idx % 16
-        else:
-            index = self.sfp_ctrl_idx
+            # Mask off the bit corresponding to our port
+            mask = (1 << index)
 
-        # Mask off the bit corresponding to our port
-        mask = (1 << index)
+            # ResetL is active low
+            reg_value = (reg_value & ~mask)
 
-        # ResetL is active low
-        reg_value = (reg_value & ~mask)
+            # Convert our register value back to a
+            # hex string and write back
+            reg_file.seek(0)
+            reg_file.write(hex(reg_value))
+            reg_file.close()
 
-        # Convert our register value back to a
-        # hex string and write back
-        reg_file.seek(0)
-        reg_file.write(hex(reg_value))
-        reg_file.close()
-
-        # Sleep 1 second to allow it to settle
-        time.sleep(1)
-
-        # Flip the bit back high and write back to the
-        # register to take port out of reset
-        try:
+            # Sleep 1 second to allow it to settle
+            time.sleep(1)
+            # Flip the bit back high and write back to the
+            # register to take port out of reset
             reg_file = open(reset_ctrl, "w")
-        except IOError as e:
+
+            reg_value = reg_value | mask
+            reg_file.seek(0)
+            reg_file.write(hex(reg_value))
+            reg_file.close()
+
+        except (IOError, ValueError) as err:
+            print("Error:%s" %str(err))
             return False
-
-        reg_value = reg_value | mask
-        reg_file.seek(0)
-        reg_file.write(hex(reg_value))
-        reg_file.close()
-
         return True
 
     def set_lpmode(self, lpmode):
@@ -779,35 +772,35 @@ class Sfp(SfpBase):
         lpmode_ctrl = self.sfp_control + 'qsfp_lpmode'
         try:
             reg_file = open(lpmode_ctrl, "r+")
-        except IOError as e:
+
+            reg_hex = reg_file.readline().rstrip()
+            # content is a string containing the hex
+            # representation of the register
+            reg_value = int(reg_hex, 16)
+
+            # Mask off the bit corresponding to our port
+            if (self.sfp_ctrl_idx > 15):
+                index = self.sfp_ctrl_idx % 16
+            else:
+                index = self.sfp_ctrl_idx
+
+            mask = (1 << index)
+
+            # LPMode is active high; set or clear the bit accordingly
+            if lpmode is True:
+                reg_value = (reg_value | mask)
+            else:
+                reg_value = (reg_value & ~mask)
+
+            # Convert our register value back to a hex string and write back
+            content = hex(reg_value)
+
+            reg_file.seek(0)
+            reg_file.write(content)
+            reg_file.close()
+        except (IOError, ValueError) as err:
+            print("Error:%s" %str(err))
             return False
-
-        reg_hex = reg_file.readline().rstrip()
-
-        # content is a string containing the hex
-        # representation of the register
-        reg_value = int(reg_hex, 16)
-
-        # Mask off the bit corresponding to our port
-        if (self.sfp_ctrl_idx > 15):
-            index = self.sfp_ctrl_idx % 16
-        else:
-            index = self.sfp_ctrl_idx
-
-        mask = (1 << index)
-
-        # LPMode is active high; set or clear the bit accordingly
-        if lpmode is True:
-            reg_value = (reg_value | mask)
-        else:
-            reg_value = (reg_value & ~mask)
-
-        # Convert our register value back to a hex string and write back
-        content = hex(reg_value)
-
-        reg_file.seek(0)
-        reg_file.write(content)
-        reg_file.close()
 
         return True
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/sfp.py
@@ -440,7 +440,7 @@ class Sfp(SfpBase):
             if ((reg_value & mask) == 0):
                 return True
         except (IOError, ValueError) as err:
-            syslog.syslog(syslog.LOG_ERR, str(e))
+            syslog.syslog(syslog.LOG_ERR, str(err))
         return False
 
     def get_model(self):
@@ -494,7 +494,7 @@ class Sfp(SfpBase):
                 reset_status = False
 
         except (IOError, ValueError) as err:
-            syslog.syslog(syslog.LOG_ERR, str(e))
+            syslog.syslog(syslog.LOG_ERR, str(err))
             return False
         return reset_status
 
@@ -632,7 +632,7 @@ class Sfp(SfpBase):
                 lpmode_state = True
 
         except (IOError, ValueError) as err:
-            syslog.syslog(syslog.LOG_ERR, str(e))
+            syslog.syslog(syslog.LOG_ERR, str(err))
             return False
 
         return lpmode_state
@@ -762,7 +762,7 @@ class Sfp(SfpBase):
             reg_file.close()
 
         except (IOError, ValueError) as err:
-            syslog.syslog(syslog.LOG_ERR, str(e))
+            syslog.syslog(syslog.LOG_ERR, str(err))
             return False
         return True
 
@@ -800,7 +800,7 @@ class Sfp(SfpBase):
             reg_file.write(content)
             reg_file.close()
         except (IOError, ValueError) as err:
-            syslog.syslog(syslog.LOG_ERR, str(e))
+            syslog.syslog(syslog.LOG_ERR, str(err))
             return False
 
         return True

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/sfp.py
@@ -12,6 +12,7 @@ try:
     import re
     import struct
     import time
+    import syslog
     from sonic_platform_base.sfp_base import SfpBase
     from sonic_platform_base.sonic_sfp.sff8436 import sff8436InterfaceId
     from sonic_platform_base.sonic_sfp.sff8436 import sff8436Dom
@@ -439,7 +440,7 @@ class Sfp(SfpBase):
             if ((reg_value & mask) == 0):
                 return True
         except (IOError, ValueError) as err:
-            print("Error:%s" %str(err))
+            syslog.syslog(syslog.LOG_ERR, str(e))
         return False
 
     def get_model(self):
@@ -493,7 +494,7 @@ class Sfp(SfpBase):
                 reset_status = False
 
         except (IOError, ValueError) as err:
-            print("Error:%s" %str(err))
+            syslog.syslog(syslog.LOG_ERR, str(e))
             return False
         return reset_status
 
@@ -631,7 +632,7 @@ class Sfp(SfpBase):
                 lpmode_state = True
 
         except (IOError, ValueError) as err:
-            print("Error:%s" %str(err))
+            syslog.syslog(syslog.LOG_ERR, str(e))
             return False
 
         return lpmode_state
@@ -761,7 +762,7 @@ class Sfp(SfpBase):
             reg_file.close()
 
         except (IOError, ValueError) as err:
-            print("Error:%s" %str(err))
+            syslog.syslog(syslog.LOG_ERR, str(e))
             return False
         return True
 
@@ -799,7 +800,7 @@ class Sfp(SfpBase):
             reg_file.write(content)
             reg_file.close()
         except (IOError, ValueError) as err:
-            print("Error:%s" %str(err))
+            syslog.syslog(syslog.LOG_ERR, str(e))
             return False
 
         return True


### PR DESCRIPTION
#### Why I did it
xcvrd crashes in Dell S6100 while fetching SFP presence
#### How I did it
Used try/except block to fix the crash issue
#### How to verify it
Check whether presence is detected after fix,Verify xcvrd syslogs.
[S6100_UT.txt](https://github.com/Azure/sonic-buildimage/files/7504409/S6100_UT.txt)

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog


#### A picture of a cute animal (not mandatory but encouraged)

