### PR TITLE
Update platform_sync

### DIFF
--- a/platform/innovium/sonic-platform-modules-wistron/sw-to3200k/utils/platform_sync
+++ b/platform/innovium/sonic-platform-modules-wistron/sw-to3200k/utils/platform_sync
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+i2c_flag=0
+sudo ipmitool raw 0x30 0x85 1
+for i in $(seq 0 9)
+do
+    sleep 0.5
+    if [ "$(sudo i2cdetect -y 0 | sed 's/^..//' | grep 71)" == "" ];then
+        i2c_flag=1
+        break
+    fi
+done
+if [ $i2c_flag -eq 0 ];then
+    sudo ipmitool raw 0x06 0x02
+fi
+
 /usr/local/bin/sonic-fanthrml-monitor &
 /usr/local/bin/sonic-led-monitor &
 /usr/local/bin/sonic-qsfp-monitor &


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Transceiver EEPROM not found when system boot up.
If I2C control is change to CPU before reboot, no other method to change it back to BMC before this modified.

#### How I did it
When system boot up in this one time service, change I2C back to BMC and check is really back to BMC. If not, cold reset the BMC.

#### How to verify it
Testing with cold reboot / sw reboot in SONiC before I2C select to CPU and BMC

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

