### PR TITLE
[build] pip3 install latest redis with hiredis together

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -444,7 +444,8 @@ RUN pip3 install "PyYAML==5.4.1"
 RUN pip3 install "lxml==4.6.2"
 
 # For sonic-platform-common testing
-RUN pip3 install redis
+# redis-py (>=4.0.0) works best with hiredis
+RUN pip3 install redis hiredis
 
 # For vs image build
 RUN pip3 install pexpect==4.8.0

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -444,7 +444,7 @@ RUN pip3 install "PyYAML==5.4.1"
 RUN pip3 install "lxml==4.6.2"
 
 # For sonic-platform-common testing
-RUN pip3 install redis==3.5.3
+RUN pip3 install redis
 
 # For vs image build
 RUN pip3 install pexpect==4.8.0

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -457,7 +457,7 @@ RUN pip2 install "lxml==4.6.2"
 RUN pip3 install "lxml==4.6.2"
 
 # For sonic-platform-common testing
-RUN pip3 install redis==3.5.3
+RUN pip3 install redis
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -457,7 +457,8 @@ RUN pip2 install "lxml==4.6.2"
 RUN pip3 install "lxml==4.6.2"
 
 # For sonic-platform-common testing
-RUN pip3 install redis
+# redis-py (>=4.0.0) works best with hiredis
+RUN pip3 install redis hiredis
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -365,7 +365,7 @@ RUN pip3 install "lxml==4.6.2"
 
 
 # For sonic-platform-common testing
-RUN pip3 install redis==3.5.3
+RUN pip3 install redis
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -365,7 +365,8 @@ RUN pip3 install "lxml==4.6.2"
 
 
 # For sonic-platform-common testing
-RUN pip3 install redis
+# redis-py (>=4.0.0) works best with hiredis
+RUN pip3 install redis hiredis
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0


### PR DESCRIPTION
#### Why I did it
Rework https://github.com/Azure/sonic-buildimage/pull/9317
redis-py (>=4.0.0) works best with hiredis
ref: https://github.com/redis/redis-py#parsers
Otherwise there will be a warning message `redis-py works best with hiredis` and will break sonic-config-engine unit test.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

