### PR TITLE
[sonic-py-common] Add recirc_prefix definition

### DIFF
--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -15,6 +15,7 @@ SONIC_INTERFACE_PREFIXES = {
     "Loopback": "Loopback",
     "Ethernet-Backplane": "Ethernet-BP",
     "Ethernet-Inband": "Ethernet-IB",
+    "Ethernet-Recirc": "Ethernet-Rec",
     "Ethernet-SubPort": "Eth",
     "PortChannel-SubPort": "Po"
 }
@@ -56,6 +57,12 @@ def inband_prefix():
     Retrieves the SONIC recycle port inband interface name prefix.
     """
     return SONIC_INTERFACE_PREFIXES["Ethernet-Inband"]
+
+def recirc_prefix():
+    """
+    Retrieves the SONIC recirculation port interface name prefix.
+    """
+    return SONIC_INTERFACE_PREFIXES["Ethernet-Recirc"]
 
 def physical_subinterface_prefix():
     """


### PR DESCRIPTION

#### Why I did it

This interface type is used for recirculation on chassis.
The definition is required to prevent this interface from being
considered a physical interface in sonic-platform-common and sonic-platform-daemon

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [x] 202111

Required for chassis work

#### Description for the changelog
Add recirc_prefix definition in sonic_py_common