### PR TITLE
[Mellanox] Fan speed should not be 100% when PSU is powered off

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_infos.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_infos.py
@@ -61,7 +61,7 @@ class FanInfo(ThermalPolicyInfoBase):
                 elif status and fan in self._fault_fans:
                     self._fault_fans.remove(fan)
                     self._status_changed = True
-                    
+
 
     def get_absence_fans(self):
         """
@@ -112,12 +112,12 @@ class PsuInfo(ThermalPolicyInfoBase):
         """
         self._status_changed = False
         for psu in chassis.get_all_psus():
-            if psu.get_presence() and psu.get_powergood_status() and psu not in self._presence_psus:
+            if psu.get_presence() and psu not in self._presence_psus:
                 self._presence_psus.add(psu)
                 self._status_changed = True
                 if psu in self._absence_psus:
                     self._absence_psus.remove(psu)
-            elif (not psu.get_presence() or not psu.get_powergood_status()) and psu not in self._absence_psus:
+            elif (not psu.get_presence()) and psu not in self._absence_psus:
                 self._absence_psus.add(psu)
                 self._status_changed = True
                 if psu in self._presence_psus:

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_policy.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_policy.py
@@ -108,9 +108,9 @@ def test_psu_info():
 
     psu_list[0].powergood = False
     psu_info.collect(chassis)
-    assert len(psu_info.get_absence_psus()) == 1
-    assert len(psu_info.get_presence_psus()) == 0
-    assert psu_info.is_status_changed()
+    assert len(psu_info.get_absence_psus()) == 0
+    assert len(psu_info.get_presence_psus()) == 1
+    assert not psu_info.is_status_changed()
 
 
 def test_fan_policy(thermal_manager):
@@ -351,12 +351,12 @@ def test_load_control_thermal_algo_action():
     json_str = '{\"status\": \"false\"}'
     json_obj = json.loads(json_str)
     action.load_from_json(json_obj)
-    assert not action.status 
+    assert not action.status
 
     json_str = '{\"status\": \"true\"}'
     json_obj = json.loads(json_str)
     action.load_from_json(json_obj)
-    assert action.status 
+    assert action.status
 
     json_str = '{\"status\": \"invalid\"}'
     json_obj = json.loads(json_str)
@@ -455,7 +455,7 @@ def test_load_policy_with_same_conditions():
 
     with pytest.raises(Exception):
         MockThermalManager.load(os.path.join(test_path, 'policy_with_same_conditions.json'))
-    
+
 def test_dynamic_minimum_table_data():
     from sonic_platform.device_data import DEVICE_DATA
     for platform, platform_data in DEVICE_DATA.items():
@@ -480,7 +480,7 @@ def check_minimum_table_data(platform, minimum_table):
         for item in data_list:
             cooling_level = item[0]
             range_str = item[1]
-            
+
             ranges = range_str.split(':')
             low = int(ranges[0])
             high = int(ranges[1])


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When PSU is powered off, the PSU is still on the switch and the air flow is still the same. In this case, it is not necessary to set FAN speed to 100%.

#### How I did it

When PSU is powered of, don't treat it as absent.

#### How to verify it

1. Adjust existing unit test case
2. Add new case in sonic-mgmt

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

