### PR TITLE
[Build]: Fix lxml version conflict issue

### DIFF
--- a/files/build/versions/dockers/sonic-slave-stretch/versions-py2
+++ b/files/build/versions/dockers/sonic-slave-stretch/versions-py2
@@ -30,7 +30,7 @@ jinja2==2.11.3
 keyring==10.1
 keyrings.alt==1.3
 lazy-object-proxy==1.2.2
-lxml==4.6.2
+lxml==4.6.5
 m2crypto==0.36.0
 markupsafe==1.1.1
 mmh3==3.0.0

--- a/files/build/versions/dockers/sonic-slave-stretch/versions-py3
+++ b/files/build/versions/dockers/sonic-slave-stretch/versions-py3
@@ -11,7 +11,7 @@ imagesize==0.7.1
 jinja2==2.8
 keyring==10.1
 keyrings.alt==1.3
-lxml==4.6.2
+lxml==4.6.5
 markupsafe==0.23
 mockredispy==2.9.3
 nose==1.3.7


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The version of the python package lxml is mismatched with the one in Dockerfile.j2, we need to upgrade from 4.6.2 to 4.6.5.
The automation job will do the similar thing, the PR can be skipped if any new successful build in below link.
https://dev.azure.com/mssonic/build/_build?definitionId=40&_a=summary&repositoryFilter=1&branchFilter=573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573%2C573
The automation job failed for some test cases not stable, we can do a quick fix for it, in case of the upgrading version job not succeeded in a long time.
It should be caused by code merge without PR checks.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

