### PR TITLE
Revert "CRM init config for SRV6 Nexthop and MY_SID resource"

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -13,7 +13,7 @@
 {%- for crm_res in ["ipv4_route", "ipv6_route", "ipv4_nexthop", "ipv6_nexthop", "ipv4_neighbor",
                     "ipv6_neighbor", "nexthop_group_member", "nexthop_group", "acl_table",
                     "acl_group", "acl_entry", "acl_counter", "fdb_entry", "snat_entry", "dnat_entry",
-                    "ipmc_entry", "mpls_inseg", "mpls_nexthop", "srv6_my_sid_entry", "srv6_nexthop"] %}
+                    "ipmc_entry", "mpls_inseg", "mpls_nexthop"] %}
             "{{crm_res}}_threshold_type": "percentage",
             "{{crm_res}}_low_threshold": "70",
             "{{crm_res}}_high_threshold": "85"{% if not loop.last %},{% endif -%}


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#9238

We met test issue https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/build/builds/58353/logs/33
```
2021-12-10T17:56:58.2382264Z + sudo LANG=C DOCKER_HOST= chroot ./fsroot-vs /usr/local/bin/generate_shutdown_order.py
2021-12-10T17:56:58.2382658Z sonic_yang(3):All Keys are not parsed in CRM
2021-12-10T17:56:58.2383548Z dict_keys(['srv6_my_sid_entry_threshold_type', 'srv6_my_sid_entry_low_threshold', 'srv6_my_sid_entry_high_threshold', 'srv6_nexthop_threshold_type', 'srv6_nexthop_low_threshold', 'srv6_nexthop_high_threshold'])
2021-12-10T17:56:58.2384117Z sonic_yang(3):exceptionList:[]
2021-12-10T17:56:58.2384485Z sonic_yang(3):Data Loading Failed:All Keys are not parsed in CRM
2021-12-10T17:56:58.2385395Z dict_keys(['srv6_my_sid_entry_threshold_type', 'srv6_my_sid_entry_low_threshold', 'srv6_my_sid_entry_high_threshold', 'srv6_nexthop_threshold_type', 'srv6_nexthop_low_threshold', 'srv6_nexthop_high_threshold'])
2021-12-10T17:56:58.2386099Z Data Loading Failed
2021-12-10T17:56:58.2386356Z All Keys are not parsed in CRM
2021-12-10T17:56:58.2387245Z dict_keys(['srv6_my_sid_entry_threshold_type', 'srv6_my_sid_entry_low_threshold', 'srv6_my_sid_entry_high_threshold', 'srv6_nexthop_threshold_type', 'srv6_nexthop_low_threshold', 'srv6_nexthop_high_threshold'])
2021-12-10T17:56:58.2387821Z Traceback (most recent call last):
2021-12-10T17:56:58.2388414Z   File "/usr/local/lib/python3.9/dist-packages/sonic_yang_ext.py", line 1057, in loadData
2021-12-10T17:56:58.2388959Z     self._xlateConfigDB(xlateFile=xlateFile)
2021-12-10T17:56:58.2389521Z   File "/usr/local/lib/python3.9/dist-packages/sonic_yang_ext.py", line 690, in _xlateConfigDB
2021-12-10T17:56:58.2389885Z     self._xlateConfigDBtoYang(jIn, yangJ)
2021-12-10T17:56:58.2390881Z   File "/usr/local/lib/python3.9/dist-packages/sonic_yang_ext.py", line 677, in _xlateConfigDBtoYang
2021-12-10T17:56:58.2394966Z     self._xlateContainer(cmap['container'], yangJ[key][subkey], \
2021-12-10T17:56:58.2396102Z   File "/usr/local/lib/python3.9/dist-packages/sonic_yang_ext.py", line 634, in _xlateContainer
2021-12-10T17:56:58.2396601Z     self._xlateContainerInContainer(ccontainer, yang, configC, table)
2021-12-10T17:56:58.2397285Z   File "/usr/local/lib/python3.9/dist-packages/sonic_yang_ext.py", line 597, in _xlateContainerInContainer
2021-12-10T17:56:58.2397952Z     self._xlateContainer(ccontainer, yang[ccontainer['@name']], \
2021-12-10T17:56:58.2398600Z   File "/usr/local/lib/python3.9/dist-packages/sonic_yang_ext.py", line 657, in _xlateContainer
2021-12-10T17:56:58.2399075Z     raise(Exception("All Keys are not parsed in {}\n{}".format(table, \
2021-12-10T17:56:58.2399443Z Exception: All Keys are not parsed in CRM
2021-12-10T17:56:58.2400361Z dict_keys(['srv6_my_sid_entry_threshold_type', 'srv6_my_sid_entry_low_threshold', 'srv6_my_sid_entry_high_threshold', 'srv6_nexthop_threshold_type', 'srv6_nexthop_low_threshold', 'srv6_nexthop_high_threshold'])
2021-12-10T17:56:58.2401097Z 
2021-12-10T17:56:58.2401484Z During handling of the above exception, another exception occurred:
2021-12-10T17:56:58.2401719Z 
2021-12-10T17:56:58.2401976Z Traceback (most recent call last):
2021-12-10T17:56:58.2402694Z   File "/usr/local/lib/python3.9/dist-packages/config/config_mgmt.py", line 61, in __init__
2021-12-10T17:56:58.2403081Z     self.__init_sonic_yang()
2021-12-10T17:56:58.2403707Z   File "/usr/local/lib/python3.9/dist-packages/config/config_mgmt.py", line 80, in __init_sonic_yang
2021-12-10T17:56:58.2404125Z     self.sy.loadData(self.configdbJsonIn)
2021-12-10T17:56:58.2404719Z   File "/usr/local/lib/python3.9/dist-packages/sonic_yang_ext.py", line 1067, in loadData
2021-12-10T17:56:58.2405179Z     raise SonicYangException("Data Loading Failed\n{}".format(str(e)))
2021-12-10T17:56:58.2405577Z sonic_yang_ext.SonicYangException: Data Loading Failed
2021-12-10T17:56:58.2405934Z All Keys are not parsed in CRM
2021-12-10T17:56:58.2406811Z dict_keys(['srv6_my_sid_entry_threshold_type', 'srv6_my_sid_entry_low_threshold', 'srv6_my_sid_entry_high_threshold', 'srv6_nexthop_threshold_type', 'srv6_nexthop_low_threshold', 'srv6_nexthop_high_threshold'])
2021-12-10T17:56:58.2407410Z 
2021-12-10T17:56:58.2407906Z During handling of the above exception, another exception occurred:
2021-12-10T17:56:58.2408286Z 
2021-12-10T17:56:58.2408539Z Traceback (most recent call last):
2021-12-10T17:56:58.2408894Z   File "/usr/local/bin/generate_shutdown_order.py", line 15, in <module>
2021-12-10T17:56:58.2409404Z     main()
2021-12-10T17:56:58.2409714Z   File "/usr/local/bin/generate_shutdown_order.py", line 8, in main
2021-12-10T17:56:58.2410087Z     manager = PackageManager.get_manager()
2021-12-10T17:56:58.2410732Z   File "/usr/local/lib/python3.9/dist-packages/sonic_package_manager/manager.py", line 1012, in get_manager
2021-12-10T17:56:58.2411360Z     cfg_mgmt = config_mgmt.ConfigMgmt(source=INIT_CFG_JSON)
2021-12-10T17:56:58.2411964Z   File "/usr/local/lib/python3.9/dist-packages/config/config_mgmt.py", line 65, in __init__
2021-12-10T17:56:58.2412953Z     raise Exception('ConfigMgmt Class creation failed')
2021-12-10T17:56:58.2413492Z Exception: ConfigMgmt Class creation failed
2021-12-10T17:56:58.2413763Z + clean_proc
2021-12-10T17:56:58.2414008Z + sudo umount /proc
2021-12-10T17:56:58.2414235Z + clean_sys
2021-12-10T17:56:58.2415560Z + sudo chroot ./fsroot-vs umount /sys/fs/cgroup/blkio /sys/fs/cgroup/cpu /sys/fs/cgroup/cpu,cpuacct /sys/fs/cgroup/cpuacct /sys/fs/cgroup/cpuset /sys/fs/cgroup/devices /sys/fs/cgroup/freezer /sys/fs/cgroup/hugetlb /sys/fs/cgroup/memory /sys/fs/cgroup/net_cls /sys/fs/cgroup/net_cls,net_prio /sys/fs/cgroup/net_prio /sys/fs/cgroup/perf_event /sys/fs/cgroup/pids /sys/fs/cgroup/rdma /sys/fs/cgroup/systemd /sys/fs/cgroup /sys
2021-12-10T17:56:58.2416494Z umount: /sys/fs/cgroup/cpu: no mount point specified.
2021-12-10T17:56:58.2417276Z umount: /sys/fs/cgroup/cpu,cpuacct: no mount point specified.
2021-12-10T17:56:58.2417688Z umount: /sys/fs/cgroup/cpuacct: no mount point specified.
2021-12-10T17:56:58.2418212Z umount: /sys/fs/cgroup/net_cls: no mount point specified.
2021-12-10T17:56:58.2418619Z umount: /sys/fs/cgroup/net_cls,net_prio: no mount point specified.
2021-12-10T17:56:58.2419008Z umount: /sys/fs/cgroup/net_prio: no mount point specified.
2021-12-10T17:56:58.2419377Z umount: /sys/fs/cgroup/systemd: no mount point specified.
2021-12-10T17:56:58.2419869Z + true
2021-12-10T17:56:58.2420073Z + true
2021-12-10T17:56:58.2420552Z + sudo LANG=C chroot ./fsroot-vs umount /proc
2021-12-10T17:56:58.2420985Z + true
2021-12-10T17:56:58.2421676Z [  FAIL LOG END  ] [ target/sonic-vs.img.gz ]
2021-12-10T17:56:58.2422213Z make: *** [slave.mk:989: target/sonic-vs.img.gz] Error 1
2021-12-10T17:57:00.2326960Z make[1]: *** [Makefile.work:304: target/sonic-vs.img.gz] Error 2
2021-12-10T17:57:00.2328324Z make[1]: Leaving directory '/agent/_work/2/s'
2021-12-10T17:57:00.2330988Z make: *** [Makefile:33: target/sonic-vs.img.gz] Error 2
```