### PR TITLE
[Mellanox] Fix issue: SFP index got from get_change_event is wrong when an xSFP module is plugged in/out

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
@@ -360,15 +360,11 @@ class sfp_event:
                 logical_port = sx_port_log_id_t_arr_getitem(logical_port_list, i)
                 rc = sx_api_port_device_get(self.handle, 1 , 0, port_attributes_list,  port_cnt_p)
                 port_cnt = uint32_t_p_value(port_cnt_p)
-                x = 0 # x is the port index within a LC
                 for i in range(port_cnt):
                     port_attributes = sx_port_attributes_t_arr_getitem(port_attributes_list,i)
                     if port_attributes.log_port == logical_port:
-                        label_port = slot_id * DeviceDataManager.get_linecard_max_port_count() + x + 1
+                        label_port = slot_id * DeviceDataManager.get_linecard_max_port_count() + port_attributes.port_mapping.module_port
                         break
-
-                    if port_attributes.port_mapping.slot == slot_id:
-                        x += 1
 
                 if label_port is not None:
                     label_port_list.append(label_port)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix issue: SFP index got from get_change_event is wrong when an xSFP module is plugged in/out
The error message like `Fail to re-initialize SFP 54 - IndexError('list index out of range')` is observed.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it

Manually test and regression test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

