### PR TITLE
[BFN] Updated SDK to 20220127_sai_1.9.1

### DIFF
--- a/platform/barefoot/bfn-platform.mk
+++ b/platform/barefoot/bfn-platform.mk
@@ -1,4 +1,4 @@
-BFN_PLATFORM = bfnplatform_20211216_sai_1.9.1_deb10.deb
+BFN_PLATFORM = bfnplatform_20220127_sai_1.9.1_deb10.deb
 $(BFN_PLATFORM)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/$(BFN_PLATFORM)"
 
 SONIC_ONLINE_DEBS += $(BFN_PLATFORM)

--- a/platform/barefoot/bfn-sai.mk
+++ b/platform/barefoot/bfn-sai.mk
@@ -1,4 +1,4 @@
-BFN_SAI = bfnsdk_20211216_sai_1.9.1_deb10.deb
+BFN_SAI = bfnsdk_20220127_sai_1.9.1_deb10.deb
 $(BFN_SAI)_URL = "https://github.com/barefootnetworks/sonic-release-pkgs/raw/dev/$(BFN_SAI)"
 
 $(BFN_SAI)_DEPENDS += $(LIBNL_GENL3_DEV)

--- a/platform/barefoot/docker-syncd-bfn/Dockerfile.j2
+++ b/platform/barefoot/docker-syncd-bfn/Dockerfile.j2
@@ -22,6 +22,7 @@ RUN apt-get install -y \
         libunwind8-dev \
         libpython3.4 \
         libc-ares2 \
+        libedit2 \
         libgoogle-perftools4
 
 RUN dpkg -i \


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <andriyx.kokhan@intel.com>

#### Why I did it
- Added support of SAI bridge ports isolation group needed for MC-LAG

#### How I did it

#### How to verify it
```
make init
make configure PLATFORM=barefoot
make all
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
