### PR TITLE
[sonic-config-engine][portconfig] Do not parse JSON as Python AST

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -45,16 +45,25 @@ BRKOUT_PATTERN_GROUPS = 6
 #
 # Helper Functions
 #
+
+# For python2 compatibility
+def py2JsonStrHook(j):
+    if isinstance(j, unicode):
+        return j.encode('utf-8', 'backslashreplace')
+    if isinstance(j, list):
+        return [py2JsonStrHook(item) for item in j]
+    if isinstance(j, dict):
+        return {py2JsonStrHook(key): py2JsonStrHook(value)
+            for key, value in j.iteritems()}
+    return j
+
 def readJson(filename):
     # Read 'platform.json' or 'hwsku.json' file
     try:
         with open(filename) as fp:
-            try:
-                data = json.load(fp)
-            except json.JSONDecodeError:
-                print("Json file does not exist")
-        data_dict = ast.literal_eval(json.dumps(data))
-        return data_dict
+            if sys.version_info.major == 2:
+                return json.load(fp, object_hook=py2JsonStrHook)
+            return json.load(fp)
     except Exception as e:
         print("error occurred while parsing json: {}".format(sys.exc_info()[1]))
         return None

--- a/src/sonic-config-engine/tests/sample_platform.json
+++ b/src/sonic-config-engine/tests/sample_platform.json
@@ -1,4 +1,16 @@
 {
+    "chassis": {
+        "psus": [
+            {
+                "name": "PSU 1",
+                "temperature": false
+            },
+            {
+                "name": "PSU 2",
+                "temperature": false
+            }
+        ]
+    },
     "interfaces": {
         "Ethernet0": {
             "index": "1,1,1,1",


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix https://github.com/Azure/sonic-buildimage/issues/9643

#### How I did it
Instead of ast.literal_eval added python2 compat code for json strings unicode -> str convertion.

We need python2 compatibility since py2 sonic config engine (buster/sonic_config_engine-1.0-py2-none-any.whl target) is still included into the build (ENABLE_PY2_MODULES flag is set for buster). Once we abandon buster and python2, this compat and ast.literal_eval could be cleaned up all through the code base.

#### How to verify it
run steps from the linked issue

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

