### PR TITLE
[yang]: Add admin_status to BGP_NEIGHBOR_TEMPLATE_LIST.

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1087,7 +1087,8 @@
                 "local_addr": "10.0.0.2",
                 "name":"PEER1",
                 "nhopself":"0",
-                "rrclient":"0"
+                "rrclient":"0",
+                "admin_status":"up"
             },
             "default|192.168.1.1": {
                 "local_asn": "65200",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -24,6 +24,11 @@
         "desc": "Referring non-existing BGP neighbor table.",
         "eStrKey" : "LeafRef"
     },
+    "BGP_NEIGHBOR_NEG_INVALID_ADMIN_STATUS": {
+        "desc": "Incorrect admin status.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["admin_status"]
+    },
     "BGP_NEIGHBOR_NEG_INVALID_NAME": {
         "desc": "Incorrect neighbor name.",
         "eStrKey": "InvalidValue",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -133,6 +133,19 @@
         },
         "sonic-bgp-neighbor:sonic-bgp-neighbor": {
             "sonic-bgp-neighbor:BGP_NEIGHBOR": {
+                "BGP_NEIGHBOR_TEMPLATE_LIST": [
+                {
+                    "neighbor": "10.0.0.1",
+                    "asn": "65200",
+                    "holdtime": "180",
+                    "keepalive": "60",
+                    "local_addr": "10.0.0.2",
+                    "name":"PEER1",
+                    "nhopself":"0",
+                    "rrclient":"0",
+                    "admin_status":"up"
+                }
+                ],
                 "BGP_NEIGHBOR_LIST": [
                 {
                     "vrf_name": "default",
@@ -431,6 +444,29 @@
                     "admin_status": true,
                     "send_default_route": true
                 }]}
+        }
+    },
+
+    "BGP_NEIGHBOR_NEG_INVALID_ADMIN_STATUS": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-neighbor:sonic-bgp-neighbor": {
+            "sonic-bgp-neighbor:BGP_NEIGHBOR": {
+                "BGP_NEIGHBOR_TEMPLATE_LIST": [
+                    {
+                        "neighbor": "11.12.13.14",
+                        "admin_status": "right"
+                    }
+                ]
+            }
         }
     },
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -7,6 +7,11 @@ module sonic-bgp-neighbor {
         prefix inet;
     }
 
+    import sonic-types {
+        prefix stypes;
+        revision-date 2019-07-01;
+    }
+
     import sonic-bgp-common {
         prefix bgpcmn;
     }
@@ -99,8 +104,8 @@ module sonic-bgp-neighbor {
                 }
 
                 leaf admin_status {
-                    type boolean;
-                    description "To enable BGP peer";
+                    type stypes:admin_status;
+                    description "Admin status of BGP peer";
                 }
             }
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -97,6 +97,11 @@ module sonic-bgp-neighbor {
                     }
                     description "Route reflector client";
                 }
+
+                leaf admin_status {
+                    type boolean;
+                    description "To enable BGP peer";
+                }
             }
 
             list BGP_NEIGHBOR_LIST {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -9,7 +9,6 @@ module sonic-bgp-neighbor {
 
     import sonic-types {
         prefix stypes;
-        revision-date 2019-07-01;
     }
 
     import sonic-bgp-common {


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
#9119
BGP_NEIGHBOR_TEMPLATE_LIST does not have admin_status field.

#### How I did it
Add admin_status to BGP_NEIGHBOR_TEMPLATE_LIST.

#### How to verify it
Follow the steps in #9119.
Build sonic-yang-model.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix #9119 

#### A picture of a cute animal (not mandatory but encouraged)

