### PR TITLE
[BFN] Reset BMC port on syncd start

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -28,6 +28,14 @@ function startplatform() {
         debug "Firmware update procedure ended"
     fi
 
+    if [[ x"$sonic_asic_platform" == x"barefoot" ]]; then
+        is_usb0=$(ls /sys/class/net | grep usb0)
+        if [[ "$is_usb0" == "usb0" ]]; then
+            /usr/bin/ip link set usb0 down
+            /usr/bin/ip link set usb0 up
+        fi
+    fi
+
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         if [ x$sonic_asic_platform == x'cavium' ]; then
             /etc/init.d/xpnet.sh start


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
improvement of starting barefoot SDK
#### How I did it
restart of the interface for cleaning txquee through which communication takes place between Sonic and openBMC 
#### How to verify it
run sonic autorestart  tests
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

