### PR TITLE
DellEMC: Z9332f - Fix error message during Chassis initialization

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
@@ -50,9 +50,10 @@ def get_cpld2_version():
 def get_ssd_version():
     val = 'NA'
     try:
-        ssd_ver = subprocess.check_output(['ssdutil','-v'], text=True)
-    except Exception:
-        return val
+        ssd_ver = subprocess.check_output(['ssdutil', '-v'],
+                                          stderr=subprocess.STDOUT, text=True)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
     else:
         version = re.search(r'Firmware\s*:(.*)',ssd_ver)
         if version:
@@ -63,9 +64,10 @@ def get_ssd_version():
 def get_pciephy_version():
     val = 'NA'
     try:
-        pcie_ver = subprocess.check_output('bcmcmd "pciephy fw version"', shell=True, text=True)
-    except Exception:
-        return val
+        pcie_ver = subprocess.check_output(['bcmcmd', 'pciephy fw version'],
+                                           stderr=subprocess.STDOUT, text=True)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
     else:
         version = re.search(r'PCIe FW loader version:\s(.*)', pcie_ver)
         if version:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To fix error message during Chassis initialization in pmon.

#### How I did it

Handle the absence of bcmcmd in pmon gracefully.

#### How to verify it

In pmon, instantiate a Chassis object and verify no error messages are seen.
Logs: [UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/7513306/UT_logs.txt)


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

DellEMC: Z9332f - Fix error message during Chassis initialization

#### A picture of a cute animal (not mandatory but encouraged)

