### PR TITLE
[Build]: Improve the linux kernel build cache hit rate

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -68,6 +68,7 @@
 # Run the 'touch cache.skip.common' command in the base directory to exclude the common files from caching
 SONIC_COMMON_FILES_LIST :=  $(if $(wildcard cache.skip.common),, .platform slave.mk rules/functions Makefile.cache)
 SONIC_COMMON_FLAGS_LIST :=  $(CONFIGURED_PLATFORM) \
+                            $(CONFIGURED_ARCH) \
                             $(BLDENV) \
                             $(SONIC_DEBUGGING_ON) \
                             $(SONIC_PROFILING_ON) $(SONIC_ENABLE_SYNCD_RPC)

--- a/rules/linux-kernel.dep
+++ b/rules/linux-kernel.dep
@@ -1,7 +1,6 @@
 
 SPATH       := $($(LINUX_HEADERS_COMMON)_SRC_PATH)
-DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/linux-kernel.mk rules/linux-kernel.dep
-DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+DEP_FILES   := rules/linux-kernel.mk rules/linux-kernel.dep
 SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
 
 DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST) \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Improve the linux kernel build cache hit rate.
Current the the hit rate is around 85.8% (based on the last 3 month, 3479 PR builds totally, 494 PR build not hit).
We can improve the hit rate up to 95% or better.
The Linux kernel build will take really long time, most of the PRs are nothing to do with the kernel change. The remaining cache options should be enough to detect the Linux kernel cache status (dirty or not).

#### How I did it
Some of the file changes are not relative to the Linux kernel build, such as sonic-slave-stretch/Dockerfile.j2, we can exclude it.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

