### PR TITLE
[build]: Fix SAE to support debug flavor build

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -1008,10 +1008,10 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	export lazy_installer_debs="$(foreach deb, $($*_LAZY_INSTALLS),$(foreach device, $($(deb)_PLATFORM),$(addprefix $(device)@, $(IMAGE_DISTRO_DEBS_PATH)/$(deb))))"
 	export lazy_build_installer_debs="$(foreach deb, $($*_LAZY_BUILD_INSTALLS), $(addprefix $($(deb)_MACHINE)|,$(deb)))"
 	export installer_images="$(foreach docker, $($*_DOCKERS),\
-				$(addprefix $($(docker)_PACKAGE_NAME)|,\
-				$(addprefix $($(docker)_PATH)|,\
-				$(addprefix $($(docker)_MACHINE)|,\
-				$(addprefix $(TARGET_PATH)/,$(addsuffix :$($(docker)_VERSION),$(docker)))))))"
+				$(addprefix $($(docker:-dbg.gz=.gz)_PACKAGE_NAME)|,\
+				$(addprefix $($(docker:-dbg.gz=.gz)_PATH)|,\
+				$(addprefix $($(docker:-dbg.gz=.gz)_MACHINE)|,\
+				$(addprefix $(TARGET_PATH)/,$(addsuffix :$($(docker:-dbg.gz=.gz)_VERSION),$(docker)))))))"
 	export sonic_packages="$(foreach package, $(SONIC_PACKAGES),\
 				$(addsuffix |$($(package)_DEFAULT_FEATURE_STATE_ENABLED),\
 				$(addsuffix |$($(package)_DEFAULT_FEATURE_OWNER),\


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
**Before:**
```
+ SONIC_PACKAGE_MANAGER_FOLDER=/var/lib/sonic-package-manager/
+ sudo mkdir -p ./fsroot-mellanox//var/lib/sonic-package-manager/
+ sudo tee ./fsroot-mellanox//var/lib/sonic-package-manager//packages.json
+ target_machine=mellanox
+ j2 files/build_templates/packages.json.j2
{
"": {
        "repository": "docker-database-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-fpm-frr-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-lldp-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-macsec-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-mux-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-nat-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-orchagent-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-platform-monitor-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-router-advertiser-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-sflow-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-snmp-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-sonic-mgmt-framework-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-teamd-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-sonic-telemetry-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    },
"": {
        "repository": "docker-syncd-mlnx-dbg",
        "description": "SONiC  package",
        "default-reference": "",
        "installed-version": "",
        "built-in": true,
        "installed": true
    }
}
```

**After:**
```
+ SONIC_PACKAGE_MANAGER_FOLDER=/var/lib/sonic-package-manager/
+ sudo mkdir -p ./fsroot-mellanox//var/lib/sonic-package-manager/
+ target_machine=mellanox
+ j2 files/build_templates/packages.json.j2
+ sudo tee ./fsroot-mellanox//var/lib/sonic-package-manager//packages.json
{
"database": {
        "repository": "docker-database-dbg",
        "description": "SONiC database package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"fpm-frr": {
        "repository": "docker-fpm-frr-dbg",
        "description": "SONiC fpm-frr package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"lldp": {
        "repository": "docker-lldp-dbg",
        "description": "SONiC lldp package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"macsec": {
        "repository": "docker-macsec-dbg",
        "description": "SONiC macsec package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"mux": {
        "repository": "docker-mux-dbg",
        "description": "SONiC mux package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"nat": {
        "repository": "docker-nat-dbg",
        "description": "SONiC nat package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"swss": {
        "repository": "docker-orchagent-dbg",
        "description": "SONiC swss package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"pmon": {
        "repository": "docker-platform-monitor-dbg",
        "description": "SONiC pmon package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"radv": {
        "repository": "docker-router-advertiser-dbg",
        "description": "SONiC radv package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"sflow": {
        "repository": "docker-sflow-dbg",
        "description": "SONiC sflow package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"snmp": {
        "repository": "docker-snmp-dbg",
        "description": "SONiC snmp package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"mgmt-framework": {
        "repository": "docker-sonic-mgmt-framework-dbg",
        "description": "SONiC mgmt-framework package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"teamd": {
        "repository": "docker-teamd-dbg",
        "description": "SONiC teamd package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"telemetry": {
        "repository": "docker-sonic-telemetry-dbg",
        "description": "SONiC telemetry package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    },
"syncd": {
        "repository": "docker-syncd-mlnx-dbg",
        "description": "SONiC syncd package",
        "default-reference": "1.0.0",
        "installed-version": "1.0.0",
        "built-in": true,
        "installed": true
    }
}
```

#### Why I did it
* To fix build with `DEBUG` flavor

#### How I did it
* Fixed `slave.mk`

#### How to verify it
1. make configure PLATFORM=mellanox
2. INSTALL_DEBUG_TOOLS=y make target/sonic-mellanox.bin

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```