### PR TITLE
[dhcp_relay] Remove dhcpv6 servers from VlanBrief

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcp_relay.py
@@ -20,7 +20,7 @@ class TestVlanDhcpRelay(object):
 
     def test_dhcp_relay_column_output(self):
         ctx = (
-            ({'Vlan100': {'dhcp_servers': ['192.0.0.1', '192.168.0.2']}}, {}),
+            ({'Vlan100': {'dhcp_servers': ['192.0.0.1', '192.168.0.2']}}, {}, {}),
             (),
         )
         assert show_dhcp_relay.get_dhcp_helper_address(ctx, 'Vlan100') == '192.0.0.1\n192.168.0.2'

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcp_relay.py
@@ -20,9 +20,9 @@ class TestVlanDhcpRelay(object):
 
     def test_dhcp_relay_column_output(self):
         ctx = (
-            ({'Vlan100': {'dhcp_servers': ['192.0.0.1', '192.168.0.2'], 'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2']}}, {}, {}),
+            ({'Vlan100': {'dhcp_servers': ['192.0.0.1', '192.168.0.2']}}, {}),
             (),
         )
-        assert show_dhcp_relay.get_dhcp_helper_address(ctx, 'Vlan100') == '192.0.0.1\n192.168.0.2\nfc02:2000::1\nfc02:2000::2'
+        assert show_dhcp_relay.get_dhcp_helper_address(ctx, 'Vlan100') == '192.0.0.1\n192.168.0.2'
 
 

--- a/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
@@ -27,7 +27,7 @@ def get_dhcp_helper_address(ctx, vlan):
 
     dhcp_helpers = vlan_config.get('dhcp_servers', [])
 
-    return '\n'.join(natsorted(dhcp_helpers) + natsorted(dhcpv6_helpers))
+    return '\n'.join(natsorted(dhcp_helpers))
 
 
 vlan.VlanBrief.register_column('DHCP Helper Address', get_dhcp_helper_address)

--- a/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
@@ -26,7 +26,6 @@ def get_dhcp_helper_address(ctx, vlan):
         return ""
 
     dhcp_helpers = vlan_config.get('dhcp_servers', [])
-    dhcpv6_helpers = vlan_config.get('dhcpv6_servers', [])
 
     return '\n'.join(natsorted(dhcp_helpers) + natsorted(dhcpv6_helpers))
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We want to move DHCP_RELAY CLI away from VlanBrief.

#### How I did it
Delete dhcpv6_servers from VlanBrief. 
"Show vlan brief" will no longer output dhcpv6 servers.

#### How to verify it
Run "show vlan brief"
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

