### PR TITLE
[yang]: Add yang models for table BGP_ALLOWED_PREFIXES

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -85,6 +85,7 @@ setup(
                          './yang-models/sonic-bgp-neighbor.yang',
                          './yang-models/sonic-bgp-peergroup.yang',
                          './yang-models/sonic-bgp-peerrange.yang',
+                         './yang-models/sonic-bgp-allowed-prefix.yang',
                          './yang-models/sonic-breakout_cfg.yang',
                          './yang-models/sonic-buffer-pg.yang',
                          './yang-models/sonic-buffer-pool.yang',
@@ -125,11 +126,8 @@ setup(
                          './yang-models/sonic-versions.yang',
                          './yang-models/sonic-vlan.yang',
                          './yang-models/sonic-vrf.yang',
-
                          './yang-models/sonic-mclag.yang',
-
                          './yang-models/sonic-vlan-sub-interface.yang',
-
                          './yang-models/sonic-warm-restart.yang',
                          './yang-models/sonic-lldp.yang',
                          './yang-models/sonic-scheduler.yang',
@@ -152,6 +150,7 @@ setup(
                          './cvlyang-models/sonic-bgp-neighbor.yang',
                          './cvlyang-models/sonic-bgp-peergroup.yang',
                          './cvlyang-models/sonic-bgp-peerrange.yang',
+                         './cvlyang-models/sonic-bgp-allowed-prefix.yang',
                          './cvlyang-models/sonic-breakout_cfg.yang',
                          './cvlyang-models/sonic-copp.yang',
                          './cvlyang-models/sonic-crm.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1216,6 +1216,14 @@
                 "peer_group": "PG1"
             }
         },
+        "BGP_ALLOWED_PREFIXES" :{
+            "DEPLOYMENT_ID|4|123:123": {
+                "default_action": "permit"
+            },
+            "DEPLOYMENT_ID|5": {
+                "default_action": "permit"
+            }
+        },
         "ROUTE_MAP_SET": {
             "map1": {
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -157,7 +157,46 @@
     },
     "BGP_PEERRANGE_ALL_VALID": {
         "desc": "Configure BGP peer range table."
+    },
+    "BGP_ALLOWED_PREFIXES_COM_LIST_ALL_VALID": {
+        "desc": "Configue BGP allowed prefix list."
+    },
+    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_DEPLOYMENT": {
+        "desc": "Invalid default action.",
+        "eStrKey" : "Pattern"
+    },
+    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_DEFAULT_ACTION": {
+        "desc": "Invalid default action.",
+        "eStrKey" : "InvalidValue",
+        "eStr" : ["default_action"]
+    },
+    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_PREFIXES_IPV4": {
+        "desc": "Invalid IPv4 prefix.",
+        "eStrKey" : "Pattern"
+    },
+    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_PREFIXES_IPV6": {
+        "desc": "Invalid IPv6 prefix.",
+        "eStrKey" : "Pattern"
+    },
+    "BGP_ALLOWED_PREFIXES_LIST_ALL_VALID": {
+        "desc": "Configue BGP allowed prefix list."
+    },
+    "BGP_ALLOWED_PREFIXES_LIST_INVALID_DEPLOYMENT": {
+        "desc": "Invalid default action.",
+        "eStrKey" : "Pattern"
+    },
+    "BGP_ALLOWED_PREFIXES_LIST_INVALID_DEFAULT_ACTION": {
+        "desc": "Invalid default action.",
+        "eStrKey" : "InvalidValue",
+        "eStr" : ["default_action"]
+    },
+    "BGP_ALLOWED_PREFIXES_LIST_INVALID_PREFIXES_IPV4": {
+        "desc": "Invalid IPv4 prefix.",
+        "eStrKey" : "Pattern"
+    },
+    "BGP_ALLOWED_PREFIXES_LIST_INVALID_PREFIXES_IPV6": {
+        "desc": "Invalid IPv6 prefix.",
+        "eStrKey" : "Pattern"
     }
-
 }
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -1420,6 +1420,177 @@
                 ]
             }
         }
