### PR TITLE
[Bug][Build]: fix the file not found issue caused by the relative pat…

### DIFF
--- a/.azure-pipelines/docker-sonic-slave.yml
+++ b/.azure-pipelines/docker-sonic-slave.yml
@@ -23,6 +23,7 @@ pr:
     - sonic-slave-stretch
     - sonic-slave-buster
     - sonic-slave-bullseye
+    - src/sonic-build-hooks
 
 parameters:
 - name: 'arches'

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -70,7 +70,7 @@ set_reproducible_mirrors()
         expression="s/^deb.*$REPR_MIRROR_URL_PATTERN/#\0/"
     fi
 
-    local mirrors="/etc/apt/sources.list $(ls /etc/apt/sources.list.d/)"
+    local mirrors="/etc/apt/sources.list $(find /etc/apt/sources.list.d/ -type f)"
     for mirror in $mirrors; do
         sed -i "$expression" "$mirror"
     done


### PR DESCRIPTION
…h used

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the nodesource.list cannot read issue, it is cased by the full path not used.

```
2021-12-03T06:59:26.0019306Z Removing intermediate container 77cfe980cd36
2021-12-03T06:59:26.0020872Z  ---> 528fd40e60f6
2021-12-03T06:59:26.0021457Z Step 81/81 : RUN post_run_buildinfo
2021-12-03T06:59:26.0841136Z  ---> Running in d804bd7e1b06
2021-12-03T06:59:29.1626594Z [91mDEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
2021-12-03T06:59:34.2960105Z [0m[91m/usr/bin/sed: can't read nodesource.list: No such file or directory
2021-12-03T06:59:34.5094880Z [0mThe command '/bin/sh -c post_run_buildinfo' returned a non-zero code: 2
```

```
2021-12-03T06:57:28.7641528Z + apt-get update
2021-12-03T06:57:30.3580912Z Hit:1 http://security.debian.org buster/updates InRelease
2021-12-03T06:57:30.3581692Z Hit:2 http://deb.debian.org/debian buster InRelease
2021-12-03T06:57:30.3583380Z Hit:3 http://deb.debian.org/debian buster-updates InRelease
2021-12-03T06:57:30.3584169Z Hit:4 http://packages.trafficmanager.net/debian/debian buster InRelease
2021-12-03T06:57:30.3585622Z Hit:5 http://packages.trafficmanager.net/debian/debian buster-updates InRelease
2021-12-03T06:57:30.5032604Z Hit:6 http://ftp.debian.org/debian buster-backports InRelease
2021-12-03T06:57:30.5549047Z Hit:7 https://download.docker.com/linux/debian buster InRelease
2021-12-03T06:57:54.8311976Z Reading package lists...
2021-12-03T06:57:55.7616344Z 
2021-12-03T06:57:55.7617444Z ## Confirming "buster" is supported...
2021-12-03T06:57:55.7617767Z 
2021-12-03T06:57:55.7620836Z + curl -sLf -o /dev/null 'https://deb.nodesource.com/node_14.x/dists/buster/Release'
2021-12-03T06:57:56.8265675Z 
2021-12-03T06:57:56.8267627Z ## Adding the NodeSource signing key to your keyring...
2021-12-03T06:57:56.8268023Z 
2021-12-03T06:57:56.8276109Z + curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null
2021-12-03T06:57:57.8203680Z 
2021-12-03T06:57:57.8206634Z ## Creating apt sources list file for the NodeSource Node.js 14.x repo...
2021-12-03T06:57:57.8207316Z 
2021-12-03T06:57:57.8209267Z + echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_14.x buster main' > /etc/apt/sources.list.d/nodesource.list
2021-12-03T06:57:57.8727989Z + echo 'deb-src [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_14.x buster main' >> /etc/apt/sources.list.d/nodesource.list
```


#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 20211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

