### PR TITLE
[system-health] Remove booting stage in system health service

### DIFF
--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -218,7 +218,7 @@ class ServiceChecker(HealthChecker):
         output = utils.run_command(ServiceChecker.CHECK_CMD)
         lines = output.splitlines()
         if not lines or len(lines) < ServiceChecker.MIN_CHECK_CMD_LINES:
-            self.set_object_not_ok('Service', 'monit', 'output of \"monit summary -B\" is invalid or incompatible')
+            self.set_object_not_ok('Service', 'monit', 'monit service is not ready')
             return
 
         status_begin = lines[1].find('Status')

--- a/src/system-health/health_checker/utils.py
+++ b/src/system-health/health_checker/utils.py
@@ -8,7 +8,7 @@ def run_command(command):
     :return: Output of the shell command.
     """
     try:
-        process = subprocess.Popen(command, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
+        process = subprocess.Popen(command, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return process.communicate()[0]
     except Exception:
         return None

--- a/src/system-health/scripts/healthd
+++ b/src/system-health/scripts/healthd
@@ -18,7 +18,7 @@ SYSLOG_IDENTIFIER = 'healthd'
 
 class HealthDaemon(DaemonBase):
     """
-    A daemon that run as a service to perform system health checker with a configurable interval. Also set system LED 
+    A daemon that run as a service to perform system health checker with a configurable interval. Also set system LED
     according to the check result and store the check result to redis.
     """
     SYSTEM_HEALTH_TABLE_NAME = 'SYSTEM_HEALTH_INFO'
@@ -35,7 +35,7 @@ class HealthDaemon(DaemonBase):
     def deinit(self):
         """
         Destructor. Remove all entries in $SYSTEM_HEALTH_TABLE_NAME table.
-        :return: 
+        :return:
         """
         self._clear_system_health_table()
 
@@ -64,7 +64,7 @@ class HealthDaemon(DaemonBase):
     def run(self):
         """
         Check system health in an infinite loop.
-        :return: 
+        :return:
         """
         self.log_notice("Starting up...")
 
@@ -76,9 +76,8 @@ class HealthDaemon(DaemonBase):
                 self.log_warning("System health configuration file not found, exit...")
                 return
             while 1:
-                state, stat = manager.check(chassis)
-                if state == HealthCheckerManager.STATE_RUNNING:
-                    self._process_stat(chassis, manager.config, stat)
+                stat = manager.check(chassis)
+                self._process_stat(chassis, manager.config, stat)
 
                 if self.stop_event.wait(manager.config.interval):
                     break


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Depends on https://github.com/Azure/sonic-utilities/pull/2022. Suggest merge order:
1. Merge https://github.com/Azure/sonic-utilities/pull/2022 first
2. Merge this and update sonic-utilities submodule pointer

#### Why I did it

For SYSTEM READY feature. Currently, there is a booting stage in system health service to indicate that the system is loading SONiC component. This booting stage is no longer needed because SYSTEM READY feature will treat that stage as system "NOT READY".

#### How I did it

1. Remove booting stage
2. Adjust unit test cases

#### How to verify it

1. Manual test
2. Unit test
3. sonic-mgmt Regression

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

