### PR TITLE
[202012][BRCM TH3] Add SOC properties to prevent FDB events during warmboot

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D/th3-as9716-32x400G.config.bcm
+++ b/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D/th3-as9716-32x400G.config.bcm
@@ -1,3 +1,7 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
+
 pbmp_xport_xe.0=0x3ffffffffffffffffffffffffffffffffffffffe
 
 # Reference specfic

--- a/device/arista/x86_64-arista_7060dx4_32/Arista-7060DX4-C32/th3-a7060dx4-c32-32x400G.config.bcm
+++ b/device/arista/x86_64-arista_7060dx4_32/Arista-7060DX4-C32/th3-a7060dx4-c32-32x400G.config.bcm
@@ -1,3 +1,7 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
+
 arl_clean_timeout_usec=15000000
 asf_mem_profile.0=2
 bcm_num_cos.0=8

--- a/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-C64/th3-a7060px4-32-64x100G.config.bcm
+++ b/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-C64/th3-a7060px4-32-64x100G.config.bcm
@@ -1,3 +1,7 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 # disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose

--- a/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-O32/th3-a7060px4-o32-32x400G.config.bcm
+++ b/device/arista/x86_64-arista_7060px4_32/Arista-7060PX4-O32/th3-a7060px4-o32-32x400G.config.bcm
@@ -1,3 +1,7 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
+
 # Disable Counting ACL Drop towards interface RX_DRP counter
 sai_adjust_acl_drop_in_rx_drop=1
 # disables bcmALPMDH (ALPM distributed hitbit) thread.  This thread is purely for debug purpose

--- a/device/celestica/x86_64-cel_silverstone-r0/Silverstone-128x100/th3-128x100G.config.bcm
+++ b/device/celestica/x86_64-cel_silverstone-r0/Silverstone-128x100/th3-128x100G.config.bcm
@@ -1,3 +1,7 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
+
 pbmp_xport_xe.0=0x8ffff8ffffcffff8ffff8ffff8ffffcffff9fffe
 ccm_dma_enable=0
 ccmdma_intr_enable=0

--- a/device/celestica/x86_64-cel_silverstone-r0/Silverstone/th3-32x400G.config.bcm
+++ b/device/celestica/x86_64-cel_silverstone-r0/Silverstone/th3-32x400G.config.bcm
@@ -1,3 +1,6 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
 
 pbmp_xport_xe.0=0x8111181111c1111811118111181111c111182222
 ccm_dma_enable=0

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-C32/th3-z9332f-32x100G.config.bcm
@@ -1,3 +1,7 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
+
 sai_tunnel_global_sip_mask_enable=1
 core_clock_frequency=1325
 dpr_clock_frequency=1000

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-M-O16C64/th3-z9332f-16x400G-64x100G.config.bcm
@@ -1,3 +1,7 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
+
 sai_tunnel_global_sip_mask_enable=1
 core_clock_frequency=1325
 dpr_clock_frequency=1000

--- a/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
+++ b/device/dell/x86_64-dellemc_z9332f_d1508-r0/DellEMC-Z9332f-O32/th3-z9332f-32x400G.config.bcm
@@ -1,3 +1,7 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
+
 sai_tunnel_global_sip_mask_enable=1
 core_clock_frequency=1325
 dpr_clock_frequency=1000

--- a/device/delta/x86_64-delta_agc032-r0/Delta-agc032/th3-agc032-32x400G.config.bcm
+++ b/device/delta/x86_64-delta_agc032-r0/Delta-agc032/th3-agc032-32x400G.config.bcm
@@ -1,3 +1,7 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
+
 #########################################
 ## cfg for AGC032
 #########################################

--- a/device/quanta/x86_64-quanta_ix9_bwde-r0/Quanta-IX9-32X/th3-ix9-32x400G.config.bcm
+++ b/device/quanta/x86_64-quanta_ix9_bwde-r0/Quanta-IX9-32X/th3-ix9-32x400G.config.bcm
@@ -1,3 +1,7 @@
+# The following 2 SOC properties are needed to prevent FDB Events during Warmboot due to TH3 is SW Managed MACs
+l2xmsg_shadow_hit_bits=0
+l2xmsg_no_cb_during_table_rebuild=1
+
 phy_null=1
 pll_bypass=1
 

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -239,3 +239,5 @@ buf.map.egress_pool2.ingress_pool
 sai_adjust_acl_drop_in_rx_drop
 sai_verify_incoming_chksum
 l3_alpm_hit_skip
+l2xmsg_shadow_hit_bits
+l2xmsg_no_cb_during_table_rebuild


### PR DESCRIPTION
#### Why I did it
This is to fix issue reported by (https://github.com/Azure/sonic-buildimage/issues/8558)
The fix requires 2 changes:

1.  in BRCM SAI 4.3.5.2 which can be found in this PR (https://github.com/Azure/sonic-buildimage/pull/9754)
2.  This PR itself where it needs to set 2 SOC properties in order to activate the code changed in BRCM SAI 4.3.5.2

#### How to verify it

1. Repeat the steps documented in issue (https://github.com/Azure/sonic-buildimage/issues/8558) without these 2 SOC properties on a TH3 based HWSKU (Z9332F) and with any BRCM SAI (including 4.3.5.2) and see the issue.
2. Enable these two SOC properties and repeat the same steps again with Z9332F running with BRCM SAI 4.3.5.2 and observe that the problem no longer can be reproduced.

#### Which release branch to backport (provide reason below if selected)
Once verified that the fix that went into SAI 4.3.5.2 is also present in the SAI 6.0 branch, we should then port this to master branch (running BRCM SAI 6.0.x).
There is no plan to port this to 
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
[202012][BRCM TH3] Add SOC properties to prevent FDB events during warmboot


#### A picture of a cute animal (not mandatory but encouraged)

