### PR TITLE
[sonic-cfggen]: Update test minigraph to add deployment_id

### DIFF
--- a/src/sonic-config-engine/tests/pc-test-graph.xml
+++ b/src/sonic-config-engine/tests/pc-test-graph.xml
@@ -202,6 +202,21 @@
       </Device>
     </Devices>
   </PngDec>
+<MetadataDeclaration>
+ <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+  <a:DeviceMetadata>
+   <a:Name>switch-t0</a:Name>
+   <a:Properties>
+    <a:DeviceProperty>
+     <a:Name>DeploymentId</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>1</a:Value>
+    </a:DeviceProperty>
+  </a:Properties>
+  </a:DeviceMetadata>
+ </Devices>
+ <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+</MetadataDeclaration>
   <Hostname>switch-t0</Hostname>
   <HwSku>Force10-S6000</HwSku>
 </DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/sample-graph-resource-type.xml
+++ b/src/sonic-config-engine/tests/sample-graph-resource-type.xml
@@ -463,6 +463,11 @@
         <a:Name>switch-t0</a:Name>
         <a:Properties>
           <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
             <a:Name>ResourceType</a:Name>
             <a:Reference i:nil="true"/>
             <a:Value>Storage</a:Value>

--- a/src/sonic-config-engine/tests/sample-graph-subintf.xml
+++ b/src/sonic-config-engine/tests/sample-graph-subintf.xml
@@ -465,6 +465,21 @@
       </ManagementInterfaces>
     </DeviceInfo>
   </DeviceInfos>
+<MetadataDeclaration>
+ <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+  <a:DeviceMetadata>
+   <a:Name>switch-t0</a:Name>
+   <a:Properties>
+    <a:DeviceProperty>
+     <a:Name>DeploymentId</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>1</a:Value>
+    </a:DeviceProperty>
+  </a:Properties>
+  </a:DeviceMetadata>
+ </Devices>
+ <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+</MetadataDeclaration>
   <Hostname>switch-t0</Hostname>
   <HwSku>Force10-S6000</HwSku>
 </DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/sample_graph.xml
+++ b/src/sonic-config-engine/tests/sample_graph.xml
@@ -124,6 +124,21 @@
       </Device>
     </Devices>
   </PngDec>
+<MetadataDeclaration>
+ <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+  <a:DeviceMetadata>
+   <a:Name>OCPSCH01040DDLF</a:Name>
+   <a:Properties>
+    <a:DeviceProperty>
+     <a:Name>DeploymentId</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>1</a:Value>
+    </a:DeviceProperty>
+  </a:Properties>
+  </a:DeviceMetadata>
+ </Devices>
+ <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+</MetadataDeclaration>
   <Hostname>OCPSCH01040DDLF</Hostname>
   <HwSku>Force10-Z9100</HwSku>
 </DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -457,6 +457,21 @@
       </ManagementInterfaces>
     </DeviceInfo>
   </DeviceInfos>
+<MetadataDeclaration>
+ <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+  <a:DeviceMetadata>
+   <a:Name>switch-t0</a:Name>
+   <a:Properties>
+    <a:DeviceProperty>
+     <a:Name>DeploymentId</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>1</a:Value>
+    </a:DeviceProperty>
+  </a:Properties>
+  </a:DeviceMetadata>
+ </Devices>
+ <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+</MetadataDeclaration>
   <Hostname>switch-t0</Hostname>
   <HwSku>Force10-S6000</HwSku>
 </DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/t0-sample-graph.xml
+++ b/src/sonic-config-engine/tests/t0-sample-graph.xml
@@ -549,6 +549,21 @@
       </a:LinkMetadata>
     </Link>
   </LinkMetadataDeclaration>
+<MetadataDeclaration>
+ <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+  <a:DeviceMetadata>
+   <a:Name>switch-t0</a:Name>
+   <a:Properties>
+    <a:DeviceProperty>
+     <a:Name>DeploymentId</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>1</a:Value>
+    </a:DeviceProperty>
+  </a:Properties>
+  </a:DeviceMetadata>
+ </Devices>
+ <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+</MetadataDeclaration>
   <Hostname>switch-t0</Hostname>
   <HwSku>Force10-S6000</HwSku>
 </DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1,14 +1,11 @@
 import json
 import subprocess
 import os
-import re
 
-import sonic_yang
 import tests.common_utils as utils
 
 from unittest import TestCase
 
-YANG_MODELS_DIR = "/usr/local/yang-models"
 TOR_ROUTER = 'ToRRouter'
 BACKEND_TOR_ROUTER = 'BackEndToRRouter'
 LEAF_ROUTER = 'LeafRouter'
@@ -17,8 +14,6 @@ BACKEND_LEAF_ROUTER = 'BackEndLeafRouter'
 class TestCfgGen(TestCase):
 
     def setUp(self):
