### PR TITLE
[yang]: Support VLAN alias

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -1,29 +1,32 @@
 {
+    "VALID_VLAN": {
+        "desc": "Configure VLAN table."
+    },
     "VLAN_INTERFACE_IPPREFIX_MUST_CONDITION_FALSE": {
-	"desc": "Vlan Interface Ip-prefix must condition failure.",
-	"eStrKey" : "Must"
+        "desc": "Vlan Interface Ip-prefix must condition failure.",
+        "eStrKey" : "Must"
     },
     "INCORRECT_VLAN_NAME": {
-	"desc": "INCORRECT VLAN_NAME FIELD IN VLAN TABLE.",
-	"eStrKey" : "Pattern",
-	"eStr": ["Vlan"]
+        "desc": "INCORRECT VLAN_NAME FIELD IN VLAN TABLE.",
+        "eStrKey" : "Pattern",
+        "eStr": ["Vlan"]
     },
     "WRONG_FAMILY_WITH_IP_PREFIX": {
-	"desc": "Configure Wrong family with ip-prefix for VLAN_Interface Table",
-	"eStrKey" : "Must"
+        "desc": "Configure Wrong family with ip-prefix for VLAN_Interface Table",
+        "eStrKey" : "Must"
     },
     "DHCP_SERVER_INCORRECT_FORMAT": {
-	"desc": "Add dhcp_server which is not in correct ip-prefix format.",
-	"eStrKey" : "InvalidValue",
-	"eStr": ["dhcp_servers"]
+        "desc": "Add dhcp_server which is not in correct ip-prefix format.",
+        "eStrKey" : "InvalidValue",
+        "eStr": ["dhcp_servers"]
     },
     "DHCPV6_SERVER_INCORRECT_FORMAT": {
         "desc": "Add dhcpv6_server which is not in correct ipv6-address format.",
         "eStrKey" : "Pattern"
     },
     "VLAN_WITH_NON_EXIST_PORT": {
-	"desc": "Configure a member port in VLAN_MEMBER table which does not exist.",
-	"eStrKey" : "InvalidValue"
+        "desc": "Configure a member port in VLAN_MEMBER table which does not exist.",
+        "eStrKey" : "InvalidValue"
     },
     "VLAN_WITH_PORTCHANNEL_MEMBER": {
         "desc": "Configure a PortChannel as a member of Vlan."
@@ -33,13 +36,13 @@
         "eStrKey" : "InvalidValue"
     },
     "VLAN_MEMEBER_WITH_NON_EXIST_VLAN": {
-	"desc": "Configure vlan-id in VLAN_MEMBER table which does not exist in VLAN  table.",
-	"eStrKey" : "LeafRef"
+        "desc": "Configure vlan-id in VLAN_MEMBER table which does not exist in VLAN  table.",
+        "eStrKey" : "LeafRef"
     },
     "TAGGING_MODE_WRONG_VALUE": {
-	"desc": "Configure wrong value for tagging_mode.",
-	"eStrKey" : "InvalidValue",
-	"eStr": ["tagging_mode"]
+        "desc": "Configure wrong value for tagging_mode.",
+        "eStrKey" : "InvalidValue",
+        "eStr": ["tagging_mode"]
     },
     "VLAN_INTERFACE_WRONG_NAT_ZONE_RANGE": {
         "desc": "Configure wrong value for nat zone.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -1,4 +1,32 @@
 {
+    "VALID_VLAN": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "first_vlan",
+                        "description": "server_vlan",
+                        "dhcp_servers": [
+                            "10.186.72.56"
+                        ],
+                        "mtu": "9100",
+                        "name": "Vlan100"
+                    },
+                    {
+                        "admin_status": "up",
+                        "alias": "second_vlan",
+                        "description": "server_vlan",
+                        "dhcp_servers": [
+                            "10.186.72.66"
+                        ],
+                        "mtu": "9100",
+                        "name": "Vlan200"
+                    }
+                ]
+            }
+        }
+    },
     "INCORRECT_VLAN_NAME": {
         "sonic-vlan:sonic-vlan": {
             "sonic-vlan:VLAN": {

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -155,6 +155,10 @@ module sonic-vlan {
 					}
 				}
 
+				leaf alias {
+					type string;
+				}
+
 				leaf description {
 					type string {
 						length 1..255;


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Config db schema generated by minigraph can’t pass yang validation, and there's no 'alias' field in yang model.
Minigraph parser supports 'alias' field for VLAN.

#### How I did it
Add 'alias' field to sonic-vlan.yang

#### How to verify it
Build sonic-yang-models.
Run command 'sonic-cfggen -m xxx.xml --print-data', and run yang validation.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix #9557


#### A picture of a cute animal (not mandatory but encouraged)

