### PR TITLE
[build] Fix docker-sonic-mgmt pylint dependency lazy-object-proxy version

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -56,6 +56,7 @@ RUN pip install cffi==1.10.0 \
                 psutil \
                 pyasn1==0.1.9 \
                 pyfiglet \
+                lazy-object-proxy==1.6.0 \
                 pylint==1.8.1 \
                 pyro4 \
                 pysnmp==4.2.5 \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
https://pypi.org/project/lazy-object-proxy/#description
lazy-object-proxy's latest version does not support python2, while pylint denpends on lazy-object-proxy.

1.7.1 (2021-12-15)
Removed most of the Python 2 support code and fixed python_requires to require at least Python 3.6.

Note that 1.7.0 has been yanked because it could not install on Python 2.7. Installing lazy-object-proxy on Python 2.7 should automatically fall back to the 1.6.0 release now.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

