### PR TITLE
[yang] Fixing groupings when grouping is in the same module file

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -330,11 +330,11 @@ class SonicYangExtMixin:
                 # Assume ':'  means reference to another module
                 if ':' in uses['@name']:
                     prefix = uses['@name'].split(':')[0].strip()
-                    uses_module = self._findYangModuleFromPrefix(prefix, table_module)
+                    uses_module_name = self._findYangModuleFromPrefix(prefix, table_module)
                 else:
-                    uses_module = table_module
+                    uses_module_name = table_module['@name']
                 grouping = uses['@name'].split(':')[-1].strip()
-                leafs = self.preProcessedYang['grouping'][uses_module][grouping]
+                leafs = self.preProcessedYang['grouping'][uses_module_name][grouping]
                 self._fillLeafDict(leafs, leafDict)
         except Exception as e:
             self.sysLog(msg="_fillLeafDictUses failed:{}".format(str(e)), \

--- a/src/sonic-yang-models/yang-models/sonic-lldp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-lldp.yang
@@ -28,6 +28,7 @@ module sonic-lldp {
     grouping lldp_mode_config {
         leaf enabled {
             type boolean;
+            default true;
             description
                 "Enable/Disable LLDP";
         }
@@ -99,24 +100,7 @@ module sonic-lldp {
                         "Suppress sending of System Capabilities TLV in LLDP frames";
                 }
 
-                leaf enabled {
-                    type boolean;
-                    default true;
-                    description
-                        "Enable/Disable LLDP";
-                }
-
-                leaf mode {
-                    type enumeration {
-                        enum RECEIVE;
-                        enum TRANSMIT;
-                    }
-
-                    description
-                        "RX/TX mode for LLDP frames";
-                }
-
-                //uses lldp_mode_config;
+                uses lldp_mode_config;
             }
         }
 
@@ -132,23 +116,7 @@ module sonic-lldp {
                         "Reference of port on which LLDP to be configured.";
                 }
 
-                leaf enabled {
-                    type boolean;
-                    default true;
-                    description
-                        "Enable/Disable LLDP";
-                }
-
-                leaf mode {
-                    type enumeration {
-                        enum RECEIVE;
-                        enum TRANSMIT;
-                    }
-
-                    description
-                        "RX/TX mode for LLDP frames";
-                }
-                //uses lldp_mode_config;
+                uses lldp_mode_config;
             }
         }
     }


### PR DESCRIPTION
#### Why I did it
If the grouping is in the same file in the module, fetching the grouping fails

#### How I did it
fixing the `uses_module_name` when the grouping is under the same file

#### How to verify it
Enabled a grouping under the same file which is `lldp`, there is a test in sonic-yang-mgmt that translates `sample-config-db` into yang format. This test passes with grouping in `lldp` used.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

