### PR TITLE
[build] Add more dependencies to sonic-config-engine

### DIFF
--- a/rules/sonic-config.dep
+++ b/rules/sonic-config.dep
@@ -4,7 +4,7 @@ SPATH       := $($(SONIC_CONFIG_ENGINE_PY3)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-config.mk rules/sonic-config.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(SPATH))
-DEP_FILES   += files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-orchagent/ipinip.json.j2 $(wildcard device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/*.j2 device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/*.j2) files/build_templates/qos_config.j2 dockers/docker-orchagent/switch.json.j2 dockers/docker-orchagent/vxlan.json.j2 files/image_config/constants/constants.yml
+DEP_FILES   += files/image_config/interfaces/interfaces.j2 dockers/docker-orchagent/ports.json.j2 dockers/docker-dhcp-relay/wait_for_intf.sh.j2 dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2 dockers/docker-lldp/lldpd.conf.j2 dockers/docker-orchagent/ipinip.json.j2 $(wildcard device/arista/x86_64-arista_7050_qx32s/Arista-7050-QX-32S/* device/dell/x86_64-dell_s6100_c2538-r0/Force10-S6100/*) files/build_templates/qos_config.j2 dockers/docker-orchagent/switch.json.j2 dockers/docker-orchagent/vxlan.json.j2 files/image_config/constants/constants.yml
 
 ifeq ($(ENABLE_PY2_MODULES), y)
     $(SONIC_CONFIG_ENGINE_PY2)_CACHE_MODE  := GIT_CONTENT_SHA 


### PR DESCRIPTION
sonic-config-engine unit test always fails. let's restrict using cache in sonic-config-engine

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
restrict using cache when building sonic-config-engine
sonic-config-engine unit test failing rate is high.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

