### PR TITLE
[Build]: Fix hundreds of thousands lines of logs printed in marvell-armhf build

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -609,6 +609,7 @@ $(SONIC_INSTALL_DEBS) : $(DEBS_PATH)/%-install : .platform $$(addsuffix -install
 		if mkdir $(DEBS_PATH)/dpkg_lock &> /dev/null; then
 			{ sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(DEBS_PATH)/$* $(LOG) && rm -d $(DEBS_PATH)/dpkg_lock && break; } || { rm -d $(DEBS_PATH)/dpkg_lock && sudo lsof /var/lib/dpkg/lock-frontend && ps aux && exit 1 ; }
 		fi
+		sleep 10
 	done
 	$(FOOTER)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It prints too many unuse logs in marvell-armhf build. See https://dev.azure.com/mssonic/build/_build/results?buildId=71963&view=logs&j=268525a4-f0a8-5106-2898-2602f02ebdb0&t=59457689-49a2-5da2-bad6-5355ff2da0c7

It is caused by the bad format of the marvell sai package mrvllibsai_armhf_1.7.1-6.deb, see https://github.com/Azure/sonic-buildimage/blob/b621dafff77642db541553f5a2f8ec85e70ea695/platform/marvell-armhf/sai.mk#L4 and https://github.com/Marvell-switching/sonic-marvell-binaries/tree/master/armhf/sai-plugin, the expected package is mrvllibsai_1.7.1-6_armhf.deb, in the format as below:
```
<PackageName>_<VersionNumber>-<DebianRevisionNumber>_<DebianArchitecture>.deb
```

#### How I did it
It is not to fix the marvell package name, only add waiting time to reduce the issue, print less logs.
Add relative issue to Marvell, https://github.com/Marvell-switching/sonic-marvell-binaries/issues/62

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

