### PR TITLE
ACL_RULE can set ACCEPT in packet action but yang model doesn't support that

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-types.yang
+++ b/src/sonic-yang-models/yang-models/sonic-types.yang
@@ -60,6 +60,7 @@ module sonic-types {
 
     typedef packet_action{
         type enumeration {
+            enum ACCEPT;
             enum DROP;
             enum FORWARD;
             enum REDIRECT;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
ACL_RULE can set ACCEPT in packet action but yang model doesn't support that
#### How I did it
Add ACCEPT to packet_action
#### How to verify it
`sudo config apply-patch acl.json` will not report failure
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

