### PR TITLE
[Marvell][build] Marvell armhf SAI debian.

### DIFF
--- a/platform/marvell-armhf/sai.mk
+++ b/platform/marvell-armhf/sai.mk
@@ -1,8 +1,7 @@
 # Marvell SAI
 
-export MRVL_SAI_VERSION = 1.7.1-6
+export MRVL_SAI_VERSION = 1.7.1-7
 export MRVL_SAI = mrvllibsai_$(MRVL_SAI_VERSION)_$(PLATFORM_ARCH).deb
-export MRVL_SAI_PACKAGE = mrvllibsai_$(PLATFORM_ARCH)_$(MRVL_SAI_VERSION).deb
 
 $(MRVL_SAI)_SRC_PATH = $(PLATFORM_PATH)/sai
 $(eval $(call add_conflict_package,$(MRVL_SAI),$(LIBSAIVS_DEV)))

--- a/platform/marvell-armhf/sai/Makefile
+++ b/platform/marvell-armhf/sai/Makefile
@@ -2,7 +2,7 @@
 SHELL = /bin/bash
 .SHELLFLAGS += -e
 
-MRVL_SAI_URL = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/armhf/sai-plugin/$(MRVL_SAI_PACKAGE)
+MRVL_SAI_URL = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/armhf/sai-plugin/$(MRVL_SAI)
 
 $(addprefix $(DEST)/, $(MRVL_SAI)): $(DEST)/% :
 	# get deb package


### PR DESCRIPTION



Signed-off-by: Rajkumar Pennadam Ramamoorthy <rpennadamram@marvell.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1) Fixed SAI debian version name issue reported in https://github.com/Marvell-switching/sonic-marvell-binaries/issues/62
2) Implement DHCP, DHCv6 traps as per SAI Specifications
3) Added support to return SAI_STATUS_NOT_SUPPORTED for ERSPAN feature #9830 
#### How I did it

#### How to verify it
Verify the SONiC compilation and SAI functionality.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix SAI debian name, DHCP trap and added support to return SAI_STATUS_NOT_SUPPORTED error code for ERSPAN feature #9830
#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

