### PR TITLE
[Mellanox] Allow user to set LED to orange

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
@@ -62,6 +62,16 @@ class Led(object):
 
                 utils.write_file(led_path, Led.LED_ON)
                 status = True
+            elif color == Led.STATUS_LED_COLOR_ORANGE:
+                if Led.STATUS_LED_COLOR_ORANGE in led_cap_list:
+                    led_path = self.get_orange_led_path()
+                elif Led.STATUS_LED_COLOR_RED in led_cap_list:
+                    led_path = self.get_red_led_path()
+                else:
+                    return False
+
+                utils.write_file(led_path, Led.LED_ON)
+                status = True
             elif color == Led.STATUS_LED_COLOR_OFF:
                 if Led.STATUS_LED_COLOR_GREEN in led_cap_list:
                     utils.write_file(self.get_green_led_path(), Led.LED_OFF)

--- a/platform/mellanox/mlnx-platform-api/tests/test_led.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_led.py
@@ -62,7 +62,9 @@ class TestLed:
         assert obj.set_status_led(Led.STATUS_LED_COLOR_GREEN) is True
         assert obj.get_status_led() == Led.STATUS_LED_COLOR_GREEN
         mock_file_content[physical_led.get_green_led_path()] = Led.LED_OFF
-        assert obj.set_status_led(Led.STATUS_LED_COLOR_ORANGE) is False
+        assert obj.set_status_led(Led.STATUS_LED_COLOR_ORANGE) is True
+        assert obj.get_status_led() == Led.STATUS_LED_COLOR_RED
+        mock_file_content[physical_led.get_orange_led_path()] = Led.LED_OFF
 
         assert obj.set_status_led(Led.STATUS_LED_COLOR_RED_BLINK)
         assert obj.get_status_led() == Led.STATUS_LED_COLOR_RED_BLINK
@@ -85,7 +87,7 @@ class TestLed:
             led.get_green_led_path(): Led.LED_ON,
             led.get_red_led_path(): Led.LED_OFF,
             led.get_orange_led_path(): Led.LED_OFF,
-            led.get_led_cap_path(): 'none green green_blink red red_blink',
+            led.get_led_cap_path(): 'none green green_blink red red_blink orange',
             led.get_green_led_delay_off_path(): Led.LED_OFF,
             led.get_green_led_delay_on_path(): Led.LED_OFF,
             led.get_red_led_delay_off_path(): Led.LED_OFF,


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Nvidia platform API does not support set LED to orange 

#### How I did it

Allow user to set LED to orange

#### How to verify it

Added unit test
Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

