### PR TITLE
[yang] fix yang model tests to run on installed models

### DIFF
--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
@@ -268,7 +268,7 @@ class Test_SonicYang(object):
     """
     @pytest.fixture(autouse=True, scope='class')
     def sonic_yang_data(self):
-        sonic_yang_dir = "../sonic-yang-models/yang-models/"
+        sonic_yang_dir = "/usr/local/yang-models/"
         sonic_yang_test_file = "../sonic-yang-models/tests/files/sample_config_db.json"
 
         syc = sy.SonicYang(sonic_yang_dir)

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -105,6 +105,7 @@ setup(
                          './yang-models/sonic-mgmt_vrf.yang',
                          './yang-models/sonic-ntp.yang',
                          './yang-models/sonic-nat.yang',
+                         './yang-models/sonic-pbh.yang',
                          './yang-models/sonic-port.yang',
                          './yang-models/sonic-portchannel.yang',
                          './yang-models/sonic-pfcwd.yang',
@@ -150,6 +151,7 @@ setup(
                          './cvlyang-models/sonic-mgmt_vrf.yang',
                          './cvlyang-models/sonic-ntp.yang',
                          './cvlyang-models/sonic-nat.yang',
+                         './cvlyang-models/sonic-pbh.yang'
                          './cvlyang-models/sonic-port.yang',
                          './cvlyang-models/sonic-portchannel.yang',
                          './cvlyang-models/sonic-pfcwd.yang',

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -151,7 +151,7 @@ setup(
                          './cvlyang-models/sonic-mgmt_vrf.yang',
                          './cvlyang-models/sonic-ntp.yang',
                          './cvlyang-models/sonic-nat.yang',
-                         './cvlyang-models/sonic-pbh.yang'
+                         './cvlyang-models/sonic-pbh.yang',
                          './cvlyang-models/sonic-port.yang',
                          './cvlyang-models/sonic-portchannel.yang',
                          './cvlyang-models/sonic-pfcwd.yang',


### PR DESCRIPTION
**Description**

Previously the Yang model unit tests pulled directly from the Yang model source code for their models. This worked up to a point where we had jinja templates which needed to be rendered before they could be tested on. Now we need to reference the install location of the rendered templates for the unit tests.

Additionally, PBH yang was never added to the list of models to install onto a switch so I have resolved that (another example why pulling directly from the source was not correct)

My best explanation for why we only saw this failing on mellanox was that these tests could not have possibly been running on the broadcom build (I have not investigated this specifically). There was no way for these tests to pass recently given they were referencing Yang models which did not exist in the source (ACL).

**How to Verify**

Compile and build successfully and see that unit tests pass.

**Backports**

None, this was a unit test issue that only became relevant once we enabled templating.

**Changelog**
[yang] fix yang model tests to run on installed models

**Picture of a cute animal**
![giant_panda_bear-snow-good_housekeeping_uk](https://user-images.githubusercontent.com/5898707/142659209-7758d7ca-db86-4416-bb2b-eed59a55277f.jpg)

