### PR TITLE
[201911] DellEMC: S6000, S6100 - Enable thermalctld, Platform API changes

### DIFF
--- a/device/dell/x86_64-dell_s6000_s1220-r0/pmon_daemon_control.json
+++ b/device/dell/x86_64-dell_s6000_s1220-r0/pmon_daemon_control.json
@@ -1,4 +1,3 @@
 {
-    "skip_ledd": true,
-    "skip_thermalctld": true
+    "skip_ledd": true
 }

--- a/device/dell/x86_64-dell_s6100_c2538-r0/pmon_daemon_control.json
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/pmon_daemon_control.json
@@ -1,4 +1,3 @@
 {
-    "skip_ledd": true,
-    "skip_thermalctld": true
+    "skip_ledd": true
 }

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/chassis.py
@@ -10,21 +10,21 @@
 try:
     import os
     import time
-    import datetime
-    import struct
     import subprocess
+    import struct
     from sonic_platform_base.chassis_base import ChassisBase
-    from sonic_platform.sfp import Sfp
+    from sonic_platform.component import Component
     from sonic_platform.eeprom import Eeprom, EepromS6000
     from sonic_platform.fan import Fan
     from sonic_platform.psu import Psu
+    from sonic_platform.sfp import Sfp
     from sonic_platform.thermal import Thermal
-    from sonic_platform.component import Component
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 
-MAX_S6000_FAN = 3
+MAX_S6000_FANTRAY = 3
+MAX_S6000_FAN_PER_FANTRAY = 2
 MAX_S6000_PSU = 2
 MAX_S6000_THERMAL = 10
 MAX_S6000_COMPONENT = 4
@@ -76,9 +76,10 @@ class Chassis(ChassisBase):
         else:
             self._eeprom = EepromS6000()
 
-        for i in range(MAX_S6000_FAN):
-            fan = Fan(i)
-            self._fan_list.append(fan)
+        for i in range(1, MAX_S6000_FANTRAY+1):
+            for j in range(1, MAX_S6000_FAN_PER_FANTRAY+1):
+                fan = Fan(fantray_index=i, fan_index=j)
+                self._fan_list.append(fan)
 
         for i in range(MAX_S6000_PSU):
             psu = Psu(i)
@@ -102,7 +103,7 @@ class Chassis(ChassisBase):
         try:
             with open(mb_reg_file, 'r') as fd:
                 rv = fd.read()
-        except Exception as error:
+        except IOError:
             rv = 'ERR'
 
         rv = rv.rstrip('\r\n')

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/eeprom.py
@@ -18,7 +18,6 @@
 
 try:
     import binascii
-    import os
     import redis
     import struct
     from collections import OrderedDict
@@ -37,8 +36,8 @@ psu_eeprom_format = [
     ('Fab Rev', 's', 2)
     ]
 
