### PR TITLE
[Accton] Enable pca954x i2c mux idle_disconnect for 5.10 kernel

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
@@ -32,7 +32,7 @@
         [
             "i2c-i801",
             "i2c_dev",
-            "i2c_mux_pca954x force_deselect_on_exit=1",
+            "i2c_mux_pca954x",
             "optoe"
         ],
         "pddf_kos":

--- a/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
@@ -33,7 +33,7 @@
         [
             "i2c-i801",
             "i2c_dev",
-            "i2c_mux_pca954x force_deselect_on_exit=1",
+            "i2c_mux_pca954x",
             "optoe"
         ],
         "pddf_kos":

--- a/device/accton/x86_64-accton_as7816_64x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7816_64x-r0/pddf/pddf-device.json
@@ -32,7 +32,7 @@
         [
             "i2c-i801",
             "i2c_dev",
-            "i2c_mux_pca954x force_deselect_on_exit=1",
+            "i2c_mux_pca954x",
             "optoe"
         ],
         "pddf_kos":

--- a/device/accton/x86_64-accton_as9716_32d-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/pddf/pddf-device.json
@@ -33,7 +33,7 @@
             "i2c-ismt",
             "i2c-i801",
             "i2c_dev",
-            "i2c_mux_pca954x force_deselect_on_exit=1",
+            "i2c_mux_pca954x",
             "optoe"
         ],
         "pddf_kos":

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54te/utils/accton_as4630_54te_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54te/utils/accton_as4630_54te_util.py
@@ -274,7 +274,7 @@ def driver_inserted():
 kos = [
     'depmod -ae',
     'modprobe i2c_dev',
-    'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
+    'modprobe i2c_mux_pca954x',
     'modprobe ym2651y',
     'modprobe x86_64_accton_as4630_54te_cpld',
     'modprobe x86_64_accton_as4630_54te_leds',
@@ -330,6 +330,15 @@ def device_install():
             print(output)
             if FORCE == 0:
                 return status
+
+    # set all pca954x idle_disconnect
+    cmd = 'echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state'
+    status, output = log_os_system(cmd, 1)
+    if status:
+        print(output)
+        if FORCE == 0:
+            return status
+
     print("Check SFP")
     for i in range(0, len(sfp_map)):
         if(i < 4):

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54x/utils/accton_as7312_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54x/utils/accton_as7312_util.py
@@ -164,7 +164,7 @@ def driver_check():
 
 kos = [
     'modprobe i2c_dev',
-    'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
+    'modprobe i2c_mux_pca954x',
     'modprobe accton_i2c_cpld',
     'modprobe ym2651y',
     'modprobe accton_as7312_54x_fan',
@@ -308,6 +308,15 @@ def device_install():
                 print(output)
                 if FORCE == 0:
                     return status
+
+    # set all pca954x idle_disconnect
+    cmd = 'echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state'
+    status, output = log_os_system(cmd, 1)
+    if status:
+        print(output)
+        if FORCE == 0:
+            return status
+
     for i in range(0, len(sfp_map)):
         if i < qsfp_start:
             (status, output) = \

--- a/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/utils/accton_as7315_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/utils/accton_as7315_util.py
@@ -158,7 +158,7 @@ def driver_check():
 
 kos = [
 'modprobe i2c_dev',
-'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
+'modprobe i2c_mux_pca954x',
 'modprobe optoe',
 'modprobe ym2651y',
 'modprobe accton_as7315_27xb_fan',
@@ -240,7 +240,7 @@ mknod =[
        
 def i2c_order_check():    
     return 0
-                     
+
 def device_install():
     global FORCE
     
@@ -254,6 +254,14 @@ def device_install():
             print(output)
             if FORCE == 0:                
                 return status  
+
+    # set all pca954x idle_disconnect
+    cmd = 'echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state'
+    status, output = log_os_system(cmd, 1)
+    if status:
+        print(output)
+        if FORCE == 0:
+            return status
 
     for i in range(0,len(sfp_map)):
         path = "/sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/new_device"

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pddf_post_device_create.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/utils/pddf_post_device_create.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set_pca_mux_idle_disconnect()
+{
+    echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state >& /dev/null
+    if [ $? -ne 0 ]; then
+        echo Fail to set pca954x mux idle disconnect
+        exit 2
+    fi
+}
+
+set_pca_mux_idle_disconnect

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/pddf_post_device_create.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/pddf_post_device_create.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set_pca_mux_idle_disconnect()
+{
+    echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state >& /dev/null
+    if [ $? -ne 0 ]; then
+        echo Fail to set pca954x mux idle disconnect
+        exit 2
+    fi
+}
+
+set_pca_mux_idle_disconnect

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/pddf_post_device_create.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/pddf_post_device_create.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set_pca_mux_idle_disconnect()
+{
+    echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state >& /dev/null
+    if [ $? -ne 0 ]; then
+        echo Fail to set pca954x mux idle disconnect
+        exit 2
+    fi
+}
+
+set_pca_mux_idle_disconnect

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/pddf_post_device_create.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/pddf_post_device_create.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set_pca_mux_idle_disconnect()
+{
+    echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state >& /dev/null
+    if [ $? -ne 0 ]; then
+        echo Fail to set pca954x mux idle disconnect
+        exit 2
+    fi
+}
+
+set_pca_mux_idle_disconnect

--- a/platform/broadcom/sonic-platform-modules-accton/as9726-32d/utils/accton_as9726_32d_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9726-32d/utils/accton_as9726_32d_util.py
@@ -277,7 +277,7 @@ def driver_inserted():
 kos = [
     'depmod -ae',
     'modprobe i2c_dev',
-    'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
+    'modprobe i2c_mux_pca954x',
     'modprobe ym2651y',
     'modprobe x86-64-accton-as9726-32d_cpld',
     'modprobe x86-64-accton-as9726-32d_fan',
@@ -326,6 +326,15 @@ def device_install():
             print(output)
             if FORCE == 0:
                 return status
+
+    # set all pca954x idle_disconnect
+    cmd = 'echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state'
+    status, output = log_os_system(cmd, 1)
+    if status:
+        print(output)
+        if FORCE == 0:
+            return status
+
     print("Check SFP")
     for i in range(0, len(sfp_map)):
         if(i >= (len(sfp_map)-2)):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Enable pca954x idle_disconnect to avoid possible I2C device address conflict.

#### How I did it
Change pca954x device_attr idle_state to -2 (MUX_IDLE_DISCONNECT).

#### How to verify it
Cat pca954x device_attr idle_state and confirm the value is -2.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
[Accton] Enable pca954x devices' idle_disconnect for 5.10 kernel
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)
![dog](https://user-images.githubusercontent.com/81406250/149117929-f004627c-abd4-4725-8d3d-5239cbaa4303.png)

