### PR TITLE
[Celestica/Seastone2] Load interface LEDs

### DIFF
--- a/device/celestica/x86_64-cel_seastone_2-r0/led_proc_init.soc
+++ b/device/celestica/x86_64-cel_seastone_2-r0/led_proc_init.soc
@@ -1,9 +1,5 @@
-#Enable all ports
-port all en=1
-sleep 6
-#linkscan 250000; port xe,ce linkscan=on
-
-#Load LED
+linkscan off
+m0 load 0 0x3800 /usr/share/sonic/platform/custom.bin
+sleep 10
 led auto on; led start
-
-
+linkscan on


### PR DESCRIPTION
#### Why I did it

The DX030 platform has all LEDs shining green, no port status indication.

#### How I did it

Looking at other platforms that are Trident 3 based, we figured out that the LED configuration blobs are checked in but not loaded. We tested a few different ways of loading these blobs and the proposed one worked fine.

#### How to verify it

Tested on a Celestica Seastone2 DX030 switch

Testing scenarios:
- Various QSFP ports in both normal and breakout config.
- 100G and 40G link speed show different colors.
- SFP1 port works.

Data forwarding of course still works.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

Reason: Having the LEDs work is considered essential for a lot of people when considering platforms.

#### Description for the changelog

cel/seastone2: Enable interface LEDs

#### A picture of a cute animal (not mandatory but encouraged)

![image](https://user-images.githubusercontent.com/149442/149655718-13b5734d-49c6-42f8-a9e7-a90dcc4bab50.png)
