### PR TITLE
Update container_checker for multi-asic devices when state is 'always_enabled'

### DIFF
--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -41,9 +41,9 @@ def get_expected_running_containers():
 
     expected_running_containers = set()
     always_running_containers = set()
-
+    
     for container_name in feature_table.keys():
-        if feature_table[container_name]["state"] not in ["disabled", "always_disabled"]:
+       if feature_table[container_name]["state"] not in ["disabled", "always_disabled"]:
             if multi_asic.is_multi_asic():
                 if feature_table[container_name]["has_global_scope"] == "True":
                     expected_running_containers.add(container_name)
@@ -51,13 +51,19 @@ def get_expected_running_containers():
                     num_asics = multi_asic.get_num_asics()
                     for asic_id in range(num_asics):
                         expected_running_containers.add(container_name + str(asic_id))
-            elif feature_table[container_name]["state"] == 'always_enabled':
-                always_running_containers.add(container_name)
             else:
                 expected_running_containers.add(container_name)
-
+        if feature_table[container_name]["state"] == 'always_enabled':
+            if multi_asic.is_multi_asic():
+                if feature_table[container_name]["has_global_scope"] == "True":
+                    always_running_containers.add(container_name)
+                if feature_table[container_name]["has_per_asic_scope"] == "True":
+                    num_asics = multi_asic.get_num_asics()
+                    for asic_id in range(num_asics):
+                        always_running_containers.add(container_name + str(asic_id))
+            else:
+                always_running_containers.add(container_name)
     return expected_running_containers, always_running_containers
-
 
 def get_current_running_from_DB(always_running_containers):
     """

--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -43,7 +43,7 @@ def get_expected_running_containers():
     always_running_containers = set()
     
     for container_name in feature_table.keys():
-       if feature_table[container_name]["state"] not in ["disabled", "always_disabled"]:
+        if feature_table[container_name]["state"] not in ["disabled", "always_disabled"]:
             if multi_asic.is_multi_asic():
                 if feature_table[container_name]["has_global_scope"] == "True":
                     expected_running_containers.add(container_name)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR of finding running containers via feature table does not consider 'database' containers as feature in multi-asic devices: https://github.com/Azure/sonic-buildimage/pull/7474

#### How I did it
Change in this PR is to add database containers for multi-asic, to always_running_containers, as their status is 'always_enabled'

#### How to verify it
Before this change on a multi-asic device, container_status says database containers are not running even if they are:
Program 'container_checker'
status Status ok
monitoring status Monitored
monitoring mode active
on reboot start
last exit value 3
last output Expected containers not running: database0, database5, database1, database2, database, database4, database3
data collected Wed, 09 Feb 2022 19:15:35


After change, result of 'monit status':
Program 'container_checker'
  status                       Status ok
  monitoring status            Monitored
  monitoring mode              active
  on reboot                    start
  last exit value              0
  last output                  -
  data collected               Wed, 23 Feb 2022 02:31:39
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

