### PR TITLE
[Mellanox] [202012] Allow user to set LED to orange

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
@@ -44,6 +44,17 @@ class Led(object):
                 with open(led_path, 'w') as led:
                     led.write(Led.LED_ON)
                     status = True
+            elif color == Led.STATUS_LED_COLOR_ORANGE:
+                if Led.STATUS_LED_COLOR_ORANGE in led_cap_list:
+                    led_path = self.get_orange_led_path()
+                elif Led.STATUS_LED_COLOR_RED in led_cap_list:
+                    led_path = self.get_red_led_path()
+                else:
+                    return False
+
+                with open(led_path, 'w') as led:
+                    led.write(Led.LED_ON)
+                    status = True
             elif color == Led.STATUS_LED_COLOR_OFF:
                 if Led.STATUS_LED_COLOR_GREEN in led_cap_list:
                     with open(self.get_green_led_path(), 'w') as led:
@@ -158,7 +169,7 @@ class Led(object):
                 cap_list = set(caps.split())
         except (ValueError, IOError):
             pass
-        
+
         return cap_list
 
     def get_green_led_path(self):
@@ -191,7 +202,7 @@ class Led(object):
     def get_led_cap_path(self):
         pass
 
- 
+
 class FanLed(Led):
     LED_PATH = "/var/run/hw-management/led/"
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Backport https://github.com/Azure/sonic-buildimage/pull/9259 to 202012

#### Why I did it

Nvidia platform API does not support set LED to orange. 

#### How I did it

Allow user to set LED to orange

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

