### PR TITLE
[sonic-cfggen]: Fix missing vlan interface

### DIFF
--- a/src/sonic-config-engine/tests/fg-ecmp-sample-minigraph.xml
+++ b/src/sonic-config-engine/tests/fg-ecmp-sample-minigraph.xml
@@ -230,6 +230,17 @@
                <Tag>1000</Tag>
                <Subnets>192.168.0.0/21</Subnets>
             </VlanInterface>
+            <VlanInterface>
+               <Name>Vlan31</Name>
+               <AttachTo>etp26</AttachTo>
+               <NoDhcpRelay>False</NoDhcpRelay>
+               <StaticDHCPRelay>0.0.0.0/0</StaticDHCPRelay>
+               <Type i:nil="true" />
+               <DhcpRelays>200.200.0.48</DhcpRelays>
+               <VlanID>31</VlanID>
+               <Tag>31</Tag>
+               <Subnets>200.200.0.0/21</Subnets>
+            </VlanInterface>
          </VlanInterfaces>
          <IPInterfaces>
             <IPInterface>


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Config db schema generated by minigraph can’t pass yang validation, there's no Vlan31 in 'VLAN' table.

#### How I did it
Update test minigraph to add vlan interface.

#### How to verify it
Build sonic-yang-models.
Run command 'sonic-cfggen -m tests/fg-ecmp-sample-minigraph.xml -p tests/mellanox-sample-port-config.ini --print-data', and run yang validation.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix #9581 


#### A picture of a cute animal (not mandatory but encouraged)

