### PR TITLE
[swss]: Wait for vlan intf to start ndppd

### DIFF
--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -68,7 +68,6 @@ RUN apt-get purge -y          \
 
 COPY ["files/arp_update", "/usr/bin"]
 COPY ["arp_update.conf", "files/arp_update_vars.j2", "/usr/share/sonic/templates/"]
-COPY ["ndppd.conf", "/usr/share/sonic/templates/"]
 COPY ["enable_counters.py", "tunnel_packet_handler.py", "/usr/bin/"]
 COPY ["orchagent.sh", "swssconfig.sh", "buffermgrd.sh", "/usr/bin/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]

--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -18,6 +18,7 @@ CFGGEN_PARAMS=" \
     -t /usr/share/sonic/templates/ndppd.conf.j2,/etc/ndppd.conf \
     -t /usr/share/sonic/templates/critical_processes.j2,/etc/supervisor/critical_processes \
     -t /usr/share/sonic/templates/supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf
+    -t /usr/share/sonic/templates/wait_for_link.sh.j2,/usr/bin/wait_for_link.sh \
 "
 VLAN=$(sonic-cfggen $CFGGEN_PARAMS)
 

--- a/dockers/docker-orchagent/ndppd.conf
+++ b/dockers/docker-orchagent/ndppd.conf
@@ -1,9 +1,0 @@
-[program:ndppd]
-command=/usr/sbin/ndppd
-priority=7
-autostart=false
-autorestart=unexpected
-stdout_logfile=syslog
-stderr_logfile=syslog
-dependent_startup=true
-dependent_startup_wait_for=vlanmgrd:running

--- a/dockers/docker-orchagent/supervisord.conf.j2
+++ b/dockers/docker-orchagent/supervisord.conf.j2
@@ -299,3 +299,28 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {%- endif %}
+
+{% if is_fabric_asic == 0 %}
+[program:ndppd]
+command=/usr/sbin/ndppd
+priority=7
+autostart=false
+autorestart=unexpected
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=wait_for_link:exited
+{%- endif %}
+
+{% if is_fabric_asic == 0 %}
+[program:wait_for_link]
+command=/usr/bin/wait_for_link.sh
+priority=7
+autostart=false
+autorestart=false
+startsecs=0
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=swssconfig:exited
+{%- endif %}

--- a/dockers/docker-orchagent/wait_for_link.sh.j2
+++ b/dockers/docker-orchagent/wait_for_link.sh.j2
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+VLAN_TABLE_PREFIX="VLAN_TABLE"
+
+function wait_until_iface_ready
+{
+    TABLE_PREFIX=$1
+    IFACE=$2
+
+    echo "Waiting until interface $IFACE is ready..."
+
+    # Wait for the interface to come up
+    # (i.e., interface is present in STATE_DB and state is "ok")
+    while true; do
+        RESULT=$(sonic-db-cli STATE_DB HGET "${TABLE_PREFIX}|${IFACE}" "state" 2> /dev/null)
+        if [ x"$RESULT" == x"ok" ]; then
+            break
+        fi
+
+        sleep 1
+    done
+
+    echo "Interface ${IFACE} is ready!"
+}
+
+
+# Wait for all interfaces to be up and ready
+{% for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
+wait_until_iface_ready ${VLAN_TABLE_PREFIX} {{ name }}
+{% endfor %}


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
If the VLAN interface is not up when ndppd starts, it will fail to enable `allmulti` mode on the interface and be unable to process received NDP packets

The following logs are seen:
```
/var/log/syslog.33.gz:Feb 18 10:33:12.825406 sonic INFO swss#/supervisord: ndppd (error) Failed to set allmulti: No such device
```
#### How I did it
Use the `wait_for_link` script currently used by `radv` to delay ndppd startup until the vlan interface is ready

#### How to verify it
Apply the changes to a device. `config reload` the device and confirm that the above error logs are not observed when ndppd starts. Run the `arp/test_arp_dualtor.py::test_proxy_arp` test case and verify it passes. 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

