### PR TITLE
[sonic-yang-mgmt] Adding in_place flag to sonic_yang.loadData

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -2,6 +2,7 @@
 # class sonic_yang. A separate file is used to avoid a single large file.
 
 from __future__ import print_function
+import copy
 import yang as ly
 import syslog
 from json import dump, dumps, loads
@@ -1038,16 +1039,21 @@ class SonicYangExtMixin:
     load_data: load Config DB, crop, xlate and create data tree from it. (Public)
     input:    data
               debug Flag
+              remove_non_yang_in_place Flag that indicates whether to remove tables without YANG
+                                       from configdbJson directly or create a copy and modify it
     returns:  True - success   False - failed
     """
-    def loadData(self, configdbJson, debug=False):
+    def loadData(self, configdbJson, debug=False, remove_non_yang_in_place=True):
 
        try:
           # write Translated config in file if debug enabled
           xlateFile = None
           if debug:
               xlateFile = "xlateConfig.json"
-          self.jIn = configdbJson
+          if remove_non_yang_in_place:
+              self.jIn = configdbJson
+          else:
+              self.jIn = copy.deepcopy(configdbJson)
           # reset xlate and tablesWithOutYang
           self.xlateJson = dict()
           self.tablesWithOutYang = dict()

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
@@ -364,5 +364,17 @@ class Test_SonicYang(object):
 
         return
 
+    def test_remove_non_yang_in_place(self, sonic_yang_data):
+        # Check remove_non_yang_in_place=False
+        configDbJson = { "TABLE_WITHOUT_YANG": {}}
+        syc = sonic_yang_data['syc']
+        syc.loadData(configDbJson, remove_non_yang_in_place=False)
+        assert {"TABLE_WITHOUT_YANG": {}} == configDbJson
+
+        # Check remove_non_yang_in_place=True
+        configDbJson = { "TABLE_WITHOUT_YANG": {}}
+        syc.loadData(configDbJson, remove_non_yang_in_place=True)
+        assert {} == configDbJson
+
     def teardown_class(self):
         pass


### PR DESCRIPTION
#### Why I did it
sonic_yang.loadData was by default removing tables without YANG from the input configdbJson i.e. modifying it in place

#### How I did it
Added an `in_place` flag so caller of `loadData` can decide whether to modify input in place or not.

#### How to verify it
unit-test added

