### PR TITLE
Fix Azure build failures

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -131,7 +131,6 @@ def
     {%- if port_names_list_inactive.append(port) %}{%- endif %}
 {%- endfor %}
 {%- set port_names_inactive  = port_names_list_inactive  | join(',') %}
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
@@ -1,3 +1,4 @@
+
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2410-dynamic.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2410-dynamic.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2410.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2410.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2700.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2700.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
@@ -1,3 +1,4 @@
+
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2410-dynamic.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2410-dynamic.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2410.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2410.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2700.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2700.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {


### PR DESCRIPTION
#### Why I did it
amrhf build fails while building sonic-config-engine whl package
  https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/build/builds/77089/logs/9

The reason for the failure is due to the fact that there is a new line generated at the top of the file in buffer config test cases while building for broadcom based platform and this issue is not seen in Marvell based platforms.

#### How I did it
Removed the new line for all the buffer test cases as there is no need to add it and accordingly changed the buffer_config.j2 where the new line is generated.
#### How to verify it
Build sonic-config-engine py2/py3 whl package for both broadcom and Marvell platforms.
#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

