### PR TITLE
[sonic-py-common][device info] Check for None before accessing the asic type

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -352,7 +352,7 @@ def get_platform_info():
     hw_info_dict['platform'] = get_platform()
     hw_info_dict['hwsku'] = get_hwsku()
     if version_info:
-        hw_info_dict['asic_type'] = version_info['asic_type']
+        hw_info_dict['asic_type'] = version_info.get('asic_type')
     hw_info_dict['asic_count'] = get_num_asics()
 
     try:

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -351,7 +351,8 @@ def get_platform_info():
 
     hw_info_dict['platform'] = get_platform()
     hw_info_dict['hwsku'] = get_hwsku()
-    hw_info_dict['asic_type'] = version_info['asic_type']
+    if version_info:
+        hw_info_dict['asic_type'] = version_info['asic_type']
     hw_info_dict['asic_count'] = get_num_asics()
 
     try:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Sonic utilities tests runs into issues after adding the check for 'is_chassis()' due to version info being None.

#### How I did it
Check for None before accessing the version_info

#### How to verify it

Before
```
samaddik@20139b1eaeb5:/sonic/src/sonic-utilities/tests$ pytest-3 watermarkstat_test.py
================================================================================ test session starts =================================================================================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /sonic/src/sonic-utilities/tests, inifile: pytest.ini
plugins: cov-2.6.0
collected 0 items / 1 errors

======================================================================================= ERRORS =======================================================================================
_______________________________________________________________________ ERROR collecting watermarkstat_test.py _______________________________________________________________________
watermarkstat_test.py:4: in <module>
    import show.main as show
../show/main.py:8: in <module>
    import utilities_common.cli as clicommon
../utilities_common/cli.py:14: in <module>
    from utilities_common.db import Db
../utilities_common/db.py:4: in <module>
    from utilities_common.multi_asic import multi_asic_ns_choices
../utilities_common/multi_asic.py:100: in <module>
    default=multi_asic_display_default_option(),
../utilities_common/multi_asic.py:91: in multi_asic_display_default_option
    if not multi_asic.is_multi_asic() and not device_info.is_chassis():
/usr/local/lib/python3.7/dist-packages/sonic_py_common/device_info.py:426: in is_chassis
    return is_voq_chassis() or is_packet_chassis()
/usr/local/lib/python3.7/dist-packages/sonic_py_common/device_info.py:416: in is_voq_chassis
    switch_type = get_platform_info().get('switch_type')
/usr/local/lib/python3.7/dist-packages/sonic_py_common/device_info.py:354: in get_platform_info
    hw_info_dict['asic_type'] = version_info.get('asic_type')
E   AttributeError: 'NoneType' object has no attribute 'get'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================================== 1 error in 0.18 seconds ===============================================================================

```

After:

```
samaddik@20139b1eaeb5:/sonic/src/sonic-utilities/tests$ pytest-3 watermarkstat_test.py
================================================================================ test session starts =================================================================================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /sonic/src/sonic-utilities/tests, inifile: pytest.ini
plugins: cov-2.6.0
collected 14 items

watermarkstat_test.py ..............                                                                                                                                           [100%]

============================================================================= 14 passed in 1.91 seconds ==============================================================================

```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

