### PR TITLE
Support for idle_state device parameter is required for muxes using i2c_mux_pca954x driver

### DIFF
--- a/platform/pddf/i2c/utils/pddfparse.py
+++ b/platform/pddf/i2c/utils/pddfparse.py
@@ -360,6 +360,7 @@ class PddfParse():
         if ret != 0:
             return create_ret.append(ret)
         cmd = "echo %s > /sys/kernel/pddf/devices/mux/virt_bus" % (dev['i2c']['dev_attr']['virt_bus'])
+        ret = self.runcmd(cmd)
         if ret != 0:
             return create_ret.append(ret)
         cmd = "echo 'add' > /sys/kernel/pddf/devices/mux/dev_ops"

--- a/platform/pddf/i2c/utils/pddfparse.py
+++ b/platform/pddf/i2c/utils/pddfparse.py
@@ -359,9 +359,17 @@ class PddfParse():
         ret = self.runcmd(cmd)
         if ret != 0:
             return create_ret.append(ret)
-        self.create_device(dev['i2c']['dev_attr'], "pddf/devices/mux", ops)
+        cmd = "echo %s > /sys/kernel/pddf/devices/mux/virt_bus" % (dev['i2c']['dev_attr']['virt_bus'])
+        if ret != 0:
+            return create_ret.append(ret)
         cmd = "echo 'add' > /sys/kernel/pddf/devices/mux/dev_ops"
         ret = self.runcmd(cmd)
+        # Check if the dev_attr array contain idle_state
+        if 'idle_state' in dev['i2c']['dev_attr']:
+            cmd = "echo {} > /sys/bus/i2c/devices/{}-00{:02x}/idle_state".format(dev['i2c']['dev_attr']['idle_state'],
+                    int(dev['i2c']['topo_info']['parent_bus'],0), int(dev['i2c']['topo_info']['dev_addr'],0))
+            ret = self.runcmd(cmd)
+
         return create_ret.append(ret)
 
     def create_xcvr_i2c_device(self, dev, ops):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
#### Why I did it
As per linux kernel 5.10, 'force_deselct_on_exit' parameter used for driver i2c_mux_pca954x is no longer valid. Instead an attribute 'idle_state' is added per MUX device. This needs to be set to 
-1 : For leaving the mux state as is
-2 : For deselecting the channel upon exit
<num> : To always set a channel <num> upon exit

This needs to be accommodated inside the PDDF JSON parser as well.

#### How I did it
Added an 'idle_state' dev_attr in the PDDF JSON object related to the MUX
 
#### How to verify it
I verified it on AS7712 platform. Below are the logs,

```
root@sonic:/home/admin# cat /sys/bus/i2c/drivers/pca954x/*/idle_state
-2
-2
-2
-2
-2
-2
root@sonic:/home/admin#
root@sonic:/home/admin# decode-syseeprom
TlvInfo Header:
   Id String:    TlvInfo
   Version:      1
   Total Length: 168
TLV Name             Code Len Value
-------------------- ---- --- -----
Manufacture Date     0x25  19 08/20/2020 23:56:54
Label Revision       0x27   4 R02H
Platform Name        0x28  27 x86_64-accton_as7712_32x-r0
ONIE Version         0x29  13 2018.11.00.02
Manufacturer         0x2B   6 Accton
Manufacture Country  0x2C   2 TW
Diag Version         0x2E   7 0.0.5.9
Base MAC Address     0x24   6 68:21:5F:0F:B5:09
Serial Number        0x23  14 771232X2012398
Part Number          0x22  13 FP3ZZ7632014A
Product Name         0x21  15 7712-32X-O-AC-F
MAC Addresses        0x2A   2 256
Vendor Name          0x2D   8 Edgecore
CRC-32               0xFE   4 0xB192413E
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# sfputil show presence
Port         Presence
-----------  -----------
Ethernet0    Not present
Ethernet4    Not present
Ethernet8    Not present
Ethernet12   Not present
Ethernet16   Not present
Ethernet20   Not present
Ethernet24   Not present
Ethernet28   Not present
Ethernet32   Not present
Ethernet36   Not present
Ethernet40   Present
Ethernet44   Present
Ethernet48   Present
Ethernet52   Present
Ethernet56   Not present
Ethernet60   Not present
Ethernet64   Not present
Ethernet68   Not present
Ethernet72   Not present
Ethernet76   Not present
Ethernet80   Not present
Ethernet84   Not present
Ethernet88   Not present
Ethernet92   Not present
Ethernet96   Not present
Ethernet100  Not present
Ethernet104  Not present
Ethernet108  Not present
Ethernet112  Not present
Ethernet116  Not present
Ethernet120  Not present
Ethernet124  Not present
root@sonic:/home/admin#
root@sonic:/home/admin# pddf_psuutil mfrinfo
PSU    Status    Manufacturer ID    Model    Serial              Fan Airflow Direction
-----  --------  -----------------  -------  ------------------  -----------------------
PSU1   NOT OK
PSU2   OK        3Y POWER           YM-2651  SA310N091939172071  EXHAUST
root@sonic:/home/admin# pddf_psuutil seninfo
pddfPSU    Status      Output Voltage (V)    Output Current (A)    Output Power (W)    Temperature1 (C)    Fan1 Speed (RPM)
-----  --------  --------------------  --------------------  ------------------  ------------------  ------------------
PSU1   NOT OK                    0.00                  0.00                0.00                0.00                   0
PSU2   OK                       12.00                 19.09              228.00               34.00               10000
root@sonic:/home/admin# pddf_fanutil getspeed
FAN           SPEED (RPM)
----------  -------------
Fantray1_1          20900
Fantray1_2          17800
Fantray2_1          20800
Fantray2_2          17800
Fantray3_1          20800
Fantray3_2          17600
Fantray4_1          20900
Fantray4_2          17900
Fantray5_1          21000
Fantray5_2          17900
Fantray6_1          21100
Fantray6_2          17800
root@sonic:/home/admin# pddf_fanutil direction
FAN         Direction
----------  -----------
Fantray1_1  Exhaust
Fantray1_2  Exhaust
Fantray2_1  Exhaust
Fantray2_2  Exhaust
Fantray3_1  Exhaust
Fantray3_2  Exhaust
Fantray4_1  Exhaust
Fantray4_2  Exhaust
Fantray5_1  Exhaust
Fantray5_2  Exhaust
Fantray6_1  Exhaust
Fantray6_2  Exhaust
root@sonic:/home/admin# pddf_thermalutil gettemp
Temp Sensor    Label          Value
-------------  -------------  -------
Temp_1         lm75-i2c-3-48  temp1	 +28.5 C (high = +80.0 C)
Temp_2         lm75-i2c-3-49  temp1	 +27.5 C (high = +80.0 C)
Temp_3         lm75-i2c-3-4a  temp1	 +31.0 C (high = +80.0 C)
Temp_CPU       lm75-i2c-3-4b  temp1	 +29.5 C (high = +80.0 C)
root@sonic:/home/admin# show platform psustatus
PSU    Model    Serial              HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -------  ------------------  --------  -------------  -------------  -----------  --------  -----
PSU 1                               N/A                0.00           0.00         0.00  NOT OK    off
PSU 2  YM-2651  SA310N091939172071  N/A               12.02          19.00       228.00  OK        green
root@sonic:/home/admin#
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

