### PR TITLE
[Nokika][IXR7250E] Update the Nokia IXR7250E platform platform.json  files

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform.json
@@ -12,148 +12,209 @@
                 "name": "FPGA2"
             }
         ],
-        
+        "watchdog": {
+	    "disarm": false
+	},
+	"get_module_attributes": {
+	    "model": false,
+	    "serial": false,
+	    "base_mac": false,
+	    "system_eeprom_info": false
+	},
+        "thermal_temperature": {
+	     "minimum": 0,
+	     "maximum": 110
+	},
         "fans": [],
         "fan_drawers": [],
         "master_psu_led_color": [], 
         "psus": [],
         "thermals": [
             {
-                "name": "temp_1(fan)"
+                "name": "temp_1(fan)",
+		"controllable": false
             },
             {
-                "name": "temp_2(fan)"
+                "name": "temp_2(fan)",
+		"controllable": false
             },
             {
-                "name": "temp_3"
+                "name": "temp_3(fan)",
+		"controllable": false
             },
             {
-                "name": "temp_4"
+                "name": "temp_4",
+		"controllable": false
             },
             {
-                "name": "temp_5"
+                "name": "temp_5",
+		"controllable": false
             },
             {
-                "name": "temp_6"
+                "name": "temp_6(fan)",
+		"controllable": false
             },
             {
-                "name": "temp_7"
+                "name": "temp_7(fan)",
+		"controllable": false
             },
             {
-                "name": "temp_8"
+                "name": "temp_8(fan)",
+		"controllable": false
             },
             {
-                "name": "temp_9"
+                "name": "temp_9(fan)",
+		"controllable": false
+            },
+            {
+                "name": "temp_10(fan)",
+		"controllable": false
             }
         ],
         "sfps": [
             {
-                "name": "QSFPDD_1"
+                "name": "QSFPDD_1",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_2"
+                "name": "QSFPDD_2",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_3"
+                "name": "QSFPDD_3",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_4"
+                "name": "QSFPDD_4",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_5"
+                "name": "QSFPDD_5",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_6"
+                "name": "QSFPDD_6",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_7"
+                "name": "QSFPDD_7",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_8"
+                "name": "QSFPDD_8",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_9"
+                "name": "QSFPDD_9",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_10"
+                "name": "QSFPDD_10",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_11"
+                "name": "QSFPDD_11",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_12"
+                "name": "QSFPDD_12",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_13"
+                "name": "QSFPDD_13",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_14"
+                "name": "QSFPDD_14",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_15"
+                "name": "QSFPDD_15",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_16"
+                "name": "QSFPDD_16",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_17"
+                "name": "QSFPDD_17",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_18"
+                "name": "QSFPDD_18",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_19"
+                "name": "QSFPDD_19",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_20"
+                "name": "QSFPDD_20",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_21"
+                "name": "QSFPDD_21",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_22"
+                "name": "QSFPDD_22",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_23"
+                "name": "QSFPDD_23",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_24"
+                "name": "QSFPDD_24",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_25"
+                "name": "QSFPDD_25",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_26"
+                "name": "QSFPDD_26",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_27"
+                "name": "QSFPDD_27",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_28"
+                "name": "QSFPDD_28",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_29"
+                "name": "QSFPDD_29",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_30"
+                "name": "QSFPDD_30",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_31"
+                "name": "QSFPDD_31",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_32"
+                "name": "QSFPDD_32",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_33"
+                "name": "QSFPDD_33",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_34"
+                "name": "QSFPDD_34",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_35"
+                "name": "QSFPDD_35",
+		"tx_disable_channel": false
             },
         {
-                "name": "QSFPDD_36"
+                "name": "QSFPDD_36",
+		"tx_disable_channel": false
             }
         ]
     },

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/platform.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/Nokia-IXR7250E-SUP-10/platform.json
@@ -9,6 +9,19 @@
                 "name": "FPGA1"
             }
         ],
+	"watchdog": {
+	    "disarm": false
+	},
+	"get_module_attributes": {
+	    "model": false,
+	    "serial": false,
+	    "base_mac": false,
+	    "system_eeprom_info": false
+	},
+        "thermal_temperature": {
+	     "minimum": 0,
+	     "maximum": 110
+	},
         "fans": [],
         "fan_drawers": [
             {
@@ -16,7 +29,8 @@
                 "num_fans": 1,
                 "fans": [
                     {
-                        "name": "Fan0"
+                        "name": "Fan0",
+			"speed": { "controllable": false }
                     }
                 ]
             },
@@ -25,7 +39,8 @@
                 "num_fans": 1,
                 "fans": [
                     {
-                        "name": "Fan1"
+                        "name": "Fan1",
+			"speed": { "controllable": false }
                     }
                 ]
             },
