### PR TITLE
[Arista] Remove duplicate logrotate configuration for arista.log

### DIFF
--- a/files/image_config/logrotate/rsyslog.j2
+++ b/files/image_config/logrotate/rsyslog.j2
@@ -24,7 +24,6 @@
 }
 
 /var/log/auth.log
-/var/log/arista.log
 /var/log/cron.log
 /var/log/syslog
 /var/log/teamd.log


### PR DESCRIPTION
#### Why I did it

In parallel of this change Arista added a custom logrotate configuration as part of its driver library.
Having 2 logrotate configuration for the same log file triggers an issue.

Fixes https://github.com/aristanetworks/sonic/issues/38 

#### How I did it

Arista merged a few changes in sonic-buildimage which added a logrotate configuration https://github.com/aristanetworks/sonic/commit/e43c7977f7473be67a7e8be7846c9dd71357feae
It is therefore the right path to remove the `arista.log` line from the `logrotate.d/rsyslog` configuration.

#### How to verify it

Logrotate works without any error message, arista log rotation happens and arista daemons still append logs once file was truncated.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

Issue also present on 202111

#### Description for the changelog

Remove duplicate arista.log logrotate from logrotate.d/rsyslog