### PR TITLE
[GitHub] Add 202111 into github PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,7 @@
 - [ ] 202006
 - [ ] 202012
 - [ ] 202106
+- [ ] 202111
 
 #### Description for the changelog
 <!--


### PR DESCRIPTION
#### Why I did it
So later PR owner could check this branch for requesting cherry-pick

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

