### PR TITLE
[PTF-SAIv2] Add xmlrunner python3 version to generate test report

### DIFF
--- a/dockers/docker-ptf-sai/Dockerfile.j2
+++ b/dockers/docker-ptf-sai/Dockerfile.j2
@@ -18,7 +18,8 @@ RUN pip3 install crc16          \
         psutil                  \
         scapy==2.4.4            \
         scapy_helper            \
-        pysubnettree
+        pysubnettree            \
+        xmlrunner
 
 COPY \
 {% for deb in docker_ptf_sai_debs.split(' ') -%}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add xmlrunner python3 version to generate the test report in xunit format

#### How I did it
Add xmlrunner python3 version to generate the test report in xunit format
#### How to verify it
built the ptf-sai docker and check the function with test cases
* local test case for sai testing
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

