### PR TITLE
[mux.service]: Remove pmon dependency

### DIFF
--- a/files/build_templates/mux.service.j2
+++ b/files/build_templates/mux.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=MUX Cable Container
-Requires=database.service updategraph.service pmon.service swss.service
-After=pmon.service swss.service
+Requires=database.service updategraph.service swss.service
+After=swss.service
 BindsTo=sonic.target
 After=sonic.target
 StartLimitIntervalSec=1200


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Dependency is not required between pmon and mux services

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

