### PR TITLE
Fix redis version during pip3 install

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -426,7 +426,7 @@ RUN pip2 install "lxml==4.6.2"
 RUN pip3 install "lxml==4.6.2"
 
 # For sonic-platform-common testing
-RUN pip3 install redis
+RUN pip3 install redis==3.5.3
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -354,7 +354,7 @@ RUN pip3 install "lxml==4.6.2"
 
 
 # For sonic-platform-common testing
-RUN pip3 install redis
+RUN pip3 install redis==3.5.3
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0


### PR DESCRIPTION
#### Why I did it
Backport https://github.com/Azure/sonic-buildimage/pull/9317 to 202012 branch.

The recent release of redis 4.0.0 or newer (for python3) breaks sonic-config-engine unit test. Fix to last known good version.
ref: https://pypi.org/project/redis/#history


#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

