### PR TITLE
[Marvell-armhf] Setting u-boot ftd_high to resolve kernel hung

### DIFF
--- a/platform/marvell-armhf/platform.conf
+++ b/platform/marvell-armhf/platform.conf
@@ -7,6 +7,7 @@ echo "Preparing for installation ... "
 # global defines
 kernel_addr=0x1100000
 fdt_addr=0x1000000
+fdt_high=0x10fffff
 initrd_addr=0x2000000
 VAR_LOG=512
 
@@ -152,6 +153,7 @@ prepare_boot_menu() {
     # Set boot configs
     fw_setenv ${FW_ARG} kernel_addr $kernel_addr > /dev/null
     fw_setenv ${FW_ARG} fdt_addr $fdt_addr > /dev/null
+    fw_setenv ${FW_ARG} fdt_high $fdt_high > /dev/null
     fw_setenv ${FW_ARG} initrd_addr $initrd_addr > /dev/null
     fw_setenv ${FW_ARG} mtdids 'nand0=armada-nand' > /dev/null
     if [ $UBOOT_FW_DEFAULT -eq 1 ]


### PR DESCRIPTION
Change-Id: I3e2521780f5ecdb3bdf6cbb6542250814ca11959
Signed-off-by: Pavan Naregundi <pnaregundi@marvell.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Kernel hang in during early boot is caused due overwriting of device tree with uncompressing kernel. Added the fdt_high which gives a safe offset from kernel location.

#### How I did it
Setting uboot environment variable fdt_high.

#### How to verify it
Successful boot of bullseye kernel on Marvell Armada 380/385.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
As issue is due to migration to bullseye, fix needs to be backported to 202111.

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Marvell-armhf: Setting u-boot fdt_high to resolve kernel hung

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

