### PR TITLE
Use unix socket path in ConfigDBConnector for some components

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -954,7 +954,7 @@ class HostConfigDaemon:
     def __init__(self):
         # Just a sanity check to verify if the CONFIG_DB has been initialized
         # before moving forward
-        self.config_db = ConfigDBConnector()
+        self.config_db = ConfigDBConnector(use_unix_socket_path=True)
         self.config_db.connect(wait_for_init=True, retry_on=True)
         self.dbconn = DBConnector(CFG_DB, 0)
         self.selector = Select()

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -43,7 +43,7 @@ CHASSIS_INFO_REV_FIELD = 'revision'
 
 def get_localhost_info(field):
     try:
-        config_db = ConfigDBConnector()
+        config_db = ConfigDBConnector(use_unix_socket_path=True)
         config_db.connect()
 
         metadata = config_db.get_table('DEVICE_METADATA')

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -356,7 +356,7 @@ def get_platform_info():
     hw_info_dict['asic_count'] = get_num_asics()
 
     try:
-        config_db = ConfigDBConnector()
+        config_db = ConfigDBConnector(use_unix_socket_path=True)
         config_db.connect()
 
         metadata = config_db.get_table('DEVICE_METADATA')["localhost"]

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -43,7 +43,7 @@ def connect_config_db_for_ns(namespace=DEFAULT_NAMESPACE):
     Returns:
       handle to the config_db for a namespace
     """
-    config_db = swsscommon.ConfigDBConnector(namespace=namespace)
+    config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
     config_db.connect()
     return config_db
 
@@ -65,7 +65,7 @@ def connect_to_all_dbs_for_ns(namespace=DEFAULT_NAMESPACE):
     Returns:
         handle to all the dbs for a namespaces
     """
-    db = swsscommon.SonicV2Connector(namespace=namespace)
+    db = swsscommon.SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
     db_list = list(db.get_db_list())
     if not is_supervisor():
         try:

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -31,7 +31,7 @@ PORT_ROLE = 'role'
 # to prevent duplicate connections from being opened
 config_db_handle = {}
 
-def connect_config_db_for_ns(namespace=DEFAULT_NAMESPACE):
+def connect_config_db_for_ns(namespace=DEFAULT_NAMESPACE, use_unix_socket_path=False):
     """
     The function connects to the config DB for a given namespace and
     returns the handle
@@ -43,17 +43,17 @@ def connect_config_db_for_ns(namespace=DEFAULT_NAMESPACE):
     Returns:
       handle to the config_db for a namespace
     """
-    config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    config_db = swsscommon.ConfigDBConnector(namespace=namespace, use_unix_socket_path=use_unix_socket_path)
     config_db.connect()
     return config_db
 
 
-def connect_to_all_dbs_for_ns(namespace=DEFAULT_NAMESPACE):
+def connect_to_all_dbs_for_ns(namespace=DEFAULT_NAMESPACE, use_unix_socket_path=False):
     """
     The function connects to the DBs for a given namespace and
-    returns the handle 
-    
-    For voq chassis systems, the db list includes databases from 
+    returns the handle
+
+    For voq chassis systems, the db list includes databases from
     supervisor card. Avoid connecting to these databases from linecards
 
     If no namespace is provided, it will connect to the db in the
@@ -65,7 +65,7 @@ def connect_to_all_dbs_for_ns(namespace=DEFAULT_NAMESPACE):
     Returns:
         handle to all the dbs for a namespaces
     """
-    db = swsscommon.SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
+    db = swsscommon.SonicV2Connector(namespace=namespace, use_unix_socket_path=use_unix_socket_path)
     db_list = list(db.get_db_list())
     if not is_supervisor():
         try:
@@ -242,7 +242,7 @@ def get_all_namespaces():
         for asic in range(num_asics):
             namespace = "{}{}".format(ASIC_NAME_PREFIX, asic)
             if namespace not in config_db_handle:
-                config_db_handle[namespace] =  connect_config_db_for_ns(namespace)
+                config_db_handle[namespace] =  connect_config_db_for_ns(namespace, use_unix_socket_path=True)
             config_db = config_db_handle[namespace]
 
             metadata = config_db.get_table('DEVICE_METADATA')
@@ -312,7 +312,7 @@ def get_port_entry_for_asic(port, namespace):
 
 def get_port_table_for_asic(namespace):
 
-    config_db = connect_config_db_for_ns(namespace)
+    config_db = connect_config_db_for_ns(namespace, use_unix_socket_path=True)
     ports = config_db.get_table(PORT_CFG_DB_TABLE)
     return ports
 


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Using TCP connection might be interrupted when restaring interfaces-config.service. Unix socket does not have this issue.

#### How I did it

Use unix socket.

#### How to verify it

Restart interfaces-config.service with hostcfgd.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

