### PR TITLE
[sonic-cfggen]: Add bgp asn for yang validation

### DIFF
--- a/src/sonic-config-engine/tests/sample-voq-graph.xml
+++ b/src/sonic-config-engine/tests/sample-voq-graph.xml
@@ -5,26 +5,7 @@
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>
           <a:Hostname>linecard-1</a:Hostname>
-          <a:Peers>
-            <BGPPeer>
-              <Address>10.0.0.57</Address>
-              <RouteMapIn i:nil="true"/>
-              <RouteMapOut i:nil="true"/>
-              <Vrf i:nil="true"/>
-            </BGPPeer>
-            <BGPPeer>
-              <Address>10.0.0.59</Address>
-              <RouteMapIn i:nil="true"/>
-              <RouteMapOut i:nil="true"/>
-              <Vrf i:nil="true"/>
-            </BGPPeer>
-            <BGPPeer>
-              <Address>10.2.0.21</Address>
-              <RouteMapIn i:nil="true"/>
-              <RouteMapOut i:nil="true"/>
-              <Vrf i:nil="true"/>
-            </BGPPeer>
-          </a:Peers>
+          <a:Peers/>
         <a:RouteMaps/>
       </a:BGPRouterDeclaration>
     </Routers>

--- a/src/sonic-config-engine/tests/sample-voq-graph.xml
+++ b/src/sonic-config-engine/tests/sample-voq-graph.xml
@@ -1,7 +1,33 @@
 <DeviceMiniGraph xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
   <CpgDec>
     <PeeringSessions/>
-    <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:BGPRouterDeclaration>
+        <a:ASN>65100</a:ASN>
+          <a:Hostname>linecard-1</a:Hostname>
+          <a:Peers>
+            <BGPPeer>
+              <Address>10.0.0.57</Address>
+              <RouteMapIn i:nil="true"/>
+              <RouteMapOut i:nil="true"/>
+              <Vrf i:nil="true"/>
+            </BGPPeer>
+            <BGPPeer>
+              <Address>10.0.0.59</Address>
+              <RouteMapIn i:nil="true"/>
+              <RouteMapOut i:nil="true"/>
+              <Vrf i:nil="true"/>
+            </BGPPeer>
+            <BGPPeer>
+              <Address>10.2.0.21</Address>
+              <RouteMapIn i:nil="true"/>
+              <RouteMapOut i:nil="true"/>
+              <Vrf i:nil="true"/>
+            </BGPPeer>
+          </a:Peers>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+    </Routers>
   </CpgDec>
   <DpgDec>
     <DeviceDataPlaneInfo>


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Config db schema generated by minigraph can’t pass yang validation, bgp_asn must not be None.

#### How I did it
Update sampe-voq-graph.xml to add bgp_asn.

#### How to verify it
Build sonic-config-engine.
Run command 'sonic-cfggen -m tests/sample-voq-graph.xml -p tests/voq-sample-port-config.ini --print-data', and check bgp_asn.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix #9576 

#### A picture of a cute animal (not mandatory but encouraged)

