### PR TITLE
[Celestica Seastone2] Build correct platform files

### DIFF
--- a/device/celestica/x86_64-cel_seastone_2-r0/plugins/sfputil.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/plugins/sfputil.py
@@ -47,7 +47,7 @@ class SfpUtil(SfpUtilBase):
         if port_num in self.qsfp_ports:
             self._port_name = "QSFP" + str(port_num - self.QSFP_PORT_START + 1)
         else:
-            self._port_name = "SFP" + str(port_num)
+            self._port_name = "SFP" + str(port_num - self.QSFP_PORT_END)
         return self._port_name
 
     # def get_eeprom_dom_raw(self, port_num):

--- a/device/celestica/x86_64-cel_seastone_2-r0/plugins/sfputil.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/plugins/sfputil.py
@@ -50,13 +50,13 @@ class SfpUtil(SfpUtilBase):
             self._port_name = "SFP" + str(port_num - self.QSFP_PORT_END)
         return self._port_name
 
-    # def get_eeprom_dom_raw(self, port_num):
-    #     if port_num in self.qsfp_ports:
-    #         # QSFP DOM EEPROM is also at addr 0x50 and thus also stored in eeprom_ifraw
-    #         return None
-    #     else:
-    #         # Read dom eeprom at addr 0x51
-    #         return self._read_eeprom_devid(port_num, self.DOM_EEPROM_ADDR, 256)
+    def get_eeprom_dom_raw(self, port_num):
+        if port_num in self.qsfp_ports:
+            # QSFP DOM EEPROM is also at addr 0x50 and thus also stored in eeprom_ifraw
+            return None
+        else:
+            # Read dom eeprom as offset 0x100 on optoe eeprom
+            return self._read_eeprom_devid(port_num, self.DOM_EEPROM_ADDR, 256)
 
     def __init__(self):
         # Override port_to_eeprom_mapping for class initialization

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/event.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/event.py
@@ -38,9 +38,14 @@ class SfpEvent:
 
         for index in range(self.num_sfp):
             port_num = index + 1
-            port_name = "QSFP{}".format(port_num)
-            port_type = "qsfp"
-            sysfs_prs_file = "{}_modprs".format(port_type)
+            if port_num <= 32:
+                port_name = "QSFP{}".format(port_num)
+                port_type = "qsfp"
+                sysfs_prs_file = "{}_modprs".format(port_type)
+            else:
+                port_name = "SFP{}".format(port_num - 32)
+                port_type = "sfp"
+                sysfs_prs_file = "{}_modabs".format(port_type)
 
             sfp_info_obj[index] = {}
             sfp_info_obj[index]['intmask_sysfs'] = self.PATH_INTMASK_SYSFS.format(

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/sfp.json
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/sfp.json
@@ -1,5 +1,5 @@
 {
-    "port_num": 32,
+    "port_num": 33,
     "eeprom_path": "/sys/bus/i2c/devices/i2c-{0}/{0}-0050/eeprom",
     "port_i2c_mapping": [
         2,
@@ -33,7 +33,8 @@
         30,
         31,
         32,
-        33
+        33,
+        34
     ],
     "get_presence": {
         "output_source": "sysfs_value",
@@ -101,6 +102,7 @@
         "QSFP29",
         "QSFP30",
         "QSFP31",
-        "QSFP32"
+        "QSFP32",
+        "SFP1"
     ]
 }

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/sfp.json
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/sfp.json
@@ -38,8 +38,8 @@
     ],
     "get_presence": {
         "output_source": "sysfs_value",
-        "sysfs_path": "/sys/devices/platform/switchboard/SFF/{}/qsfp_modprs",
-        "argument": "$ref:_port_name",
+        "sysfs_path": "/sys/devices/platform/switchboard/SFF/{}",
+        "argument": "$ref:_presence_file",
         "output_translator": "False if '{}' == '1' else True"
     },
     "get_lpmode": {
@@ -104,5 +104,40 @@
         "QSFP31",
         "QSFP32",
         "SFP1"
+    ],
+    "_presence_file": [
+      "QSFP1/qsfp_modprs",
+      "QSFP2/qsfp_modprs",
+      "QSFP3/qsfp_modprs",
+      "QSFP4/qsfp_modprs",
+      "QSFP5/qsfp_modprs",
+      "QSFP6/qsfp_modprs",
+      "QSFP7/qsfp_modprs",
+      "QSFP8/qsfp_modprs",
+      "QSFP9/qsfp_modprs",
+      "QSFP10/qsfp_modprs",
+      "QSFP11/qsfp_modprs",
+      "QSFP12/qsfp_modprs",
+      "QSFP13/qsfp_modprs",
+      "QSFP14/qsfp_modprs",
+      "QSFP15/qsfp_modprs",
+      "QSFP16/qsfp_modprs",
+      "QSFP17/qsfp_modprs",
+      "QSFP18/qsfp_modprs",
+      "QSFP19/qsfp_modprs",
+      "QSFP20/qsfp_modprs",
+      "QSFP21/qsfp_modprs",
+      "QSFP22/qsfp_modprs",
+      "QSFP23/qsfp_modprs",
+      "QSFP24/qsfp_modprs",
+      "QSFP25/qsfp_modprs",
+      "QSFP26/qsfp_modprs",
+      "QSFP27/qsfp_modprs",
+      "QSFP28/qsfp_modprs",
+      "QSFP29/qsfp_modprs",
+      "QSFP30/qsfp_modprs",
+      "QSFP31/qsfp_modprs",
+      "QSFP32/qsfp_modprs",
+      "SFP1/sfp_modabs"
     ]
 }

