### PR TITLE
[Mellanox] fix MSN4410 chassis name in platform_components.json

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4410-r0/platform_components.json
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/platform_components.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "x86_64-mlnx_msn4410-r0": {
+        "MSN4410": {
             "component": {
                 "ONIE": { },
                 "SSD": { },


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The chassis name in MSN4410 platform_components.json is not correct

#### How I did it
fix the chassis name

#### How to verify it
run relevant platform API test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [X] 202006
- [X] 202012
- [X] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

