### PR TITLE
pam: sshd patch: Update the log message

### DIFF
--- a/src/tacacs/pam/0010-handle-bad-password-set-by-sshd.patch
+++ b/src/tacacs/pam/0010-handle-bad-password-set-by-sshd.patch
@@ -1,6 +1,6 @@
-From 36f67d58c39a5aceeec3182e381735c8a4a0a657 Mon Sep 17 00:00:00 2001
+From ed8b0366d3dbe137752fbb37a4b9fd1d46402d5b Mon Sep 17 00:00:00 2001
 From: Renuka Manavalan <remanava@microsoft.com>
-Date: Fri, 5 Nov 2021 17:43:10 +0000
+Date: Fri, 18 Feb 2022 22:27:39 +0000
 Subject: [PATCH] handle bad password set by sshd
 
 ---
@@ -11,7 +11,7 @@ Subject: [PATCH] handle bad password set by sshd
  4 files changed, 50 insertions(+), 5 deletions(-)
 
 diff --git a/pam_tacplus.c b/pam_tacplus.c
-index d57657a..eb53c94 100644
+index d57657a..38b6ee3 100644
 --- a/pam_tacplus.c
 +++ b/pam_tacplus.c
 @@ -248,6 +248,13 @@ int pam_sm_authenticate (pam_handle_t * pamh, int flags,
@@ -19,7 +19,7 @@ index d57657a..eb53c94 100644
      }
  
 +    if (validate_not_sshd_bad_pass(pass) != PAM_SUCCESS) {
-+        syslog(LOG_ERR, "auth fail: Password incorrect");
++        syslog(LOG_LOCAL0|LOG_ERR, "auth fail: Password incorrect. user: %s", user);
 +        memset(pass, 0, strlen (pass));
 +        free(pass);
 +        return PAM_AUTH_ERR;
@@ -47,10 +47,10 @@ index d57657a..eb53c94 100644
          pass = NULL;
      }
 diff --git a/support.c b/support.c
-index 1ea2e30..8a7dfbb 100644
+index f056ec4..81f3466 100644
 --- a/support.c
 +++ b/support.c
-@@ -114,6 +114,43 @@ int converse(pam_handle_t * pamh, int nargs, const struct pam_message *message,
+@@ -117,6 +117,43 @@ int converse(pam_handle_t * pamh, int nargs, const struct pam_message *message,
      return retval;
  }
  
@@ -94,7 +94,7 @@ index 1ea2e30..8a7dfbb 100644
  /* stolen from pam_stress */
  int tacacs_get_password (pam_handle_t * pamh, int flags
      ,int ctrl, char **password) {
-@@ -436,4 +473,4 @@ int _pam_parse (int argc, const char **argv) {
+@@ -459,4 +496,4 @@ int _pam_parse (int argc, const char **argv) {
      }
  
      return ctrl;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Desired the log message destination to be syslog and it misses the critical info.

#### How I did it
Non logical code changes only.
Logging update, just for one message only
a) The log message is directed to /var/log/syslog, instead of /var/log/auth.log
b) Include user alias in the message

#### How to verify it

1. Pick a user alias that has not logged into the switch yet
2. Add this alias to /etc/tacplus_user
3. Attempt to login as that user
4. Look for the error message in /var/log/syslog
  e.g. "Feb 18 19:16:41.592191 sonic ERR sshd[5233]: auth fail: Password incorrect. user: user_xyz"

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

