### PR TITLE
[Mellanox] [SN4410] [202012] Fixed port_config.ini

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4410-r0/ACS-MSN4410/port_config.ini
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/ACS-MSN4410/port_config.ini
@@ -1,33 +1,57 @@
-# name          lanes                               alias     index
-Ethernet0       0,1,2,3                             etp1      1
-Ethernet8       8,9,10,11                           etp2      2
-Ethernet16      16,17,18,19                         etp3      3
-Ethernet24      24,25,26,27                         etp4      4
-Ethernet32      32,33,34,35                         etp5      5
-Ethernet40      40,41,42,43                         etp6      6
-Ethernet48      48,49,50,51                         etp7      7
-Ethernet56      56,57,58,59                         etp8      8
-Ethernet64      64,65,66,67                         etp9      9
-Ethernet72      72,73,74,75                         etp10     10
-Ethernet80      80,81,82,83                         etp11     11
-Ethernet88      88,89,90,91                         etp12     12
-Ethernet96      96,97,98,99                         etp13     13
-Ethernet104     104,105,106,107                     etp14     14
-Ethernet112     112,113,114,115                     etp15     15
-Ethernet120     120,121,122,123                     etp16     16
-Ethernet128     128,129,130,131                     etp17     17
-Ethernet136     136,137,138,139                     etp18     18
-Ethernet144     144,145,146,147                     etp19     19
-Ethernet152     152,153,154,155                     etp20     20
-Ethernet160     160,161,162,163                     etp21     21
-Ethernet168     168,169,170,171                     etp22     22
-Ethernet176     176,177,178,179                     etp23     23
-Ethernet184     184,185,186,187                     etp24     24
-Ethernet192     192,193,194,195,196,197,198,199     etp25     25
-Ethernet200     200,201,202,203,204,205,206,207     etp26     26
-Ethernet208     208,209,210,211,212,213,214,215     etp27     27
-Ethernet216     216,217,218,219,220,221,222,223     etp28     28
-Ethernet224     224,225,226,227,228,229,230,231     etp29     29
-Ethernet232     232,233,234,235,236,237,238,239     etp30     30
-Ethernet240     240,241,242,243,244,245,246,247     etp31     31
-Ethernet248     248,249,250,251,252,253,254,255     etp32     32
+# name          lanes                               alias     index    speed
+Ethernet0       0,1,2,3                             etp1a     1        100000
+Ethernet4       4,5,6,7                             etp1b     1        100000
+Ethernet8       8,9,10,11                           etp2a     2        100000
+Ethernet12      12,13,14,15                         etp2b     2        100000
+Ethernet16      16,17,18,19                         etp3a     3        100000
+Ethernet20      20,21,22,23                         etp3b     3        100000
+Ethernet24      24,25,26,27                         etp4a     4        100000
+Ethernet28      28,29,30,31                         etp4b     4        100000
+Ethernet32      32,33,34,35                         etp5a     5        100000
+Ethernet36      36,37,38,39                         etp5b     5        100000
+Ethernet40      40,41,42,43                         etp6a     6        100000
+Ethernet44      44,45,46,47                         etp6b     6        100000
+Ethernet48      48,49,50,51                         etp7a     7        100000
+Ethernet52      52,53,54,55                         etp7b     7        100000
+Ethernet56      56,57,58,59                         etp8a     8        100000
+Ethernet60      60,61,62,63                         etp8b     8        100000
+Ethernet64      64,65,66,67                         etp9a     9        100000
+Ethernet68      68,69,70,71                         etp9b     9        100000
+Ethernet72      72,73,74,75                         etp10a    10       100000
+Ethernet76      76,77,78,79                         etp10b    10       100000
+Ethernet80      80,81,82,83                         etp11a    11       100000
+Ethernet84      84,85,86,87                         etp11b    11       100000
+Ethernet88      88,89,90,91                         etp12a    12       100000
+Ethernet92      92,93,94,95                         etp12b    12       100000
+Ethernet96      96,97,98,99                         etp13a    13       100000
+Ethernet100     100,101,102,103                     etp13b    13       100000
+Ethernet104     104,105,106,107                     etp14a    14       100000
+Ethernet108     108,109,110,111                     etp14b    14       100000
+Ethernet112     112,113,114,115                     etp15a    15       100000
+Ethernet116     116,117,118,119                     etp15b    15       100000
+Ethernet120     120,121,122,123                     etp16a    16       100000
+Ethernet124     124,125,126,127                     etp16b    16       100000
+Ethernet128     128,129,130,131                     etp17a    17       100000
+Ethernet132     132,133,134,135                     etp17b    17       100000
+Ethernet136     136,137,138,139                     etp18a    18       100000
+Ethernet140     140,141,142,143                     etp18b    18       100000
+Ethernet144     144,145,146,147                     etp19a    19       100000
+Ethernet148     148,149,150,151                     etp19b    19       100000
+Ethernet152     152,153,154,155                     etp20a    20       100000
+Ethernet156     156,157,158,159                     etp20b    20       100000
+Ethernet160     160,161,162,163                     etp21a    21       100000
+Ethernet164     164,165,166,167                     etp21b    21       100000
+Ethernet168     168,169,170,171                     etp22a    22       100000
+Ethernet172     172,173,174,175                     etp22b    22       100000
+Ethernet176     176,177,178,179                     etp23a    23       100000
+Ethernet180     180,181,182,183                     etp23b    23       100000
+Ethernet184     184,185,186,187                     etp24a    24       100000
+Ethernet188     188,189,190,191                     etp24b    24       100000
+Ethernet192     192,193,194,195,196,197,198,199     etp25     25       400000
+Ethernet200     200,201,202,203,204,205,206,207     etp26     26       400000
+Ethernet208     208,209,210,211,212,213,214,215     etp27     27       400000
+Ethernet216     216,217,218,219,220,221,222,223     etp28     28       400000
+Ethernet224     224,225,226,227,228,229,230,231     etp29     29       400000
+Ethernet232     232,233,234,235,236,237,238,239     etp30     30       400000
+Ethernet240     240,241,242,243,244,245,246,247     etp31     31       400000
+Ethernet248     248,249,250,251,252,253,254,255     etp32     32       400000


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The capability files were incorrect in comparison to the marketing spec of the SN4410 platform.

#### How I did it
Aligned the capability files according to the marketing spec.

#### How to verify it
Did basic manual sanity checks:
- Check if critical docker containers were UP
- Check if interfaces were created and were UP
- Check if interfaces created in the syncd docker container by executing – sx_api_ports_dump.py script
- Check the logs from the start of the switch – everything was OK
- Verified the port breakout


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

