### PR TITLE
[yang-model] Using 'leafref' instead of 'must' for loopback

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
@@ -1,7 +1,7 @@
 {
-    "LOOPBACK_IPPREFIX_PORT_MUST_CONDITION_FALSE": {
-	"desc": "Loopback Ip-prefix port-name must condition failure.",
-	"eStrKey" : "Must"
+    "LOOPBACK_IPPREFIX_PORT_FOR_NON_EXIST_INTERFACE": {
+	"desc": "Configure Loopback Ip-prefix for non-existing Loopback interface.",
+	"eStrKey" : "LeafRef"
     },
     "LOOPBACK_INTERFACE_WRONG_NAT_ZONE_RANGE": {
         "desc": "Configure wrong value for nat zone.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
@@ -1,7 +1,7 @@
 {
     "LOOPBACK_IPPREFIX_PORT_FOR_NON_EXIST_INTERFACE": {
-	"desc": "Configure Loopback Ip-prefix for non-existing Loopback interface.",
-	"eStrKey" : "LeafRef"
+        "desc": "Configure Loopback Ip-prefix for non-existing Loopback interface.",
+        "eStrKey" : "LeafRef"
     },
     "LOOPBACK_INTERFACE_WRONG_NAT_ZONE_RANGE": {
         "desc": "Configure wrong value for nat zone.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
@@ -1,5 +1,5 @@
 {
-    "LOOPBACK_IPPREFIX_PORT_MUST_CONDITION_FALSE": {
+    "LOOPBACK_IPPREFIX_PORT_FOR_NON_EXIST_INTERFACE": {
         "sonic-loopback-interface:sonic-loopback-interface": {
             "sonic-loopback-interface:LOOPBACK_INTERFACE": {
                 "LOOPBACK_INTERFACE_IPPREFIX_LIST": [

--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -64,11 +64,10 @@ module sonic-loopback-interface {
 
                 leaf name{
                     /* This node must be present in LOOPBACK_INTERFACE_LIST */
-                    must "(current() = ../../LOOPBACK_INTERFACE_LIST[name=current()]/name)"
-                    {
-                        error-message "Must condition not satisfied, Try adding lo<>: {}, Example: 'lo1': {}";
+                    type leafref {
+                        path "../../LOOPBACK_INTERFACE_LIST/name";
+                        description "Loopback interface name";
                     }
-                    type string;
                 }
 
                 leaf ip-prefix {

--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -63,10 +63,10 @@ module sonic-loopback-interface {
                 key "name ip-prefix";
 
                 leaf name{
-                    /* This node must be present in LOOPBACK_INTERFACE_LIST */
+                    description "Loopback interface name";
+
                     type leafref {
                         path "../../LOOPBACK_INTERFACE_LIST/name";
-                        description "Loopback interface name";
                     }
                 }
 


### PR DESCRIPTION
#### Why I did it
Fix issue https://github.com/Azure/sonic-utilities/issues/1962

The problem is current implementation of [sonic-yang-mgmt::find_data_dependencies](https://github.com/Azure/sonic-buildimage/blob/f2774b635dee2d5c0e30489632b47e0210a712dd/src/sonic-yang-mgmt/sonic_yang.py#L518) does not get referrers if they are using `must` statement, it has to use `leafref`.

For now we can convert `must` to `leafref` if possible. In the future we will investigate get referrers by `must` statements as well https://github.com/Azure/sonic-buildimage/issues/9534

#### How I did it
Instead of `must` use `leafref`

#### How to verify it
unit-test

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

