### PR TITLE
[yang]: Update yang models to support 'cluster'

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -67,6 +67,9 @@
     "DEVICE_METADATA_RESOURCE_TYPE_CONFIG": {
         "desc": "Verifying resource type configuration."
     },
+    "DEVICE_METADATA_VALID_CLUSTER": {
+        "desc": "Verifying valid cluster configuration."
+    },
 	"DEVICE_METADATA_VALID_SUBTYPE": {
 		"desc": "Verifying valid subtype value"
 	},

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -1,49 +1,49 @@
 {
     "DEV_META_DEV_NEIGH_VERSION_TABLE": {
-	"desc": "DEVICE_METADATA DEVICE_NEIGHBOR VERSION TABLE."
+        "desc": "DEVICE_METADATA DEVICE_NEIGHBOR VERSION TABLE."
     },
     "DEVICE_METADATA_DEFAULT_BGP_STATUS": {
-	"desc": "DEVICE_METADATA DEFAULT VALUE FOR BGP_STATUS FIELD.",
-	"eStrKey" : "Verify",
-	"verify": {
-	    "xpath": "/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname",
-	    "key": "sonic-device_metadata:default_bgp_status",
-	    "value": "up"
-	}
+        "desc": "DEVICE_METADATA DEFAULT VALUE FOR BGP_STATUS FIELD.",
+        "eStrKey" : "Verify",
+        "verify": {
+            "xpath": "/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname",
+            "key": "sonic-device_metadata:default_bgp_status",
+            "value": "up"
+        }
     },
     "DEVICE_METADATA_DEFAULT_DOCKER_ROUTING_CONFIG_MODE": {
-	"desc": "DEVICE_METADATA DEFAULT VALUE FOR DOCKER_ROUTING_CONFIG_MODE FIELD.",
-	"eStrKey" : "Verify",
-	"verify": {
-	    "xpath": "/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname",
-	    "key": "sonic-device_metadata:docker_routing_config_mode",
-	    "value": "unified"
-	}
+        "desc": "DEVICE_METADATA DEFAULT VALUE FOR DOCKER_ROUTING_CONFIG_MODE FIELD.",
+        "eStrKey" : "Verify",
+        "verify": {
+        "xpath": "/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname",
+            "key": "sonic-device_metadata:docker_routing_config_mode",
+            "value": "unified"
+        }
     },
     "DEVICE_METADATA_DEFAULT_PFCWD_STATUS": {
-	"desc": "DEVICE_METADATA DEFAULT VALUE FOR PFCWD FIELD.",
-	"eStrKey" : "Verify",
-	"verify": {
-	    "xpath": "/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname",
-	    "key": "sonic-device_metadata:default_pfcwd_status",
-	    "value": "disable"
-	}
+        "desc": "DEVICE_METADATA DEFAULT VALUE FOR PFCWD FIELD.",
+        "eStrKey" : "Verify",
+        "verify": {
+            "xpath": "/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname",
+            "key": "sonic-device_metadata:default_pfcwd_status",
+            "value": "disable"
+        }
     },
     "DEVICE_METADATA_TYPE_INCORRECT_PATTERN": {
-	"desc": "DEVICE_METADATA_TYPE_INCORRECT_PATTERN pattern failure.",
-	"eStrKey" : "Pattern"
+        "desc": "DEVICE_METADATA_TYPE_INCORRECT_PATTERN pattern failure.",
+        "eStrKey" : "Pattern"
     },
     "DEVICE_METADATA_TYPE_CORRECT_PATTERN": {
         "desc": "DEVICE_METADATA correct value for Type field"
     },
-	"DEVICE_METADATA_DEFAULT_SYNCHRONOUS_MODE": {
-	"desc": "DEVICE_METADATA DEFAULT VALUE FOR SYNCHRONOUS MODE.",
-	"eStrKey" : "Verify",
-	"verify": {
-	    "xpath": "/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname",
-	    "key": "sonic-device_metadata:synchronous_mode",
-	    "value": "enable"
-	}
+    "DEVICE_METADATA_DEFAULT_SYNCHRONOUS_MODE": {
+        "desc": "DEVICE_METADATA DEFAULT VALUE FOR SYNCHRONOUS MODE.",
+        "eStrKey" : "Verify",
+        "verify": {
+            "xpath": "/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname",
+            "key": "sonic-device_metadata:synchronous_mode",
+            "value": "enable"
+        }
     },
     "DEVICE_METADATA_CORRECT_BUFFER_MODEL_PATTERN": {
         "desc": "DEVICE_METADATA correct value for BUFFER_MODEL field"
@@ -70,26 +70,26 @@
     "DEVICE_METADATA_VALID_CLUSTER": {
         "desc": "Verifying valid cluster configuration."
     },
-	"DEVICE_METADATA_VALID_SUBTYPE": {
-		"desc": "Verifying valid subtype value"
-	},
-	"DEVICE_METADATA_INVALID_SUBTYPE": {
-		"desc": "Verifying invalid subtype value",
-		"eStrKey": "Pattern"
-	},
-	"DEVICE_METADATA_VALID_PEER_SWITCH": {
-		"desc": "Verifying valid peer switch hostname"
-	},
-	"DEVICE_METADATA_INVALID_PEER_SWITCH": {
-		"desc": "Verifying test fails with hostname that is too long",
-		"eStrKey": "Range"
-	},
-	"DEVICE_METADATA_VALID_STORAGE_DEVICE": {
-		"desc": "Verifying valid storage device value"
-	},
-	"DEVICE_METADATA_INVALID_STORAGE_DEVICE": {
-		"desc": "Verifying invalid storage device value",
-		"eStrKey": "InvalidValue"
-	}
+    "DEVICE_METADATA_VALID_SUBTYPE": {
+        "desc": "Verifying valid subtype value"
+    },
+    "DEVICE_METADATA_INVALID_SUBTYPE": {
+        "desc": "Verifying invalid subtype value",
+        "eStrKey": "Pattern"
+    },
+    "DEVICE_METADATA_VALID_PEER_SWITCH": {
+        "desc": "Verifying valid peer switch hostname"
+    },
+    "DEVICE_METADATA_INVALID_PEER_SWITCH": {
+        "desc": "Verifying test fails with hostname that is too long",
+        "eStrKey": "Range"
+    },
+    "DEVICE_METADATA_VALID_STORAGE_DEVICE": {
+        "desc": "Verifying valid storage device value"
+    },
+    "DEVICE_METADATA_INVALID_STORAGE_DEVICE": {
+        "desc": "Verifying invalid storage device value",
+        "eStrKey": "InvalidValue"
+    }
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -178,6 +178,15 @@
             }
         }
     },
+    "DEVICE_METADATA_VALID_CLUSTER": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "cluster": "AAA00PrdStr00"
+                }
+            }
+        }
+    },
     "DEVICE_METADATA_VALID_SUBTYPE": {
         "sonic-device_metadata:sonic-device_metadata": {
             "sonic-device_metadata:DEVICE_METADATA": {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -137,6 +137,7 @@ module sonic-device_metadata {
 
                 leaf cluster {
                     type string;
+                    description "The switch is a member of this cluster.";
                 }
 
                 leaf subtype {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -135,6 +135,10 @@ module sonic-device_metadata {
                     type string;
                 }
 
+                leaf cluster {
+                    type string;
+                }
+
                 leaf subtype {
                     type string {
                         pattern "DualToR";


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Minigraph parser added a new field 'cluster' to device_metadata, and then yang validation is blocked.

#### How I did it
Add 'cluster' to  device_metadata yang models.

#### How to verify it
Run UT for sonc-yang-models.
Use minigraph parser to generate ConfigDB schema and run yang validation.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix #9699 

#### A picture of a cute animal (not mandatory but encouraged)

