### PR TITLE
[201811] Fix radv start condition logic

### DIFF
--- a/dockers/docker-router-advertiser/start.sh
+++ b/dockers/docker-router-advertiser/start.sh
@@ -6,8 +6,8 @@ supervisorctl start rsyslogd
 
 # Router advertiser should only run on ToR (T0) devices
 DEVICE_ROLE=$(sonic-cfggen -d -v "DEVICE_METADATA.localhost.type")
-if [ "$DEVICE_ROLE" != "ToRRouter" || "$DEVICE_ROLE" != "MgmtToRRouter" || "$DEVICE_ROLE" != "EPMS"]; then
-    echo "Device role is not ToRRouter. Not starting router advertiser process."
+if [ "$DEVICE_ROLE" != "ToRRouter" && "$DEVICE_ROLE" != "MgmtToRRouter" && "$DEVICE_ROLE" != "EPMS"]; then
+    echo "Device role is not ToRRouter, MgmtToRRouter, or EPMS. Not starting router advertiser process."
     exit 0
 fi
 

--- a/dockers/docker-router-advertiser/start.sh
+++ b/dockers/docker-router-advertiser/start.sh
@@ -6,7 +6,7 @@ supervisorctl start rsyslogd
 
 # Router advertiser should only run on ToR (T0) devices
 DEVICE_ROLE=$(sonic-cfggen -d -v "DEVICE_METADATA.localhost.type")
-if [ "$DEVICE_ROLE" != "ToRRouter" && "$DEVICE_ROLE" != "MgmtToRRouter" && "$DEVICE_ROLE" != "EPMS"]; then
+if [[ "$DEVICE_ROLE" != "ToRRouter" && "$DEVICE_ROLE" != "MgmtToRRouter" && "$DEVICE_ROLE" != "EPMS" ]]; then
     echo "Device role is not ToRRouter, MgmtToRRouter, or EPMS. Not starting router advertiser process."
     exit 0
 fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Wrong logic in start radv if statement. 
Was not detected before when tested because the if statement had wrong syntax that caused the loop to be skipped..

#### How I did it
Change "||" to "&&"

#### How to verify it
Run on M0 device, test radv starts and the if statement took effect.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

