### PR TITLE
[YANG]: Add support for dual ToR attributes

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
+++ b/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
@@ -16,7 +16,7 @@ PASS = 0
 FAIL = 1
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger("YANG-TEST")
-log.setLevel(logging.INFO)
+log.setLevel(logging.WARNING)
 log.addHandler(logging.NullHandler())
 
 # Global functions

--- a/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
+++ b/src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py
@@ -16,7 +16,7 @@ PASS = 0
 FAIL = 1
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger("YANG-TEST")
-log.setLevel(logging.WARNING)
+log.setLevel(logging.INFO)
 log.addHandler(logging.NullHandler())
 
 # Global functions

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -76,7 +76,7 @@
 	},
 	"DEVICE_METADATA_INVALID_STORAGE_DEVICE": {
 		"desc": "Verifying invalid storage device value",
-		"eStrKey": "Pattern"
+		"eStrKey": "InvalidValue"
 	}
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -71,6 +71,10 @@
 	"DEVICE_METADATA_VALID_PEER_SWITCH": {
 		"desc": "Verifying valid peer switch hostname"
 	},
+	"DEVICE_METADATA_INVALID_PEER_SWITCH": {
+		"desc": "Verifying test fails with hostname that is too long",
+		"eStrKey": "Range"
+	},
 	"DEVICE_METADATA_VALID_STORAGE_DEVICE": {
 		"desc": "Verifying valid storage device value"
 	},

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -60,6 +60,23 @@
     },
     "DEVICE_METADATA_CORRECT_CLOUDTYPE_REGION_CONFIG": {
         "desc": "Verifying cloudtype and region configuration."
-    }
+    },
+	"DEVICE_METADATA_VALID_SUBTYPE": {
+		"desc": "Verifying valid subtype value"
+	},
+	"DEVICE_METADATA_INVALID_SUBTYPE": {
+		"desc": "Verifying invalid subtype value",
+		"eStrKey": "Pattern"
+	},
+	"DEVICE_METADATA_VALID_PEER_SWITCH": {
+		"desc": "Verifying valid peer switch hostname"
+	},
+	"DEVICE_METADATA_VALID_STORAGE_DEVICE": {
+		"desc": "Verifying valid storage device value"
+	},
+	"DEVICE_METADATA_INVALID_STORAGE_DEVICE": {
+		"desc": "Verifying invalid storage device value",
+		"eStrKey": "Pattern"
+	}
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -66,5 +66,12 @@
         "desc": "PORT_INVALID_TPID_TEST invalid tpid value failure.",
         "eStrKey" : "Pattern",
         "eStr": ["0x8100|0x9100|0x9200|0x88a8|0x88A8"]
+     },
+     "PORT_VALID_MUX_CABLE_TEST": {
+         "desc": "PORT_VALID_MUX_CABLE_TEST no failure."
+     },
+     "PORT_INVALID_MUX_CABLE_TEST": {
+         "desc": "PORT_INVALID_MUX_CABLE_TEST non-boolean values, expect fail",
+         "eStrKey": "Pattern"
      }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -72,6 +72,6 @@
      },
      "PORT_INVALID_MUX_CABLE_TEST": {
          "desc": "PORT_INVALID_MUX_CABLE_TEST non-boolean values, expect fail",
-         "eStrKey": "Pattern"
+         "eStrKey": "InvalidValue"
      }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -56,5 +56,23 @@
     },
     "DHCPV6_SERVER_VALID_FORMAT": {
         "desc": "Add dhcpv6_server in correct format."
+    },
+    "INVALID_VLAN_MAC": {
+        "desc": "VLAN with invalid MAC address",
+        "eStrKey": "Pattern"
+    },
+    "VLAN_INTERFACE_VALID_GRAT_ARP": {
+        "desc": "VLAN_INTERFACE with valid grat_arp value"
+    },
+    "VLAN_INTERFACE_VALID_PROXY_ARP": {
+        "desc": "VLAN_INTERFACE with valid proxy_arp value"
+    },
+    "VLAN_INTERFACE_INVALID_GRAT_ARP": {
+        "desc": "VLAN_INTERFACE with invalid grat_arp value",
+        "eStrKey": "Pattern"
+    },
+    "VLAN_INTERFACE_INVALID_PROXY_ARP": {
+        "desc": "VLAN_INTERFACE with invalid proxy_arp value",
+        "eStrKey": "Pattern"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -159,5 +159,50 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_VALID_SUBTYPE": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "subtype": "DualToR"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_INVALID_SUBTYPE": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "subtype": "FakeSubtype"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_VALID_PEER_SWITCH": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "peer_switch": "peer_01_hostname"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_VALID_STORAGE_DEVICE": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "storage_device": "true"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_INVALID_STORAGE_DEVICE": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "storage_device": "yes"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -187,6 +187,15 @@
             }
         }
     },
