### PR TITLE
hostcfgd: Add one shot timer to reload tacacs config from CONFIG-DB

### DIFF
--- a/files/image_config/hostcfgd/hostcfgd
+++ b/files/image_config/hostcfgd/hostcfgd
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import threading
 import sys
 import subprocess
 import syslog
@@ -21,6 +22,20 @@ NSS_CONF = "/etc/nsswitch.conf"
 TACPLUS_SERVER_PASSKEY_DEFAULT = ""
 TACPLUS_SERVER_TIMEOUT_DEFAULT = "5"
 TACPLUS_SERVER_AUTH_TYPE_DEFAULT = "pap"
+
+global_lock = None
+
+class lock_mgr:
+    def __init__(self):
+        self.lock = global_lock
+
+    def __enter__( self ):
+        if self.lock:
+            self.lock.acquire()
+
+    def __exit__( self, exc_type, exc_value, traceback ):
+        if self.lock:
+            self.lock.release()
 
 
 def is_true(val):
@@ -118,7 +133,7 @@ class Iptables(object):
                               .format(err.cmd, err.returncode, err.output))
 
 class AaaCfg(object):
-    def __init__(self):
+    def __init__(self, config_db):
         self.auth_default = {
             'login': 'local',
         }
@@ -131,42 +146,22 @@ class AaaCfg(object):
         self.tacplus_global = {}
         self.tacplus_servers = {}
         self.debug = False
+        self.config_db = config_db
 
     # Load conf from ConfigDb
-    def load(self, aaa_conf, tac_global_conf, tacplus_conf):
-        for row in aaa_conf:
-            self.aaa_update(row, aaa_conf[row], modify_conf=False)
-        for row in tac_global_conf:
-            self.tacacs_global_update(row, tac_global_conf[row], modify_conf=False)
-        for row in tacplus_conf:
-            self.tacacs_server_update(row, tacplus_conf[row], modify_conf=False)
+    def load(self):
         self.modify_conf_file()
 
-    def aaa_update(self, key, data, modify_conf=True):
+    def aaa_update(self, key):
         if key == 'authentication':
-            self.auth = data
-            if 'failthrough' in data:
-                self.auth['failthrough'] = is_true(data['failthrough'])
-            if 'debug' in data:
-                self.debug = is_true(data['debug'])
-        if modify_conf:
             self.modify_conf_file()
 
-    def tacacs_global_update(self, key, data, modify_conf=True):
+    def tacacs_global_update(self, key):
         if key == 'global':
-            self.tacplus_global = data
-            if modify_conf:
-                self.modify_conf_file()
-
-    def tacacs_server_update(self, key, data, modify_conf=True):
-        if data == {}:
-            if key in self.tacplus_servers:
-                del self.tacplus_servers[key]
-        else:
-            self.tacplus_servers[key] = data
-
-        if modify_conf:
             self.modify_conf_file()
+
+    def tacacs_server_update(self, key):
+        self.modify_conf_file()
 
     def modify_single_file(self, filename, operations=None):
         if operations:
@@ -174,6 +169,19 @@ class AaaCfg(object):
             os.system(cmd)
 
     def modify_conf_file(self):
+        with lock_mgr():
+            self.auth = self.config_db.get_table('AAA').get("authentication", {})
+            if 'failthrough' in self.auth:
+                self.auth['failthrough'] = is_true(self.auth['failthrough'])
+            if 'debug' in self.auth:
+                self.debug = is_true(self.auth['debug'])
+
+            self.tacplus_global = self.config_db.get_table('TACPLUS').get(
+                    "global", {})
+            self.tacplus_servers = self.config_db.get_table('TACPLUS_SERVER')
+            self._modify_conf_file()
+
+    def _modify_conf_file(self):
         auth = self.auth_default.copy()
         auth.update(self.auth)
         tacplus_global = self.tacplus_global_default.copy()
@@ -219,33 +227,50 @@ class AaaCfg(object):
         with open(NSS_TACPLUS_CONF, 'w') as f:
             f.write(nss_tacplus_conf)
 
+        if 'passkey' in tacplus_global:
+            tacplus_global['passkey'] = obfuscate(tacplus_global['passkey'])
+        syslog.syslog(syslog.LOG_INFO, 'pam.d files updated auth={} global={}'.
+                format(auth, tacplus_global))
+
 
 class HostConfigDaemon:
     def __init__(self):
         self.config_db = ConfigDBConnector()
         self.config_db.connect(wait_for_init=True, retry_on=True)
         syslog.syslog(syslog.LOG_INFO, 'ConfigDB connect success')
-        aaa = self.config_db.get_table('AAA')
-        tacacs_global = self.config_db.get_table('TACPLUS')
-        tacacs_server = self.config_db.get_table('TACPLUS_SERVER')
-        self.aaacfg = AaaCfg()
-        self.aaacfg.load(aaa, tacacs_global, tacacs_server)
-        lpbk_table = self.config_db.get_table('LOOPBACK_INTERFACE')
+
+        self.aaacfg = AaaCfg(self.config_db)
         self.iptables = Iptables()
