### PR TITLE
[macsec] Add macsec_ipg setting to Arista platforms

### DIFF
--- a/device/arista/x86_64-arista_7280cr3mk_32p4/Arista-7280CR3-C40/gearbox_config.json
+++ b/device/arista/x86_64-arista_7280cr3mk_32p4/Arista-7280CR3-C40/gearbox_config.json
@@ -11,6 +11,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio0_0_0/0"
     },
     {
@@ -24,6 +25,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio1_0_0/0"
     },
     {
@@ -37,6 +39,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio2_0_0/0"
     },
     {
@@ -50,6 +53,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio3_0_0/0"
     },
     {
@@ -63,6 +67,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio4_0_0/0"
     },
     {
@@ -76,6 +81,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio5_0_0/0"
     },
     {
@@ -89,6 +95,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio6_0_0/0"
     },
     {
@@ -102,6 +109,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio7_0_0/0"
     }
   ],

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/gearbox_config.json
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/gearbox_config.json
@@ -11,6 +11,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio0_0_0/0"
     },
     {
@@ -24,6 +25,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio1_0_0/0"
     },
     {
@@ -37,6 +39,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio2_0_0/0"
     },
     {
@@ -50,6 +53,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio3_0_0/0"
     },
     {
@@ -63,6 +67,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio4_0_0/0"
     },
     {
@@ -76,6 +81,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio5_0_0/0"
     },
     {
@@ -89,6 +95,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio6_0_0/0"
     },
     {
@@ -102,6 +109,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio7_0_0/0"
     },
     {
@@ -115,6 +123,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio8_0_0/0"
     },
     {
@@ -128,6 +137,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio9_0_0/0"
     },
     {
@@ -141,6 +151,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio10_0_0/0"
     },
     {
@@ -154,6 +165,7 @@
       "phy_access": "mdio",
       "bus_id": 0,
       "context_id": 1,
+      "macsec_ipg": 352,
       "hwinfo": "mdio11_0_0/0"
     }
   ],


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For platforms with macsec enabled,  a special IPG has to be set on the ports of ASIC to avoid packet loss. This change sets macsec_ipg for Arista platforms with the assumption that SCI is included.
 
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

