### PR TITLE
Close console session due to user inactivity

### DIFF
--- a/files/image_config/bash/bash.bashrc
+++ b/files/image_config/bash/bash.bashrc
@@ -55,7 +55,7 @@ if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-no
 fi
 
 # Automatically log out console ttyS* sessions after 15 minutes of inactivity
-tty | grep ttyS >/dev/null && TMOUT=900
+tty | egrep -q '^/dev/ttyS[[:digit:]]+$' && TMOUT=900
 
 # if SSH_TARGET_CONSOLE_LINE was set, attach to console line interactive cli directly
 if [ -n "$SSH_TARGET_CONSOLE_LINE" ]; then

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -60,6 +60,9 @@ ALL     ALL=NOPASSWD: READ_ONLY_CMDS
 # Prevent password related command into syslog
 Defaults!PASSWD_CMDS !syslog
 
+# Make sure sudo password prompt times out after 5 mins
+Defaults passwd_timeout=5
+
 # See sudoers(5) for more information on "#include" directives:
 
 #includedir /etc/sudoers.d


### PR DESCRIPTION
Signed-off-by: Prince George <prgeor@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The default sudo [password prompt timeout](https://www.sudo.ws/docs/man/1.7.10/sudoers.man/#:~:text=disable%20word%20wrap\).-,passwd_timeout,-Number%20of%20minutes) is NOT working. This is causing the console session to be held up even though the user in active for a long period of time. Due to this, TMOUT or auto-logout is not taking effect because user cannot login to bash, leaving the console unusable.

#### How I did it
Explicitly set the password prompt timeout in sudoers

#### How to verify it
Verified 
1. The sudo password prompt timeout after 5 mins of inactivity
2. After user has logged in to bash via console, the session timeout if user has not pressed key for more than 15 mins (TMOUT)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

