### PR TITLE
[Accton/PDDF] Enable thermalctld in pmon

### DIFF
--- a/device/accton/x86_64-accton_as5835_54t-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as5835_54t-r0/pmon_daemon_control.json
@@ -1,5 +1,5 @@
 {
     "skip_ledd": true,
-    "skip_thermalctld": true
+    "skip_pcied": true
 }
 

--- a/device/accton/x86_64-accton_as5835_54x-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/pmon_daemon_control.json
@@ -1,5 +1,5 @@
 {
     "skip_ledd": true,
-    "skip_thermalctld": true
+    "skip_pcied": true
 }
 

--- a/device/accton/x86_64-accton_as7326_56x-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/pmon_daemon_control.json
@@ -1,5 +1,5 @@
 {
     "skip_ledd": true,
-    "skip_thermalctld": true
+    "skip_pcied": true
 }
 

--- a/device/accton/x86_64-accton_as7712_32x-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/pmon_daemon_control.json
@@ -1,5 +1,5 @@
 {
     "skip_ledd": true,
-    "skip_thermalctld": true,
     "skip_pcied": true
 }
+

--- a/device/accton/x86_64-accton_as7726_32x-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pmon_daemon_control.json
@@ -1,6 +1,5 @@
 {
     "skip_ledd": true,
-    "skip_pcied": true,
-    "skip_thermalctld": true
+    "skip_pcied": true
 }
 

--- a/device/accton/x86_64-accton_as7816_64x-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as7816_64x-r0/pmon_daemon_control.json
@@ -1,6 +1,5 @@
 {
     "skip_ledd": true,
-    "skip_pcied": true,
-    "skip_thermalctld": true
+    "skip_pcied": true
 }
 

--- a/device/accton/x86_64-accton_as9716_32d-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/pmon_daemon_control.json
@@ -1,5 +1,5 @@
 {
     "skip_ledd": true,
-    "skip_thermalctld": true
+    "skip_pcied": true
 }
 


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When do "skip_thermalcltd: true" will let "show platform fan" and "show platform temp" fail.
When enable thermalctld, these cmd will work well. 
#### How I did it
Remove "skip_thermalcltd: true" in pmon_daemon_control.json
#### How to verify it
Test show platform temp and show platform fan, results are fine in PDDF platform .
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

