### PR TITLE
[202012] Refactoring DELL platform init to reduce rc.local processing time

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -232,9 +232,8 @@ if [ ! -e /host/machine.conf ]; then
     fi
 
     umount /mnt/onie-boot
+    migrate_nos_configuration
 fi
-
-migrate_nos_configuration
 
 . /host/machine.conf
 

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -1,6 +1,6 @@
 s6100/scripts/iom_power_*.sh usr/local/bin
 s6100/scripts/s6100_platform.sh usr/local/bin
-s6100/scripts/s6100_i2c_enumeration.sh usr/local/bin
+s6100/scripts/s6100_platform_startup.sh usr/local/bin
 s6100/scripts/s6100_bitbang_reset.sh usr/local/bin
 s6100/scripts/pcisysfs.py usr/bin
 common/dell_i2c_utils.sh usr/local/bin
@@ -31,7 +31,7 @@ s6100/systemd/s6100-ssd-monitor.service etc/systemd/system
 s6100/systemd/s6100-ssd-monitor.timer etc/systemd/system
 s6100/systemd/s6100-ssd-upgrade-status.service etc/systemd/system
 s6100/systemd/s6100-reboot-cause.service etc/systemd/system
-s6100/systemd/s6100-i2c-enumerate.service etc/systemd/system
+s6100/systemd/s6100-platform-startup.service etc/systemd/system
 tools/flashrom/flashrom usr/local/bin/
 common/fw-updater usr/local/bin
 common/onie_mode_set usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/fast-reboot_plugin
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/fast-reboot_plugin
@@ -4,4 +4,4 @@ if [[ -d /sys/devices/platform/SMF.512/hwmon/ ]]; then
     cd /sys/devices/platform/SMF.512/hwmon/*
     echo 0xcc > mb_poweron_reason
 fi
-/usr/local/bin/s6100_i2c_enumeration.sh deinit & > /dev/null
+/usr/local/bin/s6100_platform_startup.sh deinit & > /dev/null

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -34,6 +34,9 @@ if [[ "$1" == "init" ]]; then
         *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
             TYPE='fast'
             ;;
+        *SONIC_BOOT_TYPE=soft*)
+            TYPE='soft'
+            ;;
         *)
             TYPE='cold'
     esac

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/s6100_platform.sh
@@ -2,27 +2,6 @@
 
 #platform init script for Dell S6100
 
-install_python_api_package() {
-    device="/usr/share/sonic/device"
-    platform=$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
-
-    rv=$(pip install $device/$platform/sonic_platform-1.0-py2-none-any.whl)
-    rv=$(pip3 install $device/$platform/sonic_platform-1.0-py3-none-any.whl)
-}
-
-remove_python_api_package() {
-    rv=$(pip show sonic-platform > /dev/null 2>/dev/null)
-    if [ $? -eq 0 ]; then
-        rv=$(pip uninstall -y sonic-platform > /dev/null 2>/dev/null)
-    fi
-
-    rv=$(pip3 show sonic-platform > /dev/null 2>/dev/null)
-    if [ $? -eq 0 ]; then
-        rv=$(pip3 uninstall -y sonic-platform > /dev/null 2>/dev/null)
-    fi
-}
-
-
 if [[ "$1" == "init" ]]; then
 
     pericom="/sys/bus/pci/devices/0000:08:00.0"
@@ -45,19 +24,29 @@ if [[ "$1" == "init" ]]; then
 
     systemctl start --no-block s6100-ssd-upgrade-status.service
 
-    is_fast_warm=$(cat /proc/cmdline | grep SONIC_BOOT_TYPE | wc -l)
+    case "$(cat /proc/cmdline)" in
+        *SONIC_BOOT_TYPE=warm*)
+            TYPE='warm'
+            ;;
+        *SONIC_BOOT_TYPE=fastfast*)
+            TYPE='fastfast'
+            ;;
+        *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
+            TYPE='fast'
+            ;;
+        *)
+            TYPE='cold'
+    esac
 
-    if [[ "$is_fast_warm" == "1" ]]; then
-        systemctl start --no-block s6100-i2c-enumerate.service
+    if [[ "$TYPE" == "cold" ]]; then
+        systemctl start s6100-platform-startup.service
     else
-        systemctl start s6100-i2c-enumerate.service
+        systemctl start --no-block s6100-platform-startup.service
     fi
 
-    install_python_api_package
-    monit reload
 
 elif [[ "$1" == "deinit" ]]; then
-    /usr/local/bin/s6100_i2c_enumeration.sh deinit
+    /usr/local/bin/s6100_platform_startup.sh deinit
 
     modprobe -r dell_s6100_lpc
     modprobe -r dell_s6100_iom_cpld
@@ -65,7 +54,6 @@ elif [[ "$1" == "deinit" ]]; then
     modprobe -r i2c-dev
     modprobe -r dell_ich
     modprobe -r nvram
-    remove_python_api_package
 else
      echo "s6100_platform : Invalid option !"
 fi

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/systemd/s6100-platform-startup.service
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/systemd/s6100-platform-startup.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=Dell S6100 I2C MUX Enumeration
+Description=Dell S6100 Platform Startup Service
 Before=pmon.service
 DefaultDependencies=no
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/s6100_i2c_enumeration.sh init
+ExecStart=/usr/local/bin/s6100_platform_startup.sh init
 RemainAfterExit=no
 
 [Install]

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/systemd/s6100-platform-startup.service
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/systemd/s6100-platform-startup.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Dell S6100 Platform Startup Service
-Before=pmon.service
+Before=pmon.service determine-reboot-cause.service
 DefaultDependencies=no
 
 [Service]


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- To reduce the processing time of rc.local, refactoring s6100 platform initialization.
- Fixing https://github.com/Azure/sonic-buildimage/issues/10150 
#### How I did it
```
On branch 202012-s6100-rclocalChanges to be committed:  (use "git restore --staged <file>..." to unstage)
        modified:   ../../../../files/image_config/platform/rc.local        
	modified:   ../debian/platform-modules-s6100.install        
	modified:   scripts/fast-reboot_plugin
        modified:   scripts/s6100_platform.sh
        renamed:    scripts/s6100_i2c_enumeration.sh -> scripts/s6100_platform_startup.sh
        renamed:    systemd/s6100-i2c-enumerate.service -> systemd/s6100-platform-startup.service
```

#### How to verify it
- Attached UT logs.
[logs.zip](https://github.com/Azure/sonic-buildimage/files/8201021/logs.zip)

- In short,
```
| Images upgraded to                 | rc.local processing time during warm-boot    | rc.local processing time during fast-boot    |
|------------------------------------|----------------------------------------------|----------------------------------------------|
| 201811 - 202012.54                 | ~28 seconds                                  | ~28 seconds                                  |
| 201811 - 202012.latest with fix    | ~21 seconds                                  | ~21 seconds                                  |
| 202012.53 - 202012.54              | ~28 seconds                                  | ~28 seconds                                  |
| 202012.53 - 202012.latest with fix | ~21 seconds                                  | ~21 seconds                                  |
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

