### PR TITLE
[202012BR] AS4630-54TE Add HW-defined thermal thresholds

### DIFF
--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/chassis.py
@@ -69,6 +69,7 @@ class Chassis(ChassisBase):
 
     def __initialize_thermals(self):
         from sonic_platform.thermal import Thermal
+        self._thermal_list.append(Thermal(is_cpu=True))
         for index in range(0, NUM_THERMAL):
             thermal = Thermal(index)
             self._thermal_list.append(thermal)


### PR DESCRIPTION
#### Why I did it
Makes customers be able to access HW-defined thermal thresholds. 

#### How I did it
1. HW guys evaluated reasonable thresholds for all sensors according to the result of the environment temperature test.
2. Add these thresholds to thermal.py

#### How to verify it
1. `show platform temperature`
```
root@sonic:/home/admin# show platform  temperature 
         Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
---------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
 CPU Board 0x4B           39           50         0              55              0      False  20211210 07:40:36
  CPU Core temp           49           81         0              91              0      False  20211210 07:40:36
 Fan Board 0x4A           34           50         0              55              0      False  20211210 07:40:36
Main Board 0x48           36.5         50         0              55              0      False  20211210 07:40:36
```
2. Code my own script to dump all thresholds
```
root@sonic:/home/admin# python3 dump_thermal_thresholds_bak.py 
{
    "1": {
        "error": 81000,
        "shutdown": 91000,
        "warning_lower": 0,
        "warning_upper": 71000
    },
    "2": {
        "error": 50000,
        "shutdown": 55000,
        "warning_lower": 0,
        "warning_upper": 45000
    },
    "3": {
        "error": 50000,
        "shutdown": 55000,
        "warning_lower": 0,
        "warning_upper": 45000
    },
    "4": {
        "error": 50000,
        "shutdown": 55000,
        "warning_lower": 0,
        "warning_upper": 45000
    }
}
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012 : The customers demand it.
- [ ] 202106

#### Description for the changelog
[AS4630-54TE] add HW-defined thermal thresholds
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### A picture of a cute animal (not mandatory but encouraged)