-        self.yang_parser = sonic_yang.SonicYang(YANG_MODELS_DIR)
-        self.yang_parser.loadYangModel()
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
         self.script_file = utils.PYTHON_INTERPRETTER + ' ' + os.path.join(self.test_dir, '..', 'sonic-cfggen')
         self.sample_graph = os.path.join(self.test_dir, 'sample_graph.xml')
@@ -54,29 +49,6 @@ class TestCfgGen(TestCase):
 
     def run_script(self, argument, check_stderr=False, verbose=False):
         print('\n    Running sonic-cfggen ' + argument)
-        if "-m" in argument:
-            pattern = r'-m\s+(\S+)\s*'
-            minigraph = re.findall(r'-m\s+(\S+)\s*', argument)
-            port_conf = re.findall(r'-p\s+(\S+)\s*', argument)
-            namespace = re.findall(r'-n\s+(\S+)\s*', argument)
-            if minigraph:
-                print('\n    Validating yang schema')
-                cmd = self.script_file + ' -m ' + minigraph[0]
-                if port_conf:
-                    cmd += ' -p ' + port_conf[0]
-                if namespace:
-                    cmd += ' -n ' + namespace[0]
-                cmd += ' --print-data'
-                output = subprocess.check_output(cmd, shell=True).decode()
-                # "NULL": "NULL" is placeholder for redis, remove to pass yang validation.
-                output = output.replace("\"NULL\": \"NULL\"", "")
-                self.yang_parser.loadData(configdbJson=json.loads(output))
-                try:
-                    self.yang_parser.validate_data_tree()
-                except sonic_yang.SonicYangException as e:
-                    print("yang data generated from %s is not valid"%(minigraph[0]))
-                    raise
-
         if check_stderr:
             output = subprocess.check_output(self.script_file + ' ' + argument, stderr=subprocess.STDOUT, shell=True)
         else:

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -1,11 +1,14 @@
 import json
 import subprocess
 import os
+import re
 
+import sonic_yang
 import tests.common_utils as utils
 
 from unittest import TestCase
 
+YANG_MODELS_DIR = "/usr/local/yang-models"
 TOR_ROUTER = 'ToRRouter'
 BACKEND_TOR_ROUTER = 'BackEndToRRouter'
 LEAF_ROUTER = 'LeafRouter'
@@ -14,6 +17,8 @@ BACKEND_LEAF_ROUTER = 'BackEndLeafRouter'
 class TestCfgGen(TestCase):
 
     def setUp(self):
+        self.yang_parser = sonic_yang.SonicYang(YANG_MODELS_DIR)
+        self.yang_parser.loadYangModel()
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
         self.script_file = utils.PYTHON_INTERPRETTER + ' ' + os.path.join(self.test_dir, '..', 'sonic-cfggen')
         self.sample_graph = os.path.join(self.test_dir, 'sample_graph.xml')
@@ -49,6 +54,29 @@ class TestCfgGen(TestCase):
 
     def run_script(self, argument, check_stderr=False, verbose=False):
         print('\n    Running sonic-cfggen ' + argument)
+        if "-m" in argument:
+            pattern = r'-m\s+(\S+)\s*'
+            minigraph = re.findall(r'-m\s+(\S+)\s*', argument)
+            port_conf = re.findall(r'-p\s+(\S+)\s*', argument)
+            namespace = re.findall(r'-n\s+(\S+)\s*', argument)
+            if minigraph:
+                print('\n    Validating yang schema')
+                cmd = self.script_file + ' -m ' + minigraph[0]
+                if port_conf:
+                    cmd += ' -p ' + port_conf[0]
+                if namespace:
+                    cmd += ' -n ' + namespace[0]
+                cmd += ' --print-data'
+                output = subprocess.check_output(cmd, shell=True).decode()
+                # "NULL": "NULL" is placeholder for redis, remove to pass yang validation.
+                output = output.replace("\"NULL\": \"NULL\"", "")
+                self.yang_parser.loadData(configdbJson=json.loads(output))
+                try:
+                    self.yang_parser.validate_data_tree()
+                except sonic_yang.SonicYangException as e:
+                    print("yang data generated from %s is not valid"%(minigraph[0]))
+                    raise
+
         if check_stderr:
             output = subprocess.check_output(self.script_file + ' ' + argument, stderr=subprocess.STDOUT, shell=True)
         else:


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Config db schema generated from test minigraph can't pass yang validation.

#### How I did it
Update minigraph xml to add DeploymentId.

#### How to verify it
Build sonic-config-engine.
Run command 'sonic-cfggen -m xxx.xml --print-data', and check deployment_id field.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix #9550


#### A picture of a cute animal (not mandatory but encouraged)

