### PR TITLE
[chassis][pmon]Fixed the chassis_db_init process shown FATAL state in PMON

### DIFF
--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -49,7 +49,7 @@ autostart=false
 autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=10
+startsecs=0
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Process chassis_db_init process shown FATAL state in pmon.  The chassis_db_init process takes less than 1 second to finish.  Since the "startsec=10' is set for chassis_db_init process in the supervisord.conf file, the process exited before the supersivor start to check.  This is reason why it is shown as FATAL.  Issue #9719

#### How I did it
Change chassis_db_init setting to "startsec=0" instead of "startsec=10" in the supervisord.conf file since this process takes less than 1 second to finsh.

#### How to verify it
login to the voq chassis, execute the "supervisorctl status" command in the PMON docker
```
admin@sonic:~$ docker exec -i pmon supervisorctl status
chassis_db_init                  EXITED    Jan 10 08:54 PM
chassisd                         RUNNING   pid 34, uptime 0:00:54
dependent-startup                EXITED    Jan 10 08:54 PM
pcied                            RUNNING   pid 38, uptime 0:00:54
psud                             RUNNING   pid 35, uptime 0:00:54
rsyslogd                         RUNNING   pid 29, uptime 0:00:56
supervisor-proc-exit-listener    RUNNING   pid 26, uptime 0:00:57
syseepromd                       RUNNING   pid 36, uptime 0:00:54
thermalctld                      RUNNING   pid 37, uptime 0:00:54
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

