### PR TITLE
[logrotate] Remove arista.log from rsyslog

### DIFF
--- a/files/image_config/logrotate/rsyslog.j2
+++ b/files/image_config/logrotate/rsyslog.j2
@@ -24,7 +24,6 @@
 }
 
 /var/log/auth.log
-/var/log/arista.log
 /var/log/cron.log
 /var/log/syslog
 /var/log/teamd.log


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix the following error when running logrotate :
> admin@igk-4-dut:~$ sudo logrotate -f /etc/logrotate.conf
> error: rsyslog:16 duplicate log entry for /var/log/arista.log
> error: found error in file rsyslog, skipping

`arista.log` is a platform-specific file and config for this file was added to platform code: 
https://github.com/aristanetworks/sonic/commit/e43c7977f7473be67a7e8be7846c9dd71357feae
For correct working need to remove duplicate entry.

Signed-off-by: Petro Bratash <petrox.bratash@intel.com>
