### PR TITLE
[yang-models] Validating 'services' exist if ACL type is 'CTRLPLANE'

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -44,6 +44,11 @@
         "eStrKey" : "Mandatory",
         "eStr": ["ACL_TABLE"]
     },
+    "ACL_TABLE_CTRLPLANE_REQUIRES_SERVICES": {
+        "desc": "ACL_TABLE CTRLPLANE type requires services presence.",
+        "eStrKey" : "Must",
+        "eStr": ["CTRLPLANE", "services"]
+    },
     "ACL_TABLE_DEFAULT_VALUE_STAGE": {
         "desc": "ACL_TABLE DEFAULT VALUE FOR STAGE FIELD.",
         "eStrKey" : "Verify",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -432,6 +432,20 @@
             }
         }
     },
+    "ACL_TABLE_CTRLPLANE_REQUIRES_SERVICES": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "NO-NSW-PACL-V4",
+                        "policy_desc": "Filter IPv4",
+                        "stage": "ingress",
+                        "type": "CTRLPLANE"
+                    }
+                ]
+            }
+        }
+    },
     "ACL_TABLE_UNDEFINED_TABLE_TYPE": {
         "sonic-acl:sonic-acl": {
             "sonic-acl:ACL_TABLE": {

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -259,7 +259,8 @@ module sonic-acl {
 					type string;
 				}
 
-				must "(type != 'CTRLPLANE') or (boolean(services))";
+				/* Validating 'services' exist if ACL type is 'CTRLPLANE' */
+				must "(not(type = 'CTRLPLANE')) or (boolean(services))";
 
 				leaf-list ports {
 					/* union of leafref is allowed in YANG 1.1 */

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -259,6 +259,8 @@ module sonic-acl {
 					type string;
 				}
 
+				must "(type != 'CTRLPLANE') or (boolean(services))";
+
 				leaf-list ports {
 					/* union of leafref is allowed in YANG 1.1 */
 					type union {


### PR DESCRIPTION
#### Why I did it
Fixing issue #9294

#### How I did it
Updating ACL yang model

#### How to verify it

Validating issue with `config patch-apply` is fixed.

- Start a KVM
- Add file `add-ctrl-plane-tbl.json-patch ` with content:
```json
[
    {
     "op": "add",
     "path": "/ACL_TABLE/ACTRLPLANETABLE",
     "value": {
      "policy_desc": "ACTRLPLANETABLE",
      "services": [
       "SSH"
      ],
      "stage": "ingress",
      "type": "CTRLPLANE"
     }
    }
]
```
- Run `sudo config apply-patch add-ctrl-plane-tbl.json-patch`


Before:
```
Patch Applier: The patch was sorted into 4 changes:
Patch Applier:   * [{"op": "add", "path": "/ACL_TABLE/ACTRLPLANETABLE", "value": {"type": "CTRLPLANE"}}]
Patch Applier:   * [{"op": "add", "path": "/ACL_TABLE/ACTRLPLANETABLE/policy_desc", "value": "ACTRLPLANETABLE"}]
Patch Applier:   * [{"op": "add", "path": "/ACL_TABLE/ACTRLPLANETABLE/services", "value": ["SSH"]}]
Patch Applier:   * [{"op": "add", "path": "/ACL_TABLE/ACTRLPLANETABLE/stage", "value": "ingress"}]
```

After:
```
Patch Applier: The patch was sorted into 1 change:
Patch Applier:   * [{"op": "add", "path": "/ACL_TABLE/ACTRLPLANETABLE", "value": {"policy_desc": "ACTRLPLANETABLE", "services": ["SSH"], "stage": "ingress", "type": "CTRLPLANE"}}]
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