-# Fan eeprom fields in format required by EepromDecoder
-fan_eeprom_format = [
+# FanTray eeprom fields in format required by EepromDecoder
+fantray_eeprom_format = [
     ('PPID', 's', 20), ('DPN Rev', 's', 3), ('Service Tag', 's', 7),
     ('Part Number', 's', 10), ('Part Num Revision', 's', 3),
     ('Mfg Test', 's', 2), ('Redundant copy', 's', 83),
@@ -52,10 +51,10 @@ class Eeprom(TlvInfoDecoder):
 
     I2C_DIR = "/sys/class/i2c-adapter/"
 
-    def __init__(self, is_psu=False, psu_index=0, is_fan=False, fan_index=0):
+    def __init__(self, is_psu=False, psu_index=0, is_fantray=False, fantray_index=0):
         self.is_psu_eeprom = is_psu
-        self.is_fan_eeprom = is_fan
-        self.is_sys_eeprom = not (is_psu | is_fan)
+        self.is_fantray_eeprom = is_fantray
+        self.is_sys_eeprom = not (is_psu | is_fantray)
 
         if self.is_sys_eeprom:
             self.start_offset = 0
@@ -72,10 +71,10 @@ class Eeprom(TlvInfoDecoder):
                     + "i2c-1/1-005{}/eeprom".format(2 - self.index)
                 self.format = psu_eeprom_format
             else:
-                self.index = fan_index
+                self.index = fantray_index
                 self.eeprom_path = self.I2C_DIR \
                     + "i2c-11/11-005{}/eeprom".format(4 - self.index)
-                self.format = fan_eeprom_format
+                self.format = fantray_eeprom_format
             EepromDecoder.__init__(self, self.eeprom_path, self.format,
                                    self.start_offset, '', True)
             self._load_device_eeprom()

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/psu.py
@@ -26,6 +26,7 @@ class Psu(PsuBase):
     I2C_DIR = "/sys/class/i2c-adapter/"
 
     def __init__(self, psu_index):
+        PsuBase.__init__(self)
         # PSU is 1-based in DellEMC platforms
         self.index = psu_index + 1
         self.psu_presence_reg = "psu{}_prs".format(psu_index)
@@ -52,11 +53,7 @@ class Psu(PsuBase):
 
         self.eeprom = Eeprom(is_psu=True, psu_index=self.index)
 
-        # Overriding _fan_list class variable defined in PsuBase, to
-        # make it unique per Psu object
-        self._fan_list = []
-
-        self._fan_list.append(Fan(self.index, psu_fan=True, dependency=self))
+        self._fan_list.append(Fan(psu_index=self.index, psu_fan=True, dependency=self))
 
     def _get_cpld_register(self, reg_name):
         # On successful read, returns the value read from given
@@ -109,9 +106,9 @@ class Psu(PsuBase):
         power_reg = glob.glob(self.psu_power_reg)
 
         if len(voltage_reg) and len(current_reg) and len(power_reg):
-            self.psu_voltage_reg = voltage_reg_path[0]
-            self.psu_current_reg = current_reg_path[0]
-            self.psu_power_reg = power_reg_path[0]
+            self.psu_voltage_reg = voltage_reg[0]
+            self.psu_current_reg = current_reg[0]
+            self.psu_power_reg = power_reg[0]
             self.is_driver_initialized = True
 
     def get_name(self):

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/sonic_platform/thermal.py
@@ -96,7 +96,7 @@ class Thermal(ThermalBase):
         try:
             with open(sysfs_file, 'r') as fd:
                 rv = fd.read()
-        except:
+        except IOError:
             rv = 'ERR'
 
         rv = rv.rstrip('\r\n')

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -17,7 +17,6 @@ try:
     from sonic_platform.fan import Fan
     from sonic_platform.module import Module
     from sonic_platform.psu import Psu
-    from sonic_platform.sfp import Sfp
     from sonic_platform.thermal import Thermal
     from sonic_platform.watchdog import Watchdog
 except ImportError as e:

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/chassis.py
@@ -10,17 +10,16 @@
 
 try:
     import os
-    from sonic_platform_base.platform_base import PlatformBase
+    import time
     from sonic_platform_base.chassis_base import ChassisBase
-    from sonic_platform.sfp import Sfp
-    from sonic_platform.psu import Psu
+    from sonic_platform.component import Component
+    from sonic_platform.eeprom import Eeprom
     from sonic_platform.fan import Fan
     from sonic_platform.module import Module
+    from sonic_platform.psu import Psu
+    from sonic_platform.sfp import Sfp
     from sonic_platform.thermal import Thermal
-    from sonic_platform.component import Component
     from sonic_platform.watchdog import Watchdog
-    from eeprom import Eeprom
-    import time
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -65,7 +64,7 @@ class Chassis(ChassisBase):
             self._module_list.append(module)
             self._sfp_list.extend(module._sfp_list)
 
-        for i in range(MAX_S6100_FAN):
+        for i in range(1, MAX_S6100_FAN+1):
             fan = Fan(i)
             self._fan_list.append(fan)
 

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/eeprom.py
@@ -73,6 +73,10 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
 
                 tlv_index += ord(eeprom[tlv_index+1]) + 2
 
+            if self.is_module:
+                # In S6100, individual modules doesn't have MAC address
+                mac_code = "0x%02X" % self._TLV_CODE_MAC_BASE
+                self.eeprom_tlv_dict[mac_code] = '00:00:00:00:00:00'
 
     def serial_number_str(self):
         (is_valid, results) = self.get_tlv_field(

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/fan.py
@@ -26,13 +26,10 @@ class Fan(FanBase):
     HWMON_NODE = os.listdir(HWMON_DIR)[0]
     MAILBOX_DIR = HWMON_DIR + HWMON_NODE
 
-    def __init__(self, fantray_index=1, fan_index=1, psu_fan=False):
+    def __init__(self, fantray_index=1, psu_index=1, psu_fan=False):
         self.is_psu_fan = psu_fan
         if not self.is_psu_fan:
-            # API index is starting from 0, DellEMC platform index is starting
-            # from 1
-            self.fantrayindex = fantray_index + 1
-            self.fanindex = fan_index + 1
+            self.fantrayindex = fantray_index
             self.fan_presence_reg = "fan{}_fault".format(
                         2 * self.fantrayindex - 1)
             self.fan_status_reg = "fan{}_alarm".format(
@@ -41,15 +38,12 @@ class Fan(FanBase):
                         2 * self.fantrayindex - 1)
             self.get_fan_dir_reg = "fan{}_airflow".format(
                         2 * self.fantrayindex - 1)
-            self.fan_serialno_reg = "fan{}_serialno".format(
-                        2 * self.fantrayindex - 1)
             self.max_fan_speed = MAX_S6100_FAN_SPEED
         else:
-            # PSU Fan index starts from 11
-            self.fanindex = fan_index + 10
-            self.fan_presence_reg = "fan{}_fault".format(self.fanindex)
-            self.get_fan_speed_reg = "fan{}_input".format(self.fanindex)
-            self.get_fan_dir_reg = "fan{}_airflow".format(self.fanindex)
+            self.psuindex = psu_index
+            self.fan_presence_reg = "fan{}_fault".format(self.psuindex + 10)
+            self.get_fan_speed_reg = "fan{}_input".format(self.psuindex + 10)
+            self.get_fan_dir_reg = "fan{}_airflow".format(self.psuindex + 10)
             self.max_fan_speed = MAX_S6100_PSU_FAN_SPEED
 
     def _get_pmc_register(self, reg_name):
@@ -77,10 +71,9 @@ class Fan(FanBase):
             string: The name of the device
         """
         if not self.is_psu_fan:
-            return "FanTray{}-Fan{}".format(
-                                self.fantrayindex, self.fanindex - 1)
+            return "FanTray{}-Fan1".format(self.fantrayindex)
         else:
-            return "PSU{} Fan".format(self.fanindex - 10)
+            return "PSU{} Fan".format(self.psuindex)
 
     def get_model(self):
         """
@@ -88,21 +81,7 @@ class Fan(FanBase):
         Returns:
             string: Part number of FAN
         """
-        # For Serial number "US-01234D-54321-25A-0123-A00", the part
-        # number is "01234D"
-        if self.is_psu_fan:
-            return 'NA'
-
-        fan_serialno = self._get_pmc_register(self.fan_serialno_reg)
-        if (fan_serialno != 'ERR') and self.get_presence():
-            if (len(fan_serialno.split('-')) > 1):
-                fan_partno = fan_serialno.split('-')[1]
-            else:
-                fan_partno = 'NA'
-        else:
-            fan_partno = 'NA'
-
-        return fan_partno
+        return 'NA'
 
     def get_serial(self):
         """
@@ -110,15 +89,7 @@ class Fan(FanBase):
         Returns:
             string: Serial number of FAN
         """
-        # Sample Serial number format "US-01234D-54321-25A-0123-A00"
-        if self.is_psu_fan:
-            return 'NA'
-
-        fan_serialno = self._get_pmc_register(self.fan_serialno_reg)
-        if (fan_serialno == 'ERR') or not self.get_presence():
-            fan_serialno = 'NA'
-
-        return fan_serialno
+        return 'NA'
 
     def get_presence(self):
         """
@@ -126,14 +97,14 @@ class Fan(FanBase):
         Returns:
             bool: True if fan is present, False if not
         """
-        status = False
-        fantray_presence = self._get_pmc_register(self.fan_presence_reg)
-        if (fantray_presence != 'ERR'):
-            fantray_presence = int(fantray_presence, 10)
-            if (~fantray_presence & 0b1):
-                status = True
+        presence = False
+        fan_presence = self._get_pmc_register(self.fan_presence_reg)
+        if (fan_presence != 'ERR'):
+            fan_presence = int(fan_presence, 10)
+            if (~fan_presence & 0b1):
+                presence = True
 
-        return status
+        return presence
 
     def get_status(self):
         """
@@ -216,7 +187,6 @@ class Fan(FanBase):
         Returns:
             bool: True if set success, False if fail.
         """
-
         # Fan speeds are controlled by Smart-fussion FPGA.
         return False
 
@@ -229,9 +199,9 @@ class Fan(FanBase):
         Returns:
             bool: True if set success, False if fail.
         """
-        # Leds are controlled by Smart-fussion FPGA.
-        status = False
-        return status
+        # No LED available for FanTray and PSU Fan
+        # Return True to avoid thermalctld alarm.
+        return True
 
     def get_status_led(self):
         """
@@ -240,17 +210,8 @@ class Fan(FanBase):
         Returns:
             A string, one of the predefined STATUS_LED_COLOR_* strings.
         """
-        if self.is_psu_fan:
-            # No LED available for PSU Fan
-            return None
-        else:
-            if self.get_presence():
-                if self.get_status():
-                    return self.STATUS_LED_COLOR_GREEN
-                else:
-                    return self.STATUS_LED_COLOR_AMBER
-            else:
-                return self.STATUS_LED_COLOR_OFF
+        # No LED available for FanTray and PSU Fan
+        return None
 
     def get_target_speed(self):
         """
@@ -259,6 +220,6 @@ class Fan(FanBase):
             An integer, the percentage of full fan speed, in the range 0 (off)
                  to 100 (full speed)
         """
-        return  0
-
-
+        # Fan speeds are controlled by Smart-fussion FPGA.
+        # Return current speed to avoid false thermalctld alarm.
+        return self.get_speed()

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/module.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/module.py
@@ -51,6 +51,7 @@ class Module(ModuleBase):
       }
 
     def __init__(self, module_index):
+        ModuleBase.__init__(self)
         # Modules are 1-based in DellEMC platforms
         self.index = module_index + 1
         self.port_start = (self.index - 1) * 16
@@ -60,11 +61,6 @@ class Module(ModuleBase):
 
         self.iom_status_reg = "iom_status"
         self.iom_presence_reg = "iom_presence"
-
-        # Overriding _component_list and _sfp_list class variables defined in
-        # ModuleBase, to make them unique per Module object
-        self._component_list = []
-        self._sfp_list = []
 
         component = Component(is_module=True, iom_index=self.index,
                               i2c_line=self.port_i2c_line)

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/psu.py
@@ -25,6 +25,7 @@ class Psu(PsuBase):
     MAILBOX_DIR = HWMON_DIR + HWMON_NODE
 
     def __init__(self, psu_index):
+        PsuBase.__init__(self)
         # PSU is 1-based in DellEMC platforms
         self.index = psu_index + 1
         self.psu_presence_reg = "psu{}_presence".format(self.index)
@@ -38,12 +39,8 @@ class Psu(PsuBase):
             self.psu_current_reg = "curr702_input"
             self.psu_power_reg = "power4_input"
 
-        # Overriding _fan_list class variable defined in PsuBase, to
-        # make it unique per Psu object
-        self._fan_list = []
-
         # Passing True to specify it is a PSU fan
-        psu_fan = Fan(fan_index=self.index, psu_fan=True)
+        psu_fan = Fan(psu_index=self.index, psu_fan=True)
         self._fan_list.append(psu_fan)
 
     def _get_pmc_register(self, reg_name):

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/sonic_platform/thermal.py
@@ -49,9 +49,13 @@ class Thermal(ThermalBase):
         self.thermal_temperature_file = self.HWMON_DIR \
             + "temp{}_input".format(hwmon_temp_index)
         self.thermal_high_threshold_file = self.HWMON_DIR \
-            + "temp{}_crit".format(hwmon_temp_index)
+            + "temp{}_max".format(hwmon_temp_index)
         self.thermal_low_threshold_file = self.HWMON_DIR \
             + "temp{}_min".format(hwmon_temp_index)
+
+        if not self.is_cpu_thermal:
+            self.thermal_high_crit_threshold_file = self.HWMON_DIR \
+                + "temp{}_crit".format(hwmon_temp_index)
 
     def _read_sysfs_file(self, sysfs_file):
         # On successful read, returns the value read from given
@@ -179,6 +183,27 @@ class Thermal(ThermalBase):
             thermal_low_threshold = 0
 
         return thermal_low_threshold / 1000.0
+
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold temperature of thermal
+
+        Returns:
+            A float number, the high critical threshold temperature of
+            thermal in Celsius up to nearest thousandth of one degree
+            Celsius, e.g. 30.125
+        """
+        if self.is_cpu_thermal:
+            return super(Thermal, self).get_high_critical_threshold()
+
+        thermal_high_crit_threshold = self._read_sysfs_file(
+            self.thermal_high_crit_threshold_file)
+        if (thermal_high_crit_threshold != 'ERR'):
+            thermal_high_crit_threshold = float(thermal_high_crit_threshold)
+        else:
+            thermal_high_crit_threshold = 0
+
+        return thermal_high_crit_threshold / 1000.0
 
     def set_high_threshold(self, temperature):
         """


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To incorporate the below changes in DellEMC S6100, S6000 platforms.

- Enable thermalctld
- Backport Platform API changes from master branch.

#### How I did it

- Remove 'skip_thermalctld:true' in pmon_daemon_control.json
- Implement the platform API methods in the respective device files

#### How to verify it

Verified that platform data is displayed by `show platform fan` and `show platform temperature` commands.

UT Logs:
[S6000_platform_api_201911_logs.txt](https://github.com/Azure/sonic-buildimage/files/7608789/S6000_platform_api_201911_logs.txt)
[S6100_platform_api_201911_logs.txt](https://github.com/Azure/sonic-buildimage/files/7608790/S6100_platform_api_201911_logs.txt)


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[201911] DellEMC: S6000, S6100 - Enable thermalctld, Platform API changes

#### A picture of a cute animal (not mandatory but encouraged)