+    "DEVICE_METADATA_INVALID_PEER_SWITCH": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "peer_switch": "this_super_duper_long_hostname_is_too_long_according_to_RFC_1035"
+                }
+            }
+        }
+    },
     "DEVICE_METADATA_VALID_STORAGE_DEVICE": {
         "sonic-device_metadata:sonic-device_metadata": {
             "sonic-device_metadata:DEVICE_METADATA": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -275,5 +275,44 @@
                 ]
             }
         }
+    },
+    
+    "PORT_VALID_MUX_CABLE_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 50000,
+                        "mux_cable": "true"
+                    },
+                    {
+                        "name": "Ethernet12",
+                        "alias": "eth12",
+                        "lanes": "6",
+                        "speed": 50000,
+                        "mux_cable": "false"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_INVALID_MUX_CABLE_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 50000,
+                        "mux_cable": "enabled"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -21,7 +21,8 @@
                             "10.186.72.66"
                         ],
                         "mtu": "9100",
-                        "name": "Vlan200"
+                        "name": "Vlan200",
+                        "mac": "00:aa:bb:cc:dd:ee"
                     }
                 ]
             }
@@ -520,6 +521,95 @@
                 "VLAN_INTERFACE_LIST": [
                     {
                         "name": "Vlan400"
+                    }
+                ]
+            }
+        }
+    },
+    "INVALID_VLAN_MAC": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "admin_status": "up",
+                        "name": "Vlan1000",
+                        "mac": "12345678"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_VALID_GRAT_ARP": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan1000"
+                    },
+                    {
+                        "name": "Vlan2000"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "grat_arp": "enabled"
+                    },
+                    {
+                        "name": "Vlan2000",
+                        "grat_arp": "disabled"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_VALID_PROXY_ARP": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan1000"
+                    },
+                    {
+                        "name": "Vlan2000"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "proxy_arp": "enabled"
+                    },
+                    {
+                        "name": "Vlan2000",
+                        "proxy_arp": "disabled"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_INVALID_GRAT_ARP": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "grat_arp": "true"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_INVALID_PROXY_ARP": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan1000",
+                        "proxy_arp": "true"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -138,9 +138,7 @@ module sonic-device_metadata {
                 }
 
                 leaf storage_device {
-                    type string {
-                        pattern "true|false";
-                    }
+                    type boolean;
                 }
             }
             /* end of container localhost */

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -56,9 +56,7 @@ module sonic-device_metadata {
                 }
 
                 leaf hostname {
-                    type string {
-                        length 1..255;
-                    }
+                    type stypes:hostname;
                 }
 
                 leaf platform {
@@ -127,6 +125,22 @@ module sonic-device_metadata {
 
                 leaf region {
                     type string;
+                }
+
+                leaf subtype {
+                    type string {
+                        pattern "DualToR";
+                    }
+                }
+
+                leaf peer_switch {
+                    type stypes:hostname;
+                }
+
+                leaf storage_device {
+                    type string {
+                        pattern "true|false";
+                    }
                 }
             }
             /* end of container localhost */

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -138,6 +138,12 @@ module sonic-port{
 					type stypes:tpid_type;
 				}
 
+				leaf mux_cable {
+					type string {
+						pattern "true|false";
+					}
+				}
+
 			} /* end of list PORT_LIST */
 
 		} /* end of container PORT */

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -139,9 +139,7 @@ module sonic-port{
 				}
 
 				leaf mux_cable {
-					type string {
-						pattern "true|false";
-					}
+					type boolean;
 				}
 
 			} /* end of list PORT_LIST */

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -9,6 +9,10 @@ module sonic-vlan {
 		prefix inet;
 	}
 
+	import ietf-yang-types {
+		prefix yang;
+	}
+
 	import sonic-types {
 		prefix stypes;
 	}
@@ -83,6 +87,18 @@ module sonic-vlan {
 					type enumeration {
 						enum enable;
 						enum disable;
+					}
+				}
+
+				leaf grat_arp {
+					type string {
+						pattern "enabled|disabled";
+					}
+				}
+
+				leaf proxy_arp {
+					type string {
+						pattern "enabled|disabled";
 					}
 				}
 			}
@@ -183,6 +199,10 @@ module sonic-vlan {
 
 				leaf admin_status {
 					type stypes:admin_status;
+				}
+
+				leaf mac {
+					type yang:mac-address;
 				}
 			}
 			/* end of VLAN_LIST */

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -231,7 +231,7 @@ module sonic-types {
 
     typedef hostname {
         type string {
-            length 1..255;
+            length 1..63;
         }
     }
 

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -229,9 +229,14 @@ module sonic-types {
         }
     }
 
+    typedef hostname {
+        type string {
+            length 1..255;
+        }
+    }
 
-    /* Required for CVL */
     {% if yang_model_type == "cvl" %}
+    /* Required for CVL */
     container operation {
         description
             "This definition is used internally by CVL and


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Fixes #9561
Fixes #9570 
Fixes #9563
Partial fix for #9556 

#### Why I did it
- Attributes for dual ToR configs lack YANG model support

#### How I did it
- Extend YANG tests to cover dual ToR use cases
- Extend YANG model to cover dual ToR use cases
- Reduce the default log level to warning so only test failures are printed

#### How to verify it
- Run the YANG model unit tests

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

