### PR TITLE
[Accton/PDDF] Support show cmd for psu-temp and fan

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/sonic_platform/fan_drawer.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan_drawer import PddfFanDrawer
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class FanDrawer(PddfFanDrawer):
+    """PDDF Platform-Specific Fan-Drawer class"""
+
+    def __init__(self, tray_idx, pddf_data=None, pddf_plugin_data=None):
+        # idx is 0-based 
+        PddfFanDrawer.__init__(self, tray_idx, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/sonic_platform/thermal.py
@@ -11,7 +11,7 @@ except ImportError as e:
 class Thermal(PddfThermal):
     """PDDF Platform-Specific Thermal class"""
 
-    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
-        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data)
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None, is_psu_thermal=False, psu_index=0):
+        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data, is_psu_thermal, psu_index)
 
     # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/fan_drawer.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan_drawer import PddfFanDrawer
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class FanDrawer(PddfFanDrawer):
+    """PDDF Platform-Specific Fan-Drawer class"""
+
+    def __init__(self, tray_idx, pddf_data=None, pddf_plugin_data=None):
+        # idx is 0-based 
+        PddfFanDrawer.__init__(self, tray_idx, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/thermal.py
@@ -11,7 +11,7 @@ except ImportError as e:
 class Thermal(PddfThermal):
     """PDDF Platform-Specific Thermal class"""
 
-    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
-        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data)
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None, is_psu_thermal=False, psu_index=0):
+        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data, is_psu_thermal, psu_index)
 
     # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/fan_drawer.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan_drawer import PddfFanDrawer
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class FanDrawer(PddfFanDrawer):
+    """PDDF Platform-Specific Fan-Drawer class"""
+
+    def __init__(self, tray_idx, pddf_data=None, pddf_plugin_data=None):
+        # idx is 0-based 
+        PddfFanDrawer.__init__(self, tray_idx, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/thermal.py
@@ -11,7 +11,7 @@ except ImportError as e:
 class Thermal(PddfThermal):
     """PDDF Platform-Specific Thermal class"""
 
-    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
-        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data)
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None, is_psu_thermal=False, psu_index=0):
+        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data, is_psu_thermal, psu_index)
 
     # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/fan_drawer.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan_drawer import PddfFanDrawer
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class FanDrawer(PddfFanDrawer):
+    """PDDF Platform-Specific Fan-Drawer class"""
+
+    def __init__(self, tray_idx, pddf_data=None, pddf_plugin_data=None):
+        # idx is 0-based 
+        PddfFanDrawer.__init__(self, tray_idx, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/thermal.py
@@ -11,7 +11,7 @@ except ImportError as e:
 class Thermal(PddfThermal):
     """PDDF Platform-Specific Thermal class"""
 
-    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
-        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data)
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None, is_psu_thermal=False, psu_index=0):
+        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data, is_psu_thermal, psu_index)
 
     # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/fan_drawer.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan_drawer import PddfFanDrawer
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class FanDrawer(PddfFanDrawer):
+    """PDDF Platform-Specific Fan-Drawer class"""
+
+    def __init__(self, tray_idx, pddf_data=None, pddf_plugin_data=None):
+        # idx is 0-based 
+        PddfFanDrawer.__init__(self, tray_idx, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/thermal.py
@@ -11,7 +11,7 @@ except ImportError as e:
 class Thermal(PddfThermal):
     """PDDF Platform-Specific Thermal class"""
 
-    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
-        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data)
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None, is_psu_thermal=False, psu_index=0):
+        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data, is_psu_thermal, psu_index)
 
     # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/fan_drawer.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+
+try:
+    from sonic_platform_pddf_base.pddf_fan_drawer import PddfFanDrawer
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class FanDrawer(PddfFanDrawer):
+    """PDDF Platform-Specific Fan-Drawer class"""
+
+    def __init__(self, tray_idx, pddf_data=None, pddf_plugin_data=None):
+        # idx is 0-based 
+        PddfFanDrawer.__init__(self, tray_idx, pddf_data, pddf_plugin_data)
+
+    # Provide the functions/variables below for which implementation is to be overwritten

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/thermal.py
@@ -11,7 +11,7 @@ except ImportError as e:
 class Thermal(PddfThermal):
     """PDDF Platform-Specific Thermal class"""
 
-    def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
-        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data)
+    def __init__(self, index, pddf_data=None, pddf_plugin_data=None, is_psu_thermal=False, psu_index=0):
+        PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data, is_psu_thermal, psu_index)
 
     # Provide the functions/variables below for which implementation is to be overwritten


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 Support for show platform temp/fan for psu-temp and fan.
Original code doesn't has fan_drawer to support these information.
#### How I did it
 Support for show platform temp/fan for psu-temp and fan.
Add fan_drawer.py and update thermal.py to add needed code.
It need PDDF common code to support . (Refer to  https://github.com/Azure/sonic-buildimage/pull/10213)
#### How to verify it
Test show platform temp and show platform fan.
root@as7726-32x-2:~# show platform fan
  Drawer    LED         FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  ----------  -------  -----------  ----------  --------  -----------------
Fantray1  green  Fantray1_1      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray1  green  Fantray1_2      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray2  green  Fantray2_1      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray2  green  Fantray2_2      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray3  green  Fantray3_1      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray3  green  Fantray3_2      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray4  green  Fantray4_1      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray4  green  Fantray4_2      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray5  green  Fantray5_1      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray5  green  Fantray5_2      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray6  green  Fantray6_1      38%      EXHAUST     Present        OK  20220311 08:13:04
Fantray6  green  Fantray6_2      38%      EXHAUST     Present        OK  20220311 08:13:04
     N/A  green   PSU1_FAN1      23%      EXHAUST     Present        OK  20220311 08:13:04
     N/A  green   PSU2_FAN1      22%      EXHAUST     Present        OK  20220311 08:13:04
root@as7726-32x-2:~# show platform temp
    Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
----------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
PSU1_TEMP1           28          N/A       N/A             N/A            N/A      False  20220311 08:13:04
PSU2_TEMP1           25          N/A       N/A             N/A            N/A      False  20220311 08:13:04
     TEMP1           23.5       80.0       N/A             N/A            N/A      False  20220311 08:13:04
     TEMP2           27         80.0       N/A             N/A            N/A      False  20220311 08:13:04
     TEMP3           24         80.0       N/A             N/A            N/A      False  20220311 08:13:04
     TEMP4           27         80.0       N/A             N/A            N/A      False  20220311 08:13:04
     TEMP5           24         80.0       N/A             N/A            N/A      False  20220311 08:13:04   

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

