### PR TITLE
[memory_monitoring] Enhance the feature of monitoring the memory usage of containers

### DIFF
--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -25,15 +25,17 @@ import sys
 import syslog
 import re
 
+CGROUP_DOCKER_MEMORY_DIR = "/sys/fs/cgroup/memory/docker/"
+
 
 def get_command_result(command):
-    """Executes the command and return the resulting output.
+    """Executes command and returns command's stdout.
 
     Args:
         command: A string contains the command to be executed.
 
     Returns:
-        A string which contains the output of command.
+        A string contains command's stdout.
     """
     command_stdout = ""
 
@@ -53,9 +55,88 @@ def get_command_result(command):
     return command_stdout.strip()
 
 
+def get_container_id(container_name):
+    """Gets full container ID of the specified container
+
+    Args:
+        container_name: A string indicates the name of specified container.
+
+    Returns:
+        container_id: A string indicates the full ID of specified container.
+    """
+    container_id = ""
+
+    get_container_info_cmd = "docker ps --no-trunc | grep -i {}".format(container_name)
+    command_stdout = get_command_result(get_container_info_cmd)
+
+    for line in command_stdout.splitlines():
+        if container_name in line:
+            container_id = line.split()[0]
+            break
+
+    if not container_id:
+        syslog.syslog(syslog.LOG_ERR, "[memory_checker] Failed to get contianer ID of '{}'!"
+                      .format(container_name))
+        sys.exit(4)
+
+    return container_id
+
+
+def get_memory_usage(container_id):
+    """Reads the container's memory usage from the control group subsystem's file
+    '/sys/fs/cgroup/memory/docker/<container_id>/memory.usage_in_bytes'.
+
+    Args:
+        container_id: A string indicates the full ID of a container.
+
+    Returns:
+        memory_usage_in_bytes: A string indicates memory usage (Bytes) of a container.
+    """
+    memory_usage_in_bytes = ""
+
+    docker_memory_usage_file_path = CGROUP_DOCKER_MEMORY_DIR + container_id + "/memory.usage_in_bytes"
+    get_memory_usage_cmd = "sudo cat {}".format(docker_memory_usage_file_path)
+    memory_usage_in_bytes = get_command_result(get_memory_usage_cmd)
+    if not memory_usage_in_bytes:
+        syslog.syslog(syslog.LOG_ERR, "[memory_checker] Failed to get the memory usage of container '{}'!"
+                      .format(container_id))
+        sys.exit(5)
+
+    return memory_usage_in_bytes
+
+
+def get_cache_usage(container_id):
+    """Reads the container's cache usage from the field 'total_inactive_file' in control
+    group subsystem's file '/sys/fs/cgroup/memory/docker/<container_id>/memory.stat'.
+
+    Args:
+        container_id: A string indicates the full ID of a container.
+
+    Returns:
+        cache_usage_in_bytes: A string indicates the cache usage (Bytes) of a container.
+    """
+    cache_usage_in_bytes = ""
+
+    docker_memory_stat_file_path = CGROUP_DOCKER_MEMORY_DIR + container_id + "/memory.stat"
+    get_cache_usage_cmd = "sudo cat {} | grep -i 'total_inactive_file'".format(docker_memory_stat_file_path)
+    command_stdout = get_command_result(get_cache_usage_cmd)
+
+    for line in command_stdout.splitlines():
+        if "total_inactive_file" in line:
+            cache_usage_in_bytes = line.split()[1]
+            break
+
+    if not cache_usage_in_bytes:
+        syslog.syslog(syslog.LOG_ERR, "[memory_checker] Failed to get the cache usage of container '{}'!"
+                      .format(container_id))
+        sys.exit(6)
+
+    return cache_usage_in_bytes
+
+
 def check_memory_usage(container_name, threshold_value):
-    """Checks the memory usage of a container and writes an alerting messages into
-    the syslog if the memory usage is larger than the threshold value.
+    """Checks the memory usage of a container from its cgroup subsystem and writes an alerting
+    messages into the syslog if the memory usage is larger than the threshold value.
 
     Args:
         container_name: A string represtents name of a container
@@ -64,32 +145,33 @@ def check_memory_usage(container_name, threshold_value):
     Returns:
         None.
     """
-    command = "docker stats --no-stream --format \{{\{{.MemUsage\}}\}} {}".format(container_name)
-    command_stdout = get_command_result(command)
-    mem_usage = command_stdout.split("/")[0].strip()
-    match_obj = re.match(r"\d+\.?\d*", mem_usage)
-    if match_obj:
-        mem_usage_value = float(mem_usage[match_obj.start():match_obj.end()])
-        mem_usage_unit = mem_usage[match_obj.end():]
+    container_id = get_container_id(container_name)
+    syslog.syslog(syslog.LOG_INFO, "[memory_checker] Container ID of '{}' is: '{}'."
+                  .format(container_name, container_id))
 
