### PR TITLE
[yang] Fix for sonic-scheduler.yang name pattern

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1339,6 +1339,24 @@
                 "pbs": "2048",
                 "pir": "2560000",
                 "type": "STRICT"
+            },
+            "scheduler.0": {
+                "cbs": "256",
+                "cir": "1250000",
+                "meter_type": "bytes",
+                "pbs": "1024",
+                "pir": "25000000",
+                "type": "DWRR",
+                "weight": "20"
+            },
+
+            "scheduler.1": {
+                "cbs": "1024",
+                "cir": "1280000",
+                "meter_type": "bytes",
+                "pbs": "2048",
+                "pir": "2560000",
+                "type": "STRICT"
             }
         },
 
@@ -1368,6 +1386,12 @@
             "Ethernet0|1": {
                 "scheduler": "TEST@1",
                 "wred_profile": "Wred1"
+            },
+            "Ethernet0|2": {
+                "scheduler": "scheduler.0"
+            },
+            "Ethernet0|3": {
+                "scheduler": "scheduler.1"
             }
         },
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
@@ -35,6 +35,10 @@
         "eStr": ["pir must be greater than or equal to cir"]
     },
 
+    "SCHEDULER_VALID_NAME": {
+        "desc": "Configure SCHEDULER table."
+    },
+
     "WRED_PROFILE_EMPTY": {
         "desc": "Configure Empty WRED profile."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qos.json
@@ -116,7 +116,45 @@
             }
         }
     },
-
+   
+    "SCHEDULER_VALID_NAME": {
+        "sonic-scheduler:sonic-scheduler":{
+            "sonic-scheduler:SCHEDULER": {
+                "SCHEDULER_LIST": [
+                {
+                    "name":"scheduler.0",
+                     "cbs": 256,
+                     "cir": 1250000,
+                     "meter_type": "bytes",
+                     "pbs": 1024,
+                     "pir": 25000000,
+                     "type": "DWRR",
+                     "weight": 10
+                },
+                {
+                    "name":"scheduler.1",
+                    "cbs": 1024,
+                    "cir": 1280000,
+                    "meter_type": "bytes",
+                    "pbs": 2048,
+                    "pir": 2560000,
+                    "type": "STRICT", 
+                    "priority": 0
+                },
+                {
+                    "name":"scheduler.2",
+                    "cbs": 256,
+                    "cir": 1250000,
+                    "meter_type": "bytes",
+                    "pbs": 1024,
+                    "pir": 25000000,
+                    "type": "WRR",
+                    "weight": 20
+                }
+                ]
+            }
+        }
+    },
 
     "WRED_PROFILE_EMPTY": {
         "sonic-wred-profile:sonic-wred-profile":{

--- a/src/sonic-yang-models/yang-models/sonic-scheduler.yang
+++ b/src/sonic-yang-models/yang-models/sonic-scheduler.yang
@@ -31,14 +31,7 @@ module sonic-scheduler {
                 key "name";
 
                 leaf name {
-
-                    type string {
-                        pattern "[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,31})|[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,31})([@]{1})([0-9]{1,3})";
-                        length 1..36 {
-                            error-message "Invalid length for scheduler name.";
-                            error-app-tag scheduler-name-invalid-length;
-                        }
-                    }
+                    type string; 
                     description "Scheduler name";
                 }
 


### PR DESCRIPTION

#### Why I did it

PR9611 - sonic-scheduler.yang pattern issue

#### How I did it
Modified the scheduler name pattern string to accept any string 

#### How to verify it

Sonic yang tests

#### Which release branch to backport (provide reason below if selected)


#### A picture of a cute animal (not mandatory but encouraged)

