### PR TITLE
Fix issue of parsing syseeprom value with whitespace in middle

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/eeprom.py
+++ b/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/eeprom.py
@@ -45,7 +45,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.*$)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Fixes #10020

#### Why I did it
The platform api for parsing syseeprom information read from STATE DB has issue
with parsing the value part that has whitespace in the middle. The current
code assumes that the value part does not have whitespace. So everything after
the whitespace will be ignored. The syseeprom values returned from platform
API do not match the output of "show platform syseeprom".

#### How I did it
This change improved the regular expression for parsing syseeprom values to
accommodate whitespaces in the value.

#### How to verify it
Locally updated the code on a dx010 device. Call the platform API:
```
>>> import sonic_platform
>>> platform = sonic_platform.platform.Platform()
>>> chassis = platform.get_chassis()
>>> chassis.get_system_eeprom_info()
{'0x21': 'DX010', '0x22': 'R0872-F0020-02', '0x23': 'DX010B2F030A27BY200002', '0x24': '00:E0:EC:E7:71:0F', '0x25': '11/03/2020 21:22:56', '0x26': '3', '0x27': 'Seastone', '0x28': 'RANGELEY', '0x29': '2014.08', '0x2A': '131', '0x2B': 'CELESTICA', '0x2C': 'THA', '0x2D': 'Celestica', '0x2E': '1.0.5', '0x2F': 'LB', '0xFD': '', '0xFE': '0xAAB39BDB'}
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

