### PR TITLE
[YANG]: Update port Yang models to support multi-asic platform

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -411,7 +411,10 @@
                 "description": "",
                 "speed": "11100",
                 "tpid": "0x8100",
-                "admin_status": "up"
+                "admin_status": "up",
+                "index", "0",
+                "asic_port_name": "Eth0-ASIC1",
+                "role": "Ext"
             },
             "Ethernet1": {
                 "alias": "Eth1/2",

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -412,7 +412,7 @@
                 "speed": "11100",
                 "tpid": "0x8100",
                 "admin_status": "up",
-                "index", "0",
+                "index": "0",
                 "asic_port_name": "Eth0-ASIC1",
                 "role": "Ext"
             },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -77,9 +77,13 @@
      "PORT_VALID_MULTIASIC_TEST": {
          "desc": "PORT_VALID_MULTIASIC_TEST no failure."
      },
-     "PORT_INVALID_MULTIASIC_TEST": {
-         "desc": "PORT_INVALID_MULTIASIC_TEST invalid role, expect fail",
+     "PORT_INVALID_MULTIASIC_TEST_1": {
+         "desc": "PORT_INVALID_MULTIASIC_TEST invalid role pattern, expect fail",
          "eStrKey": "Pattern"
+     },
+     "PORT_INVALID_MULTIASIC_TEST_2": {
+         "desc": "PORT_INVALID_MULTIASIC_TEST invalid role, expect fail",
+         "eStrKey": "When"
      }
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -73,5 +73,13 @@
      "PORT_INVALID_MUX_CABLE_TEST": {
          "desc": "PORT_INVALID_MUX_CABLE_TEST non-boolean values, expect fail",
          "eStrKey": "InvalidValue"
+     },
+     "PORT_VALID_MULTIASIC_TEST": {
+         "desc": "PORT_VALID_MULTIASIC_TEST no failure."
+     },
+     "PORT_INVALID_MULTIASIC_TEST": {
+         "desc": "PORT_INVALID_MULTIASIC_TEST invalid role, expect fail",
+         "eStrKey": "Pattern"
      }
+
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -77,13 +77,9 @@
      "PORT_VALID_MULTIASIC_TEST": {
          "desc": "PORT_VALID_MULTIASIC_TEST no failure."
      },
-     "PORT_INVALID_MULTIASIC_TEST_1": {
+     "PORT_INVALID_MULTIASIC_TEST": {
          "desc": "PORT_INVALID_MULTIASIC_TEST invalid role pattern, expect fail",
          "eStrKey": "Pattern"
-     },
-     "PORT_INVALID_MULTIASIC_TEST_2": {
-         "desc": "PORT_INVALID_MULTIASIC_TEST invalid role, expect fail",
-         "eStrKey": "When"
      }
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -334,7 +334,7 @@
         }
     },
 
-    "PORT_INVALID_MULTIASIC_TEST": {
+    "PORT_INVALID_MULTIASIC_TEST_1": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {
                 "PORT_LIST": [
@@ -346,6 +346,23 @@
                         "index": "0",
                         "asic_port_name": "Eth8-ASIC1",
                         "role": "Invalid"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_INVALID_MULTIASIC_TEST_2": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 50000,
+                        "index": "0",
+                        "role": "Int"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -314,5 +314,41 @@
                 ]
             }
         }
+    },
+    
+    "PORT_VALID_MULTIASIC_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 50000,
+                        "index": "0",
+                        "asic_port_name": "Eth8-ASIC1",
+                        "role": "Ext"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_INVALID_MULTIASIC_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 50000,
+                        "index": "0",
+                        "asic_port_name": "Eth8-ASIC1",
+                        "role": "Invalid"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -328,6 +328,41 @@
                         "index": "0",
                         "asic_port_name": "Eth8-ASIC1",
                         "role": "Ext"
