### PR TITLE
[Build]: Fix installing dpkg packages in parallel issue

### DIFF
--- a/src/sonic-build-hooks/hooks/apt
+++ b/src/sonic-build-hooks/hooks/apt
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 . /usr/local/share/buildinfo/scripts/buildinfo_base.sh
-APT_REAL_COMMAND=$(get_command apt) ./apt-get "$@"
+
+APT_REAL_COMMAND=$(get_command apt) $(dirname "$0")/apt-get "$@"

--- a/src/sonic-build-hooks/hooks/apt
+++ b/src/sonic-build-hooks/hooks/apt
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+APT_REAL_COMMAND=$(get_command apt) ./apt-get "$@"

--- a/src/sonic-build-hooks/hooks/apt
+++ b/src/sonic-build-hooks/hooks/apt
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+. /usr/local/share/buildinfo/scripts/buildinfo_base.sh
 APT_REAL_COMMAND=$(get_command apt) ./apt-get "$@"

--- a/src/sonic-build-hooks/hooks/apt-get
+++ b/src/sonic-build-hooks/hooks/apt-get
@@ -4,35 +4,21 @@ INSTALL=
 . /usr/local/share/buildinfo/scripts/buildinfo_base.sh
 
 REAL_COMMAND=$(get_command apt-get)
+[ -n "$APT_REAL_COMMAND" ] && REAL_COMMAND=$APT_REAL_COMMAND
 if [ -z "$REAL_COMMAND" ]; then
     echo "The command apt-get does not exist." 1>&2
     exit 1
 fi
 
-VERSION_FILE="/usr/local/share/buildinfo/versions/versions-deb"
-if [ "$ENABLE_VERSION_CONTROL_DEB" == "y" ]; then
-    for para in $@
-    do
-        if [[ "$para" != -* ]]; then
-            continue
-        fi
-        if [ ! -z "$INSTALL" ]; then
-            if [[ "$para" == *=* ]]; then
-                continue
-            elif [[ "$para" == *=* ]]; then
-                continue
-            else
-                package=$para
-                if ! grep -q "^${package}=" $VERSION_FILE; then
-                    echo "The version of the package ${package} is not specified."
-                    exit 1
-                fi
-            fi
-        elif [[ "$para" == "install"  ]]; then
-            INSTALL=y
-        fi
-    done
+INSTALL=$(check_apt_install)
+if [ "$INSTALL" == y ]; then
+    check_apt_version
+    lock_result=$(acquire_apt_installation_lock)
+    $REAL_COMMAND "$@"
+    command_result=$?
+    [ "$lock_result" == y ] && release_apt_installation_lock
+    exit $command_result
+else
+    $REAL_COMMAND "$@"
 fi
 
-
-$REAL_COMMAND "$@"

--- a/src/sonic-build-hooks/hooks/apt-get
+++ b/src/sonic-build-hooks/hooks/apt-get
@@ -3,8 +3,8 @@
 INSTALL=
 . /usr/local/share/buildinfo/scripts/buildinfo_base.sh
 
-REAL_COMMAND=$(get_command apt-get)
-[ -n "$APT_REAL_COMMAND" ] && REAL_COMMAND=$APT_REAL_COMMAND
+REAL_COMMAND=$APT_REAL_COMMAND
+[ -z "$REAL_COMMAND" ] && REAL_COMMAND=$(get_command apt-get)
 if [ -z "$REAL_COMMAND" ]; then
     echo "The command apt-get does not exist." 1>&2
     exit 1

--- a/src/sonic-build-hooks/hooks/apt-get
+++ b/src/sonic-build-hooks/hooks/apt-get
@@ -11,9 +11,10 @@ if [ -z "$REAL_COMMAND" ]; then
 fi
 
 INSTALL=$(check_apt_install)
+COMMAND_INFO="Locked by command: $REAL_COMMAND $@"
 if [ "$INSTALL" == y ]; then
     check_apt_version
-    lock_result=$(acquire_apt_installation_lock)
+    lock_result=$(acquire_apt_installation_lock "$COMMAND_INFO" )
     $REAL_COMMAND "$@"
     command_result=$?
     [ "$lock_result" == y ] && release_apt_installation_lock

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -12,6 +12,7 @@ VERSION_DEB_PREFERENCE=$BUILDINFO_PATH/versions/01-versions-deb
 WEB_VERSION_FILE=$VERSION_PATH/versions-web
 BUILD_WEB_VERSION_FILE=$BUILD_VERSION_PATH/versions-web
 REPR_MIRROR_URL_PATTERN='http:\/\/packages.trafficmanager.net\/debian'
