### PR TITLE
sonic-port.yang: add link training support

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1152,7 +1152,8 @@ optional attributes.
             "description": "fortyGigE1/1/1",
             "mtu": "9100",
             "alias": "fortyGigE1/1/1",
-            "speed": "40000"
+            "speed": "40000",
+            "link_training": "off"
         },
         "Ethernet1": {
             "index": "1",
@@ -1161,9 +1162,10 @@ optional attributes.
             "mtu": "9100",
             "alias": "fortyGigE1/1/2",
             "admin_status": "up",
-            "speed": "40000"
+            "speed": "40000",
+            "link_training": "on"
         },
-		"Ethernet63": {
+        "Ethernet63": {
             "index": "63",
             "lanes": "87,88",
             "description": "fortyGigE1/4/16",

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -438,7 +438,8 @@
                 "index": "0",
                 "asic_port_name": "Eth0-ASIC1",
                 "role": "Ext",
-                "macsec": "test"
+                "macsec": "test",
+                "link_training": "off"
             },
             "Ethernet1": {
                 "alias": "Eth1/2",
@@ -449,7 +450,8 @@
                 "admin_status": "up",
                 "autoneg": "on",
                 "adv_speeds": "100000,50000",
-                "adv_interface_types": "CR,CR4"
+                "adv_interface_types": "CR,CR4",
+                "link_training": "on"
             },
             "Ethernet2": {
                 "alias": "Eth1/3",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -69,6 +69,17 @@
         "desc": "PORT_INVALID_ADVTYPES_TEST_2 must condition failure.",
         "eStrKey" : "Must"
     },
+    "PORT_VALID_LINK_TRAINING_TEST_1": {
+        "desc": "PORT_VALID_LINK_TRAINING_TEST_1 no failure."
+    },
+    "PORT_VALID_LINK_TRAINING_TEST_2": {
+        "desc": "PORT_VALID_LINK_TRAINING_TEST_2 no failure."
+    },
+    "PORT_INVALID_LINK_TRAINING_TEST": {
+        "desc": "PORT_INVALID_LINK_TRAINING_TEST must condition failure.",
+        "eStrKey" : "Pattern",
+        "eStr": ["on|off"]
+    },
     "PORT_INVALID_TPID_TEST": {
         "desc": "PORT_INVALID_TPID_TEST invalid tpid value failure.",
         "eStrKey" : "Pattern",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -311,6 +311,57 @@
         }
     },
 
+    "PORT_VALID_LINK_TRAINING_TEST_1": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "tpid": "0x8100",
+                        "link_training": "on"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_VALID_LINK_TRAINING_TEST_2": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "tpid": "0x8100",
+                        "link_training": "off"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_INVALID_LINK_TRAINING_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "tpid": "0x8100",
+                        "link_training": 0
+                    }
+                ]
+            }
+        }
+    },
+
     "PORT_INVALID_TPID_TEST": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -65,6 +65,14 @@ module sonic-port{
 					}
 				}
 
+				leaf link_training {
+					description "Port link training mode";
+
+					type string {
+						pattern "on|off";
+					}
+				}
+
 				leaf autoneg {
 					description "Port auto negotiation mode";
 


### PR DESCRIPTION
This is part of HLD  Azure/SONiC#925

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add link-training support

#### How I did it
Update SONiC YANG for port link-training support

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add "link_training" to sonic-port.yang

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->
https://github.com/sonic-net/SONiC/wiki/Configuration#port

#### A picture of a cute animal (not mandatory but encouraged)

