### PR TITLE
[centec][arm64] upgrade centec sai to 1.9.1-0

### DIFF
--- a/platform/centec-arm64/sai.mk
+++ b/platform/centec-arm64/sai.mk
@@ -1,6 +1,6 @@
 # Centec SAI
 
-export CENTEC_SAI_VERSION = 1.7.1-1
+export CENTEC_SAI_VERSION = 1.9.1-0
 export CENTEC_SAI = libsai_$(CENTEC_SAI_VERSION)_$(PLATFORM_ARCH).deb
 
 $(CENTEC_SAI)_URL = https://github.com/CentecNetworks/sonic-binaries/raw/master/$(PLATFORM_ARCH)/sai/$(CENTEC_SAI)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
upgrade centec arm64 sai to v1.9.1 and fix syncd compile error:
```
2021-11-21T19:58:09.0294367Z /usr/bin/ld: libSyncd.a(libSyncd_a-VendorSai.o): in function `syncd::VendorSai::queryStatsCapability(unsigned long, _sai_object_type_t, _sai_stat_capability_list_t*)':
2021-11-21T19:58:09.0297367Z ./syncd/VendorSai.cpp:439: undefined reference to `sai_query_stats_capability'
2021-11-21T19:58:09.0298900Z collect2: error: ld returned 1 exit status
```

#### How I did it
upgrade centec arm64 sai to v1.9.1.

#### How to verify it
build syncd_1.0.0_arm64.deb.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