--- a/platform/broadcom/sonic-platform-modules-cel/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/rules
@@ -14,7 +14,7 @@ override_dh_auto_build:
 	(for mod in $(MODULE_DIRS); do \
 		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
 		if [ $$mod = "seastone2" ]; then \
-			cd services/platform_api; \
+			cd $(MOD_SRC_DIR)/services/platform_api; \
 			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
 			continue; \
 		fi; \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
I noticed `show interfaces transceiver presence` was not showing correct state for our inserted transceivers

#### How I did it
Redis database was missing `TRANSCEIVER_INFO` keys and found out that xcvrd process was crashing:
```
Dec 28 22:54:12.246211 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd Traceback (most recent call last):
Dec 28 22:54:12.246246 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd   File "/usr/local/bin/xcvrd", line 8, in <module>
Dec 28 22:54:12.246280 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd     sys.exit(main())
Dec 28 22:54:12.247190 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python2.7/dist-packages/xcvrd/xcvrd.py", line 1441, in main
Dec 28 22:54:12.247190 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd     xcvrd.run()
Dec 28 22:54:12.247190 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python2.7/dist-packages/xcvrd/xcvrd.py", line 1389, in run
Dec 28 22:54:12.247190 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd     self.init()
Dec 28 22:54:12.247255 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python2.7/dist-packages/xcvrd/xcvrd.py", line 1352, in init
Dec 28 22:54:12.247904 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd     post_port_sfp_dom_info_to_db(is_warm_start, self.stop_event)
Dec 28 22:54:12.247904 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python2.7/dist-packages/xcvrd/xcvrd.py", line 518, in post_port_sfp_dom_info_to_db
Dec 28 22:54:12.247904 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd     post_port_sfp_info_to_db(logical_port_name, int_tbl[asic_index], transceiver_dict, stop_event)
Dec 28 22:54:12.247904 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python2.7/dist-packages/xcvrd/xcvrd.py", line 303, in post_port_sfp_info_to_db
Dec 28 22:54:12.247968 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd     if not _wrapper_get_presence(physical_port):
Dec 28 22:54:12.248586 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd   File "/usr/local/lib/python2.7/dist-packages/xcvrd/xcvrd.py", line 151, in _wrapper_get_presence
Dec 28 22:54:12.248586 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd     return platform_chassis.get_sfp(physical_port).get_presence()
Dec 28 22:54:12.248586 ixp-kg-sw1 INFO pmon#/supervisord: xcvrd AttributeError: 'NoneType' object has no attribute 'get_presence'
Dec 28 22:54:12.308896 ixp-kg-sw1 INFO pmon#supervisord 2021-12-28 22:54:12,307 INFO exited: xcvrd (exit status 1; not expected)
Dec 28 22:54:13.311306 ixp-kg-sw1 INFO pmon#supervisord 2021-12-28 22:54:13,309 INFO gave up: xcvrd entered FATAL state, too many start retries too quickly
```

After some investigation I figured out that the platform file `/usr/local/lib/python2.7/dist-packages/sonic_platform/sfp.py` was not intended for seastone2 but for silverstone. The build process was working in the relative directory for silverstone instead of seastone2.

#### How to verify it
Check logs for xcvrd and verify that it's not crashing anymore

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012
- [X] 202106
- [X] 202111

Backport to earlier releases as this is a bug fix for critical hardware monitoring

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[Celestica Seastone2] Build correct platform files

#### A picture of a cute animal (not mandatory but encouraged)
![LRG_DSC02033](https://user-images.githubusercontent.com/91976/147707297-29893fda-a62e-487d-bdc5-563491f55fd7.JPG)

