### PR TITLE
[Yang] Add YANG model support for vlan sub interface

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -118,6 +118,7 @@ setup(
                          './yang-models/sonic-versions.yang',
                          './yang-models/sonic-vlan.yang',
                          './yang-models/sonic-vrf.yang',
+                         './yang-models/sonic-vlan-sub-interface.yang',
                          './yang-models/sonic-warm-restart.yang',
                          './yang-models/sonic-lldp.yang',
                          './yang-models/sonic-scheduler.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -675,6 +675,15 @@
                 "speed": "11100",
                 "tpid": "0x8100",
                 "admin_status": "up"
+            },
+            "Ethernet120": {
+                "alias": "Eth31/1",
+                "lanes": "121,122",
+                "description": "",
+                "fec": "fc",
+                "speed": "11100",
+                "tpid": "0x8100",
+                "admin_status": "up"
             }
         },
         "ACL_TABLE": {
@@ -831,6 +840,13 @@
                 "scope": "global",
                 "family": "IPv4"
             }
+        },
+        "VLAN_SUB_INTERFACE": {
+            "Ethernet120.10": {
+                "admin_status": "up"
+            },
+            "Ethernet120.10|10.0.1.56/31": {},
+            "Ethernet120.10|fc00::1:71/126": {}
         },
         "VLAN_MEMBER": {
             "Vlan111|Ethernet0": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
@@ -14,6 +14,10 @@
         "desc": "Configure vlan sub interface with invalid vlan id.",
         "eStrKey": "Pattern"
     },
+    "VLAN_SUB_INTERFACE_INVALID_VLAN_ID_WITH_LEADING_ZERO_TEST": {
+        "desc": "Configure vlan sub interface with invalid vlan id with leading zeros.",
+        "eStrKey": "Pattern"
+    },
     "VLAN_SUB_INTERFACE_IP_PREFIX_EMPTY_STRING_TEST": {
         "desc": "Configure ip prefix vlan sub interface with empty ip prefx.",
         "eStrKey": "InvalidValue"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
@@ -1,0 +1,25 @@
+{
+    "VLAN_SUB_INTERFACE_MUST_CONDITION_TRUE_TEST": {
+        "desc": "Configure valid vlan sub interface must condition true."
+    },
+    "VLAN_SUB_INTERFACE_MUST_CONDITION_FALSE_TEST": {
+        "desc": "Configure vlan sub interface must condition false.",
+        "eStrKey": "Must"
+    },
+    "VLAN_SUB_INTERFACE_IP_PREFIX_PORT_NON_EXISTING_LEAF_TEST": {
+        "desc": "Configure ip prefix vlan sub interface with non-existing reference.",
+        "eStrKey": "LeafRef"
+    },
+    "VLAN_SUB_INTERFACE_INVALID_VLAN_ID_TEST": {
+        "desc": "Configure vlan sub interface with invalid vlan id.",
+        "eStrKey": "Pattern"
+    },
+    "VLAN_SUB_INTERFACE_IP_PREFIX_EMPTY_STRING_TEST": {
+        "desc": "Configure ip prefix vlan sub interface with empty ip prefx.",
+        "eStrKey": "InvalidValue"
+    },
+    "VLAN_SUB_INTERFACE_INVALID_NAME_TEST": {
+        "desc": "Configure invalid vlan sub interface name with no separator.",
+        "eStrKey": "Pattern"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
@@ -127,6 +127,38 @@
             }
         }
     },
+    "VLAN_SUB_INTERFACE_INVALID_VLAN_ID_WITH_LEADING_ZERO_TEST": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.095"
+                    }
+                ],
+                "VLAN_SUB_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet8.095",
+                        "ip-prefix": "10.0.0.1/30"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
     "VLAN_SUB_INTERFACE_IP_PREFIX_EMPTY_STRING_TEST": {
         "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
             "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
@@ -1,0 +1,194 @@
+{
+    "VLAN_SUB_INTERFACE_MUST_CONDITION_TRUE_TEST": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10"
+                    }
+                ],
+                "VLAN_SUB_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ip-prefix": "10.0.0.1/30"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_SUB_INTERFACE_MUST_CONDITION_FALSE_TEST": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10"
+                    }
+                ],
+                "VLAN_SUB_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ip-prefix": "10.0.0.1/30"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet12",
+                        "admin_status": "up",
+                        "alias": "Ethernet12/1",
+                        "description": "Ethernet12",
+                        "lanes": "49,50,51,52",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_SUB_INTERFACE_IP_PREFIX_PORT_NON_EXISTING_LEAF_TEST": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10"
+                    }
+                ],
+                "VLAN_SUB_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet8.20",
+                        "ip-prefix": "10.0.0.1/30"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_SUB_INTERFACE_INVALID_VLAN_ID_TEST": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.4095"
+                    }
+                ],
+                "VLAN_SUB_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet8.4095",
+                        "ip-prefix": "10.0.0.1/30"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_SUB_INTERFACE_IP_PREFIX_EMPTY_STRING_TEST": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10"
+                    }
+                ],
+                "VLAN_SUB_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ip-prefix": ""
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_SUB_INTERFACE_INVALID_NAME_TEST": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet810"
+                    }
+                ],
+                "VLAN_SUB_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet810",
+                        "ip-prefix": "10.0.0.1/30"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -42,7 +42,7 @@ module sonic-vlan-sub-interface {
                     }
 
                     // check if the vlan sub interface have the form as <portname>.<vlan_id>
