### PR TITLE
[TACACS] Fix auditd can't load tacplus plugin issue.

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -327,6 +327,11 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     jq                      \
     auditd
 
+
+# Needed for auditd
+sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "sudo mkdir -p var/log/audit"
+sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "sudo echo '' >> /var/log/audit/audit.log"
+
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \
@@ -447,10 +452,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 
 ## Create /var/run/redis folder for docker-database to mount
 sudo mkdir -p $FILESYSTEM_ROOT/var/run/redis
-
-# Needed for auditd
-sudo mkdir -p $FILESYSTEM_ROOT/var/log/audit
-sudo touch $FILESYSTEM_ROOT/var/log/audit/audit.log
 
 ## Config DHCP for eth0
 sudo tee -a $FILESYSTEM_ROOT/etc/network/interfaces > /dev/null <<EOF

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -450,7 +450,7 @@ sudo mkdir -p $FILESYSTEM_ROOT/var/run/redis
 
 # Needed for auditd
 sudo mkdir -p $FILESYSTEM_ROOT/var/log/audit
-sudo echo '' >> $FILESYSTEM_ROOT/var/log/audit/audit.log
+sudo touch $FILESYSTEM_ROOT/var/log/audit/audit.log
 
 ## Config DHCP for eth0
 sudo tee -a $FILESYSTEM_ROOT/etc/network/interfaces > /dev/null <<EOF

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -327,8 +327,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     jq                      \
     auditd
 
-# Change auditd log file path, because can't create /var/log/audit/ during build image
-sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "sudo sed -i 's/log_file = \/var\/log\/audit\/audit.log/log_file = \/var\/log\/audit.log/g' /etc/audit/auditd.conf"
+# Change auditd log file path to fix auditd can't startup issue.
+sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "sudo sed -i 's/^\s*log_file\s*=.*/log_file = \/var\/log\/audit.log/g' /etc/audit/auditd.conf"
 
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -448,9 +448,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 ## Create /var/run/redis folder for docker-database to mount
 sudo mkdir -p $FILESYSTEM_ROOT/var/run/redis
 
-## Create /var/log/audit folder for auditd
-sudo mkdir -p $FILESYSTEM_ROOT/var/log/audit
-
 ## Config DHCP for eth0
 sudo tee -a $FILESYSTEM_ROOT/etc/network/interfaces > /dev/null <<EOF
 

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -448,6 +448,9 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 ## Create /var/run/redis folder for docker-database to mount
 sudo mkdir -p $FILESYSTEM_ROOT/var/run/redis
 
+## Create /var/log/audit folder for auditd
+sudo mkdir -p $FILESYSTEM_ROOT/var/log/audit
+
 ## Config DHCP for eth0
 sudo tee -a $FILESYSTEM_ROOT/etc/network/interfaces > /dev/null <<EOF
 

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -346,6 +346,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "echo 'MODULES=most' >> /etc/in
 
 # Needed for auditd
 sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "mkdir -p /var/log/audit"
+sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "touch /var/log/audit/audit.log"
 
 # Copy vmcore-sysctl.conf to add more vmcore dump flags to kernel
 sudo cp files/image_config/kdump/vmcore-sysctl.conf $FILESYSTEM_ROOT/etc/sysctl.d/

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -327,10 +327,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     jq                      \
     auditd
 
-
-# Needed for auditd
-sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "sudo mkdir -p var/log/audit"
-sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "sudo echo '' >> /var/log/audit/audit.log"
+# Change auditd log file path, because can't create /var/log/audit/ during build image
+sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "sudo sed -i 's/log_file = \/var\/log\/audit\/audit.log/log_file = \/var\/log\/audit.log/g' /etc/audit/auditd.conf"
 
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -344,6 +344,9 @@ sudo LANG=c chroot $FILESYSTEM_ROOT chmod 644 /etc/group
 sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "mkdir -p /etc/initramfs-tools/conf.d"
 sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "echo 'MODULES=most' >> /etc/initramfs-tools/conf.d/driver-policy"
 
+# Needed for auditd
+sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "mkdir -p /var/log/audit"
+
 # Copy vmcore-sysctl.conf to add more vmcore dump flags to kernel
 sudo cp files/image_config/kdump/vmcore-sysctl.conf $FILESYSTEM_ROOT/etc/sysctl.d/
 

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -344,10 +344,6 @@ sudo LANG=c chroot $FILESYSTEM_ROOT chmod 644 /etc/group
 sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "mkdir -p /etc/initramfs-tools/conf.d"
 sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "echo 'MODULES=most' >> /etc/initramfs-tools/conf.d/driver-policy"
 
