### PR TITLE
caclmgrd: correct IP2ME address logic

### DIFF
--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -215,18 +215,12 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 for key, _ in iface_table.items():
                     if not _ip_prefix_in_key(key):
                         continue
-
                     iface_name, iface_cidr = key
-                    ip_ntwrk = ipaddress.ip_network(iface_cidr, strict=False)
-
-                    # For VLAN interfaces, the IP address we want to block is the default gateway (i.e.,
-                    # the first available host IP address of the VLAN subnet)
-                    ip_addr = next(ip_ntwrk.hosts()) if iface_table_name == "VLAN_INTERFACE" else ip_ntwrk.network_address
-
-                    if isinstance(ip_ntwrk, ipaddress.IPv4Network):
-                        block_ip2me_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -A INPUT -d {}/{} -j DROP".format(ip_addr, ip_ntwrk.max_prefixlen))
-                    elif isinstance(ip_ntwrk, ipaddress.IPv6Network):
-                        block_ip2me_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -A INPUT -d {}/{} -j DROP".format(ip_addr, ip_ntwrk.max_prefixlen))
+                    ip_iface = ipaddress.ip_interface(iface_cidr)
+                    if isinstance(ip_iface, ipaddress.IPv4Interface):
+                        block_ip2me_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -A INPUT -d {} -j DROP -m comment --comment 'Block IP2ME on interface {}'".format(ip_iface.ip, iface_name))
+                    elif isinstance(ip_iface, ipaddress.IPv6Interface):
+                        block_ip2me_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -A INPUT -d {} -j DROP -m comment --comment 'Block IP2ME on interface {}'".format(ip_iface.ip, iface_name))
                     else:
                         self.log_warning("Unrecognized IP address type on interface '{}': {}".format(iface_name, ip_ntwrk))
 

--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -218,12 +218,28 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                         continue
                     iface_name, iface_cidr = key
                     ip_iface = ipaddress.ip_interface(iface_cidr)
+                    ip_ntwrk = ipaddress.ip_network(iface_cidr, strict=False)
+                    ip_first_addr = next(iter(ip_ntwrk.hosts()), None)
+
                     if isinstance(ip_iface, ipaddress.IPv4Interface):
                         block_ip2me_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -A INPUT -d {} -j DROP -m comment --comment 'Block IP2ME on interface {}'".format(ip_iface.ip, iface_name))
                     elif isinstance(ip_iface, ipaddress.IPv6Interface):
                         block_ip2me_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -A INPUT -d {} -j DROP -m comment --comment 'Block IP2ME on interface {}'".format(ip_iface.ip, iface_name))
                     else:
-                        self.log_warning("Unrecognized IP address type on interface '{}': {}".format(iface_name, ip_ntwrk))
+                        self.log_warning("Unrecognized IP address type on interface '{}': {}".format(iface_name, ip_iface))
+
+                    # For more information about this part, see
+                    # https://github.com/Azure/sonic-buildimage/pull/9826
+                    # For VLAN interfaces, we additionally block the first IP
+                    # in the subnet.
+                    if (iface_table_name == "VLAN_INTERFACE" and
+                        ip_first_addr is not None and ip_first_addr != ip_iface.ip):
+                        if isinstance(ip_ntwrk, ipaddress.IPv4Network):
+                            block_ip2me_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -A INPUT -d {} -j DROP -m comment --comment 'Block IP2ME (first IP) on interface {}'".format(ip_first_addr, iface_name))
+                        elif isinstance(ip_ntwrk, ipaddress.IPv6Network):
+                            block_ip2me_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -A INPUT -d {} -j DROP -m comment --comment 'Block IP2ME (first IP) on interface {}'".format(ip_first_addr, iface_name))
+                        else:
+                            self.log_warning("Unrecognized IP address type on interface '{}': {}".format(iface_name, ip_ntwrk))
 
         return block_ip2me_cmds
 

--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -198,9 +198,10 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         return tcp_flags_str
 
     def generate_block_ip2me_traffic_iptables_commands(self, namespace):
