### PR TITLE
[202012BR][Barefoot] Wedge100bf Add HW-defined thermal thresholds

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/thermal.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/thermal.py
@@ -3,8 +3,14 @@ try:
 
     from sonic_platform.bfn_extensions.platform_sensors import platform_sensors_get
     from sonic_platform_base.thermal_base import ThermalBase
+    from collections import namedtuple
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
+
+
+Threshold = namedtuple('Threshold', ['high_crit', 'high_err', 'high_warn',
+                       'low_warn', 'low_err', 'low_crit'], defaults=[0]*6)
+
 
 '''
 data argument is in "sensors -A -u" format, example:
@@ -68,6 +74,22 @@ def _value_get(d: dict, key_prefix, key_suffix=''):
 
 # Thermal -> ThermalBase -> DeviceBase
 class Thermal(ThermalBase):
+    _thresholds = {
+        "com_e_driver-i2c-4-33:memory-temp": Threshold(85.0, 80.75, 76.5),
+        "com_e_driver-i2c-4-33:cpu-temp":    Threshold(105.0, 99.75, 94.5),
+        "pfe1100-i2c-7-59:temp1":            Threshold(50.0, 47.5, 45.0),
+        "pfe1100-i2c-7-59:temp2":            Threshold(90.0, 85.5, 81.0),
+        "pfe1100-i2c-7-5a:temp1":            Threshold(50.0, 47.5, 45.0),
+        "pfe1100-i2c-7-5a:temp2":            Threshold(90.0, 85.5, 81.0),
+        "tmp75-i2c-3-48:outlet-middle-temp": Threshold(80.0, 76.0, 72.0),
+        "tmp75-i2c-3-49:inlet-middle-temp":  Threshold(60.0, 57.0, 54.0),
+        "tmp75-i2c-3-4a:inlet-left-temp":    Threshold(60.0, 57.0, 54.0),
+        "tmp75-i2c-3-4b:switch-temp":        Threshold(105.0, 99.75, 94.5),
+        "tmp75-i2c-3-4c:inlet-right-temp":   Threshold(60.0, 57.0, 54.0),
+        "tmp75-i2c-8-48:outlet-right-temp":  Threshold(80.0, 76.0, 72.0),
+        "tmp75-i2c-8-49:outlet-left-temp":   Threshold(80.0, 76.0, 72.0),
+    }
+
     def __init__(self, chip, label):
         self.__chip = chip
         self.__label = label
@@ -83,11 +105,38 @@ class Thermal(ThermalBase):
     def get_temperature(self) -> float:
         return float(self.__get('temp', 'input'))
 
-    def get_high_threshold(self) -> float:
+    def get_high_warning_threshold(self) -> float:
+        if self.get_name() in self._thresholds:
+            return self._thresholds[self.get_name()].high_warn
         return float(self.__get('temp', 'max'))
 
+    def get_high_threshold(self) -> float:
+        if self.get_name() in self._thresholds:
+            return self._thresholds[self.get_name()].high_err
+        #cpu core case
+        temp_warn = self.get_high_warning_threshold()
+        temp_crit = self.get_high_critical_threshold()
+        return (temp_warn + temp_crit) / 2
+
     def get_high_critical_threshold(self) -> float:
+        if self.get_name() in self._thresholds:
+            return self._thresholds[self.get_name()].high_crit
         return float(self.__get('temp', 'crit'))
+
+    def get_low_warning_threshold(self) -> float:
+        if self.get_name() in self._thresholds:
+            return self._thresholds[self.get_name()].low_warn
+        return 0
+
+    def get_low_threshold(self) -> float:
+        if self.get_name() in self._thresholds:
+            return self._thresholds[self.get_name()].low_err
+        return 0
+
+    def get_low_critical_threshold(self) -> float:
+        if self.get_name() in self._thresholds:
+            return self._thresholds[self.get_name()].low_crit
+        return 0
 
     # DeviceBase interface methods:
     def get_name(self):


### PR DESCRIPTION
Signed-off-by: Sean Wu <sean_wu@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Makes customers be able to access HW-defined thermal thresholds.
#### How I did it
1. HW guys evaluated reasonable thresholds for all sensors according to the result of the environment temperature test.
2. Add these thresholds to thermal.py
#### How to verify it
1. `show platform temperature`
```
root@wedge100bf-32x-2:/tmp# show plat temp
                           Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
---------------------------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
   com_e_driver-i2c-4-33:cpu-temp         41          99.75         0             105              0      False  20211217 09:46:37
com_e_driver-i2c-4-33:memory-temp         31          80.75         0              85              0      False  20211217 09:46:54
         coretemp-isa-0000:core-0         40          93            0             104              0      False  20211217 09:45:47
         coretemp-isa-0000:core-1         41          93            0             104              0      False  20211217 09:45:47
         coretemp-isa-0000:core-2         41          93            0             104              0      False  20211217 09:45:47
         coretemp-isa-0000:core-3         41          93            0             104              0      False  20211217 09:45:47
   coretemp-isa-0000:package-id-0         40          93            0             104              0      False  20211217 09:45:47
           pfe1100-i2c-7-5a:temp1         36          47.5          0              50              0      False  20211217 09:46:41
           pfe1100-i2c-7-5a:temp2         24.125      85.5          0              90              0      False  20211217 09:46:43
           pfe1100-i2c-7-59:temp1         23.25       47.5          0              50              0      False  20211217 09:46:38
           pfe1100-i2c-7-59:temp2         22          85.5          0              90              0      False  20211217 09:46:40
   tmp75-i2c-3-4a:inlet-left-temp         27          57            0              60              0      False  20211217 09:46:47
       tmp75-i2c-3-4b:switch-temp         24          99.75         0             105              0      False  20211217 09:46:49
  tmp75-i2c-3-4c:inlet-right-temp         24          57            0              60              0      False  20211217 09:46:50
tmp75-i2c-3-48:outlet-middle-temp         30          76            0              80              0      False  20211217 09:46:44
 tmp75-i2c-3-49:inlet-middle-temp         27.5        57            0              60              0      False  20211217 09:46:46
 tmp75-i2c-8-48:outlet-right-temp         25          76            0              80              0      False  20211217 09:46:52
  tmp75-i2c-8-49:outlet-left-temp         26.5        76            0              80              0      False  20211217 09:46:53
```
2. Code my own script to dump thresholds.
```
root@wedge100bf-32x-2:/tmp# python3 dump_thermal_thresholds.py 
{
    "1": {
        "error": 80750,
        "shutdown": 85000,
        "warning_lower": 0,
        "warning_upper": 76500
    },
    "2": {
        "error": 99750,
        "shutdown": 105000,
        "warning_lower": 0,
        "warning_upper": 94500
    },
    "3": {
        "error": 47500,
        "shutdown": 50000,
        "warning_lower": 0,
        "warning_upper": 45000
    },
    "4": {
        "error": 85500,
        "shutdown": 90000,
        "warning_lower": 0,
        "warning_upper": 81000
    },
    "5": {
        "error": 47500,
        "shutdown": 50000,
        "warning_lower": 0,
        "warning_upper": 45000
    },
    "6": {
        "error": 85500,
        "shutdown": 90000,
        "warning_lower": 0,
        "warning_upper": 81000
    },
    "7": {
        "error": 76000,
        "shutdown": 80000,
        "warning_lower": 0,
        "warning_upper": 72000
    },
    "8": {
        "error": 57000,
        "shutdown": 60000,
        "warning_lower": 0,
        "warning_upper": 54000
    },
    "9": {
        "error": 57000,
        "shutdown": 60000,
        "warning_lower": 0,
        "warning_upper": 54000
    },
    "10": {
        "error": 99750,
        "shutdown": 105000,
        "warning_lower": 0,
        "warning_upper": 94500
    },
    "11": {
        "error": 57000,
        "shutdown": 60000,
        "warning_lower": 0,
        "warning_upper": 54000
    },
    "12": {
        "error": 76000,
        "shutdown": 80000,
        "warning_lower": 0,
        "warning_upper": 72000
    },
    "13": {
        "error": 76000,
        "shutdown": 80000,
        "warning_lower": 0,
        "warning_upper": 72000
    },
    "14": {
        "error": 93000,
        "shutdown": 104000,
        "warning_lower": 0,
        "warning_upper": 82000
    },
    "15": {
        "error": 93000,
        "shutdown": 104000,
        "warning_lower": 0,
        "warning_upper": 82000
    },
    "16": {
        "error": 93000,
        "shutdown": 104000,
        "warning_lower": 0,
        "warning_upper": 82000
    },
    "17": {
        "error": 93000,
        "shutdown": 104000,
        "warning_lower": 0,
        "warning_upper": 82000
    },
    "18": {
        "error": 93000,
        "shutdown": 104000,
        "warning_lower": 0,
        "warning_upper": 82000
    }
}
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012: The customers demand it.
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[Wedge100bf-32X/65X] add HW-defined thermal thresholds

#### A picture of a cute animal (not mandatory but encouraged)

