### PR TITLE
[Build]: Fix marvell sai package version parsing issue

### DIFF
--- a/platform/marvell-armhf/sai.mk
+++ b/platform/marvell-armhf/sai.mk
@@ -1,7 +1,8 @@
 # Marvell SAI
 
 export MRVL_SAI_VERSION = 1.9.1-1
-export MRVL_SAI = mrvllibsai_$(PLATFORM_ARCH)_$(MRVL_SAI_VERSION).deb
+export MRVL_SAI = mrvllibsai_$(MRVL_SAI_VERSION)_$(PLATFORM_ARCH).deb
+export MRVL_SAI_PACKAGE = mrvllibsai_$(PLATFORM_ARCH)_$(MRVL_SAI_VERSION).deb
 
 $(MRVL_SAI)_SRC_PATH = $(PLATFORM_PATH)/sai
 $(eval $(call add_conflict_package,$(MRVL_SAI),$(LIBSAIVS_DEV)))

--- a/platform/marvell-armhf/sai/Makefile
+++ b/platform/marvell-armhf/sai/Makefile
@@ -2,7 +2,7 @@
 SHELL = /bin/bash
 .SHELLFLAGS += -e
 
-MRVL_SAI_URL = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/armhf/sai-plugin/$(MRVL_SAI)
+MRVL_SAI_URL = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/armhf/sai-plugin/$(MRVL_SAI_PACKAGE)
 
 $(addprefix $(DEST)/, $(MRVL_SAI)): $(DEST)/% :
 	# get deb package


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix marvell build break issue, see below:

buildId | jobName | attempt | startTime | branchName | reason | url
-- | -- | -- | -- | -- | -- | --
70560 | marvell_armhf | 1 | 2022-02-07 07:20:06.9566667 | 202012 | pullRequest | https://dev.azure.com/mssonic/build/_build/results?buildId=70560
71680 | marvell_armhf | 1 | 2022-02-11 04:00:26.0200000 | 202012 | schedule | https://dev.azure.com/mssonic/build/_build/results?buildId=71680
71726 | marvell_armhf | 1 | 2022-02-11 07:18:33.1366667 | 202012 | manual | https://dev.azure.com/mssonic/build/_build/results?buildId=71726
71779 | marvell_armhf | 1 | 2022-02-11 08:21:08.3266667 | 202012 | manual | https://dev.azure.com/mssonic/build/_build/results?buildId=71779
71780 | marvell_armhf | 1 | 2022-02-11 08:21:25.0600000 | 202012 | manual | https://dev.azure.com/mssonic/build/_build/results?buildId=71780
72100 | marvell_armhf | 2 | 2022-02-14 07:33:53.4200000 | 202012 | schedule | https://dev.azure.com/mssonic/build/_build/results?buildId=72100

#### How I did it
Change the marvell sai package to the standard format, see https://github.com/Marvell-switching/sonic-marvell-binaries/issues/62

```
<PackageName>_<VersionNumber>-<DebianRevisionNumber>_<DebianArchitecture>.deb
```

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

