### PR TITLE
[Marvell-armhf] Fixing issues related to partition label

### DIFF
--- a/platform/marvell-armhf/platform.conf
+++ b/platform/marvell-armhf/platform.conf
@@ -196,7 +196,7 @@ create_ubi_partition() {
 
 create_gpt_partition() {
     blk_dev="/dev/sda"
-    demo_part=$(sgdisk -p $blk_dev | grep -e "$demo_volume_label" -e "$legacy_volume_label" | awk '{print $1}')
+    demo_part=$(sgdisk -p $blk_dev | grep -e "$demo_volume_label" | awk '{print $1}')
     # ONIE partition size 168MB
     onie_part_size=168
 

--- a/platform/marvell-armhf/sonic-platform-nokia/nokia-7215_plt_setup.sh
+++ b/platform/marvell-armhf/sonic-platform-nokia/nokia-7215_plt_setup.sh
@@ -10,12 +10,6 @@ fw_uboot_env_cfg()
     if [ "$PLATFORM" = "armhf-nokia_ixs7215_52x-r0" ]; then
 	# Ixs7215 / IPD6448M board Uboot ENV offset
         FW_ENV_DEFAULT='/dev/mtd0 0x00100000 0x10000 0x10000'
-
-        demo_part=$(sgdisk -p /dev/sda | grep -e "SONiC-OS")
-        if [ -z "$demo_part" ]; then
-            # ET6448M Board - For Backward compatibility
-            FW_ENV_DEFAULT='/dev/mtd0 0x00500000 0x80000 0x100000 8'
-        fi
     else
         FW_ENV_DEFAULT='/dev/mtd0 0x00500000 0x80000 0x100000 8'
     fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1) Removing incorrect check in plt setup for fw_env config: This check was added before to compare 2 different types of disk. Now the check is redundant and check is not required as transition is complete.

2)Removing legacy_volume_label in create_partition:  legacy_volume_label is not used in armhf install files. With legacy_volume_label initialized to NULL, current code will always return true for check, if demo_part exits.
 
#### How I did it
Change is about removing the redundant/incorrect code explained above.

#### How to verify it
1) uboot fw_printenv and fw_setenv is tested
2) onie-nos-install has be verified.
 
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Marvell-armhf: Fixing issues related to partition label

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

