### PR TITLE
[rsyslog.j2] fix typo in VAR_LOG_SIZE_KB

### DIFF
--- a/files/image_config/logrotate/rsyslog.j2
+++ b/files/image_config/logrotate/rsyslog.j2
@@ -57,7 +57,7 @@
         # should be disabled, just in case they get created and rotated
         RESERVED_SPACE_KB=4096
 
-        VARL_LOG_SIZE_KB={{var_log_kb}}
+        VAR_LOG_SIZE_KB={{var_log_kb}}
 
         # Limit usable space to 90% of the partition minus the reserved space for other logs
         USABLE_SPACE_KB=$(( (VAR_LOG_SIZE_KB * 90 / 100) - RESERVED_SPACE_KB))


### PR DESCRIPTION
This issue causes negative threshold value and thus deleting log files even when there is enough space.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix an issue when log files get deleted even if there is enough space.

#### How I did it
Fixed an typo.

#### How to verify it
Run the portion of the script that calculates threshold, see that the threshold is calculated correctly.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

