### PR TITLE
[YANG] add YANG model support for CABLE_LENGTH

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -8,14 +8,17 @@ from json import dump, dumps, loads
 from xmltodict import parse
 from glob import glob
 
-Type_1_list_maps_model = ['DSCP_TO_TC_MAP_LIST',
+Type_1_list_maps_model = [
+    'DSCP_TO_TC_MAP_LIST',
     'DOT1P_TO_TC_MAP_LIST',
     'TC_TO_PRIORITY_GROUP_MAP_LIST',
     'TC_TO_QUEUE_MAP_LIST',
     'MAP_PFC_PRIORITY_TO_QUEUE_LIST',
     'PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_LIST',
     'DSCP_TO_FC_MAP_LIST',
-    'EXP_TO_FC_MAP_LIST']
+    'EXP_TO_FC_MAP_LIST',
+    'CABLE_LENGTH_LIST'
+]
 
 """
 This is the Exception thrown out of all public function of this class.

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -90,6 +90,7 @@ setup(
                          './yang-models/sonic-buffer-port-egress-profile-list.yang',
                          './yang-models/sonic-buffer-profile.yang',
                          './yang-models/sonic-buffer-queue.yang',
+                         './yang-models/sonic-cable-length.yang',
                          './yang-models/sonic-copp.yang',
                          './yang-models/sonic-crm.yang',
                          './yang-models/sonic-device_metadata.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -375,6 +375,12 @@
             "20.1.1.1": {},
             "2001:aa:aa::aa": {}
         },
+        "CABLE_LENGTH": {
+            "AZURE": {
+                "Ethernet0": "5m",
+                "Ethernet1": "5m"
+            }
+        },
         "PORT": {
             "Ethernet0": {
                 "alias": "Eth1/1",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/cable_length.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/cable_length.json
@@ -1,0 +1,13 @@
+{
+    "CABLE_LENGTH_TEST": {
+        "desc": "Configure CABLE_LENGTH table."
+    },
+    "CABLE_LENGTH_NON_EXISTING_PORT_TEST": {
+        "desc": "Configure CABLE_LENGTH table with non-existing port.",
+        "eStrKey": "LeafRef"
+    },
+    "CABLE_LENGTH_INVALID_LENGTH_FORMAT_TEST": {
+        "desc": "Configure CABLE_LENGTH table with invalid length string.",
+        "eStr": "Invalid cable length"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/cable_length.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/cable_length.json
@@ -2,6 +2,9 @@
     "CABLE_LENGTH_TEST": {
         "desc": "Configure CABLE_LENGTH table."
     },
+    "CABLE_LENGTH_NAME_TEST": {
+        "desc": "Configure CABLE_LENGTH table with different name other than AZURE."
+    },
     "CABLE_LENGTH_NON_EXISTING_PORT_TEST": {
         "desc": "Configure CABLE_LENGTH table with non-existing port.",
         "eStrKey": "LeafRef"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/cable_length.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/cable_length.json
@@ -1,0 +1,137 @@
+{
+    "CABLE_LENGTH_TEST": {
+        "sonic-cable-length:sonic-cable-length": {
+            "sonic-cable-length:CABLE_LENGTH": {
+                "CABLE_LENGTH_LIST": [
+                    {
+                        "name": "AZURE",
+                        "CABLE_LENGTH": [
+                            {
+                                "port": "Ethernet8",
+                                "length": "5m"
+                            },
+                            {
+                                "port": "Ethernet12",
+                                "length": "5m"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    },
+                    {
+                        "name": "Ethernet12",
+                        "admin_status": "up",
+                        "alias": "Ethernet12/1",
+                        "description": "Ethernet12",
+                        "lanes": "49,50,51,52",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "CABLE_LENGTH_NON_EXISTING_PORT_TEST": {
+        "sonic-cable-length:sonic-cable-length": {
+            "sonic-cable-length:CABLE_LENGTH": {
+                "CABLE_LENGTH_LIST": [
+                    {
+                        "name": "AZURE",
+                        "CABLE_LENGTH": [
+                            {
+                                "port": "Ethernet8",
+                                "length": "5m"
+                            },
+                            {
+                                "port": "Ethernet16",
+                                "length": "5m"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    },
+                    {
+                        "name": "Ethernet12",
+                        "admin_status": "up",
+                        "alias": "Ethernet12/1",
+                        "description": "Ethernet12",
+                        "lanes": "49,50,51,52",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "CABLE_LENGTH_INVALID_LENGTH_FORMAT_TEST": {
+        "sonic-cable-length:sonic-cable-length": {
+            "sonic-cable-length:CABLE_LENGTH": {
+                "CABLE_LENGTH_LIST": [
+                    {
+                        "name": "AZURE",
+                        "CABLE_LENGTH": [
+                            {
+                                "port": "Ethernet8",
+                                "length": "5m"
+                            },
+                            {
+                                "port": "Ethernet12",
+                                "length": "5"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    },
+                    {
+                        "name": "Ethernet12",
+                        "admin_status": "up",
+                        "alias": "Ethernet12/1",
+                        "description": "Ethernet12",
+                        "lanes": "49,50,51,52",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/cable_length.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/cable_length.json
@@ -44,6 +44,51 @@
             }
         }
     },
+    "CABLE_LENGTH_NAME_TEST": {
+        "sonic-cable-length:sonic-cable-length": {
+            "sonic-cable-length:CABLE_LENGTH": {
+                "CABLE_LENGTH_LIST": [
+                    {
+                        "name": "SONIC",
+                        "CABLE_LENGTH": [
+                            {
+                                "port": "Ethernet8",
+                                "length": "5m"
+                            },
+                            {
+                                "port": "Ethernet12",
+                                "length": "5m"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    },
+                    {
+                        "name": "Ethernet12",
+                        "admin_status": "up",
+                        "alias": "Ethernet12/1",
+                        "description": "Ethernet12",
+                        "lanes": "49,50,51,52",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
     "CABLE_LENGTH_NON_EXISTING_PORT_TEST": {
         "sonic-cable-length:sonic-cable-length": {
             "sonic-cable-length:CABLE_LENGTH": {

--- a/src/sonic-yang-models/yang-models/sonic-cable-length.yang
+++ b/src/sonic-yang-models/yang-models/sonic-cable-length.yang
@@ -27,12 +27,12 @@ module sonic-cable-length {
                 leaf name {
                     type string {
                         pattern '[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,31})' {
-                            error-message "Invalid cable length table name.";
-                            error-app-tag cable-length-invalid-table-name;    
+                            error-message "Invalid cable length list name.";
+                            error-app-tag cable-length-invalid-list-name;
                         }
                         length 1..32 {
-                            error-message "Invalid length for the cable length table name.";
-                            error-app-tag cable-length-invalid-table-name-length;
+                            error-message "Invalid length for the cable length list name.";
+                            error-app-tag cable-length-invalid-list-name-length;
                         }
                     }
                 }

--- a/src/sonic-yang-models/yang-models/sonic-cable-length.yang
+++ b/src/sonic-yang-models/yang-models/sonic-cable-length.yang
@@ -1,0 +1,61 @@
+module sonic-cable-length {
+
+    yang-version 1.1;
+
+    namespace  "http://github.com/Azure/sonic-cable-length";
+
+    prefix cable-length;
+
+    import sonic-port {
+        prefix port;
+    }
+
+    description "CABLE_LENGTH YANG module for SONiC OS";
+
+    revision 2021-11-11 {
+        description "Initial version";
+    }
+
+    container sonic-cable-length {
+        container CABLE_LENGTH {
+
+            description "CABLE_LENGTH part of config_db.json";
+
+            list CABLE_LENGTH_LIST {
+                key "name";
+
+                leaf name {
+                    type string {
+                        pattern '[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,31})' {
+                            error-message "Invalid cable length table name.";
+                            error-app-tag cable-length-invalid-table-name;    
+                        }
+                        length 1..32 {
+                            error-message "Invalid length for the cable length table name.";
+                            error-app-tag cable-length-invalid-table-name-length;
+                        }
+                    }
+                }
+
+                list CABLE_LENGTH {
+                    key "port";
+
+                    leaf port {
+                        type leafref {
+                            path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
+                        }
+                    }
+
+                    leaf length {
+                        type string {
+                            pattern '[0-9]+m' {
+                                error-message "Invalid cable length.";
+                                error-app-tag cable-length-invalid-length;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add YANG model support for table `CABLE_LENGTH`

#### How I did it
1. Add the YANG model file
2. Add the test description file and config file
3. add list `CABLE_LENGTH_LIST` to the `qos_maps_model ` list in `sonic-yang-ext`, as it has an inner list.

#### How to verify it
Build `sonic-yang-model` and `sonic-yang-mgmt` 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

