### PR TITLE
[Build]: fix libc-bin core dump issue

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -358,10 +358,7 @@ RUN apt-get -y build-dep openssh
 
 # Build fix for ARM64 and ARMHF /etc/debian_version
 {%- if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
-RUN mv /var/lib/dpkg/info/libc-bin.* /tmp/
-RUN dpkg --remove --force-remove-reinstreq libc-bin || true
-RUN dpkg --purge libc-bin || true
-RUN apt upgrade -y base-files
+RUN apt upgrade -y base-files libc-bin=$(dpkg-query -W -f '${Version}' libc-bin)
 {%- endif %}
 
 # Build fix for ARMHF bullseye libsairedis

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -358,6 +358,9 @@ RUN apt-get -y build-dep openssh
 
 # Build fix for ARM64 and ARMHF /etc/debian_version
 {%- if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
+RUN mv /var/lib/dpkg/info/libc-bin.* /tmp/
+RUN dpkg --remove --force-remove-reinstreq libc-bin || true
+RUN dpkg --purge libc-bin || true
 RUN apt upgrade -y base-files
 {%- endif %}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the docker-slave-bullseye build break issue caused by installing libc-bin core dumpd

See https://dev.azure.com/mssonic/build/_build/results?buildId=55683&view=logs&j=715ada69-f859-5f7e-8bcf-2a94c492da59&t=883c835f-394d-5b66-f09e-4bca8e91e07f

```
(Reading database ... 179213 files and directories currently installed.)
Preparing to unpack .../libc-bin_2.31-13+deb11u2_arm64.deb ...
Unpacking libc-bin (2.31-13+deb11u2) over (2.31-3) ...
Setting up libc-bin (2.31-13+deb11u2) ...
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault (core dumped)
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault (core dumped)
dpkg: error processing package libc-bin (--configure):
 installed libc-bin package post-installation script subprocess returned error exit status 139
Errors were encountered while processing:
 libc-bin
E: Sub-process /usr/bin/dpkg returned an error code (1)
The command '/bin/sh -c apt upgrade -y base-files' returned a non-zero code: 100
```

Similar issue: https://github.com/microsoft/WSL/issues/4760

#### How I did it
A workaround to install libc-bin:
```
sudo apt install libc-bin || true
sudo mv /var/lib/dpkg/info/libc-bin.* /tmp/
sudo dpkg --remove --force-remove-reinstreq libc-bin || true
sudo dpkg --purge libc-bin || true
sudo apt install libc-bin
sudo mv /tmp/libc-bin.* /var/lib/dpkg/info/
```
Need to add a step to upgrade the libc-bin, before applying the workaround, installing libc-bin twice.

Another workaround is not to upgrade the libc-bin, using the old version.
```
apt upgrade -y base-files libc-bin=$(dpkg-query -W -f '${Version}' libc-bin)
```

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

