### PR TITLE
Updated format of generating BUFFER_QUEUE in buffers_defaults templates

### DIFF
--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t0.j2
@@ -61,11 +61,15 @@
 
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
-        "{{ port_names }}|3-4": {
-            "profile" : "egress_lossless_profile"
-        },
-        "{{ port_names }}|0-1": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-1": {
             "profile" : "q_lossy_profile"
-        }
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "egress_lossless_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t0.j2
@@ -62,7 +62,7 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
-        "{{ port }}|0-1": {
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
         },
 {% endfor %}

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t1.j2
@@ -61,11 +61,15 @@
 
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
-        "{{ port_names }}|3-4": {
-            "profile" : "egress_lossless_profile"
-        },
-        "{{ port_names }}|0-1": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-1": {
             "profile" : "q_lossy_profile"
-        }
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "egress_lossless_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7170_64c/Arista-7170-64C/buffers_defaults_t1.j2
@@ -62,7 +62,7 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
-        "{{ port }}|0-1": {
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
         },
 {% endfor %}

--- a/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t0.j2
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t0.j2
@@ -61,11 +61,15 @@
 
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
-        "{{ port_names }}|3-4": {
-            "profile" : "egress_lossless_profile"
-        },
-        "{{ port_names }}|0-1": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-1": {
             "profile" : "q_lossy_profile"
-        }
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "egress_lossless_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 {%- endmacro %}

--- a/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t0.j2
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t0.j2
@@ -62,7 +62,7 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
-        "{{ port }}|0-1": {
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
         },
 {% endfor %}

--- a/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t0.j2
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t0.j2
@@ -16,8 +16,7 @@
         "ingress_lossless_pool": {
             "size": "{{ ingress_lossless_pool_size }}",
             "type": "ingress",
-            "mode": "dynamic",
-            "xoff": "36222208"
+            "mode": "dynamic"
         },
         "ingress_lossy_pool": {
             "size": "{{ ingress_lossy_pool_size }}",

--- a/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t1.j2
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t1.j2
@@ -61,11 +61,15 @@
 
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
-        "{{ port_names }}|3-4": {
-            "profile" : "egress_lossless_profile"
-        },
-        "{{ port_names }}|0-1": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-1": {
             "profile" : "q_lossy_profile"
-        }
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "egress_lossless_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 {%- endmacro %}

--- a/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t1.j2
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t1.j2
@@ -62,7 +62,7 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
-        "{{ port }}|0-1": {
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
         },
 {% endfor %}

--- a/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t1.j2
+++ b/device/barefoot/x86_64-accton_as9516_32d-r0/newport/buffers_defaults_t1.j2
@@ -16,8 +16,7 @@
         "ingress_lossless_pool": {
             "size": "{{ ingress_lossless_pool_size }}",
             "type": "ingress",
-            "mode": "dynamic",
-            "xoff": "36222208"
+            "mode": "dynamic"
         },
         "ingress_lossy_pool": {
             "size": "{{ ingress_lossy_pool_size }}",

--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t0.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t0.j2
@@ -66,7 +66,7 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
-        "{{ port }}|0-1": {
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
         },
 {% endfor %}

--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t0.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t0.j2
@@ -63,21 +63,17 @@
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names) %}
-    "BUFFER_PG": {
-        "{{ port_names }}|3-4": {
-            "profile" : "ingress_lossless_profile"
-        }
-    },
-{%- endmacro %}
-
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
-        "{{ port_names }}|3-4": {
-            "profile" : "egress_lossless_profile"
-        },
-        "{{ port_names }}|0-1": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-1": {
             "profile" : "q_lossy_profile"
-        }
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "egress_lossless_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 {%- endmacro %}

--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t1.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t1.j2
@@ -66,7 +66,7 @@
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
-        "{{ port }}|0-1": {
+        "{{ port }}|0-2": {
             "profile" : "q_lossy_profile"
         },
 {% endfor %}

--- a/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t1.j2
+++ b/device/barefoot/x86_64-accton_wedge100bf_32x-r0/montara/buffers_defaults_t1.j2
@@ -63,21 +63,17 @@
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names) %}
-    "BUFFER_PG": {
-        "{{ port_names }}|3-4": {
-            "profile" : "ingress_lossless_profile"
-        }
-    },
-{%- endmacro %}
-
 {%- macro generate_queue_buffers(port_names) %}
     "BUFFER_QUEUE": {
-        "{{ port_names }}|3-4": {
-            "profile" : "egress_lossless_profile"
-        },
-        "{{ port_names }}|0-1": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-1": {
             "profile" : "q_lossy_profile"
-        }
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "egress_lossless_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
     }
 {%- endmacro %}


### PR DESCRIPTION
Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
This PR includes necessary changes for correct generating BUFFER_QUEUE values in DB. Changes are based on the [schema.md](https://github.com/Azure/sonic-swss/blob/master/doc/swss-schema.md#buffer_queue_table) 
#### Why I did it
Change format of generating BUFFER_QUEUE in DB according to [schema.md](https://github.com/Azure/sonic-swss/blob/master/doc/swss-schema.md#buffer_queue_table) and [yang-model](https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/yang-models/sonic-buffer-queue.yang).
##### Old format:
```
    "BUFFER_QUEUE": {
        "Ethernet0,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet12,Ethernet120,Ethernet124,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet4,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet8,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96|queue": {
            "profile": "profile"
        },
        "Ethernet0,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet12,Ethernet120,Ethernet124,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet4,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet8,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96|queue": {
            "profile": "profile"
        }
    },
```
##### New format:
```
    "BUFFER_QUEUE": {
        "Ethernet0|queue": {
            "profile": "profile"
        },
        "Ethernet0|queue": {
            "profile": "profile"
        },
        "Ethernet4|queue": {
            "profile": "profile"
        },
        "Ethernet4|queue": {
            "profile": "profile"
        },
        "Ethernet8|queue": {
            "profile": "profile"
        },
        "Ethernet8|queue": {
            "profile": "profile"
        },
        ...
    }
```
#### How I did it
Updated structure of buffers_defaults jinja templates.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

