### PR TITLE
Update asic name mapping in the required dicts 

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -109,6 +109,9 @@ def get_port_config(hwsku=None, platform=None, port_config_file=None, hwsku_conf
             for intf_name in ports.keys():
                 if "alias" in ports[intf_name]:
                     port_alias_map[ports[intf_name]["alias"]] = intf_name
+                    if "asic_port_name" in ports[intf_name]:
+                        port_alias_asic_map[ports[intf_name]["alias"]] = ports[intf_name]["asic_port_name"]
+                        port_alias_map[ports[intf_name]["asic_port_name"]] = intf_name
             return (ports, port_alias_map, port_alias_asic_map)
 
     if asic_name is not None:


### PR DESCRIPTION
when reading port information from config_db to match with data from
port_config.ini.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update asic name mapping in the required dicts 
when reading port information from config_db to match with data from
port_config.ini.
There is a mismatch when retrieving data from port_config.ini and config_db.
This change is to ensure the configuration generated from port_config.ini or config_dbX.json files are the same.
Issue seen: config_db has incorrect interface names as portchannel members also device_neighbor table does not include front end neighbor information.
This change will affect  only for multi-asic platform where port_config.ini contains asic_name for each port.

#### How I did it
if asic_port_name exists in config_db, update the dictionaries with asic_port_name information.

#### How to verify it
Verified on multi-asic vs testbed. Single asic - no change.
When config_db is not initialized, configuration generated initially will use port_config.ini.
For multi-asic vs (4 asic), the config_db generated for namespace asic0 :
```
Without the changes ---------------------------------------------- After the changes

    "PORTCHANNEL": {                                                "PORTCHANNEL": {
        "PortChannel102": {                                             "PortChannel102": {
            "members": [                                                    "members": [
                "Eth0-ASIC0",                                 |                 "Ethernet0",
                "Eth1-ASIC0"                                  |                 "Ethernet4"
            ],                                                              ],
            "min_links": "2",                                               "min_links": "2",
            "mtu": "9100",                                                  "mtu": "9100",
            "tpid": "0x8100",                                               "tpid": "0x8100",
            "admin_status": "up"                                            "admin_status": "up"
        },                                                              },
        "PortChannel105": {                                             "PortChannel105": {
            "members": [                                                    "members": [
                "Eth2-ASIC0",                                 |                 "Ethernet8",
                "Eth3-ASIC0"                                  |                 "Ethernet12"
            ],                                                              ],
            "min_links": "2",                                               "min_links": "2",
            "mtu": "9100",                                                  "mtu": "9100",
            "tpid": "0x8100",                                               "tpid": "0x8100",
            "admin_status": "up"                                            "admin_status": "up"
        },                                                              },
    "PORTCHANNEL_MEMBER": {                                         "PORTCHANNEL_MEMBER": {
        "PortChannel102|Eth0-ASIC0": {},                      |         "PortChannel102|Ethernet0": {},
        "PortChannel102|Eth1-ASIC0": {},                      |         "PortChannel102|Ethernet4": {},
        "PortChannel105|Eth2-ASIC0": {},                      |         "PortChannel105|Ethernet8": {},
        "PortChannel105|Eth3-ASIC0": {},                      |         "PortChannel105|Ethernet12": {},
        "PortChannel43|Ethernet-BP8": {},                               "PortChannel43|Ethernet-BP8": {},
        "PortChannel43|Ethernet-BP12": {},                              "PortChannel43|Ethernet-BP12": {},
        "PortChannel42|Ethernet-BP0": {},                               "PortChannel42|Ethernet-BP0": {},
        "PortChannel42|Ethernet-BP4": {}                                "PortChannel42|Ethernet-BP4": {}
    },                                                              },
    "DEVICE_NEIGHBOR": {                                            "DEVICE_NEIGHBOR": {
                                                              >         "Ethernet0": {
                                                              >             "name": "ARISTA01T2",
                                                              >             "port": "Ethernet1"
                                                              >         },
                                                              >         "Ethernet4": {
                                                              >             "name": "ARISTA01T2",
                                                              >             "port": "Ethernet2"
                                                              >         },
                                                              >         "Ethernet8": {
                                                              >             "name": "ARISTA03T2",
                                                              >             "port": "Ethernet1"
                                                              >         },
                                                              >         "Ethernet12": {
                                                              >             "name": "ARISTA03T2",
                                                              >             "port": "Ethernet2"
                                                              >         },
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

