### PR TITLE
[centec][build] Fix docker-syncd-centec-rpc build fail

### DIFF
--- a/platform/centec-arm64/docker-saiserver-centec.mk
+++ b/platform/centec-arm64/docker-saiserver-centec.mk
@@ -12,3 +12,5 @@ $(DOCKER_SAISERVER_CENTEC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SAISERVER_CENTEC)_RUN_OPT += -v /var/run/docker-saiserver:/var/run/sswsyncd
 $(DOCKER_SAISERVER_CENTEC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_SAISERVER_CENTEC)_RUN_OPT += -v /host/warmboot:/var/warmboot
+
+SONIC_BUSTER_DOCKERS += $(DOCKER_SAISERVER_CENTEC)

--- a/platform/centec-arm64/docker-syncd-centec-rpc.mk
+++ b/platform/centec-arm64/docker-syncd-centec-rpc.mk
@@ -23,3 +23,5 @@ $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+
+SONIC_BUSTER_DOCKERS += $(DOCKER_SYNCD_CENTEC_RPC)

--- a/platform/centec/docker-saiserver-centec.mk
+++ b/platform/centec/docker-saiserver-centec.mk
@@ -12,3 +12,5 @@ $(DOCKER_SAISERVER_CENTEC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SAISERVER_CENTEC)_RUN_OPT += -v /var/run/docker-saiserver:/var/run/sswsyncd
 $(DOCKER_SAISERVER_CENTEC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_SAISERVER_CENTEC)_RUN_OPT += -v /host/warmboot:/var/warmboot
+
+SONIC_BUSTER_DOCKERS += $(DOCKER_SAISERVER_CENTEC)

--- a/platform/centec/docker-syncd-centec-rpc.mk
+++ b/platform/centec/docker-syncd-centec-rpc.mk
@@ -23,3 +23,5 @@ $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_CENTEC_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+
+SONIC_BUSTER_DOCKERS += $(DOCKER_SYNCD_CENTEC_RPC)


### PR DESCRIPTION
Add docker-syncd-centec-rpc and docker-saiserver-centec to buster docker image list. These 2 docker images are based on docker-config-engine-buster.

Co-authored-by: Xianghong Gu <xgu@centecnetworks.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix docker-syncd-centec-rpc build fail. Detail fail log can be derived from https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/build/builds/71157/logs/9.
#### How I did it
Merge PR #9612 from master branch.

#### How to verify it
make ENABLE_SYNCD_RPC=y target/docker-syncd-centec-rpc.gz
make ENABLE_SYNCD_RPC=y target/docker-saiserver-centec.gz

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

