### PR TITLE
sonic-bgp-cmn/admin_status fixed

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -177,7 +177,7 @@
                     "peer_port": 0,
                     "shutdown_message": "BGP PeerGroup Shutdown Message",
                     "strict_capability_match": false,
-                    "admin_status": false,
+                    "admin_status": "down",
                     "local_as_no_prepend": false,
                     "local_as_replace_as": false
                 },
@@ -211,7 +211,7 @@
                     "peer_port": 0,
                     "shutdown_message": "BGP PeerGroup Shutdown Message",
                     "strict_capability_match": false,
-                    "admin_status": false,
+                    "admin_status": "down",
                     "local_as_no_prepend": false,
                     "local_as_replace_as": false
                 }
@@ -223,14 +223,14 @@
                     "vrf_name": "default",
                     "neighbor": "20.0.0.1",
                     "afi_safi": "ipv4_unicast",
-                    "admin_status": true,
+                    "admin_status": "up",
                     "send_default_route": true
                 },
                 {
                     "vrf_name": "Vrf1",
                     "neighbor": "20.0.0.2",
                     "afi_safi": "ipv6_unicast",
-                    "admin_status": true,
+                    "admin_status": "up",
                     "send_default_route": true
                 }
 
@@ -321,7 +321,7 @@
                     "peer_port": 0,
                     "shutdown_message": "BGP PeerGroup Shutdown Message",
                     "strict_capability_match": false,
-                    "admin_status": false,
+                    "admin_status": "down",
                     "local_as_no_prepend": false,
                     "local_as_replace_as": false
                 },
@@ -355,7 +355,7 @@
                     "peer_port": 0,
                     "shutdown_message": "BGP PeerGroup Shutdown Message",
                     "strict_capability_match": false,
-                    "admin_status": false,
+                    "admin_status": "down",
                     "local_as_no_prepend": false,
                     "local_as_replace_as": false
                 }
@@ -367,14 +367,14 @@
                     "vrf_name": "default",
                     "peer_group_name": "PG1",
                     "afi_safi": "ipv4_unicast",
-                    "admin_status": true,
+                    "admin_status": "up",
                     "send_default_route": true
                 },
                 {
                     "vrf_name": "Vrf1",
                     "peer_group_name": "PG2",
                     "afi_safi": "ipv6_unicast",
-                    "admin_status": true,
+                    "admin_status": "up",
                     "send_default_route": true
                 }
 
@@ -441,7 +441,7 @@
                     "vrf_name": "default",
                     "neighbor": "20.0.0.1",
                     "afi_safi": "ipv4_unicast",
-                    "admin_status": true,
+                    "admin_status": "up",
                     "send_default_route": true
                 }]}
         }
@@ -666,7 +666,7 @@
                         "vrf_name": "default",
                         "neighbor": "11.12.14.921",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true
+                        "admin_status": "up"
                     }
                 ]
             }
@@ -702,7 +702,7 @@
                         "vrf_name": "default",
                         "neighbor": "20.0.0.1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "max_prefix_warning_threshold": 102
                     }
                 ]
@@ -739,7 +739,7 @@
                         "vrf_name": "default",
                         "neighbor": "20.0.0.1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "soft_reconfiguration_in": "not_true"
                     }
                 ]
@@ -776,7 +776,7 @@
                         "vrf_name": "default",
                         "neighbor": "20.0.0.1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "send_community": "foobar"
                     }
                 ]
@@ -813,7 +813,7 @@
                         "vrf_name": "default",
                         "neighbor": "20.0.0.1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "route_map_in": [
                             "rtmap05"
                         ]
@@ -864,7 +864,7 @@
                         "vrf_name": "default",
                         "neighbor": "20.0.0.1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "route_map_in": [
                             "rtmap01",
                             "rtmap02"
@@ -916,7 +916,7 @@
                         "vrf_name": "default",
                         "neighbor": "20.0.0.1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "route_map_out": [
                             "rtmap01",
                             "rtmap02"
@@ -959,7 +959,7 @@
                     "vrf_name": "default",
                     "peer_group_name": "PG1",
                     "afi_safi": "ipv4_unicast",
-                    "admin_status": true,
+                    "admin_status": "up",
                     "send_default_route": true
                 }]}
         }
@@ -1099,7 +1099,7 @@
                         "vrf_name": "default",
                         "peer_group_name": "PG1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "max_prefix_warning_threshold": 102
                     }
                 ]
@@ -1136,7 +1136,7 @@
                         "vrf_name": "default",
                         "peer_group_name": "PG1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "soft_reconfiguration_in": "not_true"
                     }
                 ]
@@ -1173,7 +1173,7 @@
                         "vrf_name": "default",
                         "peer_group_name": "PG1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "send_community": "foobar"
                     }
                 ]
@@ -1210,7 +1210,7 @@
                         "vrf_name": "default",
                         "peer_group_name": "PG1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "route_map_in": [
                             "rtmap05"
                         ]
@@ -1261,7 +1261,7 @@
                         "vrf_name": "default",
                         "peer_group_name": "PG1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "route_map_in": [
                             "rtmap01",
                             "rtmap02"
@@ -1313,7 +1313,7 @@
                         "vrf_name": "default",
                         "peer_group_name": "PG1",
                         "afi_safi": "ipv4_unicast",
-                        "admin_status": true,
+                        "admin_status": "up",
                         "route_map_out": [
                             "rtmap01",
                             "rtmap02"

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -319,6 +319,7 @@ module sonic-bgp-common {
 
         leaf admin_status {
             type stypes:admin_status;
+            description "To enable BGP peer";
         }
 
         leaf local_as_no_prepend {
@@ -341,7 +342,7 @@ module sonic-bgp-common {
         }
 
         leaf admin_status {
-            type boolean;
+            type stypes:admin_status;
             description "Indicates address family active/inactive status";
         }
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -3,6 +3,10 @@ module sonic-bgp-common {
     prefix bgpcmn;
     yang-version 1.1;
 
+    import sonic-types {
+        prefix stypes;
+    }
+    
     import ietf-inet-types {
         prefix inet;
     }
@@ -314,8 +318,7 @@ module sonic-bgp-common {
         }
 
         leaf admin_status {
-            type boolean;
-            description "To enable BGP peer";
+            type stypes:admin_status;
         }
 
         leaf local_as_no_prepend {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fixing https://github.com/Azure/sonic-buildimage/issues/9350 "[yang-models] BGP neighbor admin_status should be up/down"

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

