### PR TITLE
Update YANG model for mirror session to support decimal value for GRE type

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -8,6 +8,12 @@
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_1": {
         "desc": "Configuring ERSPAN entry with valid decimal values."
     },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_2": {
+        "desc": "Configuring ERSPAN entry with valid decimal values."
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_3": {
+        "desc": "Configuring ERSPAN entry with valid decimal values."
+    },
     "MIRROR_ERSPAN_ENTRY_WRONG_TYPE": {
         "desc": "Configuring ERSPAN entry with invalid type",
         "eStrKey": "InvalidValue"
@@ -37,10 +43,6 @@
         "eStrKey" : "Pattern"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_GRE_TYPE_2": {
-        "desc": "Configuring ERSPAN entry with invalid GRE type",
-        "eStrKey" : "Pattern"
-    },
-    "MIRROR_ERSPAN_ENTRY_WRONG_GRE_TYPE_3": {
         "desc": "Configuring ERSPAN entry with invalid GRE type",
         "eStrKey" : "Pattern"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -5,6 +5,9 @@
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES": {
         "desc": "Configuring ERSPAN entry with valid decimal values."
     },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_1": {
+        "desc": "Configuring ERSPAN entry with valid decimal values."
+    },
     "MIRROR_ERSPAN_ENTRY_WRONG_TYPE": {
         "desc": "Configuring ERSPAN entry with invalid type",
         "eStrKey": "InvalidValue"
@@ -26,6 +29,18 @@
         "eStrKey" : "When"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_GRE_TYPE": {
+        "desc": "Configuring ERSPAN entry with invalid GRE type",
+        "eStrKey" : "Pattern"
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_GRE_TYPE_1": {
+        "desc": "Configuring ERSPAN entry with invalid GRE type",
+        "eStrKey" : "Pattern"
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_GRE_TYPE_2": {
+        "desc": "Configuring ERSPAN entry with invalid GRE type",
+        "eStrKey" : "Pattern"
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_GRE_TYPE_3": {
         "desc": "Configuring ERSPAN entry with invalid GRE type",
         "eStrKey" : "Pattern"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -2,6 +2,9 @@
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_VALUES": {
         "desc": "Configuring ERSPAN entry with valid values."
     },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES": {
+        "desc": "Configuring ERSPAN entry with valid decimal values."
+    },
     "MIRROR_ERSPAN_ENTRY_WRONG_TYPE": {
         "desc": "Configuring ERSPAN entry with invalid type",
         "eStrKey": "InvalidValue"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -1,6 +1,9 @@
 {
-    "MIRROR_ERSPAN_ENTRY_WITH_VALID_VALUES": {
-        "desc": "Configuring ERSPAN entry with valid values."
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_HEX_VALUES": {
+        "desc": "Configuring ERSPAN entry with valid heximal values."
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_HEX_VALUES_1": {
+        "desc": "Configuring ERSPAN entry with valid heximal values."
     },
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES": {
         "desc": "Configuring ERSPAN entry with valid decimal values."
@@ -9,9 +12,6 @@
         "desc": "Configuring ERSPAN entry with valid decimal values."
     },
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_2": {
-        "desc": "Configuring ERSPAN entry with valid decimal values."
-    },
-    "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_3": {
         "desc": "Configuring ERSPAN entry with valid decimal values."
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_TYPE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -31,6 +31,22 @@
             }
         }
     },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_1": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "65535",
+                        "dscp": "10"
+                    }
+                ]
+            }
+        }
+    },
     "MIRROR_ERSPAN_ENTRY_WRONG_TYPE": {
         "sonic-mirror-session:sonic-mirror-session": {
             "MIRROR_SESSION": {
@@ -121,6 +137,54 @@
                         "dst_ip": "11.1.1.1",
                         "src_ip": "10.1.1.1",
                         "gre_type": "0",
+                        "dscp": "10"
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_GRE_TYPE_1": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "-1",
+                        "dscp": "10"
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_GRE_TYPE_2": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "65536",
+                        "dscp": "10"
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_GRE_TYPE_3": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "100000",
                         "dscp": "10"
                     }
                 ]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -1,5 +1,5 @@
 {
-    "MIRROR_ERSPAN_ENTRY_WITH_VALID_VALUES": {
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_HEX_VALUES": {
         "sonic-mirror-session:sonic-mirror-session": {
             "MIRROR_SESSION": {
                 "MIRROR_SESSION_LIST": [
@@ -9,6 +9,22 @@
                         "dst_ip": "11.1.1.1",
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
+                        "dscp": "10"
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_HEX_VALUES_1": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x0",
                         "dscp": "10"
                     }
                 ]
@@ -57,22 +73,6 @@
                         "dst_ip": "11.1.1.1",
                         "src_ip": "10.1.1.1",
                         "gre_type": "0",
-                        "dscp": "10"
-                    }
-                ]
-            }
-        }
-    },
-    "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_3": {
-        "sonic-mirror-session:sonic-mirror-session": {
-            "MIRROR_SESSION": {
-                "MIRROR_SESSION_LIST": [
-                    {
-                        "name": "erspan",
-                        "type": "ERSPAN",
-                        "dst_ip": "11.1.1.1",
-                        "src_ip": "10.1.1.1",
-                        "gre_type": "0x0",
                         "dscp": "10"
                     }
                 ]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -47,6 +47,38 @@
             }
         }
     },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_2": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0",
