### PR TITLE
disable bullseye for PINS/p4rt -> p4rt fails

### DIFF
--- a/rules/docker-p4rt.mk
+++ b/rules/docker-p4rt.mk
@@ -33,3 +33,7 @@ $(DOCKER_P4RT)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_P4RT)_GIT_COMMIT = $(shell cd "$($(SONIC_P4RT)_SRC_PATH)" && git log -n 1 --format=format:"%H %s" || echo "Unable to fetch git log for p4rt")
 
 $(DOCKER_P4RT)_FILES += $(SUPERVISOR_PROC_EXIT_LISTENER_SCRIPT)
+
+
+SONIC_BUSTER_DOCKERS += $(DOCKER_P4RT)
+SONIC_BUSTER_DBG_DOCKERS += $(DOCKER_P4RT_DBG)


### PR DESCRIPTION
PINS only runs on buster and because of this bug, it does not run on buster and only on bullseye.

Related to issue #9885: https://github.com/Azure/sonic-buildimage/issues/9885

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
I could not build SONIC with p4rt enabled.
#### How I did it
Added two line to respective p4rt make file
#### How to verify it
Follow PINS build instructions at [here ](url) (in current state with master it is not working without this fix)

#### Which release branch to backport (provide reason below if selected)
202111: Because on the public anouncements, PINS said to be entegrated to this branch
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Added to lines for p4rt to be integrated to buster build 


<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)
:)
![image](https://user-images.githubusercontent.com/41781/156335984-b8e45b10-6e84-4c75-acdb-0b5e4686d590.png)
