### PR TITLE
Update PDDF kernel modules with 5.10 kernel and fix some compilation …

### DIFF
--- a/platform/pddf/i2c/Makefile
+++ b/platform/pddf/i2c/Makefile
@@ -1,1 +1,1 @@
-subdir-m := modules
+obj-m := modules/

--- a/platform/pddf/i2c/debian/rules
+++ b/platform/pddf/i2c/debian/rules
@@ -56,6 +56,8 @@ binary-indep:
 	(for mod in $(MODULE_DIRS); do \
 			cp $(MOD_SRC_DIR)/$(MODULE_DIR)/$${mod}/*.ko debian/$(PACKAGE_PRE_NAME)/$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
 	done) ; \
+	# Need to take a backup of symvers file for compilation of custom modules in various platforms
+	cp $(MOD_SRC_DIR)/Module.symvers $(MOD_SRC_DIR)/Module.symvers.PDDF; \
 	cp -r $(MOD_SRC_DIR)/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)/usr/local/bin/; \
 	$(PYTHON) $(MOD_SRC_DIR)/setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME) --install-layout=deb; \
 	set +e

--- a/platform/pddf/i2c/debian/rules
+++ b/platform/pddf/i2c/debian/rules
@@ -18,7 +18,7 @@ PACKAGE_PRE_NAME := sonic-platform-pddf
 KVERSION   ?= $(shell uname -r)
 KERNEL_SRC :=  /lib/modules/$(KVERSION)
 MOD_SRC_DIR:= $(shell pwd)
-MODULE_DIRS:= client cpld cpld/driver cpldmux cpldmux/driver fan fan/driver fan/vendor_api mux gpio led psu psu/driver sysstatus xcvr xcvr/driver
+MODULE_DIRS:= client cpld cpld/driver cpldmux cpldmux/driver fan fan/driver mux gpio led psu psu/driver sysstatus xcvr xcvr/driver
 MODULE_DIR:= modules
 UTILS_DIR := utils
 SERVICE_DIR := service
@@ -35,8 +35,10 @@ clean:
 	make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR) clean
 
 build:
+	set -e; \
 	make modules -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR); \
 	$(PYTHON) $(MOD_SRC_DIR)/setup.py build; \
+	set +e
 
 binary: binary-arch binary-indep
 	# Nothing to do
@@ -50,11 +52,13 @@ binary-indep:
 	dh_installdirs -p$(PACKAGE_PRE_NAME) $(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
 	dh_installdirs -p$(PACKAGE_PRE_NAME) usr/local/bin; \
 	# Custom package commands
+	set -e; \
 	(for mod in $(MODULE_DIRS); do \
 			cp $(MOD_SRC_DIR)/$(MODULE_DIR)/$${mod}/*.ko debian/$(PACKAGE_PRE_NAME)/$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
 	done) ; \
 	cp -r $(MOD_SRC_DIR)/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)/usr/local/bin/; \
-	$(PYTHON) $(MOD_SRC_DIR)/setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME) --install-layout=deb;
+	$(PYTHON) $(MOD_SRC_DIR)/setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME) --install-layout=deb; \
+	set +e
 
 	# Resuming debhelper scripts
 	dh_testroot

--- a/platform/pddf/i2c/modules/Makefile
+++ b/platform/pddf/i2c/modules/Makefile
@@ -1,1 +1,1 @@
-subdir-m := client cpld cpldmux xcvr mux gpio psu fan led sysstatus
+obj-m := client/ cpld/ cpldmux/ xcvr/ mux/ gpio/ psu/ fan/ led/ sysstatus/

--- a/platform/pddf/i2c/modules/cpld/Makefile
+++ b/platform/pddf/i2c/modules/cpld/Makefile
@@ -1,4 +1,4 @@
-subdir-m := driver
-obj-m := pddf_cpld_module.o
+obj-m := driver/
+obj-m += pddf_cpld_module.o
 
-CFLAGS_$(obj-m):= -I$(M)/modules/include
+ccflags-y:= -I$(M)/modules/include

--- a/platform/pddf/i2c/modules/cpldmux/Makefile
+++ b/platform/pddf/i2c/modules/cpldmux/Makefile
@@ -1,4 +1,4 @@
-subdir-m := driver
-obj-m := pddf_cpldmux_module.o
+obj-m := driver/
+obj-m += pddf_cpldmux_module.o
 
-CFLAGS_$(obj-m):= -I$(M)/modules/include
+ccflags-y:= -I$(M)/modules/include

--- a/platform/pddf/i2c/modules/cpldmux/driver/pddf_cpldmux_driver.c
+++ b/platform/pddf/i2c/modules/cpldmux/driver/pddf_cpldmux_driver.c
@@ -20,7 +20,6 @@
 #include <linux/slab.h>
 #include <linux/list.h>
 #include <linux/dmi.h>
-#include <linux/platform_data/pca954x.h>
 #include <linux/i2c-mux.h>
 #include <linux/platform_device.h>
 #include "pddf_client_defs.h"

--- a/platform/pddf/i2c/modules/fan/Makefile
+++ b/platform/pddf/i2c/modules/fan/Makefile
@@ -1,4 +1,4 @@
-subdir-m := driver
-obj-m := pddf_fan_module.o
+obj-m := driver/
+obj-m += pddf_fan_module.o
 
-CFLAGS_$(obj-m):= -I$(M)/modules/include
+ccflags-y:= -I$(M)/modules/include

--- a/platform/pddf/i2c/modules/fan/driver/pddf_fan_driver.c
+++ b/platform/pddf/i2c/modules/fan/driver/pddf_fan_driver.c
@@ -357,7 +357,7 @@ static int pddf_fan_probe(struct i2c_client *client,
         goto exit_free;
     }
 
-    data->hwmon_dev = hwmon_device_register(&client->dev);
+    data->hwmon_dev = hwmon_device_register_with_info(&client->dev, client->name, NULL, NULL, NULL);
     if (IS_ERR(data->hwmon_dev)) {
         status = PTR_ERR(data->hwmon_dev);
         goto exit_remove;

--- a/platform/pddf/i2c/modules/fan/pddf_fan_module.c
+++ b/platform/pddf/i2c/modules/fan/pddf_fan_module.c
@@ -159,9 +159,9 @@ static ssize_t do_device_operation(struct device *dev, struct device_attribute *
         board_info = i2c_get_fan_board_info(fdata, cdata);
 
         /* Populate the platform data for fan */
-        client_ptr = i2c_new_device(adapter, board_info);
+        client_ptr = i2c_new_client_device(adapter, board_info);
         
-        if(client_ptr != NULL)
+        if(!IS_ERR(client_ptr))
         {
             i2c_put_adapter(adapter);
             pddf_dbg(FAN, KERN_ERR "Created a %s client: 0x%p\n", cdata->i2c_name, (void *)client_ptr);

--- a/platform/pddf/i2c/modules/gpio/Makefile
+++ b/platform/pddf/i2c/modules/gpio/Makefile
@@ -1,4 +1,4 @@
 
 obj-m := pddf_gpio_module.o
 
-CFLAGS_$(obj-m):= -I$(M)/modules/include
+ccflags-y := -I$(M)/modules/include

--- a/platform/pddf/i2c/modules/gpio/pddf_gpio_module.c
+++ b/platform/pddf/i2c/modules/gpio/pddf_gpio_module.c
@@ -119,10 +119,10 @@ static ssize_t do_device_operation(struct device *dev, struct device_attribute *
         board_info = i2c_get_gpio_board_info(gpio_ptr, device_ptr);
 
         /*pddf_dbg(KERN_ERR "Creating a client %s on 0x%x, platform_data 0x%x\n", board_info->type, board_info->addr, board_info->platform_data);*/
-        client_ptr = i2c_new_device(adapter, board_info);
+        client_ptr = i2c_new_client_device(adapter, board_info);
 
         i2c_put_adapter(adapter);
-        if (client_ptr != NULL)
+        if (!IS_ERR(client_ptr))
         {
             pddf_dbg(GPIO, KERN_ERR "Created %s client: 0x%p\n", device_ptr->i2c_name, (void *)client_ptr);
             add_device_table(device_ptr->i2c_name, (void*)client_ptr);

--- a/platform/pddf/i2c/modules/include/pddf_cpld_defs.h
+++ b/platform/pddf/i2c/modules/include/pddf_cpld_defs.h
@@ -20,6 +20,7 @@
 #ifndef __PDDF_CPLD_DEFS_H__
 #define __PDDF_CPLD_DEFS_H__
 
+#define CPLD_CLIENT_NAME_LEN 32
 /* CPLD DATA - DATA FOR CPLD CLIENT READ/WRITE*/
 typedef struct CPLD_DATA
 {

--- a/platform/pddf/i2c/modules/include/pddf_mux_defs.h
+++ b/platform/pddf/i2c/modules/include/pddf_mux_defs.h
@@ -20,8 +20,6 @@
 #ifndef __PAL_MUX_DEFS_H__
 #define __PAL_MUX_DEFS_H__
 
-#include <linux/platform_data/pca954x.h>
-
 /* MUX CLIENT DATA - PLATFORM DATA FOR PSU CLIENT */
 typedef struct MUX_DATA
 {

--- a/platform/pddf/i2c/modules/include/pddf_xcvr_defs.h
+++ b/platform/pddf/i2c/modules/include/pddf_xcvr_defs.h
@@ -115,7 +115,7 @@ enum xcvr_sysfs_attributes {
     XCVR_ATTR_MAX
 };
 
-extern int board_i2c_cpld_read(unsigned short cpld_addr, u8 reg);
-extern int board_i2c_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
+extern int board_i2c_cpld_read_new(unsigned short cpld_addr, char *name, u8 reg);
+extern int board_i2c_cpld_write_new(unsigned short cpld_addr, char *name, u8 reg, u8 value);
 
 #endif 

--- a/platform/pddf/i2c/modules/led/Makefile
+++ b/platform/pddf/i2c/modules/led/Makefile
@@ -1,4 +1,4 @@
 TARGET := pddf_led_module
 obj-m := $(TARGET).o
 
-CFLAGS_$(obj-m):= -I$(M)/modules/include
+ccflags-y := -I$(M)/modules/include

--- a/platform/pddf/i2c/modules/mux/Makefile
+++ b/platform/pddf/i2c/modules/mux/Makefile
@@ -1,4 +1,4 @@
 
 obj-m := pddf_mux_module.o
 
-CFLAGS_$(obj-m):= -I$(M)/modules/include
+ccflags-y := -I$(M)/modules/include

--- a/platform/pddf/i2c/modules/psu/Makefile
+++ b/platform/pddf/i2c/modules/psu/Makefile
@@ -1,4 +1,4 @@
-subdir-m := driver
-obj-m := pddf_psu_module.o
+obj-m := driver/
+obj-m += pddf_psu_module.o
 
-CFLAGS_$(obj-m):= -I$(M)/modules/include
+ccflags-y:= -I$(M)/modules/include

--- a/platform/pddf/i2c/modules/psu/driver/pddf_psu_api.c
+++ b/platform/pddf/i2c/modules/psu/driver/pddf_psu_api.c
@@ -89,20 +89,20 @@ int psu_update_hw(struct device *dev, struct psu_attr_info *info, PSU_DATA_ATTR 
     {
         status = (sysfs_attr_data->pre_set)(client, udata, info);
         if (status!=0)
-            printk(KERN_ERR "%s: pre_set function fails for %s attribute\n", __FUNCTION__, udata->aname);
+            dev_warn(&client->dev, "%s: pre_set function fails for %s attribute. ret %d\n", __FUNCTION__, udata->aname, status);
     }
     if (sysfs_attr_data->do_set != NULL)
     {
         status = (sysfs_attr_data->do_set)(client, udata, info);
         if (status!=0)
-            printk(KERN_ERR "%s: do_set function fails for %s attribute\n", __FUNCTION__, udata->aname);
+            dev_warn(&client->dev, "%s: do_set function fails for %s attribute. ret %d\n", __FUNCTION__, udata->aname, status);
 
     }
     if (sysfs_attr_data->post_set != NULL)
     {
         status = (sysfs_attr_data->post_set)(client, udata, info);
         if (status!=0)
-            printk(KERN_ERR "%s: post_set function fails for %s attribute\n", __FUNCTION__, udata->aname);
+            dev_warn(&client->dev, "%s: post_set function fails for %s attribute. ret %d\n", __FUNCTION__, udata->aname, status);
     }
 
     mutex_unlock(&info->update_lock);
@@ -128,20 +128,20 @@ int psu_update_attr(struct device *dev, struct psu_attr_info *data, PSU_DATA_ATT
         {
             status = (sysfs_attr_data->pre_get)(client, udata, data);
             if (status!=0)
-                printk(KERN_ERR "%s: pre_get function fails for %s attribute\n", __FUNCTION__, udata->aname);
+                dev_warn(&client->dev, "%s: pre_get function fails for %s attribute. ret %d\n", __FUNCTION__, udata->aname, status);
         }
         if (sysfs_attr_data->do_get != NULL)
         {
             status = (sysfs_attr_data->do_get)(client, udata, data);
             if (status!=0)
-                printk(KERN_ERR "%s: do_get function fails for %s attribute\n", __FUNCTION__, udata->aname);
+                dev_warn(&client->dev, "%s: do_get function fails for %s attribute. ret %d\n", __FUNCTION__, udata->aname, status);
 
         }
         if (sysfs_attr_data->post_get != NULL)
         {
             status = (sysfs_attr_data->post_get)(client, udata, data);
             if (status!=0)
-                printk(KERN_ERR "%s: post_get function fails for %s attribute\n", __FUNCTION__, udata->aname);
+                dev_warn(&client->dev, "%s: post_get function fails for %s attribute. ret %d\n", __FUNCTION__, udata->aname, status);
         }
 
         data->last_updated = jiffies;

--- a/platform/pddf/i2c/modules/psu/driver/pddf_psu_driver.c
+++ b/platform/pddf/i2c/modules/psu/driver/pddf_psu_driver.c
@@ -224,7 +224,7 @@ static int psu_probe(struct i2c_client *client,
         goto exit_free;
     }
 
-	data->hwmon_dev = hwmon_device_register(&client->dev);
+	data->hwmon_dev = hwmon_device_register_with_info(&client->dev, client->name, NULL, NULL, NULL);
 	if (IS_ERR(data->hwmon_dev)) {
 		status = PTR_ERR(data->hwmon_dev);
 		goto exit_remove;

--- a/platform/pddf/i2c/modules/psu/pddf_psu_module.c
+++ b/platform/pddf/i2c/modules/psu/pddf_psu_module.c
@@ -160,9 +160,9 @@ static ssize_t do_device_operation(struct device *dev, struct device_attribute *
         board_info = i2c_get_psu_board_info(pdata, cdata);
 
         /* Populate the platform data for psu */
-        client_ptr = i2c_new_device(adapter, board_info);
+        client_ptr = i2c_new_client_device(adapter, board_info);
         
-        if(client_ptr != NULL)
+        if(!IS_ERR(client_ptr))
         {
             i2c_put_adapter(adapter);
             pddf_dbg(PSU, KERN_ERR "Created a %s client: 0x%p\n", cdata->i2c_name , (void *)client_ptr);

--- a/platform/pddf/i2c/modules/sysstatus/Makefile
+++ b/platform/pddf/i2c/modules/sysstatus/Makefile
@@ -1,4 +1,4 @@
 TARGET := pddf_sysstatus_module
 obj-m := $(TARGET).o
 
-CFLAGS_$(obj-m):= -I$(M)/modules/include
+ccflags-y := -I$(M)/modules/include

--- a/platform/pddf/i2c/modules/xcvr/Makefile
+++ b/platform/pddf/i2c/modules/xcvr/Makefile
@@ -1,4 +1,4 @@
-subdir-m := driver
-obj-m := pddf_xcvr_module.o
+obj-m := driver/
+obj-m += pddf_xcvr_module.o
 
-CFLAGS_$(obj-m):= -I$(M)/modules/include
+ccflags-y:= -I$(M)/modules/include

--- a/platform/pddf/i2c/modules/xcvr/driver/pddf_xcvr_api.c
+++ b/platform/pddf/i2c/modules/xcvr/driver/pddf_xcvr_api.c
@@ -48,11 +48,11 @@ int xcvr_i2c_cpld_read(XCVR_ATTR *info)
 {
     int status = -1;
     int retry = 10;
+    struct i2c_client *client_ptr=NULL;
 
     if (info!=NULL)
     {
         /* Get the I2C client for the CPLD */
-        struct i2c_client *client_ptr=NULL;
         client_ptr = (struct i2c_client *)get_device_table(info->devname);
         if (client_ptr)
         {

--- a/platform/pddf/i2c/modules/xcvr/driver/pddf_xcvr_api.c
+++ b/platform/pddf/i2c/modules/xcvr/driver/pddf_xcvr_api.c
@@ -47,35 +47,105 @@ int get_xcvr_module_attr_data(struct i2c_client *client, struct device *dev,
 int xcvr_i2c_cpld_read(XCVR_ATTR *info)
 {
     int status = -1;
+    int retry = 10;
 
     if (info!=NULL)
     {
-        if (info->len==1)
+        /* Get the I2C client for the CPLD */
+        struct i2c_client *client_ptr=NULL;
+        client_ptr = (struct i2c_client *)get_device_table(info->devname);
+        if (client_ptr)
         {
-            status = board_i2c_cpld_read(info->devaddr , info->offset);
-        }
-        else
-        {
-            /* Get the I2C client for the CPLD */
-            struct i2c_client *client_ptr=NULL;
-            client_ptr = (struct i2c_client *)get_device_table(info->devname);
-            if (client_ptr)
+            if (info->len==1)
             {
-                if (info->len==2)
-                {       
-                    status = i2c_smbus_read_word_swapped(client_ptr, info->offset);
+                while (retry)
+                {
+                    status = board_i2c_cpld_read_new(info->devaddr, info->devname, info->offset);
+                    if (unlikely(status < 0))
+                    {
+                        msleep(60);
+                        retry--;
+                        continue;
+                    }
+                    break;
                 }
-                else
-                    printk(KERN_ERR "PDDF_XCVR: Doesn't support block CPLD read yet");
+            }
+            else if (info->len==2)
+            {
+                while(retry)
+                {
+                    status = i2c_smbus_read_word_swapped(client_ptr, info->offset);
+                    if (unlikely(status < 0))
+                    {
+                        msleep(60);
+                        retry--;
+                        continue;
+                    }
+                    break;
+                }
             }
             else
-                printk(KERN_ERR "Unable to get the client handle for %s\n", info->devname);
+                printk(KERN_ERR "PDDF_XCVR: Doesn't support block CPLD read yet");
         }
-
+        else
+            printk(KERN_ERR "Unable to get the client handle for %s\n", info->devname);
     }
 
     return status;
 }
+
+int xcvr_i2c_cpld_write(XCVR_ATTR *info, uint32_t val)
+{
+    int status = 0;
+    unsigned int val_mask = 0, dnd_value = 0;
+    uint32_t reg;
+    struct i2c_client *client_ptr=NULL;
+
+    val_mask = BIT_INDEX(info->mask);
+    /* Get the I2C client for the CPLD */
+    client_ptr = (struct i2c_client *)get_device_table(info->devname);
+
+    if (client_ptr)
+    {
+        if (info->len == 1)
+            status = board_i2c_cpld_read_new(info->devaddr, info->devname, info->offset);
+        else if (info->len == 2)
+            status = i2c_smbus_read_word_swapped(client_ptr, info->offset);
+        else
+        {
+            printk(KERN_ERR "PDDF_XCVR: Doesn't support block CPLD read yet");
+            status = -1;
+        }
+    }
+    else
+    {
+        printk(KERN_ERR "Unable to get the client handle for %s\n", info->devname);
+        status = -1;
+    }
+
+    if (status < 0)
+        return status;
+    else
+    {
+        msleep(60);
+        dnd_value = status & ~val_mask;
+        if (((val == 1) && (info->cmpval != 0)) || ((val == 0) && (info->cmpval == 0)))
+            reg = dnd_value | val_mask;
+        else
+            reg = dnd_value;
+        if (info->len == 1)
+            status = board_i2c_cpld_write_new(info->devaddr, info->devname, info->offset, (uint8_t)reg);
+        else if (info->len == 2)
+            status = i2c_smbus_write_word_swapped(client_ptr, info->offset, (uint16_t)reg);
+        else
+        {
+            printk(KERN_ERR "PDDF_XCVR: Doesn't support block CPLD write yet");
+            status = -1;
+        }
+    }
+    return status;
+}
+
 
 int sonic_i2c_get_mod_pres(struct i2c_client *client, XCVR_ATTR *info, struct xcvr_data *data)
 {
@@ -143,7 +213,7 @@ int sonic_i2c_get_mod_intr_status(struct i2c_client *client, XCVR_ATTR *info, st
             mod_intr = ((status & BIT_INDEX(info->mask)) == info->cmpval) ? 1 : 0;
             sfp_dbg(KERN_INFO "\nModule Interrupt :0x%x, reg_value = 0x%x\n", mod_intr, status);
         }
-    } 
+    }
     else if(strcmp(info->devtype, "eeprom") == 0)
     {
         /* get client client for eeprom -  Not Applicable */
@@ -247,54 +317,15 @@ int sonic_i2c_get_mod_txfault(struct i2c_client *client, XCVR_ATTR *info, struct
 int sonic_i2c_set_mod_reset(struct i2c_client *client, XCVR_ATTR *info, struct xcvr_data *data)
 {
     int status = 0;
-    unsigned int val_mask = 0, dnd_value = 0;
-    uint32_t reg;
-    struct i2c_client *client_ptr=NULL;
 
     if (strcmp(info->devtype, "cpld") == 0)
     {
-        val_mask = BIT_INDEX(info->mask);
-        /* Get the I2C client for the CPLD */
-        client_ptr = (struct i2c_client *)get_device_table(info->devname);
-
-        if (client_ptr)
-        {
-            if (info->len == 1)
-                status = board_i2c_cpld_read(info->devaddr , info->offset);
-            else if (info->len == 2)
-                status = i2c_smbus_read_word_data(client_ptr, info->offset);
-            else
-            {
-                printk(KERN_ERR "PDDF_XCVR: Doesn't support block CPLD read yet");
-                status = -1;
-            }
-        }
-        else
-        {
-            printk(KERN_ERR "Unable to get the client handle for %s\n", info->devname);
-            status = -1;
-        }
-        /*printk(KERN_ERR "sonic_i2c_set_mod_reset:client_ptr=0x%x, status=0x%x, offset=0x%x, len=%d\n", client_ptr, status, info->offset, info->len);*/
-
-        if (status < 0)
-            return status;
-        else
-        {
-            dnd_value = status & ~val_mask;
-            if (((data->reset == 1) && (info->cmpval != 0)) || ((data->reset == 0) && (info->cmpval == 0)))
-                reg = dnd_value | val_mask;
-            else
-                reg = dnd_value;
-            if (info->len == 1)
-                status = board_i2c_cpld_write(info->devaddr, info->offset, (uint8_t)reg);
-            else if (info->len == 2)
-                status = i2c_smbus_write_word_swapped(client_ptr, info->offset, (uint16_t)reg);
-            else
-            {
-                printk(KERN_ERR "PDDF_XCVR: Doesn't support block CPLD write yet");
-                status = -1;
-            }
-        }
+        status = xcvr_i2c_cpld_write(info, data->reset);
+    }
+    else
+    {
+        printk(KERN_ERR "Error: Invalid device type (%s) to set xcvr reset\n", info->devtype);
+        status = -1;
     }
 
     return status;
@@ -303,53 +334,15 @@ int sonic_i2c_set_mod_reset(struct i2c_client *client, XCVR_ATTR *info, struct x
 int sonic_i2c_set_mod_lpmode(struct i2c_client *client, XCVR_ATTR *info, struct xcvr_data *data)
 {
     int status = 0;
-    unsigned int val_mask = 0, dnd_value = 0;
-    uint32_t reg;
-    struct i2c_client *client_ptr=NULL;
 
     if (strcmp(info->devtype, "cpld") == 0)
     {
-        val_mask = BIT_INDEX(info->mask);
-        /* Get the I2C client for the CPLD */
-        client_ptr = (struct i2c_client *)get_device_table(info->devname);
-
-        if (client_ptr)
-        {
-            if (info->len == 1)
-                status = board_i2c_cpld_read(info->devaddr , info->offset);
-            else if (info->len == 2)
-                status = i2c_smbus_read_word_data(client_ptr, info->offset);
-            else
-            {
-                printk(KERN_ERR "PDDF_XCVR: Doesn't support block CPLD read yet");
-                status = -1;
-            }
-        }
-        else
-        {
-            printk(KERN_ERR "Unable to get the client handle for %s\n", info->devname);
-            status = -1;
-        }
-
-        if (status < 0)
-            return status;
-        else
-        {
-            dnd_value = status & ~val_mask;
-            if (((data->lpmode == 1) && (info->cmpval != 0)) || ((data->lpmode == 0) && (info->cmpval == 0)))
-                reg = dnd_value | val_mask;
-            else
-                reg = dnd_value;
-            if (info->len == 1)
-                status = board_i2c_cpld_write(info->devaddr, info->offset, (uint8_t)reg);
-            else if (info->len == 2)
-                status = i2c_smbus_write_word_swapped(client_ptr, info->offset, (uint16_t)reg);
-            else
-            {
-                printk(KERN_ERR "PDDF_XCVR: Doesn't support block CPLD write yet");
-                status = -1;
-            }
-        }
+        status = xcvr_i2c_cpld_write(info, data->lpmode);
+    }
+    else
+    {
+        printk(KERN_ERR "Error: Invalid device type (%s) to set xcvr lpmode\n", info->devtype);
+        status = -1;
     }
 
     return status;
@@ -358,53 +351,15 @@ int sonic_i2c_set_mod_lpmode(struct i2c_client *client, XCVR_ATTR *info, struct 
 int sonic_i2c_set_mod_txdisable(struct i2c_client *client, XCVR_ATTR *info, struct xcvr_data *data)
 {
     int status = 0;
-    unsigned int val_mask = 0, dnd_value = 0;
-    uint32_t reg;
-    struct i2c_client *client_ptr=NULL;
 
     if (strcmp(info->devtype, "cpld") == 0)
     {
-        val_mask = BIT_INDEX(info->mask);
-        /* Get the I2C client for the CPLD */
-        client_ptr = (struct i2c_client *)get_device_table(info->devname);
-
-        if (client_ptr)
-        {
-            if (info->len == 1)
-                status = board_i2c_cpld_read(info->devaddr , info->offset);
-            else if (info->len == 2)
-                status = i2c_smbus_read_word_data(client_ptr, info->offset);
-            else
-            {
-                printk(KERN_ERR "PDDF_XCVR: Doesn't support block CPLD read yet");
-                status = -1;
-            }
-        }
-        else
-        {
-            printk(KERN_ERR "Unable to get the client handle for %s\n", info->devname);
-            status = -1;
-        }
-
-        if (status < 0)
-            return status;
-        else
-        {
-            dnd_value = status & ~val_mask;
-            if (((data->txdisable == 1) && (info->cmpval != 0)) || ((data->txdisable == 0) && (info->cmpval == 0)))
-                reg = dnd_value | val_mask;
-            else
-                reg = dnd_value;
-            if (info->len == 1)
-                status = board_i2c_cpld_write(info->devaddr, info->offset, (uint8_t)reg);
-            else if (info->len == 2)
-                status = i2c_smbus_write_word_swapped(client_ptr, info->offset, (uint16_t)reg);
-            else
-            {
-                printk(KERN_ERR "PDDF_XCVR: Doesn't support block CPLD write yet");
-                status = -1;
-            }
-        }
+        status = xcvr_i2c_cpld_write(info, data->txdisable);
+    }
+    else
+    {
+        printk(KERN_ERR "Error: Invalid device type (%s) to set xcvr txdisable\n", info->devtype);
+        status = -1;
     }
 
     return status;
@@ -433,20 +388,20 @@ ssize_t get_module_presence(struct device *dev, struct device_attribute *da,
             {
                 status = (attr_ops->pre_get)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: pre_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: pre_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
             } 
             if (attr_ops->do_get != NULL)
             {
                 status = (attr_ops->do_get)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: do_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
+                    dev_warn(&client->dev, "%s: do_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
 
             }
             if (attr_ops->post_get != NULL)
             {
                 status = (attr_ops->post_get)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: post_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: post_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
             }
             mutex_unlock(&data->update_lock);
             return sprintf(buf, "%d\n", data->modpres);
@@ -478,20 +433,20 @@ ssize_t get_module_reset(struct device *dev, struct device_attribute *da,
             {
                 status = (attr_ops->pre_get)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: pre_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: pre_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
             } 
             if (attr_ops->do_get != NULL)
             {
                 status = (attr_ops->do_get)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: do_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: do_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
 
             }
             if (attr_ops->post_get != NULL)
             {
                 status = (attr_ops->post_get)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: post_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: post_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
             }
 
             mutex_unlock(&data->update_lock);
@@ -533,20 +488,20 @@ ssize_t set_module_reset(struct device *dev, struct device_attribute *da, const 
             {
                 status = (attr_ops->pre_set)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: pre_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: pre_set function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
                 }
             if (attr_ops->do_set != NULL)
             {
                 status = (attr_ops->do_set)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: do_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: do_set function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
 
             }
             if (attr_ops->post_set != NULL)
             {
                 status = (attr_ops->post_set)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: post_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: post_set function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
             } 
             mutex_unlock(&data->update_lock);
 
@@ -579,20 +534,20 @@ ssize_t get_module_intr_status(struct device *dev, struct device_attribute *da,
             {
                 status = (attr_ops->pre_get)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: pre_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: pre_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
             } 
             if (attr_ops->do_get != NULL)
             {
                 status = (attr_ops->do_get)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: do_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: do_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
 
             }
             if (attr_ops->post_get != NULL)
             {
                 status = (attr_ops->post_get)(client, attr_data, data);
                 if (status!=0)
-                    printk(KERN_ERR "%s: post_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                    dev_warn(&client->dev, "%s: post_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
             }
 
             mutex_unlock(&data->update_lock);
@@ -645,20 +600,20 @@ ssize_t get_module_lpmode(struct device *dev, struct device_attribute *da, char 
         {
             status = (attr_ops->pre_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: pre_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: pre_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
         } 
         if (attr_ops->do_get != NULL)
         {
             status = (attr_ops->do_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: do_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: do_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
 
         }
         if (attr_ops->post_get != NULL)
         {
             status = (attr_ops->post_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: post_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: post_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
         }
         mutex_unlock(&data->update_lock);
         return sprintf(buf, "%d\n", data->lpmode);
@@ -699,20 +654,20 @@ ssize_t set_module_lpmode(struct device *dev, struct device_attribute *da, const
         {
             status = (attr_ops->pre_set)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: pre_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: pre_set function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
             }
         if (attr_ops->do_set != NULL)
         {
             status = (attr_ops->do_set)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: do_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: do_set function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
 
         }
         if (attr_ops->post_set != NULL)
         {
             status = (attr_ops->post_set)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: post_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: post_set function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
         } 
         mutex_unlock(&data->update_lock);
     }
@@ -743,20 +698,20 @@ ssize_t get_module_rxlos(struct device *dev, struct device_attribute *da,
         {
             status = (attr_ops->pre_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: pre_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: pre_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
         } 
         if (attr_ops->do_get != NULL)
         {
             status = (attr_ops->do_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: do_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: do_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
 
         }
         if (attr_ops->post_get != NULL)
         {
             status = (attr_ops->post_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: post_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: post_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
         }
         mutex_unlock(&data->update_lock);
         return sprintf(buf, "%d\n", data->rxlos);
@@ -789,20 +744,20 @@ ssize_t get_module_txdisable(struct device *dev, struct device_attribute *da,
         {
             status = (attr_ops->pre_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: pre_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: pre_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
         }
         if (attr_ops->do_get != NULL)
         {
             status = (attr_ops->do_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: do_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: do_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
 
         }
         if (attr_ops->post_get != NULL)
         {
             status = (attr_ops->post_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: post_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: post_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
         }
         mutex_unlock(&data->update_lock);
         return sprintf(buf, "%d\n", data->txdisable);
@@ -843,20 +798,20 @@ ssize_t set_module_txdisable(struct device *dev, struct device_attribute *da, co
         {
             status = (attr_ops->pre_set)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: pre_set function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: pre_set function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
             }
         if (attr_ops->do_set != NULL)
         {
             status = (attr_ops->do_set)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: do_set function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: do_set function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
 
         }
         if (attr_ops->post_set != NULL)
         {
             status = (attr_ops->post_set)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: post_set function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: post_set function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
         } 
         mutex_unlock(&data->update_lock);
     }
@@ -887,20 +842,20 @@ ssize_t get_module_txfault(struct device *dev, struct device_attribute *da,
         {
             status = (attr_ops->pre_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: pre_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: pre_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
         } 
         if (attr_ops->do_get != NULL)
         {
             status = (attr_ops->do_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: do_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: do_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
 
         }
         if (attr_ops->post_get != NULL)
         {
             status = (attr_ops->post_get)(client, attr_data, data);
             if (status!=0)
-                printk(KERN_ERR "%s: post_get function fails for %s attribute\n", __FUNCTION__, attr_data->aname);
+                dev_warn(&client->dev, "%s: post_get function fails for %s attribute. ret %d\n", __FUNCTION__, attr_data->aname, status);
         }
         mutex_unlock(&data->update_lock);
         return sprintf(buf, "%d\n", data->txfault);

--- a/platform/pddf/i2c/modules/xcvr/driver/pddf_xcvr_driver.c
+++ b/platform/pddf/i2c/modules/xcvr/driver/pddf_xcvr_driver.c
@@ -159,7 +159,7 @@ static int xcvr_probe(struct i2c_client *client,
         goto exit_free;
     }
 
-    data->xdev = hwmon_device_register(&client->dev);
+    data->xdev = hwmon_device_register_with_info(&client->dev, client->name, NULL, NULL, NULL);
     if (IS_ERR(data->xdev)) {
         status = PTR_ERR(data->xdev);
         goto exit_remove;

--- a/platform/pddf/i2c/modules/xcvr/pddf_xcvr_module.c
+++ b/platform/pddf/i2c/modules/xcvr/pddf_xcvr_module.c
@@ -129,8 +129,8 @@ static ssize_t do_device_operation(struct device *dev, struct device_attribute *
             board_info.addr = cdata->dev_addr;
             strcpy(board_info.type, cdata->dev_type);
 
-            client_ptr = i2c_new_device(adapter, &board_info); 
-            if (client_ptr != NULL) {
+            client_ptr = i2c_new_client_device(adapter, &board_info);
+            if (!IS_ERR(client_ptr)) {
                 i2c_put_adapter(adapter);
                 pddf_dbg(XCVR, KERN_ERR "Created a %s client: 0x%p\n", cdata->i2c_name, (void *)client_ptr);
                 add_device_table(cdata->i2c_name, (void*)client_ptr);
@@ -152,8 +152,8 @@ static ssize_t do_device_operation(struct device *dev, struct device_attribute *
             board_info.addr = cdata->dev_addr;
             strcpy(board_info.type, cdata->dev_type);
 
-            client_ptr = i2c_new_device(adapter, &board_info);
-            if(client_ptr != NULL) {
+            client_ptr = i2c_new_client_device(adapter, &board_info);
+            if(!IS_ERR(client_ptr)) {
                 i2c_put_adapter(adapter);
                 pddf_dbg(XCVR, KERN_ERR "Created %s, type:%s client: 0x%p\n", cdata->i2c_name, cdata->dev_type, (void *)client_ptr);
                 add_device_table(cdata->i2c_name, (void*)client_ptr);


### PR DESCRIPTION
…warnings

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
There were compilation errors and warnings like, 
1. > /usr/src/linux-headers-5.10.0-8-2-common/scripts/Makefile.build:69: You cannot use subdir-y/m to visit a module Makefile. Use obj-y/m instead.
2. > fatal error: linux/platform_data/pca954x.h: No such file or directory
3. > hwmon_device_register() is deprecated. Please convert the driver to use hwmon_device_register_with_info().
4. If PDDF kernel module compilation fails, the PDDF debian package was not detecting the break.

#### How I did it
- Modified the code with new kernel 5.10 APIs.
- Modified the Makefiles to use 'obj-m' instead of 'subdir-y'

#### How to verify it
- PDDF is supported on Accton platform. Load the build on AS7326 setup and check the 'dmesg'

Some logs are here,
```
root@sonic:/home/admin# show ver

SONiC Software Version: SONiC.master.59273-dirty-20211215.190411
Distribution: Debian 11.1
Kernel: 5.10.0-8-2-amd64
Build commit: d05afb5db
Build date: Wed Dec 15 19:11:16 UTC 2021
Built by: AzDevOps@sonic-build-workers-000ZI8

Platform: x86_64-accton_as7326_56x-r0
HwSKU: Accton-AS7326-56X
ASIC: broadcom
..
root@sonic:/home/admin#
root@sonic:/home/admin# systemctl status pddf-platform-init.service
● pddf-platform-init.service - PDDF module and device initialization service
     Loaded: loaded (/lib/systemd/system/pddf-platform-init.service; enabled; vendor preset: enabled)
     Active: active (exited) since Fri 2021-12-17 04:54:12 UTC; 20s ago
    Process: 792 ExecStart=/usr/local/bin/pddf_util.py install (code=exited, status=0/SUCCESS)
   Main PID: 792 (code=exited, status=0/SUCCESS)

Dec 17 04:54:03 sonic systemd[1]: Starting PDDF module and device initialization service...
Dec 17 04:54:12 sonic pddf_util.py[792]: Checking system....
Dec 17 04:54:12 sonic pddf_util.py[792]: PDDF has no PDDF driver installed....
Dec 17 04:54:12 sonic pddf_util.py[792]: Installing ...
Dec 17 04:54:12 sonic pddf_util.py[792]: Failed :pip3 show sonic-platform > /dev/null 2>&1
Dec 17 04:54:12 sonic pddf_util.py[792]: Attemting to install the PDDF sonic_platform wheel package ...
Dec 17 04:54:12 sonic pddf_util.py[792]: Successfully installed /usr/share/sonic/device/x86_64-accton_as7326_56x-r0/sonic_platform-1.0-py3-none-any.whl package
Dec 17 04:54:12 sonic pddf_util.py[792]: Creating devices ...
Dec 17 04:54:12 sonic systemd[1]: Finished PDDF module and device initialization service.
root@sonic:/home/admin# 
root@sonic:/home/admin# systemctl status as7326-56x-pddf-platform-monitor.service
● as7326-56x-pddf-platform-monitor.service - Accton AS7326-56X Platform Monitoring service
     Loaded: loaded (/lib/systemd/system/as7326-56x-pddf-platform-monitor.service; enabled; vendor preset: enabled)
     Active: active (running) since Fri 2021-12-17 07:08:46 UTC; 1h 56min ago
   Main PID: 4759 (python3)
      Tasks: 1 (limit: 19049)
     Memory: 18.2M
     CGroup: /system.slice/as7326-56x-pddf-platform-monitor.service
             └─4759 python3 /usr/local/bin/accton_as7326_pddf_monitor.py

Dec 17 07:08:46 sonic systemd[1]: Started Accton AS7326-56X Platform Monitoring service.
root@sonic:/home/admin#

root@sonic:/var/log/pddf#
root@sonic:/var/log/pddf# pddf_psuutil mfrinfo
PSU    Status    Manufacturer ID    Model     Serial              Fan Airflow Direction
-----  --------  -----------------  --------  ------------------  -----------------------
PSU1   NOT OK
PSU2   OK        3Y POWER           YM-2651Y  SA070V581836002372  EXHAUST
root@sonic:/var/log/pddf# pddf_psuutil seninfo
PSU    Status      Output Voltage (V)    Output Current (A)    Output Power (W)    Temperature1 (C)    Fan1 Speed (RPM)
-----  --------  --------------------  --------------------  ------------------  ------------------  ------------------
PSU1   NOT OK                    0.00                  0.00                0.00                0.00                   0
PSU2   OK                       12.02                  8.11               97.00               24.00                6400
root@sonic:/var/log/pddf# pddf_fanutil direction
FAN         Direction
----------  -----------
Fantray1_1  Exhaust
Fantray1_2  Exhaust
Fantray2_1  Exhaust
Fantray2_2  Exhaust
Fantray3_1  Exhaust
Fantray3_2  Exhaust
Fantray4_1  Exhaust
Fantray4_2  Exhaust
Fantray5_1  Exhaust
Fantray5_2  Exhaust
Fantray6_1  Exhaust
Fantray6_2  Exhaust
root@sonic:/var/log/pddf# pddf_fanutil getspeed
FAN           SPEED (RPM)
----------  -------------
Fantray1_1          10800
Fantray1_2           9700
Fantray2_1          10800
Fantray2_2           9800
Fantray3_1          10800
Fantray3_2           9800
Fantray4_1          11000
Fantray4_2          10000
Fantray5_1          10900
Fantray5_2           9900
Fantray6_1          10800
Fantray6_2           9800
root@sonic:/var/log/pddf#
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