+DPKG_INSTALLTION_LOCK_FILE=/tmp/.dpkg_installation.lock
 
 . $BUILDINFO_PATH/config/buildinfo.config
 
@@ -180,6 +181,78 @@ run_pip_command()
     local result=$?
     rm $tmp_version_file
     return $result
+}
+
+# Check if the command is to install the debian packages
+# The apt/apt-get command format: apt/apt-get [options] {update|install}
+check_apt_install()
+{
+    for para in "$@"
+    do
+        if [[ "$para" == -* ]]; then
+            continue
+        fi
+
+        if [[ "$para" == "install"  ]]; then
+            echo y
+        fi
+
+        break
+    done
+}
+
+# Print warning message if a debian package version not specified when debian version control enabled.
+check_apt_version()
+{
+    VERSION_FILE="/usr/local/share/buildinfo/versions/versions-deb"
+    local install=$(check_apt_install "$@")
+    if [ "$ENABLE_VERSION_CONTROL_DEB" == "y" ] && [ "$install" == "y" ]; then
+        for para in "$@"
+        do
+            if [[ "$para" == -* ]]; then
+                continue
+            fi
+
+            if [[ "$para" == *=* ]]; then
+                continue
+            else
+                package=$para
+                if ! grep -q "^${package}=" $VERSION_FILE; then
+                    echo "Warning: the version of the package ${package} is not specified." 1>&2
+                fi
+            fi
+        done
+    fi
+}
+
+acquire_apt_installation_lock()
+{
+    local result=n
+    local wait_in_second=10
+    local count=60
+    local info="$1"
+    for ((i=1; i<=$count; i++)); do
+        if [ -f $DPKG_INSTALLTION_LOCK_FILE ]; then
+            local lock_info=$(cat $DPKG_INSTALLTION_LOCK_FILE || true)
+            echo "Waiting dpkg lock for $wait_in_second, $i/$count, info: $lock_info" 1>&2
+            sleep $wait_in_second
+        else
+            if (set -o noclobber; echo "$info">$DPKG_INSTALLTION_LOCK_FILE) &>/dev/null; then
+                result=y
+                break
+            else
+                echo "Failed to creat lock Waiting dpkg lock for $wait_in_second, $i/$count, info: $lock_info" 1>&2
+                sleep $wait_in_second
+            fi
+        fi
+    done
+
+    echo $result
+}
+
+release_apt_installation_lock()
+{
+    rm -f $DPKG_INSTALLTION_LOCK_FILE
 }
 
 ENABLE_VERSION_CONTROL_DEB=$(check_version_control "deb")

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -237,11 +237,12 @@ acquire_apt_installation_lock()
             echo "Waiting dpkg lock for $wait_in_second, $i/$count, info: $lock_info" 1>&2
             sleep $wait_in_second
         else
+            # Create file in an atomic operation
             if (set -o noclobber; echo "$info">$DPKG_INSTALLTION_LOCK_FILE) &>/dev/null; then
                 result=y
                 break
             else
-                echo "Failed to creat lock Waiting dpkg lock for $wait_in_second, $i/$count, info: $lock_info" 1>&2
+                echo "Failed to creat lock, Waiting dpkg lock for $wait_in_second, $i/$count, info: $lock_info" 1>&2
                 sleep $wait_in_second
             fi
         fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the debian packages installing in parallel issue.
Add apt hook command to support apt to print no version control info.

#### How I did it
Add a file lock, it can block the apt/apt-get installation for 10 min in max if another apt/apt-get installation command is running. It only has effect on the build time.

Clarify the feature to the lock in slave.mk:
Currently, we already has a lock in the slave.mk, it has no effect when installing the package inside of the makefile. Comparing the method, the method in the pr is more general, take effect when using the command apt/apt-get.
And it is not as a replacement for the debian installation lock in the slave.mk, another feature of the lock in slave.mk is to block some of the conflict packages installation, so make the conflict targets not building in the same time.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

