### PR TITLE
[202012][sonic-cfggen]: Fix sonic-cfggen build failures for armhf (#10132)

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -131,7 +131,6 @@ def
     {%- if port_names_list_inactive.append(port) %}{%- endif %}
 {%- endfor %}
 {%- set port_names_inactive  = port_names_list_inactive  | join(',') %}
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2410.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2410.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2700.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2700.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2410.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2410.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2700.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2700.json
@@ -1,4 +1,3 @@
-
 {
     "CABLE_LENGTH": {
         "AZURE": {


### PR DESCRIPTION
Porting https://github.com/Azure/sonic-buildimage/pull/10132 to 202012 branch

=== From original PR ===
Why I did it
amrhf build fails while building sonic-config-engine whl package
https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/build/builds/77089/logs/9

The reason for the failure is due to the fact that there is a new line generated at the top of the file in buffer config test cases while building for broadcom based platform and this issue is not seen in Marvell based platforms.

How I did it
Removed the new line for all the buffer test cases as there is no need to add it and accordingly changed the buffer_config.j2 where the new line is generated.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

