### PR TITLE
[Nokia][platform] Modified Nokia device data to support midplane communication

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/chassisdb.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/chassisdb.conf
@@ -1,2 +1,3 @@
-chassis_db_address=10.0.5.16
+chassis_db_address=10.6.0.100
 chassis_internal_intfs=enp12s0f2,enp5s0f4,enp5s0f4.2
+midplane_subnet=10.6.0.0/16

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/platform_ndk.json
@@ -6,7 +6,7 @@
     },
     {
         "key": "midplane_subnet",
-        "stringval": "10.0.5.0"
+        "stringval": "10.6.0.0/16"
     },
     {
         "key": "midplane_monitor",

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/chassisdb.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/chassisdb.conf
@@ -1,4 +1,5 @@
 start_chassis_db=1
-chassis_db_address=10.0.5.16
+chassis_db_address=10.6.0.100
 lag_id_start=1
 lag_id_end=512
+midplane_subnet=10.6.0.0/16

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_ndk.json
@@ -2,7 +2,7 @@
     "options": [
     {
         "key": "midplane_subnet",
-        "stringval": "10.0.5.0"
+        "stringval": "10.6.0.0/16"
     },
     {
         "key": "midplane_monitor",


### PR DESCRIPTION


Signed-off-by: Sakthivadivu Saravanaraj <sakthivadivu.saravanaraj@nokia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added midplane_subnet in chassisdb.conf for interfaces-config.sh to create midplane interface in multi-asic namespaces.
#### How I did it
Added midplane_subnet in chassisdb.conf for nokia platforms
#### How to verify it
Verified all the dockers are up in all IMM's and CPM, ports are up and OC tests are passing.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

