### PR TITLE
Fix docker-sonic-mgmt reproducible related issue.

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -17,6 +17,12 @@ REPR_MIRROR_URL_PATTERN='http:\/\/packages.trafficmanager.net\/debian'
 
 URL_PREFIX=$(echo "${PACKAGE_URL_PREFIX}" | sed -E "s#(//[^/]*/).*#\1#")
 
+if [[ $USER == 'root' ]];then
+    SUDO=''
+else
+    SUDO=sudo
+fi
+
 log_err()
 {
     echo "$1" >> $LOG_PATH/error.log
@@ -72,7 +78,7 @@ set_reproducible_mirrors()
 
     local mirrors="/etc/apt/sources.list $(find /etc/apt/sources.list.d/ -type f)"
     for mirror in $mirrors; do
-        sed -i "$expression" "$mirror"
+        $SUDO sed -i "$expression" "$mirror"
     done
 }
 
@@ -161,7 +167,7 @@ run_pip_command()
             install=y
         elif [[ "$para" == *.whl ]]; then
             package_name=$(echo $para | cut -d- -f1 | tr _ .)
-            sed "/^${package_name}==/d" -i $tmp_version_file
+            $SUDO sed "/^${package_name}==/d" -i $tmp_version_file
         fi
     done
 

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -17,10 +17,10 @@ REPR_MIRROR_URL_PATTERN='http:\/\/packages.trafficmanager.net\/debian'
 
 URL_PREFIX=$(echo "${PACKAGE_URL_PREFIX}" | sed -E "s#(//[^/]*/).*#\1#")
 
-if [[ $USER == 'root' ]];then
-    SUDO=''
-else
+if [ $USER != 'root' ] && [ -n $(which sudo) ];then
     SUDO=sudo
+else
+    SUDO=''
 fi
 
 log_err()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
when using 'sed -i' the directory must also be writable as sed will create a temporary file in that directory first.
This issue breaks building sonic-mgmt docker image.
we should use sudo to resolve this issue, but sonic-base image haven't installed sudo tool.
So we should use both 'sed -i' and 'sudo sed -i'
#### How I did it
add retry with sudo.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

