### PR TITLE
Update pipeline file to generate the dependent rpc package.

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -35,6 +35,7 @@ jobs:
       docker_syncd_rpc_image: no
       syncd_rpc_image: no
       platform_rpc: no
+      dep_platform_rpc: no
     ${{ if ne(parameters.jobGroups, '') }}:
       jobGroups: ${{ parameters.jobGroups }}
     ${{ if eq(parameters.jobGroups, '') }}:
@@ -56,6 +57,7 @@ jobs:
             raw_image: yes
             docker_syncd_rpc_image: yes
             platform_rpc: brcm
+            dep_platform_rpc: brcm-dnx
 
         - name: centec
           variables:
@@ -123,6 +125,9 @@ jobs:
             fi
             if [ $(docker_syncd_rpc_image) == yes ]; then
               make $BUILD_OPTIONS ENABLE_SYNCD_RPC=y target/docker-syncd-$(platform_rpc)-rpc.gz
+              if [ $(dep_platform_rpc) != no ]; then
+                make $BUILD_OPTIONS ENABLE_SYNCD_RPC=y target/docker-syncd-$(dep_platform_rpc)-rpc.gz
+              fi
             fi
             if [ $(syncd_rpc_image) == yes ]; then
               make $BUILD_OPTIONS ENABLE_SYNCD_RPC=y target/sonic-$(GROUP_NAME).bin


### PR DESCRIPTION
#### Why I did it
Update pipeline file to generate the dependent rpc package.
In case of broadcom image, broadcom-dnx image is build as a dependent bin package.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

