### PR TITLE
[pmon] Clean up supervisord chassis_db_init entry and fix startsecs

### DIFF
--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -47,10 +47,9 @@ command=/usr/local/bin/chassis_db_init
 priority=3
 autostart=false
 autorestart=false
-exitcodes=0
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=10
+startsecs=0
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% endif %}


### PR DESCRIPTION
#### Why I did it

Code review was still in progress when https://github.com/Azure/sonic-buildimage/pull/9858 was merged and upon further testing I have arrived at a better solution. 

#### How I did it

Modified supervisord configuration j2 template for pmon to require no minimum uptime for `chassisd_db_init` and to remove the redundant `exit_codes` directive

#### How to verify it

Boot switch and verify in syslog that there are no errors related to chassis_db_init

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
[pmon] Clean up supervisord chassis_db_init entry and fix startsecs


#### A picture of a cute animal (not mandatory but encouraged)
![bff_fws_kimberly_fraser_usfws_service](https://user-images.githubusercontent.com/5898707/154411619-6427ca45-3ac6-4a34-b37a-abd3871a7f4d.jpg)

