### PR TITLE
Ensure that sonic-build-hooks are created with gzip compression

### DIFF
--- a/src/sonic-build-hooks/Makefile
+++ b/src/sonic-build-hooks/Makefile
@@ -21,7 +21,7 @@ DPKGTOOL = $(shell which dpkg-deb)
 ifeq ($(shell which dpkg-deb),)
 BUILD_COMMAND=docker run --user $(shell id -u):$(shell id -g) --rm -v $(shell pwd):/build debian:buster bash -c 'cd /build; dpkg-deb --build $(TMP_DIR)/$(SONIC_BUILD_HOOKS) $(SONIC_BUILD_HOOKS_TARGET)'
 else
-BUILD_COMMAND=dpkg-deb --build $(TMP_DIR)/$(SONIC_BUILD_HOOKS) $(SONIC_BUILD_HOOKS_TARGET)
+BUILD_COMMAND=dpkg-deb -Zgzip --build $(TMP_DIR)/$(SONIC_BUILD_HOOKS) $(SONIC_BUILD_HOOKS_TARGET)
 endif
 
 DEPENDS := $(shell find scripts hooks debian -type f)


### PR DESCRIPTION
#### Why I did it

Trying to build on newer ubuntu based workstations, the build breaks because dpkg-deb defaults there to zstd compressed debian packages which debian is not able to install.


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
Support newer ubuntu build hosts to create the image.

#### A picture of a cute animal (not mandatory but encouraged)

