### PR TITLE
[LLDPD] fix to port remove and immediately create problem

### DIFF
--- a/src/lldpd/patch/0012-fix-recreate-socket-on-ifindex-change.patch
+++ b/src/lldpd/patch/0012-fix-recreate-socket-on-ifindex-change.patch
@@ -1,0 +1,74 @@
+diff --git a/src/daemon/event.c b/src/daemon/event.c
+index 0963c1e..b56dd47 100644
+--- a/src/daemon/event.c
++++ b/src/daemon/event.c
+@@ -731,8 +731,13 @@ levent_iface_recv(evutil_socket_t fd, short what, void *arg)
+ 	}
+ 
+ 	/* Schedule local port update. We don't run it right away because we may
+-	 * receive a batch of events like this. */
+-	struct timeval one_sec = {1, 0};
++	 * receive a batch of events like this.
++	 * if it's del link event we need to execute it right away in order to avoid cases where we have del event and create event in the same
++	 * period of one sec time, in these cases the delete event will be ignored since we added the port right after. this is not good
++	 * since we need to recreate the socket (we have a new ifindex) */
++    struct timeval one_sec = {1, 0};
++    struct timeval zero_sec = {0, 0};
++
+ 	TRACE(LLDPD_INTERFACES_NOTIFICATION());
+ 	log_debug("event",
+ 	    "received notification change, schedule an update of all interfaces in one second");
+@@ -744,11 +749,20 @@ levent_iface_recv(evutil_socket_t fd, short what, void *arg)
+ 			return;
+ 		}
+ 	}
+-	if (evtimer_add(cfg->g_iface_timer_event, &one_sec) == -1) {
+-		log_warnx("event",
+-		    "unable to schedule interface updates");
+-		return;
+-	}
++
++    if (cfg->del_link_operation) {
++        if (evtimer_add(cfg->g_iface_timer_event, &zero_sec) == -1) {
++            log_warnx("event",
++                "unable to schedule interface updates");
++            return;
++        }
++    } else {
++        if (evtimer_add(cfg->g_iface_timer_event, &one_sec) == -1) {
++            log_warnx("event",
++                "unable to schedule interface updates");
++            return;
++        }
++    }
+ }
+ 
+ int
+diff --git a/src/daemon/lldpd.h b/src/daemon/lldpd.h
+index cf25dd6..c05f13d 100644
+--- a/src/daemon/lldpd.h
++++ b/src/daemon/lldpd.h
+@@ -418,6 +418,7 @@ struct lldpd {
+ 
+ #ifdef HOST_OS_LINUX
+ 	struct lldpd_netlink	*g_netlink;
++	int del_link_operation;
+ #endif
+ 
+ 	struct lldpd_port	*g_default_local_port;
+diff --git a/src/daemon/netlink.c b/src/daemon/netlink.c
+index c89e149..ea0924f 100644
+--- a/src/daemon/netlink.c
++++ b/src/daemon/netlink.c
+@@ -652,6 +652,11 @@ retry:
+ 				    "received unhandled message type %d (len: %d)",
+ 				    msg->nlmsg_type, msg->nlmsg_len);
+ 			}
++            if (msg->nlmsg_type == RTM_DELLINK) {
++                cfg->del_link_operation = 1;
++            } else {
++                cfg->del_link_operation = 0;
++            }
+ 		}
+ 	}
+ end:

--- a/src/lldpd/patch/series
+++ b/src/lldpd/patch/series
@@ -5,3 +5,4 @@
 0007-lib-fix-memory-leak-when-handling-I-O.patch
 0010-Ported-fix-for-length-exceeded-from-lldp-community.patch
 0011-fix-med-location-len.patch
+0012-fix-recreate-socket-on-ifindex-change.patch


### PR DESCRIPTION
Signed-off-by: tomeri <tomeri@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
when we remove a port and add it back immediately - lldp is keep failing
warning message keeps appearing:
...
[WARN/lldp] unable to send packet on real device for Ethernet4: No such device or address
...


#### How I did it
on delete link events it will immediately execute delete without using aggregate events mechanism.

#### How to verify it
manual tests and run mellanox lldp regression tests

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
[LLDPD] fix to port remove and immediately create problem - on delete link events it will immediately execute delete without using aggregate events mechanism.


#### A picture of a cute animal (not mandatory but encouraged)

