### PR TITLE
Updated traffic scheduler settings for HWSKUs : DellEMC-Z9332f-O32 & DellEMC-Z9332f-M-O16C64

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -30,7 +30,7 @@
 
 {%- set pfc_to_pg_map_supported_asics = ['mellanox', 'barefoot', 'marvell'] -%}
 {%- set backend_device_types = ['BackEndToRRouter', 'BackEndLeafRouter'] -%}
-
+{%- set apollo_resource_types = ['DL-NPU-Apollo'] -%}
 
 {
 {% if generate_tc_to_pg_map is defined %}
@@ -156,6 +156,22 @@
         }
     },
 {% endif %}
+{% if 'resource_type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['resource_type'] in apollo_resource_types %}
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type"  : "DWRR",
+            "weight": "1"
+        },
+        "scheduler.1": {
+            "type"  : "DWRR",
+            "weight": "1"
+        },
+        "scheduler.2": {
+            "type"  : "DWRR",
+            "weight": "100"
+        }
+    },
+{% else %}
     "SCHEDULER": {
         "scheduler.0": {
             "type"  : "DWRR",
@@ -166,6 +182,7 @@
             "weight": "15"
         }
     },
+{% endif %}
 {% if asic_type in pfc_to_pg_map_supported_asics  %}
     "PFC_PRIORITY_TO_PRIORITY_GROUP_MAP": {
         "AZURE": {
@@ -221,12 +238,21 @@
             "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
         },
 {% endfor %}
+{% if 'resource_type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['resource_type'] in apollo_resource_types %}
+{% for port in PORT_ACTIVE %}
+        "{{ port }}|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+{% endfor %}
+{% else %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|4": {
             "scheduler"   : "[SCHEDULER|scheduler.1]",
             "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
         },
 {% endfor %}
+{% endif %}
 {% for port in PORT_ACTIVE %}
         "{{ port }}|0": {
             "scheduler": "[SCHEDULER|scheduler.0]"

--- a/src/sonic-config-engine/tests/sample-dell-9332-t1-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-dell-9332-t1-minigraph.xml
@@ -1,0 +1,2023 @@
+<DeviceMiniGraph xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <CpgDec>
+    <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    <PeeringSessions>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.32</StartPeer>
+        <EndRouter>ARISTA01T0</EndRouter>
+        <EndPeer>10.0.0.33</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::41</StartPeer>
+        <EndRouter>ARISTA01T0</EndRouter>
+        <EndPeer>FC00::42</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.0</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>10.0.0.1</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::1</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>FC00::2</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.34</StartPeer>
+        <EndRouter>ARISTA02T0</EndRouter>
+        <EndPeer>10.0.0.35</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::45</StartPeer>
+        <EndRouter>ARISTA02T0</EndRouter>
+        <EndPeer>FC00::46</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.36</StartPeer>
+        <EndRouter>ARISTA03T0</EndRouter>
+        <EndPeer>10.0.0.37</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::49</StartPeer>
+        <EndRouter>ARISTA03T0</EndRouter>
+        <EndPeer>FC00::4A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.4</StartPeer>
+        <EndRouter>ARISTA03T2</EndRouter>
+        <EndPeer>10.0.0.5</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::9</StartPeer>
+        <EndRouter>ARISTA03T2</EndRouter>
+        <EndPeer>FC00::A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.38</StartPeer>
+        <EndRouter>ARISTA04T0</EndRouter>
+        <EndPeer>10.0.0.39</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::4D</StartPeer>
+        <EndRouter>ARISTA04T0</EndRouter>
+        <EndPeer>FC00::4E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.40</StartPeer>
+        <EndRouter>ARISTA05T0</EndRouter>
+        <EndPeer>10.0.0.41</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::51</StartPeer>
+        <EndRouter>ARISTA05T0</EndRouter>
+        <EndPeer>FC00::52</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.8</StartPeer>
+        <EndRouter>ARISTA05T2</EndRouter>
+        <EndPeer>10.0.0.9</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::11</StartPeer>
+        <EndRouter>ARISTA05T2</EndRouter>
+        <EndPeer>FC00::12</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.42</StartPeer>
+        <EndRouter>ARISTA06T0</EndRouter>
+        <EndPeer>10.0.0.43</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::55</StartPeer>
+        <EndRouter>ARISTA06T0</EndRouter>
+        <EndPeer>FC00::56</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.44</StartPeer>
+        <EndRouter>ARISTA07T0</EndRouter>
+        <EndPeer>10.0.0.45</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::59</StartPeer>
+        <EndRouter>ARISTA07T0</EndRouter>
+        <EndPeer>FC00::5A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.12</StartPeer>
+        <EndRouter>ARISTA07T2</EndRouter>
+        <EndPeer>10.0.0.13</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::19</StartPeer>
+        <EndRouter>ARISTA07T2</EndRouter>
+        <EndPeer>FC00::1A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.46</StartPeer>
+        <EndRouter>ARISTA08T0</EndRouter>
+        <EndPeer>10.0.0.47</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::5D</StartPeer>
+        <EndRouter>ARISTA08T0</EndRouter>
+        <EndPeer>FC00::5E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.48</StartPeer>
+        <EndRouter>ARISTA09T0</EndRouter>
+        <EndPeer>10.0.0.49</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::61</StartPeer>
+        <EndRouter>ARISTA09T0</EndRouter>
+        <EndPeer>FC00::62</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.16</StartPeer>
+        <EndRouter>ARISTA09T2</EndRouter>
+        <EndPeer>10.0.0.17</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::21</StartPeer>
+        <EndRouter>ARISTA09T2</EndRouter>
+        <EndPeer>FC00::22</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.50</StartPeer>
+        <EndRouter>ARISTA10T0</EndRouter>
+        <EndPeer>10.0.0.51</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::65</StartPeer>
+        <EndRouter>ARISTA10T0</EndRouter>
+        <EndPeer>FC00::66</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.52</StartPeer>
+        <EndRouter>ARISTA11T0</EndRouter>
+        <EndPeer>10.0.0.53</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::69</StartPeer>
+        <EndRouter>ARISTA11T0</EndRouter>
+        <EndPeer>FC00::6A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.20</StartPeer>
+        <EndRouter>ARISTA11T2</EndRouter>
+        <EndPeer>10.0.0.21</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::29</StartPeer>
+        <EndRouter>ARISTA11T2</EndRouter>
+        <EndPeer>FC00::2A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.54</StartPeer>
+        <EndRouter>ARISTA12T0</EndRouter>
+        <EndPeer>10.0.0.55</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::6D</StartPeer>
+        <EndRouter>ARISTA12T0</EndRouter>
+        <EndPeer>FC00::6E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.56</StartPeer>
+        <EndRouter>ARISTA13T0</EndRouter>
+        <EndPeer>10.0.0.57</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::71</StartPeer>
+        <EndRouter>ARISTA13T0</EndRouter>
+        <EndPeer>FC00::72</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.24</StartPeer>
+        <EndRouter>ARISTA13T2</EndRouter>
+        <EndPeer>10.0.0.25</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::31</StartPeer>
+        <EndRouter>ARISTA13T2</EndRouter>
+        <EndPeer>FC00::32</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.58</StartPeer>
+        <EndRouter>ARISTA14T0</EndRouter>
+        <EndPeer>10.0.0.59</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::75</StartPeer>
+        <EndRouter>ARISTA14T0</EndRouter>
+        <EndPeer>FC00::76</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.60</StartPeer>
+        <EndRouter>ARISTA15T0</EndRouter>
+        <EndPeer>10.0.0.61</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::79</StartPeer>
+        <EndRouter>ARISTA15T0</EndRouter>
+        <EndPeer>FC00::7A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.28</StartPeer>
+        <EndRouter>ARISTA15T2</EndRouter>
+        <EndPeer>10.0.0.29</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::39</StartPeer>
+        <EndRouter>ARISTA15T2</EndRouter>
+        <EndPeer>FC00::3A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>10.0.0.62</StartPeer>
+        <EndRouter>ARISTA16T0</EndRouter>
+        <EndPeer>10.0.0.63</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>str2-z9332f-01</StartRouter>
+        <StartPeer>FC00::7D</StartPeer>
+        <EndRouter>ARISTA16T0</EndRouter>
+        <EndPeer>FC00::7E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+    </PeeringSessions>
+    <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:BGPRouterDeclaration>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>str2-z9332f-01</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.0.0.33</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.1</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.35</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.37</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.5</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.39</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.41</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.9</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.43</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.45</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.13</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.47</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.49</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.17</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.51</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.53</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.21</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.55</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.57</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.25</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.59</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.61</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.29</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.63</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+        </a:Peers>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64001</a:ASN>
+        <a:Hostname>ARISTA01T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA01T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64002</a:ASN>
+        <a:Hostname>ARISTA02T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64003</a:ASN>
+        <a:Hostname>ARISTA03T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA03T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64004</a:ASN>
+        <a:Hostname>ARISTA04T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64005</a:ASN>
+        <a:Hostname>ARISTA05T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA05T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64006</a:ASN>
+        <a:Hostname>ARISTA06T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64007</a:ASN>
+        <a:Hostname>ARISTA07T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA07T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64008</a:ASN>
+        <a:Hostname>ARISTA08T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64009</a:ASN>
+        <a:Hostname>ARISTA09T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA09T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64010</a:ASN>
+        <a:Hostname>ARISTA10T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64011</a:ASN>
+        <a:Hostname>ARISTA11T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA11T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64012</a:ASN>
+        <a:Hostname>ARISTA12T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64013</a:ASN>
+        <a:Hostname>ARISTA13T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA13T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64014</a:ASN>
+        <a:Hostname>ARISTA14T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64015</a:ASN>
+        <a:Hostname>ARISTA15T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA15T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64016</a:ASN>
+        <a:Hostname>ARISTA16T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+    </Routers>
+  </CpgDec>
+  <DpgDec>
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.1.0.32/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.1.0.32/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:1::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.3.146.248/23</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.3.146.248/23</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:2::32/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:2::32/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
+      <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>str2-z9332f-01</Hostname>
+      <PortChannelInterfaces>
+        <PortChannel>
+          <Name>PortChannel102</Name>
+          <AttachTo>etp1;etp2</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel105</Name>
+          <AttachTo>etp3;etp4</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel108</Name>
+          <AttachTo>etp5;etp6</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel1011</Name>
+          <AttachTo>etp7;etp8</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel1014</Name>
+          <AttachTo>etp9;etp10</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel1017</Name>
+          <AttachTo>etp11;etp12</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel1020</Name>
+          <AttachTo>etp13;etp14</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel1023</Name>
+          <AttachTo>etp15;etp16</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+      </PortChannelInterfaces>
+      <VlanInterfaces>
+      </VlanInterfaces>
+      <IPInterfaces>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp17</AttachTo>
+          <Prefix>10.0.0.32/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp17</AttachTo>
+          <Prefix>FC00::41/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel102</AttachTo>
+          <Prefix>10.0.0.0/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel102</AttachTo>
+          <Prefix>FC00::1/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp18</AttachTo>
+          <Prefix>10.0.0.34/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp18</AttachTo>
+          <Prefix>FC00::45/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp19</AttachTo>
+          <Prefix>10.0.0.36/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp19</AttachTo>
+          <Prefix>FC00::49/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel105</AttachTo>
+          <Prefix>10.0.0.4/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel105</AttachTo>
+          <Prefix>FC00::9/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp20</AttachTo>
+          <Prefix>10.0.0.38/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp20</AttachTo>
+          <Prefix>FC00::4D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp21</AttachTo>
+          <Prefix>10.0.0.40/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp21</AttachTo>
+          <Prefix>FC00::51/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel108</AttachTo>
+          <Prefix>10.0.0.8/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel108</AttachTo>
+          <Prefix>FC00::11/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp22</AttachTo>
+          <Prefix>10.0.0.42/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp22</AttachTo>
+          <Prefix>FC00::55/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp23</AttachTo>
+          <Prefix>10.0.0.44/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp23</AttachTo>
+          <Prefix>FC00::59/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel1011</AttachTo>
+          <Prefix>10.0.0.12/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel1011</AttachTo>
+          <Prefix>FC00::19/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp24</AttachTo>
+          <Prefix>10.0.0.46/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp24</AttachTo>
+          <Prefix>FC00::5D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp25</AttachTo>
+          <Prefix>10.0.0.48/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp25</AttachTo>
+          <Prefix>FC00::61/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel1014</AttachTo>
+          <Prefix>10.0.0.16/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel1014</AttachTo>
+          <Prefix>FC00::21/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp26</AttachTo>
+          <Prefix>10.0.0.50/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp26</AttachTo>
+          <Prefix>FC00::65/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp27</AttachTo>
+          <Prefix>10.0.0.52/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp27</AttachTo>
+          <Prefix>FC00::69/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel1017</AttachTo>
+          <Prefix>10.0.0.20/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel1017</AttachTo>
+          <Prefix>FC00::29/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp28</AttachTo>
+          <Prefix>10.0.0.54/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp28</AttachTo>
+          <Prefix>FC00::6D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp29</AttachTo>
+          <Prefix>10.0.0.56/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp29</AttachTo>
+          <Prefix>FC00::71/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel1020</AttachTo>
+          <Prefix>10.0.0.24/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel1020</AttachTo>
+          <Prefix>FC00::31/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp30</AttachTo>
+          <Prefix>10.0.0.58/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp30</AttachTo>
+          <Prefix>FC00::75/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp31</AttachTo>
+          <Prefix>10.0.0.60/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp31</AttachTo>
+          <Prefix>FC00::79/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel1023</AttachTo>
+          <Prefix>10.0.0.28/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel1023</AttachTo>
+          <Prefix>FC00::39/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>etp32</AttachTo>
+          <Prefix>10.0.0.62/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>etp32</AttachTo>
+          <Prefix>FC00::7D/126</Prefix>
+        </IPInterface>
+      </IPInterfaces>
+      <DataAcls/>
+      <AclInterfaces>
+        <AclInterface>
+          <InAcl>NTP_ACL</InAcl>
+          <AttachTo>NTP</AttachTo>
+          <Type>NTP</Type>
+        </AclInterface>
+        <AclInterface>
+          <InAcl>SNMP_ACL</InAcl>
+          <AttachTo>SNMP</AttachTo>
+          <Type>SNMP</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPAN</AttachTo>
+          <InAcl>Everflow</InAcl>
+          <Type>Everflow</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPANV6</AttachTo>
+          <InAcl>EverflowV6</InAcl>
+          <Type>EverflowV6</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+      </AclInterfaces>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+  </DpgDec>
+  <PngDec>
+    <DeviceInterfaceLinks>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp17</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp1</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp2</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA02T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp18</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA03T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp19</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA03T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp3</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA03T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp4</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA04T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp20</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA05T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp21</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA05T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp5</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA05T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp6</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA06T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp22</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA07T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp23</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA07T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp7</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA07T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp8</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA08T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp24</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA09T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp25</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA09T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp9</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA09T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp10</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA10T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp26</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA11T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp27</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA11T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp11</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA11T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp12</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA12T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp28</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA13T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp29</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA13T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp13</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA13T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp14</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA14T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp30</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA15T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp31</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA15T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp15</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA15T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp16</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA16T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>str2-z9332f-01</StartDevice>
+        <StartPort>etp32</StartPort>
+      </DeviceLinkBase>
+    </DeviceInterfaceLinks>
+    <Devices>
+      <Device i:type="LeafRouter">
+        <Hostname>str2-z9332f-01</Hostname>
+        <HwSku>DellEMC-Z9332f-O32</HwSku>
+        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.3.146.248</a:IPPrefix>
+        </ManagementAddress>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA16T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.111</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA11T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.106</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA10T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.105</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA11T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.93</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA09T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.92</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA09T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.104</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA06T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.101</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA08T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.103</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA07T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.102</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA07T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.91</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA01T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.88</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA01T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.96</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA05T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.90</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA05T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.100</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA02T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.97</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA03T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.98</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA03T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.89</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA04T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.99</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA15T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.110</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA15T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.95</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA14T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.109</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA12T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.107</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA13T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.94</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA13T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>172.16.142.108</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+    </Devices>
+  </PngDec>
+  <DeviceInfos>
+    <DeviceInfo>
+      <AutoNegotiation>true</AutoNegotiation>
+      <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp1</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp2</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp3</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp5</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp6</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp7</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp9</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp10</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp11</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp13</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp14</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp15</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp25</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp26</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp27</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp28</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp29</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp30</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp31</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp32</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>400000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp33</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>10000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp34</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>10000</Speed>
+        </a:EthernetInterface>
+      </EthernetInterfaces>
+      <FlowControl>true</FlowControl>
+      <Height>0</Height>
+      <HwSku>DellEMC-Z9332f-O32</HwSku>
+      <ManagementInterfaces/>
+    </DeviceInfo>
+  </DeviceInfos>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>str2-z9332f-01</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>QosProfile</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Profile0</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4;192.0.0.5;192.0.0.6;192.0.0.7;192.0.0.8;192.0.0.9;192.0.0.10;192.0.0.11;192.0.0.12;192.0.0.13;192.0.0.14;192.0.0.15;192.0.0.16;192.0.0.17;192.0.0.18;192.0.0.19;192.0.0.20;192.0.0.21;192.0.0.22;192.0.0.23;192.0.0.24;192.0.0.25;192.0.0.26;192.0.0.27;192.0.0.28;192.0.0.29;192.0.0.30;192.0.0.31;192.0.0.32;192.0.0.33;192.0.0.34;192.0.0.35;192.0.0.36;192.0.0.37;192.0.0.38;192.0.0.39;192.0.0.40;192.0.0.41;192.0.0.42;192.0.0.43;192.0.0.44;192.0.0.45;192.0.0.46;192.0.0.47;192.0.0.48</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.20.8.129;10.20.8.130</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SnmpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.3.145.98</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SyslogResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.64.246.95</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>TacacsGroup</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Starlab</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>TacacsServer</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>100.127.20.21</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ForcedMgmtRoutes</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.3.145.98/31;10.3.145.8;100.127.20.16/28;10.3.149.170/31;40.122.216.24;13.91.48.226;10.3.145.14;10.64.246.0/24;10.3.146.0/23;10.64.5.5</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+          <a:Name>ResourceType</a:Name>
+          <a:Reference i:nil="true"/>
+          <a:Value>DL-NPU-Apollo</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ErspanDestinationIpv4</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.20.6.16</a:Value>
+         </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
+  <Hostname>str2-z9332f-01</Hostname>
+  <HwSku>DellEMC-Z9332f-O32</HwSku>
+</DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/sample_output/py2/qos-dell9332.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/qos-dell9332.json
@@ -1,0 +1,1101 @@
+{
+    "TC_TO_PRIORITY_GROUP_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "0",
+            "2": "0",
+            "3": "3",
+            "4": "4",
+            "5": "0",
+            "6": "0",
+            "7": "7"
+        }
+    },
+    "MAP_PFC_PRIORITY_TO_QUEUE": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7"
+        }
+    },
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7"
+        }
+    },
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0" : "1",
+            "1" : "1",
+            "2" : "1",
+            "3" : "3",
+            "4" : "4",
+            "5" : "2",
+            "6" : "1",
+            "7" : "1",
+            "8" : "0",
+            "9" : "1",
+            "10": "1",
+            "11": "1",
+            "12": "1",
+            "13": "1",
+            "14": "1",
+            "15": "1",
+            "16": "1",
+            "17": "1",
+            "18": "1",
+            "19": "1",
+            "20": "1",
+            "21": "1",
+            "22": "1",
+            "23": "1",
+            "24": "1",
+            "25": "1",
+            "26": "1",
+            "27": "1",
+            "28": "1",
+            "29": "1",
+            "30": "1",
+            "31": "1",
+            "32": "1",
+            "33": "1",
+            "34": "1",
+            "35": "1",
+            "36": "1",
+            "37": "1",
+            "38": "1",
+            "39": "1",
+            "40": "1",
+            "41": "1",
+            "42": "1",
+            "43": "1",
+            "44": "1",
+            "45": "1",
+            "46": "5",
+            "47": "1",
+            "48": "6",
+            "49": "1",
+            "50": "1",
+            "51": "1",
+            "52": "1",
+            "53": "1",
+            "54": "1",
+            "55": "1",
+            "56": "1",
+            "57": "1",
+            "58": "1",
+            "59": "1",
+            "60": "1",
+            "61": "1",
+            "62": "1",
+            "63": "1"
+        }
+    },
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type"  : "DWRR",
+            "weight": "1"
+        },
+        "scheduler.1": {
+            "type"  : "DWRR",
+            "weight": "1"
+        },
+        "scheduler.2": {
+            "type"  : "DWRR",
+            "weight": "100"
+        }
+    },
+    "PORT_QOS_MAP": {
+        "Ethernet0": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet8": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet16": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet24": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet32": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet40": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet48": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet56": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet64": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet72": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet80": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet88": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet96": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet104": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet112": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet120": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet128": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet136": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet144": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet152": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet160": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet168": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet176": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet184": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet192": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet200": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet208": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet216": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet224": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet232": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet240": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet248": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        }
+    },
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "2097152",
+            "green_min_threshold"    : "1048576",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+    "QUEUE": {
+        "Ethernet0|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet8|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet16|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet24|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet32|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet40|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet48|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet56|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet64|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet72|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet80|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet88|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet96|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet104|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet112|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet120|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet128|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet136|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet144|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet152|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet160|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet168|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet176|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet184|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet192|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet200|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet208|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet216|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet224|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet232|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet240|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet248|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet0|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet8|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet16|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet24|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet32|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet40|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet48|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet56|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet64|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet72|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet80|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet88|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet96|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet104|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet112|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet120|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet128|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet136|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet144|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet152|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet160|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet168|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet176|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet184|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet192|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet200|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet208|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet216|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet224|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet232|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet240|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet248|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet0|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet8|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet16|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet24|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet32|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet40|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet48|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet56|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet64|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet72|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet80|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet88|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet96|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet104|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet112|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet120|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet128|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet136|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet160|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet176|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet184|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet192|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet200|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet224|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet240|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet248|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet0|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet8|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet16|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet24|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet32|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet40|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet48|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet56|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet64|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet72|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet80|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet88|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet96|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet104|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet112|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet120|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet128|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet136|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet160|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet176|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet184|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet192|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet200|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet224|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet240|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet248|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet0|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet8|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet16|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet24|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet32|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet40|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet48|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet56|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet64|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet72|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet80|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet88|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet96|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet104|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet112|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet120|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet128|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet136|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet160|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet176|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet184|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet192|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet200|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet224|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet240|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet248|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet0|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet8|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet16|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet24|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet32|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet40|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet48|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet56|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet64|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet72|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet80|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet88|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet96|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet104|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet112|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet120|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet128|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet136|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet160|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet176|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet184|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet192|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet200|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet224|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet240|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet248|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet0|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet8|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet16|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet24|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet32|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet40|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet48|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet56|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet64|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet72|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet80|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet88|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet96|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet104|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet112|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet120|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet128|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet136|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet160|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet176|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet184|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet192|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet200|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet224|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet240|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet248|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/sample_output/py3/qos-dell9332.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/qos-dell9332.json
@@ -1,0 +1,1101 @@
+{
+    "TC_TO_PRIORITY_GROUP_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "0",
+            "2": "0",
+            "3": "3",
+            "4": "4",
+            "5": "0",
+            "6": "0",
+            "7": "7"
+        }
+    },
+    "MAP_PFC_PRIORITY_TO_QUEUE": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7"
+        }
+    },
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7"
+        }
+    },
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0" : "1",
+            "1" : "1",
+            "2" : "1",
+            "3" : "3",
+            "4" : "4",
+            "5" : "2",
+            "6" : "1",
+            "7" : "1",
+            "8" : "0",
+            "9" : "1",
+            "10": "1",
+            "11": "1",
+            "12": "1",
+            "13": "1",
+            "14": "1",
+            "15": "1",
+            "16": "1",
+            "17": "1",
+            "18": "1",
+            "19": "1",
+            "20": "1",
+            "21": "1",
+            "22": "1",
+            "23": "1",
+            "24": "1",
+            "25": "1",
+            "26": "1",
+            "27": "1",
+            "28": "1",
+            "29": "1",
+            "30": "1",
+            "31": "1",
+            "32": "1",
+            "33": "1",
+            "34": "1",
+            "35": "1",
+            "36": "1",
+            "37": "1",
+            "38": "1",
+            "39": "1",
+            "40": "1",
+            "41": "1",
+            "42": "1",
+            "43": "1",
+            "44": "1",
+            "45": "1",
+            "46": "5",
+            "47": "1",
+            "48": "6",
+            "49": "1",
+            "50": "1",
+            "51": "1",
+            "52": "1",
+            "53": "1",
+            "54": "1",
+            "55": "1",
+            "56": "1",
+            "57": "1",
+            "58": "1",
+            "59": "1",
+            "60": "1",
+            "61": "1",
+            "62": "1",
+            "63": "1"
+        }
+    },
+    "SCHEDULER": {
+        "scheduler.0": {
+            "type"  : "DWRR",
+            "weight": "1"
+        },
+        "scheduler.1": {
+            "type"  : "DWRR",
+            "weight": "1"
+        },
+        "scheduler.2": {
+            "type"  : "DWRR",
+            "weight": "100"
+        }
+    },
+    "PORT_QOS_MAP": {
+        "Ethernet0": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet8": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet16": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet24": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet32": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet40": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet48": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet56": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet64": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet72": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet80": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet88": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet96": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet104": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet112": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet120": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet128": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet136": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet144": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet152": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet160": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet168": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet176": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet184": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet192": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet200": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet208": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet216": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet224": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet232": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet240": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        },
+        "Ethernet248": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP|AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP|AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP|AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE|AZURE]",
+            "pfc_enable"      : "3,4"
+        }
+    },
+    "WRED_PROFILE": {
+        "AZURE_LOSSLESS" : {
+            "wred_green_enable"      : "true",
+            "wred_yellow_enable"     : "true",
+            "wred_red_enable"        : "true",
+            "ecn"                    : "ecn_all",
+            "green_max_threshold"    : "2097152",
+            "green_min_threshold"    : "1048576",
+            "yellow_max_threshold"   : "2097152",
+            "yellow_min_threshold"   : "1048576",
+            "red_max_threshold"      : "2097152",
+            "red_min_threshold"      : "1048576",
+            "green_drop_probability" : "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability"   : "5"
+        }
+    },
+    "QUEUE": {
+        "Ethernet0|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet8|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet16|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet24|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet32|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet40|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet48|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet56|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet64|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet72|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet80|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet88|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet96|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet104|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet112|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet120|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet128|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet136|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet144|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet152|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet160|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet168|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet176|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet184|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet192|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet200|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet208|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet216|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet224|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet232|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet240|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet248|3": {
+            "scheduler"   : "[SCHEDULER|scheduler.1]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet0|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet8|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet16|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet24|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet32|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet40|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet48|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet56|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet64|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet72|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet80|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet88|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet96|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet104|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet112|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet120|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet128|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet136|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet144|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet152|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet160|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet168|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet176|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet184|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet192|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet200|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet208|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet216|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet224|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet232|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet240|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet248|4": {
+            "scheduler"   : "[SCHEDULER|scheduler.2]",
+            "wred_profile": "[WRED_PROFILE|AZURE_LOSSLESS]"
+        },
+        "Ethernet0|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet8|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet16|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet24|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet32|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet40|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet48|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet56|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet64|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet72|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet80|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet88|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet96|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet104|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet112|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet120|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet128|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet136|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet160|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet176|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet184|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet192|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet200|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet224|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet240|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet248|0": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet0|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet8|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet16|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet24|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet32|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet40|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet48|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet56|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet64|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet72|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet80|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet88|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet96|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet104|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet112|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet120|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet128|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet136|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet160|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet176|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet184|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet192|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet200|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet224|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet240|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet248|1": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet0|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet8|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet16|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet24|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet32|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet40|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet48|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet56|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet64|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet72|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet80|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet88|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet96|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet104|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet112|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet120|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet128|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet136|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet160|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet176|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet184|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet192|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet200|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet224|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet240|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet248|2": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet0|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet8|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet16|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet24|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet32|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet40|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet48|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet56|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet64|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet72|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet80|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet88|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet96|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet104|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet112|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet120|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet128|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet136|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet160|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet176|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet184|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet192|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet200|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet224|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet240|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet248|5": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet0|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet8|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet16|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet24|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet32|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet40|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet48|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet56|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet64|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet72|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet80|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet88|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet96|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet104|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet112|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet120|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet128|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet136|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet144|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet152|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet160|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet168|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet176|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet184|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet192|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet200|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet208|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet216|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet224|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet232|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet240|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        },
+        "Ethernet248|6": {
+            "scheduler": "[SCHEDULER|scheduler.0]"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -27,6 +27,7 @@ class TestJ2Files(TestCase):
         self.arista7050_t0_minigraph = os.path.join(self.test_dir, 'sample-arista-7050-t0-minigraph.xml')
         self.multi_asic_minigraph = os.path.join(self.test_dir, 'multi_npu_data', 'sample-minigraph.xml')
         self.multi_asic_port_config = os.path.join(self.test_dir, 'multi_npu_data', 'sample_port_config-0.ini')
+        self.dell9332_t1_minigraph = os.path.join(self.test_dir, 'sample-dell-9332-t1-minigraph.xml')
         self.output_file = os.path.join(self.test_dir, 'output')
 
     def run_script(self, argument):
@@ -217,6 +218,25 @@ class TestJ2Files(TestCase):
         os.remove(qos_config_file_new)
 
         sample_output_file = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'qos-arista7050.json')
+        assert filecmp.cmp(sample_output_file, self.output_file)
+
+    def test_qos_dell9332_render_template(self):
+        dell_dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', 'dell', 'x86_64-dellemc_z9332f_d1508-r0', 'DellEMC-Z9332f-O32')
+        qos_file = os.path.join(dell_dir_path, 'qos.json.j2')
+        port_config_ini_file = os.path.join(dell_dir_path, 'port_config.ini')
+
+        # copy qos_config.j2 to the Dell Z9332 directory to have all templates in one directory
+        qos_config_file = os.path.join(self.test_dir, '..', '..', '..', 'files', 'build_templates', 'qos_config.j2')
+        shutil.copy2(qos_config_file, dell_dir_path)
+
+        argument = '-m ' + self.dell9332_t1_minigraph + ' -p ' + port_config_ini_file + ' -t ' + qos_file + ' > ' + self.output_file
+        self.run_script(argument)
+
+        # cleanup
+        qos_config_file_new = os.path.join(dell_dir_path, 'qos_config.j2')
+        os.remove(qos_config_file_new)
+
+        sample_output_file = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'qos-dell9332.json')
         assert filecmp.cmp(sample_output_file, self.output_file)
 
     def test_qos_dell6100_render_template(self):


### PR DESCRIPTION
…DellEMC-Z9332f-M-O16C64

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is to fulfill specific traffic requirements for HWSKUs [DellEMC-Z9332f-O32 & DellEMC-Z9332f-M-O16C64] in production.

#### How I did it
For deployment with above HWSKUs, parser will generate configuration file with updated scheduler settings.

#### How to verify it
Verified that configuration file is generated properly as well as HW settings is good if ResourceType is correctly set for above HWSKUs.

DUT output after applying new settings:-
d chg MMU_QSCH_L0_WEIGHT_MEM_PIPE0 0 12
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[0]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[1]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[2]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[3]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[4]: <WEIGHT=0x64,PARITY=1,ECCP=0x13,ECC=3,DATA=0x64>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[5]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[6]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[7]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[8]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[9]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[10]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>
MMU_QSCH_L0_WEIGHT_MEM_PIPE0.mmu_eb0[11]: <WEIGHT=1,PARITY=1,ECCP=0x13,ECC=3,DATA=1>

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Updated traffic scheduler settings for HWSKUs : DellEMC-Z9332f-O32 & DellEMC-Z9332f-M-O16C64

#### A picture of a cute animal (not mandatory but encouraged)

