### PR TITLE
[Build]: Fix marvell-armhf build conflict sai package issue

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -604,7 +604,7 @@ $(SONIC_INSTALL_DEBS) : $(DEBS_PATH)/%-install : .platform $$(addsuffix -install
 	while true; do
 		# wait for conflicted packages to be uninstalled
 		$(foreach deb, $($*_CONFLICT_DEBS), \
-			{ while dpkg -s $(firstword $(subst _, ,$(basename $(deb)))) | grep "^Version: $(word 2, $(subst _, ,$(basename $(deb))))" &> /dev/null; do echo "waiting for $(deb) to be uninstalled" $(LOG); sleep 1; done } )
+			{ while dpkg -s $(firstword $(subst _, ,$(basename $(deb)))) &> /dev/null; do echo "waiting for $(deb) to be uninstalled" $(LOG); sleep 1; done } )
 		# put a lock here because dpkg does not allow installing packages in parallel
 		if mkdir $(DEBS_PATH)/dpkg_lock &> /dev/null; then
 			{ sudo DEBIAN_FRONTEND=noninteractive dpkg -i $(DEBS_PATH)/$* $(LOG) && rm -d $(DEBS_PATH)/dpkg_lock && break; } || { rm -d $(DEBS_PATH)/dpkg_lock && sudo lsof /var/lib/dpkg/lock-frontend && ps aux && exit 1 ; }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix marvell build break issue, see below, caused by https://github.com/Marvell-switching/sonic-marvell-binaries/issues/62

buildId | jobName | attempt | startTime | branchName | reason | url
-- | -- | -- | -- | -- | -- | --
70560 | marvell_armhf | 1 | 2022-02-07 07:20:06.9566667 | 202012 | pullRequest | https://dev.azure.com/mssonic/build/_build/results?buildId=70560
71680 | marvell_armhf | 1 | 2022-02-11 04:00:26.0200000 | 202012 | schedule | https://dev.azure.com/mssonic/build/_build/results?buildId=71680
71726 | marvell_armhf | 1 | 2022-02-11 07:18:33.1366667 | 202012 | manual | https://dev.azure.com/mssonic/build/_build/results?buildId=71726
71779 | marvell_armhf | 1 | 2022-02-11 08:21:08.3266667 | 202012 | manual | https://dev.azure.com/mssonic/build/_build/results?buildId=71779
71780 | marvell_armhf | 1 | 2022-02-11 08:21:25.0600000 | 202012 | manual | https://dev.azure.com/mssonic/build/_build/results?buildId=71780
72100 | marvell_armhf | 2 | 2022-02-14 07:33:53.4200000 | 202012 | schedule | https://dev.azure.com/mssonic/build/_build/results?buildId=72100

#### How I did it
Not check the version part in build

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

