### PR TITLE
saibcm-modules: Send full packet size information to psample

### DIFF
--- a/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/knet-cb/psample-cb.c
+++ b/platform/broadcom/saibcm-modules/systems/linux/kernel/modules/knet-cb/psample-cb.c
@@ -509,7 +509,7 @@ psample_filter_cb(uint8_t * pkt, int size, int dev_no, void *pkt_meta,
         /* setup skb to point to pkt */
         memcpy(skb->data, pkt, meta.trunc_size);
         skb_put(skb, meta.trunc_size);
-        skb->len = meta.trunc_size;
+        skb->len = size;
         psample_pkt->skb = skb;
 
         spin_lock_irqsave(&g_psample_work.lock, flags);


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

I noticed that sFlow accounting was reporting incorrect packet size. See https://groups.google.com/g/sonicproject/c/RFlJfuYynf0 for more debugging. 

#### How I did it

I figured out that `skb->len` is the only code path that sets `origsize` and thus we must set it to the original length. Data should not be read further than `truncsize` anyway, so it should be a safe change.

#### How to verify it

Client:
```
# Send a lot of  large packets from a host through the DUT
sudo ping 169.254.0.1 -i 0.01 -s 1024
```

DUT:
```
# Configure and set up sFlow
admin@sonic:~$ sudo config feature state sflow enabled
admin@sonic:~$ sudo config sflow enable
admin@sonic:~$ sudo config sflow interface sample-rate Ethernet44 256
admin@sonic:~$ sudo config sflow interface sample-rate Ethernet46 256

# Use 'psample' to read the raw psample frames
admin@sonic:~$ psample -v
group 1 in-ifindex 52 out-ifindex 54 origsize 1070 sample-rate 256 seq 29 data len 128
0x0000:  82 e3 3f 86 00 0a 82 e3 3f 86 00 09 81 00 00 64  ..?.....?......d
0x0010:  08 00 45 00 04 1c c5 1c 00 00 40 01 5d c5 a9 fe  ..E.......@.]...
0x0020:  00 01 a9 fe 00 02 00 00 23 b8 fd 5d 05 14 b9 fc  ........#..]....
0x0030:  ca 61 00 00 00 00 80 b8 0c 00 00 00 00 00 10 11  .a..............
0x0040:  12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21  .............. !
0x0050:  22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f 30 31  "#$%&'()*+,-./01
0x0060:  32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f 40 41  23456789:;<=>?@A
0x0070:  42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f 50 51  BCDEFGHIJKLMNOPQ
```

Note how `origsize` is now correct.

I have verified the full sFlow implementation using an Edge-core AS5712-54X with SONiC 202012 together with an ElastiFlow stack with the suggested patch applied. It correctly accounts the data throughput with this patch applied. Before the patch it is off by ~10x when the packet size is 1480.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

Backport to earlier releases as this is a bug fix that affects accounting.

#### Description for the changelog

sflow: Report original packet size instead of truncated packet size

#### A picture of a cute animal (not mandatory but encouraged)

![image](https://user-images.githubusercontent.com/149442/147511566-1135f23f-ed07-45e7-94ba-fd5ae6ee11e6.png)
