### PR TITLE
Revert "Fix redis version during pip3 install"

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -447,7 +447,7 @@ RUN pip3 install "PyYAML==5.4.1"
 RUN pip3 install "lxml==4.6.2"
 
 # For sonic-platform-common testing
-RUN pip3 install redis==3.5.3
+RUN pip3 install redis
 
 # For vs image build
 RUN pip3 install pexpect==4.8.0

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -466,7 +466,7 @@ RUN pip2 install "lxml==4.6.5"
 RUN pip3 install "lxml==4.6.5"
 
 # For sonic-platform-common testing
-RUN pip3 install redis==3.5.3
+RUN pip3 install redis
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -371,7 +371,7 @@ RUN pip3 install "lxml==4.6.5"
 
 
 # For sonic-platform-common testing
-RUN pip3 install redis==3.5.3
+RUN pip3 install redis
 
 # For vs image build
 RUN pip2 install pexpect==4.6.0


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#9317
Since upstream fixed the issue https://github.com/redis/redis-py/pull/1726
We can continue use latest version on master branch.

Fixes https://github.com/Azure/sonic-buildimage/issues/9318