### PR TITLE
[yang]: Add constraint for pfcwd

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
@@ -31,6 +31,10 @@
         "desc": "PFC_WDOG_WITH_WRONG_DETECTION_TIME_HIGH_VALUE",
         "eStr": "range"
     },
+    "PFC_WDOG_WITH_INVALID_DETECTION_TIME": {
+        "desc": "PFC_WDOG_WITH_INVALID_DETECTION_TIME",
+        "eStr": ["detection_time can't be less than the POLL_INTERVAL"]
+    },
     "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_LOW_VALUE": {
         "desc": "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_LOW_VALUE",
         "eStr": "range"
@@ -38,5 +42,9 @@
     "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_HIGH_VALUE": {
         "desc": "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_HIGH_VALUE",
         "eStr": "range"
+    },
+    "PFC_WDOG_WITH_INVALID_RESTORATION_TIME": {
+        "desc": "PFC_WDOG_WITH_INVALID_RESTORATION_TIME",
+        "eStr": ["restoration_time can't be less than the POLL_INTERVAL"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
@@ -33,7 +33,7 @@
     },
     "PFC_WDOG_WITH_INVALID_DETECTION_TIME": {
         "desc": "PFC_WDOG_WITH_INVALID_DETECTION_TIME",
-        "eStr": ["detection_time can't be less than the POLL_INTERVAL"]
+        "eStr": ["detection_time must be greater than or equal to POLL_INTERVAL"]
     },
     "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_LOW_VALUE": {
         "desc": "PFC_WDOG_WITH_WRONG_RESTORATION_TIME_LOW_VALUE",
@@ -45,6 +45,6 @@
     },
     "PFC_WDOG_WITH_INVALID_RESTORATION_TIME": {
         "desc": "PFC_WDOG_WITH_INVALID_RESTORATION_TIME",
-        "eStr": ["restoration_time can't be less than the POLL_INTERVAL"]
+        "eStr": ["restoration_time must be greater than or equal to POLL_INTERVAL"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/pfc.json
@@ -105,36 +105,102 @@
         }
     },
     "PFC_WDOG_WITH_CORRECT_POLL_INTERVAL_VALUE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
         "sonic-pfcwd:sonic-pfcwd": {
             "sonic-pfcwd:PFC_WD": {
                 "PFC_WD_LIST": [
                     {
                         "ifname": "GLOBAL",
                         "POLL_INTERVAL": 101
+                    },
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 101,
+                        "restoration_time": 3000
                     }
                 ]
             }
         }
     },
     "PFC_WDOG_WITH_WRONG_POLL_INTERVAL_LOW_VALUE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
         "sonic-pfcwd:sonic-pfcwd": {
             "sonic-pfcwd:PFC_WD": {
                 "PFC_WD_LIST": [
                     {
                         "ifname": "GLOBAL",
                         "POLL_INTERVAL":99
+                    },
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 100,
+                        "restoration_time": 3000
                     }
                 ]
             }
         }
     },
     "PFC_WDOG_WITH_WRONG_POLL_INTERVAL_HIGH_VALUE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
         "sonic-pfcwd:sonic-pfcwd": {
             "sonic-pfcwd:PFC_WD": {
                 "PFC_WD_LIST": [
                     {
                         "ifname": "GLOBAL",
                         "POLL_INTERVAL": 3001
+                    },
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 3001,
+                        "restoration_time": 3001
                     }
                 ]
             }
@@ -160,9 +226,43 @@
                 "PFC_WD_LIST": [
                     {
                         "ifname": "Ethernet4",
-                        "action": "wrong",
+                        "action": "drop",
                         "detection_time": 5001,
                         "restoration_time": 3000
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_INVALID_DETECTION_TIME": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "GLOBAL",
+                        "POLL_INTERVAL": 1000
+                    },
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 999,
+                        "restoration_time": 1000
                     }
                 ]
             }
@@ -188,9 +288,43 @@
                 "PFC_WD_LIST": [
                     {
                         "ifname": "Ethernet4",
-                        "action": "wrong",
+                        "action": "drop",
                         "detection_time": 60001,
                         "restoration_time": 3000
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_INVALID_RESTORATION_TIME": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "GLOBAL",
+                        "POLL_INTERVAL": 1000
+                    },
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 1000,
+                        "restoration_time": 999
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
@@ -51,6 +51,9 @@ module sonic-pfcwd {
                 }
                 leaf detection_time {
                     must "../ifname != 'GLOBAL'";
+                    must "(not(boolean(current()/../../PFC_WD_LIST[ifname='GLOBAL'])) or (current() >= current()/../../PFC_WD_LIST[ifname='GLOBAL']/POLL_INTERVAL))" {
+                        error-message "detection_time can't be less than the POLL_INTERVAL";
+                    }
                     type uint32 {
                         range 100..5000;
                     }
@@ -59,6 +62,9 @@ module sonic-pfcwd {
                 }
                 leaf restoration_time {
                     must "../ifname != 'GLOBAL'";
+                    must "(not(boolean(current()/../../PFC_WD_LIST[ifname='GLOBAL'])) or (current() >= current()/../../PFC_WD_LIST[ifname='GLOBAL']/POLL_INTERVAL))" {
+                        error-message "restoration_time can't be less than the POLL_INTERVAL";
+                    }
                     type uint32 {
                         range 100..60000;
                     }

--- a/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
@@ -52,7 +52,7 @@ module sonic-pfcwd {
                 leaf detection_time {
                     must "../ifname != 'GLOBAL'";
                     must "(not(boolean(current()/../../PFC_WD_LIST[ifname='GLOBAL'])) or (current() >= current()/../../PFC_WD_LIST[ifname='GLOBAL']/POLL_INTERVAL))" {
-                        error-message "detection_time can't be less than the POLL_INTERVAL";
+                        error-message "detection_time must be greater than or equal to POLL_INTERVAL";
                     }
                     type uint32 {
                         range 100..5000;
@@ -63,7 +63,7 @@ module sonic-pfcwd {
                 leaf restoration_time {
                     must "../ifname != 'GLOBAL'";
                     must "(not(boolean(current()/../../PFC_WD_LIST[ifname='GLOBAL'])) or (current() >= current()/../../PFC_WD_LIST[ifname='GLOBAL']/POLL_INTERVAL))" {
-                        error-message "restoration_time can't be less than the POLL_INTERVAL";
+                        error-message "restoration_time must be greater than or equal to POLL_INTERVAL";
                     }
                     type uint32 {
                         range 100..60000;


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
POLL_INTERVAL cannot be set if any of the detection/restoration times in this table is less than the POLL_INTERVAL.

#### How I did it
Add "must" constraint to make sure detection/restoration times are greater than POLL_INTERVAL.

#### How to verify it
Use apply-patch command to update POLL_INTERVAL.
Build sonic-yang-model.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix #9490


#### A picture of a cute animal (not mandatory but encouraged)

