### PR TITLE
[ptf-docker] Add OpenBFDD into ptf docker

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -85,6 +85,14 @@ RUN rm -rf /debs \
     && make install \
     && cd  .. \
     && rm -fr sflowtool \
+    && git clone https://github.com/dyninc/OpenBFDD.git \
+    && cd OpenBFDD \
+    && ./autogen.sh \
+    && ./configure \
+    && make \
+    && make install \
+    && cd  .. \
+    && rm -fr OpenBFDD \
     && wget https://github.com/nanomsg/nanomsg/archive/1.0.0.tar.gz \
     && tar xvfz 1.0.0.tar.gz \
     && cd nanomsg-1.0.0    \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To enable test support for BFD-related features, the PTF docker needs to have the proper support for BFD. This PR aims to add BFD support in ptf docker.

#### How I did it
Clone and build OpenBFDD for PTF docker.

#### How to verify it
Build locally and verify BFD is supported.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