+
+
+    def timer_load(self):
+        global global_lock
+
+        syslog.syslog(syslog.LOG_INFO, 'reloading tacacs from timer thread')
+        self.aaacfg.load()
+
+        # Remove lock as timer is one shot
+        global_lock = None
+
+
+    def load(self):
+        self.aaacfg.load()
+        lpbk_table = self.config_db.get_table('LOOPBACK_INTERFACE')
         self.iptables.load(lpbk_table)
 
     def aaa_handler(self, key, data):
-        self.aaacfg.aaa_update(key, data)
+        self.aaacfg.aaa_update(key)
+        syslog.syslog(syslog.LOG_INFO, 'value of {} changed to {}'.format(key, data))
 
     def tacacs_server_handler(self, key, data):
-        self.aaacfg.tacacs_server_update(key, data)
+        self.aaacfg.tacacs_server_update(key)
         log_data = copy.deepcopy(data)
         if log_data.has_key('passkey'):
             log_data['passkey'] = obfuscate(log_data['passkey'])
         syslog.syslog(syslog.LOG_INFO, 'value of {} changed to {}'.format(key, log_data))
 
     def tacacs_global_handler(self, key, data):
-        self.aaacfg.tacacs_global_update(key, data)
+        self.aaacfg.tacacs_global_update(key)
         log_data = copy.deepcopy(data)
         if log_data.has_key('passkey'):
             log_data['passkey'] = obfuscate(log_data['passkey'])
@@ -263,10 +288,20 @@ class HostConfigDaemon:
         self.iptables.iptables_handler(key, data, add)
 
     def start(self):
+        global global_lock
+
         self.config_db.subscribe('AAA', lambda table, key, data: self.aaa_handler(key, data))
         self.config_db.subscribe('TACPLUS_SERVER', lambda table, key, data: self.tacacs_server_handler(key, data))
         self.config_db.subscribe('TACPLUS', lambda table, key, data: self.tacacs_global_handler(key, data))
         self.config_db.subscribe('LOOPBACK_INTERFACE', lambda table, key, data: self.lpbk_handler(key, data))
+
+        # Defer load until subscribe
+        self.load()
+
+        global_lock = threading.Lock()
+        self.tmr_thread = threading.Timer(30, self.timer_load)
+        self.tmr_thread.start()
+          
         self.config_db.listen()
 
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
There is a small window between load & listen to config-DB. If TACACS config got updated during that gap, the listen will not show it, hence hostcfgd would miss it, until another update.

#### How I did it
porting PR #8223, which uses one shot timer to reload tacacs config.

#### How to verify it
Copy this binary to a 201811 device and 
Run config reload & restart of hostcfd concurrently, multiple times to see, if hostcfgd miss the update or not.

Ran a repeated config reload for testing.
It did succeed.
But it could not really hit the repro, which is kind of expected as it is is very hard to hit the repro in 201811

[_Tweaked code with a log message, that dumps the read value with isTimer to indicate normal load vs via timer_]
```
admin@str-s6000-acs-8:/var/log$ zgrep -i istimer syslog*
syslog:Feb 16 18:53:25.006739 str-s6000-acs-8 INFO hostcfgd: pam.d files updated isTimer=False auth={'login': 'tacacs+', 'failthrough': True} global={'auth_type': 'login', 'timeout': '5', 'passkey': 't*****'}
syslog:Feb 16 18:53:55.707662 str-s6000-acs-8 INFO hostcfgd: pam.d files updated isTimer=True auth={'login': 'tacacs+', 'failthrough': True} global={'auth_type': 'login', 'timeout': '5', 'passkey': 't*****'}
syslog.1:Feb 16 18:29:18.661496 str-s6000-acs-8 INFO hostcfgd: pam.d files updated isTimer=False auth={'login': 'tacacs+', 'failthrough': True} global={'auth_type': 'login', 'timeout': '5', 'passkey': 't*****'}
syslog.1:Feb 16 18:29:49.193510 str-s6000-acs-8 INFO hostcfgd: pam.d files updated isTimer=True auth={'login': 'tacacs+', 'failthrough': True} global={'auth_type': 'login', 'timeout': '5', 'passkey': 't*****'}
syslog.1:Feb 16 18:41:22.170889 str-s6000-acs-8 INFO hostcfgd: pam.d files updated isTimer=False auth={'login': 'tacacs+', 'failthrough': True} global={'auth_type': 'login', 'timeout': '5', 'passkey': 't*****'}
...
admin@str-s6000-acs-8:~$ cat scripts/r.sh 
#! /bin/bash

set -x

for ((i=0; i<10; ++i))
do
    echo "-------------------- $i -----------------------"
    sleep 10m
    sudo config reload -y
    t=$(cat /etc/pam.d/common-auth-sonic  | grep testing123 | wc -l) 
    if [ "$t" -eq "1" ]; then
        echo "Success"
    else
        echo "Failure"
        exit -1
    fi
done


admin@str-s6000-acs-8:~$ 
```

#### Which release branch to backport (provide reason below if selected)
This is the backport to 201811
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add a one shot timer after load; Reload tacacs config from DB, upon the timer.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

