### PR TITLE
[sonic-cfggen]: Fix syslog_server output

### DIFF
--- a/src/sonic-config-engine/tests/sample-voq-graph.xml
+++ b/src/sonic-config-engine/tests/sample-voq-graph.xml
@@ -109,7 +109,7 @@
     <a:DeviceProperty>
      <a:Name>SyslogResources</a:Name>
      <a:Value>
-      10.0.10.5;10.0.10.6;
+      10.0.10.5;10.0.10.6
      </a:Value>
     </a:DeviceProperty>
     <a:DeviceProperty>

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -446,7 +446,7 @@
     <a:DeviceProperty>
      <a:Name>SyslogResources</a:Name>
      <a:Value>
-      10.0.10.5;10.0.10.6;
+      10.0.10.5;10.0.10.6
      </a:Value>
     </a:DeviceProperty>
     <a:DeviceProperty>

--- a/src/sonic-config-engine/tests/simple-sample-graph-metadata.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-metadata.xml
@@ -245,7 +245,7 @@
     <a:DeviceProperty>
      <a:Name>SyslogResources</a:Name>
      <a:Value>
-      10.0.10.5;10.0.10.6;
+      10.0.10.5;10.0.10.6
      </a:Value>
     </a:DeviceProperty>
     <a:DeviceProperty>


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
'SYSLOG_SERVER': {'': {}, '10.0.10.5': {}, '10.0.10.6': {}},
Config db schema generated by minigraph can’t pass yang validation, server address can't be empty.

#### How I did it
Update test minigraph to remove wrong configuration.

#### How to verify it
Build sonic-config-engine.
Run command 'sonic-cfggen -m xxx.xml --print-data', and SYSLOG_SERVERS table.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix #9571 


#### A picture of a cute animal (not mandatory but encouraged)

