### PR TITLE
[201911][Arista] Add emmc quirks for Upperlake

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -277,6 +277,7 @@ platform_specific() {
         aboot_machine=arista_7050_qx32s
         flash_size=3700
         echo "modprobe.blacklist=radeon,sp5100_tco" >>/tmp/append
+        echo "sdhci.append_quirks2=0x40" >> /tmp/append
     fi
     if [ "$sid" = "Upperlake" ] || [ "$sid" = "UpperlakeES" ]; then
         aboot_machine=arista_7060_cx32s
@@ -352,6 +353,8 @@ platform_specific() {
     echo "varlog_size=$varlog_size" >>/tmp/append
     # disable deterministic interface naming
     echo "net.ifnames=0" >>/tmp/append
+    # increase kernel log circular buffer size
+    echo "log_buf_len=1M" >>/tmp/append
 }
 
 get_uuid_for() {


### PR DESCRIPTION
#### Why I did it

Fix some unreliability seen on emmc device with some AMD CPUs

#### How I did it

Added a kernel parameter to add quirks to 
It depends on a sonic-linux-kernel change to work properly but will be a no-op without it.


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add emmc quirks for Upperlake