### PR TITLE
[broadcom-dnx] Fix dnx image and dnx platform mismatch issue

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -97,7 +97,7 @@ generate_device_list()
 
     for d in `find -L ./device  -maxdepth 2 -mindepth 2 -type d`; do
         if [ -f $d/platform_asic ]; then
-            if [ "$CONFIGURED_PLATFORM" = "generic" ] || grep -Fxq "$CONFIGURED_PLATFORM" $d/platform_asic; then
+            if [ "$TARGET_MACHINE" = "generic" ] || grep -Fxq "$TARGET_MACHINE" $d/platform_asic; then
                 echo "${d##*/}" >> "$platforms_asic";
             fi;
         fi;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Fix https://github.com/Azure/sonic-buildimage/issues/9759
#### Why I did it
`sonic-broadcom-dnx.bin` should be able to installed on DNX supported platform, whereas it doesn't.
#### How I did it
Changed `CONFIGUTED_PLATFORM` to `TARGET_MACHINE` to distinguish `broadcom` and `broadcom-dnx`
#### How to verify it
tar `sonic-broadcom-dnx.bin` and verify its `platforms_asic` contians dnx platforms
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

