### PR TITLE
[Mellanox] Include CPU board and switch board sensors only on SN2201 system

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -157,7 +157,9 @@ DEVICE_DATA = {
     'x86_64-nvidia_sn2201-r0': {
         'thermal': {
             "capability": {
-                "comex_amb": False
+                "comex_amb": False,
+                "cpu_amb": True,
+                "swb_amb": True
             }
         }
     },

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -112,11 +112,13 @@ THERMAL_NAMING_RULE = {
         },
         {
             "name": "Ambient CPU Board Temp",
-            "temperature": "cpu_amb"
+            "temperature": "cpu_amb",
+            "default_present": False
         },
         {
             "name": "Ambient Switch Board Temp",
-            "temperature": "swb_amb"
+            "temperature": "swb_amb",
+            "default_present": False
         }
     ],
     'linecard thermals': {
@@ -226,10 +228,14 @@ def create_indexable_thermal(rule, index, sysfs_folder, position, presence_cb=No
 
 def create_single_thermal(rule, sysfs_folder, position, presence_cb=None):
     temp_file = rule['temperature']
+    default_present = rule.get('default_present', True)
     thermal_capability = DeviceDataManager.get_thermal_capability()
+
     if thermal_capability:
-        if not thermal_capability.get(temp_file, True):
+        if not thermal_capability.get(temp_file, default_present):
             return None
+    elif not default_present:
+        return None
 
     temp_file = os.path.join(sysfs_folder, temp_file)
     _check_thermal_sysfs_existence(temp_file)

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
@@ -51,6 +51,10 @@ class TestThermal:
                 if rule['temperature'] == 'comex_amb':
                     assert thermal_name not in thermal_dict
                     continue
+                default_present = rule.get('default_present', True)
+                if not default_present:
+                    assert thermal_name not in thermal_dict
+                    continue
                 assert thermal_name in thermal_dict
                 thermal = thermal_dict[thermal_name]
                 assert rule['temperature'] in thermal.temperature
@@ -85,16 +89,17 @@ class TestThermal:
         assert gearbox_thermal_count == 2
         assert cpu_thermal_count == 2
 
-    def test_chassis_thermal_excludes(self):
+    def test_chassis_thermal_includes(self):
         from sonic_platform.thermal import THERMAL_NAMING_RULE
         DeviceDataManager.get_platform_name = mock.MagicMock(return_value='x86_64-nvidia_sn2201-r0')
+        DeviceDataManager.get_thermal_capability = mock.MagicMock(return_value={'comex_amb': False, 'cpu_amb': True, 'swb_amb': True})
         chassis = Chassis()
         thermal_list = chassis.get_all_thermals()
         assert thermal_list
         thermal_dict = {thermal.get_name(): thermal for thermal in thermal_list}
         for rule in THERMAL_NAMING_RULE['chassis thermals']:
             default_present = rule.get('default_present', True)
-            if default_present == False:
+            if not default_present:
                 thermal_name = rule['name']
                 assert thermal_name in thermal_dict
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
@@ -85,6 +85,19 @@ class TestThermal:
         assert gearbox_thermal_count == 2
         assert cpu_thermal_count == 2
 
+    def test_chassis_thermal_excludes(self):
+        from sonic_platform.thermal import THERMAL_NAMING_RULE
+        DeviceDataManager.get_platform_name = mock.MagicMock(return_value='x86_64-nvidia_sn2201-r0')
+        chassis = Chassis()
+        thermal_list = chassis.get_all_thermals()
+        assert thermal_list
+        thermal_dict = {thermal.get_name(): thermal for thermal in thermal_list}
+        for rule in THERMAL_NAMING_RULE['chassis thermals']:
+            default_present = rule.get('default_present', True)
+            if default_present == False:
+                thermal_name = rule['name']
+                assert thermal_name in thermal_dict
+
     def test_psu_thermal(self):
         from sonic_platform.thermal import initialize_psu_thermal, THERMAL_NAMING_RULE
         os.path.exists = mock.MagicMock(return_value=True)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Recently additional sensors that were needed only for specific system added to all systems and caused errors.

#### How I did it
Enhanced current implementation to support inclusions per sensor type.

#### How to verify it
Run show platform temperature

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This PR is fixing issue in "show platform temperature", now the right sensors are being showed.
