### PR TITLE
[as4630-54pe] Branch:202012 Fixed issue for management port eth2 change to eth0(using udev method)

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/udev/70-persistent-net.rules
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/udev/70-persistent-net.rules
@@ -1,0 +1,3 @@
+# net device ()
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?", ATTR{ifindex}=="4", ATTR{type}=="1", KERNEL=="eth*", NAME="eth0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?", ATTR{ifindex}=="2", ATTR{type}=="1", KERNEL=="eth*", NAME="eth2"

--- a/platform/broadcom/sonic-platform-modules-accton/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/rules
@@ -26,6 +26,7 @@ MODULE_DIRS += as5835-54x as9716-32d as9726-32d as5835-54t as7312-54xs as7315-27
 MODULE_DIR := modules
 UTILS_DIR := utils
 SERVICE_DIR := service
+UDEV_DIR := udev
 CONF_DIR := conf
 
 %:
@@ -70,9 +71,11 @@ binary-indep:
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} $(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} usr/local/bin; \
 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} lib/systemd/system; \
+		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} etc/udev/rules.d; \
 		cp $(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)/*.ko debian/$(PACKAGE_PRE_NAME)-$${mod}/$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
 		cp $(MOD_SRC_DIR)/$${mod}/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/usr/local/bin/; \
 		cp $(MOD_SRC_DIR)/$${mod}/$(SERVICE_DIR)/*.service debian/$(PACKAGE_PRE_NAME)-$${mod}/lib/systemd/system/; \
+		cp $(MOD_SRC_DIR)/$${mod}/$(UDEV_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/etc/udev/rules.d/; \
 		$(PYTHON) $${mod}/setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME)-$${mod} --install-layout=deb; \
 	done)
 	# Resuming debhelper scripts


### PR DESCRIPTION
…ge to eth0(using udev method)

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Our management port is using eth2, but now need to change to using eth0.
#### How I did it
Use the method: u-dev rules to name the management interface(eth2-->eth0)
#### How to verify it
After the modify, I set eth0 new ipaddress in DUT:
using "ifconfig eth0 192.168.1.12"
and ping 192.168.1.37(my PC host side) is success。

Test log:
root@sonic:# ifconfig eth0 192.168.1.12
root@sonic:#
root@sonic:~# ping 192.168.1.37 (Note: 192.168.1.37my local ipddress)
PING 192.168.1.37 (192.168.1.37) 56(84) bytes of data.
64 bytes from 192.168.1.37: icmp_seq=1 ttl=128 time=2.52 ms
64 bytes from 192.168.1.37: icmp_seq=2 ttl=128 time=1.49 ms
64 bytes from 192.168.1.37: icmp_seq=3 ttl=128 time=1.92 ms
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Using udev method to manage interface: eth2 to eth0.
#### A picture of a cute animal (not mandatory but encouraged)

