### PR TITLE
[device] as5712-54x, fix Python error and log location

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/fanutil.py
@@ -122,7 +122,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -153,7 +153,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/thermalutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/thermalutil.py
@@ -80,7 +80,7 @@ class ThermalUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/service/as5712-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/service/as5712-platform-monitor.service
@@ -5,6 +5,7 @@ After=sysinit.target
 DefaultDependencies=no
 
 [Service]
+WorkingDirectory=/var/log/
 ExecStartPre=/usr/local/bin/accton_as5712_util.py install
 ExecStart=/usr/local/bin/accton_as5712_monitor.py
 KillSignal=SIGKILL

--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_monitor.py
@@ -28,6 +28,7 @@ try:
     import logging.config
     import time  # this is only being used as part of the example
     import signal
+    import sys
     from as5712_54x.fanutil import FanUtil
     from as5712_54x.thermalutil import ThermalUtil
 except ImportError as e:


### PR DESCRIPTION
#### Why I did it

The service `as5712-platform-monitor.service` was listed as failed on my AS5712-54X device.

#### How I did it

Looking at the logs and resolving the three Python3 exceptions allowed the service to start. Then I detected some log files that were created straight in the root (/), so I moved them.

#### How to verify it

Run SONiC on an Edge-core/Accton AS5712-54X and see the service now work.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog

- [device] as5712-54x, fix platform monitor

#### A picture of a cute animal (not mandatory but encouraged)

![image](https://user-images.githubusercontent.com/149442/148775880-9d048902-0982-497e-91b0-ce623be810e3.png)
