### PR TITLE
Add dualtor TSA/B/C support

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -1,13 +1,11 @@
 #!/bin/bash
 
 # toggle the mux to standby if dualtor and any mux active
-[[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]]
-is_dualtor=$?
-[[ $(show mux status | grep active | wc -l) > 0 ]]
-any_active=$?
-
-if [[ (${is_dualtor} -eq 0) && (${any_active} -eq 0) ]];
+if
+[[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]] &&
+[[ $(show mux status | grep active | wc -l) > 0 ]];
 then
+  logger -t TSA -p user.info "Toggle all mux mode to standby"
   sudo config mux mode standby all
 fi
 

--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -1,3 +1,14 @@
 #!/bin/bash
 
+# toggle the mux to standby if dualtor and any mux active
+[[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]]
+is_dualtor=$?
+[[ $(show mux status | grep active | wc -l) > 0 ]]
+any_active=$?
+
+if [[ (${is_dualtor} -eq 0) && (${any_active} -eq 0) ]];
+then
+  sudo config mux mode standby all
+fi
+
 /usr/bin/TS TSA

--- a/dockers/docker-fpm-frr/base_image_files/TSB
+++ b/dockers/docker-fpm-frr/base_image_files/TSB
@@ -1,3 +1,10 @@
 #!/bin/bash
 
+# toggle the mux to auto if dualtor
+if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]];
+then
+  logger -t TSB -p user.info "Toggle all mux mode to auto"
+  sudo config mux mode auto all
+fi
+
 /usr/bin/TS TSB

--- a/dockers/docker-fpm-frr/base_image_files/TSC
+++ b/dockers/docker-fpm-frr/base_image_files/TSC
@@ -3,3 +3,9 @@
 /usr/bin/TS TSC
 
 portstat -p 5
+
+if [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]]
+then
+  echo
+  show mux status
+fi


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add TSA/B/C dualtor support

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How I did it
For TSA, toggle all the mux to standby if the device type is `dualtor` and there are active mux ports.
For TSC, add mux status output.

#### How to verify it
Run TSA/B/C on a dualtor setup

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