-        mem_usage_bytes = 0.0
-        if mem_usage_unit == "B":
-            mem_usage_bytes = mem_usage_value
-        elif mem_usage_unit == "KiB":
-            mem_usage_bytes = mem_usage_value * 1024
-        elif mem_usage_unit == "MiB":
-            mem_usage_bytes = mem_usage_value * 1024 ** 2
-        elif mem_usage_unit == "GiB":
-            mem_usage_bytes = mem_usage_value * 1024 ** 3
+    memory_usage_in_bytes = get_memory_usage(container_id)
+    syslog.syslog(syslog.LOG_INFO, "[memory_checker] The memory usage of container '{}' is '{}' Bytes!"
+                  .format(container_name, memory_usage_in_bytes))
 
-        if mem_usage_bytes > threshold_value:
-            print("[{}]: Memory usage ({} Bytes) is larger than the threshold ({} Bytes)!"
-                  .format(container_name, mem_usage_bytes, threshold_value))
-            sys.exit(3)
-    else:
-        syslog.syslog(syslog.LOG_ERR, "[memory_checker] Failed to retrieve memory value from '{}'"
-                      .format(mem_usage))
-        sys.exit(4)
+    cache_usage_in_bytes = get_cache_usage(container_id)
+    syslog.syslog(syslog.LOG_INFO, "[memory_checker] The cache usage of container '{}' is '{}' Bytes!"
+                  .format(container_name, cache_usage_in_bytes))
+
+    try:
+        memory_usage = int(memory_usage_in_bytes)
+        cache_usage = int(cache_usage_in_bytes)
+    except ValueError as err:
+        syslog.syslog(syslog.LOG_ERR, "[memory_checker] Failed to convert the memory or cache usage in string to integer!")
+        sys.exit(7)
+
+    total_memory_usage = memory_usage - cache_usage
+    syslog.syslog(syslog.LOG_INFO, "[memory_checker] Total memory usage of container '{}' is '{}' Bytes!"
+                  .format(container_name, total_memory_usage))
+
+    if total_memory_usage > threshold_value:
+        print("[{}]: Memory usage ({} Bytes) is larger than the threshold ({} Bytes)!"
+              .format(container_name, total_memory_usage, threshold_value))
+        sys.exit(3)
 
 
 def main():

--- a/files/image_config/monit/restart_service
+++ b/files/image_config/monit/restart_service
@@ -24,72 +24,137 @@ import subprocess
 
 
 def get_command_result(command):
-    """Executes command and return the exit code, stdout and stderr.
+    """Executes command and return command's stdout.
 
     Args:
         command: A string contains the command to be executed.
 
     Returns:
-        An integer contains the exit code.
-        A string contains the output of stdout.
-        A string contains the output of stderr.
+        A string contains the command's stdout.
     """
     command_stdout = ""
-    command_stderr = ""
 
     try:
         proc_instance = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                          shell=True, universal_newlines=True)
         command_stdout, command_stderr = proc_instance.communicate()
         if proc_instance.returncode != 0:
-            return 1, command_stdout.strip(), command_stderr.strip()
+            syslog.syslog(syslog.LOG_ERR, "[restart_service] Failed to execute the command '{}'. Return code: '{}'"
+                          .format(command, proc_instance.returncode))
+            sys.exit(1)
     except (OSError, ValueError) as err:
-        return 2, command_stdout.strip(), err
+        syslog.syslog(syslog.LOG_ERR, "[restart_service] Failed to execute the command '{}'. Error: '{}'"
+                      .format(command, err))
+        sys.exit(2)
 
-    return 0, command_stdout.strip(), command_stderr.strip()
+    return command_stdout.strip()
 
 
 def reset_failed_flag(service_name):
-    """Reset the failed status of a service.
+    """Reset the systemd failed status of a service.
 
     Args:
-        service_name: Name of the service.
+        service_name: A string indicates name of the service.
 
     Returns:
         None
     """
     reset_failed_command = "sudo systemctl reset-failed {}.service".format(service_name)
 
