### PR TITLE
[201811] Fix DHCP Relay Monitor Jinaja2 Template file.

### DIFF
--- a/dockers/docker-dhcp-relay/dhcpv6-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.monitors.j2
@@ -38,6 +38,7 @@ dhcpmon-{{ vlan_name }}
 {% endif %}
 {% endfor %}
 {% endif %}
+{% if relay_for_ipv4.flag or relay_for_ipv6.flag %}
 [program:dhcpmon-{{ vlan_name }}]
 {# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
 command=/usr/sbin/dhcpmon -id {{ vlan_name }}
@@ -58,10 +59,6 @@ command=/usr/sbin/dhcpmon -id {{ vlan_name }}
 {% endif %}
 {% if relay_for_ipv4.flag %} -4{% endif %}
 {% if relay_for_ipv6.flag %} -6{% endif %}
-{% if relay_for_ipv4.flag %}
-{% set _dummy = relay_for_ipv4.update({'flag': False}) %}
-{% if relay_for_ipv6.flag %}
-{% set _dummy = relay_for_ipv6.update({'flag': False}) %}
 
 priority=4
 autostart=false
@@ -72,6 +69,5 @@ stderr_logfile=syslog
 
 {% set _dummy = relay_for_ipv4.update({'flag': False}) %}
 {% set _dummy = relay_for_ipv6.update({'flag': False}) %}
-{% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Why I did:

DHCP Relay docker does not start if we don't have v6 DHCP Relay address as this caused jinja2 template generation failure.

What I did:

Fixed the template . The fix is to make template generation same as present in master code.

How I verify:

Manual Verification and make sure dhcp relay docker is running fine. 


