### PR TITLE
[Mellanox] Add copyright headers to Mellanox-SN4600C-D100C12S2 SKU

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t0.j2
@@ -1,5 +1,5 @@
 {#
-    Copyright (c) 2018-2021 NVIDIA CORPORATION & AFFILIATES.
+    Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t0.j2
@@ -1,3 +1,20 @@
+{#
+    Copyright (c) 2018-2021 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '48228352' %}
 {% set ingress_lossless_xoff_size = '2287616' %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t1.j2
@@ -1,5 +1,5 @@
 {#
-    Copyright (c) 2018-2021 NVIDIA CORPORATION & AFFILIATES.
+    Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t1.j2
@@ -1,3 +1,20 @@
+{#
+    Copyright (c) 2018-2021 NVIDIA CORPORATION & AFFILIATES.
+    Apache-2.0
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '46315520' %}
 {% set ingress_lossless_xoff_size =  '4200448' %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/port_config.ini
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/port_config.ini
@@ -1,3 +1,20 @@
+##
+## Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES.
+## Apache-2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
 # name         lanes              alias     index    speed
 Ethernet0      0,1                etp1a     1        50000
 Ethernet2      2,3                etp1b     1        50000

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/sai_4600c_100x50g_12x100g_2x10g.xml
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/sai_4600c_100x50g_12x100g_2x10g.xml
@@ -1,3 +1,20 @@
+<!--
+  Copyright (c) 2019-2021 NVIDIA CORPORATION & AFFILIATES.
+  Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 <root>
     <platform_info type="4601">
 


### PR DESCRIPTION
#### Why I did it

Missing NVIDIA copyright header from some files.

#### How I did it

Added copyright header

#### How to verify it

N/A

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
[mellanox] Add copyright headers to Mellanox-SN4600C-D100C12S2 SKU
