### PR TITLE
updated jinja template for snmp contact python2 vs python3 issue

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -82,7 +82,7 @@ sysLocation    {{ SNMP.LOCATION.Location }}
 sysLocation    public
 {% endif %}
 {% if SNMP is defined and SNMP.CONTACT is defined %}
-sysContact     {{ SNMP.CONTACT.keys()[0] }} {{ SNMP.CONTACT.values()[0] }}
+sysContact     {{ SNMP.CONTACT.keys() | first }} {{ SNMP.CONTACT.values() | first }}
 {% else %}
 sysContact     Azure Cloud Switch vteam <linuxnetdev@microsoft.com>
 {% endif %}


### PR DESCRIPTION
<!--

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

-->

#### Why I did it
The SNMP contact was not generating correctly when a docker container was restarted.

#### How I did it
Root Cause: 
This was an incompatibility between python2 vs python3. 


```
Type "help", "copyright", "credits" or "license" for more information.
>>> from swsssdk import ConfigDBConnector, SonicV2Connector, SonicDBConfig
>>> config_db = ConfigDBConnector()
>>> config_db.connect()
>>> SNMP = config_db.get_table('SNMP')
>>> SNMP['CONTACT'].keys()[0]
'SN:MT2115X12126;Asset:12518181;PIN:mls-dla_tor_leaf;'
>>>


Python3
>>> config_db = ConfigDBConnector()
>>> config_db.connect()
>>> SNMP = config_db.get_table('SNMP')
>>> SNMP 
{'LOCATION': {'Location': 'public'}, 'CONTACT': {'SN:MT2115X12126;Asset:12518181;PIN:mls-dla_tor_leaf;': 'labneteng@microsoft.com'}}
>>> 
>>> 
>>> 
>>> SNMP['CONTACT']
{'SN:MT2115X12126;Asset:12518181;PIN:mls-dla_tor_leaf;': 'labneteng@microsoft.com'}
>>> SNMP['CONTACT'].keys()
dict_keys(['SN:MT2115X12126;Asset:12518181;PIN:mls-dla_tor_leaf;'])
>>> SNMP['CONTACT'].keys()[0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'dict_keys' object is not subscriptable


So I did some tests and this is how it needs to be fixed to work in python3.
{% if SNMP is defined and SNMP.CONTACT is defined %}
sysContact     {{ SNMP.CONTACT.keys() | first }} {{ SNMP.CONTACT.values() | first }}
{% else %}
sysContact     Azure Cloud Switch vteam [linuxnetdev@microsoft.com](mailto:linuxnetdev@microsoft.com)
{% endif %}
```

#### How to verify it
I tested this in a lab device and it all worked as expected. 
Once the Jinja2 template was updated.

Before
```
root@str-s6100-acs-1:/usr/share/sonic/templates# cat snmpd.conf.j2 | grep -a10 -i contact
#

#  Note that setting these values here, results in the corresponding MIB objects being 'read-only'
#  See snmpd.conf(5) for more details

{% if SNMP is defined and SNMP.LOCATION is defined %}
sysLocation    {{ SNMP.LOCATION.Location }}
{% else %}
sysLocation    public
{% endif %}
{% if SNMP is defined and SNMP.CONTACT is defined %}
sysContact     {{ SNMP.CONTACT.keys()[0] }} {{ SNMP.CONTACT.values()[0] }}
{% else %}
sysContact     Azure Cloud Switch vteam <linuxnetdev@microsoft.com>
{% endif %}

                                                 # Application + End-to-End layers
sysServices    72


#
#  Process Monitoring
#
# todo: should we enable snmp based monitoring of sswsyncd and other processes?
root@str-s6100-acs-1:/usr/share/sonic/templates# 
```

Before test: 
```
admin@str-s6100-acs-1:~$ show run snmp contact
Contact                                              Contact Email
---------------------------------------------------  -----------------------
SN:MT2115X12126;Asset:12518181;PIN:mls-dla_tor_leaf  labneteng@microsoft.com
admin@str-s6100-acs-1:~$ 


trvanduy@nettools4-eastus2:~$ snmpget -v 2c -c Test1 str-s6100-acs-1 sysContact.0
SNMPv2-MIB::sysContact.0 = STRING: root
```

After
```
root@str-s6100-acs-1:/usr/share/sonic/templates# cat snmpd.conf.j2 | grep -a10 -i contact
#

#  Note that setting these values here, results in the corresponding MIB objects being 'read-only'
#  See snmpd.conf(5) for more details

{% if SNMP is defined and SNMP.LOCATION is defined %}
sysLocation    {{ SNMP.LOCATION.Location }}
{% else %}
sysLocation    public
{% endif %}
{% if SNMP is defined and SNMP.CONTACT is defined %}
sysContact     {{ SNMP.CONTACT.keys() | first }} {{ SNMP.CONTACT.values() | first }}
{% else %}
sysContact     Azure Cloud Switch vteam <linuxnetdev@microsoft.com>
{% endif %}

                                                 # Application + End-to-End layers
sysServices    72


#
#  Process Monitoring
#
# todo: should we enable snmp based monitoring of sswsyncd and other processes?
root@str-s6100-acs-1:/usr/share/sonic/templates# 
```

After test:
```
admin@str-s6100-acs-1:~$ show run snmp contact
Contact                                              Contact Email
---------------------------------------------------  -----------------------
SN:MT2115X12126;Asset:12518181;PIN:mls-dla_tor_leaf  labneteng@microsoft.com
admin@str-s6100-acs-1:~$ 


trvanduy@nettools4-eastus2:~$ snmpget -v 2c -c Test1 str-s6100-acs-1 sysContact.0
SNMPv2-MIB::sysContact.0 = STRING: SN:MT2115X12126;Asset:12518181;PIN:mls-dla_tor_leaf labneteng@microsoft.com
```

If there is no contact after the fix
```
admin@str-s6100-acs-1:~$ show run snmp contact
Contact    Contact Email
---------  ---------------
admin@str-s6100-acs-1:~$ 

trvanduy@nettools4-eastus2:~$ snmpget -v 2c -c Test1 str-s6100-acs-1 sysContact.0
SNMPv2-MIB::sysContact.0 = STRING: Azure Cloud Switch vteam <linuxnetdev@microsoft.com>
trvanduy@nettools4-eastus2:~$ 
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

We should backport to these branches that have the feature enabled to use the new snmp commands.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
Bug Fix for snmpd.conf.j2 template.
-->


#### A picture of a cute animal (not mandatory but encouraged)


