### PR TITLE
[firsttime boot] suppress error message on platforms not supporting k…

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -373,7 +373,7 @@ if [ -f $FIRST_BOOT_FILE ]; then
     mkdir -p /var/platform
 
     # Kdump tools configuration
-    sed -i -e "s/__PLATFORM__/$platform/g" /etc/default/kdump-tools
+    [ -f /etc/default/kdump-tools ] && sed -i -e "s/__PLATFORM__/$platform/g" /etc/default/kdump-tools
 
     firsttime_exit
 fi


### PR DESCRIPTION
…dump

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Eliminate benign firsttime boot error reported when running on platforms that do not support kdump.

#### How I did it
Change rc.local to check for presence of the file /etc/default/kdump-tools before referencing it.

#### How to verify it
Install a new image on an armhf or arm64 platform and check for a failed reference to /etc/default/kdump-tools on firsttime boot.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