-    syslog.syslog(syslog.LOG_INFO, "Resetting failed status of service '{}' ..."
+    syslog.syslog(syslog.LOG_INFO, "[restart_service] Resetting failed status of service '{}' ..."
                   .format(service_name))
 
-    exit_code, command_stdout, command_stderr = get_command_result(reset_failed_command)
-    if exit_code == 0:
-        syslog.syslog(syslog.LOG_INFO, "Succeeded to reset failed status of service '{}.service'."
+    command_stdout = get_command_result(reset_failed_command)
+
+    syslog.syslog(syslog.LOG_INFO, "[restart_service] Succeeded in resetting failed status of service '{}.service'."
+                  .format(service_name))
+
+
+def get_container_id(service_name):
+    """Gets full container ID of the specified service.
+
+    Args:
+        service_name: A string indicates the name of specified container.
+
+    Returns:
+        container_id: A string indicates the full ID of specified container.
+    """
+    container_id = ""
+
+    get_container_info_cmd = "docker ps --no-trunc | grep -i {}".format(service_name)
+    command_stdout = get_command_result(get_container_info_cmd)
+
+    for line in command_stdout.splitlines():
+        if service_name in line:
+            container_id = line.split()[0]
+            break
+
+    if not container_id:
+        syslog.syslog(syslog.LOG_ERR, "[restart_service] Failed to get contianer ID of '{}'!"
                       .format(service_name))
-    else:
-        syslog.syslog(syslog.LOG_ERR, "Failed to reset failed status of service '{}'. Error: {}"
-                      .format(service_name, command_stderr))
+        sys.exit(3)
+
+    return container_id
+
+
+def get_containerd_shim_pid(container_id):
+    """Gets PID of process 'containerd-shim-runc' which is parent process of the
+    specified container.
+
+    Args:
+        container_id: A string indicates full ID of specified container.
+
+    Returns:
+        containerd_shim_pid: A string indicates PID of process 'containerd-shim-runc'.
+    """
+    containerd_shim_pid = ""
+
+    get_containerd_shim_info_cmd = "ps -aux | grep {} | grep -v grep".format(container_id)
+    command_stdout = get_command_result(get_containerd_shim_info_cmd)
+
+    for line in command_stdout.splitlines():
+        if container_id in line and "containerd-shim-runc" in line:
+            containerd_shim_pid = line.split()[1]
+            break
+
+    if not containerd_shim_pid:
+        syslog.syslog(syslog.LOG_ERR, "[restat_service] Failed to get PID of process 'containerd-shim-runc'!")
+        sys.exit(4)
+
+    return containerd_shim_pid
 
 
 def restart_service(service_name):
-    """Reset the failed status of a service and then restart it.
+    """Terminates the 'containerd-shim-runc' which is parent process of this service, reset the
+    failed status of service and then does restart.
 
     Args:
-        service_name: Name of specified service.
+        service_name: A string indicates the name of specified service.
 
     Returns:
         None.
     """
-    restart_command = "sudo systemctl restart {}.service".format(service_name)
+    container_id = get_container_id(service_name)
+    syslog.syslog(syslog.LOG_INFO, "[restart_service] Container ID of '{}' is: '{}'."
+                  .format(service_name, container_id))
+
+    containerd_shim_pid = get_containerd_shim_pid(container_id)
+    syslog.syslog(syslog.LOG_INFO, "[restart_service] PID of 'containerd-shim-runc' process is: '{}'"
+                  .format(containerd_shim_pid))
+
+    kill_containerd_shim_cmd = "sudo kill -SIGKILL {}".format(containerd_shim_pid)
+    command_stdout = get_command_result(kill_containerd_shim_cmd)
+    syslog.syslog(syslog.LOG_INFO, "[restart_service] Process 'containerd-shim' with PID '{}' was terminated!"
+                  .format(containerd_shim_pid))
 
     reset_failed_flag(service_name)
 
-    syslog.syslog(syslog.LOG_INFO, "Restarting service '{}' ...".format(service_name))
-    exit_code, command_stdout, command_stderr = get_command_result(restart_command)
-    if exit_code != 0:
-        syslog.syslog(syslog.LOG_ERR, "Failed to restart the service '{}'. Error: {}"
-                      .format(service_name, command_stderr))
+    syslog.syslog(syslog.LOG_INFO, "[restart_service] Restarting service '{}' ...".format(service_name))
+
+    restart_command = "sudo systemctl restart {}.service".format(service_name)
+    command_stdout = get_command_result(restart_command)
+
+    syslog.syslog(syslog.LOG_INFO, "[restart_service] Service '{}' was restarted.".format(service_name))
 
 
 def main():


### PR DESCRIPTION

Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently we have a PR (https://github.com/Azure/sonic-buildimage/pull/9867/files) which will put a hard limitation on memory usage of telemetry container.

During testing the above PR, we found that the commands `docker stats`, `docker start`, `docker stop` and `docker exec` will be no response if memory usage of telemetry container reaches or exceeds the configured hard limitation. This behavior will fail the background script `memory_checker` and `restart_service` since they depend on the command output of `docker stats`, operation of `docker start` and `docker stop`,

#### How I did it

1. Instead of depending on the output of `docker stats`, the background script `memory_checker` will calculate the memory usage of a container based on values reading from the cgroup subsystem files `memory.usage_in_bytes` and `memory.stats`. 

      I refer to this Docker official document (https://docs.docker.com/engine/reference/commandline/stats/#extended-description) to make sure the memory usage of a specific container reading from command output of `docker stats` is equal to the value subtracting cache usage from the total memory usage.

2. Initially the `restart_service` script will leverage the command `sudo systemctl restart <container_name>.service` to restart the specified container. However, this command will fail since the `docker stop` and `docker start` will be no response if memory usage exceeds the limitation.

    

#### How to verify it
I manually tested this implementation on DuT `str-msn2700-20`.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

