### PR TITLE
[Build]: Fix gmock not found issue in debian stretch slave container

### DIFF
--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -239,6 +239,8 @@ RUN apt-get update && apt-get install -y \
 {%- endif %}
 # For lockfile
         procmail \
+# For gmock
+        libgmock-dev -t stretch-backports \
 # For pam_tacplus build
         autoconf-archive \
 # For iproute2

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -239,8 +239,6 @@ RUN apt-get update && apt-get install -y \
 {%- endif %}
 # For lockfile
         procmail \
-# For gmock
-        libgmock-dev -t stretch-backports \
 # For pam_tacplus build
         autoconf-archive \
 # For iproute2
@@ -301,6 +299,9 @@ RUN apt-get update && apt-get install -y \
 # For audisp-tacplus
         libauparse-dev \
         auditd
+
+# For gmock
+RUN apt-get install -y libgmock-dev -t stretch-backports
 
 # Install dependencies for dhcp relay test 
 RUN pip3 install parameterized==0.8.1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the gmock not found issue in debian stretch slave container.
Some of platforms, such as naphos, innovium, have such issue.

See https://dev.azure.com/mssonic/build/_build/results?buildId=62861&view=logs&j=1111c693-39b7-5a16-3aee-406c790b3886&t=d6851b2d-8b22-5ce8-7267-f54b7a47081b

```
2022-01-03T09:03:27.8890266Z /usr/bin/ld: cannot find -lgmock
2022-01-03T09:03:27.8891526Z /usr/bin/ld: cannot find -lgmock_main
2022-01-03T09:03:27.8892509Z collect2: error: ld returned 1 exit status
2022-01-03T09:03:27.8893983Z Makefile:467: recipe for target 'tests' failed
2022-01-03T09:03:27.8895220Z make[4]: *** [tests] Error 1
2022-01-03T09:03:27.8896751Z make[4]: Leaving directory '/sonic/src/sonic-swss-common/tests'
2022-01-03T09:03:27.8898681Z Makefile:439: recipe for target 'all-recursive' failed
2022-01-03T09:03:27.8900527Z make[3]: *** [all-recursive] Error 1
2022-01-03T09:03:27.8901915Z make[3]: Leaving directory '/sonic/src/sonic-swss-common'
2022-01-03T09:03:27.8903525Z Makefile:371: recipe for target 'all' failed
2022-01-03T09:03:27.8904463Z make[2]: *** [all] Error 2
2022-01-03T09:03:27.8905338Z make[2]: Leaving directory '/sonic/src/sonic-swss-common'
2022-01-03T09:03:27.8910445Z dh_auto_build: make -j4 returned exit code 2
```
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

