### PR TITLE
[Arista] rename management interface in initrd

### DIFF
--- a/files/initramfs-tools/arista-net
+++ b/files/initramfs-tools/arista-net
@@ -95,19 +95,33 @@ fi
 # Iterate over all the net_maX items found in the cmdline two times.
 # First time renaming the interfaces to maX.
 # The second time renaming them to their final name ethX.
-if [ -n "$aboot_flag" -a "$platform_flag" == 'rook' ]; then
-    for item in $items; do
-        key="${item%=*}"
-        value="${item#*=}"
-        arista_net_rename "$value" "$key" eth
-    done
-    for item in $items; do
-        key="${item%=*}"
-        value="${item#*=}"
-        index="${key#ma}"
-        index="$(( $index - 1 ))"
-        newKey="eth$index"
-        arista_net_rename "$value" "$newKey" ma
-    done
+if [ -n "$aboot_flag" ]; then
+   if [ "$platform_flag" = 'rook' -o "$platform_flag" = 'lorikeet' ]; then
+      # Rename existing ethX interfaces to tmpX
+      for x in $(ls /sys/class/net/); do
+         case $x in
+            eth*)
+               value="${x#*eth}"
+               newname="tmp$value"
+               ip link set $x down
+               ip link set $x name "$newname"
+               ;;
+            *)
+         esac
+      done
+      for item in $items; do
+         key="${item%=*}"
+         value="${item#*=}"
+         arista_net_rename "$value" "$key" tmp
+      done
+      for item in $items; do
+         key="${item%=*}"
+         value="${item#*=}"
+         index="${key#ma}"
+         index="$(( $index - 1 ))"
+         newKey="eth$index"
+         arista_net_rename "$value" "$newKey" ma
+      done
+   fi
 fi
 


### PR DESCRIPTION
#### Why I did it

On some products the pci enumeration adds randomness into which nic gets
initialized first.
Because SONiC doesn't use deterministic interface naming but instead old
style interface naming, this leads to eth0 not always being the
management port.
To make sure eth0 is always the management port (SONiC expectation)
rename the interfaces in the initramfs for Arista products.

#### How I did it

Rename interfaces in the initramfs based on kernel cmdline parameters

#### How to verify it

eth0 is the management port

#### Description for the changelog

Rename management interface to always be eth0 on Arista devices