+                        "dscp": "10"
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES_3": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x0",
+                        "dscp": "10"
+                    }
+                ]
+            }
+        }
+    },
     "MIRROR_ERSPAN_ENTRY_WRONG_TYPE": {
         "sonic-mirror-session:sonic-mirror-session": {
             "MIRROR_SESSION": {
@@ -136,7 +168,7 @@
                         "type": "ERSPAN",
                         "dst_ip": "11.1.1.1",
                         "src_ip": "10.1.1.1",
-                        "gre_type": "0",
+                        "gre_type": "100000",
                         "dscp": "10"
                     }
                 ]
@@ -169,22 +201,6 @@
                         "dst_ip": "11.1.1.1",
                         "src_ip": "10.1.1.1",
                         "gre_type": "65536",
-                        "dscp": "10"
-                    }
-                ]
-            }
-        }
-    },
-    "MIRROR_ERSPAN_ENTRY_WRONG_GRE_TYPE_3": {
-        "sonic-mirror-session:sonic-mirror-session": {
-            "MIRROR_SESSION": {
-                "MIRROR_SESSION_LIST": [
-                    {
-                        "name": "erspan",
-                        "type": "ERSPAN",
-                        "dst_ip": "11.1.1.1",
-                        "src_ip": "10.1.1.1",
-                        "gre_type": "100000",
                         "dscp": "10"
                     }
                 ]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -15,6 +15,22 @@
             }
         }
     },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_DEC_VALUES": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "1234",
+                        "dscp": "10"
+                    }
+                ]
+            }
+        }
+    },
     "MIRROR_ERSPAN_ENTRY_WRONG_TYPE": {
         "sonic-mirror-session:sonic-mirror-session": {
             "MIRROR_SESSION": {

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -99,7 +99,7 @@ module sonic-mirror-session {
                 leaf gre_type {
                     when "current()/../type = 'ERSPAN'";
                     type string {
-                        pattern "0[xX][0-9a-fA-F]*|([1-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[1-5])";
+                        pattern "0[xX][0-9a-fA-F]*|([0-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[1-5])";
                         length 1..6 {
                             error-message "Invalid GRE type";
                             error-app-tag gre-type-invalid;

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -99,7 +99,7 @@ module sonic-mirror-session {
                 leaf gre_type {
                     when "current()/../type = 'ERSPAN'";
                     type string {
-                        pattern "0[xX][0-9a-fA-F]*|([0-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[1-5])";
+                        pattern "0[xX][0-9a-fA-F]*|([0-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[0-5])";
                         length 1..6 {
                             error-message "Invalid GRE type";
                             error-app-tag gre-type-invalid;

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -99,7 +99,7 @@ module sonic-mirror-session {
                 leaf gre_type {
                     when "current()/../type = 'ERSPAN'";
                     type string {
-                        pattern "0[xX][0-9a-fA-F]*";
+                        pattern "0[xX][0-9a-fA-F]*|[1-9][0-9]*";
                         length 1..6 {
                             error-message "Invalid GRE type";
                             error-app-tag gre-type-invalid;

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -99,7 +99,7 @@ module sonic-mirror-session {
                 leaf gre_type {
                     when "current()/../type = 'ERSPAN'";
                     type string {
-                        pattern "0[xX][0-9a-fA-F]*|[1-9][0-9]*";
+                        pattern "0[xX][0-9a-fA-F]*|([1-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[1-5])";
                         length 1..6 {
                             error-message "Invalid GRE type";
                             error-app-tag gre-type-invalid;


### PR DESCRIPTION
Signed-off-by: bingwang <bingwang@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
PR  https://github.com/Azure/sonic-utilities/pull/1825 added validation for the input of `config mirror session add`, and only decimal value is accepted.
An issue https://github.com/Azure/sonic-buildimage/issues/10096 was raised to suggest accepting HEX value as well, and the suggestion makes sense to me.

To accept HEX value for GRE type, and keep backward compatibility as well, I updated the YANG model to support both decimal and hexadecimal input for GRE type.

#### How I did it
Update the regex for GRE type.

#### How to verify it
Verified by UT
```
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /sonic/src/sonic-yang-models
plugins: pyfakefs-4.5.4, cov-2.10.1
collected 3 items                                                                                                                                                                                     

tests/test_sonic_yang_models.py ..                                                                                                                                                              [ 66%]
tests/yang_model_tests/test_yang_model.py .                                                                                                                                                     [100%]

========================================================================================== 3 passed in 2.53s ==========================================================================================
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update YANG model for mirror session to support decimal value for GRE type.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