+        # We do not block MGMT_INTERFACE IPs by default to allow users
+        # to manage the box with default configuration.
         INTERFACE_TABLE_NAME_LIST = [
             "LOOPBACK_INTERFACE",
-            "MGMT_INTERFACE",
             "VLAN_INTERFACE",
             "PORTCHANNEL_INTERFACE",
             "INTERFACE"

--- a/src/sonic-host-services/tests/caclmgrd/caclmgrd_dhcp_test.py
+++ b/src/sonic-host-services/tests/caclmgrd/caclmgrd_dhcp_test.py
@@ -14,19 +14,20 @@ from tests.common.mock_configdb import MockConfigDb
 DBCONFIG_PATH = '/var/run/redis/sonic-db/database_config.json'
 
 
-swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
-test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-modules_path = os.path.dirname(test_path)
-scripts_path = os.path.join(modules_path, "scripts")
-sys.path.insert(0, modules_path)
-caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
-caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
-
-
 class TestCaclmgrdDhcp(TestCase):
     """
         Test caclmgrd dhcp
     """
+    def setUp(self):
+
+        swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+
     @parameterized.expand(CACLMGRD_DHCP_TEST_VECTOR)
     @patchfs
     def test_caclmgrd_dhcp(self, test_name, test_data, fs):
@@ -46,7 +47,7 @@ class TestCaclmgrdDhcp(TestCase):
 
             mark = test_data["mark"]
 
-            caclmgrd_daemon = caclmgrd.ControlPlaneAclManager("caclmgrd")
+            caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
             mux_update = test_data["mux_update"]
 
             for key,data in mux_update:

--- a/src/sonic-host-services/tests/caclmgrd/caclmgrd_ip2me_test.py
+++ b/src/sonic-host-services/tests/caclmgrd/caclmgrd_ip2me_test.py
@@ -26,6 +26,7 @@ class TestCaclmgrdIP2Me(TestCase):
         sys.path.insert(0, modules_path)
         caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
         self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+        self.maxDiff = None
 
     @parameterized.expand(CACLMGRD_IP2ME_TEST_VECTOR)
     @patchfs
@@ -38,4 +39,4 @@ class TestCaclmgrdIP2Me(TestCase):
         self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
         caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
         ret = caclmgrd_daemon.generate_block_ip2me_traffic_iptables_commands('')
-        self.assertEqual(ret, test_data["return"])
+        self.assertListEqual(test_data["return"], ret)

--- a/src/sonic-host-services/tests/caclmgrd/caclmgrd_ip2me_test.py
+++ b/src/sonic-host-services/tests/caclmgrd/caclmgrd_ip2me_test.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+from swsscommon import swsscommon
+from parameterized import parameterized
+from sonic_py_common.general import load_module_from_source
+from unittest import TestCase, mock
+from pyfakefs.fake_filesystem_unittest import patchfs
+
+from .test_ip2me_vectors import CACLMGRD_IP2ME_TEST_VECTOR
+from tests.common.mock_configdb import MockConfigDb
+
+
+DBCONFIG_PATH = '/var/run/redis/sonic-db/database_config.json'
+
+
+class TestCaclmgrdIP2Me(TestCase):
+    """
+        Test caclmgrd IP2Me
+    """
+    def setUp(self):
+        swsscommon.ConfigDBConnector = MockConfigDb
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+
+    @parameterized.expand(CACLMGRD_IP2ME_TEST_VECTOR)
+    @patchfs
+    def test_caclmgrd_ip2me(self, test_name, test_data, fs):
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH) # fake database_config.json
+
+        MockConfigDb.set_config_db(test_data["config_db"])
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
+        caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+        ret = caclmgrd_daemon.generate_block_ip2me_traffic_iptables_commands('')
+        self.assertEqual(ret, test_data["return"])