@@ -34,7 +49,8 @@
                 "num_fans": 1,
                 "fans": [
                     {
-                        "name": "Fan2"
+                        "name": "Fan2",
+			"speed": { "controllable": false }
                     }
                 ]
             },
@@ -43,7 +59,8 @@
                 "num_fans": 1,
                 "fans": [
                     {
-                        "name": "Fan3"
+                        "name": "Fan3",
+			"speed": { "controllable": false }
                     }
                 ]
             }
@@ -113,136 +130,184 @@
         ],
         "thermals": [
             {
-                "name": "temp_1"
+                "name": "temp_1(fan)",
+		"controllable": false
             },
             {
-                "name": "temp_2"
+                "name": "temp_2",
+		"controllable": false
             },
             {
-                "name": "temp_3(fan)"
+                "name": "temp_3",
+		"controllable": false
             },
             {
-                "name": "temp_4(fan)"
+                "name": "temp_4(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm1_1(fan)"
+                "name": "temp_5(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm1_2"
+                "name": "sfm1_1(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm1_3"
+                "name": "sfm1_2",
+		"controllable": false
             },
             {
-                "name": "sfm1_4"
+                "name": "sfm1_3",
+		"controllable": false
             },
             {
-                "name": "sfm1_5"
+                "name": "sfm1_4(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm2_1(fan)"
+                "name": "sfm1_5(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm2_2"
+                "name": "sfm2_1(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm2_3"
+                "name": "sfm2_2",
+		"controllable": false
             },
             {
-                "name": "sfm2_4"
+                "name": "sfm2_3",
+		"controllable": false
             },
             {
-                "name": "sfm2_5"
+                "name": "sfm2_4(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm3_1(fan)"
+                "name": "sfm2_5(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm3_2"
+                "name": "sfm3_1(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm3_3"
+                "name": "sfm3_2",
+		"controllable": false
             },
             {
-                "name": "sfm3_4"
+                "name": "sfm3_3",
+		"controllable": false
             },
             {
-                "name": "sfm3_5"
+                "name": "sfm3_4(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm4_1(fan)"
+                "name": "sfm3_5(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm4_2"
+                "name": "sfm4_1(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm4_3"
+                "name": "sfm4_2",
+		"controllable": false
             },
             {
-                "name": "sfm4_4"
+                "name": "sfm4_3",
+		"controllable": false
             },
             {
-                "name": "sfm4_5"
+                "name": "sfm4_4(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm5_1(fan)"
+                "name": "sfm4_5(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm5_2"
+                "name": "sfm5_1(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm5_3"
+                "name": "sfm5_2",
+		"controllable": false
             },
             {
-                "name": "sfm5_4"
+                "name": "sfm5_3",
+		"controllable": false
             },
             {
-                "name": "sfm5_5"
+                "name": "sfm5_4(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm6_1(fan)"
+                "name": "sfm5_5(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm6_2"
+                "name": "sfm6_1(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm6_3"
+                "name": "sfm6_2",
+		"controllable": false
             },
             {
-                "name": "sfm6_4"
+                "name": "sfm6_3",
+		"controllable": false
             },
             {
-                "name": "sfm6_5"
+                "name": "sfm6_4(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm7_1(fan)"
+                "name": "sfm6_5(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm7_2"
+                "name": "sfm7_1(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm7_3"
+                "name": "sfm7_2",
+		"controllable": false
             },
             {
-                "name": "sfm7_4"
+                "name": "sfm7_3",
+		"controllable": false
             },
             {
-                "name": "sfm7_5"
+                "name": "sfm7_4(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm8_1(fan)"
+                "name": "sfm7_5(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm8_2"
+                "name": "sfm8_1(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm8_3"
+                "name": "sfm8_2",
+		"controllable": false
+	    },
+            {
+                "name": "sfm8_3",
+		"controllable": false
             },
             {
-                "name": "sfm8_4"
+                "name": "sfm8_4(fan)",
+		"controllable": false
             },
             {
-                "name": "sfm8_5"
+                "name": "sfm8_5(fan)",
+		"controllable": false
             }
         ],
         "sfps": [


### PR DESCRIPTION

#### Why I did it
Update the Nokia IXR7250E platform  platform.json files with correct thermal info table  

#### How I did it
Modify the platform.json file for Nokia IXR7250E linecard x86_64-nokia_ixr7250e_36x400g-r0 and supervisor card x86_64-nokia_ixr7250e_sup-r0

#### How to verify it
1)  login the IXR7250E linecard x86_64-nokia_ixr7250e_36x400g-r0
2)  check file /usr/share/sonic/device/x86_64-nokia_ixr7250e_36x400g-r0/platform.json .
3) The thermal sensor names in the thermal table should match the name in the output of "show platform temperature"
```
admin@sonic:~$ show platform temperature 
      Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
 temp_1(fan)             40        100        10           100                1      False  20211215 00:09:04
 temp_2(fan)             32         78        10            85.8              1      False  20211215 00:09:06
 temp_3(fan)             43         99        10           100                1      False  20211215 00:09:08
      temp_4             36         85        10            93.5              1      False  20211215 00:09:10
      temp_5             37         85        10            93.5              1      False  20211215 00:09:11
 temp_6(fan)             37        100        10           100                1      False  20211215 00:09:13
 temp_7(fan)             24         68        10            74.8              1      False  20211215 00:09:15
 temp_8(fan)             27         68        10            74.8              1      False  20211215 00:09:17
 temp_9(fan)             28         68        10            74.8              1      False  20211215 00:09:18
temp_10(fan)             35         99        10           100                1      False  20211215 00:09:20

```  
4) login the IXR7250E supervisor card x86_64-nokia_ixr7250e_sup-r0
5)  check file /usr/share/sonic/device/x86_64-nokia_ixr7250_sup-r0/platform.json .
6) The thermal sensor names in the thermal table should match the name in the output of "show platform temperature"
```
admin@supervisor:~$ show platform temperature 
     Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
-----------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
sfm1_1(fan)             49         99        10           100                1      False  20211215 00:27:55
     sfm1_2             36         68        10            74.8              1      False  20211215 00:27:57
     sfm1_3             37         68        10            74.8              1      False  20211215 00:27:59
sfm1_4(fan)             55        100        10           100                1      False  20211215 00:28:02
sfm1_5(fan)             68        100        10           100                1      False  20211215 00:28:04
sfm2_1(fan)             53         99        10           100                1      False  20211215 00:28:06
     sfm2_2             39         68        10            74.8              1      False  20211215 00:28:09
     sfm2_3             39         68        10            74.8              1      False  20211215 00:28:11
sfm2_4(fan)             59        100        10           100                1      False  20211215 00:28:13
sfm2_5(fan)             70        100        10           100                1      False  20211215 00:28:16
sfm3_1(fan)             53         99        10           100                1      False  20211215 00:28:18
     sfm3_2             41         68        10            74.8              1      False  20211215 00:28:20
     sfm3_3             39         68        10            74.8              1      False  20211215 00:28:23
sfm3_4(fan)             58        100        10           100                1      False  20211215 00:28:25
sfm3_5(fan)             68        100        10           100                1      False  20211215 00:28:27
sfm4_1(fan)             54         99        10           100                1      False  20211215 00:28:30
     sfm4_2             41         68        10            74.8              1      False  20211215 00:28:32
     sfm4_3             39         68        10            74.8              1      False  20211215 00:28:34
sfm4_4(fan)             58        100        10           100                1      False  20211215 00:28:37
sfm4_5(fan)             69        100        10           100                1      False  20211215 00:28:39
sfm5_1(fan)             55         99        10           100                1      False  20211215 00:28:41
     sfm5_2             43         68        10            74.8              1      False  20211215 00:28:44
     sfm5_3             38         68        10            74.8              1      False  20211215 00:28:46
sfm5_4(fan)             60        100        10           100                1      False  20211215 00:28:48
sfm5_5(fan)             72        100        10           100                1      False  20211215 00:28:51
sfm6_1(fan)             58         99        10           100                1      False  20211215 00:28:53
     sfm6_2             44         68        10            74.8              1      False  20211215 00:28:55
     sfm6_3             40         68        10            74.8              1      False  20211215 00:28:58
sfm6_4(fan)             62        100        10           100                1      False  20211215 00:29:00
sfm6_5(fan)             74        100        10           100                1      False  20211215 00:29:02
sfm7_1(fan)             55         99        10           100                1      False  20211215 00:29:05
     sfm7_2             44         68        10            74.8              1      False  20211215 00:29:07
     sfm7_3             40         68        10            74.8              1      False  20211215 00:29:09
sfm7_4(fan)             60        100        10           100                1      False  20211215 00:29:12
sfm7_5(fan)             71        100        10           100                1      False  20211215 00:29:14
sfm8_1(fan)             52         99        10           100                1      False  20211215 00:29:16
     sfm8_2             40         68        10            74.8              1      False  20211215 00:27:04
     sfm8_3             37         68        10            74.8              1      False  20211215 00:27:07
sfm8_4(fan)             60        100        10           100                1      False  20211215 00:27:09
sfm8_5(fan)             70        100        10           100                1      False  20211215 00:27:11
temp_1(fan)             35        100        10           100                1      False  20211215 00:27:43
     temp_2             34         85        10            93.5              1      False  20211215 00:27:45
     temp_3             34         85        10            93.5              1      False  20211215 00:27:48
temp_4(fan)             31         50        10            55                1      False  20211215 00:27:50
temp_5(fan)             41         90        10            99                1      False  20211215 00:27:52
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

