### PR TITLE
Fix build issue: cannot import name FW_AUTO_ERR_UKNOWN- required module not found

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -37,8 +37,13 @@ try:
     from sonic_platform_base.component_base import ComponentBase,           \
                                                     FW_AUTO_INSTALLED,      \
                                                     FW_AUTO_ERR_BOOT_TYPE,  \
-                                                    FW_AUTO_ERR_IMAGE,      \
-                                                    FW_AUTO_ERR_UKNOWN
+                                                    FW_AUTO_ERR_IMAGE
+
+    # Temp workaround to fix build issue, shall be refactor once sonic-platform-common submodule pointer is updated
+    try:
+        from sonic_platform_base.component_base import FW_AUTO_ERR_UNKNOWN
+    except ImportError as e:
+        from sonic_platform_base.component_base import FW_AUTO_ERR_UKNOWN as FW_AUTO_ERR_UNKNOWN
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -138,9 +143,9 @@ class ONIEUpdater(object):
             self.__umount_onie_fs()
 
         cmd = "fdisk -l | grep 'ONIE boot' | awk '{print $1}'"
-        fs_path = subprocess.check_output(cmd, 
-                                          stderr=subprocess.STDOUT, 
-                                          shell=True, 
+        fs_path = subprocess.check_output(cmd,
+                                          stderr=subprocess.STDOUT,
+                                          shell=True,
                                           universal_newlines=True).rstrip('\n')
 
         os.mkdir(fs_mountpoint)
@@ -194,8 +199,8 @@ class ONIEUpdater(object):
         cmd = self.ONIE_FW_UPDATE_CMD_SHOW_PENDING
 
         try:
-            output = subprocess.check_output(cmd.split(), 
-                                             stderr=subprocess.STDOUT, 
+            output = subprocess.check_output(cmd.split(),
+                                             stderr=subprocess.STDOUT,
                                              universal_newlines=True).rstrip('\n')
         except subprocess.CalledProcessError as e:
             raise RuntimeError("Failed to get pending firmware updates: {}".format(str(e)))
@@ -281,8 +286,8 @@ class ONIEUpdater(object):
             cmd = self.ONIE_IMAGE_INFO_COMMAND.format(image_path)
 
             try:
-                output = subprocess.check_output(cmd.split(), 
-                                                 stderr=subprocess.STDOUT, 
+                output = subprocess.check_output(cmd.split(),
+                                                 stderr=subprocess.STDOUT,
                                                  universal_newlines=True).rstrip('\n')
             except subprocess.CalledProcessError as e:
                 raise RuntimeError("Failed to get ONIE firmware info: {}".format(str(e)))
@@ -303,8 +308,8 @@ class ONIEUpdater(object):
         cmd = self.ONIE_FW_UPDATE_CMD_SHOW_PENDING
 
         try:
-            output = subprocess.check_output(cmd.split(), 
-                                             stderr=subprocess.STDOUT, 
+            output = subprocess.check_output(cmd.split(),
+                                             stderr=subprocess.STDOUT,
                                              universal_newlines=True).rstrip('\n')
         except subprocess.CalledProcessError as e:
             raise RuntimeError("Failed to get pending firmware updates: {}".format(str(e)))
@@ -371,7 +376,7 @@ class Component(ComponentBase):
                 # Successful update
                 return FW_AUTO_INSTALLED
             # Failed update (unknown reason)
-            return FW_AUTO_ERR_UKNOWN
+            return FW_AUTO_ERR_UNKNOWN
 
         # boot_type did not match (skip)
         return FW_AUTO_ERR_BOOT_TYPE
@@ -395,10 +400,10 @@ class Component(ComponentBase):
     @staticmethod
     def _get_command_result(cmdline):
         try:
-            proc = subprocess.Popen(cmdline, 
-                                    stdout=subprocess.PIPE, 
-                                    shell=True, 
-                                    stderr=subprocess.STDOUT, 
+            proc = subprocess.Popen(cmdline,
+                                    stdout=subprocess.PIPE,
+                                    shell=True,
+                                    stderr=subprocess.STDOUT,
                                     universal_newlines=True)
             stdout = proc.communicate()[0]
             rc = proc.wait()
@@ -510,7 +515,7 @@ class ComponentSSD(Component):
     def auto_update_firmware(self, image_path, boot_action):
         """
         Handling of attempted automatic update for a SSD of a Mellanox switch.
-        Will first check the image_path to determine if a post-install reboot is required, 
+        Will first check the image_path to determine if a post-install reboot is required,
         then compares it against boot_action to determine whether to proceed with install.
         """
 
@@ -529,14 +534,14 @@ class ComponentSSD(Component):
                 supported_boot += ['warm', 'fast', 'none', 'any']
         except RuntimeError:
             # Unknown error from firmware probe
-            return FW_AUTO_ERR_UKNOWN
+            return FW_AUTO_ERR_UNKNOWN
 
         if boot_action in supported_boot:
             if self.update_firmware(image_path):
                 # Successful update
                 return FW_AUTO_INSTALLED
             # Failed update (unknown reason)
-            return FW_AUTO_ERR_UKNOWN
+            return FW_AUTO_ERR_UNKNOWN
 
         # boot_type did not match (skip)
         return FW_AUTO_ERR_BOOT_TYPE
@@ -545,8 +550,8 @@ class ComponentSSD(Component):
         cmd = self.SSD_INFO_COMMAND
 
         try:
-            output = subprocess.check_output(cmd.split(), 
-                                             stderr=subprocess.STDOUT, 
+            output = subprocess.check_output(cmd.split(),
+                                             stderr=subprocess.STDOUT,
                                              universal_newlines=True).rstrip('\n')
         except subprocess.CalledProcessError as e:
             raise RuntimeError("Failed to get {} info: {}".format(self.name, str(e)))
@@ -561,8 +566,8 @@ class ComponentSSD(Component):
         cmd = self.SSD_FIRMWARE_INFO_COMMAND.format(image_path)
 
         try:
-            output = subprocess.check_output(cmd.split(), 
-                                             stderr=subprocess.STDOUT, 
+            output = subprocess.check_output(cmd.split(),
+                                             stderr=subprocess.STDOUT,
                                              universal_newlines=True).rstrip('\n')
         except subprocess.CalledProcessError as e:
             raise RuntimeError("Failed to get {} firmware info: {}".format(self.name, str(e)))
@@ -596,8 +601,8 @@ class ComponentSSD(Component):
         cmd = self.SSD_FIRMWARE_INFO_COMMAND.format(image_path)
 
         try:
-            output = subprocess.check_output(cmd.split(), 
-                                             stderr=subprocess.STDOUT, 
+            output = subprocess.check_output(cmd.split(),
+                                             stderr=subprocess.STDOUT,
                                              universal_newlines=True).rstrip('\n')
         except subprocess.CalledProcessError as e:
             raise RuntimeError("Failed to get {} firmware info: {}".format(self.name, str(e)))
@@ -670,8 +675,8 @@ class ComponentBIOS(Component):
         cmd = self.BIOS_VERSION_COMMAND
 
         try:
-            version = subprocess.check_output(cmd.split(), 
-                                              stderr=subprocess.STDOUT, 
+            version = subprocess.check_output(cmd.split(),
+                                              stderr=subprocess.STDOUT,
                                               universal_newlines=True).rstrip('\n')
         except subprocess.CalledProcessError as e:
             raise RuntimeError("Failed to get {} version: {}".format(self.name, str(e)))

--- a/platform/mellanox/mlnx-platform-api/tests/test_firmware.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_firmware.py
@@ -29,8 +29,13 @@ from sonic_platform.component import Component, ComponentSSD
 from sonic_platform_base.component_base import ComponentBase,           \
                                                 FW_AUTO_INSTALLED,      \
                                                 FW_AUTO_ERR_BOOT_TYPE,  \
-                                                FW_AUTO_ERR_IMAGE,      \
-                                                FW_AUTO_ERR_UKNOWN
+                                                FW_AUTO_ERR_IMAGE
+# Temp workaround to fix build issue, shall be refactor once sonic-platform-common submodule pointer is updated
+try:
+    from sonic_platform_base.component_base import FW_AUTO_ERR_UNKNOWN
+except ImportError as e:
+    from sonic_platform_base.component_base import FW_AUTO_ERR_UKNOWN as FW_AUTO_ERR_UNKNOWN
+
 
 def mock_update_firmware_success(image_path):
     return True
@@ -50,14 +55,14 @@ def mock_update_notification_error(image_path):
 test_data_default = [
         (None, False, None, FW_AUTO_ERR_IMAGE),
         (None, True, 'warm', FW_AUTO_ERR_BOOT_TYPE),
-        (mock_update_firmware_fail, True, 'cold', FW_AUTO_ERR_UKNOWN),
+        (mock_update_firmware_fail, True, 'cold', FW_AUTO_ERR_UNKNOWN),
         (mock_update_firmware_success, True, 'cold', FW_AUTO_INSTALLED)
         ]
 
 test_data_ssd = [
         (None, None, False, None, FW_AUTO_ERR_IMAGE),
-        (None, mock_update_notification_error, True, None, FW_AUTO_ERR_UKNOWN),
-        (mock_update_firmware_fail,    mock_update_notification_cold_boot, True, 'cold', FW_AUTO_ERR_UKNOWN),
+        (None, mock_update_notification_error, True, None, FW_AUTO_ERR_UNKNOWN),
+        (mock_update_firmware_fail,    mock_update_notification_cold_boot, True, 'cold', FW_AUTO_ERR_UNKNOWN),
         (mock_update_firmware_success, mock_update_notification_cold_boot, True, 'warm', FW_AUTO_ERR_BOOT_TYPE),
         (mock_update_firmware_success, mock_update_notification_cold_boot, True, 'cold', FW_AUTO_INSTALLED),
         (mock_update_firmware_success, mock_update_notification_warm_boot, True, 'warm', FW_AUTO_INSTALLED),


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

PR https://github.com/Azure/sonic-platform-common/pull/254 fixed a typo in sonic-platform-common, but it does not fix the same typo in Mellanox platform API. So it causes a build issue when updating sonic-platform-common submodule pointer.

```
==================================== ERRORS ====================================
2022-01-13T06:33:43.5047338Z ___________________ ERROR collecting tests/test_firmware.py ____________________
2022-01-13T06:33:43.5048665Z ImportError while importing test module '/sonic/platform/mellanox/mlnx-platform-api/tests/test_firmware.py'.
2022-01-13T06:33:43.5049454Z Hint: make sure your test modules/packages have valid Python names.
2022-01-13T06:33:43.5050210Z Traceback:
2022-01-13T06:33:43.5051411Z /usr/lib/python2.7/dist-packages/_pytest/python.py:450: in _importtestmodule
2022-01-13T06:33:43.5052148Z     mod = self.fspath.pyimport(ensuresyspath=importmode)
2022-01-13T06:33:43.5053548Z /usr/lib/python2.7/dist-packages/py/_path/local.py:668: in pyimport
2022-01-13T06:33:43.5054139Z     __import__(modname)
2022-01-13T06:33:43.5055087Z /usr/lib/python2.7/dist-packages/_pytest/assertion/rewrite.py:294: in load_module
2022-01-13T06:33:43.5055724Z     six.exec_(co, mod.__dict__)
2022-01-13T06:33:43.5056653Z /usr/lib/python2.7/dist-packages/six.py:709: in exec_
2022-01-13T06:33:43.5057242Z     exec("""exec _code_ in _globs_, _locs_""")
2022-01-13T06:33:43.5057736Z <string>:1: in <module>
2022-01-13T06:33:43.5058135Z     ???
2022-01-13T06:33:43.5058602Z tests/test_firmware.py:27: in <module>
2022-01-13T06:33:43.5059179Z     from sonic_platform.component import Component, ComponentSSD
2022-01-13T06:33:43.5060037Z sonic_platform/component.py:43: in <module>
2022-01-13T06:33:43.5061372Z     raise ImportError(str(e) + "- required module not found")
2022-01-13T06:33:43.5062563Z E   ImportError: cannot import name FW_AUTO_ERR_UKNOWN- required module not found
2022-01-13T06:33:43.5064027Z  generated xml file: /sonic/platform/mellanox/mlnx-platform-api/test-results.xml 
```

Actually this is kind of circuit dependency:

1. If we fix the typo in platform API code while do not fix typo in sonic-platform-common, the platform API PR can never pass checker
2. If we fix the typo in sonic-platform-common, the submodule pointer update PR can never pass checker

So this PR is just a workaround for this.

#### How I did it

Try to import the correct name first. If there is a import error, try to import the previous name.

#### How to verify it

Run build

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

