### PR TITLE
[Build][Ci]: Support to use the cisco sai packages built by azp

### DIFF
--- a/.azure-pipelines/official-build-cisco-8000.yml
+++ b/.azure-pipelines/official-build-cisco-8000.yml
@@ -22,6 +22,11 @@ resources:
     name: Cisco-8000-sonic/platform-cisco-8000
     endpoint: cisco-connection
 
+variables:
+- group: SONIC-AKV-STROAGE-1
+- name: StorageSASKey
+  value: $(sonicstorage-SasToken)
+
 stages:
 - stage: Build
   pool: sonic
@@ -29,6 +34,7 @@ stages:
     CACHE_MODE: wcache
     SKIP_CHECKOUT: true
     TERM: ''
+    PACKAGE_URL: "https://sonicstorage.blob.core.windows.net/packages"
 
   jobs:
   - template: azure-pipelines-build.yml
@@ -60,5 +66,29 @@ stages:
           make PLATFORM=cisco-8000 platform/cisco-8000
           tar xfz $(System.ArtifactsDirectory)/artifactory-*.tar.gz -C platform/cisco-8000
         displayName: 'Setup cisco artifacts'
+      - script: |
+          set -ex
+          filename=$(find platform/cisco-8000/artifactory/sonic -name cisco-* -type f | head -n 1)
+          if [ -z "$filename" ]; then
+            echo "Cisco sai package not found" 1>&2
+            exit 1
+          fi
+          cd $(dirname $filename)
+          echo "PWD=$(pwd)"
+          ls -l *.deb
+          while read -r package; do
+            # Cisco version format: <VERSION>-sai-<sai-ver>-<distribution>-<COMMIT HASH>
+            # The <sai-ver> may contain several values in one build, the part is skipped when publishing to storage
+            # See https://github.com/Cisco-8000-sonic/sdk/blob/master/azure-pipelines.yml
+            # The $PACKAGE_URL is only accessible for AZP
+            version=$(echo $package | awk -F_ '{print $(NF-1)}' | cut -d- -f1,2,4,5)
+            package_url="$PACKAGE_URL/sai/ciscosai/master/$version/$package"
+            echo "Override package $package from $package_url"
+            wget "$package_url$StorageSASKey" -O "$package"
+          done < <(ls *.deb)
+        env:
+          StorageSASKey: $(StorageSASKey)
+        condition: ne(variables['Build.Reason'], 'PullRequest')
+        displayName: "Override cisco sai packages"
       jobGroups:
       - name: cisco-8000


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support to use the cisco sai packages built by azp

#### How I did it

Download the sai packages from azure storage and override the sai package which from GitHub release.

Prerequisite tasks: [done]
1. When push on the cisco sai repo, azp will start an Azure Pipeline build.
2. When azp build finished, it will trigger an artifacts uploading pipelines to publish to azure storage.



#### How to verify it
https://dev.azure.com/mssonic/cisco/_build/results?buildId=76434&view=logs&j=62f941c1-829a-538b-5bf0-e540f1e71cee&t=1762bf4f-25d9-58cc-9916-0fe8be7bbaff
```
Line 40: 2022-02-28T13:29:47.3008983Z + wget 'https://***/cisco-gibraltar-dev_1.47.11.9-sai-1.7.1-buster-911d3aeb1fb_amd64.deb***' -O cisco-gibraltar-dev_1.47.11.9-sai-1.7.1-buster-911d3aeb1fb_amd64.deb
Line 1267: 2022-02-28T13:29:51.4232229Z 2022-02-28 13:29:51 (16.9 MB/s) - ‘cisco-gibraltar-dev_1.47.11.9-sai-1.7.1-buster-911d3aeb1fb_amd64.deb’ saved [62279612/62279612]
Line 1277: 2022-02-28T13:29:51.6317780Z + wget 'https://***/cisco-gibraltar-doc_1.47.11.9-sai-1.7.1-buster-911d3aeb1fb_all.deb***' -O cisco-gibraltar-doc_1.47.11.9-sai-1.7.1-buster-911d3aeb1fb_all.deb
Line 1287: 2022-02-28T13:29:52.0427729Z 2022-02-28 13:29:52 (220 MB/s) - ‘cisco-gibraltar-doc_1.47.11.9-sai-1.7.1-buster-911d3aeb1fb_all.deb’ saved [1868/1868]
Line 1296: 2022-02-28T13:29:52.0496196Z + wget 'https://***/cisco-gibraltar-kmod-src_1.47.11.9-sai-1.7.1-buster-911d3aeb1fb_amd64.deb***' -O cisco-gibraltar-kmod-src_1.47.11.9-sai-1.7.1-buster-911d3aeb1fb_amd64.deb
Line 1308: 2022-02-28T13:29:52.4617090Z 2022-02-28 13:29:52 (391 KB/s) - ‘cisco-gibraltar-kmod-src_1.47.11.9-sai-1.7.1-buster-911d3aeb1fb_amd64.deb’ saved [51744/51744]
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

