### PR TITLE
[Arista] Add platform.json configs for all chassis SKUs

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/platform.json
+++ b/device/arista/x86_64-arista_7800_sup/platform.json
@@ -1,0 +1,12 @@
+{
+    "chassis": {
+        "name": "DCS-7800A-SUP1A",
+        "components": [],
+        "fans": [],
+        "fan_drawers": [],
+        "psus": [],
+        "thermals": [],
+        "sfps": []
+    },
+    "interfaces": {}
+}

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/platform.json
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/platform.json
@@ -1,0 +1,173 @@
+{
+    "chassis": {
+        "name": "7800R3-48CQ2-LC",
+        "components": [],
+        "fans": [],
+        "fan_drawers": [],
+        "psus": [],
+        "thermals": [
+            {
+                "name": "Cpu temp sensor"
+            },
+            {
+                "name": "Center back"
+            },
+            {
+                "name": "Fap0 core0"
+            },
+            {
+                "name": "Fap0 core1"
+            },
+            {
+                "name": "PCIE"
+            }
+        ],
+        "sfps": [
+            {
+                "name": "qsfp1"
+            },
+            {
+                "name": "qsfp2"
+            },
+            {
+                "name": "qsfp3"
+            },
+            {
+                "name": "qsfp4"
+            },
+            {
+                "name": "qsfp5"
+            },
+            {
+                "name": "qsfp6"
+            },
+            {
+                "name": "qsfp7"
+            },
+            {
+                "name": "qsfp8"
+            },
+            {
+                "name": "qsfp9"
+            },
+            {
+                "name": "qsfp10"
+            },
+            {
+                "name": "qsfp11"
+            },
+            {
+                "name": "qsfp12"
+            },
+            {
+                "name": "qsfp13"
+            },
+            {
+                "name": "qsfp14"
+            },
+            {
+                "name": "qsfp15"
+            },
+            {
+                "name": "qsfp16"
+            },
+            {
+                "name": "qsfp17"
+            },
+            {
+                "name": "qsfp18"
+            },
+            {
+                "name": "qsfp19"
+            },
+            {
+                "name": "qsfp20"
+            },
+            {
+                "name": "qsfp21"
+            },
+            {
+                "name": "qsfp22"
+            },
+            {
+                "name": "qsfp23"
+            },
+            {
+                "name": "qsfp24"
+            },
+            {
+                "name": "qsfp25"
+            },
+            {
+                "name": "qsfp26"
+            },
+            {
+                "name": "qsfp27"
+            },
+            {
+                "name": "qsfp28"
+            },
+            {
+                "name": "qsfp29"
+            },
+            {
+                "name": "qsfp30"
+            },
+            {
+                "name": "qsfp31"
+            },
+            {
+                "name": "qsfp32"
+            },
+            {
+                "name": "qsfp33"
+            },
+            {
+                "name": "qsfp34"
+            },
+            {
+                "name": "qsfp35"
+            },
+            {
+                "name": "qsfp36"
+            },
+            {
+                "name": "qsfp37"
+            },
+            {
+                "name": "qsfp38"
+            },
+            {
+                "name": "qsfp39"
+            },
+            {
+                "name": "qsfp40"
+            },
+            {
+                "name": "qsfp41"
+            },
+            {
+                "name": "qsfp42"
+            },
+            {
+                "name": "qsfp43"
+            },
+            {
+                "name": "qsfp44"
+            },
+            {
+                "name": "qsfp45"
+            },
+            {
+                "name": "qsfp46"
+            },
+            {
+                "name": "qsfp47"
+            },
+            {
+                "name": "qsfp48"
+            }
+        ]
+    },
+    "interfaces": {}
+}

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/platform.json
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/platform.json
@@ -1,0 +1,1 @@
+../x86_64-arista_7800r3_48cq2_lc/platform.json


### PR DESCRIPTION
#### What I did

Add missing platform.json configuration files for chassis skus

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [x] 202111

Needed for the chassis testing effort

#### Description for the changelog

Add missing platform.json configurations for chassis sup and linecards

