### PR TITLE
Generic updater

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -3,6 +3,10 @@ module sonic-bgp-neighbor {
     prefix bgpnbr;
     yang-version 1.1;
 
+    import sonic-types {
+        prefix stypes;
+    }
+
     import ietf-inet-types {
         prefix inet;
     }
@@ -58,7 +62,7 @@ module sonic-bgp-neighbor {
                 }
 
                 leaf admin_status {
-                    type string;
+                    type stypes:admin_status;
                     description "Admin status";
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -7,10 +7,6 @@ module sonic-bgp-neighbor {
         prefix inet;
     }
 
-    import sonic-types {
-        prefix stypes;
-    }
-
     import sonic-bgp-common {
         prefix bgpcmn;
     }
@@ -61,6 +57,11 @@ module sonic-bgp-neighbor {
                     description "BGP Neighbor address";
                 }
 
+                leaf admin_status {
+                    type string;
+                    description "Admin status";
+                }
+
                 leaf asn {
                     type uint32 {
                         range "1..4294967295";
@@ -100,11 +101,6 @@ module sonic-bgp-neighbor {
                         range "0..1";
                     }
                     description "Route reflector client";
-                }
-
-                leaf admin_status {
-                    type stypes:admin_status;
-                    description "Admin status of BGP peer";
                 }
             }
 

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -15,6 +15,7 @@ module sonic-device_metadata {
 
     import sonic-types {
         prefix stypes;
+        revision-date 2019-07-01;
     }
 
     description "DEVICE_METADATA YANG Module for SONiC OS";
@@ -122,12 +123,17 @@ module sonic-device_metadata {
                 }
 
                 leaf cloudtype {
-                    type string;
+                    type string {
+                        length 1..255;
+                    }
                 }
 
                 leaf region {
-                    type string;
+                    type string {
+                        length 1..255;
+                    }
                 }
+
             }
             /* end of container localhost */
         }

--- a/src/sonic-yang-models/yang-models/sonic-device_neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_neighbor.yang
@@ -11,6 +11,7 @@ module sonic-device_neighbor {
 
     import sonic-extension {
         prefix ext;
+        revision-date 2019-07-01;
     }
 
     import sonic-port {
@@ -60,6 +61,45 @@ module sonic-device_neighbor {
                     type string {
                         length 1..255;
                     }
+                }
+
+                leaf type {
+                    type string {
+                        length 1..255;
+                    }
+                }
+            }
+            /* end of list DEVICE_NEIGHBOR_LIST */
+        }
+
+        container DEVICE_NEIGHBOR_METADATA {
+
+            description "DEVICE_NEIGHBOR_METADATA part of config_db.json";
+
+            list DEVICE_NEIGHBOR_METADATA_LIST {
+
+                key "peer_name";
+
+                leaf peer_name {
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf hwsku {
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf lo_addr {
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf mgmt_addr {
+                    type inet:ip-address;
                 }
 
                 leaf type {

--- a/src/sonic-yang-models/yang-models/sonic-feature.yang
+++ b/src/sonic-yang-models/yang-models/sonic-feature.yang
@@ -28,9 +28,23 @@ module sonic-feature{
                     }
                 }
 
+                leaf set_owner {
+                    description "feature set_owner in Feature table";
+                    type string {
+                        length 1..32;
+                    }
+                }
+
+                leaf status {
+                    description "feature status in Feature table";
+                    type string {
+                        length 1..32;
+                    }
+                }
+
                 leaf state {
                     description "state of the feature";
-                    type stypes:feature_state;
+                    type string;
                     default "enabled";
                 }
 
@@ -42,22 +56,19 @@ module sonic-feature{
                 leaf has_timer {
                     description "This configuration identicates if there is
                                 timer associated to this feature";
-                    type boolean;
-                    default false;
+                    type string;
                 }
 
                 leaf has_global_scope {
                     description "This configuration identicates there will only one service
                                 spawned for the device";
-                    type boolean;
-                    default false;
+                    type string;
                 }
 
                 leaf has_per_asic_scope {
                     description "This configuration identicates there will only one service
                                 spawned per asic";
-                    type boolean;
-                    default false;
+                    type string;
                 }
 
                 leaf high_mem_alert {

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -27,12 +27,6 @@ module sonic-flex_counter {
                 type boolean;
             }
 
-            typedef poll_interval {
-                type uint32 {
-                    range 100..4294967295;
-                }
-            }
-
             description "FLEX_COUNTER_TABLE part of config_db.json";
 
             /* below are in alphabetical order */
@@ -44,9 +38,6 @@ module sonic-flex_counter {
                 }
                 leaf FLEX_COUNTER_DELAY_STATUS {
                     type flex_delay_status;
-                }
-                leaf POLL_INTERVAL {
-                    type poll_interval;
                 }
             }
 
@@ -78,9 +69,6 @@ module sonic-flex_counter {
                 leaf FLEX_COUNTER_DELAY_STATUS {
                     type flex_delay_status;
                 }
-                leaf POLL_INTERVAL {
-                    type poll_interval;
-                }
             }
 
             container PG_WATERMARK {
@@ -90,9 +78,6 @@ module sonic-flex_counter {
                 }
                 leaf FLEX_COUNTER_DELAY_STATUS {
                     type flex_delay_status;
-                }
-                leaf POLL_INTERVAL {
-                    type poll_interval;
                 }
             }
 
@@ -104,13 +89,10 @@ module sonic-flex_counter {
                 leaf FLEX_COUNTER_DELAY_STATUS {
                     type flex_delay_status;
                 }
-                leaf POLL_INTERVAL {
-                    type poll_interval;
-                }
             }
 
             container PORT_RATES {
-                /* PORT_RATES_COUNTER_FLEX_COUNTER_GROUP */
+                /* PORT_BUFFER_DROP_COUNTER_FLEX_COUNTER_GROUP */
                 leaf FLEX_COUNTER_STATUS {
                     type flex_status;
                 }
@@ -127,9 +109,6 @@ module sonic-flex_counter {
                 leaf FLEX_COUNTER_DELAY_STATUS {
                     type flex_delay_status;
                 }
-                leaf POLL_INTERVAL {
-                    type poll_interval;
-                }
             }
 
             container QUEUE {
@@ -139,9 +118,6 @@ module sonic-flex_counter {
                 }
                 leaf FLEX_COUNTER_DELAY_STATUS {
                     type flex_delay_status;
-                }
-                leaf POLL_INTERVAL {
-                    type poll_interval;
                 }
             }
 
@@ -153,9 +129,6 @@ module sonic-flex_counter {
                 leaf FLEX_COUNTER_DELAY_STATUS {
                     type flex_delay_status;
                 }
-                leaf POLL_INTERVAL {
-                    type poll_interval;
-                }
             }
 
             container RIF {
@@ -165,9 +138,6 @@ module sonic-flex_counter {
                 }
                 leaf FLEX_COUNTER_DELAY_STATUS {
                     type flex_delay_status;
-                }
-                leaf POLL_INTERVAL {
-                    type poll_interval;
                 }
             }
 
@@ -190,20 +160,7 @@ module sonic-flex_counter {
                     type flex_delay_status;
                 }
                 leaf POLL_INTERVAL {
-                    type poll_interval;
-                }
-            }
-
-            container FLOW_CNT_TRAP {
-                /* HOSTIF_TRAP_COUNTER_FLEX_COUNTER_GROUP */
-                leaf FLEX_COUNTER_STATUS {
-                    type flex_status;
-                }
-                leaf FLEX_COUNTER_DELAY_STATUS {
-                    type flex_delay_status;
-                }
-                leaf POLL_INTERVAL {
-                    type poll_interval;
+                    type string;
                 }
             }
 

--- a/src/sonic-yang-models/yang-models/sonic-queue.yang
+++ b/src/sonic-yang-models/yang-models/sonic-queue.yang
@@ -70,15 +70,15 @@ module sonic-queue {
                 }
 
                 leaf scheduler {
-                    type leafref {
-                        path "/sch:sonic-scheduler/sch:SCHEDULER/sch:SCHEDULER_LIST/sch:name"; //Reference to SCHEDULER table
+                    type string {
+                        length 1..255;
                     }
                     description "Scheduler for queue.";
                 }
 
                 leaf wred_profile {
-                    type leafref {
-                        path "/wrd:sonic-wred-profile/wrd:WRED_PROFILE/wrd:WRED_PROFILE_LIST/wrd:name"; // Reference to WRED_PROFILE table
+                    type string {
+                        length 1..255;
                     }
                     description "Wred profile for queue.";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-scheduler.yang
+++ b/src/sonic-yang-models/yang-models/sonic-scheduler.yang
@@ -33,11 +33,7 @@ module sonic-scheduler {
                 leaf name {
 
                     type string {
-                        pattern "[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,31})|[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,31})([@]{1})([0-9]{1,3})";
-                        length 1..36 {
-                            error-message "Invalid length for scheduler name.";
-                            error-app-tag scheduler-name-invalid-length;
-                        }
+                        length 1..255;
                     }
                     description "Scheduler name";
                 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fixing https://github.com/Azure/sonic-utilities/issues/1935 "Running "sudo config apply-patch ..." in latest (as of 11/15) master image applied in SONiC switches fails with inability to parse config for given yang models."

#### How I did it
If fact I just checked and applied [the updates](https://github.com/Azure/sonic-utilities/files/7557303/yang_updated.tar.gz) provided by @renukamanavalan with some changes.

#### How to verify it
Perform `sudo config apply-patch <some_patch>.json-patch`
Patch should be applied and there should be no errors*.
<details><summary>Example of a dummy patch</summary>

```
[
    { "op": "replace", "path": "/PORT/Ethernet124/admin_status", "value": "up" }
]

```
</details>
*NOTE that errors might be caused by improper config too.<br><br><br><br>


@renukamanavalan @praveen-li @prsunny @zhangyanzhao 
I think that despite the changes fix the issue, they are not complete.
Could you provide any documentation to make YANG models correspond to actual config?

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

