### PR TITLE
[multi-asic] Cache connection handles to prevent duplicate

### DIFF
--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -27,6 +27,10 @@ DEFAULT_NAMESPACE = ''
 PORT_ROLE = 'role'
 
 
+# Dictionary to cache config_db connection handle per namespace
+# to prevent duplicate connections from being opened
+config_db_handle = {}
+
 def connect_config_db_for_ns(namespace=DEFAULT_NAMESPACE):
     """
     The function connects to the config DB for a given namespace and
@@ -237,7 +241,9 @@ def get_all_namespaces():
     if is_multi_asic():
         for asic in range(num_asics):
             namespace = "{}{}".format(ASIC_NAME_PREFIX, asic)
-            config_db = connect_config_db_for_ns(namespace)
+            if namespace not in config_db_handle:
+                config_db_handle[namespace] =  connect_config_db_for_ns(namespace)
+            config_db = config_db_handle[namespace]
 
             metadata = config_db.get_table('DEVICE_METADATA')
             if metadata['localhost']['sub_role'] == FRONTEND_ASIC_SUB_ROLE:


### PR DESCRIPTION
Signed-off-by: anamehra <anamehra@cisco.com>

   On a multi-asic Supervisor card, running commands like
   'show interface counter' opens a confid_db connection per
   namespace per interface which results in many duplicate connections
   exceeding the allowed open file handles. This causes the command to fail.

   Caching the connections to prevent duplicate handles.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

