### PR TITLE
[Arista] Change default_sku for 7050QX-32S

### DIFF
--- a/device/arista/x86_64-arista_7050_qx32s/default_sku
+++ b/device/arista/x86_64-arista_7050_qx32s/default_sku
@@ -1,1 +1,1 @@
-Arista-7050-QX-32S t1
+Arista-7050QX-32S t1


### PR DESCRIPTION
#### Why I did it

Booting SONiC on a 7050QX-32S without configuration led to a broken state.
This happened because the previous default_sku uses a `hwsku.json` which is incompatible with `platform.json`
This product has this capability of either enabling the first 4 SFP(1-4) ports or the first QSFP(5).
It is currently not possible to express this in terms of SONiC DPB.  

#### How I did it

Change the `default_sku` to point to the 32x40G DPB HwSku for the 7050QX-32S.
Allowing the broken HwSku to work will be a much bigger task, but this should be good enough for now.

Fixes https://github.com/Azure/sonic-buildimage/issues/9090 and https://github.com/aristanetworks/sonic/issues/35

#### How to verify it

Boot SONiC without minigraph.xml nor config_db.json, validates that ports show up in `show interface status`

#### Description for the changelog

Change default_sku for 7050QX-32S
