### PR TITLE
[build] Fix the urllib3 version in sonic-mgmt-framework constrain file because

### DIFF
--- a/files/build/versions/dockers/docker-sonic-mgmt-framework/versions-py3
+++ b/files/build/versions/dockers/docker-sonic-mgmt-framework/versions-py3
@@ -21,6 +21,6 @@ python-dateutil==2.6.0
 requests==2.27.1
 six==1.11.0
 typing_extensions==4.1.1
-urllib3==1.21.1
+urllib3==1.26.5
 werkzeug==2.0.3
 zipp==3.7.0


### PR DESCRIPTION
it is already updated in Dockerfile 


#### Why I did it
ref: https://github.com/Azure/sonic-buildimage/pull/10024
To fix the build of 202012 branch.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)



- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

