### PR TITLE
[Bug][Build]: Fix the package url not found when package name encoded issue

### DIFF
--- a/scripts/build_debian_base_system.sh
+++ b/scripts/build_debian_base_system.sh
@@ -61,7 +61,7 @@ rm -rf $BASEIMAGE_TARBALLPATH $BASEIMAGE_TARBALL
 ARCHIEVES=$BASEIMAGE_TARBALLPATH/var/cache/apt/archives
 APTLIST=$BASEIMAGE_TARBALLPATH/var/lib/apt/lists
 TARGET_DEBOOTSTRAP=$BASEIMAGE_TARBALLPATH/debootstrap
-APTDEBIAN="$APTLIST/deb.debian.org_debian_dists_buster_main_binary-${CONFIGURED_ARCH}_Packages"
+APTDEBIAN="$APTLIST/deb.debian.org_debian_dists_${DISTRO}_main_binary-${CONFIGURED_ARCH}_Packages"
 DEBPATHS=$TARGET_DEBOOTSTRAP/debpaths
 DEBOOTSTRAP_BASE=$TARGET_DEBOOTSTRAP/base
 DEBOOTSTRAP_REQUIRED=$TARGET_DEBOOTSTRAP/required
@@ -84,7 +84,7 @@ do
         exit 1
     fi
     filename=$(basename "$url")
-    SKIP_BUILD_HOOK=y wget $url -P $ARCHIEVES
+    SKIP_BUILD_HOOK=y wget $url -O $ARCHIEVES/$filename
     echo $packagename >> $DEBOOTSTRAP_REQUIRED
     echo "$packagename /var/cache/apt/archives/$filename" >> $DEBPATHS
 done

--- a/scripts/build_debian_base_system.sh
+++ b/scripts/build_debian_base_system.sh
@@ -13,6 +13,8 @@ TARGET=$TARGET_PATH
 TARGET_BASEIMAGE_PATH=$TARGET/versions/host-base-image
 mkdir -p $TARGET_BASEIMAGE_PATH
 
+alias urlencode='python3 -c "import sys, urllib.parse as ul; print (ul.quote_plus(sys.argv[1]))"'
+
 generate_version_file()
 {
     sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "dpkg-query -W -f '\${Package}==\${Version}\n'" > $TARGET_BASEIMAGE_PATH/versions-deb-${IMAGE_DISTRO}-${CONFIGURED_ARCH}
@@ -74,7 +76,8 @@ for ((i=0;i<LENGTH;i++))
 do
     package=${PACKAGE_ARR[$i]}
     packagename=$(echo $package | sed -E 's/=[^=]*$//')
-    url=$(echo "$URL_ARR" | grep "/${packagename}_")
+    encoded_packagename=$(urlencode $packagename)
+    url=$(echo "$URL_ARR" | grep -i "/${packagename}_\|/${encode_packagename}_")
     if [ -z "$url" ] || [[ $(echo "$url" | wc -l) -gt 1 ]]; then
         echo "No found package or found multiple package for package $packagename, url: $url" 2>&1
         exit 1

--- a/scripts/build_debian_base_system.sh
+++ b/scripts/build_debian_base_system.sh
@@ -77,7 +77,7 @@ do
     package=${PACKAGE_ARR[$i]}
     packagename=$(echo $package | sed -E 's/=[^=]*$//')
     encoded_packagename=$(urlencode $packagename)
-    url=$(echo "$URL_ARR" | grep -i "/${packagename}_\|/${encode_packagename}_")
+    url=$(echo "$URL_ARR" | grep -i "/${packagename}_\|/${encoded_packagename}_")
     if [ -z "$url" ] || [[ $(echo "$url" | wc -l) -gt 1 ]]; then
         echo "No found package or found multiple package for package $packagename, url: $url" 2>&1
         exit 1

--- a/scripts/build_debian_base_system.sh
+++ b/scripts/build_debian_base_system.sh
@@ -14,6 +14,7 @@ TARGET_BASEIMAGE_PATH=$TARGET/versions/host-base-image
 mkdir -p $TARGET_BASEIMAGE_PATH
 
 alias urlencode='python3 -c "import sys, urllib.parse as ul; print (ul.quote_plus(sys.argv[1]))"'
+shopt -s expand_aliases
 
 generate_version_file()
 {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When the package name with special characters, such as +, the package name may be encoded as %2b, the package url will not be found when reproducible build enabled.
see https://dev.azure.com/kamelnetworks/53a5c7e8-3f52-4611-a688-a61ab05a4216/_apis/build/builds/24/logs/10

```
2022-01-05T15:12:48.9426322Z 2022-01-05 15:12:48 (119 MB/s) - 'target/baseimage/var/cache/apt/archives/libssl1.1_1.1.1k-1+deb11u1_amd64.deb' saved [1554464/1554464]
2022-01-05T15:12:48.9426584Z 
2022-01-05T15:12:48.9426887Z No found package or found multiple package for package libstdc++6, url: 
2022-01-05T15:12:48.9427392Z [  FAIL LOG END  ] [ target/sonic-aboot-broadcom.swi ]
```

#### How I did it
Fix the filename encoding issue.
Fix the buster hardcode issue.

#### How to verify it
```
root@491bb27ffd95:~# encoded_packagename=$(urlencode $packagename)
root@491bb27ffd95:~# echo ${packagename} ${encoded_packagename}
libstdc++6 libstdc%2B%2B6
root@491bb27ffd95:~# echo "$URL_ARR" | grep -i "/${packagename}_"
root@491bb27ffd95:~# echo "$URL_ARR" | grep -i "/${packagename}_\|/${encoded_packagename}_"
http://deb.debian.org/debian/pool/main/g/gcc-10/libstdc%2b%2b6_10.2.1-6_amd64.deb
root@491bb27ffd95:~# 
```

1. Start sonic-slave-bullseye
2. Clone code: git clone -b 202111 https://github.com/azure/sonic-buildimage
3. Change the config in /usr/local/share/buildinfo/config/buildinfo.config
   SONIC_VERSION_CONTROL_COMPONENTS=all
4. Apply the commits in this PR
5. Run following command to build the base image:
   ./scripts/build_debian_base_system.sh amd64 bullseye fsroot

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

