### PR TITLE
[minigraph] do not use NULL:NULL explicitly in json

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -487,7 +487,7 @@ def parse_dpg(dpg, hname):
             for i, member in enumerate(pcmbr_list):
                 pcmbr_list[i] = port_alias_map.get(member, member)
                 intfs_inpc.append(pcmbr_list[i])
-                pc_members[(pcintfname, pcmbr_list[i])] = {'NULL': 'NULL'}
+                pc_members[(pcintfname, pcmbr_list[i])] = {}
             if pcintf.find(str(QName(ns, "Fallback"))) != None:
                 pcs[pcintfname] = {'members': pcmbr_list, 'fallback': pcintf.find(str(QName(ns, "Fallback"))).text, 'min_links': str(int(math.ceil(len() * 0.75)))}
             else:


### PR DESCRIPTION
#### Why I did it
It should be handled by `ConfigDBConnector.typed_to_raw()`.

This is a bug for `sonic-cfggen -m --print-data` only
```
    "PORTCHANNEL_MEMBER": {
        "PortChannel0001|Ethernet112": {
            "NULL": "NULL"
        },
        "PortChannel0002|Ethernet116": {
            "NULL": "NULL"
        },
        "PortChannel0003|Ethernet120": {
            "NULL": "NULL"
        },
        "PortChannel0004|Ethernet124": {
            "NULL": "NULL"
        }
    },
```
But not appears in `sonic-cfgen -d --print-data`.
```
    "PORTCHANNEL_MEMBER": {
        "PortChannel0001|Ethernet112": {},
        "PortChannel0002|Ethernet116": {},
        "PortChannel0003|Ethernet120": {},
        "PortChannel0004|Ethernet124": {}
    },
```
Tested in a T0 KVM.


#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

