### PR TITLE
[dhcp_relay] Fix import for dhcp_counters on clear_dhcp6relay_counter.py

### DIFF
--- a/dockers/docker-dhcp-relay/cli/clear/plugins/clear_dhcp6relay_counter.py
+++ b/dockers/docker-dhcp-relay/cli/clear/plugins/clear_dhcp6relay_counter.py
@@ -1,6 +1,7 @@
 import sys
 import click
-from show.plugins.dhcprelay import DHCPv6_Counter
+import importlib
+importlib.import_module('show.plugins.dhcp-relay')
 
 import utilities_common.cli as clicommon
 


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Import issue will cause:
root@sonic:/# sudo sonic-clear arp
failed to import plugin clear.plugins.dhcprelay: No module named 'show_dhcp_relay'

#### How I did it

Fix the import.

#### How to verify it

run sudo sonic-clear arp

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

