### PR TITLE
[bbr] Add ability to disable bbr for storage backend

### DIFF
--- a/files/image_config/constants/constants.yml
+++ b/files/image_config/constants/constants.yml
@@ -32,6 +32,7 @@ constants:
     bbr:
       enabled: true
       default_state: "disabled"
+      storage_backend_state: "disabled"
     peers:
       general: # peer_type
         db_table: "BGP_NEIGHBOR"

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bbr.py
@@ -53,6 +53,7 @@ class BBRMgr(Manager):
                 and self.constants['bgp']['bbr']['enabled']:
             self.bbr_enabled_pgs = self.__read_pgs()
             if self.bbr_enabled_pgs:
+                msg = ""
                 self.enabled = True
                 if 'default_state' in self.constants['bgp']['bbr'] \
                         and self.constants['bgp']['bbr']['default_state'] == 'enabled':
@@ -60,7 +61,11 @@ class BBRMgr(Manager):
                 else:
                     default_status = "disabled"
                 self.directory.put(self.db_name, self.table_name, 'status', default_status)
-                log_info("BBRMgr::Initialized and enabled. Default state: '%s'" % default_status)
+                if 'storage_backend_state' in self.constants['bgp']['bbr']:
+                    storage_backend_status = self.constants['bgp']['bbr']['storage_backend_state']
+                    self.directory.put(self.db_name, self.table_name, 'storage_backend_status', storage_backend_status)
+                    msg = ". Storage backend status: '%s'" % storage_backend_status
+                log_info("BBRMgr::Initialized and enabled. Default state: '%s'%s" % (default_status, msg))
             else:
                 log_info("BBRMgr::Disabled: no BBR enabled peers")
         else:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
BBR is enabled by default and needs to be disabled for storage backend

#### How I did it
Introduce a new var 'storage_backend_state' in constants.yml which will be used to set/unset bbr configurations for storage backend devices

#### How to verify it
Unit test and tested the change on storage backend device

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

