### PR TITLE
[Mellanox] Fix issue: thermal zone threshold value 0 causes fan speed stuck at 100%

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -400,9 +400,14 @@ class Thermal(ThermalBase):
         thermal_zone_present = False
         try:
             for thermal_zone_folder in glob.iglob(THERMAL_ZONE_FOLDER_WILDCARD):
+                current = utils.read_int_from_file(os.path.join(thermal_zone_folder, THERMAL_ZONE_TEMP_FILE))
+                if current == 0:
+                    # Temperature value 0 means that this thermal zone has no
+                    # sensor and it should be ignored in this loop
+                    continue
+
                 thermal_zone_present = True
                 normal_thresh = utils.read_int_from_file(os.path.join(thermal_zone_folder, THERMAL_ZONE_NORMAL_THRESHOLD))
-                current = utils.read_int_from_file(os.path.join(thermal_zone_folder, THERMAL_ZONE_TEMP_FILE))
                 if current < normal_thresh - THERMAL_ZONE_HYSTERESIS:
                     continue
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In SONiC thermal control algorithm, it compares thermal zone temperature with thermal zone threshold. Previously, a thermal zone with no thermal sensor can still get its threshold. However, a recently driver patch changes this behavior: a thermal zone with no thermal sensor will return 0 for threshold.  We need to ignore such thermal zone.

#### How I did it

Ignore thermal zones whose temperature is 0.

#### How to verify it

1. Added unit test case
2. Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

