### PR TITLE
[202012] Revert "[build]: Use zstd compression for base filesystem squashfs"

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -586,7 +586,7 @@ sudo rm -f $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS
 sudo du -hsx $FILESYSTEM_ROOT
 sudo mkdir -p $FILESYSTEM_ROOT/var/lib/docker
 scripts/collect_host_image_version_files.sh $TARGET_PATH $FILESYSTEM_ROOT
-sudo mksquashfs $FILESYSTEM_ROOT $FILESYSTEM_SQUASHFS -comp zstd -b 1M -e boot -e var/lib/docker -e $PLATFORM_DIR
+sudo mksquashfs $FILESYSTEM_ROOT $FILESYSTEM_SQUASHFS -e boot -e var/lib/docker -e $PLATFORM_DIR
 
 # Ensure admin gid is 1000
 gid_user=$(sudo LANG=C chroot $FILESYSTEM_ROOT id -g $USERNAME) || gid_user="none"


### PR DESCRIPTION
When upgrading from an older image (with an older kernel that doesn't
support zstd) to 202012, the squashfs filesystem from the 202012 image
can't be mounted on the older image, because zstd was introduced in
4.14, and older images will likely be running 4.9.

Therefore, disable zstd compression in the squashfs image for 202012
image. When upgrading from 202012 to newer images, since 202012 is
running on 4.19, it can read and mount zstd-compressed squashfs images.

This reverts commit 35e88e5f6a743422496d79540e46e4cb464186be.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The kernel in 201811 image (4.9 kernel) doesn't support zstd. In some cases, it may be needed to mount the squashfs image from the new image while the current (old) image is booted. If the squashfs image is compressed with zstd, then it cannot be mounted on a 4.9 kernel, because zstd was introduced in 4.14.

#### How I did it

Remove zstd compression option; squashfs will now use the default gzip compression.

#### How to verify it

201811 image should now be able to mount a squashfs image from a 202012 image.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

