### PR TITLE
[arista] Update serdes tuning values for 7280cr3mk

### DIFF
--- a/device/arista/x86_64-arista_7280cr3mk_32p4/Arista-7280CR3-C40/gearbox_100G_PAM4.xml
+++ b/device/arista/x86_64-arista_7280cr3mk_32p4/Arista-7280CR3-C40/gearbox_100G_PAM4.xml
@@ -4,11 +4,6 @@
     <phy_addr>0</phy_addr>
     <mode>gearbox</mode>
     <topology>2</topology>
-    <tx-taps>
-        <PAM4>2,-8,17,0,0</PAM4>
-        <NRZ>0,-8,17,0,0</NRZ>
-    </tx-taps>
-    <tx-taps-scale>0,0,1,0,0</tx-taps-scale>
 
     <lane id="0" system-side="true" />
     <lane id="1" system-side="true" />
@@ -34,4 +29,33 @@
     <lane id="21" system-side="false"  />
     <lane id="22" system-side="false"  />
     <lane id="23" system-side="false"  />
+
+    <PAM4>
+        <lane id="0" tx-taps="1,-5,14,0,0"/>
+        <lane id="1" tx-taps="1,-5,14,0,0"/>
+        <lane id="2" tx-taps="1,-5,14,0,0"/>
+        <lane id="3" tx-taps="1,-5,14,0,0"/>
+        <lane id="4" tx-taps="1,-5,14,0,0"/>
+        <lane id="5" tx-taps="1,-5,14,0,0"/>
+        <lane id="6" tx-taps="1,-5,14,0,0"/>
+        <lane id="7" tx-taps="1,-5,14,0,0"/>
+    </PAM4>
+    <NRZ>
+        <lane id="8" tx-taps="0,-1,13,-5,0"/>
+        <lane id="9" tx-taps="0,-1,13,-5,0"/>
+        <lane id="10" tx-taps="0,-1,13,-5,0"/>
+        <lane id="11" tx-taps="0,-1,13,-5,0"/>
+        <lane id="12" tx-taps="0,-1,13,-5,0"/>
+        <lane id="13" tx-taps="0,-1,13,-5,0"/>
+        <lane id="14" tx-taps="0,-1,13,-5,0"/>
+        <lane id="15" tx-taps="0,-1,13,-5,0"/>
+        <lane id="16" tx-taps="0,-1,13,-5,0"/>
+        <lane id="17" tx-taps="0,-1,13,-5,0"/>
+        <lane id="18" tx-taps="0,-1,13,-5,0"/>
+        <lane id="19" tx-taps="0,-1,13,-5,0"/>
+        <lane id="20" tx-taps="0,-1,13,-5,0"/>
+        <lane id="21" tx-taps="0,-1,13,-5,0"/>
+        <lane id="22" tx-taps="0,-1,13,-5,0"/>
+        <lane id="23" tx-taps="0,-1,13,-5,0"/>
+    </NRZ>
 </root>


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This update the serdes tuning values for Arista 7280cr3mk. The values are for the optical transceivers.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

