### PR TITLE
[multiasic][database]database.sh failed to create the database for namespace in multiasic platform

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -368,6 +368,7 @@ start() {
         fi
 
         {%- if docker_container_name == "database" %}
+        NET="bridge"
         DB_OPT=$DB_OPT" -v /var/run/redis$DEV:/var/run/redis:rw "
         {%- else %}
         NET="container:database$DEV"


### PR DESCRIPTION
#### Why I did it
database.sh failed to create the database for namespace in multiasic platform.
The latest code Docker version 20.10.x, command "docker create" no longer takes optional  "NET=" with empty value. Syntax error show with current docker create command in database.sh.  Issue #9503

#### How I did it
Modify the docker_image_ctl.j2 to set default network setting  NET="bridge" instead of empty for namespace database.  

#### How to verify it
boot up the new image in a multiasic platform.  the namespace database containers should be created.  Also the following error message should not be seen in syslog file
``` 
docker: no name set for network.
See 'docker create --help'.
Failed to docker run
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

