### PR TITLE
[build] Fix platform vs build failure: install_sonic.py:45 timeout

### DIFF
--- a/install_sonic.py
+++ b/install_sonic.py
@@ -23,7 +23,7 @@ def main():
     i = 0
     while True:
         try:
-            p = pexpect.spawn("telnet 127.0.0.1 {}".format(args.p), timeout=600, logfile=sys.stdout, encoding='utf-8')
+            p = pexpect.spawn("telnet 127.0.0.1 {}".format(args.p), timeout=1200, logfile=sys.stdout, encoding='utf-8')
             break
         except Exception as e:
             print(str(e))

--- a/install_sonic.py
+++ b/install_sonic.py
@@ -23,7 +23,7 @@ def main():
     i = 0
     while True:
         try:
-            p = pexpect.spawn("telnet 127.0.0.1 {}".format(args.p), timeout=1200, logfile=sys.stdout, encoding='utf-8')
+            p = pexpect.spawn("telnet 127.0.0.1 {}".format(args.p), timeout=900, logfile=sys.stdout, encoding='utf-8')
             break
         except Exception as e:
             print(str(e))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix platform vs master branch build failure:
Traceback (most recent call last):
  File "/sonic/./install_sonic.py", line 49, in <module>
    main()
  File "/sonic/./install_sonic.py", line 45, in main
    p.expect([grub_selection])
  File "/usr/local/lib/python3.9/dist-packages/pexpect/spawnbase.py", line 343, in expect
    return self.expect_list(compiled_pattern_list,
  File "/usr/local/lib/python3.9/dist-packages/pexpect/spawnbase.py", line 372, in expect_list
    return exp.expect_loop(timeout)
  File "/usr/local/lib/python3.9/dist-packages/pexpect/expect.py", line 181, in expect_loop
    return self.timeout(e)
  File "/usr/local/lib/python3.9/dist-packages/pexpect/expect.py", line 144, in timeout
    raise exc
pexpect.exceptions.TIMEOUT: Timeout exceeded.
<pexpect.pty_spawn.spawn object at 0x7f868790df10>
command: /usr/bin/telnet
args: [b'/usr/bin/telnet', b'127.0.0.1', b'9000']
#### How I did it
extend timeout from 600 seconds to 900 seconds
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

