### PR TITLE
Get asic PCI ID from CHASSIS_STATE_DB and update asic_id in CONFIG_DB

### DIFF
--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -40,4 +40,21 @@ if [ "$VLAN" != "" ]; then
     cp /usr/share/sonic/templates/ndppd.conf /etc/supervisor/conf.d/
 fi
 
+USE_PCI_ID_IN_CHASSIS_STATE_DB=/usr/share/sonic/platform/use_pci_id_chassis
+ASIC_ID="asic$NAMESPACE_ID"
+if [ -f "$USE_PCI_ID_IN_CHASSIS_STATE_DB" ]; then
+    while true; do
+        PCI_ID=$(sonic-db-cli -s CHASSIS_STATE_DB HGET "CHASSIS_ASIC_TABLE|$ASIC_ID" asic_pci_address)
+        if [ -z "$PCI_ID" ]; then
+            sleep 3
+        else
+            # Update asic_id in CONFIG_DB, which is used by orchagent and fed to syncd
+            if [[ $PCI_ID == ????:??:??.? ]]; then
+                sonic-db-cli CONFIG_DB HSET 'DEVICE_METADATA|localhost' 'asic_id' ${PCI_ID#*:}
+                break
+            fi
+        fi
+    done
+fi
+
 exec /usr/local/bin/supervisord


### PR DESCRIPTION
Asic PCI ID (PCI address) is collected by chassisd (inside pmon -
Azure/sonic-platform-daemons#175) and saved in CHASSIS_STATE_DB (in
redis_chassis). CHASSIS_STATE_DB is accessible by swss containers.

At docker-init.sh (script is called after swss container is created and before
anything that could run in swss like orchagent...), we wait until asic PCI ID
of the corresponding asic is populated by chassisd. We then update asic_id in
CONFIG_DB of asic's database.

A system supporting dynamic asic PCI ID identification requires to have a file
(empty) use_pci_id_chassis in its platform dir.

When orchagent runs, it has correct asic PCI ID in its CONFIG_DB.

Together with this PR:

Azure/sonic-platform-daemons#175
Azure/sonic-platform-common#185

Signed-off-by: Maxime Lorrillere <mlorrillere@arista.com>