### PR TITLE
[chassis] [BGP CLI] Add chassis platform to check for internal BGP session

### DIFF
--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -9,6 +9,7 @@ from .device_info import CONTAINER_PLATFORM_PATH
 from .device_info import HOST_DEVICE_PATH
 from .device_info import get_platform
 from .device_info import is_supervisor
+from .device_info import is_chassis
 
 ASIC_NAME_PREFIX = 'asic'
 NAMESPACE_PATH_GLOB = '/run/netns/*'
@@ -410,7 +411,7 @@ def get_back_end_interface_set(namespace=None):
 
 def is_bgp_session_internal(bgp_neigh_ip, namespace=None):
 
-    if not is_multi_asic():
+    if not is_multi_asic() and not is_chassis():
         return False
 
     ns_list = get_namespace_list(namespace)
@@ -418,7 +419,15 @@ def is_bgp_session_internal(bgp_neigh_ip, namespace=None):
     for ns in ns_list:
 
         config_db = connect_config_db_for_ns(ns)
-        bgp_sessions = config_db.get_entry(BGP_INTERNAL_NEIGH_CFG_DB_TABLE, bgp_neigh_ip)
+        bgp_sessions = config_db.get_entry(
+            BGP_INTERNAL_NEIGH_CFG_DB_TABLE, bgp_neigh_ip
+        )
+        if bgp_sessions:
+            return True
+
+        bgp_sessions = config_db.get_entry(
+            'BGP_VOQ_CHASSIS_NEIGHBOR', bgp_neigh_ip
+        )
         if bgp_sessions:
             return True
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add chassis platform to check for internal BGP session. With this check 'show ip bgp summary' will not show internal BGP sessions by default.

#### How I did it
Check if platform is chassis, and check if BGP neighbor is of type BGP_VOQ_NEIGHBOR

#### How to verify it
```
admin@str2-chassis-lc3-1:~$ show ip bgp summary

IPv4 Unicast Summary:
BGP router identifier 192.0.0.3, local AS number 65100 vrf-id 0
BGP table version 8576
RIB entries 17069, using 3277248 bytes of memory
Peers 21, using 458136 KiB of memory
Peer groups 2, using 128 bytes of memory


Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down    State/PfxRcd    NeighborName
-----------  ---  -----  ---------  ---------  --------  -----  ------  ---------  --------------  --------------
10.0.0.1       4  65200       1190       1190         0      0       0  00:45:57   8513            ARISTA01T3
10.0.0.9       4  65200          0          0         0      0       0  never      Active          ARISTA05T3
10.0.0.13      4  65200          0          0         0      0       0  never      Active          ARISTA07T3
10.0.0.17      4  65200          0          0         0      0       0  never      Active          ARISTA09T3
10.0.0.21      4  65200          0          0         0      0       0  never      Active          ARISTA11T3
10.0.0.25      4  65200          0          0         0      0       0  never      Active          ARISTA13T3
.
.

```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

