### PR TITLE
[Cherry-pick][202111]Generate sai.profile from j2 tempalte when saiserver start

### DIFF
--- a/platform/broadcom/docker-saiserver-brcm/start.sh
+++ b/platform/broadcom/docker-saiserver-brcm/start.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+HWSKU_DIR=/usr/share/sonic/hwsku
 
 start_bcm()
 {
@@ -7,11 +8,37 @@ start_bcm()
     [ -e /dev/linux-kernel-bde ] || mknod /dev/linux-kernel-bde c 127 0
 }
 
+generate_profile()
+{
+    # There are two ways to specify the contents of the SAI_INIT_CONFIG_FILE and they are mutually exclusive
+    # via current method (sai.profile.j2) or new method (config.bcm.j2)
+    # If delta is large, use sai.profile.j2 which basically require the user to select which config file to use
+    # If delta is small, use config.bcm.j2 where additional SAI INIT config properties are added
+    #   based on specific device metadata requirement
+    #   in this case sai.profile should have been modified to use the path /etc/sai.d/config.bcm
+    # There is also a possibility that both sai.profile.j2 and config.bcm.j2 are absent.  in that cacse just copy
+    # sai.profile to the new /etc/said directory.
+
+    # Create/Copy the sai.profile to /etc/sai.d/sai.profile
+    mkdir -p /etc/sai.d/
+
+    if [ -f $HWSKU_DIR/sai.profile.j2 ]; then
+        sonic-cfggen -d -t $HWSKU_DIR/sai.profile.j2 > /etc/sai.d/sai.profile
+    else
+        if [ -f $HWSKU_DIR/config.bcm.j2 ]; then
+            sonic-cfggen -d -t $HWSKU_DIR/config.bcm.j2 > /etc/sai.d/config.bcm
+        fi
+        if [ -f $HWSKU_DIR/sai.profile ]; then
+            cp $HWSKU_DIR/sai.profile /etc/sai.d/sai.profile
+        fi
+    fi
+}
 
 rm -f /var/run/rsyslogd.pid
 
 supervisorctl start rsyslogd
 
+generate_profile
 start_bcm
 
 supervisorctl start saiserver

--- a/platform/broadcom/docker-saiserver-brcm/supervisord.conf
+++ b/platform/broadcom/docker-saiserver-brcm/supervisord.conf
@@ -20,7 +20,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 
 [program:saiserver]
-command=/usr/sbin/saiserver -p /usr/share/sonic/hwsku/sai.profile -f /usr/share/sonic/hwsku/port_config.ini
+command=/usr/sbin/saiserver -p /etc/sai.d/sai.profile -f /usr/share/sonic/hwsku/port_config.ini
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
Generate the sai.profile base on the brcm j2 file if the sai.profile (cherry-pick from #10022)
is not existing in the dut mounted folder.
Change the supervisor service configuration accordingly.

Testing done:
Add the script and config in dut
saiservice server can start automatically with [systemctl start saiserver]

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

