### PR TITLE
pam: sshd patch: Update the log message

### DIFF
--- a/src/tacacs/pam/0007-handle-bad-password-set-by-sshd.patch
+++ b/src/tacacs/pam/0007-handle-bad-password-set-by-sshd.patch
@@ -1,6 +1,6 @@
-From f2687e7a442c83e19190695021fb9a60fe07ba60 Mon Sep 17 00:00:00 2001
+From 4ef102dfa137c2c6e3dd63c2d16f2966b6f5add8 Mon Sep 17 00:00:00 2001
 From: Renuka Manavalan <remanava@microsoft.com>
-Date: Wed, 17 Nov 2021 02:31:45 +0000
+Date: Fri, 18 Feb 2022 22:07:24 +0000
 Subject: [PATCH] handle bad password set by sshd
 
 ---
@@ -11,7 +11,7 @@ Subject: [PATCH] handle bad password set by sshd
  4 files changed, 49 insertions(+), 4 deletions(-)
 
 diff --git a/pam_tacplus.c b/pam_tacplus.c
-index ec8ea27..014421b 100644
+index ec8ea27..2421874 100644
 --- a/pam_tacplus.c
 +++ b/pam_tacplus.c
 @@ -251,6 +251,13 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
@@ -19,7 +19,7 @@ index ec8ea27..014421b 100644
      }
  
 +    if (validate_not_sshd_bad_pass(pass) != PAM_SUCCESS) {
-+        syslog(LOG_ERR, "auth fail: Password incorrect");
++        syslog(LOG_LOCAL0|LOG_ERR, "auth fail: Password incorrect. user: %s", user);
 +        memset(pass, 0, strlen (pass));
 +        free(pass);
 +        return PAM_AUTH_ERR;


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Desired the log message destination to be syslog and it misses the critical info.

#### How I did it
Non logical code changes only.
Logging update, just for one message only
a) The log message is directed to /var/log/syslog, instead of /var/log/auth.log
b) Include user alias in the message

#### How to verify it

1. Pick a user alias that has not logged into the switch yet
2. Add this alias to /etc/tacplus_user
3. Attempt to login as that user
4. Look for the error message in /var/log/syslog
    e.g. "Feb 18 19:16:41.592191 sonic ERR sshd[5233]: auth fail: Password incorrect. user: user_xyz"

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

