### PR TITLE
docker-dhcp-relay: Fix test call to MockConfigDb

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcpv6_helper.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcpv6_helper.py
@@ -34,7 +34,8 @@ class TestDhcpRelayHelper(object):
             fs.create_file(DBCONFIG_PATH) 
         MockConfigDb.set_config_db(test_data["config_db"])
         runner = CliRunner()
-        table = MockConfigDb.get_table(self, "DHCP_RELAY")
+        config_db = MockConfigDb()
+        table = config_db.get_table("DHCP_RELAY")
         result = show.get_data(table, "Vlan1000")
         assert result == expected_table
 


### PR DESCRIPTION
#### Why I did it

Spun out from discussion in #9826 - https://github.com/Azure/sonic-buildimage/pull/9826#discussion_r796239870

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog

docker-dhcp-relay: Fix test call to MockConfigDb

#### A picture of a cute animal (not mandatory but encouraged)

None this time ;-)