### PR TITLE
[Nokia][platform]Modified BCM config & platform_reboot script for Nokia-IXR7250E-36x400G

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
@@ -2048,5 +2048,4 @@ dpp_db_path=/usr/share/bcm/db
 sai_recycle_port_lane_base=96
 appl_param_nof_ports_per_modid=64
 udh_exists=1
-
-
+modreg IPS_FORCE_LOCAL_OR_FABRIC FORCE_FABRIC=1

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
@@ -2050,5 +2050,4 @@ dpp_db_path=/usr/share/bcm/db
 sai_recycle_port_lane_base=96
 appl_param_nof_ports_per_modid=64
 udh_exists=1
-
-
+modreg IPS_FORCE_LOCAL_OR_FABRIC FORCE_FABRIC=1

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_reboot
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/platform_reboot
@@ -7,4 +7,6 @@ kick_date=`date -u`
 echo "last watchdog kick $kick_date" > /var/log/nokia-watchdog-last.log
 rm -f /sys/firmware/efi/efivars/dump-*
 sync
+echo "Rebooting all Linecards"
+python3 -c 'import sonic_platform.platform; platform_chassis = sonic_platform.platform.Platform().get_chassis(); platform_chassis.reboot_imms()'
 /sbin/reboot


### PR DESCRIPTION

Signed-off-by: Sakthivadivu Saravanaraj <sakthivadivu.saravanaraj@nokia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 Added "modreg IPS_FORCE_LOCAL_OR_FABRIC FORCE_FABRIC=1" in .bcm config as suggested by BCM to address the throughput issue. Also modified platform_reboot script to reboot all Linecards when CPM is rebooted.
#### How I did it
  Added "modreg IPS_FORCE_LOCAL_OR_FABRIC FORCE_FABRIC=1" in .bcm config & modified platform_reboot script
#### How to verify it
 Verified Linecards are rebooted when CPM is rebooted.
 Verified OC tests are passing.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

