### PR TITLE
[DPB] Fix verbose mode issue

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -49,7 +49,7 @@ class SonicYangExtMixin:
             self.yangFiles = [f.split('/')[-1] for f in self.yangFiles]
             self.yangFiles = [f.split('.')[0] for f in self.yangFiles]
             self.sysLog(syslog.LOG_DEBUG,'Loaded below Yang Models')
-            self.sysLog(syslog.LOG_DEBUG,self.yangFiles)
+            self.sysLog(syslog.LOG_DEBUG,str(self.yangFiles))
 
             # load json for each yang model
             self._loadJsonYangModel()


### PR DESCRIPTION
#### Why I did it
To fix https://github.com/Azure/sonic-buildimage/issues/9606 

root@sonic:~# config interface breakout Ethernet0 1x400G -y -f -v

Running Breakout Mode : 4x100G
Target Breakout Mode : 1x400G

Ports to be deleted :
{
"Ethernet0": "100000",
"Ethernet2": "100000",
"Ethernet4": "100000",
"Ethernet6": "100000"
}
Ports to be added :
{
"Ethernet0": "400000"
}



After running Logic to limit the impact

Final list of ports to be deleted :
{
"Ethernet0": "100000",
"Ethernet2": "100000",
"Ethernet4": "100000",
"Ethernet6": "100000"
}
Final list of ports to be added :
{
"Ethernet0": "400000"
}
sonic_yang(3):Yang Models Load failed:[priority,] message string
Yang Models Load failed
[priority,] message string
ConfigMgmt Class creation failed
Failed to break out Port. Error: Failed to load the config. Error: ConfigMgmtDPB Class creation failed
root@sonic:~#

#### How I did it
List was used to print in syslog which was not supported
#### How to verify it
Verify breakout in verbose mode
#### Which release branch to backport (provide reason below if selected)


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog


#### A picture of a cute animal (not mandatory but encouraged)