-# Needed for auditd
-sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "mkdir -p /var/log/audit"
-sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "touch /var/log/audit/audit.log"
-
 # Copy vmcore-sysctl.conf to add more vmcore dump flags to kernel
 sudo cp files/image_config/kdump/vmcore-sysctl.conf $FILESYSTEM_ROOT/etc/sysctl.d/
 
@@ -451,6 +447,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 
 ## Create /var/run/redis folder for docker-database to mount
 sudo mkdir -p $FILESYSTEM_ROOT/var/run/redis
+
+# Needed for auditd
+sudo mkdir -p $FILESYSTEM_ROOT/var/log/audit
+sudo echo '' >> $FILESYSTEM_ROOT/var/log/audit/audit.log
 
 ## Config DHCP for eth0
 sudo tee -a $FILESYSTEM_ROOT/etc/network/interfaces > /dev/null <<EOF

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -97,6 +97,8 @@ sudo mkdir -p $FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE/
 # This is needed for Stretch and might not be needed for Buster where Linux create this directory by default.
 # Keeping it generic. It should not harm anyways.
 sudo mkdir -p $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+# This is needed for auditd
+sudo mkdir -p $FILESYSTEM_ROOT/var/log/audit/
 
 # Install a patched version of ifupdown2  (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/ifupdown2_*.deb || \

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -97,8 +97,6 @@ sudo mkdir -p $FILESYSTEM_ROOT_USR_SHARE_SONIC_FIRMWARE/
 # This is needed for Stretch and might not be needed for Buster where Linux create this directory by default.
 # Keeping it generic. It should not harm anyways.
 sudo mkdir -p $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
-# This is needed for auditd
-sudo mkdir -p $FILESYSTEM_ROOT/var/log/audit/
 
 # Install a patched version of ifupdown2  (and its dependencies via 'apt-get -y install -f')
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/ifupdown2_*.deb || \

--- a/src/tacacs/audisp/patches/0001-Porting-to-sonic.patch
+++ b/src/tacacs/audisp/patches/0001-Porting-to-sonic.patch
@@ -34,10 +34,12 @@ index ad70ca0..caead49 100644
  
 @@ -27,7 +27,6 @@ install-data-hook:
  	${INSTALL} -m 755 audisp-tacplus $(DESTDIR)$(sbindir)
- 	${INSTALL} -d $(DESTDIR)$(sysconfdir)/audisp/plugins.d
+-	${INSTALL} -d $(DESTDIR)$(sysconfdir)/audisp/plugins.d
++	${INSTALL} -d $(DESTDIR)$(sysconfdir)/audit/plugins.d
  	${INSTALL} -d $(DESTDIR)$(sysconfdir)/audit/rules.d
 -	${INSTALL} -m 600 audisp-tac_plus.conf $(DESTDIR)$(sysconfdir)/audisp/
- 	${INSTALL} -m 644 audisp-tacplus.conf $(DESTDIR)$(sysconfdir)/audisp/plugins.d
+-	${INSTALL} -m 644 audisp-tacplus.conf $(DESTDIR)$(sysconfdir)/audisp/plugins.d
++	${INSTALL} -m 644 audisp-tacplus.conf $(DESTDIR)$(sysconfdir)/audit/plugins.d
  	${INSTALL} -m 644 -o 0 audisp-tacplus.rules $(DESTDIR)$(sysconfdir)/audit/rules.d
  
 diff --git a/Makefile.in b/Makefile.in


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. Fix auditd log file path, because known issue: https://github.com/Azure/sonic-buildimage/issues/9548

2. When SONiC change to based on bullseye, auditd version upgrade from 2.8.4 to 3.0.2, and in auditd 3.0.2 the plugin file path changed to /etc/audit/plugins.d, however the upstream auditisp-tacplus project not follow-up this change, it still install plugin config file to /etc/audit/audisp.d. so the plugin can't be launch correctly, the code change in src/tacacs/audisp/patches/0001-Porting-to-sonic.patch fix this issue.
#### How I did it
        Fix tacacs plugin config file path.
        Create /var/log/audit folder for auditd.

#### How to verify it
        Pass all UT, also run per-command acccounting UT to validate plugin loaded.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
        Fix tacacs plugin config file path.
        Create /var/log/audit folder for auditd.

#### A picture of a cute animal (not mandatory but encouraged)

