### PR TITLE
[bcmsai] upgrade Broadcom SAI to 3.5.3.8

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,9 +1,9 @@
-BRCM_SAI = libsaibcm_3.5.3.7-6_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm_3.5.3.7-6_amd64.deb?sv=2019-10-10&st=2021-09-23T23%3A20%3A57Z&se=2040-09-24T23%3A20%3A00Z&sr=b&sp=r&sig=zYE0zYDSvshvDaBsmxgXnZlw2XuGMbN%2FKQ7Wdx5mr44%3D"
+BRCM_SAI = libsaibcm_3.5.3.8_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm_3.5.3.8_amd64.deb?sv=2019-10-10&st=2022-02-08T22%3A45%3A37Z&se=2037-02-09T22%3A45%3A00Z&sr=b&sp=r&sig=ilAmnbEhsCG2iI%2Bm3WBXBJ05lEU2xjoR5ef7ypN%2B%2F6c%3D"
 
-BRCM_SAI_DEV = libsaibcm-dev_3.5.3.7-6_amd64.deb
+BRCM_SAI_DEV = libsaibcm-dev_3.5.3.8_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm-dev_3.5.3.7-6_amd64.deb?sv=2019-10-10&st=2021-09-23T23%3A22%3A10Z&se=2040-09-24T23%3A22%3A00Z&sr=b&sp=r&sig=GkqH6luvSrPBIukhGwlm7dKtiLja%2FQKVDrZ%2BDKt7OJk%3D"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.5/jessie/libsaibcm-dev_3.5.3.8_amd64.deb?sv=2019-10-10&st=2022-02-08T22%3A44%3A53Z&se=2037-02-09T22%3A44%3A00Z&sr=b&sp=r&sig=ZtrKEWVV9ds1EBPo0NwnzW9v39%2BNQhMlnn0qkBZWJ7o%3D"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
#### How I did it

Upgrade Broadcom SAI to version 3.5.3.8 to installnclude following fixes:

CS00012225760, CS00012212820, CS00012215529, CS00012218100

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

