### PR TITLE
[Mellanox] [202012] fail the build when hw-mgmt patches do not apply

### DIFF
--- a/platform/mellanox/hw-management/Makefile
+++ b/platform/mellanox/hw-management/Makefile
@@ -6,7 +6,8 @@ MAIN_TARGET = hw-management_1.mlnx.$(MLNX_HW_MANAGEMENT_VERSION)_amd64.deb
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	pushd hw-mgmt
-	git am ../*.patch
+	git stash
+	git apply -3 ../*.patch || exit 1
 	chmod +x ./debian/rules
 	KVERSION=$(KVERSION) dpkg-buildpackage -us -uc -b -rfakeroot -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 	popd


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Taken from https://github.com/Azure/sonic-buildimage/pull/9539

####  Why I did it
To fix an issue that hw-mgmt patches were not applied. One patch was already in upstream hw-mgmt package thus applying it again caused an error and no other patches were applied. Also, I did it to improve the Makefile, so that the make will fail in case patches fail to apply.

####  How I did it
Removed obsolete patch, made applying patches a hard failure in the build.

####  How to verify it
Run the make and verify patches are applied.

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

