### PR TITLE
[YANG] Add route flow counter support

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -957,6 +957,21 @@
             },
             "DEBUG_COUNTER": {
                 "FLEX_COUNTER_STATUS": "enable"
+            },
+            "FLOW_CNT_ROUTE": {
+                "FLEX_COUNTER_STATUS": "enable",
+                "POLL_INTERVAL": "10000"
+            }
+        },
+        "FLOW_COUNTER_ROUTE_PATTERN": {
+            "1.1.1.0/24": {
+                "max_match_count": "30"
+            },
+            "2000::/64": {
+                "max_match_count": "30"
+            },
+            "Vnet1|2.2.2.0/24": {
+                "max_match_count": "30"
             }
         },
         "CRM": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/flex_counter.json
@@ -6,5 +6,16 @@
         "desc": "Out of range poll interval.",
         "eStrKey": "Range",
         "eStr": "100..4294967295"
+    },
+    "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_VRF": {
+        "desc": "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_VRF no failure."
+    },
+    "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_DEFAULT_VRF": {
+        "desc": "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_DEFAULT_VRF no failure."
+    },
+    "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_INVALID_MAX_MATCH_COUNT": {
+        "desc": "Out of range max_match_count.",
+        "eStrKey": "Range",
+        "eStr": "1..50"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -121,7 +121,7 @@
         },
         "sonic-flex_counter:sonic-flex_counter": {
             "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN": {
-                "PATTERN_LIST": [
+                "FLOW_COUNTER_ROUTE_PATTERN_VRF_LIST": [
                     {
                         "vrf_name": "Vrf1",
                         "ip_prefix": "1.1.1.0/24",
@@ -139,14 +139,12 @@
     "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_DEFAULT_VRF": {
         "sonic-flex_counter:sonic-flex_counter": {
             "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN": {
-                "PATTERN_LIST": [
+                "FLOW_COUNTER_ROUTE_PATTERN_LIST": [
                     {
-                        "vrf_name": "",
                         "ip_prefix": "1.1.1.0/24",
                         "max_match_count": 30
                     },
                     {
-                        "vrf_name": "",
                         "ip_prefix": "2000::/64",
                         "max_match_count": 30
                     }
@@ -158,15 +156,15 @@
         "sonic-vrf:sonic-vrf":{
             "sonic-vrf:VRF": {
                 "VRF_LIST": [
-                {
-                    "name":"Vrf1"
-                }
+                    {
+                        "name":"Vrf1"
+                    }
                 ]
             }
         },
         "sonic-flex_counter:sonic-flex_counter": {
             "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN": {
-                "PATTERN_LIST": [
+                "FLOW_COUNTER_ROUTE_PATTERN_VRF_LIST": [
                     {
                         "vrf_name": "Vrf1",
                         "ip_prefix": "1.1.1.0/24",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -120,7 +120,7 @@
             }
         },
         "sonic-flex_counter:sonic-flex_counter": {
-            "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN_TABLE": {
+            "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN": {
                 "PATTERN_LIST": [
                     {
                         "vrf_name": "Vrf1",
@@ -138,7 +138,7 @@
     },
     "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_DEFAULT_VRF": {
         "sonic-flex_counter:sonic-flex_counter": {
-            "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN_TABLE": {
+            "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN": {
                 "PATTERN_LIST": [
                     {
                         "vrf_name": "",
@@ -165,7 +165,7 @@
             }
         },
         "sonic-flex_counter:sonic-flex_counter": {
-            "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN_TABLE": {
+            "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN": {
                 "PATTERN_LIST": [
                     {
                         "vrf_name": "Vrf1",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -46,6 +46,10 @@
                 "FLOW_CNT_TRAP": {
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 10000
+                },
+                "FLOW_CNT_ROUTE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
                 }
             }
         }
@@ -97,7 +101,78 @@
                 "FLOW_CNT_TRAP": {
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 99
+                },
+                "FLOW_CNT_ROUTE": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 99
                 }
+            }
+        }
+    },
+    "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_VRF": {
+        "sonic-vrf:sonic-vrf":{
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                    {
+                        "name":"Vrf1"
+                    }
+                ]
+            }
+        },
+        "sonic-flex_counter:sonic-flex_counter": {
+            "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN_TABLE": {
+                "PATTERN_LIST": [
+                    {
+                        "vrf_name": "Vrf1",
+                        "ip_prefix": "1.1.1.0/24",
+                        "max_match_count": 30
+                    },
+                    {
+                        "vrf_name": "Vrf1",
+                        "ip_prefix": "2000::/64",
+                        "max_match_count": 30
+                    }
+                ]
+            }
+        }
+    },
+    "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_DEFAULT_VRF": {
+        "sonic-flex_counter:sonic-flex_counter": {
+            "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN_TABLE": {
+                "PATTERN_LIST": [
+                    {
+                        "vrf_name": "",
+                        "ip_prefix": "1.1.1.0/24",
+                        "max_match_count": 30
+                    },
+                    {
+                        "vrf_name": "",
+                        "ip_prefix": "2000::/64",
+                        "max_match_count": 30
+                    }
+                ]
+            }
+        }
+    },
+    "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_INVALID_MAX_MATCH_COUNT": {
+        "sonic-vrf:sonic-vrf":{
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                {
+                    "name":"Vrf1"
+                }
+                ]
+            }
+        },
+        "sonic-flex_counter:sonic-flex_counter": {
+            "sonic-flex_counter:FLOW_COUNTER_ROUTE_PATTERN_TABLE": {
+                "PATTERN_LIST": [
+                    {
+                        "vrf_name": "Vrf1",
+                        "ip_prefix": "1.1.1.0/24",
+                        "max_match_count": 0
+                    }
+                ]
             }
         }
     }

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -227,7 +227,7 @@ module sonic-flex_counter {
         }
         /* end of container FLEX_COUNTER_TABLE */
 
-        container FLOW_COUNTER_ROUTE_PATTERN_TABLE {
+        container FLOW_COUNTER_ROUTE_PATTERN {
             description "Flow counter route pattern of config_db.json";
 
             list PATTERN_LIST {

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -5,6 +5,10 @@ module sonic-flex_counter {
     namespace "http://github.com/Azure/sonic-flex_counter";
     prefix flex_counter;
 
+    import ietf-inet-types {
+        prefix inet;
+    }
+
     import sonic-types {
         prefix stypes;
     }
@@ -230,7 +234,23 @@ module sonic-flex_counter {
         container FLOW_COUNTER_ROUTE_PATTERN {
             description "Flow counter route pattern of config_db.json";
 
-            list PATTERN_LIST {
+            list FLOW_COUNTER_ROUTE_PATTERN_LIST {
+
+                key "ip_prefix";
+
+                leaf ip_prefix {
+                    type inet:ip-prefix;
+                }
+
+                leaf max_match_count {
+                    type uint32 {
+                        range 1..50;
+                    }
+                }
+
+            }
+
+            list FLOW_COUNTER_ROUTE_PATTERN_VRF_LIST {
 
                 key "vrf_name ip_prefix";
 
@@ -246,7 +266,7 @@ module sonic-flex_counter {
                 }
 
                 leaf ip_prefix {
-                    type stypes:sonic-ip-prefix;
+                    type inet:ip-prefix;
                 }
 
                 leaf max_match_count {
@@ -257,7 +277,7 @@ module sonic-flex_counter {
 
             }
         }
-        /* end of container FLOW_COUNTER_ROUTE_PATTERN_TABLE */
+        /* end of container FLOW_COUNTER_ROUTE_PATTERN */
     }
     /* end of top level container */
 }

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -211,8 +211,51 @@ module sonic-flex_counter {
                 }
             }
 
+            container FLOW_CNT_ROUTE {
+                /* ROUTE_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+                leaf POLL_INTERVAL {
+                    type poll_interval;
+                }
+            }
+
         }
         /* end of container FLEX_COUNTER_TABLE */
+
+        container FLOW_COUNTER_ROUTE_PATTERN_TABLE {
+            description "Flow counter route pattern of config_db.json";
+
+            list PATTERN_LIST {
+
+                key "vrf_name ip_prefix";
+
+                leaf vrf_name {
+                    type string {
+                        length 0..16;
+                    }
+                }
+
+                leaf ip_prefix {
+                    type union {
+                        type stypes:sonic-ip4-prefix;
+                        type stypes:sonic-ip6-prefix;
+                    }
+                }
+
+                leaf max_match_count {
+                    type uint32 {
+                        range 1..50;
+                    }
+                }
+
+            }
+        }
+        /* end of container FLOW_COUNTER_ROUTE_PATTERN_TABLE */
     }
     /* end of top level container */
 }

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -241,10 +241,7 @@ module sonic-flex_counter {
                 }
 
                 leaf ip_prefix {
-                    type union {
-                        type stypes:sonic-ip4-prefix;
-                        type stypes:sonic-ip6-prefix;
-                    }
+                    type stypes:sonic-ip-prefix;
                 }
 
                 leaf max_match_count {

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -235,6 +235,11 @@ module sonic-flex_counter {
                 key "vrf_name ip_prefix";
 
                 leaf vrf_name {
+                    /*
+                    We don't use vrf_name reference here because:
+                    1. User is allowed to configure a VRF that does not exist yet here, orchagent is designed to resolve the VRF name once the VRF is created.
+                    2. The field vrf_name accept both VRF name and VNET name.
+                    */
                     type string {
                         length 0..16;
                     }


### PR DESCRIPTION
HLD: https://github.com/Azure/SONiC/pull/908

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add YANG models for route flow counters

#### How I did it

1. Add a new YANG definition for new counter group FLOW_CNT_ROUTE
2. Add a new YANG definition for new table FLOW_COUNTER_ROUTE_PATTERN_TABLE

#### How to verify it

New unit test cases

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