+                    },
+                    {
+                        "name": "Ethernet9",
+                        "alias": "eth9",
+                        "lanes": "66",
+                        "speed": 50000,
+                        "index": "1",
+                        "asic_port_name": "Eth9-ASIC1"
+                    },
+                    {
+                        "name": "Ethernet10",
+                        "alias": "eth10",
+                        "lanes": "67",
+                        "speed": 50000,
+                        "index": "2",
+                        "asic_port_name": "Eth10-ASIC1",
+                        "role": "Int"
+                    },
+                    {
+                        "name": "Ethernet11",
+                        "alias": "eth11",
+                        "lanes": "68",
+                        "speed": 50000,
+                        "index": "3",
+                        "asic_port_name": "Eth11-ASIC1",
+                        "role": "Inb"
+                    },
+                    {
+                        "name": "Ethernet12",
+                        "alias": "eth12",
+                        "lanes": "69",
+                        "speed": 50000,
+                        "index": "4",
+                        "asic_port_name": "Eth12-ASIC1",
+                        "role": "Rec"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -334,7 +334,7 @@
         }
     },
 
-    "PORT_INVALID_MULTIASIC_TEST_1": {
+    "PORT_INVALID_MULTIASIC_TEST": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {
                 "PORT_LIST": [
@@ -346,23 +346,6 @@
                         "index": "0",
                         "asic_port_name": "Eth8-ASIC1",
                         "role": "Invalid"
-                    }
-                ]
-            }
-        }
-    },
-
-    "PORT_INVALID_MULTIASIC_TEST_2": {
-        "sonic-port:sonic-port": {
-            "sonic-port:PORT": {
-                "PORT_LIST": [
-                    {
-                        "name": "Ethernet8",
-                        "alias": "eth8",
-                        "lanes": "65",
-                        "speed": 50000,
-                        "index": "0",
-                        "role": "Int"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -122,7 +122,8 @@ module sonic-port{
 					type string {
 						pattern "Ext|Int";
 					}
-					description "Internal port or External port for multi-asic platform";
+					description "Internal port or External port for multi-asic platform, e.g Eth0-ASIC1";
+					when "(current()/../asic_port_name)";
 				}
 
 				leaf admin_status {

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -123,7 +123,6 @@ module sonic-port{
 						pattern "Ext|Int";
 					}
 					description "Internal port or External port for multi-asic platform";
-					when "(current()/../asic_port_name)";
 				}
 
 				leaf admin_status {

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -110,9 +110,19 @@ module sonic-port{
 				}
 
 				leaf index {
-					type uint16 {
-						range 0..256;
+					type uint16;
+				}
+
+				leaf asic_port_name {
+					type string;
+					description "port name in asic and asic name";
+				}
+
+				leaf role {
+					type string {
+						pattern "Ext|Int";
 					}
+					description "Internal port or External port for multi-asic platform";
 				}
 
 				leaf admin_status {

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -120,7 +120,7 @@ module sonic-port{
 
 				leaf role {
 					type string {
-						pattern "Ext|Int|Inb|Rec|";
+						pattern "Ext|Int|Inb|Rec";
 					}
 					description "Internal port or External port for multi-asic platform";
 					default "Ext";

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -115,14 +115,14 @@ module sonic-port{
 
 				leaf asic_port_name {
 					type string;
-					description "port name in asic and asic name";
+					description "port name in asic and asic name, e.g Eth0-ASIC1";
 				}
 
 				leaf role {
 					type string {
 						pattern "Ext|Int";
 					}
-					description "Internal port or External port for multi-asic platform, e.g Eth0-ASIC1";
+					description "Internal port or External port for multi-asic platform";
 					when "(current()/../asic_port_name)";
 				}
 

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -120,9 +120,10 @@ module sonic-port{
 
 				leaf role {
 					type string {
-						pattern "Ext|Int";
+						pattern "Ext|Int|Inb|Rec|";
 					}
 					description "Internal port or External port for multi-asic platform";
+					default "Ext";
 				}
 
 				leaf admin_status {


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Multi-asic platform add aisc_port_name and role to PORT table, and port_index range is changed.

#### How I did it
Update sonic-port.yang, add asic_port_name and role, and remove range limitation.

#### How to verify it
Run UT for sonic-yang-models.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix #9580

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

