### PR TITLE
[DPB][YANG] Fix cases when boolean is used in different literal cases

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1207,9 +1207,9 @@
         "FEATURE": {
             "bgp": {
                 "auto_restart": "enabled",
-                "has_global_scope": "false",
-                "has_per_asic_scope": "true",
-                "has_timer": "false",
+                "has_global_scope": "False",
+                "has_per_asic_scope": "True",
+                "has_timer": "False",
                 "high_mem_alert": "disabled",
                 "state": "enabled",
                 "set_owner": "local"
@@ -1322,7 +1322,7 @@
                 "scheduler": "TEST@1",
                 "wred_profile": "Wred1"
             }
-         },		
+         },
 
         "DSCP_TO_TC_MAP": {
            "Dscp_to_tc_map1": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/feature.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/feature.json
@@ -14,5 +14,10 @@
     },
     "FEATURE_WITH_NO_OWNER" : {
         "desc": "Config feature table without set_owner"
+    },
+    "FEATURE_WITH_INVALID_BOOLEAN_TYPE" : {
+        "desc": "Referring invalid feature boolean types.",
+        "eStrKey": "Pattern",
+        "eStr": ["false|true|False|True"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/feature.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/feature.json
@@ -7,6 +7,11 @@
         "eStrKey": "Pattern",
         "eStr": ["enabled|disabled|always_enabled|always_disabled"]
     },
+    "FEATURE_WITH_INVALID_BOOLEAN_TYPE" : {
+        "desc": "Referring invalid feature boolean types.",
+        "eStrKey": "Pattern",
+        "eStr": ["false|true|False|True"]
+    },
     "FEATURE_WITH_INVALID_OWNER" : {
         "desc": "Referring invalid feature set_owner field.",
         "eStrKey": "Pattern",
@@ -14,10 +19,5 @@
     },
     "FEATURE_WITH_NO_OWNER" : {
         "desc": "Config feature table without set_owner"
-    },
-    "FEATURE_WITH_INVALID_BOOLEAN_TYPE" : {
-        "desc": "Referring invalid feature boolean types.",
-        "eStrKey": "Pattern",
-        "eStr": ["false|true|False|True"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/feature.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/feature.json
@@ -7,9 +7,9 @@
                         "name": "database",
                         "state": "always_enabled",
                         "auto_restart": "always_enabled",
-                        "has_timer": "false",
-                        "has_global_scope": "true",
-                        "has_per_asic_scope": "true",
+                        "has_timer": "False",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
                         "set_owner": "local"
                     },
                     {
@@ -97,6 +97,22 @@
                         "has_timer": "false",
                         "has_global_scope": "false",
                         "has_per_asic_scope": "true"
+                    }
+                ]
+            }
+        }
+    },
+    "FEATURE_WITH_INVALID_BOOLEAN_TYPE": {
+        "sonic-feature:sonic-feature": {
+            "sonic-feature:FEATURE": {
+                "FEATURE_LIST": [
+                    {
+                        "name": "database",
+                        "state": "always_enabled",
+                        "auto_restart": "always_enabled",
+                        "has_timer": "FALSE",
+                        "has_global_scope": "TRUE",
+                        "has_per_asic_scope": "TRUE"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-feature.yang
+++ b/src/sonic-yang-models/yang-models/sonic-feature.yang
@@ -5,8 +5,12 @@ module sonic-feature{
     namespace "http://github.com/Azure/sonic-feature";
     prefix feature;
 
+    import sonic-types {
+        prefix stypes;
+    }
+
     description "Feature Table yang Module for SONiC";
-    
+
     typedef feature-state {
         description "configuration to set the feature running state";
         type string {
@@ -53,22 +57,22 @@ module sonic-feature{
                 leaf has_timer {
                     description "This configuration identicates if there is
                                 timer associated to this feature";
-                    type boolean;
-                    default false;
+                    type stypes:boolean_type;
+                    default "false";
                 }
 
                 leaf has_global_scope {
                     description "This configuration identicates there will only one service
                                 spawned for the device";
-                    type boolean;
-                    default false;
+                    type stypes:boolean_type;
+                    default "false";
                 }
 
                 leaf has_per_asic_scope {
                     description "This configuration identicates there will only one service
                                 spawned per asic";
-                    type boolean;
-                    default false;
+                    type stypes:boolean_type;
+                    default "false";
                 }
 
                 leaf high_mem_alert {

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -5,6 +5,10 @@ module sonic-flex_counter {
     namespace "http://github.com/Azure/sonic-flex_counter";
     prefix flex_counter;
 
+    import sonic-types {
+        prefix stypes;
+    }
+
     description "FLEX COUNTER YANG Module for SONiC OS";
 
     revision 2020-04-10 {
@@ -24,7 +28,7 @@ module sonic-flex_counter {
             }
 
             typedef flex_delay_status {
-                type boolean;
+                type stypes:boolean_type;
             }
 
             typedef poll_interval {

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -217,6 +217,12 @@ module sonic-types {
         }
     }
 
+    typedef boolean_type {
+        type string {
+            pattern "false|true|False|True";
+        }
+    }
+
     typedef mac-addr-and-mask {
         type string {
             pattern "[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}|[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}/[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}";


### PR DESCRIPTION
* Add boolean as typedef to sonic-types
* Fix boolean in sonic-feature yang model
* Fix boolean in sonic-flex_counter yang model

Signed-off-by: Mykola Gerasymenko <mykolax.gerasymenko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It was request to cherry-pick fix from master (#9418) to 202111 branch to fix issue when boolean is used in different literal cases.

#### How I did it
Added boolean to sonic-types as typedef with different literal cases.

#### How to verify it
Run the command config interface breakout <interface_name> <breakout_mode>

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