-                    // the vlan_id should be chosen from range [0, 4094]
+                    // the vlan_id should be chosen from range [1, 4094]
                     type string {
                         pattern '(\w+)\.([1-9][0-9]{0,2}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
                     }

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -44,7 +44,7 @@ module sonic-vlan-sub-interface {
                     // check if the vlan sub interface have the form as <portname>.<vlan_id>
                     // the vlan_id should be chosen from range [0, 4094]
                     type string {
-                        pattern '(\w+)\.([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                        pattern '(\w+)\.([1-9][0-9]{0,2}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -1,0 +1,83 @@
+module sonic-vlan-sub-interface {
+
+    yang-version 1.1;
+
+    namespace  "http://github.com/Azure/sonic-vlan-sub-interface";
+    prefix vlan-sub-interface;
+
+	import sonic-types {
+		prefix stypes;
+	}
+
+    import sonic-port {
+        prefix port;
+    }
+
+    import sonic-portchannel {
+        prefix lag;
+    }
+
+	import sonic-vrf {
+		prefix vrf;
+	}
+
+    description "VLAN sub interface for SONiC OS";
+
+    revision 2021-11-11 {
+        description "Initial version";
+    }
+
+    container sonic-vlan-sub-interface {
+        container VLAN_SUB_INTERFACE {
+
+            description "VLAN SUB INTERFACE part of config_db.json";
+
+            list VLAN_SUB_INTERFACE_LIST {
+
+                description "VLAN_SUB_INTERFACE part of config_db.json with vrf";
+
+                key "name";
+
+                leaf name {
+                    must "substring-before(current(), '.') = /port:sonic-port/port:PORT/port:PORT_LIST/port:name"
+                    {
+                        error-message "Must condition not satisfied, Try adding PORT: {}, Example: 'Ethernet0': {}";
+                    }
+
+                    type string {
+                        pattern '(\w+)\.([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                    }
+                }
+
+                leaf admin_status {
+                    type stypes:admin_status;
+                }
+
+				leaf vrf_name {
+					type leafref {
+						path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+					}
+				}
+            }
+
+            list VLAN_SUB_INTERFACE_IPPREFIX_LIST {
+
+                description "VLAN_SUB_INTERFACE part of config_db.json with ip-prefix";
+
+                key "name ip-prefix";
+
+				leaf name {
+					type leafref {
+						path "../../VLAN_SUB_INTERFACE_LIST/name";
+					}
+				}
+
+				leaf ip-prefix {
+					type stypes:sonic-ip-prefix;
+				}
+
+            }
+
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -13,10 +13,6 @@ module sonic-vlan-sub-interface {
         prefix port;
     }
 
-    import sonic-portchannel {
-        prefix lag;
-    }
-
 	import sonic-vrf {
 		prefix vrf;
 	}

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -3,19 +3,20 @@ module sonic-vlan-sub-interface {
     yang-version 1.1;
 
     namespace  "http://github.com/Azure/sonic-vlan-sub-interface";
+
     prefix vlan-sub-interface;
 
-	import sonic-types {
-		prefix stypes;
-	}
+    import sonic-types {
+        prefix stypes;
+    }
 
     import sonic-port {
         prefix port;
     }
 
-	import sonic-vrf {
-		prefix vrf;
-	}
+    import sonic-vrf {
+        prefix vrf;
+    }
 
     description "VLAN sub interface for SONiC OS";
 
@@ -49,11 +50,11 @@ module sonic-vlan-sub-interface {
                     type stypes:admin_status;
                 }
 
-				leaf vrf_name {
-					type leafref {
-						path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
-					}
-				}
+                leaf vrf_name {
+                    type leafref {
+                        path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+                    }
+                }
             }
 
             list VLAN_SUB_INTERFACE_IPPREFIX_LIST {
@@ -62,18 +63,16 @@ module sonic-vlan-sub-interface {
 
                 key "name ip-prefix";
 
-				leaf name {
-					type leafref {
-						path "../../VLAN_SUB_INTERFACE_LIST/name";
-					}
-				}
+                leaf name {
+                    type leafref {
+                        path "../../VLAN_SUB_INTERFACE_LIST/name";
+                    }
+                }
 
-				leaf ip-prefix {
-					type stypes:sonic-ip-prefix;
-				}
-
+                leaf ip-prefix {
+                    type stypes:sonic-ip-prefix;
+                }
             }
-
         }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -41,6 +41,8 @@ module sonic-vlan-sub-interface {
                         error-message "Must condition not satisfied, Try adding PORT: {}, Example: 'Ethernet0': {}";
                     }
 
+                    // check if the vlan sub interface have the form as <portname>.<vlan_id>
+                    // the vlan_id should be chosen from range [0, 4094]
                     type string {
                         pattern '(\w+)\.([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
                     }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add YANG model file for table `VLAN_SUB_INTERFACE`

#### How I did it
1. Add YANG model file `sonic-vlan-sub-interface.yang` to describe data structure
2. modify existing unit-test to cover vlan sub interface

#### How to verify it
Build sonic-yang-models and sonic-yang-mgmt without errors

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

