### PR TITLE
[Accton] Set pca954x idle_state to enable deselect

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/utils/accton_as7726_32x_util.py
@@ -212,7 +212,7 @@ def cpld_reset_mac():
 kos = [
 'depmod -ae',
 'modprobe i2c_dev',
-'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
+'modprobe i2c_mux_pca954x',
 'modprobe ym2651y',
 'modprobe accton_as7726_32x_cpld',
 'modprobe accton_as7726_32x_fan',
@@ -261,7 +261,14 @@ def device_install():
             print(output)
             if FORCE == 0:
                 return status
-
+    
+     # set all pca954x idle_disconnect
+    cmd = 'echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state'
+    status, output = log_os_system(cmd, 1)
+    if status:
+        print(output)
+        if FORCE == 0:
+            return status
     for i in range(0,len(sfp_map)):
         status, output =log_os_system("echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/new_device", 1)
         if status:

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/utils/accton_as7816_util.py
@@ -146,7 +146,7 @@ def driver_check():
 
 kos = [
 'modprobe i2c_dev',
-'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
+'modprobe i2c_mux_pca954x',
 'modprobe optoe',
 'modprobe accton_i2c_cpld'  ,
 'modprobe ym2651y'                  ,
@@ -252,6 +252,13 @@ def device_install():
             if FORCE == 0:                
                 return status  
 
+     # set all pca954x idle_disconnect
+    cmd = 'echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state'
+    status, output = log_os_system(cmd, 1)
+    if status:
+        print(output)
+        if FORCE == 0:
+            return status
     for i in range(0,len(sfp_map)):
         path = "/sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/new_device"
         status, output =log_os_system("echo optoe1 0x50 > " + path, 1)

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/utils/accton_as9716_32d_util.py
@@ -207,7 +207,7 @@ def driver_inserted():
 kos = [
 'depmod -ae',
 'modprobe i2c_dev',
-'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
+'modprobe i2c_mux_pca954x',
 'modprobe accton_i2c_psu',
 'modprobe accton_as9716_32d_cpld',
 'modprobe accton_as9716_32d_fan',
@@ -264,6 +264,13 @@ def device_install():
             print(output)
             if FORCE == 0:
                 return status
+    # set all pca954x idle_disconnect
+    cmd = 'echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state'
+    status, output = log_os_system(cmd, 1)
+    if status:
+        print(output)
+        if FORCE == 0:
+            return status
     
     ret=eeprom_check()
     if ret==0:


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Kernel5.10 pca954x drv deselect is disable, it provide user to set via idle_state to "-2".
If  deselect is disable, some device will get error when pca channel is not closed.
#### How I did it
Input "-2" to /sys/bus/i2c/drivers/pca954x/*-00*/idle_state. 
#### How to verify it
Test to get fan or psu sysfs, it will not data.
After set "-2" to idle_state, all sysf work well.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

