### PR TITLE
[mgmt-framework] Fix docker image build failure for docker-sonic-mgmt-framework-dbg.

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -37,7 +37,7 @@ RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
 ## TODO: symbolic links will be removed when AAA improvements get merged
-RUN ln -sf /host_etc/passwd /etc/passwd	
-RUN ln -sf /host_etc/group /etc/group
+# RUN ln -sf /host_etc/passwd /etc/passwd	
+# RUN ln -sf /host_etc/group /etc/group
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
docker-sonic-mgmt-framework-dbg.gz need to install openssh-client.
Setting up openssh-client need to run command ‘groupadd’
But docker docker-sonic-mgmt-framework '/etc/group' is a fake file.
Related: https://github.com/Azure/sonic-buildimage/pull/6148
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