+    },
+
+    "BGP_ALLOWED_PREFIXES_COM_LIST_ALL_VALID": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                    },
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "5",
+                        "community": "456:456",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.10.0.0/24", "10.11.0.0/24"],
+                        "prefixes_v6": ["fc00:f1::/64", "fc00:a1::/64"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_DEPLOYMENT": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENTID",
+                        "id": "4",
+                        "community": "123:123",
+                        "default_action": "permitall",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_DEFAULT_ACTION": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "community": "123:123",
+                        "default_action": "permitall",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_PREFIXES_IPV4": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/48", "10.1.0.0/24"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_COM_LIST_INVALID_PREFIXES_IPV6": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_COM_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "community": "123:123",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0./24"],
+                        "prefixes_v6": ["fc00:f0::/129", "fc00:a0::/64"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_LIST_ALL_VALID": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                    },
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "5",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.10.0.0/24", "10.11.0.0/24"],
+                        "prefixes_v6": ["fc00:f1::/64", "fc00:a1::/64"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_LIST_INVALID_DEPLOYMENT": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_LIST": [
+                    {
+                        "deployment": "DEPLOYMENTID",
+                        "id": "4",
+                        "default_action": "permitall",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_LIST_INVALID_DEFAULT_ACTION": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "default_action": "permitall",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0/24"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_LIST_INVALID_PREFIXES_IPV4": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/48", "10.1.0.0/24"],
+                        "prefixes_v6": ["fc00:f0::/64", "fc00:a0::/64"]
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_ALLOWED_PREFIXES_LIST_INVALID_PREFIXES_IPV6": {
+        "sonic-bgp-allowed-prefix:sonic-bgp-allowed-prefix": {
+            "sonic-bgp-allowed-prefix:BGP_ALLOWED_PREFIXES": {
+                "BGP_ALLOWED_PREFIXES_LIST": [
+                    {
+                        "deployment": "DEPLOYMENT_ID",
+                        "id": "4",
+                        "default_action": "permit",
+                        "prefixes_v4": ["10.0.0.0/24", "10.1.0.0./24"],
+                        "prefixes_v6": ["fc00:f0::/129", "fc00:a0::/64"]
+                    }
+                ]
+            }
+        }
     }
 }
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
@@ -1,0 +1,102 @@
+module sonic-bgp-allowed-prefix {
+    namespace "http://github.com/Azure/sonic-bgp-allowed-prefix";
+    prefix bgppre;
+    yang-version 1.1;
+
+    import sonic-bgp-common {
+        prefix bgpcmn;
+    }
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-routing-policy-sets {
+        prefix rpolsets;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONIC BGP Allowed Prefix";
+
+    revision 2022-02-26 {
+        description
+            "Initial revision.";
+    }
+
+    container sonic-bgp-allowed-prefix {
+        container BGP_ALLOWED_PREFIXES {
+            list BGP_ALLOWED_PREFIXES_COM_LIST {
+                key "deployment id community";
+
+                leaf deployment {
+                    type string {
+                        pattern "DEPLOYMENT_ID";
+                    }
+                    description "BGP allowed prefix list key type";
+                }
+
+                leaf id {
+                    type uint32;
+                    description "BGP allowed prefix list deployment id";
+                }
+
+                leaf community {
+                    type string;
+                    description "BGP allowed prefix list deployment community";
+                }
+
+                leaf default_action {
+                    type rpolsets:routing-policy-action-type;
+                    description "Permit/Deny action for BGP allow prefix list";
+                }
+
+                leaf-list prefixes_v4 {
+                    type inet:ipv4-prefix;
+                    description "BGP V4 allowed prefix list";
+                }
+
+                leaf-list prefixes_v6 {
+                    type inet:ipv6-prefix;
+                    description "BGP V6 allowed prefix list";
+                }
+            }
+
+            list BGP_ALLOWED_PREFIXES_LIST {
+                key "deployment id";
+
+                leaf deployment {
+                    type string {
+                        pattern "DEPLOYMENT_ID";
+                    }
+                    description "BGP allowed prefix list key type";
+                }
+
+                leaf id {
+                    type uint32;
+                    description "BGP allowed prefix list deployment id";
+                }
+
+                leaf default_action {
+                    type rpolsets:routing-policy-action-type;
+                    description "Permit/Deny action for BGP allow prefix list";
+                }
+
+                leaf-list prefixes_v4 {
+                    type inet:ipv4-prefix;
+                    description "BGP V4 allowed prefix list";
+                }
+
+                leaf-list prefixes_v6 {
+                    type inet:ipv6-prefix;
+                    description "BGP V6 allowed prefix list";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
end2end test is blocked by Yang model for BGP allowed prefix list.

#### How I did it
Create new yang files for BGP allowed prefix list, and add UT.

#### How to verify it
Run UT for sonic-yang-models.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)
Fix: #9866
