### PR TITLE
Revert "Dell S6100: Addition of SFP ports (#9820)"

### DIFF
--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/port_config.ini
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/port_config.ini
@@ -63,5 +63,3 @@ Ethernet60      81,82     fortyGigE1/4/13    60      40000
 Ethernet61      83,84     fortyGigE1/4/14    61      40000
 Ethernet62      85,86     fortyGigE1/4/15    62      40000
 Ethernet63      87,88     fortyGigE1/4/16    63      40000
-Ethernet64      129       tenGige1/1         64      10000
-Ethernet65      131       tenGige1/2         65      10000

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t0.config.bcm
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t0.config.bcm
@@ -34,8 +34,6 @@ os=unix
 parity_correction=1
 parity_enable=1
 
-port_phy_addr_66=0x176
-port_phy_addr_100=0x177
 xgxs_tx_lane_map_104=0x3210
 xgxs_rx_lane_map_104=0x0312
 phy_xaui_tx_polarity_flip_104=0x0
@@ -347,9 +345,6 @@ phy_xaui_rx_polarity_flip_79=0x3
 dport_map_port_78=63
 dport_map_port_79=64
 pbmp_xport_xe=0x3fffd0000ffff40003fffc0001fffe
-
-portmap_66=129:10
-portmap_100=131:10
 portmap_33=132:10
 portmap_67=133:10
 portmap_101=134:10
@@ -418,7 +413,5 @@ portmap_114=121:40:2
 portmap_115=123:40:2
 portmap_116=125:40:2
 portmap_117=127:40:2
-dport_map_port_66=65
-dport_map_port_100=66
 
 mmu_init_config="MSFT-TH-Tier0"

--- a/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t1.config.bcm
+++ b/device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/th-s6100-64x40G-t1.config.bcm
@@ -34,8 +34,6 @@ os=unix
 parity_correction=1
 parity_enable=1
 
-port_phy_addr_66=0x176
-port_phy_addr_100=0x177
 xgxs_tx_lane_map_104=0x3210
 xgxs_rx_lane_map_104=0x0312
 phy_xaui_tx_polarity_flip_104=0x0
@@ -347,9 +345,6 @@ phy_xaui_rx_polarity_flip_79=0x3
 dport_map_port_78=63
 dport_map_port_79=64
 pbmp_xport_xe=0x3fffd0000ffff40003fffc0001fffe
-
-portmap_66=129:10
-portmap_100=131:10
 portmap_33=132:10
 portmap_67=133:10
 portmap_101=134:10
@@ -418,7 +413,5 @@ portmap_114=121:40:2
 portmap_115=123:40:2
 portmap_116=125:40:2
 portmap_117=127:40:2
-dport_map_port_66=65
-dport_map_port_100=66
 
 mmu_init_config="MSFT-TH-Tier1"


### PR DESCRIPTION
This reverts commit 533471231af6a59d81b92312e3e779d7ff94f6bb.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Master image build break - changes to reviewed and re-merged with appropriate fix
```
====================================================================== 
FAIL: test_buffers_dell6100_render_template (tests.test_j2files.TestJ2Files) 
---------------------------------------------------------------------- 
Traceback (most recent call last): 
File "/sonic/src/sonic-config-engine/tests/test_j2files.py", line 246, in test_buffers_dell6100_render_template 
self._test_buffers_render_template('dell', 'x86_64-dell_s6100_c2538-r0', 'Force10-S6100', 'sample-dell-6100-t0-minigraph.xml', 'buffers.json.j2', 'buffers-dell6100.json') 
File "/sonic/src/sonic-config-engine/tests/test_j2files.py", line 243, in _test_buffers_render_template 
assert filecmp.cmp(sample_output_file, self.output_file) 
AssertionError 
```

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

