### PR TITLE
[Mellanox] Fix issue: 4600C has 4 CPU core thermal sensors

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/platform.json
@@ -96,6 +96,12 @@
                 "name": "CPU Core 1 Temp"
             },
             {
+                "name": "CPU Core 2 Temp"
+            },
+            {
+                "name": "CPU Core 3 Temp"
+            },
+            {
                 "name": "CPU Pack Temp"
             }
         ],


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

platform.json of 4600C only has 2 CPU core thermal sensors, but there are 4 actually

#### How I did it

Added thermal sensors for CPU core 2 and core 3.

#### How to verify it

Build.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

