### PR TITLE
[202111] [TACACS] Fix auditd can't load tacplus plugin issue. (#9481)

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -327,6 +327,9 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     jq                      \
     auditd
 
+# Change auditd log file path to fix auditd can't startup issue.
+sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "sudo sed -i 's/^\s*log_file\s*=.*/log_file = \/var\/log\/audit.log/g' /etc/audit/auditd.conf"
+
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \

--- a/src/tacacs/audisp/patches/0001-Porting-to-sonic.patch
+++ b/src/tacacs/audisp/patches/0001-Porting-to-sonic.patch
@@ -34,10 +34,12 @@ index ad70ca0..caead49 100644
  
 @@ -27,7 +27,6 @@ install-data-hook:
  	${INSTALL} -m 755 audisp-tacplus $(DESTDIR)$(sbindir)
- 	${INSTALL} -d $(DESTDIR)$(sysconfdir)/audisp/plugins.d
+-	${INSTALL} -d $(DESTDIR)$(sysconfdir)/audisp/plugins.d
++	${INSTALL} -d $(DESTDIR)$(sysconfdir)/audit/plugins.d
  	${INSTALL} -d $(DESTDIR)$(sysconfdir)/audit/rules.d
 -	${INSTALL} -m 600 audisp-tac_plus.conf $(DESTDIR)$(sysconfdir)/audisp/
- 	${INSTALL} -m 644 audisp-tacplus.conf $(DESTDIR)$(sysconfdir)/audisp/plugins.d
+-	${INSTALL} -m 644 audisp-tacplus.conf $(DESTDIR)$(sysconfdir)/audisp/plugins.d
++	${INSTALL} -m 644 audisp-tacplus.conf $(DESTDIR)$(sysconfdir)/audit/plugins.d
  	${INSTALL} -m 644 -o 0 audisp-tacplus.rules $(DESTDIR)$(sysconfdir)/audit/rules.d
  
 diff --git a/Makefile.in b/Makefile.in


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. Fix auditd log file path, for this known issue: https://github.com/Azure/sonic-buildimage/issues/9548

2. When SONiC change to based on bullseye, auditd version upgrade from 2.8.4 to 3.0.2, and in auditd 3.0.2 the plugin file path changed to /etc/audit/plugins.d, however the upstream auditisp-tacplus project not follow-up this change, it still install plugin config file to /etc/audit/audisp.d. so the plugin can't be launch correctly, the code change in src/tacacs/audisp/patches/0001-Porting-to-sonic.patch fix this issue.
#### How I did it
        Change auditd log file path to /var/log/audit.log
        Fix tacacs plugin config file path.

#### How to verify it
        Pass all UT, also run per-command acccounting UT to validate plugin loaded.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
        Change auditd log file path to /var/log/audit.log
        Fix tacacs plugin config file path.

#### A picture of a cute animal (not mandatory but encouraged)
