### PR TITLE
[yang]: Update DEVICE_METADATA yang models to support 'sub_role'

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -297,7 +297,8 @@
                 "asic_name": "Asic0",
                 "switch_id": "2",
                 "switch_type": "voq",
-                "max_cores": "8"
+                "max_cores": "8",
+                "sub_role": "FrondEnd"
             }
         },
         "VLAN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -100,6 +100,9 @@
     },
     "DEVICE_METADATA_CORRECT_VOQ_CONFIG": {
         "desc": "Verifying VOQ configuration."
-     }
+    },
+    "DEVICE_METADATA_VALID_SUB_ROLE_CONFIG": {
+        "desc": "Verifying valid sub_role configuration."
+    }
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -274,5 +274,14 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_VALID_SUB_ROLE_CONFIG": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "sub_role": "FrontEnd"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -129,6 +129,7 @@ module sonic-device_metadata {
 
                 leaf sub_role {
                     type string;
+                    description "sub_roble indicates if ASIC is FrondEnd or BackEnd.";
                 }
 
                 leaf downstream_subrole {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -129,7 +129,7 @@ module sonic-device_metadata {
 
                 leaf sub_role {
                     type string;
-                    description "sub_roble indicates if ASIC is FrondEnd or BackEnd.";
+                    description "sub_role indicates if ASIC is FrondEnd or BackEnd.";
                 }
 
                 leaf downstream_subrole {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -127,6 +127,10 @@ module sonic-device_metadata {
                     type string;
                 }
 
+                leaf sub_role {
+                    type string;
+                }
+
                 leaf downstream_subrole {
                     type string;
                 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix https://github.com/Azure/sonic-buildimage/issues/9591
#### How I did it
Add 'sub_role' to device_metadata yang models.
#### How to verify it
Run UT for sonc-yang-models.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

