### PR TITLE
[Arista] Increase switch PCIe timeout for 7060

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/platform-init
+++ b/device/arista/x86_64-arista_7060_cx32s/platform-init
@@ -1,0 +1,3 @@
+# Increase PCIe timeout value to 210ms
+setpci -s01:00.0 CAP_EXP+0x28.B=6
+setpci -s01:00.1 CAP_EXP+0x28.B=6

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -19,6 +19,7 @@ RUN apt-get update &&       \
         bridge-utils        \
         conntrack           \
         ndppd               \
+        pciutils            \
         # Needed for installing netifaces Python package
         build-essential     \
         python3-dev

--- a/dockers/docker-orchagent/docker-init.sh
+++ b/dockers/docker-orchagent/docker-init.sh
@@ -17,6 +17,11 @@ CFGGEN_PARAMS=" \
 "
 VLAN=$(sonic-cfggen $CFGGEN_PARAMS)
 
+# Executed platform specific initialization tasks.
+if [ -x /usr/share/sonic/platform/platform-init ]; then
+    /usr/share/sonic/platform/platform-init
+fi
+
 # Executed HWSKU specific initialization tasks.
 if [ -x /usr/share/sonic/hwsku/hwsku-init ]; then
     /usr/share/sonic/hwsku/hwsku-init


### PR DESCRIPTION
The platform-init, similar to hwsku-init, would be scripts that need to
be called for a specific platform.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Arista 7060 platform has a rare and unreproduceable PCIe timeout that could possibly be solved with increasing the switch PCIe timeout value. To do this we'll call a script for this platform to increase the PCIe timeout on boot-up.

No issues would be expected from the setpci command. From the PCIe spec:

"Software is permitted to change the value in this field at any
time. For Requests already pending when the Completion
Timeout Value is changed, hardware is permitted to use either
the new or the old value for the outstanding Requests, and is
permitted to base the start time for each Request either on when
this value was changed or on when each request was issued. "

#### How I did it
Add "platform-init" support in swss docker similar to how "hwsku-init" is called, only this would be for any device belonging to a platform. Then the script would reside in device data folder.

Additionally, add pciutils dependency to docker-orchagent so it can run the setpci commands.

#### How to verify it
On bootup of an Arista 7060, can execute:
lspci -vv -s 01:00.0 | grep -i "devctl2"
In order to check that the timeout has changed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

