### PR TITLE
[dockers] Barefoot fix bulleye build

### DIFF
--- a/platform/barefoot/bfn-modules/debian/control
+++ b/platform/barefoot/bfn-modules/debian/control
@@ -2,7 +2,7 @@ Source: bfn-modules
 Section: main
 Priority: extra
 Maintainer: support <support@barefootnetworks.com>
-Build-Depends: debhelper (>= 8.0.0), bzip2
+Build-Depends: debhelper (>= 8.0.0), bzip2, python3
 Standards-Version: 3.9.3
 
 Package: bfn-modules

--- a/platform/barefoot/bfn-modules/debian/rules
+++ b/platform/barefoot/bfn-modules/debian/rules
@@ -8,7 +8,7 @@ KERNEL_SRC :=  /lib/modules/$(KVERSION)
 MODULE_SRC := $(shell pwd)/modules
 
 %:
-	dh $@
+	dh $@ --with python3
 
 override_dh_auto_build:
 	make -C $(KERNEL_SRC)/build M=$(MODULE_SRC)

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/debian/control
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/debian/control
@@ -2,7 +2,7 @@ Source: sonic-platform-modules-bfn-montara
 Section: main
 Priority: extra
 Maintainer: Support <support@edge-core.com>
-Build-Depends: debhelper (>= 9.0.0), bzip2
+Build-Depends: debhelper (>= 9.0.0), bzip2, python3
 Standards-Version: 3.9.3
 
 Package: sonic-platform-modules-bfn-montara

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/debian/rules
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/debian/rules
@@ -8,7 +8,7 @@ BUILD_DIR := $(shell pwd)/build
 WHEEL_BUILD_DIR := $(BUILD_DIR)/wheel
 
 %:
-	dh $@
+	dh $@ --with python3
 
 override_dh_auto_build:
 	set -e

--- a/platform/barefoot/sonic-platform-modules-bfn-newport/debian/control
+++ b/platform/barefoot/sonic-platform-modules-bfn-newport/debian/control
@@ -2,7 +2,7 @@ Source: sonic-platform-modules-bfn-newport
 Section: main
 Priority: extra
 Maintainer: Support <support@edge-core.com>
-Build-Depends: debhelper (>= 9.0.0), bzip2
+Build-Depends: debhelper (>= 9.0.0), bzip2, python3
 Standards-Version: 3.9.3
 
 Package: sonic-platform-modules-bfn-newport-as9516

--- a/platform/barefoot/sonic-platform-modules-bfn-newport/debian/rules
+++ b/platform/barefoot/sonic-platform-modules-bfn-newport/debian/rules
@@ -13,13 +13,13 @@ WHEEL_BUILD_DIR := $(BUILD_DIR)/wheel
 MODULE_NAMES := as9516 as9516bf
 
 %:
-	dh $@
+	dh $@ --with python3
 
 override_dh_auto_build:
 	make -C $(KERNEL_SRC)/build M=$(MODULE_SRC)
 	set -e
 	python3 setup.py bdist_wheel -d $(WHEEL_BUILD_DIR)
-	set +e 
+	set +e
 
 override_dh_auto_install:
 	(for mod in $(MODULE_NAMES); do \
@@ -39,8 +39,8 @@ override_dh_pysupport:
 
 override_dh_clean:
 	dh_clean
-	rm -fr $(WHEEL_BUILD_DIR) 
-	rm -fr *.egg-info 
+	rm -fr $(WHEEL_BUILD_DIR)
+	rm -fr *.egg-info
 	rm -fr $(BUILD)
 	rm -f $(MODULE_SRC)/*.o $(MODULE_SRC)/*.ko $(MODULE_SRC)/*.mod.c $(MODULE_SRC)/.*.cmd
 	rm -f $(MODULE_SRC)/Module.markers $(MODULE_SRC)/Module.symvers $(MODULE_SRC)/modules.order

--- a/platform/barefoot/sonic-platform-modules-bfn/debian/control
+++ b/platform/barefoot/sonic-platform-modules-bfn/debian/control
@@ -2,7 +2,7 @@ Source: sonic-platform-modules-bfn
 Section: main
 Priority: extra
 Maintainer: support <support@edge-core.com>
-Build-Depends: debhelper (>= 9.0.0), bzip2
+Build-Depends: debhelper (>= 9.0.0), bzip2, python3
 Standards-Version: 3.9.3
 
 Package: sonic-platform-modules-bfn

--- a/platform/barefoot/sonic-platform-modules-bfn/debian/rules
+++ b/platform/barefoot/sonic-platform-modules-bfn/debian/rules
@@ -8,7 +8,7 @@ BUILD_DIR := $(shell pwd)/build
 WHEEL_BUILD_DIR := $(BUILD_DIR)/wheel
 
 %:
-	dh $@
+	dh $@ --with python3
 
 override_dh_auto_build:
 	set -e
@@ -28,8 +28,8 @@ override_dh_usrlocal:
 override_dh_pysupport:
 
 override_dh_clean:
-	rm -fr $(WHEEL_BUILD_DIR) 
-	rm -fr *.egg-info 
+	rm -fr $(WHEEL_BUILD_DIR)
+	rm -fr *.egg-info
 	rm -fr $(BUILD)
 	dh_clean
 

--- a/platform/barefoot/sonic-platform-modules-wnc-osw1800/debian/control
+++ b/platform/barefoot/sonic-platform-modules-wnc-osw1800/debian/control
@@ -2,7 +2,7 @@ Source: platform-modules-wnc-osw1800
 Section: main
 Priority: extra
 Maintainer: WNC <wnc@wnc.com.tw>
-Build-Depends: debhelper (>= 8.0.0), bzip2
+Build-Depends: debhelper (>= 8.0.0), bzip2, python3
 Standards-Version: 3.9.3
 
 Package: platform-modules-wnc-osw1800

--- a/platform/barefoot/sonic-platform-modules-wnc-osw1800/debian/rules
+++ b/platform/barefoot/sonic-platform-modules-wnc-osw1800/debian/rules
@@ -10,7 +10,7 @@ SCRIPT_SRC := $(shell pwd)/scripts
 SERVICE_SRC := $(shell pwd)/service
 
 %:
-	dh $@
+	dh $@ --with python3
 
 override_dh_auto_build:
 	make -C $(KERNEL_SRC)/build M=$(MODULE_SRC)


### PR DESCRIPTION
#### Why I did it
Build failed.

Due to the error message looks like build failed because `pyversions` utility was not found.

`pyversions` utility is a part of `python2-minimal` package and it wasn't installed.


#### How I did it
To avoid installing python2 just specify explicit python version `--with python3` and use build system for py3 `--buildsystem=pybuild`

#### How to verify it
Run build

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106


#### Description for the changelog
Fix SONiC build.
