### PR TITLE
[BRCM-SAI] 6.0.0.10-1 Stubbed missing SAI API sai_query_stats_capability()

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,12 +1,12 @@
-BRCM_SAI = libsaibcm_6.0.0.10_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/6.0/master/libsaibcm_6.0.0.10_amd64.deb?sv=2020-08-04&st=2021-10-20T15%3A46%3A03Z&se=2030-10-21T15%3A46%3A00Z&sr=b&sp=r&sig=zhosphas9cBuH%2B7mLC%2ByarQPQSIe2LY%2FXOATIW96cVY%3D"
-BRCM_SAI_DEV = libsaibcm-dev_6.0.0.10_amd64.deb
+BRCM_SAI = libsaibcm_6.0.0.10-1_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/6.0/master/XGS/libsaibcm_6.0.0.10-1_amd64.deb?sv=2015-04-05&sr=b&sig=5fW6otWPCPrsSIXeomEcllS8sEDXMo0YOD8UhB370U0%3D&se=2035-07-22T20%3A50%3A51Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_6.0.0.10-1_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/6.0/master/libsaibcm-dev_6.0.0.10_amd64.deb?sv=2020-08-04&st=2021-10-20T15%3A47%3A11Z&se=2030-10-21T15%3A47%3A00Z&sr=b&sp=r&sig=pKZxnQKw%2BY6CzAd8swa5yZDduKIrQw7TWyChT5tkqlk%3D"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/6.0/master/XGS/libsaibcm-dev_6.0.0.10-1_amd64.deb?sv=2015-04-05&sr=b&sig=8h7bO9EizzMXduSOf%2Ffc3JH0EcHxcE8p51LyUw0CA6o%3D&se=2035-07-22T20%3A51%3A57Z&sp=r"
 
 # SAI module for DNX Asic family
-BRCM_DNX_SAI = libsaibcm_dnx_6.0.0.10_amd64.deb
-$(BRCM_DNX_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/6.0/master/libsaibcm_dnx_6.0.0.10_amd64.deb?sv=2020-08-04&st=2021-10-20T15%3A48%3A05Z&se=2030-10-21T15%3A48%3A00Z&sr=b&sp=r&sig=1sqJI5dLLrci9iu%2FPhNWZJzj0nf5lmcRrAUkASOQVjo%3D"
+BRCM_DNX_SAI = libsaibcm_dnx_6.0.0.10-1_amd64.deb
+$(BRCM_DNX_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/6.0/master/DNX/libsaibcm_dnx_6.0.0.10-1_amd64.deb?sv=2015-04-05&sr=b&sig=J1lE1SI1Mtwrl0vZ2tAPvkNLKpkyz2XVgRe98DnPNfo%3D&se=2035-07-22T20%3A53%3A24Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 SONIC_ONLINE_DEBS += $(BRCM_DNX_SAI)


### PR DESCRIPTION
#### Why I did it
BRCM SAI missed implementing the SAI API "sai_query_stats_capability()" which is causing build issue.
The build issue is impacting PR(s) that need to use this API.
This PR is to stubbed BRCM SAI to add this SAI API and return not implemented so that it will fix build issue that it is causing.
No other functional changes were made.

#### How I did it
Add the missing SAI API and default it to return NOT_IMPLEMENTED.

#### How to verify it
It will be validated by the other PR that is having build dependency on this PR.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
[BRCM-SAI] 6.0.0.10-1 Stubbed missing SAI API sai_query_stats_capability() that was causing PR build issue.


#### A picture of a cute animal (not mandatory but encouraged)

