### PR TITLE
[CoPP] Add always_enabled field

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -13,7 +13,7 @@
 		    "trap_priority":"4",
 		    "queue": "4"
 	    },
-	    "queue4_group2": {            
+	    "queue4_group2": {
 		    "trap_action":"copy",
 		    "trap_priority":"4",
 		    "queue": "4",
@@ -69,11 +69,13 @@
 	    },
 	    "lacp": {
 		    "trap_ids": "lacp",
-		    "trap_group": "queue4_group1"
+		    "trap_group": "queue4_group1",
+		    "always_enabled": "true"
 	    },
 	    "arp": {
 		    "trap_ids": "arp_req,arp_resp,neigh_discovery",
-		    "trap_group": "queue4_group2"
+		    "trap_group": "queue4_group2",
+		    "always_enabled": "true"
 	    },
 	    "lldp": {
 		    "trap_ids": "lldp",
@@ -87,11 +89,13 @@
 {% endif %}
 	    "udld": {
 		    "trap_ids": "udld",
-		    "trap_group": "queue4_group3"
+		    "trap_group": "queue4_group3",
+		    "always_enabled": "true"
 	    },
 	    "ip2me": {
 		    "trap_ids": "ip2me",
-		    "trap_group": "queue1_group1"
+		    "trap_group": "queue1_group1",
+		    "always_enabled": "true"
 	    },
 	    "nat": {
 		    "trap_ids": "src_nat_miss,dest_nat_miss",


### PR DESCRIPTION
*Add the "always_enabled" field to copp_cfg.j2 file, in order to allow traps without an entry in features table, to be installed automatically.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->


this is a cherry-pick of https://github.com/Azure/sonic-buildimage/pull/9302
#### Why I did it
in order to allow traps without an entry in features table, to be installed automatically.
#### How I did it
Add always_enabled field to traps without a feature
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

