### PR TITLE
[arm64][qemu] upgrade qemu for fix systemd-sonic-generator compile error

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -3,7 +3,7 @@ FROM multiarch/qemu-user-static:x86_64-arm-5.2.0-2 as qemu
 FROM multiarch/debian-debootstrap:armhf-bullseye
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
 {%- elif CONFIGURED_ARCH == "arm64" and MULTIARCH_QEMU_ENVIRON == "y" %}
-FROM multiarch/qemu-user-static:x86_64-aarch64-5.2.0-2 as qemu
+FROM multiarch/qemu-user-static:x86_64-aarch64-6.1.0-8 as qemu
 FROM multiarch/debian-debootstrap:arm64-bullseye
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 {%- else -%}


### PR DESCRIPTION
[arm64][qemu] upgrade qemu for fix systemd-sonic-generator compile error

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
for compile error when build systemd-sonic-generator_1.0.0_arm64.deb on qemu arm64 bullseye.
```
boost::filesystem::copy_file: Function not implemented: "tests/testfiles/single_inst.service", "tests/ssg-test/systemd/single_inst.service"
boost::filesystem::copy_file: Function not implemented: "tests/testfiles/multi_inst_b.service", "tests/ssg-test/systemd/multi_inst_b.service"
boost::filesystem::copy_file: Function not implemented: "tests/testfiles/multi_inst_a.service", "tests/ssg-test/systemd/multi_inst_a.service"
boost::filesystem::copy_file: Function not implemented: "tests/testfiles/multi_inst_b@.service", "tests/ssg-test/systemd/multi_inst_b@.service"
boost::filesystem::copy_file: Function not implemented: "tests/testfiles/multi_inst_a@.service", "tests/ssg-test/systemd/multi_inst_a@.service"
boost::filesystem::copy_file: Function not implemented: "tests/testfiles/test.timer", "tests/ssg-test/systemd/test.timer"
boost::filesystem::copy_file: Function not implemented: "tests/testfiles/test.service", "tests/ssg-test/systemd/test.service"
ssg-test.cc:244: Failure
Expected equality of these values:
  fs::exists(path)
    Which is: false
  expected_result
    Which is: true
Failed validation: "tests/ssg-test/generator/multi-user.target.wants/multi_inst_b.service"
```

#### How I did it
upgrade qemu to latest for arm64 bullseye.

#### How to verify it
build systemd-sonic-generator_1.0.0_arm64.deb package
```
shil@vultr:~/sonic-buildimage$ ls target/debs/bullseye/systemd-sonic-generator_1.0.0_arm64.deb*
target/debs/bullseye/systemd-sonic-generator_1.0.0_arm64.deb      target/debs/bullseye/systemd-sonic-generator_1.0.0_arm64.deb.log.bak
target/debs/bullseye/systemd-sonic-generator_1.0.0_arm64.deb.log
shil@vultr:~/sonic-buildimage$
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