--- a/src/sonic-host-services/tests/caclmgrd/test_ip2me_vectors.py
+++ b/src/sonic-host-services/tests/caclmgrd/test_ip2me_vectors.py
@@ -1,0 +1,97 @@
+from unittest.mock import call
+
+"""
+    caclmgrd ip2me block test vector
+"""
+CACLMGRD_IP2ME_TEST_VECTOR = [
+    [
+        "Only MGMT interface, no block",
+        {
+            "config_db": {
+                "MGMT_INTERFACE": {
+                    "eth0|172.18.0.100/24": {
+                        "gwaddr": "172.18.0.1"
+                    }
+                },
+                "LOOPBACK_INTERFACE": {},
+                "VLAN_INTERFACE": {},
+                "PORTCHANNEL_INTERFACE": {},
+                "INTERFACE": {},
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+            },
+            "return": [
+            ],
+        },
+    ],
+    [
+        "One interface of each type, /32 - block all interfaces but MGMT",
+        {
+            "config_db": {
+                "LOOPBACK_INTERFACE": {
+                    "Loopback0|10.10.10.10/32": {},
+                },
+                "VLAN_INTERFACE": {
+                    "Vlan110|10.10.11.10/32": {},
+                },
+                "PORTCHANNEL_INTERFACE": {
+                    "PortChannel0001|10.10.12.10/32": {},
+                },
+                "INTERFACE": {
+                    "Ethernet0|10.10.13.10/32": {}
+                },
+                "MGMT_INTERFACE": {
+                    "eth0|172.18.0.100/24": {
+                        "gwaddr": "172.18.0.1"
+                    }
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+            },
+            "return": [
+                "iptables -A INPUT -d 10.10.10.10 -j DROP -m comment --comment 'Block IP2ME on interface Loopback0'",
+                "iptables -A INPUT -d 10.10.11.10 -j DROP -m comment --comment 'Block IP2ME on interface Vlan110'",
+                "iptables -A INPUT -d 10.10.12.10 -j DROP -m comment --comment 'Block IP2ME on interface PortChannel0001'",
+                "iptables -A INPUT -d 10.10.13.10 -j DROP -m comment --comment 'Block IP2ME on interface Ethernet0'"
+            ],
+        },
+    ],
+    [
+        "One interface of each type, /25 - block all interfaces but MGMT",
+        {
+            "config_db": {
+                "LOOPBACK_INTERFACE": {
+                    "Loopback0|10.10.10.150/25": {},
+                },
+                "VLAN_INTERFACE": {
+                    "Vlan110|10.10.11.100/25": {},
+                },
+                "PORTCHANNEL_INTERFACE": {
+                    "PortChannel0001|10.10.12.100/25": {},
+                },
+                "INTERFACE": {
+                    "Ethernet0|10.10.13.1/25": {}
+                },
+                "MGMT_INTERFACE": {
+                    "eth0|172.18.0.100/24": {
+                        "gwaddr": "172.18.0.1"
+                    }
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+            },
+            "return": [
+                "iptables -A INPUT -d 10.10.10.150 -j DROP -m comment --comment 'Block IP2ME on interface Loopback0'",
+                "iptables -A INPUT -d 10.10.11.100 -j DROP -m comment --comment 'Block IP2ME on interface Vlan110'",
+                "iptables -A INPUT -d 10.10.12.100 -j DROP -m comment --comment 'Block IP2ME on interface PortChannel0001'",
+                "iptables -A INPUT -d 10.10.13.1 -j DROP -m comment --comment 'Block IP2ME on interface Ethernet0'"
+            ],
+        },
+    ]
+]

--- a/src/sonic-host-services/tests/caclmgrd/test_ip2me_vectors.py
+++ b/src/sonic-host-services/tests/caclmgrd/test_ip2me_vectors.py
@@ -89,9 +89,71 @@ CACLMGRD_IP2ME_TEST_VECTOR = [
             "return": [
                 "iptables -A INPUT -d 10.10.10.150 -j DROP -m comment --comment 'Block IP2ME on interface Loopback0'",
                 "iptables -A INPUT -d 10.10.11.100 -j DROP -m comment --comment 'Block IP2ME on interface Vlan110'",
+                "iptables -A INPUT -d 10.10.11.1 -j DROP -m comment --comment 'Block IP2ME (first IP) on interface Vlan110'",
                 "iptables -A INPUT -d 10.10.12.100 -j DROP -m comment --comment 'Block IP2ME on interface PortChannel0001'",
                 "iptables -A INPUT -d 10.10.13.1 -j DROP -m comment --comment 'Block IP2ME on interface Ethernet0'"
             ],
         },
+    ],
+    [
+        "One VLAN interface, /24, we are .1 -- regression testing to ensure compatibility with old behavior",
+        {
+            "config_db": {
+                "MGMT_INTERFACE": {
+                    "eth0|172.18.0.100/24": {
+                        "gwaddr": "172.18.0.1"
+                    }
+                },
+                "LOOPBACK_INTERFACE": {},
+                "VLAN_INTERFACE": {
+                    "Vlan110|10.10.11.1/24": {},
+                },
+                "PORTCHANNEL_INTERFACE": {},
+                "INTERFACE": {},
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+            },
+            "return": [
+                "iptables -A INPUT -d 10.10.11.1 -j DROP -m comment --comment 'Block IP2ME on interface Vlan110'",
+            ],
+        },
+    ],
+    [
+        "One interface of each type, IPv6, /64 - block all interfaces but MGMT",
+        {
+            "config_db": {
+                "LOOPBACK_INTERFACE": {
+                    "Loopback0|2001:db8:10::/64": {},
+                },
+                "VLAN_INTERFACE": {
+                    "Vlan110|2001:db8:11::/64": {},
+                },
+                "PORTCHANNEL_INTERFACE": {
+                    "PortChannel0001|2001:db8:12::/64": {},
+                },
+                "INTERFACE": {
+                    "Ethernet0|2001:db8:13::/64": {}
+                },
+                "MGMT_INTERFACE": {
+                    "eth0|2001:db8:200::200/64": {
+                        "gwaddr": "2001:db8:200::100"
+                    }
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+            },
+            "return": [
+                "ip6tables -A INPUT -d 2001:db8:10:: -j DROP -m comment --comment 'Block IP2ME on interface Loopback0'",
+                "ip6tables -A INPUT -d 2001:db8:11:: -j DROP -m comment --comment 'Block IP2ME on interface Vlan110'",
+                "ip6tables -A INPUT -d 2001:db8:11::1 -j DROP -m comment --comment 'Block IP2ME (first IP) on interface Vlan110'",
+                "ip6tables -A INPUT -d 2001:db8:12:: -j DROP -m comment --comment 'Block IP2ME on interface PortChannel0001'",
+                "ip6tables -A INPUT -d 2001:db8:13:: -j DROP -m comment --comment 'Block IP2ME on interface Ethernet0'"
+            ],
+        },
     ]
+
 ]

--- a/src/sonic-host-services/tests/common/mock_configdb.py
+++ b/src/sonic-host-services/tests/common/mock_configdb.py
@@ -43,7 +43,10 @@ class MockConfigDb(object):
         MockConfigDb.CONFIG_DB[key][field] = data
 
     def get_table(self, table_name):
-        return MockConfigDb.CONFIG_DB[table_name]
+        data = {}
+        for k, v in MockConfigDb.CONFIG_DB[table_name].items():
+            data[self.deserialize_key(k)] = v
+        return data
 
     def subscribe(self, table_name, callback):
         self.handlers[table_name] = callback


### PR DESCRIPTION
#### Why I did it

Fixes #7008.

Ensure that the destination IP that is permitted is the interface IP.

Currently the logic does not handle IP interfaces correctly and only produces correct results for `/32` or `/128` subnets.

```json
{
    "LOOPBACK_INTERFACE": {
        "Loopback0": {},
        "Loopback0|10.10.10.10/32": {}
    },
    "MGMT_INTERFACE": {
        "eth0|172.18.0.249/24": {
            "gwaddr": "172.18.0.1"
        }
    },
    "VLAN_INTERFACE": {
        "Vlan110": {},
        "Vlan110|172.18.0.250/24": {},
    }
}
```

See `iptables -vnL`
```
    0     0 DROP       all  --  *      *       0.0.0.0/0            10.10.10.10         
    0     0 DROP       all  --  *      *       0.0.0.0/0            172.18.0.0          
    0     0 DROP       all  --  *      *       0.0.0.0/0            172.18.0.1         
```

#### How I did it

Corrected the logic and the iptables commands executed.

It is likely that the initial implementation was only ever tested on L3 interfaces with `/32` and VLAN-interfaces where the switch had the first IP in the network (e.g. `192.168.0.1/24`).

#### How to verify it

 1. Apply patch
 2. Configure some interfaces and VLAN interfaces
 3. Execute `iptables -vnL`

You will see something like this:
```
    0     0 DROP       all  --  *      *       0.0.0.0/0            10.10.10.10          /* Block IP2ME on interface Loopback0 */
    0     0 DROP       all  --  *      *       0.0.0.0/0            172.18.0.250         /* Block IP2ME on interface Vlan110 */
```

Note that MGMT_INTERFACEs are not blocked by default.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog

caclmgrd: handle IP2ME subnets

#### A picture of a cute animal (not mandatory but encouraged)

![image](https://user-images.githubusercontent.com/149442/150576872-76b65ec1-e34e-4418-bf9e-0ab1545207e9.png)

Note: The original code was added in https://github.com/Azure/sonic-buildimage/pull/4412