### PR TITLE
[config-engine]: add option to print verbose debug info in unit tests

### DIFF
--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -47,7 +47,7 @@ class TestCfgGen(TestCase):
         except OSError:
             pass
 
-    def run_script(self, argument, check_stderr=False):
+    def run_script(self, argument, check_stderr=False, verbose=False):
         print('\n    Running sonic-cfggen ' + argument)
         if check_stderr:
             output = subprocess.check_output(self.script_file + ' ' + argument, stderr=subprocess.STDOUT, shell=True)
@@ -62,6 +62,8 @@ class TestCfgGen(TestCase):
             print('    Output: ' + output.strip())
         else:
             print('    Output: ({0} lines, {1} bytes)'.format(linecount + 1, len(output)))
+            if verbose == True:
+                print('    Output: ' + output.strip())
         return output
 
     def test_dummy_run(self):
@@ -201,7 +203,7 @@ class TestCfgGen(TestCase):
     # more robust by adding better parsing logic.
     def test_minigraph_acl(self):
         argument = '-m "' + self.sample_graph_t0 + '" -p "' + self.port_config + '" -v ACL_TABLE'
-        output = self.run_script(argument, True)
+        output = self.run_script(argument, True, True)
         self.assertEqual(
             utils.to_dict(output.strip().replace("Warning: Ignoring Control Plane ACL NTP_ACL without type\n", '')),
             utils.to_dict(


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
add option to print verbose debug info in unit tests

#### How I did it

#### How to verify it
tested locally.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

