### PR TITLE
[Security]: Upgrade urllib3 to fix CVE-2021-33503

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -15,7 +15,7 @@ RUN pip3 install connexion==2.7.0 \
                  certifi==2017.4.17 \
                  python-dateutil==2.6.0 \
                  six==1.11.0 \
-                 urllib3==1.21.1
+                 urllib3==1.26.5
 
 COPY \
 {% for deb in docker_sonic_mgmt_framework_debs.split(' ') -%}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
See https://security.archlinux.org/CVE-2021-33503

#### How I did it
Upgrade urllib3 to 1.26.5 to fix the vulnerability.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

