### PR TITLE
[yang] Add missing device types to the device_metadata yang 

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -34,7 +34,7 @@
 	"eStrKey" : "Pattern"
     },
     "DEVICE_METADATA_TYPE_CORRECT_PATTERN": {
-       "desc": "DEVICE_METADATA correct value for Type field"
+        "desc": "DEVICE_METADATA correct value for Type field"
     },
 	"DEVICE_METADATA_DEFAULT_SYNCHRONOUS_MODE": {
 	"desc": "DEVICE_METADATA DEFAULT VALUE FOR SYNCHRONOUS MODE.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -33,6 +33,9 @@
 	"desc": "DEVICE_METADATA_TYPE_INCORRECT_PATTERN pattern failure.",
 	"eStrKey" : "Pattern"
     },
+    "DEVICE_METADATA_TYPE_CORRECT_PATTERN": {
+    "desc": "DEVICE_METADATA correct value for Type field"
+    },
 	"DEVICE_METADATA_DEFAULT_SYNCHRONOUS_MODE": {
 	"desc": "DEVICE_METADATA DEFAULT VALUE FOR SYNCHRONOUS MODE.",
 	"eStrKey" : "Verify",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -34,7 +34,7 @@
 	"eStrKey" : "Pattern"
     },
     "DEVICE_METADATA_TYPE_CORRECT_PATTERN": {
-    "desc": "DEVICE_METADATA correct value for Type field"
+       "desc": "DEVICE_METADATA correct value for Type field"
     },
 	"DEVICE_METADATA_DEFAULT_SYNCHRONOUS_MODE": {
 	"desc": "DEVICE_METADATA DEFAULT VALUE FOR SYNCHRONOUS MODE.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -44,6 +44,16 @@
             }
         }
     },
+    "DEVICE_METADATA_TYPE_CORRECT_PATTERN": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "bgp_asn": "65002",
+                    "type": "BackEndToRRouter"
+                }
+            }
+        }
+    },
     "DEVICE_METADATA_DEFAULT_SYNCHRONOUS_MODE": {
         "sonic-device_metadata:sonic-device_metadata": {
             "sonic-device_metadata:DEVICE_METADATA": {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -90,7 +90,7 @@ module sonic-device_metadata {
                 leaf type {
                     type string {
                         length 1..255;
-                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC";
+                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|SpineRouter|BackEndToRRouter|BackEndLeafRouter";
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -90,7 +90,7 @@ module sonic-device_metadata {
                 leaf type {
                     type string {
                         length 1..255;
-                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|SpineRouter|BackEndToRRouter|BackEndLeafRouter";
+                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|SpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR";
                     }
                 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Bring back the changes in #9226 that were reverted. Unable to do a revert-revert.

Why I did it
Few device types were missing in the DEVICE_METADATA type field

How I did it
Added missing device types to the device metadata yang

