### PR TITLE
yang models fixed to make config apply-patch work

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-crm.yang
+++ b/src/sonic-yang-models/yang-models/sonic-crm.yang
@@ -404,6 +404,46 @@ module sonic-crm {
                     type threshold;
                 }
 
+		leaf srv6_my_sid_entry_threshold_type{
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../srv6_my_sid_entry_high_threshold<100 and
+                        ../srv6_my_sid_entry_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+		}
+
+                leaf srv6_my_sid_entry_high_threshold {
+                    must "(current() > ../srv6_my_sid_entry_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+		
+		leaf srv6_my_sid_entry_low_threshold {
+                    type threshold;
+		}
+
+
+		leaf srv6_nexthop_threshold_type{
+                    must "(((current()='PERCENTAGE' or current()='percentage') and
+                        ../srv6_nexthop_high_threshold<100 and
+                        ../srv6_nexthop_low_threshold<100) or
+                        (current()!='PERCENTAGE' and current()!='percentage'))";
+                    type stypes:crm_threshold_type;
+		}
+
+                leaf srv6_nexthop_high_threshold {
+                    must "(current() > ../srv6_nexthop_low_threshold)"
+                    {
+                        error-message "high_threshold should be more than low_threshold";
+                    }
+                    type threshold;
+                }
+		
+		leaf srv6_nexthop_low_threshold {
+                    type threshold;
+		}
             }
             /* end of Config */
         }

--- a/src/sonic-yang-models/yang-models/sonic-sflow.yang
+++ b/src/sonic-yang-models/yang-models/sonic-sflow.yang
@@ -56,6 +56,10 @@ module sonic-sflow{
                     default 6343;
                 }
 
+		leaf collector_vrf {
+		    type string; //TODO
+		}
+
             } /* end of list SFLOW_COLLECTOR_LIST */
         } /* end of container SFLOW_COLLECTOR */
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fixing https://github.com/Azure/sonic-utilities/issues/1935 _Running "sudo config apply-patch ..." in latest (as of 11/15) master image applied in SONiC switches fails with inability to parse config for given yang models._

Note that the updates described in the issue are not actual any more because of new changes in the yang models.

#### How I did it
I improved yang models to make them correspond to config.

#### TODO
"collector_vrf" type is set to "string". It should be more accurate type.

#### How to verify it
Perform `sudo config apply-patch <some_patch>.json-patch`
Patch should be applied and there should be no errors*.
<details><summary>Example of a dummy patch</summary>

```
[
    { "op": "replace", "path": "/PORT/Ethernet124/admin_status", "value": "up" }
]

```
</details>

<details><summary>Example of an empty patch</summary>

```
[]

```
</details>

<details><summary>NOTE that errors might be caused by improper config.</summary>
E.g. I changed

```
    "ACL_TABLE": {
        "1": {
            "policy_desc": "Mirror Session",
            "ports": "Ethernet16",
            "stage": "INGRESS",
            "type": "MIRROR"
        },
        "2": {
            "policy_desc": "Mirror Session",
            "ports": "Ethernet16,Ethernet20",
            "stage": "INGRESS",
            "type": "MIRROR"
        },
.........................................
.........................................
.........................................

``` 
to

```
    "ACL_TABLE": {
        "1": {
            "policy_desc": "Mirror Session",
            "ports": ["Ethernet16"],
            "stage": "INGRESS",
            "type": "MIRROR"
        },
        "2": {
            "policy_desc": "Mirror Session",
            "ports": ["Ethernet16", "Ethernet20"],
            "stage": "INGRESS",
            "type": "MIRROR"
        },
.........................................
.........................................
.........................................

``` 

to avoid libyang error

```
libyang[0]: Duplicated instance of "ports" leaf-list ("e"). (path: /sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='1']/ports[.='e'])
sonic_yang(3):Data Loading Failed:Duplicated instance of "ports" leaf-list ("e").

```
</details>