### PR TITLE
[Reclaim buffer][202106] Common infrastructure update for reclaiming buffer

### DIFF
--- a/dockers/docker-orchagent/buffermgrd.sh
+++ b/dockers/docker-orchagent/buffermgrd.sh
@@ -3,14 +3,16 @@
 BUFFER_CALCULATION_MODE=$(redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model)
 
 if [ "$BUFFER_CALCULATION_MODE" == "dynamic" ]; then
+    BUFFERMGRD_ARGS="-a /etc/sonic/asic_table.json"
     if [ -f /etc/sonic/peripheral_table.json ]; then
-        BUFFERMGRD_ARGS="-a /etc/sonic/asic_table.json -p /etc/sonic/peripheral_table.json"
-    else
-        BUFFERMGRD_ARGS="-a /etc/sonic/asic_table.json"
+        BUFFERMGRD_PERIPHERIAL_ARGS=" -p /etc/sonic/peripheral_table.json"
+    fi
+    if [ -f /etc/sonic/zero_profiles.json ]; then
+        BUFFERMGRD_ZERO_PROFILE_ARGS=" -z /etc/sonic/zero_profiles.json"
     fi
 else
     # Should we use the fallback MAC in case it is not found in Device.Metadata
     BUFFERMGRD_ARGS="-l /usr/share/sonic/hwsku/pg_profile_lookup.ini"
 fi
 
-exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS}
+exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS} ${BUFFERMGRD_PERIPHERIAL_ARGS} ${BUFFERMGRD_ZERO_PROFILE_ARGS}

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -93,30 +93,17 @@ def
     {%- endif %}
 {%- endmacro %}
 
-{%- set PORT_ALL  = [] %}
-
-{%- if PORT is not defined %}
-    {%- if defs.generate_port_lists(PORT_ALL) %} {% endif %}
-{%- else %}
-    {%- for port in PORT %}
-        {%- if PORT_ALL.append(port) %}{%- endif %}
-    {%- endfor %}
-{%- endif %}
-
-{%- set PORT_ACTIVE  = [] %}
-{%- if DEVICE_NEIGHBOR is not defined %}
-    {%- set PORT_ACTIVE = PORT_ALL %}
-{%- else %}
-    {%- for port in DEVICE_NEIGHBOR.keys() %}
-        {%- if PORT_ACTIVE.append(port) %}{%- endif %}
-    {%- endfor %}
-{%- endif %}
-
 {%- set port_names_list_active  = [] %}
 {%- for port in PORT_ACTIVE %}
     {%- if port_names_list_active.append(port) %}{%- endif %}
 {%- endfor %}
 {%- set port_names_active  = port_names_list_active  | join(',') %}
+
+{%- set port_names_list_inactive  = [] %}
+{%- for port in PORT_INACTIVE %}
+    {%- if port_names_list_inactive.append(port) %}{%- endif %}
+{%- endfor %}
+{%- set port_names_inactive  = port_names_list_inactive  | join(',') %}
 
 {
     "CABLE_LENGTH": {
@@ -135,10 +122,14 @@ def
 
 {%- if defs.generate_profile_lists is defined %}
 {{ defs.generate_profile_lists(port_names_active) }},
+{% elif defs.generate_profile_lists_with_inactive_ports is defined %}
+{{ defs.generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) }},
 {% endif %}
 
 {%- if defs.generate_pg_profils is defined %}
 {{ defs.generate_pg_profils(port_names_active) }}
+{% elif defs.generate_pg_profiles_with_inactive_ports is defined %}
+{{ defs.generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) }},
 {% else %}
     "BUFFER_PG": {
 {% for port in PORT_ACTIVE %}
@@ -157,6 +148,8 @@ def
 
 {% if defs.generate_queue_buffers is defined %}
 {{ defs.generate_queue_buffers(port_names_active) }}
+{% elif defs.generate_queue_buffers_with_inactive_ports is defined %}
+{{ defs.generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) }}
 {% else %}
     "BUFFER_QUEUE": {
 {% for port in PORT_ACTIVE %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -286,6 +286,9 @@ start() {
     if [ ! -f /etc/sonic/peripheral_table.json ] && [ -f /usr/share/sonic/device/$PLATFORM/port_peripheral_config.j2 ]; then
         sonic-cfggen -d -t /usr/share/sonic/device/$PLATFORM/port_peripheral_config.j2 > /etc/sonic/peripheral_table.json
     fi
+    if [ ! -f /etc/sonic/zero_profiles.json ] && [ -f /usr/share/sonic/templates/zero_profiles.j2 ]; then
+        sonic-cfggen -d -t /usr/share/sonic/device/$PLATFORM/zero_profiles.j2 > /etc/sonic/zero_profiles.json
+    fi
     {%- endif %}
 
     # In Multi ASIC platforms the global database config file database_global.json will exist.

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -504,6 +504,11 @@ if [ -f platform/{{ sonic_asic_platform }}/peripheral_table.j2 ]
 then
     sudo cp platform/{{ sonic_asic_platform }}/peripheral_table.j2 $FILESYSTEM_ROOT/usr/share/sonic/templates/peripheral_table.j2
 fi
+
+if [ -f platform/{{ sonic_asic_platform }}/zero_profiles.j2 ]
+then
+    sudo cp platform/{{ sonic_asic_platform }}/zero_profiles.j2 $FILESYSTEM_ROOT/usr/share/sonic/templates/zero_profiles.j2
+fi
 {% endif %}
 
 # Copy hostname configuration scripts

--- a/platform/vs/docker-sonic-vs/buffermgrd.sh
+++ b/platform/vs/docker-sonic-vs/buffermgrd.sh
@@ -10,4 +10,8 @@ else
     BUFFERMGRD_ARGS="-l /usr/share/sonic/hwsku/pg_profile_lookup.ini"
 fi
 
-exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS}
+if [ -f /etc/sonic/zero_profiles.json ]; then
+    BUFFERMGRD_ZERO_PROFILE_ARGS=" -z /etc/sonic/zero_profiles.json"
+fi
+
+exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS} ${BUFFERMGRD_ZERO_PROFILE_ARGS}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This is to update the common sonic-buildimage infra for reclaiming buffer.

#### How I did it

- Render `zero_profiles.j2` to `zero_profiles.json` for vendors that support reclaiming buffer
  The zero profiles will be referenced in PR #9062 on Mellanox platforms and there will be test cases to verify the behavior there.
  Rendering is done here for passing azure pipeline.
- Load `zero_profiles.json` when the dynamic buffer manager starts
- Generate inactive port list to reclaim buffer

It depends on PR Azure/sonic-swss#2038

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

