### PR TITLE
Fix marvell-armhf build hung issue

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -601,6 +601,7 @@ for f in $(find $FILESYSTEM_ROOT/var/cache/apt/archives -name "*.deb"); do
 done
 
 sudo dpkg --root=$FILESYSTEM_ROOT -P {{ debname }}
+ps -eo pid,cmd | grep python | grep "/etc/entropy.py" | awk '{print $1}' | xargs sudo kill -9 2>/dev/null || true
 
 {% endfor %}
 {% endif %}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -601,10 +601,14 @@ for f in $(find $FILESYSTEM_ROOT/var/cache/apt/archives -name "*.deb"); do
 done
 
 sudo dpkg --root=$FILESYSTEM_ROOT -P {{ debname }}
-ps -eo pid,cmd | grep python | grep "/etc/entropy.py" | awk '{print $1}' | xargs sudo kill -9 2>/dev/null || true
 
 {% endfor %}
 {% endif %}
+
+if [[ $CONFIGURED_ARCH == armhf ]]; then
+    # A workaround to fix the armhf build hung issue, caused by sonic-platform-nokia-7215_1.0_armhf.deb post installation script 
+    ps -eo pid,cmd | grep python | grep "/etc/entropy.py" | awk '{print $1}' | xargs sudo kill -9 2>/dev/null || true
+fi
 
 sudo rm -f $FILESYSTEM_ROOT/usr/sbin/policy-rc.d
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -605,11 +605,6 @@ sudo dpkg --root=$FILESYSTEM_ROOT -P {{ debname }}
 {% endfor %}
 {% endif %}
 
-if [[ $CONFIGURED_ARCH == armhf ]]; then
-    # A workaround to fix the armhf build hung issue, caused by sonic-platform-nokia-7215_1.0_armhf.deb post installation script 
-    ps -eo pid,cmd | grep python | grep "/etc/entropy.py" | awk '{print $1}' | xargs sudo kill -9 2>/dev/null || true
-fi
-
 sudo rm -f $FILESYSTEM_ROOT/usr/sbin/policy-rc.d
 
 # Copy fstrim service and timer file, enable fstrim timer
@@ -642,6 +637,11 @@ clean_proc() {
 }
 trap_push clean_proc
 sudo mount proc /proc -t proc
+if [[ $CONFIGURED_ARCH == armhf ]]; then
+    # A workaround to fix the armhf build hung issue, caused by sonic-platform-nokia-7215_1.0_armhf.deb post installation script 
+    ps -eo pid,cmd | grep python | grep "/etc/entropy.py" | awk '{print $1}' | xargs sudo kill -9 2>/dev/null || true
+fi
+
 sudo mkdir $FILESYSTEM_ROOT/target
 sudo mount --bind target $FILESYSTEM_ROOT/target
 sudo chroot $FILESYSTEM_ROOT docker $SONIC_NATIVE_DOCKERD_FOR_DOCKERFS info


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The marvel-armhf build is hung, it does not exist after waiting for a long time.
I is caused by the process /etc/entropy.py which is started by the postinst script in target/debs/buster/sonic-platform-nokia-7215_1.0_armhf.deb

```
$ cat postinst 
sh /usr/sbin/nokia-7215_plt_setup.sh
...

$ cat usr/sbin/nokia-7215_plt_setup.sh | tail

    python /etc/entropy.py &


$ cat etc/entropy.py 
if path.exists("/proc/sys/kernel/random/entropy_avail"):
    while 1:
        while avail() < 2048:
            with open('/dev/urandom', 'rb') as urnd, open("/dev/random", mode='wb') as rnd:
                d = urnd.read(512)
                t = struct.pack('ii', 4 * len(d), len(d)) + d
                fcntl.ioctl(rnd, RNDADDENTROPY, t)
        time.sleep(30)
```

It is a workaround to fix the build issue, need to fix debian package, and revert the change.


#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

